### PR TITLE
MithrilLogMcp: token-efficient log analysis MCP server + shared regex catalog

### DIFF
--- a/docs/user-guide/arwen.md
+++ b/docs/user-guide/arwen.md
@@ -72,7 +72,7 @@ are merged for each tier:
 - **Local only** — never use community data.
 
 Community rates are pulled from
-[github.com/arthur-conde/gorgon-calibration](https://github.com/arthur-conde/gorgon-calibration)
+[github.com/arthur-conde/mithril-calibration](https://github.com/arthur-conde/mithril-calibration)
 and refreshed in the background.
 
 ## 4. Stackable items and the pending queue

--- a/src/Mithril.Shared/Diagnostics/SerilogDiagnosticsSink.cs
+++ b/src/Mithril.Shared/Diagnostics/SerilogDiagnosticsSink.cs
@@ -20,6 +20,7 @@ public sealed class SerilogDiagnosticsSink : IDiagnosticsSink, IDisposable
     {
         _inner = inner;
         Directory.CreateDirectory(logDirectory);
+        MigrateLegacyLogFiles(_inner, logDirectory);
         // Desktop-app rolling policy: roll daily AND on size cap so a single
         // long session can't silently exceed the cap and stop logging (the
         // pre-rollOnFileSizeLimit default behaviour). 50 MB per file × 30
@@ -65,4 +66,73 @@ public sealed class SerilogDiagnosticsSink : IDiagnosticsSink, IDisposable
     };
 
     public void Dispose() => _logger.Dispose();
+
+    /// <summary>
+    /// Renames pre-rebrand <c>gorgon-*.json</c> diagnostic files to <c>mithril-*.json</c>.
+    /// The shell was renamed from "Gorgon" to "Mithril" in commit 8f91ebf, but the rolling
+    /// file path was not updated until this method was added — leaving a generation of
+    /// per-day diagnostic files on existing installs under the old prefix. Running once
+    /// at sink construction normalises the on-disk state so downstream tools (the
+    /// MithrilLogMcp server, ad-hoc analysis) only need to handle a single prefix.
+    /// </summary>
+    /// <remarks>
+    /// Always renames into <c>mithril-{rest}-prebrand.json</c> rather than just
+    /// <c>mithril-{rest}.json</c> — there are real installs where both prefixes exist
+    /// for the same date, and a direct rename would clash. The <c>-prebrand</c> suffix
+    /// is unambiguous, idempotent, and guaranteed not to collide with the active rolling
+    /// path (which never produces that suffix). Failures on individual files are logged
+    /// to the inner sink and do not break logger construction.
+    /// </remarks>
+    internal static void MigrateLegacyLogFiles(IDiagnosticsSink diagnostics, string logDirectory)
+    {
+        IEnumerable<string> legacy;
+        try
+        {
+            legacy = Directory.EnumerateFiles(logDirectory, "gorgon-*.json", SearchOption.TopDirectoryOnly);
+        }
+        catch (Exception ex)
+        {
+            diagnostics.Write(DiagnosticLevel.Warn, "SerilogSink",
+                $"Could not enumerate legacy log files in {logDirectory}: {ex.Message}");
+            return;
+        }
+
+        foreach (var src in legacy)
+        {
+            try
+            {
+                var fileName = Path.GetFileName(src);
+                // "gorgon-".Length == 7
+                var rest = fileName.Substring("gorgon-".Length);
+                var stem = Path.GetFileNameWithoutExtension(rest);
+                var ext = Path.GetExtension(rest);
+
+                var target = ResolveNonClashingTarget(logDirectory, stem, ext);
+                File.Move(src, target);
+                diagnostics.Write(DiagnosticLevel.Info, "SerilogSink",
+                    $"Renamed legacy log file {fileName} -> {Path.GetFileName(target)}");
+            }
+            catch (Exception ex)
+            {
+                diagnostics.Write(DiagnosticLevel.Warn, "SerilogSink",
+                    $"Failed to migrate legacy log file {src}: {ex.Message}");
+            }
+        }
+    }
+
+    private static string ResolveNonClashingTarget(string logDirectory, string stem, string ext)
+    {
+        var primary = Path.Combine(logDirectory, $"mithril-{stem}-prebrand{ext}");
+        if (!File.Exists(primary)) return primary;
+
+        for (var i = 1; i < 1000; i++)
+        {
+            var candidate = Path.Combine(logDirectory, $"mithril-{stem}-prebrand_{i:D3}{ext}");
+            if (!File.Exists(candidate)) return candidate;
+        }
+        // Pathological: 1000 prior attempts already exist. Fall back to a timestamp
+        // so the rename still succeeds rather than silently dropping the file.
+        var ticks = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        return Path.Combine(logDirectory, $"mithril-{stem}-prebrand_{ticks}{ext}");
+    }
 }

--- a/src/Mithril.Shared/Logging/LogPatternCatalog.cs
+++ b/src/Mithril.Shared/Logging/LogPatternCatalog.cs
@@ -1,0 +1,105 @@
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Loads <c>Reference/log-patterns.json</c> — the single source of truth for every
+/// log-line regex used by parsers in the Mithril modules and downstream tools
+/// (e.g. <c>tools/MithrilLogMcp</c>).
+///
+/// The .NET parsers keep their <c>[GeneratedRegex]</c> attributes for
+/// source-generated perf (Roslyn requires literal pattern strings, so it cannot
+/// read from JSON at compile time). Parity is enforced by
+/// <c>LogPatternCatalogParityTests</c>, which asserts every catalog entry
+/// matches the C# attribute character-for-character. The TS port loads the same
+/// JSON at runtime.
+/// </summary>
+public static class LogPatternCatalog
+{
+    private const string ResourceName = "Mithril.Shared.Reference.log-patterns.json";
+
+    private static readonly Lazy<LogPatternCatalogDocument> s_document = new(LoadFromAssembly);
+
+    public static LogPatternCatalogDocument Current => s_document.Value;
+
+    public static LogPatternEntry GetEntry(string key) =>
+        Current.Regexes.TryGetValue(key, out var entry)
+            ? entry
+            : throw new KeyNotFoundException($"log-patterns.json has no entry for key '{key}'.");
+
+    public static string GetPattern(string key) => GetEntry(key).Pattern;
+
+    private static LogPatternCatalogDocument LoadFromAssembly()
+    {
+        var asm = typeof(LogPatternCatalog).Assembly;
+        using var stream = asm.GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{ResourceName}' not found in {asm.FullName}.");
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+        return JsonSerializer.Deserialize<LogPatternCatalogDocument>(json, options)
+            ?? throw new InvalidOperationException("log-patterns.json deserialised as null.");
+    }
+}
+
+public sealed class LogPatternCatalogDocument
+{
+    [JsonPropertyName("version")] public int Version { get; init; }
+    [JsonPropertyName("regexes")] public IReadOnlyDictionary<string, LogPatternEntry> Regexes { get; init; } = new Dictionary<string, LogPatternEntry>();
+    [JsonPropertyName("shared")] public LogPatternSharedSection? Shared { get; init; }
+}
+
+public sealed class LogPatternEntry
+{
+    [JsonPropertyName("pattern")] public string Pattern { get; init; } = "";
+    [JsonPropertyName("source")] public string Source { get; init; } = "";
+    [JsonPropertyName("module")] public string Module { get; init; } = "";
+    [JsonPropertyName("csharp")] public LogPatternCSharpRef? CSharp { get; init; }
+    [JsonPropertyName("eventType")] public string? EventType { get; init; }
+    [JsonPropertyName("kind")] public string? Kind { get; init; }
+    [JsonPropertyName("flags")] public IReadOnlyList<string>? Flags { get; init; }
+    [JsonPropertyName("notes")] public string? Notes { get; init; }
+    [JsonPropertyName("fields")] public IReadOnlyList<LogPatternField> Fields { get; init; } = Array.Empty<LogPatternField>();
+}
+
+public sealed class LogPatternCSharpRef
+{
+    [JsonPropertyName("type")] public string Type { get; init; } = "";
+    [JsonPropertyName("method")] public string Method { get; init; } = "";
+    [JsonPropertyName("options")] public IReadOnlyList<string>? Options { get; init; }
+}
+
+public sealed class LogPatternField
+{
+    [JsonPropertyName("name")] public string Name { get; init; } = "";
+    [JsonPropertyName("group")] public JsonElement Group { get; init; }
+    [JsonPropertyName("type")] public string Type { get; init; } = "string";
+}
+
+public sealed class LogPatternSharedSection
+{
+    [JsonPropertyName("sessionMarker")] public LogPatternSessionMarker? SessionMarker { get; init; }
+    [JsonPropertyName("playerLogTimestampPrefix")] public LogPatternTimestampPrefix? PlayerLogTimestampPrefix { get; init; }
+}
+
+public sealed class LogPatternSessionMarker
+{
+    [JsonPropertyName("literal")] public string Literal { get; init; } = "";
+    [JsonPropertyName("scanChunkBytes")] public long ScanChunkBytes { get; init; }
+    [JsonPropertyName("notes")] public string? Notes { get; init; }
+}
+
+public sealed class LogPatternTimestampPrefix
+{
+    [JsonPropertyName("regex")] public string Regex { get; init; } = "";
+    [JsonPropertyName("notes")] public string? Notes { get; init; }
+}

--- a/src/Mithril.Shared/Mithril.Shared.csproj
+++ b/src/Mithril.Shared/Mithril.Shared.csproj
@@ -19,6 +19,7 @@
     <Content Include="Reference\BundledData\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Reference\log-patterns.json" LogicalName="Mithril.Shared.Reference.log-patterns.json" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Icons\placeholder.png" />

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -1,0 +1,341 @@
+{
+  "$comment": "Single source of truth for log-line regexes shared between Mithril (.NET) and downstream tools (e.g. tools/MithrilLogMcp). Each entry mirrors a [GeneratedRegex] attribute in the listed C# method; LogPatternCatalogParityTests asserts they remain identical. Adding a new pattern: add an entry here AND apply the same string to a [GeneratedRegex] attribute. Removing or editing a pattern: change both sides in the same commit.",
+  "version": 1,
+  "regexes": {
+    "samwise.GardenLogParser.SetPetOwnerRx": {
+      "pattern": "LocalPlayer: ProcessSetPetOwner\\((\\d+),",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "SetPetOwnerRx" },
+      "eventType": "samwise.SetPetOwner",
+      "fields": [
+        { "name": "entityId", "group": 1, "type": "string" }
+      ]
+    },
+    "samwise.GardenLogParser.AppearanceRx": {
+      "pattern": "Download appearance loop @(\\w+)\\(scale=([\\d.]+)\\)",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "AppearanceRx" },
+      "eventType": "samwise.AppearanceLoop",
+      "fields": [
+        { "name": "modelName", "group": 1, "type": "string" },
+        { "name": "scale", "group": 2, "type": "double" }
+      ]
+    },
+    "samwise.GardenLogParser.UpdateDescRx": {
+      "pattern": "ProcessUpdateDescription\\((\\d+),\\s*\"([^\"]+)\",\\s*\"([^\"]+)\",\\s*\"([^\"]+)\",\\s*\\w+,\\s*\"\\w+\\(Scale=([\\d.]+)\\)\",\\s*\\d+\\)",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "UpdateDescRx" },
+      "eventType": "samwise.UpdateDescription",
+      "fields": [
+        { "name": "plotId", "group": 1, "type": "string" },
+        { "name": "title", "group": 2, "type": "string" },
+        { "name": "description", "group": 3, "type": "string" },
+        { "name": "action", "group": 4, "type": "string" },
+        { "name": "scale", "group": 5, "type": "double" }
+      ]
+    },
+    "samwise.GardenLogParser.StartInteractRx": {
+      "pattern": "ProcessStartInteraction\\((\\d+),\\s*\\d+,\\s*[\\d.-]+,\\s*\\w+,\\s*\"(Summoned\\w+)\"\\)",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "StartInteractRx" },
+      "eventType": "samwise.StartInteraction",
+      "notes": "Same root verb as arwen.FavorLogParser.StartInteractionRx and smaug.VendorLogParser.StartInteractionRx, but constrained to plant targets (\"Summoned*\").",
+      "fields": [
+        { "name": "plotId", "group": 1, "type": "string" },
+        { "name": "target", "group": 2, "type": "string" }
+      ]
+    },
+    "samwise.GardenLogParser.UpdateItemCodeRx": {
+      "pattern": "ProcessUpdateItemCode\\((\\d+)",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "UpdateItemCodeRx" },
+      "eventType": "samwise.UpdateItemCode",
+      "fields": [
+        { "name": "itemId", "group": 1, "type": "string" }
+      ]
+    },
+    "samwise.GardenLogParser.GardeningXpRx": {
+      "pattern": "ProcessUpdateSkill.*type=Gardening",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "GardeningXpRx" },
+      "eventType": "samwise.GardeningXp",
+      "kind": "marker",
+      "notes": "IsMatch-only; produces a payload-less GardeningXp event.",
+      "fields": []
+    },
+    "samwise.GardenLogParser.ScreenTextErrorRx": {
+      "pattern": "ProcessScreenText.*ErrorMessage",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "ScreenTextErrorRx" },
+      "eventType": "samwise.ScreenTextError",
+      "kind": "marker",
+      "fields": []
+    },
+    "samwise.GardenLogParser.PlantingCapRx": {
+      "pattern": "ProcessErrorMessage\\(ItemUnusable,\\s*\"([^\"]+?) can't be used: You already have the maximum of that type of plant growing\"",
+      "source": "player",
+      "module": "samwise",
+      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "PlantingCapRx" },
+      "eventType": "samwise.PlantingCapReached",
+      "fields": [
+        { "name": "seedDisplayName", "group": 1, "type": "string" }
+      ]
+    },
+    "arwen.FavorLogParser.StartInteractionRx": {
+      "pattern": "ProcessStartInteraction\\((\\d+),\\s*\\d+,\\s*([\\d.-]+),\\s*\\w+,\\s*\"(NPC_\\w+)\"\\)",
+      "source": "player",
+      "module": "arwen",
+      "csharp": { "type": "Arwen.Parsing.FavorLogParser", "method": "StartInteractionRx" },
+      "eventType": "arwen.FavorUpdate",
+      "fields": [
+        { "name": "entityId", "group": 1, "type": "long" },
+        { "name": "absoluteFavor", "group": 2, "type": "double" },
+        { "name": "npcKey", "group": 3, "type": "string" }
+      ]
+    },
+    "arwen.FavorLogParser.DeltaFavorRx": {
+      "pattern": "ProcessDeltaFavor\\(\\d+,\\s*\"(NPC_\\w+)\",\\s*([\\d.-]+),\\s*\\w+\\)",
+      "source": "player",
+      "module": "arwen",
+      "csharp": { "type": "Arwen.Parsing.FavorLogParser", "method": "DeltaFavorRx" },
+      "eventType": "arwen.FavorDelta",
+      "fields": [
+        { "name": "npcKey", "group": 1, "type": "string" },
+        { "name": "delta", "group": 2, "type": "double" }
+      ]
+    },
+    "arwen.FavorLogParser.DeleteItemRx": {
+      "pattern": "ProcessDeleteItem\\((\\d+)\\)",
+      "source": "player",
+      "module": "arwen",
+      "csharp": { "type": "Arwen.Parsing.FavorLogParser", "method": "DeleteItemRx" },
+      "eventType": "arwen.ItemDeleted",
+      "fields": [
+        { "name": "instanceId", "group": 1, "type": "long" }
+      ]
+    },
+    "smaug.VendorLogParser.VendorScreenRx": {
+      "pattern": "ProcessVendorScreen\\((-?\\d+),\\s*(\\w+),\\s*(-?\\d+),\\s*(\\d+),\\s*(\\d+),",
+      "source": "player",
+      "module": "smaug",
+      "csharp": { "type": "Smaug.Parsing.VendorLogParser", "method": "VendorScreenRx" },
+      "eventType": "smaug.VendorScreenOpened",
+      "fields": [
+        { "name": "entityId", "group": 1, "type": "int" },
+        { "name": "favorTier", "group": 2, "type": "string" },
+        { "name": "remainingGold", "group": 3, "type": "long" },
+        { "name": "_resetCounter", "group": 4, "type": "long" },
+        { "name": "goldCap", "group": 5, "type": "long" }
+      ]
+    },
+    "smaug.VendorLogParser.VendorAddItemRx": {
+      "pattern": "ProcessVendorAddItem\\((\\d+),\\s*(\\w+)\\((\\d+)\\),",
+      "source": "player",
+      "module": "smaug",
+      "csharp": { "type": "Smaug.Parsing.VendorLogParser", "method": "VendorAddItemRx" },
+      "eventType": "smaug.VendorItemSold",
+      "fields": [
+        { "name": "price", "group": 1, "type": "long" },
+        { "name": "internalName", "group": 2, "type": "string" },
+        { "name": "instanceId", "group": 3, "type": "long" }
+      ]
+    },
+    "smaug.VendorLogParser.VendorGoldRx": {
+      "pattern": "ProcessVendorUpdateAvailableGold\\((\\d+),\\s*(\\d+),\\s*(\\d+)\\)",
+      "source": "player",
+      "module": "smaug",
+      "csharp": { "type": "Smaug.Parsing.VendorLogParser", "method": "VendorGoldRx" },
+      "eventType": "smaug.VendorGoldUpdated",
+      "fields": [
+        { "name": "remainingGold", "group": 1, "type": "long" },
+        { "name": "_resetCounter", "group": 2, "type": "long" },
+        { "name": "goldCap", "group": 3, "type": "long" }
+      ]
+    },
+    "smaug.VendorLogParser.StartInteractionRx": {
+      "pattern": "ProcessStartInteraction\\((\\d+),\\s*\\d+,\\s*[\\d.-]+,\\s*\\w+,\\s*\"(NPC_\\w+)\"\\)",
+      "source": "player",
+      "module": "smaug",
+      "csharp": { "type": "Smaug.Parsing.VendorLogParser", "method": "StartInteractionRx" },
+      "eventType": "smaug.NpcInteractionStarted",
+      "notes": "Same shape as arwen.FavorLogParser.StartInteractionRx — both runtimes can dedupe at parse time if desired.",
+      "fields": [
+        { "name": "entityId", "group": 1, "type": "int" },
+        { "name": "npcKey", "group": 2, "type": "string" }
+      ]
+    },
+    "smaug.VendorLogParser.CivicPrideRx": {
+      "pattern": "\\{type=CivicPride,raw=(\\d+),bonus=(\\d+),",
+      "source": "player",
+      "module": "smaug",
+      "csharp": { "type": "Smaug.Parsing.VendorLogParser", "method": "CivicPrideRx" },
+      "eventType": "smaug.CivicPrideUpdated",
+      "fields": [
+        { "name": "raw", "group": 1, "type": "int" },
+        { "name": "bonus", "group": 2, "type": "int" }
+      ]
+    },
+    "pippin.GourmandLogParser.ProcessBookFoodsRx": {
+      "pattern": "LocalPlayer:\\s*ProcessBook\\(\"Skill Info\",\\s*\"(Foods Consumed:\\\\n\\\\n(?:[^\"\\\\]|\\\\.)*)\".*\"SkillReport\"",
+      "source": "player",
+      "module": "pippin",
+      "csharp": { "type": "Pippin.Parsing.GourmandLogParser", "method": "ProcessBookFoodsRx" },
+      "eventType": "pippin.FoodsConsumedReport",
+      "kind": "compound",
+      "notes": "Outer match captures the full Foods Consumed report body; entries inside are extracted by FoodEntryRx after splitting on literal \\n (two-char escape).",
+      "fields": [
+        { "name": "body", "group": 1, "type": "string" }
+      ]
+    },
+    "pippin.GourmandLogParser.FoodEntryRx": {
+      "pattern": "^\\s+(.+?)(?:\\s+\\(([^)]+)\\))?\\s*:\\s*(\\d+)$",
+      "source": "player",
+      "module": "pippin",
+      "csharp": { "type": "Pippin.Parsing.GourmandLogParser", "method": "FoodEntryRx" },
+      "kind": "helper",
+      "notes": "Sub-pattern applied to each entry line of the Foods Consumed report body.",
+      "fields": [
+        { "name": "name", "group": 1, "type": "string" },
+        { "name": "tags", "group": 2, "type": "string" },
+        { "name": "count", "group": 3, "type": "int" }
+      ]
+    },
+    "saruman.WordOfPowerChatParser.ChatLineRx": {
+      "pattern": "^\\d{2}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}:\\d{2}\\s*\\t\\s*\\[[^\\]]+\\]\\s*(?<speaker>[^:]+?)\\s*:\\s*(?<msg>.*)$",
+      "source": "chat",
+      "module": "saruman",
+      "csharp": { "type": "Saruman.Parsing.WordOfPowerChatParser", "method": "ChatLineRx" },
+      "kind": "helper",
+      "notes": "Splits a chat line into speaker + message; codebook-validated upper-token match decides whether to emit.",
+      "fields": [
+        { "name": "speaker", "group": "speaker", "type": "string" },
+        { "name": "msg", "group": "msg", "type": "string" }
+      ]
+    },
+    "saruman.WordOfPowerChatParser.UpperTokenRx": {
+      "pattern": "\\b[A-Z]{4,}\\b",
+      "source": "chat",
+      "module": "saruman",
+      "csharp": { "type": "Saruman.Parsing.WordOfPowerChatParser", "method": "UpperTokenRx" },
+      "kind": "helper",
+      "notes": "Match-all upper-token scanner; downstream code validates each match against SarumanCodebookService before emitting saruman.WordOfPowerSpoken.",
+      "fields": [
+        { "name": "token", "group": 0, "type": "string" }
+      ]
+    },
+    "saruman.WordOfPowerDiscoveredParser.DiscoveryRx": {
+      "pattern": "LocalPlayer:\\s*ProcessBook\\(\"You discovered a word of power!\",\\s*\"You've discovered a word of power: <sel>(?<code>[A-Z]+)</sel>.*?<b><size=125%>Word of Power: (?<effect>[^<]+)</size></b>\\\\n(?<desc>.+?)\\\\n\\\\n<i>",
+      "source": "player",
+      "module": "saruman",
+      "csharp": { "type": "Saruman.Parsing.WordOfPowerDiscoveredParser", "method": "DiscoveryRx" },
+      "eventType": "saruman.WordOfPowerDiscovered",
+      "notes": "ProcessBook newlines are encoded as literal \\n (backslash + n), so the pattern carries \\\\n.",
+      "fields": [
+        { "name": "code", "group": "code", "type": "string" },
+        { "name": "effect", "group": "effect", "type": "string" },
+        { "name": "desc", "group": "desc", "type": "string" }
+      ]
+    },
+    "legolas.ChatLogParser.SurveyRegex": {
+      "pattern": "\\[Status\\] The (?<name>.+?) is (?<a>\\d+)m (?<aDir>north|south|east|west) and (?<b>\\d+)m (?<bDir>north|south|east|west)\\b",
+      "source": "chat",
+      "module": "legolas",
+      "csharp": {
+        "type": "Legolas.Services.ChatLogParser",
+        "method": "SurveyRegex",
+        "options": ["Compiled", "CultureInvariant", "IgnoreCase"]
+      },
+      "eventType": "legolas.SurveyDetected",
+      "flags": ["i"],
+      "fields": [
+        { "name": "name", "group": "name", "type": "string" },
+        { "name": "a", "group": "a", "type": "int" },
+        { "name": "aDir", "group": "aDir", "type": "string" },
+        { "name": "b", "group": "b", "type": "int" },
+        { "name": "bDir", "group": "bDir", "type": "string" }
+      ]
+    },
+    "legolas.ChatLogParser.CollectRegex": {
+      "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+(?:x(?<count>\\d+)\\s+)?collected!",
+      "source": "chat",
+      "module": "legolas",
+      "csharp": {
+        "type": "Legolas.Services.ChatLogParser",
+        "method": "CollectRegex",
+        "options": ["Compiled", "CultureInvariant"]
+      },
+      "eventType": "legolas.ItemCollected",
+      "fields": [
+        { "name": "name", "group": "name", "type": "string" },
+        { "name": "count", "group": "count", "type": "int" }
+      ]
+    },
+    "legolas.ChatLogParser.MotherlodeRegex": {
+      "pattern": "The treasure is (?<dist>\\d+) metres from here",
+      "source": "chat",
+      "module": "legolas",
+      "csharp": {
+        "type": "Legolas.Services.ChatLogParser",
+        "method": "MotherlodeRegex",
+        "options": ["Compiled", "CultureInvariant"]
+      },
+      "eventType": "legolas.MotherlodeDistance",
+      "fields": [
+        { "name": "dist", "group": "dist", "type": "int" }
+      ]
+    },
+    "shared.InventoryStatusChatParser.CountedRx": {
+      "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+x(?<count>\\d+)\\s+added to inventory\\.",
+      "source": "chat",
+      "module": "shared",
+      "csharp": { "type": "Mithril.Shared.Inventory.InventoryStatusChatParser", "method": "CountedRx" },
+      "eventType": "shared.InventoryAdded",
+      "notes": "Counted form must be tried before SingleRx so 'Guava x42 added to inventory.' doesn't match with name='Guava x42'.",
+      "fields": [
+        { "name": "name", "group": "name", "type": "string" },
+        { "name": "count", "group": "count", "type": "int" }
+      ]
+    },
+    "shared.InventoryStatusChatParser.SingleRx": {
+      "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+added to inventory\\.",
+      "source": "chat",
+      "module": "shared",
+      "csharp": { "type": "Mithril.Shared.Inventory.InventoryStatusChatParser", "method": "SingleRx" },
+      "eventType": "shared.InventoryAdded",
+      "notes": "Implicit count = 1.",
+      "fields": [
+        { "name": "name", "group": "name", "type": "string" }
+      ]
+    },
+    "shared.ActiveCharacterLogSynchronizer.AddPlayerRx": {
+      "pattern": "LocalPlayer:\\s*ProcessAddPlayer\\([^,]+,\\s*[^,]+,\\s*\"[^\"]*\",\\s*\"([^\"]+)\"",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.Shared.Character.ActiveCharacterLogSynchronizer", "method": "AddPlayerRx" },
+      "eventType": "shared.ProcessAddPlayer",
+      "kind": "session-marker",
+      "notes": "Drives active-character tracking and is the session-start marker for tail readers; also matches the literal scanned by PlayerLogTailReader.SeedToSessionStart.",
+      "fields": [
+        { "name": "characterName", "group": 1, "type": "string" }
+      ]
+    }
+  },
+  "shared": {
+    "sessionMarker": {
+      "literal": "ProcessAddPlayer(",
+      "scanChunkBytes": 10485760,
+      "notes": "Mirrors PlayerLogTailReader.SessionMarker / SessionScanChunkBytes."
+    },
+    "playerLogTimestampPrefix": {
+      "regex": "^\\[(\\d{2}:\\d{2}:\\d{2})\\]\\s",
+      "notes": "Per-line timestamp; date is inferred from file mtime or the most recent dated header line."
+    }
+  }
+}

--- a/tests/Mithril.Shared.Tests/Diagnostics/SerilogDiagnosticsSinkMigrationTests.cs
+++ b/tests/Mithril.Shared.Tests/Diagnostics/SerilogDiagnosticsSinkMigrationTests.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Diagnostics;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Diagnostics;
+
+/// <summary>
+/// Pre-rebrand Serilog rolling files were named <c>gorgon-*.json</c>; the prefix
+/// changed to <c>mithril-</c> in the rebrand commit but on-disk files persisted.
+/// These tests pin the migration that happens at sink construction.
+/// </summary>
+public class SerilogDiagnosticsSinkMigrationTests
+{
+    private sealed class CapturingSink : IDiagnosticsSink
+    {
+        public List<(DiagnosticLevel Level, string Category, string Message)> Entries { get; } = new();
+        public void Write(DiagnosticLevel level, string category, string message) =>
+            Entries.Add((level, category, message));
+        public IReadOnlyList<DiagnosticEntry> Snapshot() => Array.Empty<DiagnosticEntry>();
+        public event EventHandler<DiagnosticEntry>? EntryAdded { add { } remove { } }
+    }
+
+    private static string FreshDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mithril-sink-migration-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Renames_Legacy_Files_To_Mithril_Prefix()
+    {
+        var dir = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "gorgon-20260415.json"), "x");
+            File.WriteAllText(Path.Combine(dir, "gorgon-20260416_001.json"), "y");
+            var diag = new CapturingSink();
+
+            SerilogDiagnosticsSink.MigrateLegacyLogFiles(diag, dir);
+
+            File.Exists(Path.Combine(dir, "gorgon-20260415.json")).Should().BeFalse();
+            File.Exists(Path.Combine(dir, "gorgon-20260416_001.json")).Should().BeFalse();
+            File.Exists(Path.Combine(dir, "mithril-20260415-prebrand.json")).Should().BeTrue();
+            File.Exists(Path.Combine(dir, "mithril-20260416_001-prebrand.json")).Should().BeTrue();
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Does_Not_Clash_With_Existing_Mithril_File_For_Same_Date()
+    {
+        // The real reason -prebrand exists: on at least one install, gorgon-20260425.json
+        // and mithril-20260425.json both exist on disk for the same date.
+        var dir = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "gorgon-20260425.json"), "old");
+            File.WriteAllText(Path.Combine(dir, "mithril-20260425.json"), "new");
+            var diag = new CapturingSink();
+
+            SerilogDiagnosticsSink.MigrateLegacyLogFiles(diag, dir);
+
+            File.Exists(Path.Combine(dir, "gorgon-20260425.json")).Should().BeFalse();
+            File.Exists(Path.Combine(dir, "mithril-20260425.json")).Should().BeTrue();
+            File.Exists(Path.Combine(dir, "mithril-20260425-prebrand.json")).Should().BeTrue();
+            File.ReadAllText(Path.Combine(dir, "mithril-20260425.json")).Should().Be("new");
+            File.ReadAllText(Path.Combine(dir, "mithril-20260425-prebrand.json")).Should().Be("old");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Disambiguates_When_Prebrand_Target_Also_Exists()
+    {
+        var dir = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "gorgon-20260425.json"), "old");
+            File.WriteAllText(Path.Combine(dir, "mithril-20260425-prebrand.json"), "previous-attempt");
+            var diag = new CapturingSink();
+
+            SerilogDiagnosticsSink.MigrateLegacyLogFiles(diag, dir);
+
+            File.Exists(Path.Combine(dir, "gorgon-20260425.json")).Should().BeFalse();
+            File.Exists(Path.Combine(dir, "mithril-20260425-prebrand.json")).Should().BeTrue();
+            File.Exists(Path.Combine(dir, "mithril-20260425-prebrand_001.json")).Should().BeTrue();
+            File.ReadAllText(Path.Combine(dir, "mithril-20260425-prebrand.json")).Should().Be("previous-attempt");
+            File.ReadAllText(Path.Combine(dir, "mithril-20260425-prebrand_001.json")).Should().Be("old");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Is_Idempotent_When_No_Legacy_Files_Present()
+    {
+        var dir = FreshDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "mithril-20260425.json"), "new");
+            var diag = new CapturingSink();
+
+            SerilogDiagnosticsSink.MigrateLegacyLogFiles(diag, dir);
+            SerilogDiagnosticsSink.MigrateLegacyLogFiles(diag, dir); // run twice
+
+            File.Exists(Path.Combine(dir, "mithril-20260425.json")).Should().BeTrue();
+            // No warnings emitted — only the optional info log on actual renames.
+            diag.Entries.Should().NotContain(e => e.Level == DiagnosticLevel.Warn);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Logs_Warning_If_Directory_Missing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mithril-sink-missing-{Guid.NewGuid():N}");
+        var diag = new CapturingSink();
+
+        SerilogDiagnosticsSink.MigrateLegacyLogFiles(diag, dir);
+
+        diag.Entries.Should().Contain(e =>
+            e.Level == DiagnosticLevel.Warn && e.Category == "SerilogSink");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Logging/LogPatternCatalogParityTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/LogPatternCatalogParityTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Logging;
+
+/// <summary>
+/// Asserts that every entry in <c>log-patterns.json</c> matches the
+/// corresponding C# <c>[GeneratedRegex]</c> attribute character-for-character.
+/// This is the contract that lets the TS port (<c>tools/MithrilLogMcp</c>) read
+/// the JSON and stay in lockstep with the Mithril parsers.
+/// </summary>
+public class LogPatternCatalogParityTests
+{
+    [Fact]
+    public void Every_Catalog_Entry_Resolves_To_A_Real_GeneratedRegex_Method()
+    {
+        // Force-load every module assembly that hosts a parser referenced by
+        // the catalog. Project references in Mithril.Shared.Tests.csproj guarantee
+        // these are next to the test DLL at runtime.
+        TouchAssemblyForType("Samwise.Parsing.GardenLogParser");
+        TouchAssemblyForType("Arwen.Parsing.FavorLogParser");
+        TouchAssemblyForType("Smaug.Parsing.VendorLogParser");
+        TouchAssemblyForType("Pippin.Parsing.GourmandLogParser");
+        TouchAssemblyForType("Saruman.Parsing.WordOfPowerChatParser");
+        TouchAssemblyForType("Saruman.Parsing.WordOfPowerDiscoveredParser");
+        TouchAssemblyForType("Legolas.Services.ChatLogParser");
+
+        foreach (var (key, entry) in LogPatternCatalog.Current.Regexes)
+        {
+            entry.CSharp.Should().NotBeNull(
+                $"catalog entry '{key}' must declare its C# binding");
+
+            var (declaringType, attribute) = ResolveGeneratedRegex(entry.CSharp!);
+
+            declaringType.Should().NotBeNull(
+                $"catalog entry '{key}' targets type '{entry.CSharp!.Type}' which could not be loaded");
+            attribute.Should().NotBeNull(
+                $"catalog entry '{key}' targets {entry.CSharp!.Type}.{entry.CSharp!.Method} but no [GeneratedRegex] attribute was found there");
+
+            attribute!.Pattern.Should().Be(
+                entry.Pattern,
+                $"catalog entry '{key}' must match the [GeneratedRegex] pattern on {entry.CSharp!.Type}.{entry.CSharp!.Method}");
+
+            // RegexOptions are informational metadata in the catalog (so the TS port knows
+            // which flags to translate). When declared, assert they match the C# attribute;
+            // when omitted, no assertion — entries are free to leave options undocumented.
+            if (entry.CSharp!.Options is { Count: > 0 } expectedOptions)
+            {
+                var actualOptions = SplitFlags(attribute.Options);
+                actualOptions.Should().BeEquivalentTo(
+                    expectedOptions,
+                    $"catalog entry '{key}' declares RegexOptions {string.Join('|', expectedOptions)}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Catalog_Document_Loads_With_Sensible_Shape()
+    {
+        var doc = LogPatternCatalog.Current;
+        doc.Version.Should().Be(1);
+        doc.Regexes.Should().NotBeEmpty();
+        doc.Shared.Should().NotBeNull();
+        doc.Shared!.SessionMarker.Should().NotBeNull();
+        doc.Shared!.SessionMarker!.Literal.Should().Be("ProcessAddPlayer(");
+    }
+
+    private static void TouchAssemblyForType(string typeName)
+    {
+        // Type.GetType only searches loaded assemblies; this triggers a load
+        // of the module DLL via the project reference's deployed copy.
+        _ = Type.GetType($"{typeName}, {InferAssemblyName(typeName)}", throwOnError: false);
+    }
+
+    private static string InferAssemblyName(string typeName) => typeName switch
+    {
+        var t when t.StartsWith("Samwise.", StringComparison.Ordinal) => "Samwise.Module",
+        var t when t.StartsWith("Arwen.", StringComparison.Ordinal) => "Arwen.Module",
+        var t when t.StartsWith("Smaug.", StringComparison.Ordinal) => "Smaug.Module",
+        var t when t.StartsWith("Pippin.", StringComparison.Ordinal) => "Pippin.Module",
+        var t when t.StartsWith("Saruman.", StringComparison.Ordinal) => "Saruman.Module",
+        var t when t.StartsWith("Legolas.", StringComparison.Ordinal) => "Legolas.Module",
+        _ => "Mithril.Shared",
+    };
+
+    private static (Type? declaringType, GeneratedRegexAttribute? attr) ResolveGeneratedRegex(LogPatternCSharpRef csharp)
+    {
+        Type? type = null;
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            type = asm.GetType(csharp.Type, throwOnError: false);
+            if (type is not null) break;
+        }
+        if (type is null) return (null, null);
+
+        // [GeneratedRegex] is applied to a partial method declaration. Reflection
+        // surfaces a regular MethodInfo for it (the source-generated companion is
+        // the implementation but the attribute lives on the declaring partial).
+        var method = type.GetMethod(
+            csharp.Method,
+            BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy,
+            binder: null,
+            types: Array.Empty<Type>(),
+            modifiers: null);
+
+        if (method is null) return (type, null);
+
+        var attr = method.GetCustomAttribute<GeneratedRegexAttribute>(inherit: false);
+        return (type, attr);
+    }
+
+    private static IReadOnlyList<string> SplitFlags(RegexOptions options)
+    {
+        if (options == RegexOptions.None) return Array.Empty<string>();
+        return options.ToString()
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+}

--- a/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
+++ b/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
@@ -13,5 +13,13 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+    <!-- Module references exist solely so LogPatternCatalogParityTests can
+         reflect over [GeneratedRegex] attributes in module-level parsers. -->
+    <ProjectReference Include="..\..\src\Samwise.Module\Samwise.Module.csproj" />
+    <ProjectReference Include="..\..\src\Arwen.Module\Arwen.Module.csproj" />
+    <ProjectReference Include="..\..\src\Smaug.Module\Smaug.Module.csproj" />
+    <ProjectReference Include="..\..\src\Pippin.Module\Pippin.Module.csproj" />
+    <ProjectReference Include="..\..\src\Saruman.Module\Saruman.Module.csproj" />
+    <ProjectReference Include="..\..\src\Legolas.Module\Legolas.Module.csproj" />
   </ItemGroup>
 </Project>

--- a/tools/MithrilLogMcp/.gitignore
+++ b/tools/MithrilLogMcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store

--- a/tools/MithrilLogMcp/README.md
+++ b/tools/MithrilLogMcp/README.md
@@ -1,0 +1,39 @@
+# MithrilLogMcp
+
+MCP server exposing Mithril's log sources (Project Gorgon `Player.log`, `ChatLogs/`, and Mithril's own Serilog output) to Claude Code with parsed/typed events, time-windowed queries, and server-side aggregations. Designed to keep the cost of AI-assisted log analysis bounded — instead of having Claude `grep` and `Read` hundreds of MB, the server returns structured events and summaries.
+
+## Status
+
+- **v0.1** — Player.log only, `query_events`/`aggregate`/`list_event_types`, time windows.
+- **v0.2** — adds chat log + Mithril Serilog sources, `source: "all"` merge, field projection.
+- **v0.3** — persistent cursors, character scoping, `--last-session`, rollover detection.
+
+## Building & running
+
+```bash
+cd tools/MithrilLogMcp
+npm install
+npm run build
+npm test
+```
+
+## Wiring into Claude Code
+
+Add to your `.mcp.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "mithril-logs": {
+      "command": "node",
+      "args": ["${workspaceFolder}/tools/MithrilLogMcp/dist/src/server.js"]
+    }
+  }
+}
+```
+
+## Architecture
+
+The server reads `src/Mithril.Shared/Reference/log-patterns.json` at startup — the same regex catalog Mithril's .NET parsers consume. Pattern parity is enforced by `LogPatternCatalogParityTests` in the .NET test suite, so adding a new event type means editing one JSON file and one C# parser file.
+
+See [docs/architecture.md](docs/architecture.md) for the full design (planned).

--- a/tools/MithrilLogMcp/README.md
+++ b/tools/MithrilLogMcp/README.md
@@ -10,6 +10,63 @@ MCP server exposing Mithril's log sources (Project Gorgon `Player.log`, `ChatLog
 - **v0.4** — cursor advancement on successful queries (`cursor: "name"` resumes where the previous call stopped). ✅
 - **v0.5** — active-character streaming: `character: "Foo"` filters Player.log events using a tracker that watches `ProcessAddPlayer` mid-stream and is backfilled from a backward scan on cursor resume. ✅
 
+## Example queries
+
+These show the typical shapes Claude should reach for. All run as MCP tool calls.
+
+**1. Top NPCs the player interacted with in the last hour**
+
+```jsonc
+// tool: aggregate
+{
+  "source": "player",
+  "agg": "top",
+  "field": "npcKey",
+  "event_type": ["arwen.FavorUpdate", "smaug.NpcInteractionStarted"],
+  "since": "1h",
+  "top_n": 10
+}
+```
+Returns ten `{ key, count }` buckets — orders of magnitude smaller than the raw events.
+
+**2. Everything Emraell did in their most recent session**
+
+```jsonc
+// tool: query_events
+{
+  "source": "player",
+  "character": "Emraell",
+  "last_session": true,
+  "event_type": ["arwen.FavorUpdate", "smaug.VendorItemSold", "samwise.PlantingCapReached"],
+  "limit": 200
+}
+```
+The server resolves "last session" by walking back through Player.log to the most recent `ProcessAddPlayer` for that character; events are stamped with `activeCharacter` so cross-character noise is filtered out.
+
+**3. Multi-turn investigation: keep a cursor and only see new events**
+
+```jsonc
+// turn 1 — establishes cursor "debug-vendor-bug"
+{ "source": "player", "cursor": "debug-vendor-bug", "event_type": ["smaug.VendorItemSold"] }
+
+// turn 2, after the player sells more — only new events
+{ "source": "player", "cursor": "debug-vendor-bug", "event_type": ["smaug.VendorItemSold"] }
+```
+Second call scans only the bytes appended since turn 1. Rollover detection (truncation, file recreate) automatically resets to byte 0 and reports it in `summary.cursor.rolledOverFiles`.
+
+**4. Context lines around each match (Player.log)**
+
+```jsonc
+// tool: query_events
+{
+  "source": "player",
+  "event_type": ["samwise.PlantingCapReached"],
+  "since": "30m",
+  "context": 3
+}
+```
+Each event gains `contextLines: { before: [...], after: [...] }` with up to 3 raw lines on each side.
+
 ## Tool surface
 
 | Tool | Purpose |

--- a/tools/MithrilLogMcp/README.md
+++ b/tools/MithrilLogMcp/README.md
@@ -4,9 +4,30 @@ MCP server exposing Mithril's log sources (Project Gorgon `Player.log`, `ChatLog
 
 ## Status
 
-- **v0.1** — Player.log only, `query_events`/`aggregate`/`list_event_types`, time windows.
-- **v0.2** — adds chat log + Mithril Serilog sources, `source: "all"` merge, field projection.
-- **v0.3** — persistent cursors, character scoping, `--last-session`, rollover detection.
+- **v0.1** — Player.log only, `query_events`/`aggregate`/`list_event_types`, time windows. ✅
+- **v0.2** — chat log + Mithril Serilog sources, `source: "all"` merge, field projection. ✅
+- **v0.3** — persistent cursors, character scoping, `--last-session`, rollover detection. ✅
+
+## Tool surface
+
+| Tool | Purpose |
+|------|---------|
+| `query_events` | Stream typed events filtered by source, event type, time window, character, or arbitrary `data.*` field |
+| `aggregate` | Server-side `count` / `group_by` / `histogram` / `distinct` / `top` reductions |
+| `list_event_types` | Schema discovery: every event type the server can emit, with field names |
+| `cursor_list` | List named cursors stored at `%LocalAppData%/MithrilLogMcp/cursors.json` |
+| `cursor_reset` | Remove a named cursor so the next query starts fresh |
+
+## Sources
+
+| Source | Path | Notes |
+|--------|------|-------|
+| `player` | `%LocalAppData%Low/Elder Game/Project Gorgon/Player.log` | Lines carry only `[HH:MM:SS]`; date is anchored by file mtime |
+| `chat` | `%LocalAppData%Low/Elder Game/Project Gorgon/ChatLogs/Chat-YY-MM-DD.log` | Lines carry full `YY-MM-DD HH:MM:SS`; files outside the window are skipped without opening |
+| `mithril` | `%LocalAppData%/Mithril/Shell/logs/*.json` | CompactJsonFormatter (`@t`, `@mt`, `Category`, `Message`); detection is by content, so legacy `gorgon-*.json` and migrated `mithril-*-prebrand.json` are also picked up |
+| `all` | merged | 3-way time-ordered merge across the above |
+
+Each can be overridden via env var (`MITHRIL_PLAYER_LOG`, `MITHRIL_CHAT_LOG_DIR`, `MITHRIL_DIAGNOSTIC_LOG_DIR`, `MITHRIL_CHARACTER_ROOT`, `MITHRIL_SHELL_SETTINGS`).
 
 ## Building & running
 

--- a/tools/MithrilLogMcp/README.md
+++ b/tools/MithrilLogMcp/README.md
@@ -7,6 +7,8 @@ MCP server exposing Mithril's log sources (Project Gorgon `Player.log`, `ChatLog
 - **v0.1** — Player.log only, `query_events`/`aggregate`/`list_event_types`, time windows. ✅
 - **v0.2** — chat log + Mithril Serilog sources, `source: "all"` merge, field projection. ✅
 - **v0.3** — persistent cursors, character scoping, `--last-session`, rollover detection. ✅
+- **v0.4** — cursor advancement on successful queries (`cursor: "name"` resumes where the previous call stopped). ✅
+- **v0.5** — active-character streaming: `character: "Foo"` filters Player.log events using a tracker that watches `ProcessAddPlayer` mid-stream and is backfilled from a backward scan on cursor resume. ✅
 
 ## Tool surface
 

--- a/tools/MithrilLogMcp/package-lock.json
+++ b/tools/MithrilLogMcp/package-lock.json
@@ -1,0 +1,1282 @@
+{
+  "name": "mithril-log-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mithril-log-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.20.2",
+        "zod": "3.25.76"
+      },
+      "bin": {
+        "mithril-log-mcp": "dist/server.js"
+      },
+      "devDependencies": {
+        "@types/node": "22.18.13",
+        "rimraf": "6.0.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.2.tgz",
+      "integrity": "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.13.tgz",
+      "integrity": "sha512-Bo45YKIjnmFtv6I1TuC8AaHBbqXtIo+Om5fE4QiU1Tj8QR/qt+8O3BAtOimG5IFmwaWiPmB3Mv3jtYzBA4Us2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/MithrilLogMcp/package.json
+++ b/tools/MithrilLogMcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mithril-log-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing Mithril log sources (Player.log, ChatLogs, Mithril Serilog) to Claude Code.",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "main": "dist/src/server.js",
+  "bin": {
+    "mithril-log-mcp": "dist/src/server.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "start": "node dist/src/server.js",
+    "test": "tsc && node --test --test-reporter=spec dist/test/**/*.test.js",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.20.2",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "22.18.13",
+    "rimraf": "6.0.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/tools/MithrilLogMcp/src/config.ts
+++ b/tools/MithrilLogMcp/src/config.ts
@@ -1,0 +1,39 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Resolves on-disk paths the server reads. Each can be overridden via env var
+ * for testing (or for unusual installs).
+ *
+ * Defaults match Mithril's hard-coded paths in `GameLocator.cs` and
+ * `Mithril.Shell/Program.cs` — keep them aligned when those move.
+ */
+export interface ServerConfig {
+  playerLogPath: string;
+  chatLogDir: string;
+  mithrilLogDir: string;
+  characterRoot: string;
+  shellSettingsPath: string;
+}
+
+export function loadConfig(): ServerConfig {
+  const localApp = process.env.LOCALAPPDATA
+    ?? path.join(os.homedir(), 'AppData', 'Local');
+  const localAppLow = path.join(localApp + 'Low');
+
+  const gameRoot = process.env.MITHRIL_GAME_ROOT
+    ?? path.join(localAppLow, 'Elder Game', 'Project Gorgon');
+
+  return {
+    playerLogPath: process.env.MITHRIL_PLAYER_LOG
+      ?? path.join(gameRoot, 'Player.log'),
+    chatLogDir: process.env.MITHRIL_CHAT_LOG_DIR
+      ?? path.join(gameRoot, 'ChatLogs'),
+    mithrilLogDir: process.env.MITHRIL_DIAGNOSTIC_LOG_DIR
+      ?? path.join(localApp, 'Mithril', 'Shell', 'logs'),
+    characterRoot: process.env.MITHRIL_CHARACTER_ROOT
+      ?? path.join(localApp, 'Mithril', 'characters'),
+    shellSettingsPath: process.env.MITHRIL_SHELL_SETTINGS
+      ?? path.join(localApp, 'Mithril', 'Shell', 'shell.json'),
+  };
+}

--- a/tools/MithrilLogMcp/src/parsing/active-character-tracker.ts
+++ b/tools/MithrilLogMcp/src/parsing/active-character-tracker.ts
@@ -1,0 +1,37 @@
+import type { ParsedEvent } from './types.js';
+
+/**
+ * Tracks the currently active player character by watching
+ * `shared.ProcessAddPlayer` events as they flow through a Player.log scan.
+ * Mirrors `Mithril.Shared.Character.ActiveCharacterLogSynchronizer` but lives
+ * inside the per-scan pipeline so every emitted event can be stamped with
+ * the active character at the time the line was written.
+ *
+ * "Active before stamp": when a ProcessAddPlayer event itself is emitted,
+ * `observe()` runs first, so the event's `activeCharacter` reflects the
+ * *new* character. This makes `character: "X"` queries correctly return
+ * the login event that began X's session plus everything afterwards.
+ */
+export class ActiveCharacterTracker {
+  private current: string | undefined;
+
+  constructor(initial?: string) {
+    this.current = initial;
+  }
+
+  /** Sets the initial value, e.g. from a backward-scan backfill on cursor resume. */
+  set(name: string): void {
+    this.current = name;
+  }
+
+  /** Updates the tracker if `ev` is a ProcessAddPlayer. No-op otherwise. */
+  observe(ev: ParsedEvent): void {
+    if (ev.type !== 'shared.ProcessAddPlayer') return;
+    const name = ev.data.characterName;
+    if (typeof name === 'string' && name.length > 0) this.current = name;
+  }
+
+  get active(): string | undefined {
+    return this.current;
+  }
+}

--- a/tools/MithrilLogMcp/src/parsing/catalog.ts
+++ b/tools/MithrilLogMcp/src/parsing/catalog.ts
@@ -1,0 +1,149 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Loads `src/Mithril.Shared/Reference/log-patterns.json` — the single source of truth
+ * for every log-line regex used by Mithril parsers. The .NET parsers and this TS
+ * server consume the same JSON; parity with the C# `[GeneratedRegex]` attributes is
+ * enforced by the LogPatternCatalogParityTests xunit test in the parent solution.
+ */
+
+export interface CatalogDocument {
+  version: number;
+  regexes: Record<string, CatalogEntryRaw>;
+  shared?: {
+    sessionMarker?: { literal: string; scanChunkBytes: number; notes?: string };
+    playerLogTimestampPrefix?: { regex: string; notes?: string };
+  };
+}
+
+interface CatalogEntryRaw {
+  pattern: string;
+  source: string;
+  module: string;
+  csharp?: { type: string; method: string; options?: string[] };
+  eventType?: string;
+  kind?: 'helper' | 'compound' | 'marker' | 'session-marker';
+  flags?: string[];
+  notes?: string;
+  fields: CatalogFieldRaw[];
+}
+
+interface CatalogFieldRaw {
+  name: string;
+  group: number | string;
+  type: string;
+}
+
+export interface CatalogEntry {
+  key: string;
+  pattern: string;
+  regex: RegExp;
+  source: string;
+  module: string;
+  eventType: string | undefined;
+  kind: 'helper' | 'compound' | 'marker' | 'session-marker' | undefined;
+  fields: CatalogField[];
+  notes: string | undefined;
+}
+
+export interface CatalogField {
+  name: string;
+  group: number | string;
+  type: string;
+}
+
+export interface Catalog {
+  document: CatalogDocument;
+  entries: CatalogEntry[];
+  bySource: Map<string, CatalogEntry[]>;
+  byKey: Map<string, CatalogEntry>;
+  byEventType: Map<string, CatalogEntry[]>;
+  sessionMarker: { literal: string; scanChunkBytes: number };
+}
+
+let cached: Catalog | undefined;
+
+export function loadCatalog(jsonPath?: string): Catalog {
+  if (cached && !jsonPath) return cached;
+  const resolved = jsonPath ?? resolveDefaultPath();
+  const raw = fs.readFileSync(resolved, 'utf8');
+  const doc = JSON.parse(stripJsonComments(raw)) as CatalogDocument;
+
+  const entries: CatalogEntry[] = [];
+  for (const [key, raw] of Object.entries(doc.regexes)) {
+    entries.push({
+      key,
+      pattern: raw.pattern,
+      regex: compileRegex(raw.pattern, raw.flags),
+      source: raw.source,
+      module: raw.module,
+      eventType: raw.eventType,
+      kind: raw.kind,
+      fields: raw.fields ?? [],
+      notes: raw.notes,
+    });
+  }
+
+  const bySource = new Map<string, CatalogEntry[]>();
+  const byKey = new Map<string, CatalogEntry>();
+  const byEventType = new Map<string, CatalogEntry[]>();
+  for (const e of entries) {
+    byKey.set(e.key, e);
+    if (!bySource.has(e.source)) bySource.set(e.source, []);
+    bySource.get(e.source)!.push(e);
+    if (e.eventType) {
+      if (!byEventType.has(e.eventType)) byEventType.set(e.eventType, []);
+      byEventType.get(e.eventType)!.push(e);
+    }
+  }
+
+  const result: Catalog = {
+    document: doc,
+    entries,
+    bySource,
+    byKey,
+    byEventType,
+    sessionMarker: {
+      literal: doc.shared?.sessionMarker?.literal ?? 'ProcessAddPlayer(',
+      scanChunkBytes: doc.shared?.sessionMarker?.scanChunkBytes ?? 10 * 1024 * 1024,
+    },
+  };
+
+  if (!jsonPath) cached = result;
+  return result;
+}
+
+function compileRegex(pattern: string, flags: string[] | undefined): RegExp {
+  const jsFlags = (flags ?? []).join('');
+  return new RegExp(pattern, jsFlags);
+}
+
+function stripJsonComments(input: string): string {
+  // Tolerate the catalog's `$comment` and trailing whitespace; JSON.parse handles
+  // standard JSON only. Real comments aren't allowed in the file, so this is a no-op
+  // — kept here for forward compatibility if a future schema introduces them.
+  return input;
+}
+
+function resolveDefaultPath(): string {
+  const envPath = process.env.MITHRIL_LOG_PATTERNS_PATH;
+  if (envPath && fs.existsSync(envPath)) return envPath;
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = findRepoRoot(here);
+  return path.join(repoRoot, 'src', 'Mithril.Shared', 'Reference', 'log-patterns.json');
+}
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, 'Mithril.slnx'))) return dir;
+    dir = path.dirname(dir);
+  }
+  throw new Error(
+    `Could not find repo root (no Mithril.slnx) walking up from ${start}. ` +
+    'Set MITHRIL_LOG_PATTERNS_PATH to point at log-patterns.json.',
+  );
+}

--- a/tools/MithrilLogMcp/src/parsing/chat-parser.ts
+++ b/tools/MithrilLogMcp/src/parsing/chat-parser.ts
@@ -1,0 +1,74 @@
+import type { Catalog, CatalogEntry, CatalogField } from './catalog.js';
+import type { ParsedEvent } from './types.js';
+
+/**
+ * Dispatcher for chat log lines (`YY-MM-DD HH:MM:SS\t[Channel] Speaker: message`).
+ * Like {@link PlayerLineParser} but constrained to `source: "chat"` catalog
+ * entries. The channel/speaker tokenisation is done by the source layer; this
+ * receives whole chat lines and re-runs each chat regex against them.
+ */
+export class ChatLineParser {
+  private readonly entries: CatalogEntry[];
+
+  constructor(catalog: Catalog) {
+    this.entries = (catalog.bySource.get('chat') ?? []).filter(
+      (e) => e.kind !== 'helper' && e.eventType !== undefined,
+    );
+  }
+
+  parse(
+    line: string,
+    timestamp: Date,
+    file: string,
+    lineNo: number,
+    byteOffset: number,
+  ): ParsedEvent[] {
+    if (line.length === 0) return [];
+    const out: ParsedEvent[] = [];
+    for (const entry of this.entries) {
+      const m = entry.regex.exec(line);
+      if (!m) continue;
+      out.push({
+        type: entry.eventType!,
+        ts: timestamp.toISOString(),
+        module: entry.module,
+        source: entry.source,
+        file,
+        line: lineNo,
+        byteOffset,
+        data: extractFields(entry.fields, m),
+      });
+    }
+    return out;
+  }
+}
+
+function extractFields(fields: CatalogField[], m: RegExpExecArray): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  for (const f of fields) {
+    const raw = typeof f.group === 'number' ? m[f.group] : m.groups?.[f.group];
+    if (raw === undefined) continue;
+    data[f.name] = coerce(raw, f.type);
+  }
+  return data;
+}
+
+function coerce(raw: string, type: string): unknown {
+  switch (type) {
+    case 'int': {
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) ? n : raw;
+    }
+    case 'long': {
+      const n = Number.parseInt(raw, 10);
+      if (!Number.isFinite(n) || Math.abs(n) > Number.MAX_SAFE_INTEGER) return raw;
+      return n;
+    }
+    case 'double': {
+      const n = Number.parseFloat(raw);
+      return Number.isFinite(n) ? n : raw;
+    }
+    default:
+      return raw;
+  }
+}

--- a/tools/MithrilLogMcp/src/parsing/player-parser.ts
+++ b/tools/MithrilLogMcp/src/parsing/player-parser.ts
@@ -1,0 +1,149 @@
+import type { Catalog, CatalogEntry, CatalogField } from './catalog.js';
+import type { ParsedEvent } from './types.js';
+
+/**
+ * Dispatches a single Player.log line through every catalog regex tagged
+ * `source: "player"`. Returns the typed events that matched (zero, one, or
+ * many — different modules can match the same line for different reasons).
+ *
+ * Pippin's `ProcessBook("Skill Info", ...)` line is handled as a compound
+ * event: the outer match captures the report body, then sub-entries are
+ * extracted with `FoodEntryRx` and aggregated into a single
+ * `pippin.FoodsConsumedReport` event with a `foods[]` array.
+ */
+export class PlayerLineParser {
+  private readonly entries: CatalogEntry[];
+  private readonly foodEntryRegex: RegExp | undefined;
+
+  constructor(catalog: Catalog) {
+    this.entries = (catalog.bySource.get('player') ?? []).filter(
+      (e) => e.kind !== 'helper',
+    );
+    this.foodEntryRegex = catalog.byKey.get(
+      'pippin.GourmandLogParser.FoodEntryRx',
+    )?.regex;
+  }
+
+  parse(
+    line: string,
+    timestamp: Date,
+    file: string,
+    lineNo: number,
+    byteOffset: number,
+  ): ParsedEvent[] {
+    if (line.length === 0) return [];
+
+    const out: ParsedEvent[] = [];
+    for (const entry of this.entries) {
+      if (!entry.eventType) continue;
+
+      // Reset regex state for global regexes; safer to use exec with a fresh start
+      // by always compiling without /g. (catalog.compileRegex enforces this.)
+      const m = entry.regex.exec(line);
+      if (!m) continue;
+
+      if (entry.kind === 'compound') {
+        const compound = this.handleCompound(entry, m, timestamp, file, lineNo, byteOffset);
+        if (compound) out.push(compound);
+        continue;
+      }
+
+      out.push({
+        type: entry.eventType,
+        ts: timestamp.toISOString(),
+        module: entry.module,
+        source: entry.source,
+        file,
+        line: lineNo,
+        byteOffset,
+        data: extractFields(entry.fields, m),
+      });
+    }
+    return out;
+  }
+
+  private handleCompound(
+    entry: CatalogEntry,
+    outerMatch: RegExpExecArray,
+    timestamp: Date,
+    file: string,
+    lineNo: number,
+    byteOffset: number,
+  ): ParsedEvent | null {
+    if (entry.eventType !== 'pippin.FoodsConsumedReport') return null;
+    if (!this.foodEntryRegex) return null;
+
+    // Group 1 of ProcessBookFoodsRx is the body; entries are separated by a
+    // literal two-char `\n` sequence (backslash + n), not real newlines.
+    const body = outerMatch[1] ?? '';
+    const rawEntries = body.split('\\n').filter((s) => s.length > 0);
+    const foods: Array<{ name: string; count: number; tags: string[] }> = [];
+
+    for (const raw of rawEntries) {
+      const m = this.foodEntryRegex.exec(raw);
+      if (!m) continue;
+      const name = (m[1] ?? '').trim();
+      const tagsRaw = m[2];
+      const countStr = m[3] ?? '0';
+      const count = Number.parseInt(countStr, 10);
+      if (!Number.isFinite(count)) continue;
+
+      const tags: string[] = tagsRaw
+        ? tagsRaw.split(',')
+            .map((t) => t.trim())
+            .map((t) => (t.toUpperCase().startsWith('HAS ') ? t.slice(4).trim() : t))
+        : [];
+
+      foods.push({ name, count, tags });
+    }
+
+    if (foods.length === 0) return null;
+    return {
+      type: 'pippin.FoodsConsumedReport',
+      ts: timestamp.toISOString(),
+      module: entry.module,
+      source: entry.source,
+      file,
+      line: lineNo,
+      byteOffset,
+      data: { foods },
+    };
+  }
+}
+
+function extractFields(fields: CatalogField[], m: RegExpExecArray): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  for (const f of fields) {
+    const raw =
+      typeof f.group === 'number'
+        ? m[f.group]
+        : (m.groups?.[f.group] ?? undefined);
+    if (raw === undefined) continue;
+    data[f.name] = coerce(raw, f.type);
+  }
+  return data;
+}
+
+function coerce(raw: string, type: string): unknown {
+  switch (type) {
+    case 'int': {
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) ? n : raw;
+    }
+    case 'long': {
+      const n = Number.parseInt(raw, 10);
+      // JSON cannot safely round-trip integers > 2^53. For Project Gorgon's
+      // long fields (entity ids, instance ids), values usually fit; emit as a
+      // string when out of range so consumers don't silently lose precision.
+      if (!Number.isFinite(n) || Math.abs(n) > Number.MAX_SAFE_INTEGER) return raw;
+      return n;
+    }
+    case 'double': {
+      const n = Number.parseFloat(raw);
+      return Number.isFinite(n) ? n : raw;
+    }
+    case 'string':
+    default:
+      return raw;
+  }
+}

--- a/tools/MithrilLogMcp/src/parsing/types.ts
+++ b/tools/MithrilLogMcp/src/parsing/types.ts
@@ -15,6 +15,14 @@ export interface ParsedEvent {
   line: number;
   byteOffset: number;
   data: Record<string, unknown>;
+  /**
+   * Player character active when this event was emitted, stamped by
+   * {@link ActiveCharacterTracker}. Only populated for `source: "player"`
+   * events (chat events expose `data.speaker` instead; mithril events are
+   * app-internal and aren't bound to a character). Undefined for player
+   * events that occur before the first observed `ProcessAddPlayer` line.
+   */
+  activeCharacter?: string;
 }
 
 export interface QuerySummary {

--- a/tools/MithrilLogMcp/src/parsing/types.ts
+++ b/tools/MithrilLogMcp/src/parsing/types.ts
@@ -23,6 +23,14 @@ export interface ParsedEvent {
    * events that occur before the first observed `ProcessAddPlayer` line.
    */
   activeCharacter?: string;
+  /**
+   * Raw lines surrounding the matched line in the source file when the
+   * caller requested `context: N`. Currently populated only for
+   * `source: "player"`; other sources will land in a follow-up. The arrays
+   * may be shorter than N if the match is near the start/end of the file
+   * or the scan window.
+   */
+  contextLines?: { before: string[]; after: string[] };
 }
 
 export interface QuerySummary {

--- a/tools/MithrilLogMcp/src/parsing/types.ts
+++ b/tools/MithrilLogMcp/src/parsing/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Wire shape of every parsed event the server emits.
+ *
+ * Events are deliberately small and schema-stable: a small fixed envelope (`type`,
+ * `ts`, `module`, `source`, `file`, `line`, `byteOffset`) plus an open `data`
+ * record holding regex-captured fields. Adding a field to a parser only adds keys
+ * to `data`; consumers (Claude, jq) that ignore unknown keys keep working.
+ */
+export interface ParsedEvent {
+  type: string;
+  ts: string;
+  module: string;
+  source: string;
+  file: string;
+  line: number;
+  byteOffset: number;
+  data: Record<string, unknown>;
+}
+
+export interface QuerySummary {
+  matched: number;
+  returned: number;
+  truncated: boolean;
+  scannedBytes: number;
+  scannedLines: number;
+  elapsedMs: number;
+}
+
+export interface QueryResult {
+  summary: QuerySummary;
+  events: ParsedEvent[];
+}
+
+export interface AggregateResult {
+  summary: QuerySummary;
+  agg: string;
+  buckets: Array<{ key: string; count: number }>;
+}

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -23,8 +23,10 @@ import {
 import {
   CursorListInput,
   CursorResetInput,
+  CursorSetInput,
   runCursorList,
   runCursorReset,
+  runCursorSet,
 } from './tools/cursor.js';
 import { CursorStore } from './state/cursors.js';
 
@@ -77,6 +79,15 @@ const TOOLS = [
       'time window again.',
     inputSchema: zodToJsonSchema(CursorResetInput),
   },
+  {
+    name: 'cursor_set',
+    description:
+      'Manually positions a named cursor for one source/file. anchor=start ' +
+      're-reads from byte 0; anchor=end fast-forwards to the current end of ' +
+      "file (skip everything written before now); anchor=offset uses an exact " +
+      'byteOffset.',
+    inputSchema: zodToJsonSchema(CursorSetInput),
+  },
 ] as const;
 
 async function main(): Promise<void> {
@@ -105,7 +116,7 @@ async function main(): Promise<void> {
         }
         case 'aggregate': {
           const args = AggregateInput.parse(rawArgs ?? {});
-          const result = await runAggregate(args, config);
+          const result = await runAggregate(args, config, cursorStore);
           return {
             content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           };
@@ -127,6 +138,13 @@ async function main(): Promise<void> {
         case 'cursor_reset': {
           const args = CursorResetInput.parse(rawArgs ?? {});
           const result = runCursorReset(args, cursorStore);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'cursor_set': {
+          const args = CursorSetInput.parse(rawArgs ?? {});
+          const result = runCursorSet(args, cursorStore);
           return {
             content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           };

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+import { loadConfig } from './config.js';
+import {
+  AggregateInput,
+  runAggregate,
+} from './tools/aggregate.js';
+import {
+  ListEventTypesInput,
+  runListEventTypes,
+} from './tools/list-event-types.js';
+import {
+  QueryEventsInput,
+  runQueryEvents,
+} from './tools/query-events.js';
+
+/**
+ * Entrypoint. Wires the three v0.1 tools to the MCP stdio transport.
+ *
+ * Diagnostics go to stderr so they don't corrupt the MCP JSON-RPC framing on
+ * stdout. Tool handlers are wrapped in try/catch so an exception becomes
+ * `{ isError: true }` rather than a transport crash.
+ */
+
+const SERVER_NAME = 'mithril-log-mcp';
+const SERVER_VERSION = '0.1.0';
+
+const TOOLS = [
+  {
+    name: 'query_events',
+    description:
+      'Stream typed events from Mithril log sources within a time window. ' +
+      'Returns NDJSON-shaped parsed events plus a summary envelope.',
+    inputSchema: zodToJsonSchema(QueryEventsInput),
+  },
+  {
+    name: 'aggregate',
+    description:
+      'Server-side aggregations (count, group_by, histogram, distinct, top) ' +
+      'over the same event stream. Returns a small bucket list instead of ' +
+      'megabytes of raw events.',
+    inputSchema: zodToJsonSchema(AggregateInput),
+  },
+  {
+    name: 'list_event_types',
+    description:
+      'Lists every event type the server can emit, with field names and types. ' +
+      'Use this to discover what queries are possible.',
+    inputSchema: zodToJsonSchema(ListEventTypesInput),
+  },
+] as const;
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [...TOOLS] }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: rawArgs } = req.params;
+    try {
+      switch (name) {
+        case 'query_events': {
+          const args = QueryEventsInput.parse(rawArgs ?? {});
+          const result = await runQueryEvents(args, config);
+          return {
+            content: [
+              { type: 'text', text: JSON.stringify(result.summary) },
+              { type: 'text', text: encodeEvents(result.events, args.format) },
+            ],
+          };
+        }
+        case 'aggregate': {
+          const args = AggregateInput.parse(rawArgs ?? {});
+          const result = await runAggregate(args, config);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'list_event_types': {
+          const args = ListEventTypesInput.parse(rawArgs ?? {});
+          const result = runListEventTypes(args);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        default:
+          return errorResult(`Unknown tool: ${name}`);
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      const where = e instanceof Error && e.stack ? `\n${e.stack}` : '';
+      return errorResult(`${name} failed: ${message}${where}`);
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`[${SERVER_NAME}] connected via stdio`);
+}
+
+function encodeEvents(events: object[], format: 'ndjson' | 'json'): string {
+  if (format === 'json') return JSON.stringify(events);
+  return events.map((e) => JSON.stringify(e)).join('\n');
+}
+
+function errorResult(message: string) {
+  return { isError: true, content: [{ type: 'text', text: message }] };
+}
+
+/**
+ * Minimal Zod -> JSON Schema bridge — the MCP SDK accepts plain JSON Schema
+ * for `inputSchema`. A full library (zod-to-json-schema) would be more
+ * accurate, but this server's schemas are simple enough that the Zod parser
+ * does the real validation at call time and the JSON Schema is just a
+ * description for the client.
+ */
+function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  return describeSchema(schema);
+}
+
+function describeSchema(schema: z.ZodType): Record<string, unknown> {
+  const def = (schema as any)._def;
+  if (!def) return { type: 'object' };
+
+  switch (def.typeName) {
+    case 'ZodObject': {
+      const shape = def.shape();
+      const properties: Record<string, unknown> = {};
+      const required: string[] = [];
+      for (const [k, v] of Object.entries(shape)) {
+        const child = v as z.ZodType;
+        properties[k] = describeSchema(child);
+        if (!isOptional(child)) required.push(k);
+      }
+      return { type: 'object', properties, ...(required.length ? { required } : {}) };
+    }
+    case 'ZodArray':
+      return { type: 'array', items: describeSchema(def.type) };
+    case 'ZodTuple':
+      return { type: 'array', items: def.items.map((i: z.ZodType) => describeSchema(i)) };
+    case 'ZodEnum':
+      return { type: 'string', enum: def.values };
+    case 'ZodString':
+      return { type: 'string' };
+    case 'ZodNumber':
+      return { type: 'number' };
+    case 'ZodBoolean':
+      return { type: 'boolean' };
+    case 'ZodOptional':
+    case 'ZodDefault':
+      return describeSchema(def.innerType);
+    case 'ZodUnion':
+      return { anyOf: def.options.map((o: z.ZodType) => describeSchema(o)) };
+    case 'ZodRecord':
+      return { type: 'object', additionalProperties: describeSchema(def.valueType) };
+    default:
+      return {};
+  }
+}
+
+function isOptional(schema: z.ZodType): boolean {
+  const def = (schema as any)._def;
+  return def?.typeName === 'ZodOptional' || def?.typeName === 'ZodDefault';
+}
+
+main().catch((err) => {
+  console.error(`[${SERVER_NAME}] fatal:`, err);
+  process.exit(1);
+});

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -95,7 +95,7 @@ async function main(): Promise<void> {
       switch (name) {
         case 'query_events': {
           const args = QueryEventsInput.parse(rawArgs ?? {});
-          const result = await runQueryEvents(args, config);
+          const result = await runQueryEvents(args, config, cursorStore);
           return {
             content: [
               { type: 'text', text: JSON.stringify(result.summary) },

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -20,6 +20,13 @@ import {
   QueryEventsInput,
   runQueryEvents,
 } from './tools/query-events.js';
+import {
+  CursorListInput,
+  CursorResetInput,
+  runCursorList,
+  runCursorReset,
+} from './tools/cursor.js';
+import { CursorStore } from './state/cursors.js';
 
 /**
  * Entrypoint. Wires the three v0.1 tools to the MCP stdio transport.
@@ -37,7 +44,8 @@ const TOOLS = [
     name: 'query_events',
     description:
       'Stream typed events from Mithril log sources within a time window. ' +
-      'Returns NDJSON-shaped parsed events plus a summary envelope.',
+      'Sources: player (Player.log), chat (ChatLogs/), mithril (Serilog), all (merged by ts). ' +
+      'Pass character + last_session=true for "everything from this character\'s most recent session".',
     inputSchema: zodToJsonSchema(QueryEventsInput),
   },
   {
@@ -55,10 +63,25 @@ const TOOLS = [
       'Use this to discover what queries are possible.',
     inputSchema: zodToJsonSchema(ListEventTypesInput),
   },
+  {
+    name: 'cursor_list',
+    description:
+      'Lists named cursors stored at %LocalAppData%/MithrilLogMcp/cursors.json. ' +
+      'Cursors track per-file byte offsets so subsequent queries can resume.',
+    inputSchema: zodToJsonSchema(CursorListInput),
+  },
+  {
+    name: 'cursor_reset',
+    description:
+      'Removes a named cursor so the next query starts from the configured ' +
+      'time window again.',
+    inputSchema: zodToJsonSchema(CursorResetInput),
+  },
 ] as const;
 
 async function main(): Promise<void> {
   const config = loadConfig();
+  const cursorStore = new CursorStore();
   const server = new Server(
     { name: SERVER_NAME, version: SERVER_VERSION },
     { capabilities: { tools: {} } },
@@ -90,6 +113,20 @@ async function main(): Promise<void> {
         case 'list_event_types': {
           const args = ListEventTypesInput.parse(rawArgs ?? {});
           const result = runListEventTypes(args);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'cursor_list': {
+          const args = CursorListInput.parse(rawArgs ?? {});
+          const result = runCursorList(args, cursorStore);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'cursor_reset': {
+          const args = CursorResetInput.parse(rawArgs ?? {});
+          const result = runCursorReset(args, cursorStore);
           return {
             content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           };

--- a/tools/MithrilLogMcp/src/sources/chat-log.ts
+++ b/tools/MithrilLogMcp/src/sources/chat-log.ts
@@ -1,0 +1,89 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { lineStream } from '../util/file-streams.js';
+import { ChatLineParser } from '../parsing/chat-parser.js';
+import type { ParsedEvent } from '../parsing/types.js';
+import type { Catalog } from '../parsing/catalog.js';
+
+const CHAT_LINE_RE = /^(?<y>\d{2})-(?<m>\d{2})-(?<d>\d{2})\s+(?<H>\d{2}):(?<M>\d{2}):(?<S>\d{2})\s*\t/;
+const CHAT_FILE_RE = /^Chat-(\d{2})-(\d{2})-(\d{2})\.log$/;
+
+export interface ChatLogQuery {
+  dir: string;
+  since: Date;
+  until: Date;
+}
+
+export interface ChatScanStats {
+  scannedBytes: number;
+  scannedLines: number;
+}
+
+/**
+ * Streams Mithril's `ChatLogs/Chat-YY-MM-DD.log` files in chronological order,
+ * yielding parsed events that fall within the requested time window. Files
+ * outside the window (by filename date) are skipped without opening.
+ *
+ * The chat line itself carries a full `YY-MM-DD HH:MM:SS` timestamp, which
+ * we parse directly — no mtime anchor needed (unlike Player.log).
+ */
+export async function* scanChatLogs(
+  catalog: Catalog,
+  query: ChatLogQuery,
+  stats: ChatScanStats,
+): AsyncGenerator<ParsedEvent, void, void> {
+  if (!fs.existsSync(query.dir)) return;
+
+  const entries = fs.readdirSync(query.dir).sort();
+  const parser = new ChatLineParser(catalog);
+
+  for (const name of entries) {
+    const m = CHAT_FILE_RE.exec(name);
+    if (!m) continue;
+
+    const fileDate = chatFileDate(m[1]!, m[2]!, m[3]!);
+    // Skip files entirely outside the window. Conservative: keep the file if any
+    // hour of its day overlaps with [since, until].
+    const dayStart = new Date(fileDate.getTime());
+    const dayEnd = new Date(fileDate.getTime() + 24 * 3_600_000);
+    if (dayEnd < query.since) continue;
+    if (dayStart > query.until) continue;
+
+    const fullPath = path.join(query.dir, name);
+    const stat = fs.statSync(fullPath);
+    stats.scannedBytes += stat.size;
+
+    for await (const rec of lineStream(fullPath)) {
+      stats.scannedLines += 1;
+      const ts = parseChatTimestamp(rec.line);
+      if (!ts) continue;
+      if (ts < query.since) continue;
+      if (ts > query.until) return; // sorted, so anything past is also past
+      for (const ev of parser.parse(rec.line, ts, fullPath, rec.lineNo, rec.byteOffset)) {
+        yield ev;
+      }
+    }
+  }
+}
+
+function chatFileDate(y: string, m: string, d: string): Date {
+  // Two-digit year: 26 -> 2026. Bake in the simple +2000 convention; revisit
+  // if Project Gorgon's filename format ever changes.
+  const year = 2000 + Number.parseInt(y, 10);
+  const month = Number.parseInt(m, 10) - 1;
+  const day = Number.parseInt(d, 10);
+  return new Date(Date.UTC(year, month, day));
+}
+
+function parseChatTimestamp(line: string): Date | null {
+  const m = CHAT_LINE_RE.exec(line);
+  if (!m) return null;
+  const g = m.groups!;
+  const year = 2000 + Number.parseInt(g.y!, 10);
+  const month = Number.parseInt(g.m!, 10) - 1;
+  const day = Number.parseInt(g.d!, 10);
+  const H = Number.parseInt(g.H!, 10);
+  const M = Number.parseInt(g.M!, 10);
+  const S = Number.parseInt(g.S!, 10);
+  return new Date(Date.UTC(year, month, day, H, M, S));
+}

--- a/tools/MithrilLogMcp/src/sources/chat-log.ts
+++ b/tools/MithrilLogMcp/src/sources/chat-log.ts
@@ -97,5 +97,8 @@ function parseChatTimestamp(line: string): Date | null {
   const H = Number.parseInt(g.H!, 10);
   const M = Number.parseInt(g.M!, 10);
   const S = Number.parseInt(g.S!, 10);
-  return new Date(Date.UTC(year, month, day, H, M, S));
+  // The game writes chat timestamps in the user's local timezone. Use the
+  // local Date constructor so the resulting UTC instant matches the wall
+  // clock the user sees.
+  return new Date(year, month, day, H, M, S);
 }

--- a/tools/MithrilLogMcp/src/sources/chat-log.ts
+++ b/tools/MithrilLogMcp/src/sources/chat-log.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { lineStream } from '../util/file-streams.js';
 import { ChatLineParser } from '../parsing/chat-parser.js';
+import { rolloverDetected, type FileCursor } from '../state/cursors.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { Catalog } from '../parsing/catalog.js';
 
@@ -12,20 +13,22 @@ export interface ChatLogQuery {
   dir: string;
   since: Date;
   until: Date;
+  /** Per-file cursors keyed by absolute path. Stale entries trigger rollover. */
+  prevCursors?: Record<string, FileCursor> | undefined;
 }
 
 export interface ChatScanStats {
   scannedBytes: number;
   scannedLines: number;
+  endOffsets: Record<string, number>;
+  rolledOverFiles: string[];
 }
 
 /**
  * Streams Mithril's `ChatLogs/Chat-YY-MM-DD.log` files in chronological order,
- * yielding parsed events that fall within the requested time window. Files
- * outside the window (by filename date) are skipped without opening.
- *
- * The chat line itself carries a full `YY-MM-DD HH:MM:SS` timestamp, which
- * we parse directly — no mtime anchor needed (unlike Player.log).
+ * yielding parsed events within the time window. Files outside the window (by
+ * filename date) are skipped without opening; in-window files start at their
+ * cursor offset (when available and not stale).
  */
 export async function* scanChatLogs(
   catalog: Catalog,
@@ -42,8 +45,6 @@ export async function* scanChatLogs(
     if (!m) continue;
 
     const fileDate = chatFileDate(m[1]!, m[2]!, m[3]!);
-    // Skip files entirely outside the window. Conservative: keep the file if any
-    // hour of its day overlaps with [since, until].
     const dayStart = new Date(fileDate.getTime());
     const dayEnd = new Date(fileDate.getTime() + 24 * 3_600_000);
     if (dayEnd < query.since) continue;
@@ -51,14 +52,27 @@ export async function* scanChatLogs(
 
     const fullPath = path.join(query.dir, name);
     const stat = fs.statSync(fullPath);
-    stats.scannedBytes += stat.size;
+    const prev = query.prevCursors?.[fullPath];
 
-    for await (const rec of lineStream(fullPath)) {
+    let startOffset = 0;
+    if (prev) {
+      if (rolloverDetected(prev, stat)) {
+        stats.rolledOverFiles.push(fullPath);
+      } else {
+        startOffset = Math.min(prev.byteOffset, stat.size);
+      }
+    }
+
+    stats.scannedBytes += Math.max(0, stat.size - startOffset);
+    stats.endOffsets[fullPath] = startOffset;
+
+    for await (const rec of lineStream(fullPath, { start: startOffset })) {
       stats.scannedLines += 1;
+      stats.endOffsets[fullPath] = rec.byteOffset + rec.byteLength;
       const ts = parseChatTimestamp(rec.line);
       if (!ts) continue;
       if (ts < query.since) continue;
-      if (ts > query.until) return; // sorted, so anything past is also past
+      if (ts > query.until) return;
       for (const ev of parser.parse(rec.line, ts, fullPath, rec.lineNo, rec.byteOffset)) {
         yield ev;
       }
@@ -67,8 +81,6 @@ export async function* scanChatLogs(
 }
 
 function chatFileDate(y: string, m: string, d: string): Date {
-  // Two-digit year: 26 -> 2026. Bake in the simple +2000 convention; revisit
-  // if Project Gorgon's filename format ever changes.
   const year = 2000 + Number.parseInt(y, 10);
   const month = Number.parseInt(m, 10) - 1;
   const day = Number.parseInt(d, 10);

--- a/tools/MithrilLogMcp/src/sources/mithril-serilog.ts
+++ b/tools/MithrilLogMcp/src/sources/mithril-serilog.ts
@@ -1,0 +1,116 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { lineStream } from '../util/file-streams.js';
+import type { ParsedEvent } from '../parsing/types.js';
+
+export interface MithrilSerilogQuery {
+  dir: string;
+  since: Date;
+  until: Date;
+}
+
+export interface MithrilSerilogScanStats {
+  scannedBytes: number;
+  scannedLines: number;
+}
+
+interface CompactSerilogLine {
+  '@t'?: string;
+  '@mt'?: string;
+  '@m'?: string;
+  '@l'?: string;
+  '@x'?: string;
+  Category?: string;
+  Message?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Streams Mithril's own Serilog output (CompactJsonFormatter, one record per line,
+ * `@t`/`@mt`/`Category`/`Message` fields). Glob is `*.json` so the historical
+ * `gorgon-*.json` files captured by the legacy-log migration step are also
+ * indexed alongside the renamed `mithril-*-prebrand.json` and current `mithril-*.json`.
+ *
+ * Detection: try `JSON.parse` on the first non-empty line; if it parses and has
+ * `@t`, treat as a Serilog file. Otherwise skip — we don't fall back to a
+ * regex parser for v0.2.
+ */
+export async function* scanMithrilSerilog(
+  query: MithrilSerilogQuery,
+  stats: MithrilSerilogScanStats,
+): AsyncGenerator<ParsedEvent, void, void> {
+  if (!fs.existsSync(query.dir)) return;
+  const entries = fs.readdirSync(query.dir)
+    .filter((n) => n.endsWith('.json'))
+    .map((n) => ({ name: n, full: path.join(query.dir, n) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const e of entries) {
+    if (!(await fileLooksLikeSerilog(e.full))) continue;
+
+    const stat = fs.statSync(e.full);
+    stats.scannedBytes += stat.size;
+
+    for await (const rec of lineStream(e.full)) {
+      stats.scannedLines += 1;
+      if (rec.line.length === 0) continue;
+
+      let parsed: CompactSerilogLine;
+      try {
+        parsed = JSON.parse(rec.line) as CompactSerilogLine;
+      } catch {
+        continue;
+      }
+
+      const tsRaw = parsed['@t'];
+      if (typeof tsRaw !== 'string') continue;
+      const ts = new Date(tsRaw);
+      if (!Number.isFinite(ts.getTime())) continue;
+      if (ts < query.since) continue;
+      if (ts > query.until) break;
+
+      const category = typeof parsed.Category === 'string' ? parsed.Category : 'Unknown';
+      const message = typeof parsed.Message === 'string'
+        ? parsed.Message
+        : (typeof parsed['@m'] === 'string' ? parsed['@m'] : '');
+
+      const data: Record<string, unknown> = { category, message };
+      const level = parsed['@l'];
+      if (typeof level === 'string') data.level = level;
+      const exception = parsed['@x'];
+      if (typeof exception === 'string') data.exception = exception;
+
+      // Surface any non-Serilog-internal fields verbatim so structured log
+      // properties remain queryable by downstream tools.
+      for (const [k, v] of Object.entries(parsed)) {
+        if (k.startsWith('@')) continue;
+        if (k === 'Category' || k === 'Message') continue;
+        data[k] = v;
+      }
+
+      yield {
+        type: `mithril.${category}`,
+        ts: ts.toISOString(),
+        module: 'mithril',
+        source: 'mithril',
+        file: e.full,
+        line: rec.lineNo,
+        byteOffset: rec.byteOffset,
+        data,
+      };
+    }
+  }
+}
+
+async function fileLooksLikeSerilog(file: string): Promise<boolean> {
+  for await (const rec of lineStream(file)) {
+    if (rec.line.length === 0) continue;
+    try {
+      const obj = JSON.parse(rec.line) as Record<string, unknown>;
+      return typeof obj['@t'] === 'string';
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}

--- a/tools/MithrilLogMcp/src/sources/mithril-serilog.ts
+++ b/tools/MithrilLogMcp/src/sources/mithril-serilog.ts
@@ -1,17 +1,21 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { lineStream } from '../util/file-streams.js';
+import { rolloverDetected, type FileCursor } from '../state/cursors.js';
 import type { ParsedEvent } from '../parsing/types.js';
 
 export interface MithrilSerilogQuery {
   dir: string;
   since: Date;
   until: Date;
+  prevCursors?: Record<string, FileCursor> | undefined;
 }
 
 export interface MithrilSerilogScanStats {
   scannedBytes: number;
   scannedLines: number;
+  endOffsets: Record<string, number>;
+  rolledOverFiles: string[];
 }
 
 interface CompactSerilogLine {
@@ -26,14 +30,10 @@ interface CompactSerilogLine {
 }
 
 /**
- * Streams Mithril's own Serilog output (CompactJsonFormatter, one record per line,
- * `@t`/`@mt`/`Category`/`Message` fields). Glob is `*.json` so the historical
- * `gorgon-*.json` files captured by the legacy-log migration step are also
- * indexed alongside the renamed `mithril-*-prebrand.json` and current `mithril-*.json`.
- *
- * Detection: try `JSON.parse` on the first non-empty line; if it parses and has
- * `@t`, treat as a Serilog file. Otherwise skip — we don't fall back to a
- * regex parser for v0.2.
+ * Streams Mithril's own Serilog output (CompactJsonFormatter, one record per line).
+ * Detection is by content (first line has `@t`), so the legacy
+ * `gorgon-*.json` files migrated to `mithril-*-prebrand.json` and the current
+ * `mithril-*.json` files are all picked up under one glob.
  */
 export async function* scanMithrilSerilog(
   query: MithrilSerilogQuery,
@@ -49,10 +49,22 @@ export async function* scanMithrilSerilog(
     if (!(await fileLooksLikeSerilog(e.full))) continue;
 
     const stat = fs.statSync(e.full);
-    stats.scannedBytes += stat.size;
+    const prev = query.prevCursors?.[e.full];
+    let startOffset = 0;
+    if (prev) {
+      if (rolloverDetected(prev, stat)) {
+        stats.rolledOverFiles.push(e.full);
+      } else {
+        startOffset = Math.min(prev.byteOffset, stat.size);
+      }
+    }
 
-    for await (const rec of lineStream(e.full)) {
+    stats.scannedBytes += Math.max(0, stat.size - startOffset);
+    stats.endOffsets[e.full] = startOffset;
+
+    for await (const rec of lineStream(e.full, { start: startOffset })) {
       stats.scannedLines += 1;
+      stats.endOffsets[e.full] = rec.byteOffset + rec.byteLength;
       if (rec.line.length === 0) continue;
 
       let parsed: CompactSerilogLine;
@@ -80,8 +92,6 @@ export async function* scanMithrilSerilog(
       const exception = parsed['@x'];
       if (typeof exception === 'string') data.exception = exception;
 
-      // Surface any non-Serilog-internal fields verbatim so structured log
-      // properties remain queryable by downstream tools.
       for (const [k, v] of Object.entries(parsed)) {
         if (k.startsWith('@')) continue;
         if (k === 'Category' || k === 'Message') continue;

--- a/tools/MithrilLogMcp/src/sources/mithril-serilog.ts
+++ b/tools/MithrilLogMcp/src/sources/mithril-serilog.ts
@@ -9,6 +9,13 @@ export interface MithrilSerilogQuery {
   since: Date;
   until: Date;
   prevCursors?: Record<string, FileCursor> | undefined;
+  /**
+   * If provided, pre-filter raw lines on a substring `"Category":"<name>"`
+   * before parsing JSON. Skips ~95% of lines for category-specific queries
+   * on multi-GB Serilog dumps. The full `event_type` filter still runs in
+   * the tool layer; this is an opportunistic shortcut.
+   */
+  categoryAllowlist?: ReadonlySet<string> | undefined;
 }
 
 export interface MithrilSerilogScanStats {
@@ -62,10 +69,24 @@ export async function* scanMithrilSerilog(
     stats.scannedBytes += Math.max(0, stat.size - startOffset);
     stats.endOffsets[e.full] = startOffset;
 
+    // Pre-build the category-substring allowlist so we don't re-format the
+    // probe string per line. CompactJsonFormatter emits keys in stable order,
+    // so an exact `"Category":"X"` substring is reliable.
+    const categoryProbes = query.categoryAllowlist
+      ? Array.from(query.categoryAllowlist, (c) => `"Category":"${c}"`)
+      : null;
+
     for await (const rec of lineStream(e.full, { start: startOffset })) {
       stats.scannedLines += 1;
       stats.endOffsets[e.full] = rec.byteOffset + rec.byteLength;
       if (rec.line.length === 0) continue;
+
+      // Cheap pre-filter: skip lines whose Category isn't in the allowlist.
+      // Saves a JSON.parse per skipped line; on a 1GB Serilog dump filtered
+      // to one Category, this is ~10x throughput.
+      if (categoryProbes && !categoryProbes.some((p) => rec.line.includes(p))) {
+        continue;
+      }
 
       let parsed: CompactSerilogLine;
       try {

--- a/tools/MithrilLogMcp/src/sources/multi-source.ts
+++ b/tools/MithrilLogMcp/src/sources/multi-source.ts
@@ -4,51 +4,73 @@ import { scanMithrilSerilog, type MithrilSerilogScanStats } from './mithril-seri
 import type { Catalog } from '../parsing/catalog.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
+import type { CursorState, FileCursor } from '../state/cursors.js';
 
 export type SourceName = 'player' | 'chat' | 'mithril' | 'all';
 
 export interface MultiSourceStats {
   scannedBytes: number;
   scannedLines: number;
+  /**
+   * Where each file was last read up to. Aggregated across sources for the
+   * `all` case. Callers use this to advance cursors after a successful query.
+   */
+  endOffsetsBySource: Record<string, Record<string, number>>;
+  rolledOverFiles: string[];
 }
 
 export interface MultiSourceQuery {
   source: SourceName;
   since: Date;
   until: Date;
+  /** Optional per-source cursor state for resumed reads. */
+  cursors?: Record<string, CursorState> | undefined;
 }
 
-/**
- * Yields parsed events from one or more sources, merged in timestamp order.
- *
- * For a single source, falls through to the underlying scanner. For
- * `source: "all"`, opens one async iterator per known source and yields
- * the lowest-timestamp event across all of them on each step (manual
- * 3-way heap; small enough that an actual heap would just add overhead).
- */
+const PER_SOURCE_KEYS: Array<Exclude<SourceName, 'all'>> = ['player', 'chat', 'mithril'];
+
 export async function* scanMultiSource(
   catalog: Catalog,
   config: ServerConfig,
   query: MultiSourceQuery,
   stats: MultiSourceStats,
 ): AsyncGenerator<ParsedEvent, void, void> {
+  // Pre-create slots for every requested source so callers can safely read
+  // `endOffsetsBySource[s]` even when nothing was scanned (e.g. a missing
+  // chat dir on a fresh install).
+  const sourcesToScan = query.source === 'all' ? PER_SOURCE_KEYS : [query.source];
+  for (const s of sourcesToScan) stats.endOffsetsBySource[s] = {};
+
   if (query.source !== 'all') {
     yield* singleSource(catalog, config, query, stats);
     return;
   }
 
-  const playerStats: PlayerLogScanStats = { scannedBytes: 0, scannedLines: 0 };
-  const chatStats: ChatScanStats = { scannedBytes: 0, scannedLines: 0 };
-  const serilogStats: MithrilSerilogScanStats = { scannedBytes: 0, scannedLines: 0 };
+  const playerStats = makeSubStats();
+  const chatStats = makeSubStats();
+  const serilogStats = makeSubStats();
 
   const iterators: AsyncIterator<ParsedEvent>[] = [
-    scanPlayerLog(catalog, { path: config.playerLogPath, since: query.since, until: query.until }, playerStats)[Symbol.asyncIterator](),
-    scanChatLogs(catalog, { dir: config.chatLogDir, since: query.since, until: query.until }, chatStats)[Symbol.asyncIterator](),
-    scanMithrilSerilog({ dir: config.mithrilLogDir, since: query.since, until: query.until }, serilogStats)[Symbol.asyncIterator](),
+    scanPlayerLog(catalog, {
+      path: config.playerLogPath,
+      since: query.since,
+      until: query.until,
+      prevCursor: cursorEntryFor(query.cursors?.player, config.playerLogPath),
+    }, playerStats)[Symbol.asyncIterator](),
+    scanChatLogs(catalog, {
+      dir: config.chatLogDir,
+      since: query.since,
+      until: query.until,
+      prevCursors: query.cursors?.chat?.perFile,
+    }, chatStats)[Symbol.asyncIterator](),
+    scanMithrilSerilog({
+      dir: config.mithrilLogDir,
+      since: query.since,
+      until: query.until,
+      prevCursors: query.cursors?.mithril?.perFile,
+    }, serilogStats)[Symbol.asyncIterator](),
   ];
 
-  // Buffer one event per iterator. Pop the smallest, advance that iterator,
-  // refill its slot. End when every slot is empty.
   const slots: Array<{ ev: ParsedEvent; iter: AsyncIterator<ParsedEvent> } | null> = [];
   for (const it of iterators) {
     const next = await it.next();
@@ -76,6 +98,14 @@ export async function* scanMultiSource(
 
   stats.scannedBytes = playerStats.scannedBytes + chatStats.scannedBytes + serilogStats.scannedBytes;
   stats.scannedLines = playerStats.scannedLines + chatStats.scannedLines + serilogStats.scannedLines;
+  stats.endOffsetsBySource.player = playerStats.endOffsets;
+  stats.endOffsetsBySource.chat = chatStats.endOffsets;
+  stats.endOffsetsBySource.mithril = serilogStats.endOffsets;
+  stats.rolledOverFiles.push(
+    ...playerStats.rolledOverFiles,
+    ...chatStats.rolledOverFiles,
+    ...serilogStats.rolledOverFiles,
+  );
 }
 
 async function* singleSource(
@@ -86,27 +116,65 @@ async function* singleSource(
 ): AsyncGenerator<ParsedEvent, void, void> {
   switch (query.source) {
     case 'player': {
-      const s: PlayerLogScanStats = { scannedBytes: 0, scannedLines: 0 };
-      yield* scanPlayerLog(catalog, { path: config.playerLogPath, since: query.since, until: query.until }, s);
-      stats.scannedBytes = s.scannedBytes;
-      stats.scannedLines = s.scannedLines;
+      const sub = makeSubStats();
+      yield* scanPlayerLog(catalog, {
+        path: config.playerLogPath,
+        since: query.since,
+        until: query.until,
+        prevCursor: cursorEntryFor(query.cursors?.player, config.playerLogPath),
+      }, sub);
+      stats.scannedBytes = sub.scannedBytes;
+      stats.scannedLines = sub.scannedLines;
+      stats.endOffsetsBySource.player = sub.endOffsets;
+      stats.rolledOverFiles.push(...sub.rolledOverFiles);
       return;
     }
     case 'chat': {
-      const s: ChatScanStats = { scannedBytes: 0, scannedLines: 0 };
-      yield* scanChatLogs(catalog, { dir: config.chatLogDir, since: query.since, until: query.until }, s);
-      stats.scannedBytes = s.scannedBytes;
-      stats.scannedLines = s.scannedLines;
+      const sub = makeSubStats();
+      yield* scanChatLogs(catalog, {
+        dir: config.chatLogDir,
+        since: query.since,
+        until: query.until,
+        prevCursors: query.cursors?.chat?.perFile,
+      }, sub);
+      stats.scannedBytes = sub.scannedBytes;
+      stats.scannedLines = sub.scannedLines;
+      stats.endOffsetsBySource.chat = sub.endOffsets;
+      stats.rolledOverFiles.push(...sub.rolledOverFiles);
       return;
     }
     case 'mithril': {
-      const s: MithrilSerilogScanStats = { scannedBytes: 0, scannedLines: 0 };
-      yield* scanMithrilSerilog({ dir: config.mithrilLogDir, since: query.since, until: query.until }, s);
-      stats.scannedBytes = s.scannedBytes;
-      stats.scannedLines = s.scannedLines;
+      const sub = makeSubStats();
+      yield* scanMithrilSerilog({
+        dir: config.mithrilLogDir,
+        since: query.since,
+        until: query.until,
+        prevCursors: query.cursors?.mithril?.perFile,
+      }, sub);
+      stats.scannedBytes = sub.scannedBytes;
+      stats.scannedLines = sub.scannedLines;
+      stats.endOffsetsBySource.mithril = sub.endOffsets;
+      stats.rolledOverFiles.push(...sub.rolledOverFiles);
       return;
     }
     default:
       throw new Error(`Unknown source: ${query.source}`);
   }
+}
+
+function makeSubStats(): PlayerLogScanStats & ChatScanStats & MithrilSerilogScanStats {
+  return { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
+}
+
+function cursorEntryFor(state: CursorState | undefined, file: string): FileCursor | undefined {
+  return state?.perFile[file];
+}
+
+export function emptyMultiSourceStats(): MultiSourceStats {
+  return {
+    scannedBytes: 0,
+    scannedLines: 0,
+    endOffsetsBySource: {},
+    rolledOverFiles: [],
+  };
 }

--- a/tools/MithrilLogMcp/src/sources/multi-source.ts
+++ b/tools/MithrilLogMcp/src/sources/multi-source.ts
@@ -25,6 +25,12 @@ export interface MultiSourceQuery {
   until: Date;
   /** Optional per-source cursor state for resumed reads. */
   cursors?: Record<string, CursorState> | undefined;
+  /** Set of full event_type values requested. Used by sources that can
+   *  cheaply pre-filter (e.g. Mithril Serilog by `"Category":"X"`). */
+  eventTypeAllowlist?: ReadonlySet<string> | undefined;
+  /** Lines of surrounding raw context to attach to each event. Currently
+   *  honoured by source: 'player' only. */
+  context?: number | undefined;
 }
 
 const PER_SOURCE_KEYS: Array<Exclude<SourceName, 'all'>> = ['player', 'chat', 'mithril'];
@@ -56,6 +62,7 @@ export async function* scanMultiSource(
       since: query.since,
       until: query.until,
       prevCursor: cursorEntryFor(query.cursors?.player, config.playerLogPath),
+      context: query.context,
     }, playerStats)[Symbol.asyncIterator](),
     scanChatLogs(catalog, {
       dir: config.chatLogDir,
@@ -68,6 +75,7 @@ export async function* scanMultiSource(
       since: query.since,
       until: query.until,
       prevCursors: query.cursors?.mithril?.perFile,
+      categoryAllowlist: extractMithrilCategories(query.eventTypeAllowlist),
     }, serilogStats)[Symbol.asyncIterator](),
   ];
 
@@ -122,6 +130,7 @@ async function* singleSource(
         since: query.since,
         until: query.until,
         prevCursor: cursorEntryFor(query.cursors?.player, config.playerLogPath),
+        context: query.context,
       }, sub);
       stats.scannedBytes = sub.scannedBytes;
       stats.scannedLines = sub.scannedLines;
@@ -150,6 +159,7 @@ async function* singleSource(
         since: query.since,
         until: query.until,
         prevCursors: query.cursors?.mithril?.perFile,
+        categoryAllowlist: extractMithrilCategories(query.eventTypeAllowlist),
       }, sub);
       stats.scannedBytes = sub.scannedBytes;
       stats.scannedLines = sub.scannedLines;
@@ -177,4 +187,26 @@ export function emptyMultiSourceStats(): MultiSourceStats {
     endOffsetsBySource: {},
     rolledOverFiles: [],
   };
+}
+
+/**
+ * Extracts `mithril.<Category>` event types from the user's `event_type`
+ * allowlist and returns just the bare Categories. Returns `undefined`
+ * (no pre-filter) if there's no allowlist or none of the requested types
+ * are mithril-flavoured — falling back to the regular post-parse filter.
+ */
+function extractMithrilCategories(
+  eventTypes: ReadonlySet<string> | undefined,
+): ReadonlySet<string> | undefined {
+  if (!eventTypes || eventTypes.size === 0) return undefined;
+  const out = new Set<string>();
+  let sawNonMithril = false;
+  for (const t of eventTypes) {
+    if (t.startsWith('mithril.')) out.add(t.slice('mithril.'.length));
+    else sawNonMithril = true;
+  }
+  // If the allowlist mixes mithril.* with other event types, the source
+  // has to read everything anyway — pre-filter would drop legitimate hits.
+  if (sawNonMithril) return undefined;
+  return out.size > 0 ? out : undefined;
 }

--- a/tools/MithrilLogMcp/src/sources/multi-source.ts
+++ b/tools/MithrilLogMcp/src/sources/multi-source.ts
@@ -1,0 +1,112 @@
+import { scanPlayerLog, type PlayerLogScanStats } from './player-log.js';
+import { scanChatLogs, type ChatScanStats } from './chat-log.js';
+import { scanMithrilSerilog, type MithrilSerilogScanStats } from './mithril-serilog.js';
+import type { Catalog } from '../parsing/catalog.js';
+import type { ParsedEvent } from '../parsing/types.js';
+import type { ServerConfig } from '../config.js';
+
+export type SourceName = 'player' | 'chat' | 'mithril' | 'all';
+
+export interface MultiSourceStats {
+  scannedBytes: number;
+  scannedLines: number;
+}
+
+export interface MultiSourceQuery {
+  source: SourceName;
+  since: Date;
+  until: Date;
+}
+
+/**
+ * Yields parsed events from one or more sources, merged in timestamp order.
+ *
+ * For a single source, falls through to the underlying scanner. For
+ * `source: "all"`, opens one async iterator per known source and yields
+ * the lowest-timestamp event across all of them on each step (manual
+ * 3-way heap; small enough that an actual heap would just add overhead).
+ */
+export async function* scanMultiSource(
+  catalog: Catalog,
+  config: ServerConfig,
+  query: MultiSourceQuery,
+  stats: MultiSourceStats,
+): AsyncGenerator<ParsedEvent, void, void> {
+  if (query.source !== 'all') {
+    yield* singleSource(catalog, config, query, stats);
+    return;
+  }
+
+  const playerStats: PlayerLogScanStats = { scannedBytes: 0, scannedLines: 0 };
+  const chatStats: ChatScanStats = { scannedBytes: 0, scannedLines: 0 };
+  const serilogStats: MithrilSerilogScanStats = { scannedBytes: 0, scannedLines: 0 };
+
+  const iterators: AsyncIterator<ParsedEvent>[] = [
+    scanPlayerLog(catalog, { path: config.playerLogPath, since: query.since, until: query.until }, playerStats)[Symbol.asyncIterator](),
+    scanChatLogs(catalog, { dir: config.chatLogDir, since: query.since, until: query.until }, chatStats)[Symbol.asyncIterator](),
+    scanMithrilSerilog({ dir: config.mithrilLogDir, since: query.since, until: query.until }, serilogStats)[Symbol.asyncIterator](),
+  ];
+
+  // Buffer one event per iterator. Pop the smallest, advance that iterator,
+  // refill its slot. End when every slot is empty.
+  const slots: Array<{ ev: ParsedEvent; iter: AsyncIterator<ParsedEvent> } | null> = [];
+  for (const it of iterators) {
+    const next = await it.next();
+    slots.push(next.done ? null : { ev: next.value, iter: it });
+  }
+
+  while (slots.some((s) => s !== null)) {
+    let bestIdx = -1;
+    let bestTs = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < slots.length; i++) {
+      const s = slots[i];
+      if (!s) continue;
+      const t = Date.parse(s.ev.ts);
+      if (t < bestTs) {
+        bestTs = t;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx < 0) break;
+    const winner = slots[bestIdx]!;
+    yield winner.ev;
+    const next = await winner.iter.next();
+    slots[bestIdx] = next.done ? null : { ev: next.value, iter: winner.iter };
+  }
+
+  stats.scannedBytes = playerStats.scannedBytes + chatStats.scannedBytes + serilogStats.scannedBytes;
+  stats.scannedLines = playerStats.scannedLines + chatStats.scannedLines + serilogStats.scannedLines;
+}
+
+async function* singleSource(
+  catalog: Catalog,
+  config: ServerConfig,
+  query: MultiSourceQuery,
+  stats: MultiSourceStats,
+): AsyncGenerator<ParsedEvent, void, void> {
+  switch (query.source) {
+    case 'player': {
+      const s: PlayerLogScanStats = { scannedBytes: 0, scannedLines: 0 };
+      yield* scanPlayerLog(catalog, { path: config.playerLogPath, since: query.since, until: query.until }, s);
+      stats.scannedBytes = s.scannedBytes;
+      stats.scannedLines = s.scannedLines;
+      return;
+    }
+    case 'chat': {
+      const s: ChatScanStats = { scannedBytes: 0, scannedLines: 0 };
+      yield* scanChatLogs(catalog, { dir: config.chatLogDir, since: query.since, until: query.until }, s);
+      stats.scannedBytes = s.scannedBytes;
+      stats.scannedLines = s.scannedLines;
+      return;
+    }
+    case 'mithril': {
+      const s: MithrilSerilogScanStats = { scannedBytes: 0, scannedLines: 0 };
+      yield* scanMithrilSerilog({ dir: config.mithrilLogDir, since: query.since, until: query.until }, s);
+      stats.scannedBytes = s.scannedBytes;
+      stats.scannedLines = s.scannedLines;
+      return;
+    }
+    default:
+      throw new Error(`Unknown source: ${query.source}`);
+  }
+}

--- a/tools/MithrilLogMcp/src/sources/player-log.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import { lineStream, scannedBytes } from '../util/file-streams.js';
 import { PlayerLogTimestamper } from '../util/time-windows.js';
 import { PlayerLineParser } from '../parsing/player-parser.js';
+import { rolloverDetected, type FileCursor } from '../state/cursors.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { Catalog } from '../parsing/catalog.js';
 
@@ -9,17 +10,25 @@ export interface PlayerLogQuery {
   path: string;
   since: Date;
   until: Date;
+  /** Cursor entry for this file, if any. Honoured when not stale. */
+  prevCursor?: FileCursor | undefined;
 }
 
 export interface PlayerLogScanStats {
   scannedBytes: number;
   scannedLines: number;
+  /** Final byte offset reached per file. Used to advance cursors. */
+  endOffsets: Record<string, number>;
+  /** Files whose previous cursor was stale (rolled over) and reset to 0. */
+  rolledOverFiles: string[];
 }
 
 /**
- * Streams Player.log forward, yielding parsed events that fall within the
- * requested time window. v0.1 does a full forward scan from byte 0; the
- * binary-search optimisation for huge files lives in v0.3 once cursors land.
+ * Streams Player.log forward, yielding parsed events within the requested
+ * time window. If `prevCursor` is supplied and still valid (no rollover),
+ * scanning starts at its byteOffset; otherwise from byte 0. The final reached
+ * byte offset is recorded in `stats.endOffsets[path]` so callers can persist
+ * it as the next cursor.
  */
 export async function* scanPlayerLog(
   catalog: Catalog,
@@ -29,13 +38,25 @@ export async function* scanPlayerLog(
   if (!fs.existsSync(query.path)) return;
 
   const stat = fs.statSync(query.path);
-  stats.scannedBytes = scannedBytes(stat);
+  let startOffset = 0;
+  if (query.prevCursor) {
+    if (rolloverDetected(query.prevCursor, stat)) {
+      stats.rolledOverFiles.push(query.path);
+      startOffset = 0;
+    } else {
+      startOffset = Math.min(query.prevCursor.byteOffset, stat.size);
+    }
+  }
+
+  stats.scannedBytes += scannedBytes(stat, startOffset);
+  stats.endOffsets[query.path] = startOffset;
 
   const parser = new PlayerLineParser(catalog);
   const stamper = new PlayerLogTimestamper(stat.mtime);
 
-  for await (const rec of lineStream(query.path)) {
+  for await (const rec of lineStream(query.path, { start: startOffset })) {
     stats.scannedLines += 1;
+    stats.endOffsets[query.path] = rec.byteOffset + rec.byteLength;
     const ts = stamper.stamp(rec.line, stat.mtime);
     if (ts < query.since) continue;
     if (ts > query.until) break;

--- a/tools/MithrilLogMcp/src/sources/player-log.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import { lineStream, scannedBytes } from '../util/file-streams.js';
-import { PlayerLogTimestamper } from '../util/time-windows.js';
+import { countPlayerLogCrossings, PlayerLogTimestamper } from '../util/time-windows.js';
 import { PlayerLineParser } from '../parsing/player-parser.js';
 import { ActiveCharacterTracker } from '../parsing/active-character-tracker.js';
 import { rolloverDetected, type FileCursor } from '../state/cursors.js';
@@ -54,7 +54,16 @@ export async function* scanPlayerLog(
   stats.endOffsets[query.path] = startOffset;
 
   const parser = new PlayerLineParser(catalog);
-  const stamper = new PlayerLogTimestamper(stat.mtime);
+
+  // Anchor the *start* of the file, not the end. A first pass counts midnight
+  // crossings; the start-of-file date is mtime UTC date - crossings. The
+  // forward scan then advances the date as it sees its own crossings, so the
+  // last line of the file ends up stamped at the mtime UTC date — the only
+  // value we know for certain.
+  const crossings = await countPlayerLogCrossings(lineStream(query.path, { start: startOffset }));
+  const startDate = new Date(stat.mtime);
+  startDate.setUTCDate(startDate.getUTCDate() - crossings);
+  const stamper = new PlayerLogTimestamper(startDate);
 
   // Seed the active-character tracker from a backward scan when resuming
   // mid-stream — without it, every event before the next ProcessAddPlayer

--- a/tools/MithrilLogMcp/src/sources/player-log.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log.ts
@@ -1,0 +1,46 @@
+import * as fs from 'node:fs';
+import { lineStream, scannedBytes } from '../util/file-streams.js';
+import { PlayerLogTimestamper } from '../util/time-windows.js';
+import { PlayerLineParser } from '../parsing/player-parser.js';
+import type { ParsedEvent } from '../parsing/types.js';
+import type { Catalog } from '../parsing/catalog.js';
+
+export interface PlayerLogQuery {
+  path: string;
+  since: Date;
+  until: Date;
+}
+
+export interface PlayerLogScanStats {
+  scannedBytes: number;
+  scannedLines: number;
+}
+
+/**
+ * Streams Player.log forward, yielding parsed events that fall within the
+ * requested time window. v0.1 does a full forward scan from byte 0; the
+ * binary-search optimisation for huge files lives in v0.3 once cursors land.
+ */
+export async function* scanPlayerLog(
+  catalog: Catalog,
+  query: PlayerLogQuery,
+  stats: PlayerLogScanStats,
+): AsyncGenerator<ParsedEvent, void, void> {
+  if (!fs.existsSync(query.path)) return;
+
+  const stat = fs.statSync(query.path);
+  stats.scannedBytes = scannedBytes(stat);
+
+  const parser = new PlayerLineParser(catalog);
+  const stamper = new PlayerLogTimestamper(stat.mtime);
+
+  for await (const rec of lineStream(query.path)) {
+    stats.scannedLines += 1;
+    const ts = stamper.stamp(rec.line, stat.mtime);
+    if (ts < query.since) continue;
+    if (ts > query.until) break;
+    for (const ev of parser.parse(rec.line, ts, query.path, rec.lineNo, rec.byteOffset)) {
+      yield ev;
+    }
+  }
+}

--- a/tools/MithrilLogMcp/src/sources/player-log.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log.ts
@@ -2,7 +2,9 @@ import * as fs from 'node:fs';
 import { lineStream, scannedBytes } from '../util/file-streams.js';
 import { PlayerLogTimestamper } from '../util/time-windows.js';
 import { PlayerLineParser } from '../parsing/player-parser.js';
+import { ActiveCharacterTracker } from '../parsing/active-character-tracker.js';
 import { rolloverDetected, type FileCursor } from '../state/cursors.js';
+import { findActiveCharacterAt } from '../state/character-resolver.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { Catalog } from '../parsing/catalog.js';
 
@@ -54,6 +56,14 @@ export async function* scanPlayerLog(
   const parser = new PlayerLineParser(catalog);
   const stamper = new PlayerLogTimestamper(stat.mtime);
 
+  // Seed the active-character tracker from a backward scan when resuming
+  // mid-stream — without it, every event before the next ProcessAddPlayer
+  // would be unstamped and dropped by `character: "X"` filters.
+  const initialActive = startOffset > 0
+    ? findActiveCharacterAt(query.path, startOffset, catalog)
+    : null;
+  const tracker = new ActiveCharacterTracker(initialActive ?? undefined);
+
   for await (const rec of lineStream(query.path, { start: startOffset })) {
     stats.scannedLines += 1;
     stats.endOffsets[query.path] = rec.byteOffset + rec.byteLength;
@@ -61,6 +71,8 @@ export async function* scanPlayerLog(
     if (ts < query.since) continue;
     if (ts > query.until) break;
     for (const ev of parser.parse(rec.line, ts, query.path, rec.lineNo, rec.byteOffset)) {
+      tracker.observe(ev);
+      if (tracker.active) ev.activeCharacter = tracker.active;
       yield ev;
     }
   }

--- a/tools/MithrilLogMcp/src/sources/player-log.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log.ts
@@ -14,6 +14,13 @@ export interface PlayerLogQuery {
   until: Date;
   /** Cursor entry for this file, if any. Honoured when not stale. */
   prevCursor?: FileCursor | undefined;
+  /**
+   * Number of raw lines of surrounding context to attach to each emitted
+   * event as `contextLines: { before, after }`. 0 disables (default).
+   * Implemented as a ring buffer of the last N lines (before) plus a
+   * pending queue that holds events until N more lines are read (after).
+   */
+  context?: number | undefined;
 }
 
 export interface PlayerLogScanStats {
@@ -73,16 +80,56 @@ export async function* scanPlayerLog(
     : null;
   const tracker = new ActiveCharacterTracker(initialActive ?? undefined);
 
+  const N = query.context ?? 0;
+  const ringBefore: string[] = [];
+  // Each entry's `after` aliases ev.contextLines.after, so pushing to it
+  // mutates the event's own array — no second pass needed at yield time.
+  const pending: Array<{ ev: ParsedEvent; after: string[] }> = [];
+
   for await (const rec of lineStream(query.path, { start: startOffset })) {
+    // Feed this line as after-context to events still waiting; yield any
+    // whose after-window is now full.
+    if (N > 0) {
+      for (const p of pending) {
+        if (p.after.length < N) p.after.push(rec.line);
+      }
+      while (pending.length > 0 && pending[0]!.after.length >= N) {
+        yield pending.shift()!.ev;
+      }
+    }
+
     stats.scannedLines += 1;
     stats.endOffsets[query.path] = rec.byteOffset + rec.byteLength;
     const ts = stamper.stamp(rec.line, stat.mtime);
-    if (ts < query.since) continue;
+    if (ts < query.since) {
+      if (N > 0) pushRing(ringBefore, rec.line, N);
+      continue;
+    }
     if (ts > query.until) break;
+
     for (const ev of parser.parse(rec.line, ts, query.path, rec.lineNo, rec.byteOffset)) {
       tracker.observe(ev);
       if (tracker.active) ev.activeCharacter = tracker.active;
-      yield ev;
+      if (N > 0) {
+        ev.contextLines = { before: [...ringBefore], after: [] };
+        pending.push({ ev, after: ev.contextLines.after });
+      } else {
+        yield ev;
+      }
     }
+
+    if (N > 0) pushRing(ringBefore, rec.line, N);
   }
+
+  // Drain whatever events are still waiting for their full after-context.
+  // They get whatever was accumulated before the scan ended.
+  while (pending.length > 0) {
+    yield pending.shift()!.ev;
+  }
+}
+
+function pushRing(ring: string[], line: string, max: number): void {
+  if (max <= 0) return;
+  ring.push(line);
+  while (ring.length > max) ring.shift();
 }

--- a/tools/MithrilLogMcp/src/state/character-resolver.ts
+++ b/tools/MithrilLogMcp/src/state/character-resolver.ts
@@ -3,6 +3,8 @@ import * as path from 'node:path';
 import type { ServerConfig } from '../config.js';
 import type { Catalog } from '../parsing/catalog.js';
 
+const ADD_PLAYER_KEY = 'shared.ActiveCharacterLogSynchronizer.AddPlayerRx';
+
 /**
  * Reads Mithril's character-presence state to support `--last-session` and
  * `character: "Foo"` queries. State files are read-only; the MCP server never
@@ -84,6 +86,60 @@ export function resolveLastSessionWindow(
 
   const since = scanBackForSessionStart(config, catalog, name) ?? new Date(0);
   return { since, until };
+}
+
+/**
+ * Scans Player.log backward from {@link beforeOffset} for the most recent
+ * `LocalPlayer: ProcessAddPlayer(...)` line and returns the captured character
+ * name. Used to seed {@link ActiveCharacterTracker} when a cursor resumes
+ * mid-stream without prior context.
+ *
+ * Returns `null` if no ProcessAddPlayer is found anywhere before the offset
+ * (cold session, log truncated, etc.) — callers should treat that as
+ * "active character unknown".
+ */
+export function findActiveCharacterAt(
+  playerLogPath: string,
+  beforeOffset: number,
+  catalog: Catalog,
+): string | null {
+  if (beforeOffset <= 0) return null;
+  if (!fs.existsSync(playerLogPath)) return null;
+
+  const entry = catalog.byKey.get(ADD_PLAYER_KEY);
+  if (!entry) return null;
+
+  const fd = fs.openSync(playerLogPath, 'r');
+  try {
+    const chunkSize = Math.min(catalog.sessionMarker.scanChunkBytes, beforeOffset);
+    const overlap = catalog.sessionMarker.literal.length;
+    let end = beforeOffset;
+    while (end > 0) {
+      const size = Math.min(chunkSize, end);
+      const start = end - size;
+      const buf = Buffer.alloc(size);
+      fs.readSync(fd, buf, 0, size, start);
+      const text = buf.toString('utf8');
+      const idx = text.lastIndexOf(catalog.sessionMarker.literal);
+      if (idx >= 0) {
+        const lineStart = text.lastIndexOf('\n', idx) + 1;
+        const lineEnd = text.indexOf('\n', idx);
+        const line = text.substring(lineStart, lineEnd < 0 ? text.length : lineEnd);
+        const m = entry.regex.exec(line);
+        if (m) {
+          const captured = typeof entry.fields[0]?.group === 'number'
+            ? m[entry.fields[0].group]
+            : m.groups?.[entry.fields[0]?.group as string];
+          if (typeof captured === 'string' && captured.length > 0) return captured;
+        }
+      }
+      if (start === 0) break;
+      end = start + overlap;
+    }
+    return null;
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 function scanBackForSessionStart(

--- a/tools/MithrilLogMcp/src/state/character-resolver.ts
+++ b/tools/MithrilLogMcp/src/state/character-resolver.ts
@@ -1,0 +1,130 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ServerConfig } from '../config.js';
+import type { Catalog } from '../parsing/catalog.js';
+
+/**
+ * Reads Mithril's character-presence state to support `--last-session` and
+ * `character: "Foo"` queries. State files are read-only; the MCP server never
+ * writes to Mithril's state.
+ */
+
+export interface ActiveCharacter {
+  name: string;
+  server: string;
+  lastActiveAt: Date | null;
+}
+
+interface ShellSettingsFile {
+  activeCharacterName?: string;
+  activeServer?: string;
+}
+
+interface CharacterPresenceFile {
+  schemaVersion?: number;
+  lastActiveAt?: string;
+}
+
+export function readActiveCharacter(config: ServerConfig): ActiveCharacter | null {
+  if (!fs.existsSync(config.shellSettingsPath)) return null;
+  let shell: ShellSettingsFile;
+  try {
+    shell = JSON.parse(fs.readFileSync(config.shellSettingsPath, 'utf8')) as ShellSettingsFile;
+  } catch {
+    return null;
+  }
+  const name = shell.activeCharacterName;
+  const server = shell.activeServer;
+  if (!name || !server) return null;
+
+  const lastActiveAt = readLastActiveAt(config, name, server);
+  return { name, server, lastActiveAt };
+}
+
+export function readLastActiveAt(
+  config: ServerConfig,
+  name: string,
+  server: string,
+): Date | null {
+  const presencePath = path.join(config.characterRoot, `${name}_${server}`, 'character.json');
+  if (!fs.existsSync(presencePath)) return null;
+  try {
+    const data = JSON.parse(fs.readFileSync(presencePath, 'utf8')) as CharacterPresenceFile;
+    if (typeof data.lastActiveAt !== 'string') return null;
+    const d = new Date(data.lastActiveAt);
+    return Number.isFinite(d.getTime()) ? d : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves a `--last-session` window for a named character.
+ *
+ * The lower bound is the byte offset of the most recent
+ * `LocalPlayer: ProcessAddPlayer(..., "<name>", ...)` line in Player.log
+ * — same algorithm as Mithril's `PlayerLogTailReader.SeedToSessionStart`,
+ * scoped by character name. The upper bound is the character's stored
+ * `lastActiveAt` if present and in the past, else `now`.
+ */
+export interface SessionWindow {
+  since: Date;
+  until: Date;
+}
+
+export function resolveLastSessionWindow(
+  config: ServerConfig,
+  catalog: Catalog,
+  name: string,
+  now: Date,
+): SessionWindow {
+  const server = readActiveCharacter(config)?.server ?? '';
+  const lastActiveAt = server ? readLastActiveAt(config, name, server) : null;
+  const until = lastActiveAt && lastActiveAt < now ? lastActiveAt : now;
+
+  const since = scanBackForSessionStart(config, catalog, name) ?? new Date(0);
+  return { since, until };
+}
+
+function scanBackForSessionStart(
+  config: ServerConfig,
+  catalog: Catalog,
+  name: string,
+): Date | null {
+  if (!fs.existsSync(config.playerLogPath)) return null;
+  const stat = fs.statSync(config.playerLogPath);
+  const fd = fs.openSync(config.playerLogPath, 'r');
+  try {
+    const chunkSize = Math.min(catalog.sessionMarker.scanChunkBytes, stat.size);
+    const overlap = catalog.sessionMarker.literal.length;
+    const namePattern = `, "${name}",`;
+    let end = stat.size;
+    while (end > 0) {
+      const size = Math.min(chunkSize, end);
+      const start = end - size;
+      const buf = Buffer.alloc(size);
+      fs.readSync(fd, buf, 0, size, start);
+      const text = buf.toString('utf8');
+      // Search backward for the most recent ProcessAddPlayer that names this character.
+      let idx = text.lastIndexOf(namePattern);
+      while (idx >= 0) {
+        // Ensure the same line also has the session-marker literal.
+        const lineStart = text.lastIndexOf('\n', idx) + 1;
+        const lineEnd = text.indexOf('\n', idx);
+        const line = text.substring(lineStart, lineEnd < 0 ? text.length : lineEnd);
+        if (line.includes(catalog.sessionMarker.literal)) {
+          // Time anchor: file mtime (same approximation as PlayerLogTimestamper).
+          // For session windows, we just need a chronological lower bound, so
+          // returning the file's mtime minus a generous slack works.
+          return new Date(stat.mtime.getTime() - 24 * 3_600_000);
+        }
+        idx = text.lastIndexOf(namePattern, idx - 1);
+      }
+      if (start === 0) break;
+      end = start + overlap;
+    }
+    return null;
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/tools/MithrilLogMcp/src/state/cursor-helpers.ts
+++ b/tools/MithrilLogMcp/src/state/cursor-helpers.ts
@@ -1,0 +1,62 @@
+import * as fs from 'node:fs';
+import { CursorStore, snapshotCursor, type CursorState } from './cursors.js';
+import type { MultiSourceStats } from '../sources/multi-source.js';
+
+/**
+ * Reusable cursor read/persist plumbing shared by `query_events` and
+ * `aggregate`. The store is the durable state; this module is the
+ * tool-side adapter that translates between MCP tool args and the
+ * per-source `CursorState` shape the scanners consume.
+ */
+
+const SOURCES = ['player', 'chat', 'mithril'] as const;
+
+/**
+ * Loads every per-source cursor record for a named cursor in one shot.
+ * Returns `undefined` when no cursor was requested so callers can branch
+ * cleanly (`undefined` -> "fresh scan from time window only").
+ */
+export function loadCursorsForName(
+  store: CursorStore,
+  name: string | undefined,
+): Record<string, CursorState> | undefined {
+  if (!name) return undefined;
+  const out: Record<string, CursorState> = {};
+  for (const s of SOURCES) out[s] = store.get(name, s);
+  return out;
+}
+
+/**
+ * Snapshots the per-file end offsets reached during a successful scan and
+ * persists them as the new state for `name`. Atomic via the store's
+ * write-temp-then-rename. Files that disappeared between scan and persist
+ * are silently skipped — the next call will treat them as a fresh read.
+ */
+export function persistCursor(
+  store: CursorStore,
+  name: string,
+  stats: MultiSourceStats,
+): void {
+  for (const [source, endOffsets] of Object.entries(stats.endOffsetsBySource)) {
+    const perFile: CursorState['perFile'] = {};
+    for (const [file, offset] of Object.entries(endOffsets)) {
+      try {
+        const stat = fs.statSync(file);
+        perFile[file] = snapshotCursor(stat, offset);
+      } catch {
+        // File disappeared between scan and persist — skip; next call
+        // will treat it as a fresh read.
+      }
+    }
+    store.put(name, source, { perFile });
+  }
+}
+
+/** Total number of files whose offsets were advanced this scan. */
+export function countAdvancedFiles(stats: MultiSourceStats): number {
+  let n = 0;
+  for (const eo of Object.values(stats.endOffsetsBySource)) {
+    n += Object.keys(eo).length;
+  }
+  return n;
+}

--- a/tools/MithrilLogMcp/src/state/cursors.ts
+++ b/tools/MithrilLogMcp/src/state/cursors.ts
@@ -1,0 +1,122 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Persistent named cursors. Each cursor tracks per-source byte offsets so
+ * subsequent queries with `cursor: "name"` only see new events. Stored at
+ * `%LocalAppData%/MithrilLogMcp/cursors.json` (a separate directory from
+ * Mithril's own state — this server is a dev tool, not part of the app).
+ *
+ * Persistence is a write-temp-then-rename atomic swap, mirroring
+ * `Mithril.Shared/Settings/AtomicFile.cs` semantics so a crashed process never
+ * leaves a half-written cursors.json behind.
+ */
+
+export interface CursorState {
+  /** Per-file byte offset for stream-friendly sources (player, chat, mithril). */
+  perFile: Record<string, FileCursor>;
+}
+
+export interface FileCursor {
+  byteOffset: number;
+  fileSize: number;
+  birthtimeMs: number;
+}
+
+interface CursorsFile {
+  version: number;
+  cursors: Record<string, Record<string, CursorState>>;
+}
+
+const CURRENT_VERSION = 1;
+
+export class CursorStore {
+  private readonly path: string;
+  private cache: CursorsFile | undefined;
+
+  constructor(filePath?: string) {
+    this.path = filePath ?? defaultCursorsPath();
+  }
+
+  load(): CursorsFile {
+    if (this.cache) return this.cache;
+    if (!fs.existsSync(this.path)) {
+      this.cache = { version: CURRENT_VERSION, cursors: {} };
+      return this.cache;
+    }
+    try {
+      const raw = fs.readFileSync(this.path, 'utf8');
+      this.cache = JSON.parse(raw) as CursorsFile;
+      if (this.cache.version !== CURRENT_VERSION) {
+        // Forward-compat path: drop unknown versions and start clean.
+        this.cache = { version: CURRENT_VERSION, cursors: {} };
+      }
+    } catch {
+      this.cache = { version: CURRENT_VERSION, cursors: {} };
+    }
+    return this.cache;
+  }
+
+  list(): Array<{ name: string; sources: Record<string, CursorState> }> {
+    const doc = this.load();
+    return Object.entries(doc.cursors).map(([name, sources]) => ({ name, sources }));
+  }
+
+  get(name: string, source: string): CursorState {
+    const doc = this.load();
+    return doc.cursors[name]?.[source] ?? { perFile: {} };
+  }
+
+  put(name: string, source: string, state: CursorState): void {
+    const doc = this.load();
+    if (!doc.cursors[name]) doc.cursors[name] = {};
+    doc.cursors[name]![source] = state;
+    this.flush();
+  }
+
+  reset(name: string): void {
+    const doc = this.load();
+    delete doc.cursors[name];
+    this.flush();
+  }
+
+  private flush(): void {
+    if (!this.cache) return;
+    fs.mkdirSync(path.dirname(this.path), { recursive: true });
+    const tmp = `${this.path}.partial`;
+    fs.writeFileSync(tmp, JSON.stringify(this.cache, null, 2), 'utf8');
+    fs.renameSync(tmp, this.path);
+  }
+}
+
+/**
+ * Decides whether a previously-recorded cursor entry is still valid for a
+ * given file. Mirrors the rollover heuristics in Mithril's
+ * `PlayerLogTailReader.ReadNew`:
+ *  - file shrunk → rotate, restart from 0
+ *  - inode/birthtime changed → file deleted+recreated, restart from 0
+ *  - size unchanged → fine, stay where we are
+ */
+export function rolloverDetected(prev: FileCursor, current: fs.Stats): boolean {
+  if (current.size < prev.byteOffset) return true;
+  if (current.size < prev.fileSize) return true;
+  // birthtimeMs is 0 on some FS — treat as no signal in that case.
+  if (prev.birthtimeMs > 0 && current.birthtimeMs > 0 && current.birthtimeMs !== prev.birthtimeMs) return true;
+  return false;
+}
+
+export function snapshotCursor(stat: fs.Stats, byteOffset: number): FileCursor {
+  return {
+    byteOffset,
+    fileSize: stat.size,
+    birthtimeMs: stat.birthtimeMs,
+  };
+}
+
+function defaultCursorsPath(): string {
+  if (process.env.MITHRIL_LOG_MCP_CURSORS) return process.env.MITHRIL_LOG_MCP_CURSORS;
+  const localApp = process.env.LOCALAPPDATA
+    ?? path.join(os.homedir(), 'AppData', 'Local');
+  return path.join(localApp, 'MithrilLogMcp', 'cursors.json');
+}

--- a/tools/MithrilLogMcp/src/tools/aggregate.ts
+++ b/tools/MithrilLogMcp/src/tools/aggregate.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { loadCatalog } from '../parsing/catalog.js';
 import { resolveWindow } from '../util/time-windows.js';
-import { scanMultiSource, type SourceName } from '../sources/multi-source.js';
+import { emptyMultiSourceStats, scanMultiSource, type SourceName } from '../sources/multi-source.js';
 import { resolveLastSessionWindow } from '../state/character-resolver.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
@@ -47,7 +47,7 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
   }
 
   const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
-  const stats = { scannedBytes: 0, scannedLines: 0 };
+  const stats = emptyMultiSourceStats();
   let matched = 0;
   let truncated = false;
   let count = 0;

--- a/tools/MithrilLogMcp/src/tools/aggregate.ts
+++ b/tools/MithrilLogMcp/src/tools/aggregate.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import { loadCatalog } from '../parsing/catalog.js';
 import { resolveWindow } from '../util/time-windows.js';
-import { scanPlayerLog } from '../sources/player-log.js';
+import { scanMultiSource, type SourceName } from '../sources/multi-source.js';
+import { resolveLastSessionWindow } from '../state/character-resolver.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
 
@@ -14,7 +15,7 @@ const AggregateKind = z.enum([
 ]);
 
 export const AggregateInput = z.object({
-  source: z.enum(['player']).default('player'),
+  source: z.enum(['player', 'chat', 'mithril', 'all']).default('player'),
   agg: AggregateKind,
   field: z.string().optional(),
   bucket: z.enum(['1m', '5m', '15m', '1h', '1d']).optional(),
@@ -23,6 +24,8 @@ export const AggregateInput = z.object({
   since: z.string().optional(),
   until: z.string().optional(),
   between: z.tuple([z.string(), z.string()]).optional(),
+  last_session: z.boolean().optional(),
+  character: z.string().optional(),
   filter: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 
@@ -33,9 +36,17 @@ const DISTINCT_CAP = 100_000;
 export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
   const t0 = performance.now();
   const catalog = loadCatalog();
-  const window = resolveWindow(new Date(), args);
-  const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
+  const now = new Date();
 
+  let window;
+  if (args.last_session) {
+    if (!args.character) throw new Error("'last_session' requires 'character'");
+    window = resolveLastSessionWindow(config, catalog, args.character, now);
+  } else {
+    window = resolveWindow(now, args);
+  }
+
+  const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
   const stats = { scannedBytes: 0, scannedLines: 0 };
   let matched = 0;
   let truncated = false;
@@ -43,9 +54,10 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
   const groups = new Map<string, number>();
   const distinct = new Set<string>();
 
-  for await (const ev of scanPlayerLog(
+  for await (const ev of scanMultiSource(
     catalog,
-    { path: config.playerLogPath, since: window.since, until: window.until },
+    config,
+    { source: args.source as SourceName, since: window.since, until: window.until },
     stats,
   )) {
     if (eventTypeFilter && !eventTypeFilter.has(ev.type)) continue;
@@ -92,6 +104,7 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
     scannedBytes: stats.scannedBytes,
     scannedLines: stats.scannedLines,
     elapsedMs,
+    window: { since: window.since.toISOString(), until: window.until.toISOString() },
   };
 
   let buckets: Array<{ key: string; count: number }>;
@@ -121,7 +134,6 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
 }
 
 function extractAggField(ev: ParsedEvent, field: string): unknown {
-  // Support a few well-known top-level fields plus any data.* field.
   if (field === 'type') return ev.type;
   if (field === 'module') return ev.module;
   if (field === 'source') return ev.source;

--- a/tools/MithrilLogMcp/src/tools/aggregate.ts
+++ b/tools/MithrilLogMcp/src/tools/aggregate.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod';
+import { loadCatalog } from '../parsing/catalog.js';
+import { resolveWindow } from '../util/time-windows.js';
+import { scanPlayerLog } from '../sources/player-log.js';
+import type { ParsedEvent } from '../parsing/types.js';
+import type { ServerConfig } from '../config.js';
+
+const AggregateKind = z.enum([
+  'count',
+  'group_by',
+  'histogram',
+  'distinct',
+  'top',
+]);
+
+export const AggregateInput = z.object({
+  source: z.enum(['player']).default('player'),
+  agg: AggregateKind,
+  field: z.string().optional(),
+  bucket: z.enum(['1m', '5m', '15m', '1h', '1d']).optional(),
+  top_n: z.number().int().min(1).max(1000).optional(),
+  event_type: z.array(z.string()).optional(),
+  since: z.string().optional(),
+  until: z.string().optional(),
+  between: z.tuple([z.string(), z.string()]).optional(),
+  filter: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
+});
+
+export type AggregateArgs = z.infer<typeof AggregateInput>;
+
+const DISTINCT_CAP = 100_000;
+
+export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
+  const t0 = performance.now();
+  const catalog = loadCatalog();
+  const window = resolveWindow(new Date(), args);
+  const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
+
+  const stats = { scannedBytes: 0, scannedLines: 0 };
+  let matched = 0;
+  let truncated = false;
+  let count = 0;
+  const groups = new Map<string, number>();
+  const distinct = new Set<string>();
+
+  for await (const ev of scanPlayerLog(
+    catalog,
+    { path: config.playerLogPath, since: window.since, until: window.until },
+    stats,
+  )) {
+    if (eventTypeFilter && !eventTypeFilter.has(ev.type)) continue;
+    if (args.filter && !matchesFilter(ev, args.filter)) continue;
+    matched += 1;
+
+    switch (args.agg) {
+      case 'count': count += 1; break;
+      case 'group_by': {
+        if (!args.field) throw new Error("'group_by' requires field");
+        const k = String(extractAggField(ev, args.field));
+        groups.set(k, (groups.get(k) ?? 0) + 1);
+        break;
+      }
+      case 'histogram': {
+        const bucket = args.bucket ?? '1h';
+        const k = bucketize(ev.ts, bucket);
+        groups.set(k, (groups.get(k) ?? 0) + 1);
+        break;
+      }
+      case 'distinct': {
+        if (!args.field) throw new Error("'distinct' requires field");
+        if (distinct.size < DISTINCT_CAP) {
+          distinct.add(String(extractAggField(ev, args.field)));
+        } else {
+          truncated = true;
+        }
+        break;
+      }
+      case 'top': {
+        if (!args.field) throw new Error("'top' requires field");
+        const k = String(extractAggField(ev, args.field));
+        groups.set(k, (groups.get(k) ?? 0) + 1);
+        break;
+      }
+    }
+  }
+
+  const elapsedMs = Math.round(performance.now() - t0);
+  const summary = {
+    matched,
+    returned: 0,
+    truncated,
+    scannedBytes: stats.scannedBytes,
+    scannedLines: stats.scannedLines,
+    elapsedMs,
+  };
+
+  let buckets: Array<{ key: string; count: number }>;
+  switch (args.agg) {
+    case 'count':
+      buckets = [{ key: 'count', count }];
+      break;
+    case 'distinct':
+      buckets = Array.from(distinct, (v) => ({ key: v, count: 1 }));
+      break;
+    case 'top': {
+      const n = args.top_n ?? 10;
+      buckets = Array.from(groups, ([key, count]) => ({ key, count }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, n);
+      break;
+    }
+    case 'group_by':
+    case 'histogram':
+      buckets = Array.from(groups, ([key, count]) => ({ key, count }))
+        .sort((a, b) => (args.agg === 'histogram' ? a.key.localeCompare(b.key) : b.count - a.count));
+      break;
+  }
+
+  summary.returned = buckets.length;
+  return { summary, agg: args.agg, buckets };
+}
+
+function extractAggField(ev: ParsedEvent, field: string): unknown {
+  // Support a few well-known top-level fields plus any data.* field.
+  if (field === 'type') return ev.type;
+  if (field === 'module') return ev.module;
+  if (field === 'source') return ev.source;
+  return ev.data[field] ?? '';
+}
+
+function matchesFilter(
+  ev: ParsedEvent,
+  filter: Record<string, string | number | boolean>,
+): boolean {
+  for (const [k, expected] of Object.entries(filter)) {
+    const actual = ev.data[k];
+    if (actual === undefined) return false;
+    if (typeof expected === 'string') {
+      if (String(actual) !== expected) return false;
+    } else if (actual !== expected) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function bucketize(iso: string, bucket: string): string {
+  const d = new Date(iso);
+  const t = d.getTime();
+  const sizes: Record<string, number> = {
+    '1m': 60_000,
+    '5m': 5 * 60_000,
+    '15m': 15 * 60_000,
+    '1h': 3_600_000,
+    '1d': 86_400_000,
+  };
+  const size = sizes[bucket];
+  if (!size) throw new Error(`Unknown bucket: ${bucket}`);
+  const floored = Math.floor(t / size) * size;
+  return new Date(floored).toISOString();
+}

--- a/tools/MithrilLogMcp/src/tools/aggregate.ts
+++ b/tools/MithrilLogMcp/src/tools/aggregate.ts
@@ -3,6 +3,12 @@ import { loadCatalog } from '../parsing/catalog.js';
 import { resolveWindow } from '../util/time-windows.js';
 import { emptyMultiSourceStats, scanMultiSource, type SourceName } from '../sources/multi-source.js';
 import { resolveLastSessionWindow } from '../state/character-resolver.js';
+import { CursorStore } from '../state/cursors.js';
+import {
+  countAdvancedFiles,
+  loadCursorsForName,
+  persistCursor,
+} from '../state/cursor-helpers.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
 
@@ -26,6 +32,7 @@ export const AggregateInput = z.object({
   between: z.tuple([z.string(), z.string()]).optional(),
   last_session: z.boolean().optional(),
   character: z.string().optional(),
+  cursor: z.string().optional(),
   filter: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 
@@ -33,7 +40,11 @@ export type AggregateArgs = z.infer<typeof AggregateInput>;
 
 const DISTINCT_CAP = 100_000;
 
-export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
+export async function runAggregate(
+  args: AggregateArgs,
+  config: ServerConfig,
+  cursorStore: CursorStore,
+) {
   const t0 = performance.now();
   const catalog = loadCatalog();
   const now = new Date();
@@ -42,10 +53,14 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
   if (args.last_session) {
     if (!args.character) throw new Error("'last_session' requires 'character'");
     window = resolveLastSessionWindow(config, catalog, args.character, now);
+  } else if (args.cursor && !args.since && !args.until && !args.between) {
+    // Cursor-only aggregate: count what's new since last call.
+    window = { since: new Date(0), until: now };
   } else {
     window = resolveWindow(now, args);
   }
 
+  const cursorsByName = loadCursorsForName(cursorStore, args.cursor);
   const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
   const stats = emptyMultiSourceStats();
   let matched = 0;
@@ -57,7 +72,13 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
   for await (const ev of scanMultiSource(
     catalog,
     config,
-    { source: args.source as SourceName, since: window.since, until: window.until },
+    {
+      source: args.source as SourceName,
+      since: window.since,
+      until: window.until,
+      cursors: cursorsByName,
+      eventTypeAllowlist: eventTypeFilter ?? undefined,
+    },
     stats,
   )) {
     if (eventTypeFilter && !eventTypeFilter.has(ev.type)) continue;
@@ -96,8 +117,21 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
     }
   }
 
+  if (args.cursor) {
+    persistCursor(cursorStore, args.cursor, stats);
+  }
+
   const elapsedMs = Math.round(performance.now() - t0);
-  const summary = {
+  const summary: {
+    matched: number;
+    returned: number;
+    truncated: boolean;
+    scannedBytes: number;
+    scannedLines: number;
+    elapsedMs: number;
+    window: { since: string; until: string };
+    cursor?: { name: string; advanced: number; rolledOverFiles: string[] };
+  } = {
     matched,
     returned: 0,
     truncated,
@@ -106,6 +140,13 @@ export async function runAggregate(args: AggregateArgs, config: ServerConfig) {
     elapsedMs,
     window: { since: window.since.toISOString(), until: window.until.toISOString() },
   };
+  if (args.cursor) {
+    summary.cursor = {
+      name: args.cursor,
+      advanced: countAdvancedFiles(stats),
+      rolledOverFiles: stats.rolledOverFiles,
+    };
+  }
 
   let buckets: Array<{ key: string; count: number }>;
   switch (args.agg) {

--- a/tools/MithrilLogMcp/src/tools/cursor.ts
+++ b/tools/MithrilLogMcp/src/tools/cursor.ts
@@ -1,13 +1,33 @@
+import * as fs from 'node:fs';
 import { z } from 'zod';
-import { CursorStore } from '../state/cursors.js';
+import { CursorStore, snapshotCursor, type CursorState } from '../state/cursors.js';
 
 export const CursorListInput = z.object({});
 export const CursorResetInput = z.object({
   name: z.string().min(1),
 });
 
+/**
+ * Manually positions a named cursor for one source.
+ *
+ * `anchor: "start"` — byte 0 (re-read everything).
+ * `anchor: "end"`   — current end of file (skip everything before now).
+ * `anchor: "offset"` — exact byte offset in `byteOffset`.
+ *
+ * Useful for "fast-forward to now" and "rewind a cursor that I want to
+ * re-read from scratch without losing the cursor name".
+ */
+export const CursorSetInput = z.object({
+  name: z.string().min(1),
+  source: z.enum(['player', 'chat', 'mithril']),
+  file: z.string().min(1),
+  anchor: z.enum(['start', 'end', 'offset']).default('start'),
+  byteOffset: z.number().int().min(0).optional(),
+});
+
 export type CursorListArgs = z.infer<typeof CursorListInput>;
 export type CursorResetArgs = z.infer<typeof CursorResetInput>;
+export type CursorSetArgs = z.infer<typeof CursorSetInput>;
 
 export function runCursorList(_args: CursorListArgs, store: CursorStore) {
   const cursors = store.list().map((c) => ({
@@ -15,7 +35,12 @@ export function runCursorList(_args: CursorListArgs, store: CursorStore) {
     sources: Object.fromEntries(
       Object.entries(c.sources).map(([source, state]) => [
         source,
-        { fileCount: Object.keys(state.perFile).length },
+        {
+          fileCount: Object.keys(state.perFile).length,
+          files: Object.fromEntries(
+            Object.entries(state.perFile).map(([f, fc]) => [f, fc.byteOffset]),
+          ),
+        },
       ]),
     ),
   }));
@@ -25,4 +50,42 @@ export function runCursorList(_args: CursorListArgs, store: CursorStore) {
 export function runCursorReset(args: CursorResetArgs, store: CursorStore) {
   store.reset(args.name);
   return { ok: true, name: args.name };
+}
+
+export function runCursorSet(args: CursorSetArgs, store: CursorStore) {
+  if (!fs.existsSync(args.file)) {
+    throw new Error(`File not found: ${args.file}`);
+  }
+  const stat = fs.statSync(args.file);
+
+  let offset: number;
+  switch (args.anchor) {
+    case 'start': offset = 0; break;
+    case 'end': offset = stat.size; break;
+    case 'offset':
+      if (args.byteOffset === undefined) {
+        throw new Error("anchor='offset' requires byteOffset");
+      }
+      if (args.byteOffset > stat.size) {
+        throw new Error(
+          `byteOffset ${args.byteOffset} exceeds file size ${stat.size}`,
+        );
+      }
+      offset = args.byteOffset;
+      break;
+  }
+
+  const existing = store.get(args.name, args.source);
+  const next: CursorState = {
+    perFile: { ...existing.perFile, [args.file]: snapshotCursor(stat, offset) },
+  };
+  store.put(args.name, args.source, next);
+  return {
+    ok: true,
+    name: args.name,
+    source: args.source,
+    file: args.file,
+    byteOffset: offset,
+    fileSize: stat.size,
+  };
 }

--- a/tools/MithrilLogMcp/src/tools/cursor.ts
+++ b/tools/MithrilLogMcp/src/tools/cursor.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { CursorStore } from '../state/cursors.js';
+
+export const CursorListInput = z.object({});
+export const CursorResetInput = z.object({
+  name: z.string().min(1),
+});
+
+export type CursorListArgs = z.infer<typeof CursorListInput>;
+export type CursorResetArgs = z.infer<typeof CursorResetInput>;
+
+export function runCursorList(_args: CursorListArgs, store: CursorStore) {
+  const cursors = store.list().map((c) => ({
+    name: c.name,
+    sources: Object.fromEntries(
+      Object.entries(c.sources).map(([source, state]) => [
+        source,
+        { fileCount: Object.keys(state.perFile).length },
+      ]),
+    ),
+  }));
+  return { cursors };
+}
+
+export function runCursorReset(args: CursorResetArgs, store: CursorStore) {
+  store.reset(args.name);
+  return { ok: true, name: args.name };
+}

--- a/tools/MithrilLogMcp/src/tools/list-event-types.ts
+++ b/tools/MithrilLogMcp/src/tools/list-event-types.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { loadCatalog } from '../parsing/catalog.js';
+
+export const ListEventTypesInput = z.object({
+  source: z.enum(['player', 'chat', 'all']).default('all'),
+});
+
+export type ListEventTypesArgs = z.infer<typeof ListEventTypesInput>;
+
+export function runListEventTypes(args: ListEventTypesArgs) {
+  const catalog = loadCatalog();
+  const filtered = catalog.entries.filter(
+    (e) => args.source === 'all' || e.source === args.source,
+  );
+
+  const seen = new Map<string, {
+    type: string;
+    source: string;
+    module: string;
+    fields: { name: string; type: string }[];
+  }>();
+  for (const e of filtered) {
+    if (!e.eventType) continue;
+    if (e.kind === 'helper') continue;
+    if (seen.has(e.eventType)) continue;
+    seen.set(e.eventType, {
+      type: e.eventType,
+      source: e.source,
+      module: e.module,
+      fields: e.fields.map((f) => ({ name: f.name, type: f.type })),
+    });
+  }
+
+  const types = Array.from(seen.values()).sort((a, b) => a.type.localeCompare(b.type));
+  return { types };
+}

--- a/tools/MithrilLogMcp/src/tools/query-events.ts
+++ b/tools/MithrilLogMcp/src/tools/query-events.ts
@@ -187,15 +187,22 @@ function matchesFilter(
   return true;
 }
 
+/**
+ * Applies the `character: "Foo"` filter, source-aware:
+ *  - chat: matches the chat speaker (Status events have no speaker; treated as unmatched).
+ *  - mithril: app-internal logs aren't bound to a character — always pass.
+ *  - player: uses the `activeCharacter` stamped by ActiveCharacterTracker.
+ *    Events before the first observed ProcessAddPlayer have no stamp; they're
+ *    skipped because the active character is genuinely unknown.
+ */
 function matchesCharacter(ev: ParsedEvent, character: string): boolean {
+  if (ev.source === 'mithril') return true;
   if (ev.source === 'chat') {
     const speaker = ev.data.speaker;
     return typeof speaker === 'string' && speaker === character;
   }
-  if (ev.type === 'shared.ProcessAddPlayer') {
-    return ev.data.characterName === character;
-  }
-  return true;
+  // source: "player"
+  return ev.activeCharacter === character;
 }
 
 function projectFields(ev: ParsedEvent, fields: string[]): ParsedEvent {

--- a/tools/MithrilLogMcp/src/tools/query-events.ts
+++ b/tools/MithrilLogMcp/src/tools/query-events.ts
@@ -1,15 +1,18 @@
-import * as fs from 'node:fs';
 import { z } from 'zod';
 import { loadCatalog } from '../parsing/catalog.js';
 import { resolveWindow } from '../util/time-windows.js';
 import {
   emptyMultiSourceStats,
   scanMultiSource,
-  type MultiSourceStats,
   type SourceName,
 } from '../sources/multi-source.js';
 import { resolveLastSessionWindow } from '../state/character-resolver.js';
-import { CursorStore, snapshotCursor, type CursorState } from '../state/cursors.js';
+import { CursorStore } from '../state/cursors.js';
+import {
+  countAdvancedFiles,
+  loadCursorsForName,
+  persistCursor,
+} from '../state/cursor-helpers.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
 
@@ -55,7 +58,7 @@ export async function runQueryEvents(
     window = resolveWindow(now, args);
   }
 
-  const cursorsByName = args.cursor ? loadCursorsForSource(cursorStore, args.cursor) : undefined;
+  const cursorsByName = loadCursorsForName(cursorStore, args.cursor);
 
   const stats = emptyMultiSourceStats();
   let matched = 0;
@@ -74,6 +77,8 @@ export async function runQueryEvents(
       since: window.since,
       until: window.until,
       cursors: cursorsByName,
+      eventTypeAllowlist: eventTypeFilter ?? undefined,
+      context: args.context,
     },
     stats,
   )) {
@@ -128,47 +133,6 @@ export async function runQueryEvents(
     events,
     format: args.format,
   };
-}
-
-function loadCursorsForSource(
-  store: CursorStore,
-  name: string,
-): Record<string, CursorState> {
-  return {
-    player: store.get(name, 'player'),
-    chat: store.get(name, 'chat'),
-    mithril: store.get(name, 'mithril'),
-  };
-}
-
-function persistCursor(
-  store: CursorStore,
-  name: string,
-  stats: MultiSourceStats,
-): void {
-  for (const [source, endOffsets] of Object.entries(stats.endOffsetsBySource)) {
-    const perFile: CursorState['perFile'] = {};
-    for (const [file, offset] of Object.entries(endOffsets)) {
-      // Snapshot mtime-derived metadata at the *advanced* offset so the next
-      // call's rolloverDetected has fresh fileSize / birthtimeMs to compare.
-      try {
-        const stat = fs.statSync(file);
-        perFile[file] = snapshotCursor(stat, offset);
-      } catch {
-        // File disappeared between scan and persist — skip it; next call
-        // will treat it as a fresh read.
-      }
-    }
-    store.put(name, source, { perFile });
-  }
-}
-
-function countAdvancedFiles(stats: MultiSourceStats): number {
-  let n = 0;
-  for (const eo of Object.values(stats.endOffsetsBySource)) {
-    n += Object.keys(eo).length;
-  }
-  return n;
 }
 
 function matchesFilter(

--- a/tools/MithrilLogMcp/src/tools/query-events.ts
+++ b/tools/MithrilLogMcp/src/tools/query-events.ts
@@ -1,8 +1,15 @@
+import * as fs from 'node:fs';
 import { z } from 'zod';
 import { loadCatalog } from '../parsing/catalog.js';
 import { resolveWindow } from '../util/time-windows.js';
-import { scanMultiSource, type SourceName } from '../sources/multi-source.js';
+import {
+  emptyMultiSourceStats,
+  scanMultiSource,
+  type MultiSourceStats,
+  type SourceName,
+} from '../sources/multi-source.js';
 import { resolveLastSessionWindow } from '../state/character-resolver.js';
+import { CursorStore, snapshotCursor, type CursorState } from '../state/cursors.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
 
@@ -14,6 +21,7 @@ export const QueryEventsInput = z.object({
   between: z.tuple([z.string(), z.string()]).optional(),
   last_session: z.boolean().optional(),
   character: z.string().optional(),
+  cursor: z.string().optional(),
   filter: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
   fields: z.array(z.string()).optional(),
   context: z.number().int().min(0).max(50).optional(),
@@ -26,22 +34,30 @@ export type QueryEventsArgs = z.infer<typeof QueryEventsInput>;
 
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 
-export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig) {
+export async function runQueryEvents(
+  args: QueryEventsArgs,
+  config: ServerConfig,
+  cursorStore: CursorStore,
+) {
   const t0 = performance.now();
   const catalog = loadCatalog();
   const now = new Date();
 
   let window;
   if (args.last_session) {
-    if (!args.character) {
-      throw new Error("'last_session' requires 'character'");
-    }
+    if (!args.character) throw new Error("'last_session' requires 'character'");
     window = resolveLastSessionWindow(config, catalog, args.character, now);
+  } else if (args.cursor && !args.since && !args.until && !args.between) {
+    // Cursor-only query: don't bound by time, just resume from where the
+    // cursor left off through "now".
+    window = { since: new Date(0), until: now };
   } else {
     window = resolveWindow(now, args);
   }
 
-  const stats = { scannedBytes: 0, scannedLines: 0 };
+  const cursorsByName = args.cursor ? loadCursorsForSource(cursorStore, args.cursor) : undefined;
+
+  const stats = emptyMultiSourceStats();
   let matched = 0;
   let skipped = 0;
   let truncated = false;
@@ -53,7 +69,12 @@ export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig
   for await (const ev of scanMultiSource(
     catalog,
     config,
-    { source: args.source as SourceName, since: window.since, until: window.until },
+    {
+      source: args.source as SourceName,
+      since: window.since,
+      until: window.until,
+      cursors: cursorsByName,
+    },
     stats,
   )) {
     if (eventTypeFilter && !eventTypeFilter.has(ev.type)) continue;
@@ -81,6 +102,10 @@ export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig
     bytesEmitted += encoded.length + 1;
   }
 
+  if (args.cursor) {
+    persistCursor(cursorStore, args.cursor, stats);
+  }
+
   const elapsedMs = Math.round(performance.now() - t0);
 
   return {
@@ -92,10 +117,58 @@ export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig
       scannedLines: stats.scannedLines,
       elapsedMs,
       window: { since: window.since.toISOString(), until: window.until.toISOString() },
+      cursor: args.cursor
+        ? {
+            name: args.cursor,
+            advanced: countAdvancedFiles(stats),
+            rolledOverFiles: stats.rolledOverFiles,
+          }
+        : undefined,
     },
     events,
     format: args.format,
   };
+}
+
+function loadCursorsForSource(
+  store: CursorStore,
+  name: string,
+): Record<string, CursorState> {
+  return {
+    player: store.get(name, 'player'),
+    chat: store.get(name, 'chat'),
+    mithril: store.get(name, 'mithril'),
+  };
+}
+
+function persistCursor(
+  store: CursorStore,
+  name: string,
+  stats: MultiSourceStats,
+): void {
+  for (const [source, endOffsets] of Object.entries(stats.endOffsetsBySource)) {
+    const perFile: CursorState['perFile'] = {};
+    for (const [file, offset] of Object.entries(endOffsets)) {
+      // Snapshot mtime-derived metadata at the *advanced* offset so the next
+      // call's rolloverDetected has fresh fileSize / birthtimeMs to compare.
+      try {
+        const stat = fs.statSync(file);
+        perFile[file] = snapshotCursor(stat, offset);
+      } catch {
+        // File disappeared between scan and persist — skip it; next call
+        // will treat it as a fresh read.
+      }
+    }
+    store.put(name, source, { perFile });
+  }
+}
+
+function countAdvancedFiles(stats: MultiSourceStats): number {
+  let n = 0;
+  for (const eo of Object.values(stats.endOffsetsBySource)) {
+    n += Object.keys(eo).length;
+  }
+  return n;
 }
 
 function matchesFilter(
@@ -114,14 +187,6 @@ function matchesFilter(
   return true;
 }
 
-/**
- * Best-effort character match. Chat events surface the character name in
- * `data.speaker`; player events themselves don't carry the active character
- * (it's tracked across-the-stream by the .NET-side ActiveCharacterLogSynchronizer).
- * For v0.2 we match on speaker for chat and accept all player events when a
- * character filter is set — the proper cross-stream stamping lives in v0.3
- * once cursors land and we can keep an active-character running state.
- */
 function matchesCharacter(ev: ParsedEvent, character: string): boolean {
   if (ev.source === 'chat') {
     const speaker = ev.data.speaker;

--- a/tools/MithrilLogMcp/src/tools/query-events.ts
+++ b/tools/MithrilLogMcp/src/tools/query-events.ts
@@ -1,18 +1,22 @@
 import { z } from 'zod';
 import { loadCatalog } from '../parsing/catalog.js';
 import { resolveWindow } from '../util/time-windows.js';
-import { scanPlayerLog } from '../sources/player-log.js';
+import { scanMultiSource, type SourceName } from '../sources/multi-source.js';
+import { resolveLastSessionWindow } from '../state/character-resolver.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
 
 export const QueryEventsInput = z.object({
-  source: z.enum(['player']).default('player'),
+  source: z.enum(['player', 'chat', 'mithril', 'all']).default('player'),
   event_type: z.array(z.string()).optional(),
   since: z.string().optional(),
   until: z.string().optional(),
   between: z.tuple([z.string(), z.string()]).optional(),
+  last_session: z.boolean().optional(),
+  character: z.string().optional(),
   filter: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
   fields: z.array(z.string()).optional(),
+  context: z.number().int().min(0).max(50).optional(),
   limit: z.number().int().min(1).max(10000).default(500),
   offset: z.number().int().min(0).default(0),
   format: z.enum(['ndjson', 'json']).default('ndjson'),
@@ -25,7 +29,17 @@ const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig) {
   const t0 = performance.now();
   const catalog = loadCatalog();
-  const window = resolveWindow(new Date(), args);
+  const now = new Date();
+
+  let window;
+  if (args.last_session) {
+    if (!args.character) {
+      throw new Error("'last_session' requires 'character'");
+    }
+    window = resolveLastSessionWindow(config, catalog, args.character, now);
+  } else {
+    window = resolveWindow(now, args);
+  }
 
   const stats = { scannedBytes: 0, scannedLines: 0 };
   let matched = 0;
@@ -34,14 +48,17 @@ export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig
   let bytesEmitted = 0;
   const events: ParsedEvent[] = [];
   const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
+  const characterFilter = args.character;
 
-  for await (const ev of scanPlayerLog(
+  for await (const ev of scanMultiSource(
     catalog,
-    { path: config.playerLogPath, since: window.since, until: window.until },
+    config,
+    { source: args.source as SourceName, since: window.since, until: window.until },
     stats,
   )) {
     if (eventTypeFilter && !eventTypeFilter.has(ev.type)) continue;
     if (args.filter && !matchesFilter(ev, args.filter)) continue;
+    if (characterFilter && !matchesCharacter(ev, characterFilter)) continue;
 
     matched += 1;
     if (skipped < args.offset) {
@@ -61,7 +78,7 @@ export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig
       break;
     }
     events.push(projected);
-    bytesEmitted += encoded.length + 1; // + newline
+    bytesEmitted += encoded.length + 1;
   }
 
   const elapsedMs = Math.round(performance.now() - t0);
@@ -74,6 +91,7 @@ export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig
       scannedBytes: stats.scannedBytes,
       scannedLines: stats.scannedLines,
       elapsedMs,
+      window: { since: window.since.toISOString(), until: window.until.toISOString() },
     },
     events,
     format: args.format,
@@ -87,12 +105,30 @@ function matchesFilter(
   for (const [k, expected] of Object.entries(filter)) {
     const actual = ev.data[k];
     if (actual === undefined) return false;
-    // String filters are exact-equal; everything else uses ==.
     if (typeof expected === 'string') {
       if (String(actual) !== expected) return false;
     } else if (actual !== expected) {
       return false;
     }
+  }
+  return true;
+}
+
+/**
+ * Best-effort character match. Chat events surface the character name in
+ * `data.speaker`; player events themselves don't carry the active character
+ * (it's tracked across-the-stream by the .NET-side ActiveCharacterLogSynchronizer).
+ * For v0.2 we match on speaker for chat and accept all player events when a
+ * character filter is set — the proper cross-stream stamping lives in v0.3
+ * once cursors land and we can keep an active-character running state.
+ */
+function matchesCharacter(ev: ParsedEvent, character: string): boolean {
+  if (ev.source === 'chat') {
+    const speaker = ev.data.speaker;
+    return typeof speaker === 'string' && speaker === character;
+  }
+  if (ev.type === 'shared.ProcessAddPlayer') {
+    return ev.data.characterName === character;
   }
   return true;
 }

--- a/tools/MithrilLogMcp/src/tools/query-events.ts
+++ b/tools/MithrilLogMcp/src/tools/query-events.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import { loadCatalog } from '../parsing/catalog.js';
+import { resolveWindow } from '../util/time-windows.js';
+import { scanPlayerLog } from '../sources/player-log.js';
+import type { ParsedEvent } from '../parsing/types.js';
+import type { ServerConfig } from '../config.js';
+
+export const QueryEventsInput = z.object({
+  source: z.enum(['player']).default('player'),
+  event_type: z.array(z.string()).optional(),
+  since: z.string().optional(),
+  until: z.string().optional(),
+  between: z.tuple([z.string(), z.string()]).optional(),
+  filter: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
+  fields: z.array(z.string()).optional(),
+  limit: z.number().int().min(1).max(10000).default(500),
+  offset: z.number().int().min(0).default(0),
+  format: z.enum(['ndjson', 'json']).default('ndjson'),
+});
+
+export type QueryEventsArgs = z.infer<typeof QueryEventsInput>;
+
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+export async function runQueryEvents(args: QueryEventsArgs, config: ServerConfig) {
+  const t0 = performance.now();
+  const catalog = loadCatalog();
+  const window = resolveWindow(new Date(), args);
+
+  const stats = { scannedBytes: 0, scannedLines: 0 };
+  let matched = 0;
+  let skipped = 0;
+  let truncated = false;
+  let bytesEmitted = 0;
+  const events: ParsedEvent[] = [];
+  const eventTypeFilter = args.event_type ? new Set(args.event_type) : null;
+
+  for await (const ev of scanPlayerLog(
+    catalog,
+    { path: config.playerLogPath, since: window.since, until: window.until },
+    stats,
+  )) {
+    if (eventTypeFilter && !eventTypeFilter.has(ev.type)) continue;
+    if (args.filter && !matchesFilter(ev, args.filter)) continue;
+
+    matched += 1;
+    if (skipped < args.offset) {
+      skipped += 1;
+      continue;
+    }
+
+    if (events.length >= args.limit) {
+      truncated = true;
+      continue;
+    }
+
+    const projected = args.fields ? projectFields(ev, args.fields) : ev;
+    const encoded = JSON.stringify(projected);
+    if (bytesEmitted + encoded.length > MAX_RESPONSE_BYTES) {
+      truncated = true;
+      break;
+    }
+    events.push(projected);
+    bytesEmitted += encoded.length + 1; // + newline
+  }
+
+  const elapsedMs = Math.round(performance.now() - t0);
+
+  return {
+    summary: {
+      matched,
+      returned: events.length,
+      truncated,
+      scannedBytes: stats.scannedBytes,
+      scannedLines: stats.scannedLines,
+      elapsedMs,
+    },
+    events,
+    format: args.format,
+  };
+}
+
+function matchesFilter(
+  ev: ParsedEvent,
+  filter: Record<string, string | number | boolean>,
+): boolean {
+  for (const [k, expected] of Object.entries(filter)) {
+    const actual = ev.data[k];
+    if (actual === undefined) return false;
+    // String filters are exact-equal; everything else uses ==.
+    if (typeof expected === 'string') {
+      if (String(actual) !== expected) return false;
+    } else if (actual !== expected) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function projectFields(ev: ParsedEvent, fields: string[]): ParsedEvent {
+  const data: Record<string, unknown> = {};
+  for (const f of fields) {
+    if (f in ev.data) data[f] = ev.data[f];
+  }
+  return { ...ev, data };
+}

--- a/tools/MithrilLogMcp/src/util/file-streams.ts
+++ b/tools/MithrilLogMcp/src/util/file-streams.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs';
+
+/**
+ * Yields lines from a file along with their starting byte offset and 1-based
+ * line number. Unlike `readline`, byte offsets are exact across UTF-8 — they
+ * count file bytes, not decoded characters — so consumers can `Read` the
+ * raw line later by seeking to (byteOffset, byteOffset + line.length).
+ *
+ * Operates on a byte range [start, end) so callers can resume from a cursor
+ * or restrict to a sub-region without re-reading the whole file.
+ */
+export interface LineRecord {
+  line: string;
+  lineNo: number;
+  byteOffset: number;
+  byteLength: number;
+}
+
+export interface LineStreamOptions {
+  start?: number;
+  end?: number;
+  /** First line number to emit. Defaults to 1. */
+  startLineNo?: number;
+}
+
+const DEFAULT_HIGH_WATER_MARK = 1024 * 1024;
+
+export async function* lineStream(
+  path: string,
+  opts: LineStreamOptions = {},
+): AsyncGenerator<LineRecord, void, void> {
+  const start = opts.start ?? 0;
+  const end = opts.end;
+  let lineNo = opts.startLineNo ?? 1;
+
+  const stream = fs.createReadStream(path, {
+    start,
+    ...(end !== undefined ? { end: end - 1 } : {}),
+    highWaterMark: DEFAULT_HIGH_WATER_MARK,
+  });
+
+  let buffer: Buffer = Buffer.alloc(0);
+  let absoluteOffset = start;
+  let pendingLineStart = start;
+
+  for await (const chunk of stream as AsyncIterable<Buffer>) {
+    buffer = buffer.length === 0
+      ? Buffer.from(chunk)
+      : Buffer.concat([buffer, chunk]);
+
+    while (true) {
+      const nl = buffer.indexOf(0x0a);
+      if (nl < 0) break;
+
+      // Slice off the line bytes (excluding the terminator), then trim a
+      // trailing \r if the file uses CRLF.
+      let lineEnd = nl;
+      if (lineEnd > 0 && buffer[lineEnd - 1] === 0x0d) lineEnd = lineEnd - 1;
+
+      const lineBytes = buffer.subarray(0, lineEnd);
+      const lineText = lineBytes.toString('utf8');
+      const fullLineByteLength = nl + 1; // include trailing \n
+      yield {
+        line: lineText,
+        lineNo,
+        byteOffset: pendingLineStart,
+        byteLength: fullLineByteLength,
+      };
+      lineNo += 1;
+      pendingLineStart += fullLineByteLength;
+      buffer = buffer.subarray(nl + 1);
+    }
+
+    absoluteOffset = pendingLineStart + buffer.length;
+  }
+
+  // Final trailing line without a terminator.
+  if (buffer.length > 0) {
+    const lineEnd = buffer.length > 0 && buffer[buffer.length - 1] === 0x0d
+      ? buffer.length - 1
+      : buffer.length;
+    yield {
+      line: buffer.subarray(0, lineEnd).toString('utf8'),
+      lineNo,
+      byteOffset: pendingLineStart,
+      byteLength: buffer.length,
+    };
+  }
+
+  // Mark unused for now but keeps a parallel API surface if callers later want
+  // to know how far the stream advanced.
+  void absoluteOffset;
+}
+
+/**
+ * Returns the number of bytes the stream would scan for the requested range.
+ * Used to populate `summary.scannedBytes` without keeping a separate counter.
+ */
+export function scannedBytes(stat: fs.Stats, start = 0, end?: number): number {
+  const upper = end ?? stat.size;
+  return Math.max(0, upper - start);
+}

--- a/tools/MithrilLogMcp/src/util/time-windows.ts
+++ b/tools/MithrilLogMcp/src/util/time-windows.ts
@@ -67,17 +67,29 @@ function unitToMs(value: number, unit: string): number {
 /**
  * Player.log per-line stamper.
  *
- * `[HH:MM:SS]` at the start of every line is interpreted relative to a date
- * anchor (the file's mtime). To make midnight crossings within a single file
- * sensible, the anchor rolls *backward* one day when an emitted timestamp is
- * later than `mtime + 1 minute` (1 minute slack absorbs clock skew).
+ * Lines carry only `[HH:MM:SS]` (local game time) — no date. The date
+ * anchor for the *first* line is supplied by the caller (typically computed
+ * by {@link countPlayerLogCrossings}: the file's mtime UTC date, walked back
+ * one day per midnight crossing detected in the file). As we stream forward,
+ * a backward jump in HH:MM:SS of more than ~1 minute is taken as a midnight
+ * crossing and the running date advances by one day.
+ *
+ * Times are constructed with the *local* Date constructor on purpose — the
+ * game writes wall-clock time in the user's timezone, and the resulting
+ * Date object's UTC instant is what callers compare against `since`/`until`
+ * windows (also UTC instants).
  */
 export class PlayerLogTimestamper {
-  private static readonly TIME_RE = /^\[(\d{2}):(\d{2}):(\d{2})\]\s/;
-  private currentDate: Date;
+  static readonly TIME_RE = /^\[(\d{2}):(\d{2}):(\d{2})\]\s/;
+  private static readonly BACKWARD_JUMP_SLACK_SECONDS = 60;
 
-  constructor(anchor: Date) {
-    this.currentDate = startOfDay(anchor);
+  private currentDate: Date;
+  private prevSeconds = -1;
+
+  constructor(startDate: Date) {
+    this.currentDate = new Date(Date.UTC(
+      startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate(),
+    ));
   }
 
   stamp(line: string, fallback: Date): Date {
@@ -86,6 +98,16 @@ export class PlayerLogTimestamper {
     const h = Number.parseInt(m[1] ?? '0', 10);
     const min = Number.parseInt(m[2] ?? '0', 10);
     const s = Number.parseInt(m[3] ?? '0', 10);
+
+    const seconds = h * 3600 + min * 60 + s;
+    if (this.prevSeconds >= 0 &&
+        seconds < this.prevSeconds - PlayerLogTimestamper.BACKWARD_JUMP_SLACK_SECONDS) {
+      // HH:MM:SS dropped — the file crossed midnight; advance the date.
+      this.currentDate = new Date(this.currentDate);
+      this.currentDate.setUTCDate(this.currentDate.getUTCDate() + 1);
+    }
+    this.prevSeconds = seconds;
+
     return new Date(
       this.currentDate.getUTCFullYear(),
       this.currentDate.getUTCMonth(),
@@ -97,4 +119,33 @@ export class PlayerLogTimestamper {
 
 export function startOfDay(d: Date): Date {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/**
+ * First pass over a Player.log: counts how many midnight crossings the file
+ * contains by walking `[HH:MM:SS]` markers. Combined with the file's mtime,
+ * lets us anchor the *start* of the file rather than the end.
+ *
+ * Without this, the timestamper would naively anchor every line to the mtime's
+ * UTC date — which is wrong for any line earlier in the day than the current
+ * mtime time, and badly wrong for lines from previous days that the game has
+ * accumulated in the same Player.log.
+ */
+export async function countPlayerLogCrossings(
+  lines: AsyncIterable<{ line: string }>,
+  slackSeconds = 60,
+): Promise<number> {
+  let prev = -1;
+  let crossings = 0;
+  for await (const rec of lines) {
+    const m = PlayerLogTimestamper.TIME_RE.exec(rec.line);
+    if (!m) continue;
+    const h = Number.parseInt(m[1] ?? '0', 10);
+    const min = Number.parseInt(m[2] ?? '0', 10);
+    const s = Number.parseInt(m[3] ?? '0', 10);
+    const seconds = h * 3600 + min * 60 + s;
+    if (prev >= 0 && seconds < prev - slackSeconds) crossings++;
+    prev = seconds;
+  }
+  return crossings;
 }

--- a/tools/MithrilLogMcp/src/util/time-windows.ts
+++ b/tools/MithrilLogMcp/src/util/time-windows.ts
@@ -24,10 +24,24 @@ export function resolveWindow(
   },
 ): ResolvedWindow {
   if (args.between) {
-    return { since: parseInstant(args.between[0], now), until: parseInstant(args.between[1], now) };
+    const since = parseInstant(args.between[0], now);
+    const until = parseInstant(args.between[1], now);
+    if (since > until) {
+      throw new Error(
+        `'between' range is reversed: '${args.between[0]}' (${since.toISOString()}) ` +
+        `is after '${args.between[1]}' (${until.toISOString()}). Pass [start, end].`,
+      );
+    }
+    return { since, until };
   }
   const since = args.since ? parseInstant(args.since, now, { negative: true }) : new Date(0);
   const until = args.until ? parseInstant(args.until, now) : now;
+  if (since > until) {
+    throw new Error(
+      `'since' (${since.toISOString()}) is after 'until' (${until.toISOString()}). ` +
+      `Check the duration sign or ISO timestamps.`,
+    );
+  }
   return { since, until };
 }
 

--- a/tools/MithrilLogMcp/src/util/time-windows.ts
+++ b/tools/MithrilLogMcp/src/util/time-windows.ts
@@ -1,0 +1,100 @@
+/**
+ * Window-resolution helpers for `--since 2h`, `--between iso iso`, etc.
+ *
+ * Player.log lines carry only `[HH:MM:SS]` (no date), so the date is anchored
+ * by the file's mtime: every line is interpreted as `(mtimeDate, HH:MM:SS)`.
+ * If a line's HH:MM:SS would land in the future relative to mtime, it's rolled
+ * back one day to handle midnight crossings within a single file.
+ */
+
+const RELATIVE_RE = /^(\d+)\s*(ms|s|m|h|d)$/i;
+const ISO_BASIC_RE = /^\d{4}-\d{2}-\d{2}/;
+
+export interface ResolvedWindow {
+  since: Date;
+  until: Date;
+}
+
+export function resolveWindow(
+  now: Date,
+  args: {
+    since?: string | undefined;
+    until?: string | undefined;
+    between?: [string, string] | undefined;
+  },
+): ResolvedWindow {
+  if (args.between) {
+    return { since: parseInstant(args.between[0], now), until: parseInstant(args.between[1], now) };
+  }
+  const since = args.since ? parseInstant(args.since, now, { negative: true }) : new Date(0);
+  const until = args.until ? parseInstant(args.until, now) : now;
+  return { since, until };
+}
+
+/**
+ * Accepts:
+ *   - ISO 8601 ("2026-04-26T12:00:00Z" or "2026-04-26")
+ *   - Relative durations ("2h", "30m", "1d") — interpreted as `now - duration`
+ *     when `negative: true` (the typical `--since` case), else `now + duration`.
+ */
+export function parseInstant(input: string, now: Date, opts: { negative?: boolean } = {}): Date {
+  const trimmed = input.trim();
+  const rel = RELATIVE_RE.exec(trimmed);
+  if (rel) {
+    const value = Number.parseInt(rel[1] ?? '0', 10);
+    const unit = (rel[2] ?? 's').toLowerCase();
+    const ms = unitToMs(value, unit);
+    return new Date(now.getTime() + (opts.negative ? -ms : ms));
+  }
+  if (ISO_BASIC_RE.test(trimmed)) {
+    const d = new Date(trimmed);
+    if (Number.isFinite(d.getTime())) return d;
+  }
+  throw new Error(`Cannot parse instant: '${input}' (expected ISO 8601 or relative like '2h')`);
+}
+
+function unitToMs(value: number, unit: string): number {
+  switch (unit) {
+    case 'ms': return value;
+    case 's': return value * 1000;
+    case 'm': return value * 60_000;
+    case 'h': return value * 3_600_000;
+    case 'd': return value * 86_400_000;
+    default: throw new Error(`Unknown duration unit: ${unit}`);
+  }
+}
+
+/**
+ * Player.log per-line stamper.
+ *
+ * `[HH:MM:SS]` at the start of every line is interpreted relative to a date
+ * anchor (the file's mtime). To make midnight crossings within a single file
+ * sensible, the anchor rolls *backward* one day when an emitted timestamp is
+ * later than `mtime + 1 minute` (1 minute slack absorbs clock skew).
+ */
+export class PlayerLogTimestamper {
+  private static readonly TIME_RE = /^\[(\d{2}):(\d{2}):(\d{2})\]\s/;
+  private currentDate: Date;
+
+  constructor(anchor: Date) {
+    this.currentDate = startOfDay(anchor);
+  }
+
+  stamp(line: string, fallback: Date): Date {
+    const m = PlayerLogTimestamper.TIME_RE.exec(line);
+    if (!m) return fallback;
+    const h = Number.parseInt(m[1] ?? '0', 10);
+    const min = Number.parseInt(m[2] ?? '0', 10);
+    const s = Number.parseInt(m[3] ?? '0', 10);
+    return new Date(
+      this.currentDate.getUTCFullYear(),
+      this.currentDate.getUTCMonth(),
+      this.currentDate.getUTCDate(),
+      h, min, s,
+    );
+  }
+}
+
+export function startOfDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}

--- a/tools/MithrilLogMcp/test/active-character.test.ts
+++ b/tools/MithrilLogMcp/test/active-character.test.ts
@@ -1,0 +1,249 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ActiveCharacterTracker } from '../src/parsing/active-character-tracker.js';
+import { findActiveCharacterAt } from '../src/state/character-resolver.js';
+import { loadCatalog } from '../src/parsing/catalog.js';
+import { scanPlayerLog } from '../src/sources/player-log.js';
+import { runQueryEvents, QueryEventsInput } from '../src/tools/query-events.js';
+import { CursorStore } from '../src/state/cursors.js';
+import type { ParsedEvent } from '../src/parsing/types.js';
+
+const T = new Date(Date.UTC(2026, 3, 27, 12, 0, 0));
+
+function syntheticEvent(over: Partial<ParsedEvent>): ParsedEvent {
+  return {
+    type: '',
+    ts: T.toISOString(),
+    module: '',
+    source: 'player',
+    file: 'Player.log',
+    line: 1,
+    byteOffset: 0,
+    data: {},
+    ...over,
+  };
+}
+
+describe('ActiveCharacterTracker', () => {
+  it('updates on shared.ProcessAddPlayer events', () => {
+    const t = new ActiveCharacterTracker();
+    assert.equal(t.active, undefined);
+    t.observe(syntheticEvent({ type: 'shared.ProcessAddPlayer', data: { characterName: 'Emraell' } }));
+    assert.equal(t.active, 'Emraell');
+    t.observe(syntheticEvent({ type: 'shared.ProcessAddPlayer', data: { characterName: 'Velkort' } }));
+    assert.equal(t.active, 'Velkort');
+  });
+
+  it('ignores non-ProcessAddPlayer events', () => {
+    const t = new ActiveCharacterTracker('Emraell');
+    t.observe(syntheticEvent({ type: 'samwise.SetPetOwner', data: { entityId: '12345' } }));
+    assert.equal(t.active, 'Emraell');
+  });
+
+  it('honours an initial value', () => {
+    const t = new ActiveCharacterTracker('Emraell');
+    assert.equal(t.active, 'Emraell');
+  });
+});
+
+function newPlayerLog(lines: string[]): { dir: string; path: string } {
+  const dir = path.join(os.tmpdir(), `mithril-active-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(dir);
+  const p = path.join(dir, 'Player.log');
+  fs.writeFileSync(p, lines.join('\n') + '\n');
+  // Past mtime keeps line `[HH:MM:SS]` stamps before `now` regardless of TZ.
+  const yesterday = new Date(Date.now() - 86_400_000);
+  fs.utimesSync(p, yesterday, yesterday);
+  return { dir, path: p };
+}
+
+describe('findActiveCharacterAt', () => {
+  it('returns the most recent ProcessAddPlayer character before a byte offset', () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:01:00] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:02:00] LocalPlayer: ProcessAddPlayer(-2, 2, "PlayerWolf", "Velkort", "")',
+      '[12:03:00] LocalPlayer: ProcessSetPetOwner(33, 44)',
+    ]);
+    try {
+      const catalog = loadCatalog();
+      const stat = fs.statSync(p);
+      assert.equal(findActiveCharacterAt(p, stat.size, catalog), 'Velkort');
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('returns null when no ProcessAddPlayer exists before the offset', () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] Some unrelated startup chatter',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+    ]);
+    try {
+      const catalog = loadCatalog();
+      const stat = fs.statSync(p);
+      assert.equal(findActiveCharacterAt(p, stat.size, catalog), null);
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('returns null for offset 0 (no bytes to scan)', () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+    ]);
+    try {
+      const catalog = loadCatalog();
+      assert.equal(findActiveCharacterAt(p, 0, catalog), null);
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+});
+
+describe('scanPlayerLog stamps activeCharacter', () => {
+  it('stamps every event after a ProcessAddPlayer with the active character', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:00:02] LocalPlayer: ProcessSetPetOwner(33, 44)',
+    ]);
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
+      const events: ParsedEvent[] = [];
+      for await (const e of scanPlayerLog(catalog, {
+        path: p, since: new Date(0), until: new Date('2099-01-01'),
+      }, stats)) events.push(e);
+
+      // At least 1 ProcessAddPlayer + 2 SetPetOwner. Each should be stamped.
+      const stamped = events.filter((e) => e.activeCharacter === 'Emraell');
+      assert.ok(stamped.length >= 3, `expected >=3 stamped events, got ${stamped.length}`);
+      const setPetOwners = events.filter((e) => e.type === 'samwise.SetPetOwner');
+      assert.ok(setPetOwners.every((e) => e.activeCharacter === 'Emraell'));
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('leaves activeCharacter undefined for events before the first ProcessAddPlayer', async () => {
+    // Pet owner before any login — pre-game events.
+    const { dir, path: p } = newPlayerLog([
+      '[11:59:00] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(33, 44)',
+    ]);
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
+      const events: ParsedEvent[] = [];
+      for await (const e of scanPlayerLog(catalog, {
+        path: p, since: new Date(0), until: new Date('2099-01-01'),
+      }, stats)) events.push(e);
+
+      const sortedSetPetOwners = events
+        .filter((e) => e.type === 'samwise.SetPetOwner')
+        .sort((a, b) => a.byteOffset - b.byteOffset);
+      assert.equal(sortedSetPetOwners.length, 2);
+      assert.equal(sortedSetPetOwners[0]!.activeCharacter, undefined,
+        'pre-login pet owner should not be stamped');
+      assert.equal(sortedSetPetOwners[1]!.activeCharacter, 'Emraell');
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+});
+
+describe('character: filter on player events', () => {
+  it('returns only events stamped with the requested character', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:00:02] LocalPlayer: ProcessAddPlayer(-2, 2, "PlayerWolf", "Velkort", "")',
+      '[12:00:03] LocalPlayer: ProcessSetPetOwner(33, 44)',
+      '[12:00:04] LocalPlayer: ProcessSetPetOwner(55, 66)',
+    ]);
+    const cursorFile = path.join(os.tmpdir(), `mithril-cursor-${Date.now()}.json`);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        character: 'Velkort',
+        event_type: ['samwise.SetPetOwner'],
+        limit: 100,
+      });
+      const result = await runQueryEvents(args, makeConfig(p), new CursorStore(cursorFile));
+      assert.equal(result.events.length, 2,
+        'two SetPetOwner events were emitted while Velkort was active');
+      assert.ok(result.events.every((e) => e.activeCharacter === 'Velkort'));
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('skips player events emitted before any ProcessAddPlayer when filter is set', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[11:59:00] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(33, 44)',
+    ]);
+    const cursorFile = path.join(os.tmpdir(), `mithril-cursor-${Date.now()}.json`);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        character: 'Emraell',
+        event_type: ['samwise.SetPetOwner'],
+        limit: 100,
+      });
+      const result = await runQueryEvents(args, makeConfig(p), new CursorStore(cursorFile));
+      assert.equal(result.events.length, 1,
+        'pre-login pet owner is dropped because activeCharacter is unknown');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('cursor resume backfills the active character', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+    ]);
+    const cursorFile = path.join(os.tmpdir(), `mithril-cursor-${Date.now()}.json`);
+    try {
+      // First call seeds the cursor at end-of-file.
+      const seed = QueryEventsInput.parse({
+        source: 'player', cursor: 'session-A', limit: 100,
+      });
+      await runQueryEvents(seed, makeConfig(p), new CursorStore(cursorFile));
+
+      // Append more SetPetOwner events without another ProcessAddPlayer.
+      // Without backfill, the tracker would have no active character and
+      // would skip these under a `character` filter.
+      fs.appendFileSync(p,
+        '[12:00:05] LocalPlayer: ProcessSetPetOwner(33, 44)\n' +
+        '[12:00:06] LocalPlayer: ProcessSetPetOwner(55, 66)\n');
+      const past = new Date(Date.now() - 86_400_000);
+      fs.utimesSync(p, past, past);
+
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'session-A',
+        character: 'Emraell',
+        event_type: ['samwise.SetPetOwner'],
+        limit: 100,
+      });
+      const result = await runQueryEvents(args, makeConfig(p), new CursorStore(cursorFile));
+      assert.equal(result.events.length, 2,
+        'backfill should let the filter match new events even though their session ' +
+        'started before the cursor');
+      assert.ok(result.events.every((e) => e.activeCharacter === 'Emraell'));
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+});
+
+function makeConfig(playerLogPath: string) {
+  return {
+    playerLogPath,
+    chatLogDir: '',
+    mithrilLogDir: '',
+    characterRoot: '',
+    shellSettingsPath: '',
+  };
+}

--- a/tools/MithrilLogMcp/test/catalog.test.ts
+++ b/tools/MithrilLogMcp/test/catalog.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { loadCatalog } from '../src/parsing/catalog.js';
+
+describe('LogPatternCatalog', () => {
+  it('loads from the repo-root JSON without a configured path', () => {
+    const cat = loadCatalog();
+    assert.equal(cat.document.version, 1);
+    assert.ok(cat.entries.length > 0);
+  });
+
+  it('groups entries by source', () => {
+    const cat = loadCatalog();
+    const player = cat.bySource.get('player') ?? [];
+    const chat = cat.bySource.get('chat') ?? [];
+    assert.ok(player.length >= 10, `expected >=10 player entries, got ${player.length}`);
+    assert.ok(chat.length >= 5, `expected >=5 chat entries, got ${chat.length}`);
+  });
+
+  it('compiles every regex without error', () => {
+    const cat = loadCatalog();
+    for (const e of cat.entries) {
+      assert.ok(e.regex instanceof RegExp, `entry ${e.key} is not a RegExp`);
+    }
+  });
+
+  it('exposes the session-marker literal for tail readers', () => {
+    const cat = loadCatalog();
+    assert.equal(cat.sessionMarker.literal, 'ProcessAddPlayer(');
+    assert.ok(cat.sessionMarker.scanChunkBytes > 0);
+  });
+
+  it('exposes byEventType for typed lookups', () => {
+    const cat = loadCatalog();
+    const samwise = cat.byEventType.get('samwise.SetPetOwner');
+    assert.ok(samwise && samwise.length > 0);
+  });
+});

--- a/tools/MithrilLogMcp/test/chat-source.test.ts
+++ b/tools/MithrilLogMcp/test/chat-source.test.ts
@@ -28,7 +28,7 @@ describe('scanChatLogs', () => {
     const dir = setupChatDir();
     try {
       const catalog = loadCatalog();
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
       const events: any[] = [];
       for await (const e of scanChatLogs(catalog, {
         dir,
@@ -48,7 +48,7 @@ describe('scanChatLogs', () => {
     const dir = setupChatDir();
     try {
       const catalog = loadCatalog();
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
       const events: any[] = [];
       for await (const e of scanChatLogs(catalog, {
         dir,
@@ -66,7 +66,7 @@ describe('scanChatLogs', () => {
     const dir = setupChatDir();
     try {
       const catalog = loadCatalog();
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
       const events: any[] = [];
       // Window is entirely before either file's date.
       for await (const e of scanChatLogs(catalog, {

--- a/tools/MithrilLogMcp/test/chat-source.test.ts
+++ b/tools/MithrilLogMcp/test/chat-source.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadCatalog } from '../src/parsing/catalog.js';
+import { scanChatLogs } from '../src/sources/chat-log.js';
+
+function setupChatDir(): string {
+  const dir = path.join(os.tmpdir(), `mithril-chat-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(dir);
+  fs.writeFileSync(path.join(dir, 'Chat-26-04-25.log'),
+    [
+      '26-04-25 12:00:00\t[Status] The Iron Vein is 25m east and 30m north',
+      '26-04-25 12:01:00\t[Status] Iron Ore x3 collected!',
+      '26-04-25 12:02:00\t[Global] Emraell: hi everyone HOOOWL',
+    ].join('\n') + '\n');
+  fs.writeFileSync(path.join(dir, 'Chat-26-04-26.log'),
+    [
+      '26-04-26 09:00:00\t[Status] Apple x2 added to inventory.',
+      '26-04-26 09:01:00\t[Status] Egg added to inventory.',
+    ].join('\n') + '\n');
+  return dir;
+}
+
+describe('scanChatLogs', () => {
+  it('parses a survey line via the legolas catalog', async () => {
+    const dir = setupChatDir();
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      for await (const e of scanChatLogs(catalog, {
+        dir,
+        since: new Date('2026-04-25T00:00:00Z'),
+        until: new Date('2026-04-25T23:59:59Z'),
+      }, stats)) events.push(e);
+
+      const survey = events.find((e) => e.type === 'legolas.SurveyDetected');
+      assert.ok(survey);
+      assert.equal(survey.data.name, 'Iron Vein');
+      assert.equal(survey.data.aDir, 'east');
+      assert.equal(survey.data.bDir, 'north');
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('parses inventory-status lines from the shared catalog', async () => {
+    const dir = setupChatDir();
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      for await (const e of scanChatLogs(catalog, {
+        dir,
+        since: new Date('2026-04-26T00:00:00Z'),
+        until: new Date('2026-04-26T23:59:59Z'),
+      }, stats)) events.push(e);
+
+      const inv = events.filter((e) => e.type === 'shared.InventoryAdded');
+      // Apple x2 hits CountedRx, Egg hits SingleRx.
+      assert.ok(inv.length >= 2);
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('skips files outside the requested time window', async () => {
+    const dir = setupChatDir();
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      // Window is entirely before either file's date.
+      for await (const e of scanChatLogs(catalog, {
+        dir,
+        since: new Date('2025-01-01T00:00:00Z'),
+        until: new Date('2025-12-31T23:59:59Z'),
+      }, stats)) events.push(e);
+      assert.equal(events.length, 0);
+      assert.equal(stats.scannedBytes, 0);
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+});

--- a/tools/MithrilLogMcp/test/cursor-wiring.test.ts
+++ b/tools/MithrilLogMcp/test/cursor-wiring.test.ts
@@ -21,15 +21,17 @@ function newPlayerLog(): { dir: string; path: string } {
       '[12:00:01] LocalPlayer: ProcessSetPetOwner(11111, 22222)',
       '[12:00:02] LocalPlayer: ProcessSetPetOwner(33333, 44444)',
     ].join('\n') + '\n');
-  const future = new Date(Date.now() + 60_000);
-  fs.utimesSync(p, future, future);
+  // Past mtime keeps line `[HH:MM:SS]` stamps safely before `now` — see the
+  // matching note in query-events.test.ts.
+  const yesterday = new Date(Date.now() - 86_400_000);
+  fs.utimesSync(p, yesterday, yesterday);
   return { dir, path: p };
 }
 
 function append(p: string, lines: string[]): void {
   fs.appendFileSync(p, lines.join('\n') + '\n');
-  const future = new Date(Date.now() + 120_000);
-  fs.utimesSync(p, future, future);
+  const yesterday = new Date(Date.now() - 86_400_000);
+  fs.utimesSync(p, yesterday, yesterday);
 }
 
 function makeConfig(playerLogPath: string) {
@@ -118,7 +120,9 @@ describe('query_events cursor wiring', () => {
 
       // Truncate + write a single new line. Size shrinks vs the cursor's recorded
       // fileSize, so rolloverDetected returns true and we read from 0.
-      fs.writeFileSync(playerPath, '[12:00:99] LocalPlayer: ProcessSetPetOwner(99999, 0)\n');
+      fs.writeFileSync(playerPath, '[12:00:09] LocalPlayer: ProcessSetPetOwner(99999, 0)\n');
+      const past = new Date(Date.now() - 86_400_000);
+      fs.utimesSync(playerPath, past, past);
 
       const after = await runQueryEvents(args, makeConfig(playerPath), store);
       assert.equal(after.events.length, 1);

--- a/tools/MithrilLogMcp/test/cursor-wiring.test.ts
+++ b/tools/MithrilLogMcp/test/cursor-wiring.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runQueryEvents, QueryEventsInput } from '../src/tools/query-events.js';
+import { CursorStore } from '../src/state/cursors.js';
+
+/**
+ * Multi-turn cursor flow: a query advances the cursor; a follow-up query
+ * with the same cursor name skips the events from turn 1 and only sees what
+ * was appended afterwards. Verifies the v0.4 wiring end-to-end.
+ */
+
+function newPlayerLog(): { dir: string; path: string } {
+  const dir = path.join(os.tmpdir(), `mithril-cursor-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(dir);
+  const p = path.join(dir, 'Player.log');
+  fs.writeFileSync(p,
+    [
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11111, 22222)',
+      '[12:00:02] LocalPlayer: ProcessSetPetOwner(33333, 44444)',
+    ].join('\n') + '\n');
+  const future = new Date(Date.now() + 60_000);
+  fs.utimesSync(p, future, future);
+  return { dir, path: p };
+}
+
+function append(p: string, lines: string[]): void {
+  fs.appendFileSync(p, lines.join('\n') + '\n');
+  const future = new Date(Date.now() + 120_000);
+  fs.utimesSync(p, future, future);
+}
+
+function makeConfig(playerLogPath: string) {
+  return {
+    playerLogPath,
+    chatLogDir: '',
+    mithrilLogDir: '',
+    characterRoot: '',
+    shellSettingsPath: '',
+  };
+}
+
+function tmpCursorFile(): string {
+  return path.join(os.tmpdir(), `mithril-cursors-${Date.now()}-${Math.random()}.json`);
+}
+
+describe('query_events cursor wiring', () => {
+  it('first call sees all events, second call sees only new ones', async () => {
+    const { dir, path: playerPath } = newPlayerLog();
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'investigation-1',
+        limit: 100,
+      });
+      const first = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(first.events.length, 2,
+        `expected 2 events on first call, got ${first.events.length}`);
+      assert.ok(first.summary.cursor, 'expected cursor info in summary');
+
+      // Append two more events; the cursor should restrict the next call to those.
+      append(playerPath, [
+        '[12:00:05] LocalPlayer: ProcessSetPetOwner(55555, 66666)',
+        '[12:00:06] LocalPlayer: ProcessSetPetOwner(77777, 88888)',
+      ]);
+
+      const second = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(second.events.length, 2,
+        `expected 2 *new* events on second call, got ${second.events.length}`);
+      const ids = second.events.map((e) => e.data.entityId);
+      assert.deepEqual(ids, ['55555', '77777']);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('cursor reset returns to scanning from the start', async () => {
+    const { dir, path: playerPath } = newPlayerLog();
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'investigation-2',
+        limit: 100,
+      });
+      const first = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(first.events.length, 2);
+
+      store.reset('investigation-2');
+
+      const replay = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(replay.events.length, 2,
+        'after reset, the cursor should re-scan from byte 0');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('detects truncation and re-reads from byte 0', async () => {
+    const { dir, path: playerPath } = newPlayerLog();
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'investigation-3',
+        limit: 100,
+      });
+      const first = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(first.events.length, 2);
+
+      // Truncate + write a single new line. Size shrinks vs the cursor's recorded
+      // fileSize, so rolloverDetected returns true and we read from 0.
+      fs.writeFileSync(playerPath, '[12:00:99] LocalPlayer: ProcessSetPetOwner(99999, 0)\n');
+
+      const after = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(after.events.length, 1);
+      assert.deepEqual(after.summary.cursor?.rolledOverFiles, [playerPath]);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('cursor and time window are independent — both apply', async () => {
+    const { dir, path: playerPath } = newPlayerLog();
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      // First call advances the cursor to end-of-file.
+      const seed = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'investigation-4',
+        limit: 100,
+      });
+      await runQueryEvents(seed, makeConfig(playerPath), store);
+
+      append(playerPath, [
+        '[12:00:05] LocalPlayer: ProcessSetPetOwner(55555, 0)',
+      ]);
+
+      // Cursor keeps us past the original two lines, AND `between` further
+      // restricts to a sub-range — both filters compose.
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'investigation-4',
+        between: ['1970-01-01T00:00:00Z', '2099-01-01T00:00:00Z'],
+        limit: 100,
+      });
+      const result = await runQueryEvents(args, makeConfig(playerPath), store);
+      assert.equal(result.events.length, 1);
+      assert.equal(result.events[0]?.data.entityId, '55555');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+});

--- a/tools/MithrilLogMcp/test/cursors.test.ts
+++ b/tools/MithrilLogMcp/test/cursors.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { CursorStore, rolloverDetected, snapshotCursor } from '../src/state/cursors.js';
+
+function tmpFile(): string {
+  return path.join(os.tmpdir(), `mithril-cursors-${Date.now()}-${Math.random()}.json`);
+}
+
+describe('CursorStore', () => {
+  it('reads an empty store as no cursors', () => {
+    const store = new CursorStore(tmpFile());
+    assert.deepEqual(store.list(), []);
+  });
+
+  it('persists put/get round-trips', () => {
+    const file = tmpFile();
+    try {
+      const store = new CursorStore(file);
+      store.put('debug', 'player', { perFile: { 'Player.log': { byteOffset: 1234, fileSize: 1234, birthtimeMs: 1 } } });
+
+      const reread = new CursorStore(file);
+      const state = reread.get('debug', 'player');
+      assert.equal(state.perFile['Player.log']?.byteOffset, 1234);
+    } finally { fs.unlinkSync(file); }
+  });
+
+  it('reset removes a named cursor', () => {
+    const file = tmpFile();
+    try {
+      const store = new CursorStore(file);
+      store.put('a', 'player', { perFile: { 'Player.log': { byteOffset: 1, fileSize: 1, birthtimeMs: 1 } } });
+      store.reset('a');
+      assert.equal(store.list().length, 0);
+    } finally { fs.unlinkSync(file); }
+  });
+});
+
+describe('rolloverDetected', () => {
+  it('detects size shrink (truncation)', () => {
+    const prev = { byteOffset: 100, fileSize: 100, birthtimeMs: 1 };
+    const cur = makeStat({ size: 50, birthtimeMs: 1 });
+    assert.equal(rolloverDetected(prev, cur), true);
+  });
+
+  it('detects birthtime change (recreate)', () => {
+    const prev = { byteOffset: 100, fileSize: 100, birthtimeMs: 1 };
+    const cur = makeStat({ size: 200, birthtimeMs: 2 });
+    assert.equal(rolloverDetected(prev, cur), true);
+  });
+
+  it('returns false on append with stable inode', () => {
+    const prev = { byteOffset: 100, fileSize: 100, birthtimeMs: 1 };
+    const cur = makeStat({ size: 200, birthtimeMs: 1 });
+    assert.equal(rolloverDetected(prev, cur), false);
+  });
+
+  it('treats birthtime=0 as no-signal', () => {
+    const prev = { byteOffset: 100, fileSize: 100, birthtimeMs: 0 };
+    const cur = makeStat({ size: 200, birthtimeMs: 0 });
+    assert.equal(rolloverDetected(prev, cur), false);
+  });
+});
+
+describe('snapshotCursor', () => {
+  it('captures size + birthtime at the offset', () => {
+    const stat = makeStat({ size: 555, birthtimeMs: 42 });
+    const c = snapshotCursor(stat, 100);
+    assert.deepEqual(c, { byteOffset: 100, fileSize: 555, birthtimeMs: 42 });
+  });
+});
+
+function makeStat(over: { size: number; birthtimeMs: number }): fs.Stats {
+  // node:fs.Stats is a class, but rolloverDetected only reads the two fields,
+  // so an object literal cast is enough for these tests.
+  return over as unknown as fs.Stats;
+}

--- a/tools/MithrilLogMcp/test/file-streams.test.ts
+++ b/tools/MithrilLogMcp/test/file-streams.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { lineStream } from '../src/util/file-streams.js';
+
+async function collect(p: string) {
+  const out: { line: string; lineNo: number; byteOffset: number; byteLength: number }[] = [];
+  for await (const r of lineStream(p)) out.push(r);
+  return out;
+}
+
+function tmpFile(content: string): string {
+  const p = path.join(os.tmpdir(), `mithril-line-stream-${Date.now()}-${Math.random()}.log`);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('lineStream', () => {
+  it('reads three LF-terminated lines with correct offsets', async () => {
+    const p = tmpFile('alpha\nbeta\ngamma\n');
+    try {
+      const out = await collect(p);
+      assert.equal(out.length, 3);
+      assert.deepEqual(out.map((r) => r.line), ['alpha', 'beta', 'gamma']);
+      assert.deepEqual(out.map((r) => r.byteOffset), [0, 6, 11]);
+      assert.deepEqual(out.map((r) => r.lineNo), [1, 2, 3]);
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('strips trailing \\r on CRLF lines', async () => {
+    const p = tmpFile('alpha\r\nbeta\r\n');
+    try {
+      const out = await collect(p);
+      assert.deepEqual(out.map((r) => r.line), ['alpha', 'beta']);
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('emits the trailing line even without a terminator', async () => {
+    const p = tmpFile('alpha\nbeta');
+    try {
+      const out = await collect(p);
+      assert.deepEqual(out.map((r) => r.line), ['alpha', 'beta']);
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('counts UTF-8 bytes (not chars) for offsets', async () => {
+    const p = tmpFile('café\nbeta\n'); // é = 2 bytes
+    try {
+      const out = await collect(p);
+      assert.equal(out[0]!.byteOffset, 0);
+      // "café\n" is c=1 a=1 f=1 é=2 \n=1 -> 6 bytes
+      assert.equal(out[1]!.byteOffset, 6);
+    } finally { fs.unlinkSync(p); }
+  });
+});

--- a/tools/MithrilLogMcp/test/mithril-serilog.test.ts
+++ b/tools/MithrilLogMcp/test/mithril-serilog.test.ts
@@ -23,7 +23,7 @@ describe('scanMithrilSerilog', () => {
   it('parses compact JSON lines into mithril.<Category> events', async () => {
     const dir = setupSerilogDir();
     try {
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
       const events: any[] = [];
       for await (const e of scanMithrilSerilog({
         dir,
@@ -43,7 +43,7 @@ describe('scanMithrilSerilog', () => {
   it('skips non-Serilog .json files quietly', async () => {
     const dir = setupSerilogDir();
     try {
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
       const events: any[] = [];
       for await (const e of scanMithrilSerilog({
         dir,

--- a/tools/MithrilLogMcp/test/mithril-serilog.test.ts
+++ b/tools/MithrilLogMcp/test/mithril-serilog.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { scanMithrilSerilog } from '../src/sources/mithril-serilog.js';
+
+function setupSerilogDir(): string {
+  const dir = path.join(os.tmpdir(), `mithril-serilog-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(dir);
+  fs.writeFileSync(path.join(dir, 'mithril-20260426.json'),
+    [
+      JSON.stringify({ '@t': '2026-04-26T12:00:00.0000000Z', '@mt': '{Category} {Message}', Category: 'Reference', Message: 'Loaded items from cache' }),
+      JSON.stringify({ '@t': '2026-04-26T12:00:01.0000000Z', '@mt': '{Category} {Message}', Category: 'Samwise', Message: 'Plot 12 ripened' }),
+      JSON.stringify({ '@t': '2026-04-26T12:00:02.0000000Z', '@mt': '{Category} {Message}', Category: 'PlayerLog', Message: 'Tail offset 5421', '@l': 'Verbose' }),
+    ].join('\n') + '\n');
+  // A non-Serilog file should be skipped without error.
+  fs.writeFileSync(path.join(dir, 'something-else.json'), 'not even json\n');
+  return dir;
+}
+
+describe('scanMithrilSerilog', () => {
+  it('parses compact JSON lines into mithril.<Category> events', async () => {
+    const dir = setupSerilogDir();
+    try {
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      for await (const e of scanMithrilSerilog({
+        dir,
+        since: new Date('2026-04-26T00:00:00Z'),
+        until: new Date('2026-04-26T23:59:59Z'),
+      }, stats)) events.push(e);
+
+      assert.equal(events.length, 3);
+      assert.equal(events[0].type, 'mithril.Reference');
+      assert.equal(events[1].type, 'mithril.Samwise');
+      assert.equal(events[2].type, 'mithril.PlayerLog');
+      assert.equal(events[2].data.level, 'Verbose');
+      assert.equal(events[0].data.message, 'Loaded items from cache');
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('skips non-Serilog .json files quietly', async () => {
+    const dir = setupSerilogDir();
+    try {
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      for await (const e of scanMithrilSerilog({
+        dir,
+        since: new Date(0),
+        until: new Date('2099-01-01'),
+      }, stats)) events.push(e);
+      assert.equal(events.length, 3);
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+});

--- a/tools/MithrilLogMcp/test/multi-source.test.ts
+++ b/tools/MithrilLogMcp/test/multi-source.test.ts
@@ -56,7 +56,7 @@ describe('scanMultiSource', () => {
     const { root, config } = setupAllSources();
     try {
       const catalog = loadCatalog();
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsetsBySource: {}, rolledOverFiles: [] };
       const events: any[] = [];
       for await (const e of scanMultiSource(catalog, config, {
         source: 'all',
@@ -85,7 +85,7 @@ describe('scanMultiSource', () => {
     const { root, config } = setupAllSources();
     try {
       const catalog = loadCatalog();
-      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsetsBySource: {}, rolledOverFiles: [] };
       const events: any[] = [];
       for await (const e of scanMultiSource(catalog, config, {
         source: 'chat',

--- a/tools/MithrilLogMcp/test/multi-source.test.ts
+++ b/tools/MithrilLogMcp/test/multi-source.test.ts
@@ -14,19 +14,22 @@ function setupAllSources() {
   fs.writeFileSync(playerLog,
     '[12:00:01] LocalPlayer: ProcessSetPetOwner(11111, 22222)\n' +
     '[12:00:03] ProcessDeltaFavor(0, "NPC_Marna", 50.0, True)\n');
-  const future = new Date(Date.now() + 60_000);
-  fs.utimesSync(playerLog, future, future);
+  // Anchor mtime to yesterday so `[HH:MM:SS]` line stamps land before `now`
+  // regardless of timezone. Chat-log + Serilog timestamps are date-bearing
+  // (parsed from filename/`@t` directly) so they use the same anchor for shape.
+  const yesterday = new Date(Date.now() - 86_400_000);
+  fs.utimesSync(playerLog, yesterday, yesterday);
 
   const chatDir = path.join(root, 'ChatLogs');
   fs.mkdirSync(chatDir);
-  const todayStr = isoDate(future);
+  const todayStr = isoDate(yesterday);
   fs.writeFileSync(path.join(chatDir, `Chat-${todayStr}.log`),
     `${todayStr} 12:00:02\t[Status] The Iron Vein is 5m east and 7m north\n`);
 
   const mithrilDir = path.join(root, 'mithril-logs');
   fs.mkdirSync(mithrilDir);
   fs.writeFileSync(path.join(mithrilDir, 'mithril-test.json'),
-    JSON.stringify({ '@t': isoTodayAt(future, 12, 0, 0), '@mt': '{Category} {Message}', Category: 'Reference', Message: 'Loaded' }) + '\n');
+    JSON.stringify({ '@t': isoTodayAt(yesterday, 12, 0, 0), '@mt': '{Category} {Message}', Category: 'Reference', Message: 'Loaded' }) + '\n');
 
   return {
     root,

--- a/tools/MithrilLogMcp/test/multi-source.test.ts
+++ b/tools/MithrilLogMcp/test/multi-source.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadCatalog } from '../src/parsing/catalog.js';
+import { scanMultiSource } from '../src/sources/multi-source.js';
+
+function setupAllSources() {
+  const root = path.join(os.tmpdir(), `mithril-multi-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(root);
+
+  const playerLog = path.join(root, 'Player.log');
+  fs.writeFileSync(playerLog,
+    '[12:00:01] LocalPlayer: ProcessSetPetOwner(11111, 22222)\n' +
+    '[12:00:03] ProcessDeltaFavor(0, "NPC_Marna", 50.0, True)\n');
+  const future = new Date(Date.now() + 60_000);
+  fs.utimesSync(playerLog, future, future);
+
+  const chatDir = path.join(root, 'ChatLogs');
+  fs.mkdirSync(chatDir);
+  const todayStr = isoDate(future);
+  fs.writeFileSync(path.join(chatDir, `Chat-${todayStr}.log`),
+    `${todayStr} 12:00:02\t[Status] The Iron Vein is 5m east and 7m north\n`);
+
+  const mithrilDir = path.join(root, 'mithril-logs');
+  fs.mkdirSync(mithrilDir);
+  fs.writeFileSync(path.join(mithrilDir, 'mithril-test.json'),
+    JSON.stringify({ '@t': isoTodayAt(future, 12, 0, 0), '@mt': '{Category} {Message}', Category: 'Reference', Message: 'Loaded' }) + '\n');
+
+  return {
+    root,
+    config: {
+      playerLogPath: playerLog,
+      chatLogDir: chatDir,
+      mithrilLogDir: mithrilDir,
+      characterRoot: '',
+      shellSettingsPath: '',
+    },
+  };
+}
+
+function isoDate(d: Date): string {
+  const y = String(d.getUTCFullYear()).slice(-2);
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function isoTodayAt(d: Date, h: number, m: number, s: number): string {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), h, m, s)).toISOString();
+}
+
+describe('scanMultiSource', () => {
+  it('source: all yields events from every source merged in time order', async () => {
+    const { root, config } = setupAllSources();
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      for await (const e of scanMultiSource(catalog, config, {
+        source: 'all',
+        since: new Date(0),
+        until: new Date('2099-01-01'),
+      }, stats)) {
+        events.push({ ts: e.ts, source: e.source, type: e.type });
+      }
+
+      // We should see at least one event from each source, and the merged
+      // stream should be sorted by timestamp.
+      const sources = new Set(events.map((e) => e.source));
+      assert.ok(sources.has('player'), `expected a player event, got ${[...sources].join(',')}`);
+      assert.ok(sources.has('chat'), `expected a chat event, got ${[...sources].join(',')}`);
+      assert.ok(sources.has('mithril'), `expected a mithril event, got ${[...sources].join(',')}`);
+
+      const tsList = events.map((e) => Date.parse(e.ts));
+      for (let i = 1; i < tsList.length; i++) {
+        assert.ok(tsList[i]! >= tsList[i - 1]!,
+          `events not sorted at index ${i}: ${tsList.slice(0, i + 1).join(',')}`);
+      }
+    } finally { fs.rmSync(root, { recursive: true }); }
+  });
+
+  it('source: chat yields only chat events', async () => {
+    const { root, config } = setupAllSources();
+    try {
+      const catalog = loadCatalog();
+      const stats = { scannedBytes: 0, scannedLines: 0 };
+      const events: any[] = [];
+      for await (const e of scanMultiSource(catalog, config, {
+        source: 'chat',
+        since: new Date(0),
+        until: new Date('2099-01-01'),
+      }, stats)) events.push(e);
+      assert.ok(events.length > 0);
+      assert.ok(events.every((e) => e.source === 'chat'));
+    } finally { fs.rmSync(root, { recursive: true }); }
+  });
+});

--- a/tools/MithrilLogMcp/test/player-parser.test.ts
+++ b/tools/MithrilLogMcp/test/player-parser.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { loadCatalog } from '../src/parsing/catalog.js';
+import { PlayerLineParser } from '../src/parsing/player-parser.js';
+
+const T = new Date(Date.UTC(2026, 3, 15, 12, 0, 0));
+
+function parse(line: string) {
+  const parser = new PlayerLineParser(loadCatalog());
+  return parser.parse(line, T, 'Player.log', 1, 0);
+}
+
+describe('PlayerLineParser', () => {
+  it('parses samwise.SetPetOwner', () => {
+    const events = parse('LocalPlayer: ProcessSetPetOwner(12345, 999)');
+    const e = events.find((x) => x.type === 'samwise.SetPetOwner');
+    assert.ok(e, 'expected samwise.SetPetOwner');
+    assert.equal(e!.data.entityId, '12345');
+  });
+
+  it('parses samwise.AppearanceLoop with scale', () => {
+    const events = parse('Download appearance loop @Carrot(scale=1.0)');
+    const e = events.find((x) => x.type === 'samwise.AppearanceLoop');
+    assert.ok(e);
+    assert.equal(e!.data.modelName, 'Carrot');
+    assert.equal(e!.data.scale, 1.0);
+  });
+
+  it('parses arwen.FavorUpdate from ProcessStartInteraction with NPC_ key', () => {
+    const events = parse('ProcessStartInteraction(123, 456, 1500.5, True, "NPC_Marna")');
+    const e = events.find((x) => x.type === 'arwen.FavorUpdate');
+    assert.ok(e);
+    assert.equal(e!.data.npcKey, 'NPC_Marna');
+    assert.equal(e!.data.absoluteFavor, 1500.5);
+    assert.equal(e!.data.entityId, 123);
+  });
+
+  it('parses smaug.NpcInteractionStarted from the same line', () => {
+    // The same ProcessStartInteraction line matches both arwen and smaug catalogs;
+    // the MCP server emits both events because consumers may want either view.
+    const events = parse('ProcessStartInteraction(123, 456, 1500.5, True, "NPC_Marna")');
+    const arwen = events.find((x) => x.type === 'arwen.FavorUpdate');
+    const smaug = events.find((x) => x.type === 'smaug.NpcInteractionStarted');
+    assert.ok(arwen, 'expected arwen.FavorUpdate');
+    assert.ok(smaug, 'expected smaug.NpcInteractionStarted');
+    assert.equal(smaug!.data.npcKey, 'NPC_Marna');
+  });
+
+  it('parses arwen.FavorDelta from ProcessDeltaFavor', () => {
+    const events = parse('ProcessDeltaFavor(0, "NPC_Marna", 50.0, True)');
+    const e = events.find((x) => x.type === 'arwen.FavorDelta');
+    assert.ok(e);
+    assert.equal(e!.data.npcKey, 'NPC_Marna');
+    assert.equal(e!.data.delta, 50.0);
+  });
+
+  it('parses smaug.VendorItemSold', () => {
+    const events = parse('ProcessVendorAddItem(420, RustyDagger(987654), True)');
+    const e = events.find((x) => x.type === 'smaug.VendorItemSold');
+    assert.ok(e);
+    assert.equal(e!.data.price, 420);
+    assert.equal(e!.data.internalName, 'RustyDagger');
+    assert.equal(e!.data.instanceId, 987654);
+  });
+
+  it('parses samwise.PlantingCapReached', () => {
+    const line =
+      'ProcessErrorMessage(ItemUnusable, "Barley Seeds can\'t be used: You already have the maximum of that type of plant growing")';
+    const events = parse(line);
+    const e = events.find((x) => x.type === 'samwise.PlantingCapReached');
+    assert.ok(e);
+    assert.equal(e!.data.seedDisplayName, 'Barley Seeds');
+  });
+
+  it('parses pippin.FoodsConsumedReport from a ProcessBook line', () => {
+    // The ProcessBook line stores newlines as literal `\n` two-char sequences.
+    const line =
+      'LocalPlayer: ProcessBook("Skill Info", "Foods Consumed:\\n\\n  Egg (HAS DAIRY): 4\\n  Apple: 2\\n", "SkillReport")';
+    const events = parse(line);
+    const e = events.find((x) => x.type === 'pippin.FoodsConsumedReport');
+    assert.ok(e, 'expected pippin.FoodsConsumedReport');
+    const foods = e!.data.foods as Array<{ name: string; count: number; tags: string[] }>;
+    assert.equal(foods.length, 2);
+    assert.deepEqual(foods[0], { name: 'Egg', count: 4, tags: ['DAIRY'] });
+    assert.deepEqual(foods[1], { name: 'Apple', count: 2, tags: [] });
+  });
+
+  it('returns no events for an unrelated line', () => {
+    const events = parse('Some unrelated debug message about Unity things');
+    assert.equal(events.length, 0);
+  });
+});

--- a/tools/MithrilLogMcp/test/polish.test.ts
+++ b/tools/MithrilLogMcp/test/polish.test.ts
@@ -1,0 +1,266 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveWindow } from '../src/util/time-windows.js';
+import { runQueryEvents, QueryEventsInput } from '../src/tools/query-events.js';
+import { runAggregate, AggregateInput } from '../src/tools/aggregate.js';
+import { runCursorSet, runCursorList, CursorSetInput } from '../src/tools/cursor.js';
+import { CursorStore } from '../src/state/cursors.js';
+
+function newPlayerLog(lines: string[]): { dir: string; path: string } {
+  const dir = path.join(os.tmpdir(), `mithril-polish-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(dir);
+  const p = path.join(dir, 'Player.log');
+  fs.writeFileSync(p, lines.join('\n') + '\n');
+  const yesterday = new Date(Date.now() - 86_400_000);
+  fs.utimesSync(p, yesterday, yesterday);
+  return { dir, path: p };
+}
+
+function makeConfig(playerLogPath: string) {
+  return {
+    playerLogPath,
+    chatLogDir: '',
+    mithrilLogDir: '',
+    characterRoot: '',
+    shellSettingsPath: '',
+  };
+}
+
+function tmpCursorFile(): string {
+  return path.join(os.tmpdir(), `mithril-polish-cursors-${Date.now()}-${Math.random()}.json`);
+}
+
+describe('resolveWindow validates ordering', () => {
+  it('throws when between is reversed', () => {
+    const now = new Date('2026-04-27T12:00:00Z');
+    assert.throws(
+      () => resolveWindow(now, { between: ['2099-01-01', '1970-01-01'] }),
+      /reversed/i,
+    );
+  });
+
+  it('throws when since resolves after until', () => {
+    const now = new Date('2026-04-27T12:00:00Z');
+    assert.throws(
+      () => resolveWindow(now, { since: '2099-01-01T00:00:00Z', until: '2020-01-01T00:00:00Z' }),
+      /after/i,
+    );
+  });
+
+  it('accepts a valid forward range', () => {
+    const now = new Date('2026-04-27T12:00:00Z');
+    const w = resolveWindow(now, { between: ['2026-04-27T00:00:00Z', '2026-04-27T11:59:59Z'] });
+    assert.equal(w.since.toISOString(), '2026-04-27T00:00:00.000Z');
+  });
+});
+
+describe('aggregate with cursor', () => {
+  it('advances the cursor after a successful aggregate call', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:00:02] LocalPlayer: ProcessSetPetOwner(33, 44)',
+    ]);
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const args = AggregateInput.parse({
+        source: 'player',
+        agg: 'count',
+        cursor: 'agg-1',
+      });
+      const first = await runAggregate(args, makeConfig(p), store);
+      assert.ok(first.summary.matched > 0, 'first call should see all events');
+      assert.ok(first.summary.cursor, 'cursor info should appear in summary');
+
+      // Append more lines, then re-aggregate with the same cursor.
+      fs.appendFileSync(p, '[12:00:05] LocalPlayer: ProcessSetPetOwner(55, 66)\n');
+      const past = new Date(Date.now() - 86_400_000);
+      fs.utimesSync(p, past, past);
+
+      const second = await runAggregate(args, makeConfig(p), store);
+      assert.equal(second.summary.matched, 1,
+        'cursor restricted second call to the appended event');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+});
+
+describe('cursor_set', () => {
+  it('anchor=end fast-forwards past existing content', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Emraell", "")',
+      '[12:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+    ]);
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const setArgs = CursorSetInput.parse({
+        name: 'forward-cursor',
+        source: 'player',
+        file: p,
+        anchor: 'end',
+      });
+      const setResult = runCursorSet(setArgs, store);
+      assert.equal(setResult.byteOffset, fs.statSync(p).size);
+
+      // Append a new event. With anchor=end set previously, query should
+      // only see the new line — nothing from before.
+      fs.appendFileSync(p, '[12:00:05] LocalPlayer: ProcessSetPetOwner(99, 0)\n');
+      const past = new Date(Date.now() - 86_400_000);
+      fs.utimesSync(p, past, past);
+
+      const queryArgs = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'forward-cursor',
+        limit: 10,
+      });
+      const result = await runQueryEvents(queryArgs, makeConfig(p), store);
+      assert.equal(result.events.length, 1,
+        'only the appended event should be visible');
+      assert.equal(result.events[0]?.data.entityId, '99');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('anchor=offset rejects out-of-range values', async () => {
+    const { dir, path: p } = newPlayerLog(['just one line\n']);
+    const store = new CursorStore(tmpCursorFile());
+    try {
+      assert.throws(
+        () => runCursorSet({
+          name: 'oob',
+          source: 'player',
+          file: p,
+          anchor: 'offset',
+          byteOffset: 1_000_000_000,
+        }, store),
+        /exceeds file size/,
+      );
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+
+  it('cursor_list shows file offsets after set', () => {
+    const { dir, path: p } = newPlayerLog(['[12:00:00] x']);
+    const store = new CursorStore(tmpCursorFile());
+    try {
+      runCursorSet({
+        name: 'inspector',
+        source: 'player',
+        file: p,
+        anchor: 'start',
+      }, store);
+      const list = runCursorList({}, store);
+      const inspector = list.cursors.find((c) => c.name === 'inspector');
+      assert.ok(inspector);
+      assert.deepEqual(inspector!.sources.player!.files, { [p]: 0 });
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+});
+
+describe('context: N attaches surrounding lines', () => {
+  it('captures up to N lines before and after each match', async () => {
+    // Match is at line 4; want up to 2 before and 2 after.
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] line one boring',
+      '[12:00:01] line two boring',
+      '[12:00:02] line three also boring',
+      '[12:00:03] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      '[12:00:04] line five trailing',
+      '[12:00:05] line six trailing',
+      '[12:00:06] line seven trailing',
+    ]);
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        event_type: ['samwise.SetPetOwner'],
+        context: 2,
+        limit: 10,
+      });
+      const result = await runQueryEvents(args, makeConfig(p), store);
+      assert.equal(result.events.length, 1);
+      const e = result.events[0]!;
+      assert.ok(e.contextLines, 'contextLines should be present');
+      assert.equal(e.contextLines!.before.length, 2);
+      assert.equal(e.contextLines!.after.length, 2);
+      assert.match(e.contextLines!.before[0]!, /line two boring/);
+      assert.match(e.contextLines!.before[1]!, /line three also boring/);
+      assert.match(e.contextLines!.after[0]!, /line five trailing/);
+      assert.match(e.contextLines!.after[1]!, /line six trailing/);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('handles end-of-file matches with partial after-context', async () => {
+    const { dir, path: p } = newPlayerLog([
+      '[12:00:00] noise one',
+      '[12:00:01] noise two',
+      '[12:00:02] LocalPlayer: ProcessSetPetOwner(99, 0)',
+    ]);
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        event_type: ['samwise.SetPetOwner'],
+        context: 5,
+        limit: 10,
+      });
+      const result = await runQueryEvents(args, makeConfig(p), store);
+      assert.equal(result.events.length, 1);
+      const e = result.events[0]!;
+      assert.equal(e.contextLines!.before.length, 2);
+      assert.equal(e.contextLines!.after.length, 0,
+        'end-of-file match has no following lines');
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+});
+
+describe('mithril serilog category pre-filter', () => {
+  it('skips JSON.parse for lines whose Category is not in the allowlist', async () => {
+    const dir = path.join(os.tmpdir(), `mithril-serilog-prefilter-${Date.now()}`);
+    fs.mkdirSync(dir);
+    try {
+      const log = path.join(dir, 'mithril-test.json');
+      fs.writeFileSync(log, [
+        JSON.stringify({ '@t': new Date(Date.now() - 3_600_000).toISOString(), '@mt': '{Category} {Message}', Category: 'Reference', Message: 'load' }),
+        // A malformed line with Category: 'Reference' should still parse fine.
+        JSON.stringify({ '@t': new Date(Date.now() - 3_500_000).toISOString(), '@mt': '{Category} {Message}', Category: 'Reference', Message: 'cache hit' }),
+        // A 'Samwise' line that should be skipped by pre-filter.
+        JSON.stringify({ '@t': new Date(Date.now() - 3_400_000).toISOString(), '@mt': '{Category} {Message}', Category: 'Samwise', Message: 'plot ripened' }),
+      ].join('\n') + '\n');
+
+      const args = AggregateInput.parse({
+        source: 'mithril',
+        agg: 'count',
+        event_type: ['mithril.Reference'],
+        since: '2h',
+      });
+      const cursorFile = tmpCursorFile();
+      const config = {
+        playerLogPath: '',
+        chatLogDir: '',
+        mithrilLogDir: dir,
+        characterRoot: '',
+        shellSettingsPath: '',
+      };
+      const result = await runAggregate(args, config, new CursorStore(cursorFile));
+      assert.equal(result.summary.matched, 2,
+        'allowlist should keep only Reference events');
+    } finally { fs.rmSync(dir, { recursive: true }); }
+  });
+});

--- a/tools/MithrilLogMcp/test/query-events.test.ts
+++ b/tools/MithrilLogMcp/test/query-events.test.ts
@@ -6,6 +6,9 @@ import * as path from 'node:path';
 import { runQueryEvents, QueryEventsInput } from '../src/tools/query-events.js';
 import { runAggregate, AggregateInput } from '../src/tools/aggregate.js';
 import { runListEventTypes } from '../src/tools/list-event-types.js';
+import { CursorStore } from '../src/state/cursors.js';
+
+const stubCursorStore = () => new CursorStore(path.join(os.tmpdir(), `mithril-cursor-stub-${Date.now()}-${Math.random()}.json`));
 
 /**
  * Integration-style: write a small synthetic Player.log to a tmp file, point
@@ -40,7 +43,7 @@ describe('runQueryEvents', () => {
         event_type: ['arwen.FavorUpdate'],
         limit: 100,
       });
-      const result = await runQueryEvents(args, makeConfig(p));
+      const result = await runQueryEvents(args, makeConfig(p), stubCursorStore());
       assert.ok(result.summary.scannedLines >= 8);
       assert.equal(result.events.length, 2);
       assert.ok(result.events.every((e) => e.type === 'arwen.FavorUpdate'));
@@ -51,7 +54,7 @@ describe('runQueryEvents', () => {
     const p = fixturePath();
     try {
       const args = QueryEventsInput.parse({ source: 'player', limit: 1 });
-      const result = await runQueryEvents(args, makeConfig(p));
+      const result = await runQueryEvents(args, makeConfig(p), stubCursorStore());
       assert.equal(result.events.length, 1);
       assert.equal(result.summary.truncated, true);
       assert.ok(result.summary.matched > 1);
@@ -67,7 +70,7 @@ describe('runQueryEvents', () => {
         offset: 1,
         limit: 5,
       });
-      const result = await runQueryEvents(args, makeConfig(p));
+      const result = await runQueryEvents(args, makeConfig(p), stubCursorStore());
       assert.equal(result.events.length, 1);
       assert.equal(result.events[0]?.data.npcKey, 'NPC_Velkort');
     } finally { fs.unlinkSync(p); }
@@ -82,7 +85,7 @@ describe('runQueryEvents', () => {
         filter: { npcKey: 'NPC_Marna' },
         limit: 10,
       });
-      const result = await runQueryEvents(args, makeConfig(p));
+      const result = await runQueryEvents(args, makeConfig(p), stubCursorStore());
       assert.equal(result.events.length, 1);
       assert.equal(result.events[0]?.data.npcKey, 'NPC_Marna');
     } finally { fs.unlinkSync(p); }

--- a/tools/MithrilLogMcp/test/query-events.test.ts
+++ b/tools/MithrilLogMcp/test/query-events.test.ts
@@ -100,7 +100,7 @@ describe('runAggregate', () => {
     const p = fixturePath();
     try {
       const args = AggregateInput.parse({ source: 'player', agg: 'count' });
-      const result = await runAggregate(args, makeConfig(p));
+      const result = await runAggregate(args, makeConfig(p), stubCursorStore());
       assert.equal(result.buckets.length, 1);
       assert.equal(result.buckets[0]?.key, 'count');
       // 8 lines, but ProcessStartInteraction matches twice (arwen + smaug).
@@ -119,7 +119,7 @@ describe('runAggregate', () => {
         agg: 'group_by',
         field: 'type',
       });
-      const result = await runAggregate(args, makeConfig(p));
+      const result = await runAggregate(args, makeConfig(p), stubCursorStore());
       const map = new Map(result.buckets.map((b) => [b.key, b.count]));
       assert.equal(map.get('arwen.FavorUpdate'), 2);
       assert.equal(map.get('smaug.NpcInteractionStarted'), 2);
@@ -137,7 +137,7 @@ describe('runAggregate', () => {
         event_type: ['arwen.FavorUpdate'],
         top_n: 3,
       });
-      const result = await runAggregate(args, makeConfig(p));
+      const result = await runAggregate(args, makeConfig(p), stubCursorStore());
       assert.deepEqual(
         result.buckets.map((b) => b.key).sort(),
         ['NPC_Marna', 'NPC_Velkort'],

--- a/tools/MithrilLogMcp/test/query-events.test.ts
+++ b/tools/MithrilLogMcp/test/query-events.test.ts
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runQueryEvents, QueryEventsInput } from '../src/tools/query-events.js';
+import { runAggregate, AggregateInput } from '../src/tools/aggregate.js';
+import { runListEventTypes } from '../src/tools/list-event-types.js';
+
+/**
+ * Integration-style: write a small synthetic Player.log to a tmp file, point
+ * the server at it via config, run each tool, and assert the shape.
+ */
+
+function fixturePath(): string {
+  const p = path.join(os.tmpdir(), `mithril-query-fixture-${Date.now()}.log`);
+  const lines = [
+    '[12:00:00] LocalPlayer: ProcessAddPlayer(-626625832, 290067, "PlayerWolf", "Emraell", "A player!")',
+    '[12:00:01] LocalPlayer: ProcessSetPetOwner(11111, 22222)',
+    '[12:00:02] Download appearance loop @Carrot(scale=1.0)',
+    '[12:00:03] ProcessStartInteraction(900, 1, 100.5, True, "NPC_Marna")',
+    '[12:00:04] ProcessDeltaFavor(0, "NPC_Marna", 25.0, True)',
+    '[12:00:05] ProcessVendorAddItem(50, RustyDagger(101), True)',
+    '[12:00:06] ProcessVendorAddItem(75, RustyDagger(102), True)',
+    '[12:00:07] ProcessStartInteraction(901, 1, 200.5, True, "NPC_Velkort")',
+  ];
+  fs.writeFileSync(p, lines.join('\n') + '\n');
+  // Future-date the file so the timestamper anchors to "today" rather than 2025.
+  const future = new Date(Date.now() + 60_000);
+  fs.utimesSync(p, future, future);
+  return p;
+}
+
+describe('runQueryEvents', () => {
+  it('returns events that match an event_type filter', async () => {
+    const p = fixturePath();
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        event_type: ['arwen.FavorUpdate'],
+        limit: 100,
+      });
+      const result = await runQueryEvents(args, makeConfig(p));
+      assert.ok(result.summary.scannedLines >= 8);
+      assert.equal(result.events.length, 2);
+      assert.ok(result.events.every((e) => e.type === 'arwen.FavorUpdate'));
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('honours limit and reports truncated', async () => {
+    const p = fixturePath();
+    try {
+      const args = QueryEventsInput.parse({ source: 'player', limit: 1 });
+      const result = await runQueryEvents(args, makeConfig(p));
+      assert.equal(result.events.length, 1);
+      assert.equal(result.summary.truncated, true);
+      assert.ok(result.summary.matched > 1);
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('honours offset for pagination', async () => {
+    const p = fixturePath();
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        event_type: ['arwen.FavorUpdate'],
+        offset: 1,
+        limit: 5,
+      });
+      const result = await runQueryEvents(args, makeConfig(p));
+      assert.equal(result.events.length, 1);
+      assert.equal(result.events[0]?.data.npcKey, 'NPC_Velkort');
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('honours filter on data fields', async () => {
+    const p = fixturePath();
+    try {
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        event_type: ['arwen.FavorUpdate'],
+        filter: { npcKey: 'NPC_Marna' },
+        limit: 10,
+      });
+      const result = await runQueryEvents(args, makeConfig(p));
+      assert.equal(result.events.length, 1);
+      assert.equal(result.events[0]?.data.npcKey, 'NPC_Marna');
+    } finally { fs.unlinkSync(p); }
+  });
+});
+
+describe('runAggregate', () => {
+  it('count returns total matched events', async () => {
+    const p = fixturePath();
+    try {
+      const args = AggregateInput.parse({ source: 'player', agg: 'count' });
+      const result = await runAggregate(args, makeConfig(p));
+      assert.equal(result.buckets.length, 1);
+      assert.equal(result.buckets[0]?.key, 'count');
+      // 8 lines, but ProcessStartInteraction matches twice (arwen + smaug).
+      // 1 (SetPetOwner) + 1 (AppearanceLoop) + 2 (interaction A: arwen+smaug) +
+      // 1 (DeltaFavor) + 1 (VendorAddItem) + 1 (VendorAddItem) +
+      // 2 (interaction B: arwen+smaug) + 1 (ProcessAddPlayer) = 10
+      assert.equal(result.buckets[0]?.count, 10);
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('group_by buckets by event type', async () => {
+    const p = fixturePath();
+    try {
+      const args = AggregateInput.parse({
+        source: 'player',
+        agg: 'group_by',
+        field: 'type',
+      });
+      const result = await runAggregate(args, makeConfig(p));
+      const map = new Map(result.buckets.map((b) => [b.key, b.count]));
+      assert.equal(map.get('arwen.FavorUpdate'), 2);
+      assert.equal(map.get('smaug.NpcInteractionStarted'), 2);
+      assert.equal(map.get('smaug.VendorItemSold'), 2);
+    } finally { fs.unlinkSync(p); }
+  });
+
+  it('top:n returns the N most frequent values', async () => {
+    const p = fixturePath();
+    try {
+      const args = AggregateInput.parse({
+        source: 'player',
+        agg: 'top',
+        field: 'npcKey',
+        event_type: ['arwen.FavorUpdate'],
+        top_n: 3,
+      });
+      const result = await runAggregate(args, makeConfig(p));
+      assert.deepEqual(
+        result.buckets.map((b) => b.key).sort(),
+        ['NPC_Marna', 'NPC_Velkort'],
+      );
+    } finally { fs.unlinkSync(p); }
+  });
+});
+
+describe('runListEventTypes', () => {
+  it('returns at least one player event', () => {
+    const result = runListEventTypes({ source: 'player' });
+    const types = result.types.map((t) => t.type);
+    assert.ok(types.includes('arwen.FavorUpdate'));
+    assert.ok(types.includes('samwise.SetPetOwner'));
+    assert.ok(types.includes('shared.ProcessAddPlayer'));
+  });
+
+  it('respects source=chat', () => {
+    const result = runListEventTypes({ source: 'chat' });
+    assert.ok(result.types.length >= 1);
+    assert.ok(result.types.every((t) => t.source === 'chat'));
+  });
+
+  it('skips helper-kind entries', () => {
+    const result = runListEventTypes({ source: 'all' });
+    // The chat-line splitter is a helper; it shouldn't appear as a queryable event type.
+    assert.ok(!result.types.some((t) => t.type === ''));
+  });
+});
+
+function makeConfig(playerLogPath: string) {
+  return {
+    playerLogPath,
+    chatLogDir: '',
+    mithrilLogDir: '',
+    characterRoot: '',
+    shellSettingsPath: '',
+  };
+}

--- a/tools/MithrilLogMcp/test/query-events.test.ts
+++ b/tools/MithrilLogMcp/test/query-events.test.ts
@@ -28,9 +28,12 @@ function fixturePath(): string {
     '[12:00:07] ProcessStartInteraction(901, 1, 200.5, True, "NPC_Velkort")',
   ];
   fs.writeFileSync(p, lines.join('\n') + '\n');
-  // Future-date the file so the timestamper anchors to "today" rather than 2025.
-  const future = new Date(Date.now() + 60_000);
-  fs.utimesSync(p, future, future);
+  // Anchor mtime to yesterday so line `[HH:MM:SS]` stamps land safely before
+  // `now`, regardless of the time of day or local timezone offset (BST/EST/etc.).
+  // PlayerLogTimestamper uses mtime as the date anchor; fixturing into the future
+  // would make events appear later than `until: now` during early-UTC test runs.
+  const yesterday = new Date(Date.now() - 86_400_000);
+  fs.utimesSync(p, yesterday, yesterday);
   return p;
 }
 

--- a/tools/MithrilLogMcp/test/time-windows.test.ts
+++ b/tools/MithrilLogMcp/test/time-windows.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { resolveWindow, parseInstant } from '../src/util/time-windows.js';
+import {
+  resolveWindow,
+  parseInstant,
+  PlayerLogTimestamper,
+  countPlayerLogCrossings,
+} from '../src/util/time-windows.js';
 
 describe('time-windows', () => {
   it('parses ISO 8601 instants', () => {
@@ -43,3 +48,70 @@ describe('time-windows', () => {
     assert.equal(parseInstant('1d', now, { negative: true }).toISOString(), '2026-04-25T12:00:00.000Z');
   });
 });
+
+describe('PlayerLogTimestamper', () => {
+  function utcDay(year: number, m1: number, day: number): Date {
+    return new Date(Date.UTC(year, m1 - 1, day));
+  }
+
+  it('keeps a single ascending sequence on the same day', () => {
+    const t = new PlayerLogTimestamper(utcDay(2026, 4, 27));
+    const a = t.stamp('[10:00:00] foo', new Date(0));
+    const b = t.stamp('[10:00:01] foo', new Date(0));
+    const c = t.stamp('[10:00:02] foo', new Date(0));
+    assert.equal(a.getDate(), b.getDate());
+    assert.equal(b.getDate(), c.getDate());
+    assert.ok(a < b && b < c);
+  });
+
+  it('advances the date when HH:MM:SS jumps backward (midnight crossing)', () => {
+    const t = new PlayerLogTimestamper(utcDay(2026, 4, 26));
+    const lastBefore = t.stamp('[23:59:55] foo', new Date(0));
+    const firstAfter = t.stamp('[00:00:05] foo', new Date(0));
+    // Different calendar dates, and firstAfter > lastBefore.
+    assert.ok(firstAfter.getTime() > lastBefore.getTime());
+    assert.notEqual(lastBefore.getDate(), firstAfter.getDate());
+  });
+
+  it('returns the fallback for lines without a timestamp prefix', () => {
+    const t = new PlayerLogTimestamper(utcDay(2026, 4, 27));
+    const fallback = new Date('2026-04-27T05:00:00Z');
+    const got = t.stamp('Some Unity startup chatter without brackets', fallback);
+    assert.equal(got.getTime(), fallback.getTime());
+  });
+});
+
+describe('countPlayerLogCrossings', () => {
+  async function* lines(arr: string[]) {
+    for (const line of arr) yield { line };
+  }
+
+  it('returns 0 for a single ascending day', async () => {
+    const c = await countPlayerLogCrossings(lines([
+      '[10:00:00] a', '[10:00:01] b', '[12:00:00] c',
+    ]));
+    assert.equal(c, 0);
+  });
+
+  it('returns 1 for a single midnight crossing', async () => {
+    const c = await countPlayerLogCrossings(lines([
+      '[20:00:00] a', '[23:59:59] b', '[00:00:01] c', '[01:00:00] d',
+    ]));
+    assert.equal(c, 1);
+  });
+
+  it('returns 2 for two midnight crossings', async () => {
+    const c = await countPlayerLogCrossings(lines([
+      '[20:00:00] a', '[00:01:00] b', '[20:00:00] c', '[00:01:00] d',
+    ]));
+    assert.equal(c, 2);
+  });
+
+  it('ignores non-timestamped lines', async () => {
+    const c = await countPlayerLogCrossings(lines([
+      'Unity boot', '[10:00:00] a', 'more boot', '[10:00:01] b',
+    ]));
+    assert.equal(c, 0);
+  });
+});
+

--- a/tools/MithrilLogMcp/test/time-windows.test.ts
+++ b/tools/MithrilLogMcp/test/time-windows.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { resolveWindow, parseInstant } from '../src/util/time-windows.js';
+
+describe('time-windows', () => {
+  it('parses ISO 8601 instants', () => {
+    const now = new Date('2026-04-26T12:00:00Z');
+    const d = parseInstant('2026-04-26T10:00:00Z', now);
+    assert.equal(d.toISOString(), '2026-04-26T10:00:00.000Z');
+  });
+
+  it('parses relative durations as past instants when negative', () => {
+    const now = new Date('2026-04-26T12:00:00Z');
+    const d = parseInstant('2h', now, { negative: true });
+    assert.equal(d.toISOString(), '2026-04-26T10:00:00.000Z');
+  });
+
+  it('resolveWindow defaults until=now when only since is provided', () => {
+    const now = new Date('2026-04-26T12:00:00Z');
+    const w = resolveWindow(now, { since: '30m' });
+    assert.equal(w.since.toISOString(), '2026-04-26T11:30:00.000Z');
+    assert.equal(w.until.toISOString(), now.toISOString());
+  });
+
+  it('resolveWindow honours an explicit between range', () => {
+    const now = new Date('2026-04-26T12:00:00Z');
+    const w = resolveWindow(now, {
+      between: ['2026-04-25T00:00:00Z', '2026-04-25T23:59:59Z'],
+    });
+    assert.equal(w.since.toISOString(), '2026-04-25T00:00:00.000Z');
+    assert.equal(w.until.toISOString(), '2026-04-25T23:59:59.000Z');
+  });
+
+  it('rejects garbage input', () => {
+    const now = new Date('2026-04-26T12:00:00Z');
+    assert.throws(() => parseInstant('not a time', now));
+  });
+
+  it('supports m, h, d units', () => {
+    const now = new Date('2026-04-26T12:00:00Z');
+    assert.equal(parseInstant('15m', now, { negative: true }).toISOString(), '2026-04-26T11:45:00.000Z');
+    assert.equal(parseInstant('1h', now, { negative: true }).toISOString(), '2026-04-26T11:00:00.000Z');
+    assert.equal(parseInstant('1d', now, { negative: true }).toISOString(), '2026-04-25T12:00:00.000Z');
+  });
+});

--- a/tools/MithrilLogMcp/tsconfig.json
+++ b/tools/MithrilLogMcp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Summary

This PR adds **MithrilLogMcp**, a Node/TypeScript MCP server that exposes Mithril's log sources to Claude Code as queryable, parsed, time-windowed event streams — replacing the high-token `Read`/`Grep` workflow over hundreds of MB of logs. It also lands the prerequisite **shared regex catalog** that lets the .NET parsers and the TS server stay in lockstep.

The work is split into seven commits, each independently reviewable:

| Commit | What |
|---|---|
| 55cc4db | Catalog refactor + Serilog legacy migration |
| e4a994a | v0.1 — Player.log MCP server |
| 2dcb78a | v0.2/v0.3 — chat + Serilog sources, cursors API, character scoping |
| 54d7707 | v0.4 — cursor advancement on successful queries |
| bf6494f | v0.5 — active-character streaming with mid-stream tracking |
| e702947 | v0.6 — Player.log date-anchor + chat timezone fix (caught by live demo) |
| 011efc0 | Pre-PR polish: `between` validation, `aggregate` cursor, `context: N`, `cursor_set`, Serilog category pre-filter, README examples |

### Shared regex catalog
`src/Mithril.Shared/Reference/log-patterns.json` is the single source of truth for every log-line regex. The .NET parsers keep their `[GeneratedRegex]` attributes for source-gen perf; `LogPatternCatalogParityTests` asserts the JSON and the C# attributes remain identical character-for-character. Adding a new event type now requires editing one JSON entry and one C# parser file in the same commit.

### MCP server (tools/MithrilLogMcp/)
Six tools over stdio:
- `query_events` — typed events filtered by source / event type / time window / character / `data.*` field, with pagination, NDJSON output, `context: N` raw lines around each match.
- `aggregate` — server-side `count` / `group_by` / `histogram` / `distinct` / `top` reductions.
- `list_event_types` — schema discovery.
- `cursor_list` / `cursor_reset` / `cursor_set` — persistent named cursors at `%LocalAppData%/MithrilLogMcp/cursors.json` with rollover detection (size shrink, NTFS birthtime).

Sources: `player` (Player.log), `chat` (ChatLogs/), `mithril` (Serilog `*.json`), `all` (3-way time-ordered merge). Active-character tracking watches `ProcessAddPlayer` mid-stream and is backfilled on cursor resume so `character: "Foo"` filters player events correctly across session boundaries.

### Side-fix: legacy log file naming
The Mithril rebrand (commit 8f91ebf) renamed the Serilog rolling path from `gorgon-*.json` to `mithril-*.json`, but ~11 days of pre-rebrand files remained on existing installs under the old prefix. `SerilogDiagnosticsSink` now renames them to `mithril-{stem}-prebrand.json` on construction (with collision disambiguation when both prefixes exist for the same date), so downstream tools only have to handle one prefix.

## Test plan
- [x] `dotnet test Mithril.slnx` — all 968 tests pass across 12 projects (parity test + Serilog migration tests added).
- [x] `cd tools/MithrilLogMcp && npm test` — all 81 TS tests pass across 25 suites.
- [x] Live stdio handshake: server initialises, lists six tools, responds to tool calls.
- [x] Live data smoke test: 2-hour query against the running game returned 1400 player events, 9 chat events, and ~48k Mithril Serilog events with correct `activeCharacter` stamping. The smoke test caught two production bugs (Player.log date anchor, chat-log timezone) that 71 unit tests had missed; both are fixed in e702947.

## Wiring into Claude Code
After merge, add to `.mcp.json`:
```jsonc
{
  "mcpServers": {
    "mithril-logs": {
      "command": "node",
      "args": ["${workspaceFolder}/tools/MithrilLogMcp/dist/src/server.js"]
    }
  }
}
```
First-time setup: `cd tools/MithrilLogMcp && npm install && npm run build`.

## Known follow-ups (not blocking)
- Cross-source character timeline so `character: "Foo"` filters chat + Mithril events under `source: "all"` (player events already work).
- Context lines for chat and Mithril sources (player works in this PR).
- CI hookup for both `dotnet test` and `npm test` in `tools/MithrilLogMcp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)