### PR TITLE
Allow mcp__pg-data__* and mcp__mithril-logs__* without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,9 @@
       "WebFetch(domain:about.signpath.io)",
       "PowerShell(gh --version)",
       "PowerShell(gh auth status 2>&1)",
-      "PowerShell($asm = [System.Reflection.Assembly]::LoadFile\\('C:/Users/arthu/.nuget/packages/mahapps.metro.iconpacks.lucide/6.0.0/lib/net8.0-windows7.0/MahApps.Metro.IconPacks.Lucide.dll'\\); $enumType = $asm.GetTypes\\(\\) | Where-Object { $_.Name -eq 'PackIconLucideKind' }; [Enum]::GetNames\\($enumType\\) | Where-Object { $_ -match 'Help|Info|Question' } | Sort-Object)"
+      "PowerShell($asm = [System.Reflection.Assembly]::LoadFile\\('C:/Users/arthu/.nuget/packages/mahapps.metro.iconpacks.lucide/6.0.0/lib/net8.0-windows7.0/MahApps.Metro.IconPacks.Lucide.dll'\\); $enumType = $asm.GetTypes\\(\\) | Where-Object { $_.Name -eq 'PackIconLucideKind' }; [Enum]::GetNames\\($enumType\\) | Where-Object { $_ -match 'Help|Info|Question' } | Sort-Object)",
+      "mcp__pg-data__*",
+      "mcp__mithril-logs__*"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `mcp__pg-data__*` and `mcp__mithril-logs__*` to the auto-allow list in `.claude/settings.json`
- Both servers are already registered in the project-scoped `.mcp.json` (mithril-logs in-tree, pg-data via npx-from-github), so anyone working in this checkout has them available — pre-allowing their tools cuts permission churn on routine log/reference queries

## Test plan
- [ ] Confirm `.claude/settings.json` parses (Claude Code reloads settings on next session)
- [ ] Spot-check that `mcp__pg-data__cdn_version` and `mcp__mithril-logs__list_event_types` no longer trigger a permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)