### PR TITLE
mithril-log-mcp: emit prefixItems for ZodTuple (JSON Schema 2020-12)

### DIFF
--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -203,7 +203,7 @@ function describeSchema(schema: z.ZodType): Record<string, unknown> {
     case 'ZodArray':
       return { type: 'array', items: describeSchema(def.type) };
     case 'ZodTuple':
-      return { type: 'array', items: def.items.map((i: z.ZodType) => describeSchema(i)) };
+      return { type: 'array', prefixItems: def.items.map((i: z.ZodType) => describeSchema(i)) };
     case 'ZodEnum':
       return { type: 'string', enum: def.values };
     case 'ZodString':


### PR DESCRIPTION
## Summary
- Mithril's MCP shim emitted `items: [...]` for `z.tuple()`, which is JSON Schema draft-07 syntax. The Anthropic API enforces JSON Schema **2020-12**, where tuple validation uses **`prefixItems`** instead.
- The bug surfaced as `400 invalid_request_error: tools.N.custom.input_schema: JSON schema is invalid` from any session that loaded mithril-logs alongside the API tool list — `query_events` and `aggregate` both declare `between: z.tuple([z.string(), z.string()])`, which corrupts the whole tools array.
- One-line fix in [tools/MithrilLogMcp/src/server.ts](tools/MithrilLogMcp/src/server.ts): swap `items` for `prefixItems` in the `ZodTuple` branch.

## Test plan
- [x] `npm run build` in `tools/MithrilLogMcp/`
- [x] Re-dump `QueryEventsInput` schema; `between` now serializes as `{type:'array', prefixItems:[{type:'string'},{type:'string'}]}` (verified locally)
- [ ] Restart Claude Code with mithril-logs attached and confirm the API no longer 400s on tool registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)