### PR TITLE
Celebrimbor: keyword ingredients (ItemKeys) + Sources pop-out window

### DIFF
--- a/docs/celebrimbor-roadmap.md
+++ b/docs/celebrimbor-roadmap.md
@@ -115,16 +115,20 @@ The schema now models ingredients as a sealed `RecipeIngredient` hierarchy ([Rec
 
 The location-pin tooltip on shopping-list rows used to render `Locations` as a flat list of `Label × Quantity`. For keyword rows that union locations across many items at the same chest, this turned into a 30-line wall of `Serbule Community Chest × 47` repeated for items the row couldn't tell apart. The pin is now a `Button` that opens [`IngredientSourcesWindow`](../src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml) (in `Mithril.Shared.Wpf` so other modules can reuse it).
 
-`IngredientLocation` ([Mithril.Shared/Storage/IngredientLocation.cs](../src/Mithril.Shared/Storage/IngredientLocation.cs)) carries per-item identity (`ItemInternalName`, `DisplayName`, `IconId`) so the window can group by location with a per-item breakdown sorted by quantity. The window has two tabs — **On hand** (default when stock exists) and **Sources** — populated by [`IngredientSourcesViewModel.Build`](../src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs) from a module-agnostic `IngredientSourcesInput`. Sources resolve via `IReferenceDataService.ItemSources`:
+`IngredientLocation` ([Mithril.Shared/Storage/IngredientLocation.cs](../src/Mithril.Shared/Storage/IngredientLocation.cs)) carries per-item identity (`ItemInternalName`, `DisplayName`, `IconId`) so the window can group by location with a per-item breakdown sorted by quantity. The window has two tabs — **On hand** (default when stock exists) and **Sources** — populated by [`IngredientSourcesViewModel.Build`](../src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs) from a module-agnostic `IngredientSourcesInput`.
 
-- `Vendor` / `Barter` / `NpcGift` → `Npcs[npc].Name` + `Area`.
-- `Quest` → `"Quest reward"` with the raw quest id (no quest parser yet — see deferred §3).
-- `Recipe` → `"Crafted"` with the source recipe's internal name.
+**Title-bar use-gate hint:** `ItemEntry.SkillReqs` is rendered as a sub-line under the item title (`Requires Gardening 10 to use`, or comma-joined for multi-skill `Requires Alchemy 35, Werewolf 35 to use`). Distinct from acquisition gates because it filters *use* (planting a seedling, casting a scroll), not *purchase*. Skipped for keyword rows (no single item to gate).
+
+**Sources tab — `IReferenceDataService.ItemSources` resolution with gate enrichment:**
+
+- `Vendor` / `Barter` / `NpcGift` → `Npcs[npc].Name` + `Area`. Vendor and Barter sources additionally surface `NpcService.MinFavorTier` as a `Requires <Tier> or higher` sub-line (Vendor routes to the NPC's `Store` service, Barter to its `Barter` service). NpcGift skips the per-NPC line because gift acceptance is gated per-preference (`NpcPreference.RequiredFavorTier`), not per-NPC.
+- `Recipe` → resolved to the recipe's display name + `Requires <Skill> <Level>` and a `prereq: <recipe>` detail when `PrereqRecipe` is set. The parser ([`ResolveSourceContext`](../src/Mithril.Shared/Reference/ReferenceDataService.cs)) maps the JSON's numeric `recipeId` to the recipe's `InternalName` at parse time so the consumer doesn't need to know about the id form.
+- `Quest` → `Quest reward` with the raw `questId` as detail (no quest parser yet — see deferred §3).
 - `Monster` / `Drop` / `Angling` / `HangOut` → label + area resolved through the new `AreaCatalog` service.
 
 `AreaCatalog` ([AreaEntry.cs](../src/Mithril.Shared/Reference/AreaEntry.cs)) parses `Reference/BundledData/areas.json` (previously unparsed) into `IReferenceDataService.Areas` — area code → friendly + short-friendly names, falling back to the long form when the JSON omits the short variant.
 
-For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") — surfacing a deduped union of vendor/drop/quest sources across 20+ items at once is its own UX problem worth a future pass.
+For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") — surfacing a deduped union of vendor/drop/quest sources across 20+ items at once is its own UX problem worth a future pass (see deferred §4).
 
 ---
 
@@ -149,48 +153,17 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 - Render a mini-chain in the picker's row detail pane on hover/select.
 - Flag "you cannot learn this yet" when an upstream prereq is missing from `CharacterSnapshot.RecipeCompletions`.
 
-### 3. Quest source resolution
-
-**Status gap:** Quest entries from `sources_items.json` carry only a numeric `questId` (e.g. `45016`), and quests aren't parsed by `IReferenceDataService` yet. The Sources window renders quest sources as `Quest reward (45016)` until a quest parser exists.
-
-**Likely approach:** Add a `QuestEntry` projection (name, reward chain, area) parsed from a future `quests.json` if/when the CDN exposes one, or scrape from existing log/character data. Until then, the placeholder line keeps the slot in view without claiming more than we know.
-
-### 4. Sources tab enrichment for single-item rows
-
-**Why deferred:** v1 ships a minimal Sources tab — `[Kind] Label · Area` per source. The reference data already parses several gates that would meaningfully enrich each line; surveyed and confirmed reachable without new parsers:
-
-**Vendor / Barter / NpcGift — favor-tier gate** (already parsed; consumed today by Smaug's [`VendorCapResolver`](../src/Smaug.Module/Domain/VendorCapResolver.cs) and `SellPlannerService`)
-- Path: `RawNpcService.Favor` → `NpcService.MinFavorTier` (string?, e.g. `"Liked"`).
-- Lookup: `refData.Npcs[src.Npc].Services` — find the service whose `Type` matches the source kind, surface its `MinFavorTier`.
-- Render: `Vendor: Hulon · Serbule (Liked or higher)` when non-null; current rendering otherwise.
-
-**Recipe — skill gate + prereq recipe** (parsed in [`RecipeEntry`](../src/Mithril.Shared/Reference/RecipeEntry.cs#L7-L24))
-- Fields: `Skill` (string), `SkillLevelReq` (int), `PrereqRecipe` (string?).
-- Lookup: `Context` carries the source recipe's internal name (mapped from `RawItemSource.Recipe`); `refData.RecipesByInternalName[Context]` resolves the entry.
-- Render: `Crafted: Tin Bar (Smelting 5)` and a sub-line `Requires recipe TinBar0` when `PrereqRecipe` is set. If the active character is loaded, an additional "you can/cannot learn this yet" badge against `CharacterSnapshot.RecipeCompletions`.
-
-**Item-side use gate — title-bar hint** (parsed in [`ItemEntry`](../src/Mithril.Shared/Reference/ItemEntry.cs))
-
-**Why this is a separate slot from the Sources card:** Vendor / barter / recipe gates filter *acquisition* — "you can't buy this from Hulon until Liked, you can't craft it without Smelting 5." `SkillReqs` filters *use* — you can buy the seedling from anyone, but you can't plant it without Gardening 10. Mixing them in the Sources card would mislead ("oh, this NPC only sells to gardeners?" — no, anyone can buy). The title bar is the right home: it describes the item itself, independent of how you got it.
-
-**Real-world coverage:** 5,884 of the bundled items carry `SkillReqs` today. The dominant pattern is gardening seedlings (`Cabbage Leafling: { "Gardening": 10 }`), followed by crafting equipment and skill-locked consumables. Multi-skill items exist — e.g. `Alchemy: Wolfen Speed Potion` requires `{ "Alchemy": 35, "Werewolf": 35 }`, and `Battle-Priest's Pendant` requires `{ "JewelryCrafting": 47, "Priest": 47 }`. The renderer needs to handle the multi-key case cleanly; comma-join (`"Requires Alchemy 35, Werewolf 35"`) is the obvious shape.
-
-**Fields**
-- `SkillReqs` (`Dictionary<string, int>?`) — the dominant gate. Skill name → minimum level.
-- `SkillPrereqs` (`List<string>?`) — sometimes overlaps with `SkillReqs.Keys`; surface only when not redundant.
-- `EquipSlot` (`string?`) — situational; the item's name usually conveys this. Probably skip in v1, no information gain.
-
-**Render:** a single subtitle line under the title, e.g. `Requires Gardening 10 to use`, or `Requires Alchemy 35, Werewolf 35 to use`. With the active character loaded, colour green/red against `CharacterSnapshot.Skills` (matching the proposed treatment for the recipe-skill gate).
-
-**Implementation notes:**
-- Extend `AcquisitionSource` with `Requirement: string?` (and maybe `RequirementMetByActiveCharacter: bool?` for green/red colouring).
-- All three enrichments are pure projections in `IngredientSourcesViewModel.Build` — no new parsers needed. Tests follow the existing `IngredientSourcesViewModelTests` style.
-
-### 5. Sources tab for keyword rows
+### 3. Sources tab for keyword rows
 
 **Why deferred:** v1 keyword rows show a placeholder in the Sources tab. Aggregating vendor/drop/quest sources across 20+ items at once needs its own filtering/grouping UX (otherwise it floods the window). Likely needs a "common across all" vs "per item" toggle.
 
-### 6. Tighter persistence of UI state
+### 4. Active-character gate evaluation
+
+**Why deferred:** The shipped Sources-tab enrichments (favor tier, recipe skill, item use-gate) all render the requirement text but don't yet check it against the active character. A natural next step is colouring met / unmet gates against `CharacterSnapshot.Skills` (recipe + use-gate skill comparisons) and `CharacterSnapshot.NpcFavor` (favor-tier comparisons), with a "you cannot learn this yet" badge against `CharacterSnapshot.RecipeCompletions` for `PrereqRecipe`.
+
+**Likely approach:** Extend `AcquisitionSource` (and add a similar field to the title-bar hint) with `RequirementMetByActiveCharacter: bool?` populated when an active character is loaded. The window XAML adds a green/red trigger on the requirement line.
+
+### 5. Tighter persistence of UI state
 
 **Why deferred:** v1 persists the craft list, overrides, filter toggles, expansion depth, and tooltip delay. It does not persist DataGrid column layout, expanded-state of step / group headers across sessions, or recent search queries.
 
@@ -199,7 +172,7 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 - Persist `IsExpanded` per group / step so the user's mental model of what's "done" survives restarts.
 - Recent search queries — drop-down history on the query box.
 
-### 7. Variable-yield planning
+### 6. Variable-yield planning
 
 **Why deferred:** `RecipeItemRef` currently exposes `ChanceToConsume` only; there's no `PercentChance` on result items in the schema. If the schema grows to include bonus-output probabilities (certain recipes do produce bonus copies at low probability), the aggregator's expected-value pipeline is the right slot.
 
@@ -207,3 +180,25 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 - Model `RecipeItemRef.PercentChance` for result rows.
 - Add an "assume bonus yield" settings toggle that divides planned batch count by `1 + Σ percentChance * yieldMultiplier` when enabled (off by default — pessimistic planning avoids unhappy surprises).
 - Surface the raw chance in a tooltip regardless of toggle state.
+
+---
+
+## Blocked on upstream data
+
+Some enrichments aren't reachable today because the underlying CDN data doesn't include the fields. These would either need a new upstream file or out-of-band data sources to make progress.
+
+### Quest names + reward chains
+
+`sources_items.json` carries quest references as a numeric `questId` only. There's no `quests.json` on the CDN today, and `IReferenceDataService` doesn't parse one. The Sources window renders quest sources as `Quest reward (45016)` — informational that the item drops from a quest, but the quest's name, prerequisites, and chain remain unknown to the planner.
+
+**Unblocks:** A `quests.json` published by the game, or a community-maintained quest catalogue we can bundle as a fallback (similar to the way [gorgon-calibration](https://github.com/arthur-conde/gorgon-calibration) backstops Samwise rates).
+
+### Monster name / level on `Monster` and `Angling` sources
+
+`sources_items.json` `Monster` and `Angling` entries carry only `{ "type": "Monster" }` — no monster identifier, no level, no area. The Sources window can render them as `Monster: Drop` with no further detail. The bundled data simply doesn't tell us *which* monster drops the item, only that some monster does.
+
+**Unblocks:** Either an upstream change to `sources_items.json` that includes monster ids, or a separate `monsters.json` + drop-table file. Bestiary-style data would also enable Bilbo and Smaug to surface drop hints.
+
+### Recipe drop-off XP curves
+
+Recipe XP-drop-off fields (`RewardSkillXpDropOffLevel`, `RewardSkillXpDropOffPct`, `RewardSkillXpDropOffRate`) are parsed but the in-game formula for combining them is opaque without a confirmed reference implementation. Elrond approximates today; a more accurate "completions to next level" calculation would need either a wiki-confirmed formula or empirical calibration.

--- a/docs/celebrimbor-roadmap.md
+++ b/docs/celebrimbor-roadmap.md
@@ -50,39 +50,19 @@ Celebrimbor is the crafting planner. Users pick recipes and per-recipe quantitie
 
 ---
 
-## Out of scope for v1
+## What shipped after v1
 
-### 1. Multi-character inventory aggregation
+### Shareable craft-list deep links
 
-**Why deferred:** Keeps v1 focused on the shortest useful loop. `IActiveCharacterService.ActiveStorageContents` is already parsed and cached; scope grew cleanly from "active character only." Multi-character wants to iterate every export, parse each on a background thread, prefix locations with the character name, and cache by `(path, lastModifiedUtc)`. That's a modest but non-trivial feature with its own reliability surface (file-lock handling, stale-cache invalidation, memory ceiling).
+`mithril://list/<base64url>` carries a gzipped copy of the plain-text share format. The picker's "Copy share link" button (`CopyShareLinkCommand` in [RecipePickerViewModel.cs](../src/Celebrimbor.Module/ViewModels/RecipePickerViewModel.cs)) round-trips through `CraftListFormat.EncodeShareLink` / `DecodeShareLink`. The shell's `DeepLinkRouter` ([Mithril.Shared/Modules/DeepLinkRouter.cs](../src/Mithril.Shared/Modules/DeepLinkRouter.cs)) routes `list/` URIs to whichever module implements `ICraftListImportTarget` — Celebrimbor's `CraftListImportTarget` brings the tab to the foreground and prompts append-vs-replace. Registration is opt-in through the About settings toggle (HKCU only, no elevation).
 
-**Likely approach for v2:**
-- Extract `IInventoryQueryService` into `Mithril.Shared` — the shared abstraction both Celebrimbor and Bilbo would consume. The service iterates `IActiveCharacterService.StorageReports`, parses each via `StorageReportLoader.Load`, and exposes `QueryByInternalName(string) → IReadOnlyList<(Character, Location, Quantity)>`.
-- Gate the background parsing behind `IModuleGate` so it doesn't run before the shell is ready.
-- Location chips become `"{Character} · {Normalized Location}"`.
-- Bilbo migrates to consume the same service; its `StorageRowMapper` stays where it is but starts pulling from the shared parse cache.
+### ResultEffects-driven output preview
 
-### 2. Shopping-by-source hints
+**100% of `recipes.json` ResultEffects produce a preview** through one of 15 typed `Parse*` methods, the generic identifier-shape fallback, or the deliberate silent allow-list. Phase 6 (April 2026) introduced the strongly-typed preview pipeline (`AugmentPreview` for `AddItemTSysPower` plus the `EffectDescsRenderer` that resolves `{TOKEN}{value}` placeholders against `attributes.json`). Phase 7 extended it with `CraftedGearPreview` (the `TSysCraftedEquipment` / `GiveTSysItem` / `CraftSimpleTSysItem` chip), `TaughtRecipePreview` (`BestowRecipeIfNotKnown`), `WaxItemPreview` (`CraftWaxItem`), `AugmentPoolPreview` + the dedicated `AugmentPoolView`, and `EffectTagPreview` for the calligraphy / meditation tag families. The April 2026 coverage push (commits `c75aa46` → `e19eae8`) closed the long tail — adding `ResearchProgressPreview` / `XpGrantPreview` / `WordOfPowerPreview` / `LearnedAbilityPreview` (knowledge & progression), `ItemProducingPreview` (brews / surveys / treasure maps), `EquipBonusPreview` + `CraftingEnhancePreview` (equipment-property), `RecipeCooldownPreview` (`AdjustRecipeReuseTime`), `UnpreviewableExtractionPreview` (split out of `AugmentPoolPreview` for `ExtractTSysPower` since its outcome depends on the player-provided cube), the `EffectTagPreview` table-driven dispatch, and a generic identifier-shape fallback. Every typed preview renders inline on the recipe card and tooltip; clicking through opens `ItemDetailWindow` with the full per-effect breakdown — and the bundled `recipes.json` now hits 100% coverage with a standing gate test.
 
-**Why deferred:** Out-of-scope UX work for v1. The useful data exists (`IReferenceDataService.ItemSources`) but surfacing it well needs dedicated design — a popover? an inline chip list? a second tab?
+The eligibility model the pool viewer's pre-fill query uses (gear-level bracket × rolled-rarity floor × form/skill gate × `power.Slots ∋ template.EquipSlot`) is documented in [treasure-system.md](treasure-system.md). The slot clause closed [issue #8](https://github.com/arthur-conde/project-gorgon/issues/8) — without it the headline `OptionCount` over-counted by however many slot-incompatible powers lived in the profile.
 
-**Likely approach for vNext:**
-- Expand each ingredient row with a details-pane / flyout showing `ItemSources[item.InternalName]` grouped by source type (Vendor / Drop / Gather / Craft / Quest).
-- Default: hide Quest and one-off sources; let the user opt in.
-- Combine with multi-character inventory: prefer "you have it here" over "NPC X sells it."
-
-### 3. Recipe prereq chain visualization
-
-**Why deferred:** Not core to the shopping-list goal; users who already have the list in hand have committed to the recipes.
-
-**Likely approach for vNext:**
-- Resolve `RecipeEntry.PrereqRecipe` transitively into a chain.
-- Render a mini-chain in the picker's row detail pane on hover/select.
-- Flag "you cannot learn this yet" when an upstream prereq is missing from `CharacterSnapshot.RecipeCompletions`.
-
-### 3a. `ResultEffects` prefix coverage
-
-**Status: shipped — 100% of `recipes.json` ResultEffects produce a preview through one of 15 typed `Parse*` methods, the generic identifier-shape fallback, or the deliberate silent allow-list.**
+### Reference — `ResultEffects` parser surface
 
 The parser surface in [src/Mithril.Shared/Reference/ResultEffectsParser.cs](../src/Mithril.Shared/Reference/ResultEffectsParser.cs) projects every recipe's `ResultEffects` array into one of these typed preview shapes (each renders as its own collapsible section in `ItemDetailWindow`):
 
@@ -117,37 +97,74 @@ The parser surface in [src/Mithril.Shared/Reference/ResultEffectsParser.cs](../s
 
 **Coverage gate:** [tests/Mithril.Shared.Tests/Reference/ResultEffectsCoverageTests.cs](../tests/Mithril.Shared.Tests/Reference/ResultEffectsCoverageTests.cs) loads the bundled `recipes.json` and asserts every `ResultEffects` entry either produces a preview through one of the 15 `Parse*` methods or matches the silent allow-list. The only effects allow-listed at gate level are `Particle_*` and the documented `TSysCraftedEquipment` silent-skip cases (template lacks `TSysProfile` or profile not in `tsysprofiles.json` — 3 corresponding tests in `AugmentPoolParserTests`). New prefixes introduced by future game patches that don't fit existing typed shapes will surface through the generic fallback; if a future patch ever introduces a structured prefix worth a typed shape, the gate keeps passing while the typed parser gets added.
 
-**Architectural notes for future maintainers:**
+**Architectural rules for adding new prefixes:**
 - New typed preview → add the record under `Mithril.Shared/Reference/`, add the `Parse*` method, wire it through `ItemDetailContext` + `ItemDetailViewModel` + `ItemDetailWindow.xaml`, and add the prefix to `ExcludedFallbackPrefixes` in `ResultEffectsParser.cs` so it doesn't double-render.
 - New behavioural tag with a fixed display string → add to `ExactTagLines`.
 - New numbered family (`PrefixN`) with a "Tier N" rendering → add a `(Prefix, "{format} Tier {0}")` row to `SuffixedTierFamilies`. Listed prefix-longest-first so longer prefixes win over shorter ones.
 - Confirm coverage with `dotnet test tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj --filter "FullyQualifiedName~ResultEffectsCoverageTests"`.
 
-### 3b. Ingredient `ItemKeys` (keyword-matched ingredients)
+### Keyword-matched recipe ingredients (`ItemKeys`)
 
-**Status:** Not parsed today. Current `RawRecipeItem` only reads `ItemCode`; recipes that specify `{ "ItemKeys": ["Crystal"], "StackSize": 1 }` (e.g. the auxiliary-crystal slot on every `*E` enchanted recipe) silently drop that ingredient at parse time, so the user sees an incomplete ingredient list.
+Every `*E` enchanted-equipment recipe (~1,645 of them) carries an "auxiliary crystal" slot encoded as `{ "Desc": "Auxiliary Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }` — any item whose `Keywords` includes every listed tag satisfies the slot. Previously the parser dropped these entries (`ItemCode`-only filter), so the shopping list undercounted and the picker tooltip silently lost the slot.
 
-**Why it matters:** Every `TSysCraftedEquipment` enchanted recipe (1,645 of them) has at least one keyword-matched ingredient. The shopping list is currently undercounting.
+The schema now models ingredients as a sealed `RecipeIngredient` hierarchy ([RecipeIngredient.cs](../src/Mithril.Shared/Reference/RecipeIngredient.cs)) — `RecipeItemIngredient` (by `ItemCode`) plus `RecipeKeywordIngredient` (by `ItemKeys` + optional `Desc`). Results stay as `RecipeItemRef`, mirroring the data asymmetry. A new catalog-side `ItemKeywordIndex` ([ItemKeywordIndex.cs](../src/Mithril.Shared/Reference/ItemKeywordIndex.cs)) inverts the keyword → items lookup; `OnHandInventoryQuery` adds a per-keyword owned-set so the aggregator answers single-key on-hand in O(1) and AND-matches multi-key sets via set intersection.
 
-**Likely approach:**
-- Extend `RawRecipeItem` to also expose `Desc` and `ItemKeys`.
-- Surface a new `RecipeItemRef` variant that carries the keyword list instead of an item code.
-- Aggregator-side: when expanding the demand, treat keyword-matched rows as "any item keyworded `<X>` covers this slot." The on-hand resolver then has to scan inventory for any matching item rather than a single item code.
-- Tooltip / picker render: `"1× <Desc> (any Crystal)"` instead of dropping the row.
+`RecipeAggregator` dedupes keyword rows under a synthetic `"#keys:..."` key (so two recipes citing `["Crystal"]` collapse to one shopping-list row) and renders the slot as `1× Auxiliary Crystal (any Crystal)` in both the picker tooltip and shopping list. Bilbo's `CraftableRecipeCalculator` and Elrond's `SkillAdvisorEngine` light up against the same data — Bilbo sums on-hand across matching items, Elrond shows `Any Crystal x1` in skill-advisor tooltips.
 
-### 4. Shareable URL / token formats for craft lists
+### Shopping-by-source pop-out window
 
-**Why deferred:** The plain-text paste format already covers the "share this list on Discord" use case; clipboard round-trips losslessly. Any URL-flavored format is a second serialization contract to maintain.
+The location-pin tooltip on shopping-list rows used to render `Locations` as a flat list of `Label × Quantity`. For keyword rows that union locations across many items at the same chest, this turned into a 30-line wall of `Serbule Community Chest × 47` repeated for items the row couldn't tell apart. The pin is now a `Button` that opens [`IngredientSourcesWindow`](../src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml) (in `Mithril.Shared.Wpf` so other modules can reuse it).
 
-**Likely approach, ordered by cost:**
-- (a) Self-contained encoded token: `celebrimbor:v1:<base64-json>`. Compact, paste-only, no OS integration, ~30 extra lines. The right next step if users ask for shorter share strings.
-- (b) Real custom URI scheme: `celebrimbor://list?items=Butter:5,Bread:2`. Registered in `HKCU\Software\Classes\celebrimbor`, handled in `Program.cs` single-instance entry, parsed into a craft list on first-instance activation. Needs a security pass — any URL the OS can hand us is untrusted input. Only worth it if we imagine people posting clickable links rather than text.
+`IngredientLocation` ([Mithril.Shared/Storage/IngredientLocation.cs](../src/Mithril.Shared/Storage/IngredientLocation.cs)) carries per-item identity (`ItemInternalName`, `DisplayName`, `IconId`) so the window can group by location with a per-item breakdown sorted by quantity. The window has two tabs — **On hand** (default when stock exists) and **Sources** — populated by [`IngredientSourcesViewModel.Build`](../src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs) from a module-agnostic `IngredientSourcesInput`. Sources resolve via `IReferenceDataService.ItemSources`:
 
-### 5. ResultEffects-driven output preview
+- `Vendor` / `Barter` / `NpcGift` → `Npcs[npc].Name` + `Area`.
+- `Quest` → `"Quest reward"` with the raw quest id (no quest parser yet — see deferred §3).
+- `Recipe` → `"Crafted"` with the source recipe's internal name.
+- `Monster` / `Drop` / `Angling` / `HangOut` → label + area resolved through the new `AreaCatalog` service.
 
-**Status: shipped.** Phase 6 (April 2026) introduced the strongly-typed preview pipeline (`AugmentPreview` for `AddItemTSysPower` plus the `EffectDescsRenderer` that resolves `{TOKEN}{value}` placeholders against `attributes.json`). Phase 7 extended it with `CraftedGearPreview` (the `TSysCraftedEquipment` / `GiveTSysItem` / `CraftSimpleTSysItem` chip), `TaughtRecipePreview` (`BestowRecipeIfNotKnown`), `WaxItemPreview` (`CraftWaxItem`), `AugmentPoolPreview` + the dedicated `AugmentPoolView`, and `EffectTagPreview` for the calligraphy / meditation tag families. The April 2026 coverage push (commits `c75aa46` → `e19eae8`) closed the long tail — adding `ResearchProgressPreview` / `XpGrantPreview` / `WordOfPowerPreview` / `LearnedAbilityPreview` (knowledge & progression), `ItemProducingPreview` (brews / surveys / treasure maps), `EquipBonusPreview` + `CraftingEnhancePreview` (equipment-property), `RecipeCooldownPreview` (`AdjustRecipeReuseTime`), `UnpreviewableExtractionPreview` (split out of `AugmentPoolPreview` for `ExtractTSysPower` since its outcome depends on the player-provided cube), the `EffectTagPreview` table-driven dispatch, and a generic identifier-shape fallback. **Every typed preview renders inline on the recipe card and tooltip; clicking through opens `ItemDetailWindow` with the full per-effect breakdown — and the bundled `recipes.json` now hits 100% coverage with a standing gate test.** See §3a for the parser surface and the architectural rules for adding new prefixes.
+`AreaCatalog` ([AreaEntry.cs](../src/Mithril.Shared/Reference/AreaEntry.cs)) parses `Reference/BundledData/areas.json` (previously unparsed) into `IReferenceDataService.Areas` — area code → friendly + short-friendly names, falling back to the long form when the JSON omits the short variant.
 
-The eligibility model the pool viewer's pre-fill query uses (gear-level bracket × rolled-rarity floor × form/skill gate × `power.Slots ∋ template.EquipSlot`) is documented in [treasure-system.md](treasure-system.md). The slot clause closed [issue #8](https://github.com/arthur-conde/project-gorgon/issues/8) — without it the headline `OptionCount` over-counted by however many slot-incompatible powers lived in the profile.
+For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") — surfacing a deduped union of vendor/drop/quest sources across 20+ items at once is its own UX problem worth a future pass.
+
+---
+
+## Still deferred
+
+### 1. Multi-character inventory aggregation
+
+**Why deferred:** Keeps v1 focused on the shortest useful loop. `IActiveCharacterService.ActiveStorageContents` is already parsed and cached; scope grew cleanly from "active character only." Multi-character wants to iterate every export, parse each on a background thread, prefix locations with the character name, and cache by `(path, lastModifiedUtc)`. That's a modest but non-trivial feature with its own reliability surface (file-lock handling, stale-cache invalidation, memory ceiling).
+
+**Likely approach for v2:**
+- Extract `IInventoryQueryService` into `Mithril.Shared` — the shared abstraction both Celebrimbor and Bilbo would consume. The service iterates `IActiveCharacterService.StorageReports`, parses each via `StorageReportLoader.Load`, and exposes `QueryByInternalName(string) → IReadOnlyList<(Character, Location, Quantity)>`.
+- Gate the background parsing behind `IModuleGate` so it doesn't run before the shell is ready.
+- Location chips become `"{Character} · {Normalized Location}"`.
+- Bilbo migrates to consume the same service; its `StorageRowMapper` stays where it is but starts pulling from the shared parse cache.
+
+### 2. Recipe prereq chain visualization
+
+**Why deferred:** Not core to the shopping-list goal; users who already have the list in hand have committed to the recipes.
+
+**Likely approach for vNext:**
+- Resolve `RecipeEntry.PrereqRecipe` transitively into a chain.
+- Render a mini-chain in the picker's row detail pane on hover/select.
+- Flag "you cannot learn this yet" when an upstream prereq is missing from `CharacterSnapshot.RecipeCompletions`.
+
+### 3. Quest source resolution
+
+**Status gap:** Quest entries from `sources_items.json` carry only a numeric `questId` (e.g. `45016`), and quests aren't parsed by `IReferenceDataService` yet. The Sources window renders quest sources as `Quest reward (45016)` until a quest parser exists.
+
+**Likely approach:** Add a `QuestEntry` projection (name, reward chain, area) parsed from a future `quests.json` if/when the CDN exposes one, or scrape from existing log/character data. Until then, the placeholder line keeps the slot in view without claiming more than we know.
+
+### 4. Sources tab enrichment for single-item rows
+
+**Why deferred:** v1 ships a minimal Sources tab — `[Kind] Label · Area` per source. Reachable enrichments (no new parsers) include:
+- Vendor / Barter / NpcGift → `NpcEntry.Services[].MinFavorTier` so the line reads `Vendor: Hulon · Serbule (Liked or higher)`.
+- Recipe → `RecipeEntry.Skill` + `SkillLevelReq` + `PrereqRecipe`, e.g. `Crafted: Tin Bar (Smelting 5)`.
+- Title-bar context → `ItemEntry.SkillReqs` to render an equip-time `"Requires Smithing 30 to use"` line.
+
+### 5. Sources tab for keyword rows
+
+**Why deferred:** v1 keyword rows show a placeholder in the Sources tab. Aggregating vendor/drop/quest sources across 20+ items at once needs its own filtering/grouping UX (otherwise it floods the window). Likely needs a "common across all" vs "per item" toggle.
 
 ### 6. Tighter persistence of UI state
 

--- a/docs/celebrimbor-roadmap.md
+++ b/docs/celebrimbor-roadmap.md
@@ -198,7 +198,3 @@ Some enrichments aren't reachable today because the underlying CDN data doesn't 
 `sources_items.json` `Monster` and `Angling` entries carry only `{ "type": "Monster" }` — no monster identifier, no level, no area. The Sources window can render them as `Monster: Drop` with no further detail. The bundled data simply doesn't tell us *which* monster drops the item, only that some monster does.
 
 **Unblocks:** Either an upstream change to `sources_items.json` that includes monster ids, or a separate `monsters.json` + drop-table file. Bestiary-style data would also enable Bilbo and Smaug to surface drop hints.
-
-### Recipe drop-off XP curves
-
-Recipe XP-drop-off fields (`RewardSkillXpDropOffLevel`, `RewardSkillXpDropOffPct`, `RewardSkillXpDropOffRate`) are parsed but the in-game formula for combining them is opaque without a confirmed reference implementation. Elrond approximates today; a more accurate "completions to next level" calculation would need either a wiki-confirmed formula or empirical calibration.

--- a/docs/celebrimbor-roadmap.md
+++ b/docs/celebrimbor-roadmap.md
@@ -169,9 +169,18 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 - Lookup: `Context` carries the source recipe's internal name (mapped from `RawItemSource.Recipe`); `refData.RecipesByInternalName[Context]` resolves the entry.
 - Render: `Crafted: Tin Bar (Smelting 5)` and a sub-line `Requires recipe TinBar0` when `PrereqRecipe` is set. If the active character is loaded, an additional "you can/cannot learn this yet" badge against `CharacterSnapshot.RecipeCompletions`.
 
-**Item-side equip gate — title-bar hint** (parsed in [`ItemEntry`](../src/Mithril.Shared/Reference/ItemEntry.cs))
-- Fields: `SkillReqs` (`Dictionary<string, int>?`, e.g. `{ "Smithing": 30 }`), `SkillPrereqs` (`List<string>?`), `EquipSlot`.
-- Render: a single subtitle line under the title `"Requires Smithing 30 to use"` when populated. Acquisition-time vs equip-time distinction matters; place it in the title bar, not the Sources card, so it doesn't read as a source gate.
+**Item-side use gate — title-bar hint** (parsed in [`ItemEntry`](../src/Mithril.Shared/Reference/ItemEntry.cs))
+
+**Why this is a separate slot from the Sources card:** Vendor / barter / recipe gates filter *acquisition* — "you can't buy this from Hulon until Liked, you can't craft it without Smelting 5." `SkillReqs` filters *use* — you can buy the seedling from anyone, but you can't plant it without Gardening 10. Mixing them in the Sources card would mislead ("oh, this NPC only sells to gardeners?" — no, anyone can buy). The title bar is the right home: it describes the item itself, independent of how you got it.
+
+**Real-world coverage:** 5,884 of the bundled items carry `SkillReqs` today. The dominant pattern is gardening seedlings (`Cabbage Leafling: { "Gardening": 10 }`), followed by crafting equipment and skill-locked consumables. Multi-skill items exist — e.g. `Alchemy: Wolfen Speed Potion` requires `{ "Alchemy": 35, "Werewolf": 35 }`, and `Battle-Priest's Pendant` requires `{ "JewelryCrafting": 47, "Priest": 47 }`. The renderer needs to handle the multi-key case cleanly; comma-join (`"Requires Alchemy 35, Werewolf 35"`) is the obvious shape.
+
+**Fields**
+- `SkillReqs` (`Dictionary<string, int>?`) — the dominant gate. Skill name → minimum level.
+- `SkillPrereqs` (`List<string>?`) — sometimes overlaps with `SkillReqs.Keys`; surface only when not redundant.
+- `EquipSlot` (`string?`) — situational; the item's name usually conveys this. Probably skip in v1, no information gain.
+
+**Render:** a single subtitle line under the title, e.g. `Requires Gardening 10 to use`, or `Requires Alchemy 35, Werewolf 35 to use`. With the active character loaded, colour green/red against `CharacterSnapshot.Skills` (matching the proposed treatment for the recipe-skill gate).
 
 **Implementation notes:**
 - Extend `AcquisitionSource` with `Requirement: string?` (and maybe `RequirementMetByActiveCharacter: bool?` for green/red colouring).

--- a/docs/celebrimbor-roadmap.md
+++ b/docs/celebrimbor-roadmap.md
@@ -157,10 +157,25 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 
 ### 4. Sources tab enrichment for single-item rows
 
-**Why deferred:** v1 ships a minimal Sources tab — `[Kind] Label · Area` per source. Reachable enrichments (no new parsers) include:
-- Vendor / Barter / NpcGift → `NpcEntry.Services[].MinFavorTier` so the line reads `Vendor: Hulon · Serbule (Liked or higher)`.
-- Recipe → `RecipeEntry.Skill` + `SkillLevelReq` + `PrereqRecipe`, e.g. `Crafted: Tin Bar (Smelting 5)`.
-- Title-bar context → `ItemEntry.SkillReqs` to render an equip-time `"Requires Smithing 30 to use"` line.
+**Why deferred:** v1 ships a minimal Sources tab — `[Kind] Label · Area` per source. The reference data already parses several gates that would meaningfully enrich each line; surveyed and confirmed reachable without new parsers:
+
+**Vendor / Barter / NpcGift — favor-tier gate** (already parsed; consumed today by Smaug's [`VendorCapResolver`](../src/Smaug.Module/Domain/VendorCapResolver.cs) and `SellPlannerService`)
+- Path: `RawNpcService.Favor` → `NpcService.MinFavorTier` (string?, e.g. `"Liked"`).
+- Lookup: `refData.Npcs[src.Npc].Services` — find the service whose `Type` matches the source kind, surface its `MinFavorTier`.
+- Render: `Vendor: Hulon · Serbule (Liked or higher)` when non-null; current rendering otherwise.
+
+**Recipe — skill gate + prereq recipe** (parsed in [`RecipeEntry`](../src/Mithril.Shared/Reference/RecipeEntry.cs#L7-L24))
+- Fields: `Skill` (string), `SkillLevelReq` (int), `PrereqRecipe` (string?).
+- Lookup: `Context` carries the source recipe's internal name (mapped from `RawItemSource.Recipe`); `refData.RecipesByInternalName[Context]` resolves the entry.
+- Render: `Crafted: Tin Bar (Smelting 5)` and a sub-line `Requires recipe TinBar0` when `PrereqRecipe` is set. If the active character is loaded, an additional "you can/cannot learn this yet" badge against `CharacterSnapshot.RecipeCompletions`.
+
+**Item-side equip gate — title-bar hint** (parsed in [`ItemEntry`](../src/Mithril.Shared/Reference/ItemEntry.cs))
+- Fields: `SkillReqs` (`Dictionary<string, int>?`, e.g. `{ "Smithing": 30 }`), `SkillPrereqs` (`List<string>?`), `EquipSlot`.
+- Render: a single subtitle line under the title `"Requires Smithing 30 to use"` when populated. Acquisition-time vs equip-time distinction matters; place it in the title bar, not the Sources card, so it doesn't read as a source gate.
+
+**Implementation notes:**
+- Extend `AcquisitionSource` with `Requirement: string?` (and maybe `RequirementMetByActiveCharacter: bool?` for green/red colouring).
+- All three enrichments are pure projections in `IngredientSourcesViewModel.Build` — no new parsers needed. Tests follow the existing `IngredientSourcesViewModelTests` style.
 
 ### 5. Sources tab for keyword rows
 

--- a/docs/celebrimbor-roadmap.md
+++ b/docs/celebrimbor-roadmap.md
@@ -123,7 +123,7 @@ The location-pin tooltip on shopping-list rows used to render `Locations` as a f
 
 - `Vendor` / `Barter` / `NpcGift` → `Npcs[npc].Name` + `Area`. Vendor and Barter sources additionally surface `NpcService.MinFavorTier` as a `Requires <Tier> or higher` sub-line (Vendor routes to the NPC's `Store` service, Barter to its `Barter` service). NpcGift skips the per-NPC line because gift acceptance is gated per-preference (`NpcPreference.RequiredFavorTier`), not per-NPC.
 - `Recipe` → resolved to the recipe's display name + `Requires <Skill> <Level>` and a `prereq: <recipe>` detail when `PrereqRecipe` is set. The parser ([`ResolveSourceContext`](../src/Mithril.Shared/Reference/ReferenceDataService.cs)) maps the JSON's numeric `recipeId` to the recipe's `InternalName` at parse time so the consumer doesn't need to know about the id form.
-- `Quest` → `Quest reward` with the raw `questId` as detail (no quest parser yet — see deferred §3).
+- `Quest` → `Quest reward` with the raw `questId` as detail. The bundled `quests.json` exists but isn't parsed yet (see deferred §3).
 - `Monster` / `Drop` / `Angling` / `HangOut` → label + area resolved through the new `AreaCatalog` service.
 
 `AreaCatalog` ([AreaEntry.cs](../src/Mithril.Shared/Reference/AreaEntry.cs)) parses `Reference/BundledData/areas.json` (previously unparsed) into `IReferenceDataService.Areas` — area code → friendly + short-friendly names, falling back to the long form when the JSON omits the short variant.
@@ -153,17 +153,23 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 - Render a mini-chain in the picker's row detail pane on hover/select.
 - Flag "you cannot learn this yet" when an upstream prereq is missing from `CharacterSnapshot.RecipeCompletions`.
 
-### 3. Sources tab for keyword rows
+### 3. Quest source resolution
+
+**Why deferred:** `Reference/BundledData/quests.json` exists and is rich (`Name`, `InternalName`, `Description`, `DisplayedLocation`, `Objectives`, `Rewards`, `Rewards_Items`), but `IReferenceDataService` doesn't parse it yet. The Sources window currently renders quest sources as `Quest reward (45016)` — informational only.
+
+**Likely approach:** Parser side, mirror the npcs / areas pattern — add `RawQuest` + `QuestEntry` records, register `Dictionary<string, RawQuest>` in `ReferenceJsonContext`, add `LoadQuests` + `ParseAndSwapQuests` to `ReferenceDataService`, expose `IReadOnlyDictionary<string, QuestEntry> Quests` on `IReferenceDataService`. Window side, the Quest case in `BuildSources` looks up `refData.Quests[$"quest_{questId}"]` and renders `Quest: <Name> · <DisplayedLocation>` with optional objectives or reward summary as detail. Touches the existing 17 test fakes (`Quests` property addition).
+
+### 4. Sources tab for keyword rows
 
 **Why deferred:** v1 keyword rows show a placeholder in the Sources tab. Aggregating vendor/drop/quest sources across 20+ items at once needs its own filtering/grouping UX (otherwise it floods the window). Likely needs a "common across all" vs "per item" toggle.
 
-### 4. Active-character gate evaluation
+### 5. Active-character gate evaluation
 
 **Why deferred:** The shipped Sources-tab enrichments (favor tier, recipe skill, item use-gate) all render the requirement text but don't yet check it against the active character. A natural next step is colouring met / unmet gates against `CharacterSnapshot.Skills` (recipe + use-gate skill comparisons) and `CharacterSnapshot.NpcFavor` (favor-tier comparisons), with a "you cannot learn this yet" badge against `CharacterSnapshot.RecipeCompletions` for `PrereqRecipe`.
 
 **Likely approach:** Extend `AcquisitionSource` (and add a similar field to the title-bar hint) with `RequirementMetByActiveCharacter: bool?` populated when an active character is loaded. The window XAML adds a green/red trigger on the requirement line.
 
-### 5. Tighter persistence of UI state
+### 6. Tighter persistence of UI state
 
 **Why deferred:** v1 persists the craft list, overrides, filter toggles, expansion depth, and tooltip delay. It does not persist DataGrid column layout, expanded-state of step / group headers across sessions, or recent search queries.
 
@@ -172,7 +178,7 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 - Persist `IsExpanded` per group / step so the user's mental model of what's "done" survives restarts.
 - Recent search queries — drop-down history on the query box.
 
-### 6. Variable-yield planning
+### 7. Variable-yield planning
 
 **Why deferred:** `RecipeItemRef` currently exposes `ChanceToConsume` only; there's no `PercentChance` on result items in the schema. If the schema grows to include bonus-output probabilities (certain recipes do produce bonus copies at low probability), the aggregator's expected-value pipeline is the right slot.
 
@@ -186,12 +192,6 @@ For keyword rows, the Sources tab shows a placeholder ("not aggregated yet") —
 ## Blocked on upstream data
 
 Some enrichments aren't reachable today because the underlying CDN data doesn't include the fields. These would either need a new upstream file or out-of-band data sources to make progress.
-
-### Quest names + reward chains
-
-`sources_items.json` carries quest references as a numeric `questId` only. There's no `quests.json` on the CDN today, and `IReferenceDataService` doesn't parse one. The Sources window renders quest sources as `Quest reward (45016)` — informational that the item drops from a quest, but the quest's name, prerequisites, and chain remain unknown to the planner.
-
-**Unblocks:** A `quests.json` published by the game, or a community-maintained quest catalogue we can bundle as a fallback (similar to the way [gorgon-calibration](https://github.com/arthur-conde/gorgon-calibration) backstops Samwise rates).
 
 ### Monster name / level on `Monster` and `Angling` sources
 

--- a/src/Bilbo.Module/Domain/CraftableRecipeCalculator.cs
+++ b/src/Bilbo.Module/Domain/CraftableRecipeCalculator.cs
@@ -34,15 +34,33 @@ public static class CraftableRecipeCalculator
 
             foreach (var ingredient in recipe.Ingredients)
             {
-                var itemName = refData.Items.TryGetValue(ingredient.ItemCode, out var entry)
-                    ? entry.Name
-                    : $"#{ingredient.ItemCode}";
+                string itemName;
+                long available;
+                switch (ingredient)
+                {
+                    case RecipeItemIngredient byItem:
+                        itemName = refData.Items.TryGetValue(byItem.ItemCode, out var entry)
+                            ? entry.Name
+                            : $"#{byItem.ItemCode}";
+                        have.TryGetValue(byItem.ItemCode, out available);
+                        break;
+                    case RecipeKeywordIngredient kw:
+                        itemName = kw.Desc ?? ItemKeywordIndex.Humanise(kw.ItemKeys);
+                        // Sum across every owned item whose Keywords match the AND-set.
+                        available = 0;
+                        foreach (var match in refData.KeywordIndex.ItemsMatching(kw.ItemKeys))
+                            if (have.TryGetValue(match.Id, out var matchHave))
+                                available += matchHave;
+                        break;
+                    default:
+                        continue;
+                }
+
                 var part = $"{itemName} x{ingredient.StackSize}";
                 if (ingredient.ChanceToConsume is { } chance && chance < 1f)
                     part += $" (p={Math.Round(chance * 100).ToString("0", CultureInfo.InvariantCulture)}%)";
                 ingredientParts.Add(part);
 
-                have.TryGetValue(ingredient.ItemCode, out var available);
                 var perIngredient = ConsumeQuantile.MaxCrafts(available, ingredient.StackSize, ingredient.ChanceToConsume, confidence);
                 if (perIngredient < maxCraftable)
                     maxCraftable = perIngredient;

--- a/src/Celebrimbor.Module/Domain/AggregatedIngredient.cs
+++ b/src/Celebrimbor.Module/Domain/AggregatedIngredient.cs
@@ -16,7 +16,8 @@ public sealed record AggregatedIngredient(
     int? OnHandOverride,
     IReadOnlyList<IngredientLocation> Locations,
     bool IsAlsoRecipe,
-    int Depth = 0)
+    int Depth = 0,
+    string? KeywordsLabel = null)
 {
     public int EffectiveOnHand => OnHandOverride ?? OnHandDetected;
     public int Remaining => Math.Max(0, TotalNeeded - EffectiveOnHand);

--- a/src/Celebrimbor.Module/Domain/AggregatedIngredient.cs
+++ b/src/Celebrimbor.Module/Domain/AggregatedIngredient.cs
@@ -1,3 +1,5 @@
+using Mithril.Shared.Storage;
+
 namespace Celebrimbor.Domain;
 
 /// <summary>

--- a/src/Celebrimbor.Module/Domain/IngredientLocation.cs
+++ b/src/Celebrimbor.Module/Domain/IngredientLocation.cs
@@ -1,4 +1,0 @@
-namespace Celebrimbor.Domain;
-
-/// <summary>Where a chunk of an ingredient lives right now.</summary>
-public sealed record IngredientLocation(string Label, int Quantity);

--- a/src/Celebrimbor.Module/Services/OnHandInventoryQuery.cs
+++ b/src/Celebrimbor.Module/Services/OnHandInventoryQuery.cs
@@ -28,6 +28,9 @@ public sealed class OnHandInventoryQuery
 
         var counts = new Dictionary<string, int>(StringComparer.Ordinal);
         var locations = new Dictionary<string, List<IngredientLocation>>(StringComparer.Ordinal);
+        // Per-keyword set of owned InternalNames so the aggregator can resolve
+        // keyword-matched ingredient slots in O(1) for the common single-key case.
+        var ownedByKeyword = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
 
         foreach (var item in report.Items)
         {
@@ -48,6 +51,13 @@ public sealed class OnHandInventoryQuery
                 list[existingLoc] = list[existingLoc] with { Quantity = list[existingLoc].Quantity + item.StackSize };
             else
                 list.Add(new IngredientLocation(label, item.StackSize));
+
+            foreach (var kw in itemEntry.Keywords)
+            {
+                if (!ownedByKeyword.TryGetValue(kw.Tag, out var set))
+                    ownedByKeyword[kw.Tag] = set = new HashSet<string>(StringComparer.Ordinal);
+                set.Add(key);
+            }
         }
 
         var frozenLocations = locations.ToDictionary(
@@ -55,15 +65,22 @@ public sealed class OnHandInventoryQuery
             kv => (IReadOnlyList<IngredientLocation>)kv.Value.OrderByDescending(l => l.Quantity).ToList(),
             StringComparer.Ordinal);
 
-        return new OnHandInventory(counts, frozenLocations);
+        var frozenOwnedByKeyword = ownedByKeyword.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlyList<string>)[.. kv.Value],
+            StringComparer.Ordinal);
+
+        return new OnHandInventory(counts, frozenLocations, frozenOwnedByKeyword);
     }
 }
 
 public sealed record OnHandInventory(
     IReadOnlyDictionary<string, int> Counts,
-    IReadOnlyDictionary<string, IReadOnlyList<IngredientLocation>> Locations)
+    IReadOnlyDictionary<string, IReadOnlyList<IngredientLocation>> Locations,
+    IReadOnlyDictionary<string, IReadOnlyList<string>> OwnedInternalNamesByKeyword)
 {
     public static readonly OnHandInventory Empty = new(
         new Dictionary<string, int>(StringComparer.Ordinal),
-        new Dictionary<string, IReadOnlyList<IngredientLocation>>(StringComparer.Ordinal));
+        new Dictionary<string, IReadOnlyList<IngredientLocation>>(StringComparer.Ordinal),
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal));
 }

--- a/src/Celebrimbor.Module/Services/OnHandInventoryQuery.cs
+++ b/src/Celebrimbor.Module/Services/OnHandInventoryQuery.cs
@@ -50,7 +50,7 @@ public sealed class OnHandInventoryQuery
             if (existingLoc >= 0)
                 list[existingLoc] = list[existingLoc] with { Quantity = list[existingLoc].Quantity + item.StackSize };
             else
-                list.Add(new IngredientLocation(label, item.StackSize));
+                list.Add(new IngredientLocation(label, item.StackSize, key, itemEntry.Name, itemEntry.IconId));
 
             foreach (var kw in itemEntry.Keywords)
             {

--- a/src/Celebrimbor.Module/Services/RecipeAggregator.cs
+++ b/src/Celebrimbor.Module/Services/RecipeAggregator.cs
@@ -1,5 +1,6 @@
 using Celebrimbor.Domain;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
 
 namespace Celebrimbor.Services;
 

--- a/src/Celebrimbor.Module/Services/RecipeAggregator.cs
+++ b/src/Celebrimbor.Module/Services/RecipeAggregator.cs
@@ -11,6 +11,14 @@ namespace Celebrimbor.Services;
 public sealed class RecipeAggregator
 {
     /// <summary>
+    /// Synthetic <see cref="AggregatedIngredient.ItemInternalName"/> prefix used for
+    /// rows that represent a keyword-matched ingredient slot (any item whose
+    /// <see cref="ItemEntry.Keywords"/> includes every listed tag). The remainder of
+    /// the key is the comma-joined ordinal-sorted keyword list.
+    /// </summary>
+    private const string KeywordKeyPrefix = "#keys:";
+
+    /// <summary>
     /// Accumulate ingredient demand across every entry in <paramref name="entries"/>.
     /// When <paramref name="expansionDepth"/> is greater than zero, any aggregated
     /// ingredient that also resolves as a recipe is replaced by its own ingredients,
@@ -22,10 +30,12 @@ public sealed class RecipeAggregator
         IReferenceDataService refData,
         IReadOnlyDictionary<string, int>? onHandByInternalName = null,
         IReadOnlyDictionary<string, IReadOnlyList<IngredientLocation>>? locationsByInternalName = null,
-        IReadOnlyDictionary<string, int>? overridesByInternalName = null)
+        IReadOnlyDictionary<string, int>? overridesByInternalName = null,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? ownedInternalNamesByKeyword = null)
     {
         var demand = new Dictionary<string, double>(StringComparer.Ordinal);
         var seeds = new List<string>();
+        var keywordSpecs = new Dictionary<string, KeywordSpec>(StringComparer.Ordinal);
 
         foreach (var entry in entries)
         {
@@ -48,10 +58,10 @@ public sealed class RecipeAggregator
         // Chain pass: everything the plan touches at this depth, shortfall-agnostic.
         // Keeps the shopping list visible as a stable skeleton when the demand pass
         // collapses rows to zero (e.g. user overrides a target to match its needed count).
-        var chainItems = BuildChainItems(seeds, expansionDepth, refData, producers);
+        var chainItems = BuildChainItems(seeds, expansionDepth, refData, producers, keywordSpecs);
 
         if (expansionDepth > 0)
-            Expand(demand, expansionDepth, refData, producers, onHandByInternalName, overridesByInternalName);
+            Expand(demand, expansionDepth, refData, producers, onHandByInternalName, overridesByInternalName, keywordSpecs);
 
         // Backfill chain items the demand pass dropped or never reached, so projection
         // emits them as 0/0 rows (IsCraftReady=true) rather than hiding the step.
@@ -65,6 +75,15 @@ public sealed class RecipeAggregator
         var rows = new List<AggregatedIngredient>(demand.Count);
         foreach (var (itemName, expected) in demand)
         {
+            if (itemName.StartsWith(KeywordKeyPrefix, StringComparison.Ordinal))
+            {
+                if (!keywordSpecs.TryGetValue(itemName, out var spec)) continue;
+                rows.Add(BuildKeywordRow(itemName, spec, expected, refData,
+                    onHandByInternalName, locationsByInternalName, overridesByInternalName,
+                    ownedInternalNamesByKeyword));
+                continue;
+            }
+
             if (!refData.ItemsByInternalName.TryGetValue(itemName, out var item)) continue;
 
             var totalNeeded = (int)Math.Ceiling(expected);
@@ -97,17 +116,89 @@ public sealed class RecipeAggregator
             .ToList();
     }
 
+    private static AggregatedIngredient BuildKeywordRow(
+        string syntheticKey,
+        KeywordSpec spec,
+        double expected,
+        IReferenceDataService refData,
+        IReadOnlyDictionary<string, int>? onHandByInternalName,
+        IReadOnlyDictionary<string, IReadOnlyList<IngredientLocation>>? locationsByInternalName,
+        IReadOnlyDictionary<string, int>? overridesByInternalName,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? ownedInternalNamesByKeyword)
+    {
+        var keys = spec.Keys;
+        var humanised = ItemKeywordIndex.Humanise(keys);
+        var displayName = string.IsNullOrEmpty(spec.Desc) ? humanised : spec.Desc;
+        var primaryTag = keys.Count > 0 ? keys[0] : "Misc";
+
+        var matchingOwned = ResolveOwnedMatching(keys, ownedInternalNamesByKeyword);
+
+        var detected = 0;
+        var locations = new List<IngredientLocation>();
+        foreach (var name in matchingOwned)
+        {
+            if (onHandByInternalName is not null && onHandByInternalName.TryGetValue(name, out var c))
+                detected += c;
+            if (locationsByInternalName is not null && locationsByInternalName.TryGetValue(name, out var locs))
+                locations.AddRange(locs);
+        }
+
+        int? overrideCount = overridesByInternalName is not null
+            && overridesByInternalName.TryGetValue(syntheticKey, out var ov) ? ov : null;
+
+        return new AggregatedIngredient(
+            ItemInternalName: syntheticKey,
+            ItemId: 0,
+            DisplayName: displayName,
+            IconId: 0,
+            PrimaryTag: primaryTag,
+            TotalNeeded: (int)Math.Ceiling(expected),
+            ExpectedNeeded: expected,
+            OnHandDetected: detected,
+            OnHandOverride: overrideCount,
+            Locations: locations,
+            IsAlsoRecipe: false,
+            Depth: 0,
+            KeywordsLabel: $"any {humanised}");
+    }
+
+    /// <summary>
+    /// Resolve the set of owned InternalNames that satisfy every keyword in
+    /// <paramref name="keys"/> (AND-match). Single-key lookups hit the inverted
+    /// index directly; multi-key intersects per-tag sets.
+    /// </summary>
+    private static IReadOnlyCollection<string> ResolveOwnedMatching(
+        IReadOnlyList<string> keys,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? ownedInternalNamesByKeyword)
+    {
+        if (keys.Count == 0 || ownedInternalNamesByKeyword is null) return [];
+
+        if (keys.Count == 1)
+            return ownedInternalNamesByKeyword.TryGetValue(keys[0], out var list) ? list : [];
+
+        if (!ownedInternalNamesByKeyword.TryGetValue(keys[0], out var seedList)) return [];
+        var seed = new HashSet<string>(seedList, StringComparer.Ordinal);
+        for (var i = 1; i < keys.Count && seed.Count > 0; i++)
+        {
+            if (!ownedInternalNamesByKeyword.TryGetValue(keys[i], out var next)) return [];
+            seed.IntersectWith(next);
+        }
+        return seed;
+    }
+
     /// <summary>
     /// Walk the producer graph from <paramref name="seeds"/> down <paramref name="expansionDepth"/>
     /// levels, collecting every item a full expansion would touch. No shortfall filter — this is
     /// the stable plan skeleton that survives the demand pass clamping counts to zero. Cycle-safe
-    /// because the chain set prevents re-enqueuing items we've already walked.
+    /// because the chain set prevents re-enqueuing items we've already walked. Keyword-matched
+    /// ingredient slots are added as leaves (they have no producer).
     /// </summary>
     private static ISet<string> BuildChainItems(
         IReadOnlyList<string> seeds,
         int expansionDepth,
         IReferenceDataService refData,
-        IReadOnlyDictionary<string, RecipeEntry> producers)
+        IReadOnlyDictionary<string, RecipeEntry> producers,
+        Dictionary<string, KeywordSpec> keywordSpecs)
     {
         var chain = new HashSet<string>(seeds, StringComparer.Ordinal);
         var frontier = new HashSet<string>(seeds, StringComparer.Ordinal);
@@ -120,8 +211,19 @@ public sealed class RecipeAggregator
                 if (!producers.TryGetValue(item, out var recipe)) continue;
                 foreach (var ingredient in recipe.Ingredients)
                 {
-                    if (!refData.Items.TryGetValue(ingredient.ItemCode, out var ing)) continue;
-                    if (chain.Add(ing.InternalName)) next.Add(ing.InternalName);
+                    switch (ingredient)
+                    {
+                        case RecipeItemIngredient item2:
+                            if (!refData.Items.TryGetValue(item2.ItemCode, out var ing)) continue;
+                            if (chain.Add(ing.InternalName)) next.Add(ing.InternalName);
+                            break;
+                        case RecipeKeywordIngredient kw:
+                            var key = MakeKeywordKey(kw.ItemKeys);
+                            keywordSpecs.TryAdd(key, new KeywordSpec(kw.ItemKeys, kw.Desc));
+                            chain.Add(key);
+                            // Keyword rows are leaves — no recursion needed; they have no producer.
+                            break;
+                    }
                 }
             }
             if (next.Count == 0) break;
@@ -134,7 +236,8 @@ public sealed class RecipeAggregator
     /// <summary>
     /// Crafting-step depth: 0 if the item has no producer (gathered / bought),
     /// otherwise 1 + max depth of its recipe's resolvable ingredients. Cycle-safe
-    /// via <paramref name="onPath"/>.
+    /// via <paramref name="onPath"/>. Keyword-matched ingredients contribute 0
+    /// (they are always leaves).
     /// </summary>
     private static int ComputeDepth(
         string itemName,
@@ -150,8 +253,12 @@ public sealed class RecipeAggregator
         var maxIngredientDepth = 0;
         foreach (var ingredient in recipe.Ingredients)
         {
-            if (!refData.Items.TryGetValue(ingredient.ItemCode, out var item)) continue;
-            maxIngredientDepth = Math.Max(maxIngredientDepth, ComputeDepth(item.InternalName, producers, refData, cache, onPath));
+            if (ingredient is RecipeItemIngredient byItem
+                && refData.Items.TryGetValue(byItem.ItemCode, out var item))
+            {
+                maxIngredientDepth = Math.Max(maxIngredientDepth, ComputeDepth(item.InternalName, producers, refData, cache, onPath));
+            }
+            // RecipeKeywordIngredient: depth 0 leaves, no contribution.
         }
 
         onPath.Remove(itemName);
@@ -164,16 +271,31 @@ public sealed class RecipeAggregator
         Dictionary<string, double> demand,
         RecipeEntry recipe,
         double batches,
-        IReferenceDataService refData)
+        IReferenceDataService refData,
+        Dictionary<string, KeywordSpec> keywordSpecs)
     {
         foreach (var ingredient in recipe.Ingredients)
         {
-            if (!refData.Items.TryGetValue(ingredient.ItemCode, out var item)) continue;
+            string demandKey;
+            switch (ingredient)
+            {
+                case RecipeItemIngredient byItem:
+                    if (!refData.Items.TryGetValue(byItem.ItemCode, out var item)) continue;
+                    demandKey = item.InternalName;
+                    break;
+                case RecipeKeywordIngredient kw:
+                    demandKey = MakeKeywordKey(kw.ItemKeys);
+                    keywordSpecs.TryAdd(demandKey, new KeywordSpec(kw.ItemKeys, kw.Desc));
+                    break;
+                default:
+                    continue;
+            }
+
             var perBatch = ingredient.StackSize * (ingredient.ChanceToConsume ?? 1.0);
             if (perBatch <= 0) continue;
             var add = batches * perBatch;
 
-            demand[item.InternalName] = demand.TryGetValue(item.InternalName, out var existing)
+            demand[demandKey] = demand.TryGetValue(demandKey, out var existing)
                 ? existing + add
                 : add;
         }
@@ -185,7 +307,8 @@ public sealed class RecipeAggregator
         IReferenceDataService refData,
         IReadOnlyDictionary<string, RecipeEntry> producers,
         IReadOnlyDictionary<string, int>? onHandByInternalName,
-        IReadOnlyDictionary<string, int>? overridesByInternalName)
+        IReadOnlyDictionary<string, int>? overridesByInternalName,
+        Dictionary<string, KeywordSpec> keywordSpecs)
     {
         // Intermediates stay in the output so the user still sees "3x Good Metal Slab".
         // alreadyExpanded guards against cycles (A → B → A) — once we've expanded a
@@ -221,7 +344,7 @@ public sealed class RecipeAggregator
                 if (shortfall <= 0) continue;
 
                 var batches = shortfall / outputStackSize;
-                AddIngredients(demand, recipe, batches, refData);
+                AddIngredients(demand, recipe, batches, refData, keywordSpecs);
             }
         }
 
@@ -285,4 +408,13 @@ public sealed class RecipeAggregator
         // we expected (rare but possible with data drift).
         return recipe.ResultItems.FirstOrDefault()?.StackSize ?? 1;
     }
+
+    private static string MakeKeywordKey(IReadOnlyList<string> keys)
+    {
+        if (keys.Count == 1) return KeywordKeyPrefix + keys[0];
+        var ordered = keys.OrderBy(k => k, StringComparer.Ordinal);
+        return KeywordKeyPrefix + string.Join(",", ordered);
+    }
+
+    private sealed record KeywordSpec(IReadOnlyList<string> Keys, string? Desc);
 }

--- a/src/Celebrimbor.Module/ViewModels/IngredientChip.cs
+++ b/src/Celebrimbor.Module/ViewModels/IngredientChip.cs
@@ -9,4 +9,5 @@ public sealed record IngredientChip(
     int IconId,
     int StackSize,
     float? ChanceToConsume,
-    string? InternalName = null);
+    string? InternalName = null,
+    string? KeywordsLabel = null);

--- a/src/Celebrimbor.Module/ViewModels/IngredientRowViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/IngredientRowViewModel.cs
@@ -28,6 +28,7 @@ public sealed partial class IngredientRowViewModel : ObservableObject
     public int EffectiveOnHand => Override ?? OnHandDetected;
     public IReadOnlyList<IngredientLocation> Locations => Model.Locations;
     public bool IsAlsoRecipe => Model.IsAlsoRecipe;
+    public string? KeywordsLabel => Model.KeywordsLabel;
 
     /// <summary>Null means "use detected on-hand"; non-null overrides it.</summary>
     public int? Override

--- a/src/Celebrimbor.Module/ViewModels/IngredientRowViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/IngredientRowViewModel.cs
@@ -1,5 +1,6 @@
 using Celebrimbor.Domain;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Shared.Storage;
 
 namespace Celebrimbor.ViewModels;
 

--- a/src/Celebrimbor.Module/ViewModels/RecipeRowViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/RecipeRowViewModel.cs
@@ -14,9 +14,7 @@ public sealed partial class RecipeRowViewModel : ObservableObject
         _itemDetail = itemDetail;
         Recipe = recipe;
         Ingredients = recipe.Ingredients
-            .Select(r => refData.Items.TryGetValue(r.ItemCode, out var item)
-                ? new IngredientChip(item.Name, item.IconId, r.StackSize, r.ChanceToConsume, item.InternalName)
-                : null)
+            .Select(r => ProjectIngredientChip(r, refData))
             .Where(c => c is not null).Select(c => c!)
             .ToList();
         CraftedOutputs = ResultEffectsParser.ParseCraftedGear(recipe.ResultEffects, refData);
@@ -30,6 +28,21 @@ public sealed partial class RecipeRowViewModel : ObservableObject
             CraftedOutputs.Count + Augments.Count + WaxItems.Count + WaxAugments.Count + AugmentPools.Count + TaughtRecipes.Count + EffectTags.Count);
         InspectableItems = BuildInspectable(CraftedOutputs, Results);
     }
+
+    internal static IngredientChip? ProjectIngredientChip(RecipeIngredient ingredient, IReferenceDataService refData) => ingredient switch
+    {
+        RecipeItemIngredient byItem => refData.Items.TryGetValue(byItem.ItemCode, out var item)
+            ? new IngredientChip(item.Name, item.IconId, byItem.StackSize, byItem.ChanceToConsume, item.InternalName)
+            : null,
+        RecipeKeywordIngredient kw => new IngredientChip(
+            Name: kw.Desc ?? ItemKeywordIndex.Humanise(kw.ItemKeys),
+            IconId: 0,
+            StackSize: kw.StackSize,
+            ChanceToConsume: kw.ChanceToConsume,
+            InternalName: null,
+            KeywordsLabel: $"any {ItemKeywordIndex.Humanise(kw.ItemKeys)}"),
+        _ => null,
+    };
 
     private static IReadOnlyList<IngredientChip> BuildInspectable(
         IReadOnlyList<CraftedGearPreview> craftedOutputs, IReadOnlyList<IngredientChip> results)

--- a/src/Celebrimbor.Module/ViewModels/ShoppingListViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/ShoppingListViewModel.cs
@@ -92,7 +92,8 @@ public sealed partial class ShoppingListViewModel : ObservableObject
             _refData,
             onHand.Counts,
             onHand.Locations,
-            overrides);
+            overrides,
+            onHand.OwnedInternalNamesByKeyword);
 
         var rows = new ObservableCollection<IngredientRowViewModel>();
         foreach (var ingredient in aggregated)
@@ -140,9 +141,7 @@ public sealed partial class ShoppingListViewModel : ObservableObject
         {
             if (!_refData.RecipesByInternalName.TryGetValue(entry.RecipeInternalName, out var recipe)) continue;
             var ingredients = recipe.Ingredients
-                .Select(r => _refData.Items.TryGetValue(r.ItemCode, out var item)
-                    ? new IngredientChip(item.Name, item.IconId, r.StackSize, r.ChanceToConsume, item.InternalName)
-                    : null)
+                .Select(r => RecipeRowViewModel.ProjectIngredientChip(r, _refData))
                 .Where(c => c is not null).Select(c => c!)
                 .ToList();
             var results = recipe.ResultItems

--- a/src/Celebrimbor.Module/ViewModels/ShoppingListViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/ShoppingListViewModel.cs
@@ -18,6 +18,7 @@ public sealed partial class ShoppingListViewModel : ObservableObject
     private readonly IReferenceDataService _refData;
     private readonly IActiveCharacterService _activeChar;
     private readonly IItemDetailPresenter _itemDetail;
+    private readonly IIngredientSourcesPresenter _sourcesPresenter;
 
     public event EventHandler? BackRequested;
 
@@ -27,7 +28,8 @@ public sealed partial class ShoppingListViewModel : ObservableObject
         OnHandInventoryQuery onHand,
         IReferenceDataService refData,
         IActiveCharacterService activeChar,
-        IItemDetailPresenter itemDetail)
+        IItemDetailPresenter itemDetail,
+        IIngredientSourcesPresenter sourcesPresenter)
     {
         _settings = settings;
         _aggregator = aggregator;
@@ -35,6 +37,7 @@ public sealed partial class ShoppingListViewModel : ObservableObject
         _refData = refData;
         _activeChar = activeChar;
         _itemDetail = itemDetail;
+        _sourcesPresenter = sourcesPresenter;
 
         _settings.PropertyChanged += OnSettingsChanged;
         _activeChar.StorageReportsChanged += (_, _) => DispatchOnUi(Rebuild);
@@ -75,6 +78,19 @@ public sealed partial class ShoppingListViewModel : ObservableObject
     {
         _activeChar.Refresh();
         Rebuild();
+    }
+
+    [RelayCommand]
+    private void ShowSources(IngredientRowViewModel? row)
+    {
+        if (row is null) return;
+        var model = row.Model;
+        var input = new IngredientSourcesInput(
+            Title: model.DisplayName,
+            KeywordsLabel: model.KeywordsLabel,
+            ItemInternalName: model.KeywordsLabel is null ? model.ItemInternalName : null,
+            OnHand: model.Locations);
+        _sourcesPresenter.Show(input);
     }
 
     public void Rebuild()

--- a/src/Celebrimbor.Module/Views/Converters.cs
+++ b/src/Celebrimbor.Module/Views/Converters.cs
@@ -4,6 +4,7 @@ using System.Windows.Data;
 using System.Windows.Media;
 using Celebrimbor.Domain;
 using Celebrimbor.ViewModels;
+using Mithril.Shared.Storage;
 
 namespace Celebrimbor.Views;
 

--- a/src/Celebrimbor.Module/Views/Resources.xaml
+++ b/src/Celebrimbor.Module/Views/Resources.xaml
@@ -49,6 +49,18 @@
                                     <Run Text="{Binding StackSize, Mode=OneWay, StringFormat='{}{0}x '}"/>
                                 </TextBlock>
                                 <TextBlock Text="{Binding Name}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                <TextBlock Text="{Binding KeywordsLabel, Mode=OneWay, StringFormat=' ({0})'}"
+                                           Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontStyle="Italic">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding KeywordsLabel}" Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                                 <TextBlock Text="{Binding ChanceToConsume, Mode=OneWay, StringFormat=' ({0:P0} chance to consume)'}"
                                            Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontStyle="Italic">
                                     <TextBlock.Style>

--- a/src/Celebrimbor.Module/Views/ShoppingListView.xaml
+++ b/src/Celebrimbor.Module/Views/ShoppingListView.xaml
@@ -314,7 +314,22 @@
                                             <ColumnDefinition Width="80"/>
                                             <ColumnDefinition Width="90"/>
                                         </Grid.ColumnDefinitions>
-                                        <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding DisplayName}" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                            <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding DisplayName}" VerticalAlignment="Center"/>
+                                            <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                       FontStyle="Italic" VerticalAlignment="Center" Margin="6,0,0,0"
+                                                       Text="{Binding KeywordsLabel, StringFormat=({0})}">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding KeywordsLabel}" Value="{x:Null}">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
                                         <TextBlock Grid.Column="1" Text="{Binding TotalNeeded}" Foreground="#FFE8E8E8" FontWeight="SemiBold" HorizontalAlignment="Right" VerticalAlignment="Center" Padding="0,0,6,0"/>
                                         <TextBlock Grid.Column="2" Text="{Binding OnHandDetected}" Foreground="{Binding OnHandDetected, Converter={StaticResource ZeroToGhost}}" HorizontalAlignment="Right" VerticalAlignment="Center" Padding="0,0,6,0"/>
 

--- a/src/Celebrimbor.Module/Views/ShoppingListView.xaml
+++ b/src/Celebrimbor.Module/Views/ShoppingListView.xaml
@@ -333,38 +333,23 @@
                                         <TextBlock Grid.Column="1" Text="{Binding TotalNeeded}" Foreground="#FFE8E8E8" FontWeight="SemiBold" HorizontalAlignment="Right" VerticalAlignment="Center" Padding="0,0,6,0"/>
                                         <TextBlock Grid.Column="2" Text="{Binding OnHandDetected}" Foreground="{Binding OnHandDetected, Converter={StaticResource ZeroToGhost}}" HorizontalAlignment="Right" VerticalAlignment="Center" Padding="0,0,6,0"/>
 
-                                        <!-- Location pin — only visible when there are resolved on-hand locations. Hover for the full breakdown. -->
-                                        <Border Grid.Column="3" Background="Transparent"
+                                        <!-- Location pin — click to open the Sources window with on-hand breakdown + acquisition hints. -->
+                                        <Button Grid.Column="3" Background="Transparent" BorderThickness="0" Padding="0" Cursor="Hand"
                                                 Visibility="{Binding Locations.Count, Converter={StaticResource CountToVisibility}}"
-                                                ToolTipService.InitialShowDelay="{Binding DataContext.TooltipDelayMs, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                ToolTipService.BetweenShowDelay="0">
-                                            <Border.ToolTip>
-                                                <ToolTip Background="Transparent" BorderThickness="0" Padding="0">
-                                                    <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                                                            CornerRadius="4" Padding="10" MaxWidth="320">
-                                                        <StackPanel>
-                                                            <TextBlock Text="On hand at" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                                                                       FontWeight="SemiBold" Margin="0,0,0,4"/>
-                                                            <ItemsControl ItemsSource="{Binding Locations}">
-                                                                <ItemsControl.ItemTemplate>
-                                                                    <DataTemplate>
-                                                                        <StackPanel Orientation="Horizontal" Margin="0,1">
-                                                                            <TextBlock Text="{Binding Label}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                                            <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="6,0,0,0">
-                                                                                <Run Text="× "/><Run Text="{Binding Quantity, Mode=OneWay}"/>
-                                                                            </TextBlock>
-                                                                        </StackPanel>
-                                                                    </DataTemplate>
-                                                                </ItemsControl.ItemTemplate>
-                                                            </ItemsControl>
-                                                        </StackPanel>
+                                                ToolTip="View sources"
+                                                Command="{Binding DataContext.ShowSourcesCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                CommandParameter="{Binding}">
+                                            <Button.Template>
+                                                <ControlTemplate TargetType="Button">
+                                                    <Border Background="{TemplateBinding Background}">
+                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                                     </Border>
-                                                </ToolTip>
-                                            </Border.ToolTip>
+                                                </ControlTemplate>
+                                            </Button.Template>
                                             <icon:PackIconLucide Kind="MapPin" Width="12" Height="12"
                                                                  Foreground="#FFD4A847"
                                                                  VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                                        </Border>
+                                        </Button>
 
                                         <TextBox Grid.Column="4"
                                                  Text="{Binding Override, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -89,9 +89,16 @@ public sealed class SkillAdvisorEngine
             }
 
             var ingredients = recipe.Ingredients
-                .Select(i => _ref.Items.TryGetValue(i.ItemCode, out var item)
-                    ? new RecipeIngredientDisplay(item.Name, item.IconId, i.StackSize, i.ChanceToConsume)
-                    : new RecipeIngredientDisplay($"Item #{i.ItemCode}", 0, i.StackSize, i.ChanceToConsume))
+                .Select(i => i switch
+                {
+                    RecipeItemIngredient byItem => _ref.Items.TryGetValue(byItem.ItemCode, out var item)
+                        ? new RecipeIngredientDisplay(item.Name, item.IconId, byItem.StackSize, byItem.ChanceToConsume)
+                        : new RecipeIngredientDisplay($"Item #{byItem.ItemCode}", 0, byItem.StackSize, byItem.ChanceToConsume),
+                    RecipeKeywordIngredient kw => new RecipeIngredientDisplay(
+                        kw.Desc ?? $"Any {ItemKeywordIndex.Humanise(kw.ItemKeys)}",
+                        IconId: 0, kw.StackSize, kw.ChanceToConsume),
+                    _ => new RecipeIngredientDisplay("(unknown ingredient)", 0, i.StackSize, i.ChanceToConsume),
+                })
                 .ToList();
 
             var craftedOutputs = ResultEffectsParser.ParseCraftedGear(recipe.ResultEffects, _ref);

--- a/src/Legolas.Module/Views/LegolasPanelView.xaml
+++ b/src/Legolas.Module/Views/LegolasPanelView.xaml
@@ -4,7 +4,7 @@
              xmlns:vm="clr-namespace:Legolas.ViewModels"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:controls="clr-namespace:Legolas.Controls"
-             Background="{StaticResource BgPrimaryBrush}">
+             Background="{DynamicResource BgPrimaryBrush}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/Mithril.Shared/Reference/AreaEntry.cs
+++ b/src/Mithril.Shared/Reference/AreaEntry.cs
@@ -1,0 +1,8 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// One entry from <c>areas.json</c>. Maps an area's internal key (e.g. <c>"AreaSerbule"</c>)
+/// to its display names. <see cref="ShortFriendlyName"/> falls back to <see cref="FriendlyName"/>
+/// when the JSON omits it.
+/// </summary>
+public sealed record AreaEntry(string Key, string FriendlyName, string ShortFriendlyName);

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -15,6 +15,13 @@ public interface IReferenceDataService
     /// <summary>InternalName → ItemEntry lookup. Useful when the log gives an InternalName but no item id.</summary>
     IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; }
 
+    /// <summary>
+    /// Catalog-side keyword → items index. Powers keyword-matched recipe ingredients
+    /// (e.g. the auxiliary-crystal slot on every <c>*E</c> enchanted recipe). Rebuilt
+    /// whenever <c>items.json</c> reloads.
+    /// </summary>
+    ItemKeywordIndex KeywordIndex { get; }
+
     /// <summary>recipe key (e.g. "recipe_1234") → RecipeEntry.</summary>
     IReadOnlyDictionary<string, RecipeEntry> Recipes { get; }
 

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -38,6 +38,13 @@ public interface IReferenceDataService
     IReadOnlyDictionary<string, NpcEntry> Npcs { get; }
 
     /// <summary>
+    /// Area key (e.g. <c>"AreaSerbule"</c>) → friendly display names. Pulled from
+    /// <c>areas.json</c>; primary use is resolving area codes that appear on
+    /// non-NPC item sources (drops, quests).
+    /// </summary>
+    IReadOnlyDictionary<string, AreaEntry> Areas { get; }
+
+    /// <summary>
     /// Item InternalName → sources describing how the item can be obtained
     /// (Vendor / Recipe / Quest / Monster / HangOut / NpcGift / Barter / Angling / …).
     /// Pulled from <c>sources_items.json</c>.

--- a/src/Mithril.Shared/Reference/ItemKeywordIndex.cs
+++ b/src/Mithril.Shared/Reference/ItemKeywordIndex.cs
@@ -1,0 +1,49 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// Catalog-side inverted index: keyword tag → items in <c>items.json</c> carrying that tag.
+/// Built once when items reload; powers keyword-matched ingredient resolution
+/// (every <c>*E</c> enchanted recipe carries a slot like <c>{ "ItemKeys": ["Crystal"] }</c>
+/// that means "any item whose <see cref="ItemEntry.Keywords"/> includes Crystal").
+/// Multi-key sets are resolved as AND — every listed tag must be present.
+/// </summary>
+public sealed class ItemKeywordIndex
+{
+    public static readonly ItemKeywordIndex Empty = new(new Dictionary<long, ItemEntry>());
+
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<ItemEntry>> _byKeyword;
+
+    public ItemKeywordIndex(IReadOnlyDictionary<long, ItemEntry> items)
+    {
+        var map = new Dictionary<string, List<ItemEntry>>(StringComparer.Ordinal);
+        foreach (var item in items.Values)
+        {
+            foreach (var kw in item.Keywords)
+            {
+                if (!map.TryGetValue(kw.Tag, out var bucket))
+                    map[kw.Tag] = bucket = [];
+                bucket.Add(item);
+            }
+        }
+        _byKeyword = map.ToDictionary(p => p.Key, p => (IReadOnlyList<ItemEntry>)p.Value, StringComparer.Ordinal);
+    }
+
+    /// <summary>Items carrying the given single tag (empty if unknown).</summary>
+    public IReadOnlyList<ItemEntry> ByKeyword(string tag) =>
+        _byKeyword.TryGetValue(tag, out var list) ? list : [];
+
+    /// <summary>Items carrying every tag in <paramref name="keys"/> (AND-match).</summary>
+    public IReadOnlyList<ItemEntry> ItemsMatching(IReadOnlyList<string> keys)
+    {
+        if (keys.Count == 0) return [];
+        if (keys.Count == 1) return ByKeyword(keys[0]);
+
+        var seed = new HashSet<ItemEntry>(ByKeyword(keys[0]));
+        for (var i = 1; i < keys.Count && seed.Count > 0; i++)
+            seed.IntersectWith(ByKeyword(keys[i]));
+        return [.. seed];
+    }
+
+    /// <summary>Display string for a keyword set, joined with " + ".</summary>
+    public static string Humanise(IReadOnlyList<string> keys) => string.Join(" + ", keys);
+}

--- a/src/Mithril.Shared/Reference/RecipeEntry.cs
+++ b/src/Mithril.Shared/Reference/RecipeEntry.cs
@@ -17,7 +17,7 @@ public sealed record RecipeEntry(
     int? RewardSkillXpDropOffLevel,
     float? RewardSkillXpDropOffPct,
     int? RewardSkillXpDropOffRate,
-    IReadOnlyList<RecipeItemRef> Ingredients,
+    IReadOnlyList<RecipeIngredient> Ingredients,
     IReadOnlyList<RecipeItemRef> ResultItems,
     string? PrereqRecipe = null,
     IReadOnlyList<RecipeItemRef>? ProtoResultItems = null,

--- a/src/Mithril.Shared/Reference/RecipeIngredient.cs
+++ b/src/Mithril.Shared/Reference/RecipeIngredient.cs
@@ -1,0 +1,24 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// Base type for a single ingredient slot on a recipe. Two concrete shapes:
+/// <see cref="RecipeItemIngredient"/> names a specific item by code, while
+/// <see cref="RecipeKeywordIngredient"/> names a keyword set (any item whose
+/// <see cref="ItemEntry.Keywords"/> includes every listed tag satisfies the slot).
+/// </summary>
+public abstract record RecipeIngredient(int StackSize, float? ChanceToConsume);
+
+/// <summary>Ingredient slot bound to a specific item id.</summary>
+public sealed record RecipeItemIngredient(long ItemCode, int StackSize, float? ChanceToConsume)
+    : RecipeIngredient(StackSize, ChanceToConsume);
+
+/// <summary>
+/// Ingredient slot satisfied by any item carrying every keyword in <see cref="ItemKeys"/>
+/// (AND-matched). <see cref="Desc"/> is the recipe's display label, e.g. "Auxiliary Crystal".
+/// </summary>
+public sealed record RecipeKeywordIngredient(
+    IReadOnlyList<string> ItemKeys,
+    string? Desc,
+    int StackSize,
+    float? ChanceToConsume)
+    : RecipeIngredient(StackSize, ChanceToConsume);

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -40,6 +40,10 @@ public sealed class ReferenceDataService : IReferenceDataService
     private IReadOnlyDictionary<string, NpcEntry> _npcs = new Dictionary<string, NpcEntry>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _npcsSnapshot;
 
+    // Areas (areas.json) — area code → friendly display names.
+    private IReadOnlyDictionary<string, AreaEntry> _areas = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _areasSnapshot;
+
     // Item sources (sources_items.json)
     private IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> _itemSources =
         new Dictionary<string, IReadOnlyList<ItemSource>>(StringComparer.Ordinal);
@@ -72,6 +76,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _skillsSnapshot = new ReferenceFileSnapshot("skills", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _xpTablesSnapshot = new ReferenceFileSnapshot("xptables", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _npcsSnapshot = new ReferenceFileSnapshot("npcs", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _areasSnapshot = new ReferenceFileSnapshot("areas", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _itemSourcesSnapshot = new ReferenceFileSnapshot("sources_items", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _attributesSnapshot = new ReferenceFileSnapshot("attributes", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _powersSnapshot = new ReferenceFileSnapshot("tsysclientinfo", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
@@ -82,13 +87,14 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadSkills();
         LoadXpTables();
         LoadNpcs();
+        LoadAreas();
         LoadItemSources();
         LoadAttributes();
         LoadPowers();
         LoadProfiles();
     }
 
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "sources_items", "attributes", "tsysclientinfo", "tsysprofiles"];
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "attributes", "tsysclientinfo", "tsysprofiles"];
 
     public IReadOnlyDictionary<long, ItemEntry> Items => _items;
     public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _itemsByInternalName;
@@ -98,6 +104,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
     public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xpTables;
     public IReadOnlyDictionary<string, NpcEntry> Npcs => _npcs;
+    public IReadOnlyDictionary<string, AreaEntry> Areas => _areas;
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources => _itemSources;
     public IReadOnlyDictionary<string, AttributeEntry> Attributes => _attributes;
     public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;
@@ -110,6 +117,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "skills" => _skillsSnapshot,
         "xptables" => _xpTablesSnapshot,
         "npcs" => _npcsSnapshot,
+        "areas" => _areasSnapshot,
         "sources_items" => _itemSourcesSnapshot,
         "attributes" => _attributesSnapshot,
         "tsysclientinfo" => _powersSnapshot,
@@ -126,6 +134,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "skills" => RefreshFileAsync("skills", ReferenceJsonContext.Default.DictionaryStringRawSkill, ParseAndSwapSkills, ct),
         "xptables" => RefreshFileAsync("xptables", ReferenceJsonContext.Default.DictionaryStringRawXpTable, ParseAndSwapXpTables, ct),
         "npcs" => RefreshFileAsync("npcs", ReferenceJsonContext.Default.DictionaryStringRawNpc, ParseAndSwapNpcs, ct),
+        "areas" => RefreshFileAsync("areas", ReferenceJsonContext.Default.DictionaryStringRawArea, ParseAndSwapAreas, ct),
         "sources_items" => RefreshFileAsync("sources_items", ReferenceJsonContext.Default.DictionaryStringRawItemSourceEnvelope, ParseAndSwapItemSources, ct),
         "attributes" => RefreshFileAsync("attributes", ReferenceJsonContext.Default.DictionaryStringRawAttribute, ParseAndSwapAttributes, ct),
         "tsysclientinfo" => RefreshFileAsync("tsysclientinfo", ReferenceJsonContext.Default.DictionaryStringRawPower, ParseAndSwapPowers, ct),
@@ -140,6 +149,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         await RefreshAsync("skills", ct);
         await RefreshAsync("xptables", ct);
         await RefreshAsync("npcs", ct);
+        await RefreshAsync("areas", ct);
         await RefreshAsync("sources_items", ct);
         await RefreshAsync("attributes", ct);
         await RefreshAsync("tsysclientinfo", ct);
@@ -248,6 +258,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void LoadSkills() => LoadFile("skills", ReferenceJsonContext.Default.DictionaryStringRawSkill, ParseAndSwapSkills);
     private void LoadXpTables() => LoadFile("xptables", ReferenceJsonContext.Default.DictionaryStringRawXpTable, ParseAndSwapXpTables);
     private void LoadNpcs() => LoadFile("npcs", ReferenceJsonContext.Default.DictionaryStringRawNpc, ParseAndSwapNpcs);
+    private void LoadAreas() => LoadFile("areas", ReferenceJsonContext.Default.DictionaryStringRawArea, ParseAndSwapAreas);
     private void LoadItemSources() => LoadFile("sources_items", ReferenceJsonContext.Default.DictionaryStringRawItemSourceEnvelope, ParseAndSwapItemSources);
     private void LoadAttributes() => LoadFile("attributes", ReferenceJsonContext.Default.DictionaryStringRawAttribute, ParseAndSwapAttributes);
     private void LoadPowers() => LoadFile("tsysclientinfo", ReferenceJsonContext.Default.DictionaryStringRawPower, ParseAndSwapPowers);
@@ -463,6 +474,19 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _npcs = byKey;
         _npcsSnapshot = new ReferenceFileSnapshot("npcs", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
+    }
+
+    private void ParseAndSwapAreas(Dictionary<string, RawArea> raw, ReferenceFileMetadata meta)
+    {
+        var byKey = new Dictionary<string, AreaEntry>(raw.Count, StringComparer.Ordinal);
+        foreach (var (key, v) in raw)
+        {
+            var friendly = v.FriendlyName ?? key;
+            var shortFriendly = string.IsNullOrEmpty(v.ShortFriendlyName) ? friendly : v.ShortFriendlyName;
+            byKey[key] = new AreaEntry(key, friendly, shortFriendly);
+        }
+        _areas = byKey;
+        _areasSnapshot = new ReferenceFileSnapshot("areas", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
     }
 
     /// <summary>Parses <c>"Despised:5000:Armor,Weapon,CorpseTrophy"</c> strings.</summary>

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -19,6 +19,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private IReadOnlyDictionary<long, ItemEntry> _items = new Dictionary<long, ItemEntry>();
     private IReadOnlyDictionary<string, ItemEntry> _itemsByInternalName =
         new Dictionary<string, ItemEntry>(StringComparer.Ordinal);
+    private ItemKeywordIndex _keywordIndex = ItemKeywordIndex.Empty;
     private ReferenceFileSnapshot _itemsSnapshot;
 
     // Recipes
@@ -91,6 +92,7 @@ public sealed class ReferenceDataService : IReferenceDataService
 
     public IReadOnlyDictionary<long, ItemEntry> Items => _items;
     public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _itemsByInternalName;
+    public ItemKeywordIndex KeywordIndex => _keywordIndex;
     public IReadOnlyDictionary<string, RecipeEntry> Recipes => _recipes;
     public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName => _recipesByInternalName;
     public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
@@ -274,6 +276,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _items = byId;
         _itemsByInternalName = byName;
+        _keywordIndex = new ItemKeywordIndex(byId);
         _itemsSnapshot = new ReferenceFileSnapshot("items", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byId.Count);
     }
 
@@ -345,10 +348,11 @@ public sealed class ReferenceDataService : IReferenceDataService
         foreach (var (key, v) in raw)
         {
             var ingredients = v.Ingredients?
-                .Where(i => i.ItemCode.HasValue)
-                .Select(i => new RecipeItemRef(i.ItemCode!.Value, i.StackSize ?? 1, i.ChanceToConsume))
+                .Select(ProjectIngredient)
+                .Where(x => x is not null)
+                .Select(x => x!)
                 .ToList()
-                ?? (IReadOnlyList<RecipeItemRef>)[];
+                ?? (IReadOnlyList<RecipeIngredient>)[];
 
             var results = v.ResultItems?
                 .Where(i => i.ItemCode.HasValue)
@@ -388,6 +392,15 @@ public sealed class ReferenceDataService : IReferenceDataService
         _recipes = byKey;
         _recipesByInternalName = byName;
         _recipesSnapshot = new ReferenceFileSnapshot("recipes", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
+    }
+
+    private static RecipeIngredient? ProjectIngredient(RawRecipeItem i)
+    {
+        if (i.ItemCode.HasValue)
+            return new RecipeItemIngredient(i.ItemCode.Value, i.StackSize ?? 1, i.ChanceToConsume);
+        if (i.ItemKeys is { Count: > 0 } keys)
+            return new RecipeKeywordIngredient(keys, i.Desc, i.StackSize ?? 1, i.ChanceToConsume);
+        return null;
     }
 
     private void ParseAndSwapSkills(Dictionary<string, RawSkill> raw, ReferenceFileMetadata meta)

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -524,7 +524,7 @@ public sealed class ReferenceDataService : IReferenceDataService
             foreach (var r in envelope.Entries)
             {
                 if (string.IsNullOrEmpty(r.Type)) continue;
-                var context = r.Recipe ?? r.Quest ?? r.Monster ?? r.Source ?? r.Interactor;
+                var context = ResolveSourceContext(r);
                 projected.Add(new ItemSource(r.Type!, r.Npc, context));
             }
             if (projected.Count > 0)
@@ -532,6 +532,24 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _itemSources = byInternalName;
         _itemSourcesSnapshot = new ReferenceFileSnapshot("sources_items", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
+    }
+
+    /// <summary>
+    /// Resolve a <see cref="RawItemSource"/> entry to its <see cref="ItemSource.Context"/>.
+    /// Recipe entries carry a numeric <c>recipeId</c>; we look up the recipe and return its
+    /// <see cref="RecipeEntry.InternalName"/> so consumers can use it directly. Quest entries
+    /// carry a numeric <c>questId</c>; until a quest parser exists we expose the id as a
+    /// string. Other types fall through to the existing string fields. Relies on
+    /// <see cref="LoadRecipes"/> running before <see cref="LoadItemSources"/> in the ctor.
+    /// </summary>
+    private string? ResolveSourceContext(RawItemSource r)
+    {
+        if (r.RecipeId is { } recipeId
+            && _recipes.TryGetValue($"recipe_{recipeId}", out var recipe))
+            return recipe.InternalName;
+        if (r.QuestId is { } questId)
+            return questId.ToString();
+        return r.Recipe ?? r.Quest ?? r.Monster ?? r.Source ?? r.Interactor;
     }
 
     private void ParseAndSwapAttributes(Dictionary<string, RawAttribute> raw, ReferenceFileMetadata meta)

--- a/src/Mithril.Shared/Reference/ReferenceJsonContext.cs
+++ b/src/Mithril.Shared/Reference/ReferenceJsonContext.cs
@@ -85,6 +85,13 @@ public sealed class RawRecipeItem
     public long? ItemCode { get; set; }
     public int? StackSize { get; set; }
     public float? ChanceToConsume { get; set; }
+    /// <summary>Display label on keyword-matched ingredient slots, e.g. <c>"Auxiliary Crystal"</c>.</summary>
+    public string? Desc { get; set; }
+    /// <summary>
+    /// Keyword set (AND-matched) for ingredient slots that accept any item whose
+    /// <see cref="RawItem.Keywords"/> includes every listed tag. Always null on result entries.
+    /// </summary>
+    public List<string>? ItemKeys { get; set; }
 }
 
 /// <summary>Raw skills.json shape — the fields we project into <see cref="SkillEntry"/>.</summary>

--- a/src/Mithril.Shared/Reference/ReferenceJsonContext.cs
+++ b/src/Mithril.Shared/Reference/ReferenceJsonContext.cs
@@ -120,6 +120,13 @@ public sealed class RawNpc
     public List<RawNpcService>? Services { get; set; }
 }
 
+/// <summary>Raw areas.json shape — the fields we project into <see cref="AreaEntry"/>.</summary>
+public sealed class RawArea
+{
+    public string? FriendlyName { get; set; }
+    public string? ShortFriendlyName { get; set; }
+}
+
 public sealed class RawNpcPreference
 {
     public string? Desire { get; set; }
@@ -201,6 +208,7 @@ public sealed class RawItemSource
 [JsonSerializable(typeof(Dictionary<string, RawSkill>))]
 [JsonSerializable(typeof(Dictionary<string, RawXpTable>))]
 [JsonSerializable(typeof(Dictionary<string, RawNpc>))]
+[JsonSerializable(typeof(Dictionary<string, RawArea>))]
 [JsonSerializable(typeof(Dictionary<string, RawItemSourceEnvelope>))]
 [JsonSerializable(typeof(Dictionary<string, RawAttribute>))]
 [JsonSerializable(typeof(Dictionary<string, RawPower>))]

--- a/src/Mithril.Shared/Reference/ReferenceJsonContext.cs
+++ b/src/Mithril.Shared/Reference/ReferenceJsonContext.cs
@@ -195,6 +195,10 @@ public sealed class RawItemSource
     public string? Monster { get; set; }
     public string? Source { get; set; }
     public string? Interactor { get; set; }
+    /// <summary>Numeric recipe id from <c>sources_items.json</c> entries with <c>type: "Recipe"</c>.</summary>
+    public long? RecipeId { get; set; }
+    /// <summary>Numeric quest id from <c>sources_items.json</c> entries with <c>type: "Quest"</c>.</summary>
+    public long? QuestId { get; set; }
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Mithril.Shared/Storage/IngredientLocation.cs
+++ b/src/Mithril.Shared/Storage/IngredientLocation.cs
@@ -1,0 +1,15 @@
+namespace Mithril.Shared.Storage;
+
+/// <summary>
+/// One slice of an item's on-hand presence: the item's identity, the storage
+/// location it's sitting in, and how many copies live there. The Sources
+/// window groups these by <see cref="Label"/> so a keyword-matched ingredient
+/// row (e.g. "any Crystal") can show per-item breakdown per chest instead of
+/// a flat repeated list.
+/// </summary>
+public sealed record IngredientLocation(
+    string Label,
+    int Quantity,
+    string ItemInternalName,
+    string DisplayName,
+    int IconId);

--- a/src/Mithril.Shared/Wpf/IIngredientSourcesPresenter.cs
+++ b/src/Mithril.Shared/Wpf/IIngredientSourcesPresenter.cs
@@ -1,0 +1,11 @@
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Opens an <see cref="IngredientSourcesWindow"/> for a given input. Modules
+/// project their domain rows into <see cref="IngredientSourcesInput"/> and
+/// dispatch through this presenter.
+/// </summary>
+public interface IIngredientSourcesPresenter
+{
+    void Show(IngredientSourcesInput input);
+}

--- a/src/Mithril.Shared/Wpf/IngredientSourcesInput.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesInput.cs
@@ -1,0 +1,18 @@
+using Mithril.Shared.Storage;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Module-agnostic input record consumed by <see cref="IIngredientSourcesPresenter"/>.
+/// Modules (Celebrimbor today, Bilbo / Smaug later) project their domain rows into
+/// this shape and call <c>Show</c>; the window itself doesn't depend on any module.
+/// </summary>
+/// <param name="Title">Display heading, e.g. <c>"Auxiliary Crystal"</c> or the item's name.</param>
+/// <param name="KeywordsLabel">When set, e.g. <c>"any Crystal"</c>, the row represents a keyword-matched slot rather than a single item.</param>
+/// <param name="ItemInternalName">Single-item rows only; null for keyword rows. Drives the Sources lookup.</param>
+/// <param name="OnHand">Per-(item, location) slices already collected by the caller.</param>
+public sealed record IngredientSourcesInput(
+    string Title,
+    string? KeywordsLabel,
+    string? ItemInternalName,
+    IReadOnlyList<IngredientLocation> OnHand);

--- a/src/Mithril.Shared/Wpf/IngredientSourcesPresenter.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesPresenter.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Wpf;
+
+public sealed class IngredientSourcesPresenter : IIngredientSourcesPresenter
+{
+    private readonly IReferenceDataService _refData;
+
+    public IngredientSourcesPresenter(IReferenceDataService refData)
+    {
+        _refData = refData;
+    }
+
+    public void Show(IngredientSourcesInput input)
+    {
+        var vm = IngredientSourcesViewModel.Build(input, _refData);
+        var window = new IngredientSourcesWindow(vm)
+        {
+            Owner = Application.Current?.MainWindow,
+        };
+        window.Show();
+    }
+}

--- a/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
@@ -95,7 +95,8 @@ public sealed record IngredientSourcesViewModel(
                         Kind: src.Type,
                         Label: npc.Name,
                         AreaFriendlyName: string.IsNullOrEmpty(npc.Area) ? null : npc.Area,
-                        Detail: null));
+                        Detail: null,
+                        Requirement: ResolveFavorRequirement(src.Type, npc)));
                     break;
 
                 case "Quest":
@@ -137,6 +138,33 @@ public sealed record IngredientSourcesViewModel(
         if (string.IsNullOrEmpty(context)) return null;
         return refData.Areas.TryGetValue(context, out var area) ? area.FriendlyName : null;
     }
+
+    /// <summary>
+    /// Map a source kind ("Vendor", "Barter", "NpcGift") to the NpcService type that
+    /// gates access, then surface its <see cref="NpcService.MinFavorTier"/> as a
+    /// human-readable line. Vendor sources gate on the NPC's "Store" service; Barter
+    /// sources gate on the matching "Barter" service. NpcGift acceptance is gated
+    /// per-preference (<see cref="NpcPreference.RequiredFavorTier"/>) rather than per-NPC,
+    /// so we skip the requirement line for that kind.
+    /// </summary>
+    private static string? ResolveFavorRequirement(string sourceKind, NpcEntry npc)
+    {
+        var serviceType = sourceKind switch
+        {
+            "Vendor" => "Store",
+            "Barter" => "Barter",
+            _ => null,
+        };
+        if (serviceType is null) return null;
+
+        foreach (var svc in npc.Services)
+        {
+            if (!string.Equals(svc.Type, serviceType, StringComparison.Ordinal)) continue;
+            if (string.IsNullOrEmpty(svc.MinFavorTier)) return null;
+            return $"Requires {svc.MinFavorTier} or higher";
+        }
+        return null;
+    }
 }
 
 public sealed record OnHandLocationGroup(
@@ -154,4 +182,5 @@ public sealed record AcquisitionSource(
     string Kind,
     string Label,
     string? AreaFriendlyName,
-    string? Detail);
+    string? Detail,
+    string? Requirement = null);

--- a/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
@@ -1,0 +1,157 @@
+using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Backing view-model for <see cref="IngredientSourcesWindow"/>. Built once
+/// per-show by <see cref="IngredientSourcesPresenter"/> from an
+/// <see cref="IngredientSourcesInput"/> + <see cref="IReferenceDataService"/>.
+/// </summary>
+public sealed record IngredientSourcesViewModel(
+    string Title,
+    string? KeywordsLabel,
+    int OnHandTotal,
+    IReadOnlyList<OnHandLocationGroup> OnHand,
+    IReadOnlyList<AcquisitionSource> Sources,
+    string? SourcesPlaceholder,
+    int SelectedTabIndex)
+{
+    public bool HasOnHand => OnHand.Count > 0;
+    public bool HasSources => Sources.Count > 0;
+    public bool HasSourcesPlaceholder => !string.IsNullOrEmpty(SourcesPlaceholder);
+
+    public static IngredientSourcesViewModel Build(IngredientSourcesInput input, IReferenceDataService refData)
+    {
+        var onHand = BuildOnHand(input.OnHand);
+        var onHandTotal = onHand.Sum(g => g.TotalQuantity);
+
+        IReadOnlyList<AcquisitionSource> sources;
+        string? placeholder;
+
+        if (input.ItemInternalName is { } itemName)
+        {
+            sources = BuildSources(itemName, refData);
+            placeholder = sources.Count == 0
+                ? "No vendor, drop, or quest sources are catalogued for this item."
+                : null;
+        }
+        else
+        {
+            sources = [];
+            placeholder = "Sources for items matching this keyword set are not aggregated yet.";
+        }
+
+        // Default tab: On hand (0) when stock exists, otherwise Sources (1).
+        var selectedTabIndex = onHand.Count > 0 ? 0 : 1;
+
+        return new IngredientSourcesViewModel(input.Title, input.KeywordsLabel, onHandTotal, onHand, sources, placeholder, selectedTabIndex);
+    }
+
+    private static IReadOnlyList<OnHandLocationGroup> BuildOnHand(IReadOnlyList<IngredientLocation> entries)
+    {
+        if (entries.Count == 0) return [];
+        return entries
+            .GroupBy(e => e.Label, StringComparer.OrdinalIgnoreCase)
+            .Select(g =>
+            {
+                var byItem = g
+                    .GroupBy(e => e.ItemInternalName, StringComparer.Ordinal)
+                    .Select(ig => new OnHandItemBreakdown(
+                        DisplayName: ig.First().DisplayName,
+                        IconId: ig.First().IconId,
+                        Quantity: ig.Sum(x => x.Quantity),
+                        ItemInternalName: ig.Key))
+                    .OrderByDescending(b => b.Quantity)
+                    .ThenBy(b => b.DisplayName, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                return new OnHandLocationGroup(
+                    Label: g.Key,
+                    TotalQuantity: byItem.Sum(b => b.Quantity),
+                    Items: byItem);
+            })
+            .OrderByDescending(g => g.TotalQuantity)
+            .ThenBy(g => g.Label, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static IReadOnlyList<AcquisitionSource> BuildSources(string itemInternalName, IReferenceDataService refData)
+    {
+        if (!refData.ItemSources.TryGetValue(itemInternalName, out var raw)) return [];
+
+        var result = new List<AcquisitionSource>(raw.Count);
+        foreach (var src in raw)
+        {
+            if (string.IsNullOrEmpty(src.Type)) continue;
+
+            switch (src.Type)
+            {
+                case "Vendor":
+                case "Barter":
+                case "NpcGift":
+                    if (string.IsNullOrEmpty(src.Npc)) continue;
+                    if (!refData.Npcs.TryGetValue(src.Npc, out var npc)) continue;
+                    result.Add(new AcquisitionSource(
+                        Kind: src.Type,
+                        Label: npc.Name,
+                        AreaFriendlyName: string.IsNullOrEmpty(npc.Area) ? null : npc.Area,
+                        Detail: null));
+                    break;
+
+                case "Quest":
+                    result.Add(new AcquisitionSource("Quest", "Quest reward", AreaFriendlyName: null, Detail: src.Context));
+                    break;
+
+                case "Recipe":
+                    result.Add(new AcquisitionSource("Recipe", "Crafted", AreaFriendlyName: null, Detail: src.Context));
+                    break;
+
+                case "Monster":
+                case "Drop":
+                case "Angling":
+                case "HangOut":
+                {
+                    var area = ResolveArea(src.Context, refData);
+                    result.Add(new AcquisitionSource(
+                        Kind: src.Type,
+                        Label: src.Context ?? src.Type,
+                        AreaFriendlyName: area,
+                        Detail: null));
+                    break;
+                }
+
+                default:
+                    result.Add(new AcquisitionSource(src.Type, src.Context ?? src.Type, AreaFriendlyName: null, Detail: null));
+                    break;
+            }
+        }
+
+        return result
+            .OrderBy(s => s.Kind, StringComparer.Ordinal)
+            .ThenBy(s => s.Label, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string? ResolveArea(string? context, IReferenceDataService refData)
+    {
+        if (string.IsNullOrEmpty(context)) return null;
+        return refData.Areas.TryGetValue(context, out var area) ? area.FriendlyName : null;
+    }
+}
+
+public sealed record OnHandLocationGroup(
+    string Label,
+    int TotalQuantity,
+    IReadOnlyList<OnHandItemBreakdown> Items);
+
+public sealed record OnHandItemBreakdown(
+    string DisplayName,
+    int IconId,
+    int Quantity,
+    string ItemInternalName);
+
+public sealed record AcquisitionSource(
+    string Kind,
+    string Label,
+    string? AreaFriendlyName,
+    string? Detail);

--- a/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
@@ -11,6 +11,7 @@ namespace Mithril.Shared.Wpf;
 public sealed record IngredientSourcesViewModel(
     string Title,
     string? KeywordsLabel,
+    string? UseRequirement,
     int OnHandTotal,
     IReadOnlyList<OnHandLocationGroup> OnHand,
     IReadOnlyList<AcquisitionSource> Sources,
@@ -28,6 +29,7 @@ public sealed record IngredientSourcesViewModel(
 
         IReadOnlyList<AcquisitionSource> sources;
         string? placeholder;
+        string? useRequirement = null;
 
         if (input.ItemInternalName is { } itemName)
         {
@@ -35,6 +37,7 @@ public sealed record IngredientSourcesViewModel(
             placeholder = sources.Count == 0
                 ? "No vendor, drop, or quest sources are catalogued for this item."
                 : null;
+            useRequirement = ResolveUseRequirement(itemName, refData);
         }
         else
         {
@@ -45,7 +48,23 @@ public sealed record IngredientSourcesViewModel(
         // Default tab: On hand (0) when stock exists, otherwise Sources (1).
         var selectedTabIndex = onHand.Count > 0 ? 0 : 1;
 
-        return new IngredientSourcesViewModel(input.Title, input.KeywordsLabel, onHandTotal, onHand, sources, placeholder, selectedTabIndex);
+        return new IngredientSourcesViewModel(input.Title, input.KeywordsLabel, useRequirement, onHandTotal, onHand, sources, placeholder, selectedTabIndex);
+    }
+
+    /// <summary>
+    /// Item-side <em>use</em> gate (post-acquisition). Distinct from Sources-card
+    /// <em>acquisition</em> gates: SkillReqs filters who can plant the seedling /
+    /// cast the scroll, not who can buy it. Multi-key gates render comma-joined.
+    /// Keyword rows skip this (no single item to look up).
+    /// </summary>
+    private static string? ResolveUseRequirement(string itemInternalName, IReferenceDataService refData)
+    {
+        if (!refData.ItemsByInternalName.TryGetValue(itemInternalName, out var item)) return null;
+        if (item.SkillReqs is not { Count: > 0 } reqs) return null;
+        var parts = reqs
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => $"{kv.Key} {kv.Value}");
+        return $"Requires {string.Join(", ", parts)} to use";
     }
 
     private static IReadOnlyList<OnHandLocationGroup> BuildOnHand(IReadOnlyList<IngredientLocation> entries)

--- a/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesViewModel.cs
@@ -104,7 +104,7 @@ public sealed record IngredientSourcesViewModel(
                     break;
 
                 case "Recipe":
-                    result.Add(new AcquisitionSource("Recipe", "Crafted", AreaFriendlyName: null, Detail: src.Context));
+                    result.Add(BuildRecipeSource(src, refData));
                     break;
 
                 case "Monster":
@@ -147,6 +147,36 @@ public sealed record IngredientSourcesViewModel(
     /// per-preference (<see cref="NpcPreference.RequiredFavorTier"/>) rather than per-NPC,
     /// so we skip the requirement line for that kind.
     /// </summary>
+    /// <summary>
+    /// Render a Recipe source. <see cref="ItemSource.Context"/> carries the recipe's
+    /// InternalName (resolved at parse time from <c>recipeId</c>); look it up to surface
+    /// the recipe's display name + skill gate + prereq-recipe hint.
+    /// </summary>
+    private static AcquisitionSource BuildRecipeSource(ItemSource src, IReferenceDataService refData)
+    {
+        if (string.IsNullOrEmpty(src.Context)
+            || !refData.RecipesByInternalName.TryGetValue(src.Context, out var recipe))
+        {
+            // Fallback: we have a recipe source but couldn't resolve the entry.
+            return new AcquisitionSource("Recipe", "Crafted", AreaFriendlyName: null, Detail: src.Context);
+        }
+
+        var label = string.IsNullOrEmpty(recipe.Name) ? recipe.InternalName : recipe.Name;
+        var requirement = !string.IsNullOrEmpty(recipe.Skill) && recipe.SkillLevelReq > 0
+            ? $"Requires {recipe.Skill} {recipe.SkillLevelReq}"
+            : null;
+        var detail = !string.IsNullOrEmpty(recipe.PrereqRecipe)
+            ? $"prereq: {recipe.PrereqRecipe}"
+            : null;
+
+        return new AcquisitionSource(
+            Kind: "Crafted",
+            Label: label,
+            AreaFriendlyName: null,
+            Detail: detail,
+            Requirement: requirement);
+    }
+
     private static string? ResolveFavorRequirement(string sourceKind, NpcEntry npc)
     {
         var serviceType = sourceKind switch

--- a/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml
@@ -188,36 +188,51 @@
                                     <DataTemplate>
                                         <Border Background="#FF222222" BorderBrush="#22FFFFFF" BorderThickness="1"
                                                 CornerRadius="4" Padding="10,6" Margin="0,0,0,4">
-                                            <StackPanel Orientation="Horizontal">
-                                                <Border Background="#33D4A847" CornerRadius="3" Padding="6,2" Margin="0,0,8,0">
-                                                    <TextBlock Text="{Binding Kind}" Foreground="#FFD4A847"
+                                            <StackPanel>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <Border Background="#33D4A847" CornerRadius="3" Padding="6,2" Margin="0,0,8,0">
+                                                        <TextBlock Text="{Binding Kind}" Foreground="#FFD4A847"
+                                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                                   FontWeight="SemiBold"/>
+                                                    </Border>
+                                                    <TextBlock Text="{Binding Label}" Foreground="#FFE8E8E8"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBlock Foreground="#88FFFFFF" Margin="6,0,0,0"
                                                                FontSize="{DynamicResource AppFontSizeHint}"
-                                                               FontWeight="SemiBold"/>
-                                                </Border>
-                                                <TextBlock Text="{Binding Label}" Foreground="#FFE8E8E8"
-                                                           VerticalAlignment="Center"/>
-                                                <TextBlock Foreground="#88FFFFFF" Margin="6,0,0,0"
+                                                               VerticalAlignment="Center"
+                                                               Text="{Binding AreaFriendlyName, StringFormat=· {0}}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding AreaFriendlyName}" Value="{x:Null}">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                    <TextBlock Foreground="#88FFFFFF" Margin="6,0,0,0"
+                                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                                               FontStyle="Italic" VerticalAlignment="Center"
+                                                               Text="{Binding Detail, StringFormat=({0})}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding Detail}" Value="{x:Null}">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </StackPanel>
+                                                <TextBlock Text="{Binding Requirement}" Foreground="#FFB07A47"
                                                            FontSize="{DynamicResource AppFontSizeHint}"
-                                                           VerticalAlignment="Center"
-                                                           Text="{Binding AreaFriendlyName, StringFormat=· {0}}">
+                                                           Margin="0,2,0,0">
                                                     <TextBlock.Style>
                                                         <Style TargetType="TextBlock">
                                                             <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding AreaFriendlyName}" Value="{x:Null}">
-                                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </TextBlock.Style>
-                                                </TextBlock>
-                                                <TextBlock Foreground="#88FFFFFF" Margin="6,0,0,0"
-                                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                                           FontStyle="Italic" VerticalAlignment="Center"
-                                                           Text="{Binding Detail, StringFormat=({0})}">
-                                                    <TextBlock.Style>
-                                                        <Style TargetType="TextBlock">
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding Detail}" Value="{x:Null}">
+                                                                <DataTrigger Binding="{Binding Requirement}" Value="{x:Null}">
                                                                     <Setter Property="Visibility" Value="Collapsed"/>
                                                                 </DataTrigger>
                                                             </Style.Triggers>

--- a/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml
@@ -1,0 +1,238 @@
+<Window x:Class="Mithril.Shared.Wpf.IngredientSourcesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:c="clr-namespace:Mithril.Shared.Wpf"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="{Binding Title}"
+        SizeToContent="Height"
+        Width="480"
+        MaxHeight="640"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        FontFamily="{DynamicResource AppFontFamily}"
+        FontSize="{DynamicResource AppFontSize}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6">
+        <DockPanel>
+            <!-- Title bar (drag + close) -->
+            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
+                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
+                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                            ToolTip="Close" Click="CloseButton_Click">
+                        <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
+                    </Button>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Title}"
+                                   FontFamily="{DynamicResource AppHeaderFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeXLarge}"
+                                   Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding KeywordsLabel, StringFormat=({0})}"
+                                   Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                   FontStyle="Italic">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding KeywordsLabel}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+
+            <!-- Tabbed content: On hand first (when stock exists), then Sources.
+                 SelectedIndex bound one-way; view-model picks 0 when there's stock, else 1. -->
+            <TabControl Background="Transparent" BorderThickness="0" Padding="14,8,14,12"
+                        SelectedIndex="{Binding SelectedTabIndex, Mode=OneWay}">
+                <TabControl.Resources>
+                    <Style TargetType="TabItem">
+                        <Setter Property="Foreground" Value="#88FFFFFF"/>
+                        <Setter Property="FontSize" Value="{DynamicResource AppFontSize}"/>
+                        <Setter Property="Padding" Value="14,6"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="TabItem">
+                                    <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
+                                            BorderBrush="#FFD4A847" BorderThickness="0,0,0,2">
+                                        <ContentPresenter ContentSource="Header"
+                                                          HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="Bd" Property="BorderThickness" Value="0,0,0,2"/>
+                                            <Setter Property="Foreground" Value="#FFD4A847"/>
+                                            <Setter Property="FontWeight" Value="SemiBold"/>
+                                        </Trigger>
+                                        <Trigger Property="IsSelected" Value="False">
+                                            <Setter TargetName="Bd" Property="BorderThickness" Value="0"/>
+                                        </Trigger>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </TabControl.Resources>
+
+                <!-- On hand tab -->
+                <TabItem>
+                    <TabItem.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="On hand"/>
+                            <TextBlock Text="{Binding OnHandTotal, StringFormat=({0})}"
+                                       Margin="6,0,0,0" FontWeight="Normal"
+                                       Visibility="{Binding HasOnHand, Converter={StaticResource BoolToVis}}"/>
+                        </StackPanel>
+                    </TabItem.Header>
+
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="500" Padding="0,8,0,0">
+                        <StackPanel>
+                            <TextBlock Text="No on-hand stock detected." Foreground="#88FFFFFF"
+                                       FontStyle="Italic" FontSize="{DynamicResource AppFontSizeHint}"
+                                       Margin="0,0,0,8">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasOnHand}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <ItemsControl ItemsSource="{Binding OnHand}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#FF222222" BorderBrush="#22FFFFFF" BorderThickness="1"
+                                                CornerRadius="4" Padding="10,6" Margin="0,0,0,4">
+                                            <StackPanel>
+                                                <DockPanel Margin="0,0,0,4">
+                                                    <TextBlock Text="{Binding TotalQuantity, StringFormat=({0})}"
+                                                               DockPanel.Dock="Right" Foreground="#88FFFFFF"
+                                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBlock Text="{Binding Label}" FontWeight="SemiBold"
+                                                               Foreground="#FFE8E8E8"/>
+                                                </DockPanel>
+                                                <ItemsControl ItemsSource="{Binding Items}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <DockPanel Margin="0,1">
+                                                                <TextBlock DockPanel.Dock="Right" Foreground="#88FFFFFF"
+                                                                           FontSize="{DynamicResource AppFontSizeHint}">
+                                                                    <Run Text="× "/><Run Text="{Binding Quantity, Mode=OneWay}"/>
+                                                                </TextBlock>
+                                                                <c:IconImage IconId="{Binding IconId}" Width="16" Height="16"
+                                                                             Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                                                <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
+                                                                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                            </DockPanel>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
+
+                <!-- Sources tab -->
+                <TabItem>
+                    <TabItem.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="Sources"/>
+                            <TextBlock Text="{Binding Sources.Count, StringFormat=({0})}"
+                                       Margin="6,0,0,0" FontWeight="Normal"
+                                       Visibility="{Binding HasSources, Converter={StaticResource BoolToVis}}"/>
+                        </StackPanel>
+                    </TabItem.Header>
+
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="500" Padding="0,8,0,0">
+                        <StackPanel>
+                            <TextBlock Text="{Binding SourcesPlaceholder}" Foreground="#88FFFFFF"
+                                       FontStyle="Italic" FontSize="{DynamicResource AppFontSizeHint}"
+                                       TextWrapping="Wrap" Margin="0,0,0,8"
+                                       Visibility="{Binding HasSourcesPlaceholder, Converter={StaticResource BoolToVis}}"/>
+
+                            <ItemsControl ItemsSource="{Binding Sources}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#FF222222" BorderBrush="#22FFFFFF" BorderThickness="1"
+                                                CornerRadius="4" Padding="10,6" Margin="0,0,0,4">
+                                            <StackPanel Orientation="Horizontal">
+                                                <Border Background="#33D4A847" CornerRadius="3" Padding="6,2" Margin="0,0,8,0">
+                                                    <TextBlock Text="{Binding Kind}" Foreground="#FFD4A847"
+                                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                                               FontWeight="SemiBold"/>
+                                                </Border>
+                                                <TextBlock Text="{Binding Label}" Foreground="#FFE8E8E8"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Foreground="#88FFFFFF" Margin="6,0,0,0"
+                                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                                           VerticalAlignment="Center"
+                                                           Text="{Binding AreaFriendlyName, StringFormat=· {0}}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding AreaFriendlyName}" Value="{x:Null}">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <TextBlock Foreground="#88FFFFFF" Margin="6,0,0,0"
+                                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                                           FontStyle="Italic" VerticalAlignment="Center"
+                                                           Text="{Binding Detail, StringFormat=({0})}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Detail}" Value="{x:Null}">
+                                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
+            </TabControl>
+        </DockPanel>
+    </Border>
+</Window>

--- a/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml
@@ -55,6 +55,19 @@
                                 </Style>
                             </TextBlock.Style>
                         </TextBlock>
+                        <TextBlock Text="{Binding UseRequirement}"
+                                   Foreground="#FFB07A47" FontSize="{DynamicResource AppFontSizeHint}"
+                                   Margin="0,2,0,0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding UseRequirement}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                     </StackPanel>
                 </DockPanel>
             </Border>

--- a/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml.cs
+++ b/src/Mithril.Shared/Wpf/IngredientSourcesWindow.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Mithril.Shared.Wpf;
+
+public partial class IngredientSourcesWindow : Window
+{
+    public IngredientSourcesWindow(IngredientSourcesViewModel vm)
+    {
+        InitializeComponent();
+        DataContext = vm;
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) => DragMove();
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -84,6 +84,9 @@ public static class ShellServiceCollectionExtensions
                 sp.GetService<ICraftListImportTarget>(),
                 sp.GetService<IDiagnosticsSink>()));
 
+    public static IServiceCollection AddMithrilIngredientSources(this IServiceCollection services) =>
+        services.AddSingleton<IIngredientSourcesPresenter, IngredientSourcesPresenter>();
+
     public static IServiceCollection AddMithrilShellViews(this IServiceCollection services) =>
         services
             // ViewModels

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -147,7 +147,8 @@ public static class Program
                 .AddMithrilAttention()
                 .AddMithrilShellUpdates()
                 .AddMithrilShellViews()
-                .AddMithrilItemDetail();
+                .AddMithrilItemDetail()
+                .AddMithrilIngredientSources();
 
             Boot($"modules discovered: {builder.Services.Count(d => d.ServiceType == typeof(IMithrilModule))}");
             host = builder.Build();

--- a/tests/Arwen.Tests/FakeRefData.cs
+++ b/tests/Arwen.Tests/FakeRefData.cs
@@ -24,6 +24,7 @@ internal sealed class FakeRefData : IReferenceDataService
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
     public IReadOnlyDictionary<string, NpcEntry> Npcs => _npcs;
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
     public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
     public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Arwen.Tests/FakeRefData.cs
+++ b/tests/Arwen.Tests/FakeRefData.cs
@@ -18,6 +18,7 @@ internal sealed class FakeRefData : IReferenceDataService
     public IReadOnlyList<string> Keys { get; } = ["items", "npcs"];
     public IReadOnlyDictionary<long, ItemEntry> Items => _items;
     public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _byName;
+    public ItemKeywordIndex KeywordIndex => new(_items);
     public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
     public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Bilbo.Tests/CraftableRecipeCalculatorTests.cs
+++ b/tests/Bilbo.Tests/CraftableRecipeCalculatorTests.cs
@@ -12,8 +12,10 @@ public class CraftableRecipeCalculatorTests
         new(name, location, stack, 0, 0, null, null, null, 0, null, false, typeId, 0, name);
 
     private static ItemEntry Item(long id, string name) => new(id, name, name, 100, 0, []);
+    private static ItemEntry KeywordedItem(long id, string name, params string[] keywords)
+        => new(id, name, name, 100, 0, keywords.Select(k => new ItemKeyword(k, 0)).ToList());
 
-    private static RecipeEntry Recipe(string key, string name, IReadOnlyList<RecipeItemRef> ingredients, IReadOnlyList<RecipeItemRef>? results = null, string skill = "Cooking", int skillReq = 0, string internalName = "r_default") =>
+    private static RecipeEntry Recipe(string key, string name, IReadOnlyList<RecipeIngredient> ingredients, IReadOnlyList<RecipeItemRef>? results = null, string skill = "Cooking", int skillReq = 0, string internalName = "r_default") =>
         new(
             Key: key, Name: name, InternalName: internalName, IconId: 0,
             Skill: skill, SkillLevelReq: skillReq,
@@ -37,8 +39,8 @@ public class CraftableRecipeCalculatorTests
                 ["recipe_stew"] = Recipe("recipe_stew", "Stew",
                     ingredients:
                     [
-                        new(100, 2, null),
-                        new(200, 1, null),
+                        new RecipeItemIngredient(100, 2, null),
+                        new RecipeItemIngredient(200, 1, null),
                     ],
                     results: [new(900, 1, null)]),
             });
@@ -68,7 +70,7 @@ public class CraftableRecipeCalculatorTests
             recipes: new()
             {
                 ["recipe_peppered_onion"] = Recipe("recipe_peppered_onion", "Peppered Onion",
-                    ingredients: [new(100, 2, null), new(300, 1, null)]),
+                    ingredients: [new RecipeItemIngredient(100, 2, null), new RecipeItemIngredient(300, 1, null)]),
             });
 
         var rows = CraftableRecipeCalculator.Compute(
@@ -87,7 +89,7 @@ public class CraftableRecipeCalculatorTests
             items: new() { [100] = Item(100, "Onion") },
             recipes: new()
             {
-                ["r"] = Recipe("r", "OnionSoup", ingredients: [new(100, 1, null)]),
+                ["r"] = Recipe("r", "OnionSoup", ingredients: [new RecipeItemIngredient(100, 1, null)]),
             });
 
         var rows = CraftableRecipeCalculator.Compute(
@@ -107,7 +109,7 @@ public class CraftableRecipeCalculatorTests
             items: new(), // empty — no lookup succeeds
             recipes: new()
             {
-                ["r"] = Recipe("r", "Mystery", ingredients: [new(12345, 1, null)]),
+                ["r"] = Recipe("r", "Mystery", ingredients: [new RecipeItemIngredient(12345, 1, null)]),
             });
 
         var rows = CraftableRecipeCalculator.Compute([], refData, character: null, ConfidenceLevel.P95);
@@ -124,7 +126,7 @@ public class CraftableRecipeCalculatorTests
             items: new() { [100] = Item(100, "Onion") },
             recipes: new()
             {
-                ["r"] = Recipe("r", "Stew", ingredients: [new(100, 1, null)],
+                ["r"] = Recipe("r", "Stew", ingredients: [new RecipeItemIngredient(100, 1, null)],
                     skill: "Cooking", skillReq: 30, internalName: "recipe_stew"),
             });
 
@@ -152,7 +154,7 @@ public class CraftableRecipeCalculatorTests
             items: new() { [100] = Item(100, "Onion") },
             recipes: new()
             {
-                ["r"] = Recipe("r", "Stew", ingredients: [new(100, 1, null)],
+                ["r"] = Recipe("r", "Stew", ingredients: [new RecipeItemIngredient(100, 1, null)],
                     skill: "Cooking", skillReq: 30),
             });
 
@@ -168,6 +170,60 @@ public class CraftableRecipeCalculatorTests
     }
 
     [Fact]
+    public void Keyword_ingredient_satisfied_by_any_matching_item()
+    {
+        // Recipe asks for "any item keyworded Crystal x1". Player owns 3 RoughCrystal and 2 PolishedCrystal
+        // — the slot is satisfied by the sum (5 ≥ 1). MaxCraftable is bounded by min(per-slot).
+        var refData = new TestRefData(
+            items: new()
+            {
+                [100] = KeywordedItem(100, "RoughCrystal", "Crystal"),
+                [101] = KeywordedItem(101, "PolishedCrystal", "Crystal"),
+                [200] = Item(200, "EnchantedGear"),
+            },
+            recipes: new()
+            {
+                ["r"] = Recipe("r", "EnchantGear",
+                    ingredients: [new RecipeKeywordIngredient(["Crystal"], "Auxiliary Crystal", 1, null)],
+                    results: [new(200, 1, null)]),
+            });
+
+        var row = CraftableRecipeCalculator
+            .Compute([Row(100, 3, "RoughCrystal"), Row(101, 2, "PolishedCrystal")],
+                refData, character: null, ConfidenceLevel.WorstCase)
+            .Single();
+
+        row.MaxCraftable.Should().Be(5); // 3+2 crystals each consumed 1 per craft
+        row.MissingIngredients.Should().BeEmpty();
+        row.Ingredients.Should().Contain("Auxiliary Crystal x1");
+    }
+
+    [Fact]
+    public void Keyword_ingredient_with_no_matching_inventory_reports_missing()
+    {
+        var refData = new TestRefData(
+            items: new()
+            {
+                [100] = KeywordedItem(100, "RoughCrystal", "Crystal"),
+                [200] = Item(200, "EnchantedGear"),
+            },
+            recipes: new()
+            {
+                ["r"] = Recipe("r", "EnchantGear",
+                    ingredients: [new RecipeKeywordIngredient(["Crystal"], null, 1, null)],
+                    results: [new(200, 1, null)]),
+            });
+
+        // No crystals owned at all.
+        var row = CraftableRecipeCalculator
+            .Compute([], refData, character: null, ConfidenceLevel.WorstCase)
+            .Single();
+
+        row.MaxCraftable.Should().Be(0);
+        row.MissingIngredients.Should().Contain("Crystal x1 (have 0)");
+    }
+
+    [Fact]
     public void Catalyst_Ingredient_Shows_Probability_In_Display()
     {
         var refData = new TestRefData(
@@ -179,7 +235,7 @@ public class CraftableRecipeCalculatorTests
             recipes: new()
             {
                 ["r"] = Recipe("r", "Stew",
-                    ingredients: [new(100, 1, null), new(500, 1, 0.5f)]),
+                    ingredients: [new RecipeItemIngredient(100, 1, null), new RecipeItemIngredient(500, 1, 0.5f)]),
             });
 
         var row = CraftableRecipeCalculator
@@ -200,6 +256,7 @@ public class CraftableRecipeCalculatorTests
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; }
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex => new(Items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; }
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Bilbo.Tests/CraftableRecipeCalculatorTests.cs
+++ b/tests/Bilbo.Tests/CraftableRecipeCalculatorTests.cs
@@ -262,6 +262,7 @@ public class CraftableRecipeCalculatorTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Bilbo.Tests/StorageReportLoaderTests.cs
+++ b/tests/Bilbo.Tests/StorageReportLoaderTests.cs
@@ -139,6 +139,7 @@ public class StorageReportLoaderTests
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Bilbo.Tests/StorageReportLoaderTests.cs
+++ b/tests/Bilbo.Tests/StorageReportLoaderTests.cs
@@ -145,6 +145,7 @@ public class StorageReportLoaderTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Celebrimbor.Tests/CraftListFormatTests.cs
+++ b/tests/Celebrimbor.Tests/CraftListFormatTests.cs
@@ -15,7 +15,7 @@ public class CraftListFormatTests
         ],
         [
             FakeReferenceData.Recipe("Butter", "Cheesemaking", 0,
-                ingredients: [new RecipeItemRef(10, 2, null)],
+                ingredients: [new RecipeItemIngredient(10, 2, null)],
                 results: [new RecipeItemRef(11, 1, null)]),
         ]);
 

--- a/tests/Celebrimbor.Tests/FakeReferenceData.cs
+++ b/tests/Celebrimbor.Tests/FakeReferenceData.cs
@@ -22,6 +22,7 @@ internal sealed class FakeReferenceData : IReferenceDataService
     {
         _items = items.ToDictionary(i => i.Id);
         _itemsByName = _items.Values.ToDictionary(i => i.InternalName, StringComparer.Ordinal);
+        _keywordIndex = new ItemKeywordIndex(_items);
         _recipes = recipes.ToDictionary(r => r.Key, StringComparer.Ordinal);
         _recipesByName = _recipes.Values.ToDictionary(r => r.InternalName, StringComparer.Ordinal);
         _powers = (powers ?? []).ToDictionary(p => p.InternalName, StringComparer.Ordinal);
@@ -34,6 +35,8 @@ internal sealed class FakeReferenceData : IReferenceDataService
     public IReadOnlyList<string> Keys => [];
     public IReadOnlyDictionary<long, ItemEntry> Items => _items;
     public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _itemsByName;
+    public ItemKeywordIndex KeywordIndex => _keywordIndex;
+    private readonly ItemKeywordIndex _keywordIndex;
     public IReadOnlyDictionary<string, RecipeEntry> Recipes => _recipes;
     public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName => _recipesByName;
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
@@ -93,11 +96,17 @@ internal sealed class FakeReferenceData : IReferenceDataService
     public static KeyValuePair<string, IReadOnlyList<string>> Profile(string name, params string[] powers)
         => new(name, powers);
 
+    public static RecipeKeywordIngredient Keyword(int stack, params string[] keys)
+        => new(keys, Desc: null, StackSize: stack, ChanceToConsume: null);
+
+    public static RecipeKeywordIngredient KeywordWithDesc(int stack, string desc, params string[] keys)
+        => new(keys, Desc: desc, StackSize: stack, ChanceToConsume: null);
+
     public static RecipeEntry Recipe(
         string name,
         string skill,
         int skillLevelReq,
-        IReadOnlyList<RecipeItemRef> ingredients,
+        IReadOnlyList<RecipeIngredient> ingredients,
         IReadOnlyList<RecipeItemRef> results,
         IReadOnlyList<string>? resultEffects = null)
         => new(

--- a/tests/Celebrimbor.Tests/FakeReferenceData.cs
+++ b/tests/Celebrimbor.Tests/FakeReferenceData.cs
@@ -42,6 +42,7 @@ internal sealed class FakeReferenceData : IReferenceDataService
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
     public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
     public IReadOnlyDictionary<string, AttributeEntry> Attributes => _attributes;
     public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;

--- a/tests/Celebrimbor.Tests/RecipeAggregatorTests.cs
+++ b/tests/Celebrimbor.Tests/RecipeAggregatorTests.cs
@@ -11,6 +11,9 @@ public class RecipeAggregatorTests
     private static RecipeItemRef Ref(long id, int stack, float? chance = null)
         => new(id, stack, chance);
 
+    private static RecipeItemIngredient Ing(long id, int stack, float? chance = null)
+        => new(id, stack, chance);
+
     private static FakeReferenceData MakeStandardData()
     {
         var items = new[]
@@ -23,10 +26,10 @@ public class RecipeAggregatorTests
         var recipes = new[]
         {
             FakeReferenceData.Recipe("Butter", "Cheesemaking", 0,
-                ingredients: [Ref(10, 2), Ref(12, 1)],
+                ingredients: [Ing(10, 2), Ing(12, 1)],
                 results: [Ref(11, 1)]),
             FakeReferenceData.Recipe("Bread", "Cooking", 5,
-                ingredients: [Ref(11, 1), Ref(12, 1)],
+                ingredients: [Ing(11, 1), Ing(12, 1)],
                 results: [Ref(13, 1)]),
         };
         return new FakeReferenceData(items, recipes);
@@ -98,7 +101,7 @@ public class RecipeAggregatorTests
         var recipes = new[]
         {
             FakeReferenceData.Recipe("Butter", "Cheesemaking", 0,
-                ingredients: [Ref(10, 2, chance: 0.5f)],
+                ingredients: [Ing(10, 2, chance: 0.5f)],
                 results: [Ref(11, 1)]),
         };
         var data = new FakeReferenceData(items, recipes);
@@ -203,10 +206,10 @@ public class RecipeAggregatorTests
         var recipes = new[]
         {
             FakeReferenceData.Recipe("A", "Test", 0,
-                ingredients: [Ref(21, 1), Ref(22, 1)],
+                ingredients: [Ing(21, 1), Ing(22, 1)],
                 results: [Ref(20, 1)]),
             FakeReferenceData.Recipe("B", "Test", 0,
-                ingredients: [Ref(20, 1), Ref(22, 1)],
+                ingredients: [Ing(20, 1), Ing(22, 1)],
                 results: [Ref(21, 1)]),
         };
         var data = new FakeReferenceData(items, recipes);
@@ -232,7 +235,7 @@ public class RecipeAggregatorTests
         var recipes = new[]
         {
             FakeReferenceData.Recipe("Butter", "Test", 0,
-                ingredients: [Ref(10, 2), Ref(99, 1)],
+                ingredients: [Ing(10, 2), Ing(99, 1)],
                 results: [Ref(11, 1)]),
         };
         var data = new FakeReferenceData(items, recipes);
@@ -252,7 +255,7 @@ public class RecipeAggregatorTests
         var recipes = new[]
         {
             FakeReferenceData.Recipe("UseIt", "Test", 0,
-                ingredients: [Ref(10, 1)],
+                ingredients: [Ing(10, 1)],
                 results: [Ref(10, 1)]),
         };
         var data = new FakeReferenceData(items, recipes);
@@ -359,5 +362,198 @@ public class RecipeAggregatorTests
         salt.OnHandOverride.Should().Be(100);
         salt.Remaining.Should().Be(0);
         salt.IsCraftReady.Should().BeTrue();
+    }
+
+    // ── Keyword-matched ingredient slots (e.g. auxiliary-crystal on enchanted recipes) ─────────
+
+    private static FakeReferenceData MakeCrystalEnchantData()
+    {
+        var items = new[]
+        {
+            FakeReferenceData.Item(100, "Boots", "Equipment"),
+            FakeReferenceData.Item(101, "Leather", "Material"),
+            FakeReferenceData.Item(200, "RoughCrystal", "Crystal", "Material"),
+            FakeReferenceData.Item(201, "PolishedCrystal", "Crystal", "Material"),
+            FakeReferenceData.Item(300, "EnchantedBoots", "Equipment"),
+        };
+        var recipes = new[]
+        {
+            FakeReferenceData.Recipe("EnchantBoots", "Leatherworking", 0,
+                ingredients: [
+                    Ing(100, 1),
+                    Ing(101, 2),
+                    FakeReferenceData.KeywordWithDesc(1, "Auxiliary Crystal", "Crystal"),
+                ],
+                results: [Ref(300, 1)]),
+        };
+        return new FakeReferenceData(items, recipes);
+    }
+
+    [Fact]
+    public void Keyword_ingredient_emits_synthetic_row_with_label()
+    {
+        var data = MakeCrystalEnchantData();
+        var sut = new RecipeAggregator();
+
+        var entries = new[] { new CraftListEntry { RecipeInternalName = "EnchantBoots", Quantity = 1 } };
+        var result = sut.Aggregate(entries, expansionDepth: 1, data);
+
+        var crystalRow = result.Should().ContainSingle(r => r.KeywordsLabel != null).Subject;
+        crystalRow.KeywordsLabel.Should().Be("any Crystal");
+        crystalRow.DisplayName.Should().Be("Auxiliary Crystal");
+        crystalRow.PrimaryTag.Should().Be("Crystal");
+        crystalRow.TotalNeeded.Should().Be(1);
+        crystalRow.Depth.Should().Be(0); // keyword rows are leaves
+        crystalRow.IsAlsoRecipe.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Two_recipes_citing_same_keyword_set_aggregate_to_one_row()
+    {
+        var items = new[]
+        {
+            FakeReferenceData.Item(100, "GearA", "Equipment"),
+            FakeReferenceData.Item(101, "GearB", "Equipment"),
+            FakeReferenceData.Item(200, "Crystal1", "Crystal"),
+        };
+        var recipes = new[]
+        {
+            FakeReferenceData.Recipe("MakeA", "Smithing", 0,
+                ingredients: [FakeReferenceData.Keyword(1, "Crystal")],
+                results: [Ref(100, 1)]),
+            FakeReferenceData.Recipe("MakeB", "Smithing", 0,
+                ingredients: [FakeReferenceData.Keyword(2, "Crystal")],
+                results: [Ref(101, 1)]),
+        };
+        var data = new FakeReferenceData(items, recipes);
+        var sut = new RecipeAggregator();
+
+        var entries = new[]
+        {
+            new CraftListEntry { RecipeInternalName = "MakeA", Quantity = 1 },
+            new CraftListEntry { RecipeInternalName = "MakeB", Quantity = 1 },
+        };
+        var result = sut.Aggregate(entries, expansionDepth: 1, data);
+
+        result.Should().ContainSingle(r => r.KeywordsLabel == "any Crystal")
+            .Which.TotalNeeded.Should().Be(3);
+    }
+
+    [Fact]
+    public void Keyword_row_on_hand_sums_matching_items()
+    {
+        var data = MakeCrystalEnchantData();
+        var sut = new RecipeAggregator();
+
+        // Two distinct items both keyworded Crystal — both should count toward the slot's on-hand.
+        var onHand = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["RoughCrystal"] = 4,
+            ["PolishedCrystal"] = 3,
+        };
+        var ownedByKeyword = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            ["Crystal"] = ["RoughCrystal", "PolishedCrystal"],
+            ["Material"] = ["RoughCrystal", "PolishedCrystal"],
+        };
+
+        var entries = new[] { new CraftListEntry { RecipeInternalName = "EnchantBoots", Quantity = 1 } };
+        var result = sut.Aggregate(entries, expansionDepth: 1, data,
+            onHandByInternalName: onHand,
+            ownedInternalNamesByKeyword: ownedByKeyword);
+
+        var crystalRow = result.Single(r => r.KeywordsLabel == "any Crystal");
+        crystalRow.OnHandDetected.Should().Be(7);
+        crystalRow.IsCraftReady.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Keyword_row_on_hand_requires_AND_match()
+    {
+        // Two-key set: only items having BOTH tags should count. Hammer has Crystal but not
+        // EquipmentSlot:MainHand; CrystalSword has both — only the latter contributes on-hand.
+        var items = new[]
+        {
+            FakeReferenceData.Item(100, "Hammer", "Crystal"),
+            FakeReferenceData.Item(101, "CrystalSword", "Crystal", "EquipmentSlot:MainHand"),
+            FakeReferenceData.Item(200, "Output", "Equipment"),
+        };
+        var recipes = new[]
+        {
+            FakeReferenceData.Recipe("MakeOutput", "Smithing", 0,
+                ingredients: [FakeReferenceData.Keyword(1, "Crystal", "EquipmentSlot:MainHand")],
+                results: [Ref(200, 1)]),
+        };
+        var data = new FakeReferenceData(items, recipes);
+        var sut = new RecipeAggregator();
+
+        var onHand = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["Hammer"] = 5,         // has only "Crystal" — should NOT count
+            ["CrystalSword"] = 2,   // has both — counts
+        };
+        var ownedByKeyword = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            ["Crystal"] = ["Hammer", "CrystalSword"],
+            ["EquipmentSlot:MainHand"] = ["CrystalSword"],
+        };
+
+        var entries = new[] { new CraftListEntry { RecipeInternalName = "MakeOutput", Quantity = 1 } };
+        var result = sut.Aggregate(entries, expansionDepth: 1, data,
+            onHandByInternalName: onHand,
+            ownedInternalNamesByKeyword: ownedByKeyword);
+
+        var keywordRow = result.Single(r => r.KeywordsLabel != null);
+        keywordRow.OnHandDetected.Should().Be(2); // only CrystalSword
+    }
+
+    [Fact]
+    public void Override_on_keyword_row_reduces_remaining_like_item_row()
+    {
+        var data = MakeCrystalEnchantData();
+        var sut = new RecipeAggregator();
+
+        // Find the synthetic key the aggregator uses so we can override it.
+        var probe = sut.Aggregate(
+            [new CraftListEntry { RecipeInternalName = "EnchantBoots", Quantity = 1 }],
+            expansionDepth: 1, data);
+        var keywordKey = probe.Single(r => r.KeywordsLabel != null).ItemInternalName;
+
+        var overrides = new Dictionary<string, int>(StringComparer.Ordinal) { [keywordKey] = 5 };
+        var result = sut.Aggregate(
+            [new CraftListEntry { RecipeInternalName = "EnchantBoots", Quantity = 1 }],
+            expansionDepth: 1, data,
+            overridesByInternalName: overrides);
+
+        var crystalRow = result.Single(r => r.KeywordsLabel != null);
+        crystalRow.OnHandOverride.Should().Be(5);
+        crystalRow.Remaining.Should().Be(0);
+        crystalRow.IsCraftReady.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Keyword_row_PrimaryTag_is_first_keyword()
+    {
+        var items = new[]
+        {
+            FakeReferenceData.Item(100, "Output", "Equipment"),
+            FakeReferenceData.Item(200, "Eyeball", "Eye"),
+        };
+        var recipes = new[]
+        {
+            FakeReferenceData.Recipe("MakeOutput", "Necromancy", 0,
+                ingredients: [FakeReferenceData.Keyword(1, "Eye", "Fresh")],
+                results: [Ref(100, 1)]),
+        };
+        var data = new FakeReferenceData(items, recipes);
+        var sut = new RecipeAggregator();
+
+        var result = sut.Aggregate(
+            [new CraftListEntry { RecipeInternalName = "MakeOutput", Quantity = 1 }],
+            expansionDepth: 1, data);
+
+        var row = result.Single(r => r.KeywordsLabel != null);
+        row.PrimaryTag.Should().Be("Eye");
+        row.KeywordsLabel.Should().Be("any Eye + Fresh");
     }
 }

--- a/tests/Elrond.Tests/LevelingSimulatorTests.cs
+++ b/tests/Elrond.Tests/LevelingSimulatorTests.cs
@@ -269,6 +269,7 @@ public class LevelingSimulatorTests
         public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
         public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xpTables;
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Elrond.Tests/LevelingSimulatorTests.cs
+++ b/tests/Elrond.Tests/LevelingSimulatorTests.cs
@@ -263,6 +263,7 @@ public class LevelingSimulatorTests
         public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables"];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes => _recipes;
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName => _recipesByName;
         public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -305,6 +305,7 @@ public class SkillAdvisorEngineTests
         public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
         public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xpTables;
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -299,6 +299,7 @@ public class SkillAdvisorEngineTests
         public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables"];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes => _recipes;
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName => _recipesByName;
         public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;

--- a/tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs
+++ b/tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs
@@ -395,6 +395,7 @@ public sealed class InventoryServiceStackSizeTests
         public IReadOnlyList<string> Keys { get; } = ["items"];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _byName;
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs
+++ b/tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs
@@ -401,6 +401,7 @@ public sealed class InventoryServiceStackSizeTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Mithril.Shared.Tests/InventoryServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/InventoryServiceTests.cs
@@ -686,6 +686,7 @@ public sealed class InventoryServiceTests
         {
             ["BarleySeeds"] = new(10251, "Barley Seeds", "BarleySeeds", 100, 0, []),
         };
+        public ItemKeywordIndex KeywordIndex => new(Items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Mithril.Shared.Tests/InventoryServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/InventoryServiceTests.cs
@@ -692,6 +692,7 @@ public sealed class InventoryServiceTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Mithril.Shared.Tests/Reference/AreaCatalogParseTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/AreaCatalogParseTests.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class AreaCatalogParseTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cacheDir;
+    private readonly string _bundledDir;
+
+    public AreaCatalogParseTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-area-tests");
+        _cacheDir = Path.Combine(_root, "cache");
+        _bundledDir = Path.Combine(_root, "bundled");
+        Directory.CreateDirectory(_cacheDir);
+        Directory.CreateDirectory(_bundledDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Areas_load_from_bundled_with_short_name_fallback()
+    {
+        File.WriteAllText(Path.Combine(_bundledDir, "areas.json"), """
+            {
+              "AreaSerbule": { "FriendlyName": "Serbule", "ShortFriendlyName": "Serbule" },
+              "AreaSunVale": { "FriendlyName": "Sun Vale" },
+              "AreaCave1": { "FriendlyName": "Dungeons Beneath Eltibule", "ShortFriendlyName": "Beneath Eltibule" }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, new System.Net.Http.HttpClient(new ThrowingHandler()), bundledDir: _bundledDir);
+
+        svc.Areas.Should().HaveCount(3);
+        svc.Areas["AreaSerbule"].FriendlyName.Should().Be("Serbule");
+        svc.Areas["AreaSerbule"].ShortFriendlyName.Should().Be("Serbule");
+        // Missing ShortFriendlyName falls back to FriendlyName.
+        svc.Areas["AreaSunVale"].FriendlyName.Should().Be("Sun Vale");
+        svc.Areas["AreaSunVale"].ShortFriendlyName.Should().Be("Sun Vale");
+        svc.Areas["AreaCave1"].ShortFriendlyName.Should().Be("Beneath Eltibule");
+    }
+
+    private sealed class ThrowingHandler : System.Net.Http.HttpMessageHandler
+    {
+        protected override Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, CancellationToken ct)
+            => throw new InvalidOperationException("HTTP must not be called in this test");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Reference/AugmentParserTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/AugmentParserTests.cs
@@ -246,6 +246,7 @@ public class AugmentParserTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; }
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; }

--- a/tests/Mithril.Shared.Tests/Reference/AugmentParserTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/AugmentParserTests.cs
@@ -240,6 +240,7 @@ public class AugmentParserTests
         public IReadOnlyList<string> Keys => [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; }
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; }
+        public ItemKeywordIndex KeywordIndex => new(Items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Mithril.Shared.Tests/Reference/ItemKeywordIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ItemKeywordIndexTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+public class ItemKeywordIndexTests
+{
+    private static ItemEntry Item(long id, string name, params string[] keywords) =>
+        new(id, name, name, MaxStackSize: 50, IconId: 0,
+            Keywords: keywords.Select(k => new ItemKeyword(k, 0)).ToList());
+
+    private static ItemKeywordIndex Build(params ItemEntry[] items) =>
+        new(items.ToDictionary(i => i.Id));
+
+    [Fact]
+    public void Single_key_returns_all_items_with_that_tag()
+    {
+        var idx = Build(
+            Item(1, "Rough", "Crystal", "Material"),
+            Item(2, "Polished", "Crystal", "Refined"),
+            Item(3, "Wood", "Material"));
+
+        idx.ItemsMatching(["Crystal"]).Select(i => i.Id).Should().BeEquivalentTo([1L, 2L]);
+    }
+
+    [Fact]
+    public void Multi_key_intersects_AND_match()
+    {
+        var idx = Build(
+            Item(1, "Hammer", "Crystal"),
+            Item(2, "Sword", "Crystal", "EquipmentSlot:MainHand"),
+            Item(3, "Shield", "EquipmentSlot:MainHand"));
+
+        idx.ItemsMatching(["Crystal", "EquipmentSlot:MainHand"])
+            .Select(i => i.Id).Should().BeEquivalentTo([2L]);
+    }
+
+    [Fact]
+    public void Empty_keys_returns_empty()
+    {
+        var idx = Build(Item(1, "Anything", "Crystal"));
+        idx.ItemsMatching([]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Unknown_key_returns_empty()
+    {
+        var idx = Build(Item(1, "Crystal", "Crystal"));
+        idx.ItemsMatching(["Nonexistent"]).Should().BeEmpty();
+        idx.ByKeyword("Nonexistent").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Empty_index_returns_empty_for_any_query()
+    {
+        ItemKeywordIndex.Empty.ItemsMatching(["Crystal"]).Should().BeEmpty();
+        ItemKeywordIndex.Empty.ByKeyword("Crystal").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Humanise_joins_keys_with_plus()
+    {
+        ItemKeywordIndex.Humanise(["Crystal"]).Should().Be("Crystal");
+        ItemKeywordIndex.Humanise(["Eye", "Fresh"]).Should().Be("Eye + Fresh");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Reference/Phase7Fixture.cs
+++ b/tests/Mithril.Shared.Tests/Reference/Phase7Fixture.cs
@@ -17,6 +17,7 @@ internal sealed class Phase7Fixture : IReferenceDataService
     public required IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; init; }
 
     public IReadOnlyList<string> Keys => [];
+    public ItemKeywordIndex KeywordIndex => new(Items);
     public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();

--- a/tests/Mithril.Shared.Tests/Reference/Phase7Fixture.cs
+++ b/tests/Mithril.Shared.Tests/Reference/Phase7Fixture.cs
@@ -22,6 +22,7 @@ internal sealed class Phase7Fixture : IReferenceDataService
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
     public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
 
     public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);

--- a/tests/Mithril.Shared.Tests/Reference/ResultEffectsParserTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ResultEffectsParserTests.cs
@@ -192,6 +192,7 @@ public class ResultEffectsParserTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Mithril.Shared.Tests/Reference/ResultEffectsParserTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ResultEffectsParserTests.cs
@@ -186,6 +186,7 @@ public class ResultEffectsParserTests
         public IReadOnlyList<string> Keys => [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; }
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; }
+        public ItemKeywordIndex KeywordIndex => new(Items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -140,6 +140,55 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void Recipe_ingredients_with_ItemKeys_parse_as_keyword_ingredients()
+    {
+        // items.json drives keyword index population (items must be parsed for the catalog
+        // to know which items carry "Crystal"); recipes.json carries the keyword-matched slot.
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), """
+            {
+              "item_100": { "Name": "Boots", "InternalName": "Boots", "MaxStackSize": 1 },
+              "item_200": { "Name": "Rough Crystal", "InternalName": "RoughCrystal", "MaxStackSize": 50, "Keywords": ["Crystal"] }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.json"), """
+            {
+              "recipe_1": {
+                "Name": "EnchantBoots",
+                "InternalName": "EnchantBoots",
+                "Skill": "Leatherworking",
+                "Ingredients": [
+                  { "ItemCode": 100, "StackSize": 1 },
+                  { "Desc": "Auxiliary Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                ],
+                "ResultItems": [
+                  { "ItemCode": 100, "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.Recipes.Should().ContainKey("recipe_1");
+        var recipe = svc.Recipes["recipe_1"];
+        recipe.Ingredients.Should().HaveCount(2);
+
+        recipe.Ingredients[0].Should().BeOfType<RecipeItemIngredient>()
+            .Which.ItemCode.Should().Be(100);
+
+        var keyword = recipe.Ingredients[1].Should().BeOfType<RecipeKeywordIngredient>().Subject;
+        keyword.ItemKeys.Should().Equal(["Crystal"]);
+        keyword.Desc.Should().Be("Auxiliary Crystal");
+        keyword.StackSize.Should().Be(1);
+
+        // Catalog index picks up the new keyword from items.json.
+        svc.KeywordIndex.ItemsMatching(["Crystal"]).Select(i => i.InternalName)
+            .Should().BeEquivalentTo(["RoughCrystal"]);
+    }
+
+    [Fact]
     public void GetSnapshot_UnknownKey_Throws()
     {
         WriteBundled("""{}""", version: "v100");

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -189,6 +189,48 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void Recipe_item_source_resolves_recipeId_to_recipe_InternalName()
+    {
+        // sources_items.json carries recipeId numerically; the parser should look up
+        // the matching RecipeEntry and store its InternalName in ItemSource.Context.
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), """
+            {
+              "item_500": { "Name": "Tin Bar", "InternalName": "TinBar" }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.json"), """
+            {
+              "recipe_101": {
+                "Name": "Smelt Tin Bar",
+                "InternalName": "SmeltTinBar",
+                "Skill": "Smelting",
+                "SkillLevelReq": 5
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_items.json"), """
+            {
+              "item_500": {
+                "entries": [
+                  { "recipeId": 101, "type": "Recipe" }
+                ]
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.ItemSources.Should().ContainKey("TinBar");
+        var sources = svc.ItemSources["TinBar"];
+        sources.Should().ContainSingle();
+        sources[0].Type.Should().Be("Recipe");
+        sources[0].Context.Should().Be("SmeltTinBar"); // InternalName, not the raw id
+    }
+
+    [Fact]
     public void GetSnapshot_UnknownKey_Throws()
     {
         WriteBundled("""{}""", version: "v100");

--- a/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
@@ -113,13 +113,63 @@ public class IngredientSourcesViewModelTests
         var input = new IngredientSourcesInput("Iron Bar", null, "IronBar", []);
         var vm = IngredientSourcesViewModel.Build(input, refData);
 
-        vm.Sources.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(new
-            {
-                Kind = "Vendor",
-                Label = "Hulon the Huge",
-                AreaFriendlyName = "Serbule",
-            });
+        var source = vm.Sources.Should().ContainSingle().Subject;
+        source.Kind.Should().Be("Vendor");
+        source.Label.Should().Be("Hulon the Huge");
+        source.AreaFriendlyName.Should().Be("Serbule");
+        // Service has no MinFavorTier → no requirement line.
+        source.Requirement.Should().BeNull();
+    }
+
+    [Fact]
+    public void Vendor_source_surfaces_Store_service_MinFavorTier_as_Requirement()
+    {
+        // Hulon's Store service is gated on "Liked" favor; we should expose that.
+        var store = new NpcService(Type: "Store", MinFavorTier: "Liked", CapIncreases: []);
+        var npc = new NpcEntry("NPC_Hulon", "Hulon", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store]);
+        var refData = new StubRefData(
+            sources: new() { ["IronBar"] = [new ItemSource("Vendor", "NPC_Hulon", null)] },
+            npcs: new() { ["NPC_Hulon"] = npc });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Iron Bar", null, "IronBar", []), refData);
+
+        vm.Sources.Single().Requirement.Should().Be("Requires Liked or higher");
+    }
+
+    [Fact]
+    public void Barter_source_uses_Barter_service_for_Requirement_lookup()
+    {
+        // Same NPC has a Store at Neutral and a Barter at "Loved" — only the Barter gate
+        // applies for a Barter source. Confirms the service-type routing isn't conflated.
+        var store = new NpcService("Store", MinFavorTier: null, CapIncreases: []);
+        var barter = new NpcService("Barter", MinFavorTier: "Loved", CapIncreases: []);
+        var npc = new NpcEntry("NPC_Velkort", "Velkort", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store, barter]);
+        var refData = new StubRefData(
+            sources: new() { ["RareIngot"] = [new ItemSource("Barter", "NPC_Velkort", null)] },
+            npcs: new() { ["NPC_Velkort"] = npc });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Rare Ingot", null, "RareIngot", []), refData);
+
+        vm.Sources.Single().Requirement.Should().Be("Requires Loved or higher");
+    }
+
+    [Fact]
+    public void NpcGift_source_does_not_emit_per_npc_favor_Requirement()
+    {
+        // NpcGift gating lives on per-preference RequiredFavorTier, not per-NPC.
+        // The Sources tab line should not claim a vendor-style favor gate for gifts.
+        var store = new NpcService("Store", MinFavorTier: "Liked", CapIncreases: []);
+        var npc = new NpcEntry("NPC_Marna", "Marna", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store]);
+        var refData = new StubRefData(
+            sources: new() { ["GiftedItem"] = [new ItemSource("NpcGift", "NPC_Marna", null)] },
+            npcs: new() { ["NPC_Marna"] = npc });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Gifted Item", null, "GiftedItem", []), refData);
+
+        vm.Sources.Single().Requirement.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
@@ -209,6 +209,63 @@ public class IngredientSourcesViewModelTests
     }
 
     [Fact]
+    public void Single_skill_use_gate_renders_in_title_bar()
+    {
+        var item = new ItemEntry(
+            Id: 1, Name: "Cabbage Leafling", InternalName: "CabbageLeafling",
+            MaxStackSize: 50, IconId: 0, Keywords: [],
+            SkillReqs: new Dictionary<string, int> { ["Gardening"] = 10 });
+        var refData = new StubRefData(
+            itemsByInternalName: new() { ["CabbageLeafling"] = item });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Cabbage Leafling", null, "CabbageLeafling", []), refData);
+
+        vm.UseRequirement.Should().Be("Requires Gardening 10 to use");
+    }
+
+    [Fact]
+    public void Multi_skill_use_gate_renders_comma_joined_alphabetical()
+    {
+        var item = new ItemEntry(
+            Id: 2, Name: "Wolfen Speed Potion", InternalName: "WolfenSpeed",
+            MaxStackSize: 50, IconId: 0, Keywords: [],
+            SkillReqs: new Dictionary<string, int> { ["Werewolf"] = 35, ["Alchemy"] = 35 });
+        var refData = new StubRefData(
+            itemsByInternalName: new() { ["WolfenSpeed"] = item });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Wolfen Speed Potion", null, "WolfenSpeed", []), refData);
+
+        // Alphabetical ordering keeps the rendering stable across runs.
+        vm.UseRequirement.Should().Be("Requires Alchemy 35, Werewolf 35 to use");
+    }
+
+    [Fact]
+    public void Item_with_no_skill_requirements_has_null_UseRequirement()
+    {
+        var item = new ItemEntry(1, "Plain Item", "Plain", 50, 0, []);
+        var refData = new StubRefData(itemsByInternalName: new() { ["Plain"] = item });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Plain", null, "Plain", []), refData);
+
+        vm.UseRequirement.Should().BeNull();
+    }
+
+    [Fact]
+    public void Keyword_row_skips_UseRequirement()
+    {
+        // A keyword row has no single item to gate, even if some matching items have SkillReqs.
+        var refData = new StubRefData();
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Auxiliary Crystal", "any Crystal", ItemInternalName: null, OnHand: []),
+            refData);
+
+        vm.UseRequirement.Should().BeNull();
+    }
+
+    [Fact]
     public void Recipe_source_with_unresolved_context_falls_back_gracefully()
     {
         var refData = new StubRefData(
@@ -274,17 +331,19 @@ public class IngredientSourcesViewModelTests
             Dictionary<string, IReadOnlyList<ItemSource>>? sources = null,
             Dictionary<string, NpcEntry>? npcs = null,
             Dictionary<string, AreaEntry>? areas = null,
-            Dictionary<string, RecipeEntry>? recipesByInternalName = null)
+            Dictionary<string, RecipeEntry>? recipesByInternalName = null,
+            Dictionary<string, ItemEntry>? itemsByInternalName = null)
         {
             ItemSources = sources ?? new Dictionary<string, IReadOnlyList<ItemSource>>();
             Npcs = npcs ?? new Dictionary<string, NpcEntry>();
             Areas = areas ?? new Dictionary<string, AreaEntry>();
             RecipesByInternalName = recipesByInternalName ?? new Dictionary<string, RecipeEntry>();
+            ItemsByInternalName = itemsByInternalName ?? new Dictionary<string, ItemEntry>();
         }
 
         public IReadOnlyList<string> Keys => [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
-        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; }
         public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; }

--- a/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
@@ -156,6 +156,74 @@ public class IngredientSourcesViewModelTests
     }
 
     [Fact]
+    public void Recipe_source_renders_label_and_skill_gate()
+    {
+        var recipe = new RecipeEntry(
+            Key: "recipe_101",
+            Name: "Tin Bar",
+            InternalName: "TinBar",
+            IconId: 0,
+            Skill: "Smelting",
+            SkillLevelReq: 5,
+            RewardSkill: "Smelting",
+            RewardSkillXp: 10,
+            RewardSkillXpFirstTime: 0,
+            RewardSkillXpDropOffLevel: null,
+            RewardSkillXpDropOffPct: null,
+            RewardSkillXpDropOffRate: null,
+            Ingredients: [],
+            ResultItems: []);
+
+        var refData = new StubRefData(
+            sources: new() { ["TinBar"] = [new ItemSource("Recipe", null, "TinBar")] },
+            recipesByInternalName: new() { ["TinBar"] = recipe });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Tin Bar", null, "TinBar", []), refData);
+
+        var source = vm.Sources.Single();
+        source.Kind.Should().Be("Crafted");
+        source.Label.Should().Be("Tin Bar");
+        source.Requirement.Should().Be("Requires Smelting 5");
+        source.Detail.Should().BeNull();
+    }
+
+    [Fact]
+    public void Recipe_source_with_PrereqRecipe_surfaces_it_as_Detail()
+    {
+        var recipe = new RecipeEntry(
+            "recipe_500", "Advanced Bread", "AdvancedBread", 0,
+            "Cooking", 30, "Cooking", 50, 0, null, null, null,
+            Ingredients: [], ResultItems: [], PrereqRecipe: "BasicBread");
+
+        var refData = new StubRefData(
+            sources: new() { ["AdvancedBread"] = [new ItemSource("Recipe", null, "AdvancedBread")] },
+            recipesByInternalName: new() { ["AdvancedBread"] = recipe });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Advanced Bread", null, "AdvancedBread", []), refData);
+
+        var source = vm.Sources.Single();
+        source.Requirement.Should().Be("Requires Cooking 30");
+        source.Detail.Should().Be("prereq: BasicBread");
+    }
+
+    [Fact]
+    public void Recipe_source_with_unresolved_context_falls_back_gracefully()
+    {
+        var refData = new StubRefData(
+            sources: new() { ["X"] = [new ItemSource("Recipe", null, "UnknownRecipe")] });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("X", null, "X", []), refData);
+
+        var source = vm.Sources.Single();
+        source.Kind.Should().Be("Recipe");
+        source.Label.Should().Be("Crafted");
+        source.Requirement.Should().BeNull();
+    }
+
+    [Fact]
     public void NpcGift_source_does_not_emit_per_npc_favor_Requirement()
     {
         // NpcGift gating lives on per-preference RequiredFavorTier, not per-NPC.
@@ -205,11 +273,13 @@ public class IngredientSourcesViewModelTests
         public StubRefData(
             Dictionary<string, IReadOnlyList<ItemSource>>? sources = null,
             Dictionary<string, NpcEntry>? npcs = null,
-            Dictionary<string, AreaEntry>? areas = null)
+            Dictionary<string, AreaEntry>? areas = null,
+            Dictionary<string, RecipeEntry>? recipesByInternalName = null)
         {
             ItemSources = sources ?? new Dictionary<string, IReadOnlyList<ItemSource>>();
             Npcs = npcs ?? new Dictionary<string, NpcEntry>();
             Areas = areas ?? new Dictionary<string, AreaEntry>();
+            RecipesByInternalName = recipesByInternalName ?? new Dictionary<string, RecipeEntry>();
         }
 
         public IReadOnlyList<string> Keys => [];
@@ -217,7 +287,7 @@ public class IngredientSourcesViewModelTests
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
         public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
-        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; }
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; }

--- a/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
@@ -1,0 +1,190 @@
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+public class IngredientSourcesViewModelTests
+{
+    [Fact]
+    public void Single_item_row_groups_OnHand_by_location_and_sorts_items()
+    {
+        var input = new IngredientSourcesInput(
+            Title: "Iron Bar",
+            KeywordsLabel: null,
+            ItemInternalName: "IronBar",
+            OnHand:
+            [
+                new IngredientLocation("Inventory", 5, "IronBar", "Iron Bar", IconId: 100),
+                new IngredientLocation("Serbule Chest", 12, "IronBar", "Iron Bar", IconId: 100),
+            ]);
+
+        var vm = IngredientSourcesViewModel.Build(input, EmptyRefData.Instance);
+
+        vm.OnHand.Should().HaveCount(2);
+        vm.OnHandTotal.Should().Be(17);
+        // Larger location bucket sorts first.
+        vm.OnHand[0].Label.Should().Be("Serbule Chest");
+        vm.OnHand[0].TotalQuantity.Should().Be(12);
+        vm.OnHand[0].Items.Should().ContainSingle().Which.DisplayName.Should().Be("Iron Bar");
+    }
+
+    [Fact]
+    public void Keyword_row_collapses_per_item_breakdown_per_location()
+    {
+        // Two items keyworded Crystal, both stored in Serbule Chest, plus one in inventory.
+        var input = new IngredientSourcesInput(
+            Title: "Auxiliary Crystal",
+            KeywordsLabel: "any Crystal",
+            ItemInternalName: null,
+            OnHand:
+            [
+                new IngredientLocation("Serbule Chest", 47, "RoughCrystal", "Rough Crystal", 200),
+                new IngredientLocation("Serbule Chest", 33, "PolishedCrystal", "Polished Crystal", 201),
+                new IngredientLocation("Inventory", 12, "RoughCrystal", "Rough Crystal", 200),
+            ]);
+
+        var vm = IngredientSourcesViewModel.Build(input, EmptyRefData.Instance);
+
+        vm.OnHandTotal.Should().Be(92);
+        vm.OnHand.Should().HaveCount(2);
+        var serbule = vm.OnHand.Single(g => g.Label == "Serbule Chest");
+        serbule.TotalQuantity.Should().Be(80);
+        serbule.Items.Should().HaveCount(2);
+        // Items inside a bucket are sorted by quantity desc.
+        serbule.Items[0].DisplayName.Should().Be("Rough Crystal");
+        serbule.Items[0].Quantity.Should().Be(47);
+    }
+
+    [Fact]
+    public void Keyword_row_shows_placeholder_for_Sources()
+    {
+        var input = new IngredientSourcesInput("Auxiliary Crystal", "any Crystal", ItemInternalName: null, OnHand: []);
+        var vm = IngredientSourcesViewModel.Build(input, EmptyRefData.Instance);
+
+        vm.Sources.Should().BeEmpty();
+        vm.HasSourcesPlaceholder.Should().BeTrue();
+        vm.SourcesPlaceholder.Should().Contain("not aggregated yet");
+    }
+
+    [Fact]
+    public void Default_tab_is_OnHand_when_stock_exists()
+    {
+        var input = new IngredientSourcesInput(
+            Title: "Iron Bar",
+            KeywordsLabel: null,
+            ItemInternalName: "IronBar",
+            OnHand: [new IngredientLocation("Inventory", 5, "IronBar", "Iron Bar", 100)]);
+
+        var vm = IngredientSourcesViewModel.Build(input, EmptyRefData.Instance);
+
+        vm.SelectedTabIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void Default_tab_is_Sources_when_no_on_hand_stock()
+    {
+        var input = new IngredientSourcesInput("Iron Bar", null, "IronBar", []);
+        var vm = IngredientSourcesViewModel.Build(input, EmptyRefData.Instance);
+
+        vm.SelectedTabIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void Vendor_source_resolves_NPC_name_and_area()
+    {
+        var npc = new NpcEntry(
+            Key: "NPC_Hulon",
+            Name: "Hulon the Huge",
+            Area: "Serbule",
+            Preferences: [],
+            ItemGiftTiers: [],
+            Services: []);
+
+        var refData = new StubRefData(
+            sources: new()
+            {
+                ["IronBar"] = [new ItemSource("Vendor", "NPC_Hulon", null)],
+            },
+            npcs: new() { ["NPC_Hulon"] = npc });
+
+        var input = new IngredientSourcesInput("Iron Bar", null, "IronBar", []);
+        var vm = IngredientSourcesViewModel.Build(input, refData);
+
+        vm.Sources.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new
+            {
+                Kind = "Vendor",
+                Label = "Hulon the Huge",
+                AreaFriendlyName = "Serbule",
+            });
+    }
+
+    [Fact]
+    public void Monster_source_resolves_area_from_AreaCatalog_when_context_is_known()
+    {
+        var refData = new StubRefData(
+            sources: new()
+            {
+                ["DragonScale"] = [new ItemSource("Monster", null, "AreaGazluk")],
+            },
+            areas: new() { ["AreaGazluk"] = new AreaEntry("AreaGazluk", "Gazluk Plateau", "Gazluk") });
+
+        var input = new IngredientSourcesInput("Dragon Scale", null, "DragonScale", []);
+        var vm = IngredientSourcesViewModel.Build(input, refData);
+
+        var source = vm.Sources.Single();
+        source.Kind.Should().Be("Monster");
+        source.AreaFriendlyName.Should().Be("Gazluk Plateau");
+    }
+
+    [Fact]
+    public void Single_item_with_no_catalogued_sources_shows_placeholder()
+    {
+        var input = new IngredientSourcesInput("Mystery", null, "MysteryItem", []);
+        var vm = IngredientSourcesViewModel.Build(input, EmptyRefData.Instance);
+
+        vm.Sources.Should().BeEmpty();
+        vm.SourcesPlaceholder.Should().Contain("No vendor");
+    }
+
+    private sealed class StubRefData : IReferenceDataService
+    {
+        public StubRefData(
+            Dictionary<string, IReadOnlyList<ItemSource>>? sources = null,
+            Dictionary<string, NpcEntry>? npcs = null,
+            Dictionary<string, AreaEntry>? areas = null)
+        {
+            ItemSources = sources ?? new Dictionary<string, IReadOnlyList<ItemSource>>();
+            Npcs = npcs ?? new Dictionary<string, NpcEntry>();
+            Areas = areas ?? new Dictionary<string, AreaEntry>();
+        }
+
+        public IReadOnlyList<string> Keys => [];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; }
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; }
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; }
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+
+    private static class EmptyRefData
+    {
+        public static readonly StubRefData Instance = new();
+    }
+}

--- a/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
+++ b/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
@@ -160,6 +160,7 @@ public sealed class LiveInventoryViewModelTests
         public IReadOnlyList<string> Keys { get; } = ["items"];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _byName;
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
+++ b/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
@@ -166,6 +166,7 @@ public sealed class LiveInventoryViewModelTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Pippin.Tests/FoodCatalogTests.cs
+++ b/tests/Pippin.Tests/FoodCatalogTests.cs
@@ -107,6 +107,7 @@ public class FoodCatalogTests
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; }
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex => new(Items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Pippin.Tests/FoodCatalogTests.cs
+++ b/tests/Pippin.Tests/FoodCatalogTests.cs
@@ -113,6 +113,7 @@ public class FoodCatalogTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Pippin.Tests/GourmandStateMachineTests.cs
+++ b/tests/Pippin.Tests/GourmandStateMachineTests.cs
@@ -88,6 +88,7 @@ public class GourmandStateMachineTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Pippin.Tests/GourmandStateMachineTests.cs
+++ b/tests/Pippin.Tests/GourmandStateMachineTests.cs
@@ -82,6 +82,7 @@ public class GourmandStateMachineTests
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Samwise.Tests/GardenStateMachineTests.cs
+++ b/tests/Samwise.Tests/GardenStateMachineTests.cs
@@ -439,6 +439,7 @@ public class GardenStateMachineTests
         public IReadOnlyList<string> Keys { get; } = ["items"];
         public IReadOnlyDictionary<long, ItemEntry> Items => _items;
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _byName;
+        public ItemKeywordIndex KeywordIndex => new(_items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Samwise.Tests/GardenStateMachineTests.cs
+++ b/tests/Samwise.Tests/GardenStateMachineTests.cs
@@ -445,6 +445,7 @@ public class GardenStateMachineTests
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();

--- a/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
+++ b/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
@@ -203,6 +203,7 @@ public class TwoBarleyRegressionTest
         {
             ["BarleySeeds"] = new(10251, "Barley Seeds", "BarleySeeds", 100, 0, []),
         };
+        public ItemKeywordIndex KeywordIndex => new(Items);
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
+++ b/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
@@ -209,6 +209,7 @@ public class TwoBarleyRegressionTest
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();


### PR DESCRIPTION
## Summary

- **Parse keyword-matched recipe ingredients (ItemKeys).** ~1,645 enchanted (`*E`) recipes carry an auxiliary-crystal slot encoded as `{ "Desc": "Auxiliary Crystal", "ItemKeys": ["Crystal"] }`. The parser used to drop these, so the shopping list undercounted and pickers silently lost them. Adds a `RecipeIngredient` sealed hierarchy (`RecipeItemIngredient` / `RecipeKeywordIngredient`), an `ItemKeywordIndex` on `IReferenceDataService`, and per-keyword on-hand resolution. Aggregator dedupes keyword rows under a synthetic `#keys:...` key and renders an "any Crystal" label; Bilbo and Elrond pattern-match the new shape.
- **Pop-out Sources window with On-hand + Sources tabs.** Replaces the location-pin tooltip on the shopping list (which flattened to a 30+ line wall on keyword rows) with a clickable button that opens `IngredientSourcesWindow` — tabbed layout, location buckets with per-item breakdown, source resolution via NPCs/Areas. New `AreaCatalog` service in `Mithril.Shared`; `IngredientLocation` relocated to `Mithril.Shared.Storage` and extended with per-item identity fields.
- **Sources-tab enrichments.** Vendor/barter favor-tier gates (`NpcService.MinFavorTier` → "Requires Friends or higher"), recipe skill gates + prereq (`RecipeEntry.Skill/SkillLevelReq/PrereqRecipe`), and item-side use-gate hint (`ItemEntry.SkillReqs` rendered as an amber title-bar sub-line, comma-joined alphabetically for multi-skill gates). Fixes camelCase mismatch where `recipeId` wasn't being parsed from `sources_items.json`.
- **Roadmap updates** through `docs/celebrimbor-roadmap.md` reflecting what shipped vs. what's still deferred (quest source resolution, keyword-row Sources rendering, active-character gate evaluation) vs. what's blocked on upstream data (monster identity on Monster/Angling sources).
- **Legolas XAML fix.** `BgPrimaryBrush` lookup deferred to runtime via `DynamicResource` — `StaticResource` was failing during shell startup before merged dictionaries loaded.

## Test plan

- [ ] `dotnet build Mithril.slnx` clean
- [ ] `dotnet test Mithril.slnx` passes (new coverage in `Mithril.Shared.Tests/Reference/ItemKeywordIndexTests`, `Mithril.Shared.Tests/Reference/AreaCatalogParseTests`, `Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests`, expanded `Celebrimbor.Tests/RecipeAggregatorTests` and `Bilbo.Tests/CraftableRecipeCalculatorTests`)
- [ ] Open Celebrimbor shopping list with an enchanted recipe selected — verify "any Crystal" row appears and shopping list count includes it
- [ ] Click the location pin on a shopping-list row — Sources window opens with On-hand tab default when stock exists, Sources tab default otherwise
- [ ] Sources tab shows favor-tier requirement on a vendor/barter row, recipe skill + prereq on a Recipe row, and amber use-gate sub-line under the title for an item with `SkillReqs`
- [ ] Open Legolas tab from a cold shell start — no XAML resource exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)