### PR TITLE
mithril-log-mcp: add server_info tool

### DIFF
--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -28,6 +28,7 @@ import {
   runCursorReset,
   runCursorSet,
 } from './tools/cursor.js';
+import { ServerInfoInput, runServerInfo } from './tools/server-info.js';
 import { CursorStore } from './state/cursors.js';
 
 /**
@@ -42,6 +43,15 @@ const SERVER_NAME = 'mithril-log-mcp';
 const SERVER_VERSION = '0.1.0';
 
 const TOOLS = [
+  {
+    name: 'server_info',
+    description:
+      'Returns the mithril-log-mcp version, the on-disk mtime of the running ' +
+      'JS bundle (the "when was this last built" signal — useful since the ' +
+      'server is rebuilt locally rather than released), and the resolved log ' +
+      'paths the server reads from.',
+    inputSchema: zodToJsonSchema(ServerInfoInput),
+  },
   {
     name: 'query_events',
     description:
@@ -104,6 +114,17 @@ async function main(): Promise<void> {
     const { name, arguments: rawArgs } = req.params;
     try {
       switch (name) {
+        case 'server_info': {
+          const args = ServerInfoInput.parse(rawArgs ?? {});
+          const result = runServerInfo(
+            args,
+            { name: SERVER_NAME, version: SERVER_VERSION },
+            config,
+          );
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
         case 'query_events': {
           const args = QueryEventsInput.parse(rawArgs ?? {});
           const result = await runQueryEvents(args, config, cursorStore);

--- a/tools/MithrilLogMcp/src/tools/server-info.ts
+++ b/tools/MithrilLogMcp/src/tools/server-info.ts
@@ -1,0 +1,53 @@
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import type { ServerConfig } from '../config.js';
+
+export const ServerInfoInput = z.object({});
+
+export type ServerInfoArgs = z.infer<typeof ServerInfoInput>;
+
+export interface ServerInfoMetadata {
+  name: string;
+  version: string;
+}
+
+export function runServerInfo(
+  _args: ServerInfoArgs,
+  meta: ServerInfoMetadata,
+  config: ServerConfig,
+) {
+  return {
+    server: {
+      name: meta.name,
+      version: meta.version,
+    },
+    build: resolveBuildInfo(),
+    config: {
+      playerLogPath: config.playerLogPath,
+      chatLogDir: config.chatLogDir,
+      mithrilLogDir: config.mithrilLogDir,
+      characterRoot: config.characterRoot,
+      shellSettingsPath: config.shellSettingsPath,
+    },
+  };
+}
+
+// Read the on-disk mtime of the compiled JS for this module — that's the
+// "when was this server last built" signal that's actually useful for an
+// in-tree (non-released) MCP server. The version constant is hand-bumped and
+// usually lies; the file mtime doesn't.
+function resolveBuildInfo(): { sourcePath: string; builtAt: string | null } {
+  let sourcePath: string;
+  try {
+    sourcePath = fileURLToPath(import.meta.url);
+  } catch {
+    return { sourcePath: '<unknown>', builtAt: null };
+  }
+  try {
+    const stat = fs.statSync(sourcePath);
+    return { sourcePath, builtAt: stat.mtime.toISOString() };
+  } catch {
+    return { sourcePath, builtAt: null };
+  }
+}


### PR DESCRIPTION
## Summary
- New `server_info` tool on `mithril-log-mcp`, mirroring pg-data's pattern.
- Returns: server name + version, the on-disk mtime of the running JS bundle (the *actually useful* "did the rebuilt server reconnect?" signal for an in-tree MCP server), and the resolved log paths from `loadConfig()`.
- Helps diagnose "is Claude Code talking to the version I just built?" and "is the server pointing at the log directory I expect?" without restart-and-grep-stderr.

## Test plan
- [x] `npm run build` clean
- [x] Local smoke-test of `runServerInfo` returns the expected payload (verified via `node -e`)
- [ ] Reload Claude Code with the rebuilt server and call `mcp__mithril-logs__server_info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)