### PR TITLE
mithril-log-mcp: add query_raw_lines tool

### DIFF
--- a/tools/MithrilLogMcp/package.json
+++ b/tools/MithrilLogMcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-log-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "MCP server exposing Mithril log sources (Player.log, ChatLogs, Mithril Serilog) to Claude Code.",
   "type": "module",

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -44,7 +44,7 @@ import { CursorStore } from './state/cursors.js';
  */
 
 const SERVER_NAME = 'mithril-log-mcp';
-const SERVER_VERSION = '0.1.0';
+const SERVER_VERSION = '0.2.0';
 
 const TOOLS = [
   {

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -29,6 +29,10 @@ import {
   runCursorSet,
 } from './tools/cursor.js';
 import { ServerInfoInput, runServerInfo } from './tools/server-info.js';
+import {
+  QueryRawLinesInput,
+  runQueryRawLines,
+} from './tools/query-raw-lines.js';
 import { CursorStore } from './state/cursors.js';
 
 /**
@@ -67,6 +71,18 @@ const TOOLS = [
       'over the same event stream. Returns a small bucket list instead of ' +
       'megabytes of raw events.',
     inputSchema: zodToJsonSchema(AggregateInput),
+  },
+  {
+    name: 'query_raw_lines',
+    description:
+      'Stream raw log lines from Player.log + ChatLogs/ verbatim, dropping ' +
+      'Unity boot output / stack traces (everything without a [HH:MM:SS] or ' +
+      'YY-MM-DD HH:MM:SS prefix). Optional substring or regex filter. ' +
+      'Time-window forms (pick one): since/until, between, or at/around ' +
+      '("at: <iso-or-2h>, around: 30s" → ±30s window). Cursors live in ' +
+      'separate raw-player / raw-chat slots so they do not collide with ' +
+      'query_events cursors of the same name.',
+    inputSchema: zodToJsonSchema(QueryRawLinesInput),
   },
   {
     name: 'list_event_types',
@@ -138,6 +154,13 @@ async function main(): Promise<void> {
         case 'aggregate': {
           const args = AggregateInput.parse(rawArgs ?? {});
           const result = await runAggregate(args, config, cursorStore);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          };
+        }
+        case 'query_raw_lines': {
+          const args = QueryRawLinesInput.parse(rawArgs ?? {});
+          const result = await runQueryRawLines(args, config, cursorStore);
           return {
             content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
           };

--- a/tools/MithrilLogMcp/src/sources/chat-log-raw.ts
+++ b/tools/MithrilLogMcp/src/sources/chat-log-raw.ts
@@ -1,0 +1,95 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { lineStream } from '../util/file-streams.js';
+import { rolloverDetected, type FileCursor } from '../state/cursors.js';
+import { CHAT_FILE_RE, CHAT_LINE_RE, chatFileDate, parseChatTimestamp } from './chat-log.js';
+import type { RawLineRecord } from './player-log-raw.js';
+
+/**
+ * Raw counterpart to `scanChatLogs`. Walks `Chat-YY-MM-DD.log` files in date
+ * order, yielding every line whose `YY-MM-DD HH:MM:SS\t` prefix is present
+ * within the time window. Files outside the window are skipped without
+ * opening; in-window files start at their cursor offset (when valid).
+ *
+ * Chat lines are well-behaved (the game writes one parseable line per chat
+ * message, no Unity boot noise), so `droppedNonGameLines` is typically 0 —
+ * but the counter is kept for symmetry with the player scanner.
+ */
+
+export interface ChatLogRawQuery {
+  dir: string;
+  since: Date;
+  until: Date;
+  prevCursors?: Record<string, FileCursor> | undefined;
+}
+
+export interface ChatLogRawScanStats {
+  scannedBytes: number;
+  scannedLines: number;
+  droppedNonGameLines: number;
+  endOffsets: Record<string, number>;
+  rolledOverFiles: string[];
+}
+
+export async function* scanChatLogsRaw(
+  query: ChatLogRawQuery,
+  stats: ChatLogRawScanStats,
+): AsyncGenerator<RawLineRecord, void, void> {
+  if (!fs.existsSync(query.dir)) return;
+
+  const entries = fs.readdirSync(query.dir).sort();
+
+  for (const name of entries) {
+    const m = CHAT_FILE_RE.exec(name);
+    if (!m) continue;
+
+    const fileDate = chatFileDate(m[1]!, m[2]!, m[3]!);
+    const dayStart = new Date(fileDate.getTime());
+    const dayEnd = new Date(fileDate.getTime() + 24 * 3_600_000);
+    if (dayEnd < query.since) continue;
+    if (dayStart > query.until) continue;
+
+    const fullPath = path.join(query.dir, name);
+    const stat = fs.statSync(fullPath);
+    const prev = query.prevCursors?.[fullPath];
+
+    let startOffset = 0;
+    if (prev) {
+      if (rolloverDetected(prev, stat)) {
+        stats.rolledOverFiles.push(fullPath);
+      } else {
+        startOffset = Math.min(prev.byteOffset, stat.size);
+      }
+    }
+
+    stats.scannedBytes += Math.max(0, stat.size - startOffset);
+    stats.endOffsets[fullPath] = startOffset;
+
+    for await (const rec of lineStream(fullPath, { start: startOffset })) {
+      stats.scannedLines += 1;
+      stats.endOffsets[fullPath] = rec.byteOffset + rec.byteLength;
+
+      if (!CHAT_LINE_RE.test(rec.line)) {
+        stats.droppedNonGameLines += 1;
+        continue;
+      }
+
+      const ts = parseChatTimestamp(rec.line);
+      if (!ts) {
+        stats.droppedNonGameLines += 1;
+        continue;
+      }
+      if (ts < query.since) continue;
+      if (ts > query.until) return;
+
+      yield {
+        ts,
+        source: 'chat',
+        file: fullPath,
+        line: rec.lineNo,
+        raw: rec.line,
+        byteOffset: rec.byteOffset,
+      };
+    }
+  }
+}

--- a/tools/MithrilLogMcp/src/sources/chat-log.ts
+++ b/tools/MithrilLogMcp/src/sources/chat-log.ts
@@ -6,8 +6,8 @@ import { rolloverDetected, type FileCursor } from '../state/cursors.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { Catalog } from '../parsing/catalog.js';
 
-const CHAT_LINE_RE = /^(?<y>\d{2})-(?<m>\d{2})-(?<d>\d{2})\s+(?<H>\d{2}):(?<M>\d{2}):(?<S>\d{2})\s*\t/;
-const CHAT_FILE_RE = /^Chat-(\d{2})-(\d{2})-(\d{2})\.log$/;
+export const CHAT_LINE_RE = /^(?<y>\d{2})-(?<m>\d{2})-(?<d>\d{2})\s+(?<H>\d{2}):(?<M>\d{2}):(?<S>\d{2})\s*\t/;
+export const CHAT_FILE_RE = /^Chat-(\d{2})-(\d{2})-(\d{2})\.log$/;
 
 export interface ChatLogQuery {
   dir: string;
@@ -80,14 +80,14 @@ export async function* scanChatLogs(
   }
 }
 
-function chatFileDate(y: string, m: string, d: string): Date {
+export function chatFileDate(y: string, m: string, d: string): Date {
   const year = 2000 + Number.parseInt(y, 10);
   const month = Number.parseInt(m, 10) - 1;
   const day = Number.parseInt(d, 10);
   return new Date(Date.UTC(year, month, day));
 }
 
-function parseChatTimestamp(line: string): Date | null {
+export function parseChatTimestamp(line: string): Date | null {
   const m = CHAT_LINE_RE.exec(line);
   if (!m) return null;
   const g = m.groups!;

--- a/tools/MithrilLogMcp/src/sources/multi-source-raw.ts
+++ b/tools/MithrilLogMcp/src/sources/multi-source-raw.ts
@@ -1,0 +1,161 @@
+import { scanPlayerLogRaw, type PlayerLogRawScanStats, type RawLineRecord } from './player-log-raw.js';
+import { scanChatLogsRaw, type ChatLogRawScanStats } from './chat-log-raw.js';
+import type { ServerConfig } from '../config.js';
+import type { CursorState } from '../state/cursors.js';
+
+/**
+ * Orchestrates the raw-line scanners across one or more sources, mirroring
+ * `multi-source.ts` for parsed events. Mithril Serilog is excluded — it's
+ * CompactJsonFormatter, not raw text, and is already exposed through
+ * `query_events` as `mithril.*` event types.
+ */
+
+export type RawSourceName = 'player' | 'chat' | 'all';
+
+export interface MultiSourceRawStats {
+  scannedBytes: number;
+  scannedLines: number;
+  droppedNonGameLines: number;
+  /**
+   * Per-source end byte offsets keyed by absolute file path. Persisted as
+   * cursors under the `raw-player` / `raw-chat` slot names so they don't
+   * collide with `query_events` cursors.
+   */
+  endOffsetsBySource: Record<string, Record<string, number>>;
+  rolledOverFiles: string[];
+}
+
+export interface MultiSourceRawQuery {
+  source: RawSourceName;
+  since: Date;
+  until: Date;
+  cursors?: { 'raw-player'?: CursorState | undefined; 'raw-chat'?: CursorState | undefined } | undefined;
+}
+
+const PER_SOURCE_KEYS: Array<Exclude<RawSourceName, 'all'>> = ['player', 'chat'];
+
+export async function* scanMultiSourceRaw(
+  config: ServerConfig,
+  query: MultiSourceRawQuery,
+  stats: MultiSourceRawStats,
+): AsyncGenerator<RawLineRecord, void, void> {
+  const sourcesToScan = query.source === 'all' ? PER_SOURCE_KEYS : [query.source];
+  for (const s of sourcesToScan) stats.endOffsetsBySource[`raw-${s}`] = {};
+
+  if (query.source !== 'all') {
+    yield* singleSource(config, query, stats);
+    return;
+  }
+
+  const playerStats = makeSubStats();
+  const chatStats = makeSubStats();
+
+  const iterators: AsyncIterator<RawLineRecord>[] = [
+    scanPlayerLogRaw({
+      path: config.playerLogPath,
+      since: query.since,
+      until: query.until,
+      prevCursor: query.cursors?.['raw-player']?.perFile?.[config.playerLogPath],
+    }, playerStats)[Symbol.asyncIterator](),
+    scanChatLogsRaw({
+      dir: config.chatLogDir,
+      since: query.since,
+      until: query.until,
+      prevCursors: query.cursors?.['raw-chat']?.perFile,
+    }, chatStats)[Symbol.asyncIterator](),
+  ];
+
+  const slots: Array<{ rec: RawLineRecord; iter: AsyncIterator<RawLineRecord> } | null> = [];
+  for (const it of iterators) {
+    const next = await it.next();
+    slots.push(next.done ? null : { rec: next.value, iter: it });
+  }
+
+  while (slots.some((s) => s !== null)) {
+    let bestIdx = -1;
+    let bestTs = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < slots.length; i++) {
+      const s = slots[i];
+      if (!s) continue;
+      const t = s.rec.ts.getTime();
+      if (t < bestTs) {
+        bestTs = t;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx < 0) break;
+    const winner = slots[bestIdx]!;
+    yield winner.rec;
+    const next = await winner.iter.next();
+    slots[bestIdx] = next.done ? null : { rec: next.value, iter: winner.iter };
+  }
+
+  stats.scannedBytes = playerStats.scannedBytes + chatStats.scannedBytes;
+  stats.scannedLines = playerStats.scannedLines + chatStats.scannedLines;
+  stats.droppedNonGameLines = playerStats.droppedNonGameLines + chatStats.droppedNonGameLines;
+  stats.endOffsetsBySource['raw-player'] = playerStats.endOffsets;
+  stats.endOffsetsBySource['raw-chat'] = chatStats.endOffsets;
+  stats.rolledOverFiles.push(...playerStats.rolledOverFiles, ...chatStats.rolledOverFiles);
+}
+
+async function* singleSource(
+  config: ServerConfig,
+  query: MultiSourceRawQuery,
+  stats: MultiSourceRawStats,
+): AsyncGenerator<RawLineRecord, void, void> {
+  switch (query.source) {
+    case 'player': {
+      const sub = makeSubStats();
+      yield* scanPlayerLogRaw({
+        path: config.playerLogPath,
+        since: query.since,
+        until: query.until,
+        prevCursor: query.cursors?.['raw-player']?.perFile?.[config.playerLogPath],
+      }, sub);
+      stats.scannedBytes = sub.scannedBytes;
+      stats.scannedLines = sub.scannedLines;
+      stats.droppedNonGameLines = sub.droppedNonGameLines;
+      stats.endOffsetsBySource['raw-player'] = sub.endOffsets;
+      stats.rolledOverFiles.push(...sub.rolledOverFiles);
+      return;
+    }
+    case 'chat': {
+      const sub = makeSubStats();
+      yield* scanChatLogsRaw({
+        dir: config.chatLogDir,
+        since: query.since,
+        until: query.until,
+        prevCursors: query.cursors?.['raw-chat']?.perFile,
+      }, sub);
+      stats.scannedBytes = sub.scannedBytes;
+      stats.scannedLines = sub.scannedLines;
+      stats.droppedNonGameLines = sub.droppedNonGameLines;
+      stats.endOffsetsBySource['raw-chat'] = sub.endOffsets;
+      stats.rolledOverFiles.push(...sub.rolledOverFiles);
+      return;
+    }
+    default:
+      throw new Error(`Unknown raw source: ${query.source}`);
+  }
+}
+
+function makeSubStats(): PlayerLogRawScanStats & ChatLogRawScanStats {
+  return {
+    scannedBytes: 0,
+    scannedLines: 0,
+    droppedNonGameLines: 0,
+    endOffsets: {},
+    rolledOverFiles: [],
+  };
+}
+
+export function emptyMultiSourceRawStats(): MultiSourceRawStats {
+  return {
+    scannedBytes: 0,
+    scannedLines: 0,
+    droppedNonGameLines: 0,
+    endOffsetsBySource: {},
+    rolledOverFiles: [],
+  };
+}
+

--- a/tools/MithrilLogMcp/src/sources/player-log-raw.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log-raw.ts
@@ -1,0 +1,91 @@
+import * as fs from 'node:fs';
+import { lineStream, scannedBytes } from '../util/file-streams.js';
+import { countPlayerLogCrossings, PlayerLogTimestamper } from '../util/time-windows.js';
+import { rolloverDetected, type FileCursor } from '../state/cursors.js';
+
+/**
+ * Raw counterpart to `scanPlayerLog`. Streams Player.log forward and yields
+ * every line with a `[HH:MM:SS]` prefix — the gameplay-event marker — within
+ * the requested time window. Lines without that prefix (Unity boot output,
+ * stack-trace addresses, GfxDevice banners, fallback-backend chatter) are
+ * counted as `droppedNonGameLines` and dropped silently.
+ *
+ * Cursor handling, mtime-anchored date stamping, and rollover detection
+ * mirror `scanPlayerLog` — but the catalog/parser/active-character machinery
+ * is dropped because raw streaming has no use for typed events.
+ */
+
+export interface PlayerLogRawQuery {
+  path: string;
+  since: Date;
+  until: Date;
+  prevCursor?: FileCursor | undefined;
+}
+
+export interface PlayerLogRawScanStats {
+  scannedBytes: number;
+  scannedLines: number;
+  droppedNonGameLines: number;
+  endOffsets: Record<string, number>;
+  rolledOverFiles: string[];
+}
+
+export interface RawLineRecord {
+  ts: Date;
+  source: 'player' | 'chat';
+  file: string;
+  line: number;
+  raw: string;
+  byteOffset: number;
+}
+
+export async function* scanPlayerLogRaw(
+  query: PlayerLogRawQuery,
+  stats: PlayerLogRawScanStats,
+): AsyncGenerator<RawLineRecord, void, void> {
+  if (!fs.existsSync(query.path)) return;
+
+  const stat = fs.statSync(query.path);
+  let startOffset = 0;
+  if (query.prevCursor) {
+    if (rolloverDetected(query.prevCursor, stat)) {
+      stats.rolledOverFiles.push(query.path);
+      startOffset = 0;
+    } else {
+      startOffset = Math.min(query.prevCursor.byteOffset, stat.size);
+    }
+  }
+
+  stats.scannedBytes += scannedBytes(stat, startOffset);
+  stats.endOffsets[query.path] = startOffset;
+
+  // Anchor the start-of-file date the same way scanPlayerLog does: count
+  // midnight crossings, then walk back from mtime UTC date by that many days.
+  const crossings = await countPlayerLogCrossings(lineStream(query.path, { start: startOffset }));
+  const startDate = new Date(stat.mtime);
+  startDate.setUTCDate(startDate.getUTCDate() - crossings);
+  const stamper = new PlayerLogTimestamper(startDate);
+
+  for await (const rec of lineStream(query.path, { start: startOffset })) {
+    stats.scannedLines += 1;
+    stats.endOffsets[query.path] = rec.byteOffset + rec.byteLength;
+
+    if (!PlayerLogTimestamper.TIME_RE.test(rec.line)) {
+      stats.droppedNonGameLines += 1;
+      continue;
+    }
+
+    const ts = stamper.stamp(rec.line, stat.mtime);
+    if (ts < query.since) continue;
+    if (ts > query.until) break;
+
+    yield {
+      ts,
+      source: 'player',
+      file: query.path,
+      line: rec.lineNo,
+      raw: rec.line,
+      byteOffset: rec.byteOffset,
+    };
+  }
+}

--- a/tools/MithrilLogMcp/src/state/cursor-helpers.ts
+++ b/tools/MithrilLogMcp/src/state/cursor-helpers.ts
@@ -9,7 +9,7 @@ import type { MultiSourceStats } from '../sources/multi-source.js';
  * per-source `CursorState` shape the scanners consume.
  */
 
-const SOURCES = ['player', 'chat', 'mithril'] as const;
+const SOURCES = ['player', 'chat', 'mithril', 'raw-player', 'raw-chat'] as const;
 
 /**
  * Loads every per-source cursor record for a named cursor in one shot.

--- a/tools/MithrilLogMcp/src/tools/query-raw-lines.ts
+++ b/tools/MithrilLogMcp/src/tools/query-raw-lines.ts
@@ -1,0 +1,248 @@
+import { z } from 'zod';
+import { resolveAtAround, resolveWindow } from '../util/time-windows.js';
+import {
+  emptyMultiSourceRawStats,
+  scanMultiSourceRaw,
+  type RawSourceName,
+} from '../sources/multi-source-raw.js';
+import type { RawLineRecord } from '../sources/player-log-raw.js';
+import { CursorStore } from '../state/cursors.js';
+import {
+  countAdvancedFiles,
+  loadCursorsForName,
+  persistCursor,
+} from '../state/cursor-helpers.js';
+import type { ServerConfig } from '../config.js';
+
+/**
+ * Raw-line counterpart to `query_events`. Streams Player.log + ChatLogs/
+ * lines verbatim within a time window, applies a `[HH:MM:SS]` /
+ * `YY-MM-DD HH:MM:SS\t` prefix gate to drop Unity boot noise + stack traces,
+ * then filters survivors against an optional substring or regex pattern.
+ *
+ * Cursors live in the `raw-player` / `raw-chat` slots so a single named
+ * cursor can hold both parsed-event positions (`query_events`) and raw
+ * positions without one tool advancing past lines the other still wants.
+ */
+
+export const QueryRawLinesInput = z
+  .object({
+    source: z.enum(['player', 'chat', 'all']).default('player'),
+    pattern: z.string().min(1).optional(),
+    case_sensitive: z.boolean().optional().default(false),
+    regex: z.boolean().optional().default(false),
+
+    // Window form 1: since/until/between (same vocabulary as query_events).
+    since: z.string().optional(),
+    until: z.string().optional(),
+    between: z.tuple([z.string(), z.string()]).optional(),
+
+    // Window form 2: at/around (centered ± duration).
+    at: z.string().optional(),
+    around: z.string().optional(),
+
+    cursor: z.string().optional(),
+    context: z.number().int().min(0).max(50).optional().default(0),
+    limit: z.number().int().min(1).max(10000).default(500),
+    offset: z.number().int().min(0).default(0),
+    fields: z.array(z.string()).optional(),
+  })
+  .refine(
+    (v) => {
+      const aroundForm = v.at !== undefined || v.around !== undefined;
+      const sinceUntilForm = v.since !== undefined || v.until !== undefined;
+      const betweenForm = v.between !== undefined;
+      const formsUsed = [aroundForm, sinceUntilForm, betweenForm].filter(Boolean).length;
+      // 0 forms = cursor-only or unbounded (handled downstream).
+      // 1 form = legal.
+      // 2+ forms = ambiguous; reject explicitly.
+      return formsUsed <= 1;
+    },
+    {
+      message:
+        'Pick one time-window form: (since/until), between, or (at/around). Mixing them is ambiguous.',
+    },
+  )
+  .refine(
+    (v) => !(v.around !== undefined && v.at === undefined),
+    { message: "'around' requires 'at' to anchor the window." },
+  );
+
+export type QueryRawLinesArgs = z.infer<typeof QueryRawLinesInput>;
+
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+interface RawHit extends RawLineRecord {
+  contextLines?: { before: string[]; after: string[] };
+}
+
+export async function runQueryRawLines(
+  args: QueryRawLinesArgs,
+  config: ServerConfig,
+  cursorStore: CursorStore,
+) {
+  const t0 = performance.now();
+  const now = new Date();
+
+  let window;
+  if (args.at !== undefined) {
+    window = resolveAtAround(now, args.at, args.around);
+  } else if (args.cursor && !args.since && !args.until && !args.between) {
+    // Cursor-only query: don't bound by time, resume through "now".
+    window = { since: new Date(0), until: now };
+  } else {
+    window = resolveWindow(now, args);
+  }
+
+  const cursorsByName = loadCursorsForName(cursorStore, args.cursor);
+  const stats = emptyMultiSourceRawStats();
+
+  const matcher = buildMatcher(args);
+
+  const ringBefore: string[] = [];
+  const N = args.context ?? 0;
+  const pending: Array<{ hit: RawHit; after: string[] }> = [];
+
+  let matched = 0;
+  let skipped = 0;
+  let truncated = false;
+  let bytesEmitted = 0;
+  const out: RawHit[] = [];
+
+  const queryShape = {
+    source: args.source as RawSourceName,
+    since: window.since,
+    until: window.until,
+    cursors: cursorsByName
+      ? {
+          'raw-player': cursorsByName['raw-player'],
+          'raw-chat': cursorsByName['raw-chat'],
+        }
+      : undefined,
+  };
+
+  for await (const rec of scanMultiSourceRaw(config, queryShape, stats)) {
+    // Feed line as after-context to any pending hits; emit once their window fills.
+    if (N > 0) {
+      for (const p of pending) {
+        if (p.after.length < N) p.after.push(rec.raw);
+      }
+      while (pending.length > 0 && pending[0]!.after.length >= N) {
+        const h = pending.shift()!.hit;
+        if (!emit(h)) break;
+      }
+    }
+
+    if (!matcher(rec.raw)) {
+      if (N > 0) pushRing(ringBefore, rec.raw, N);
+      continue;
+    }
+
+    matched += 1;
+    if (skipped < args.offset) {
+      skipped += 1;
+      if (N > 0) pushRing(ringBefore, rec.raw, N);
+      continue;
+    }
+    if (out.length >= args.limit) {
+      truncated = true;
+      if (N > 0) pushRing(ringBefore, rec.raw, N);
+      continue;
+    }
+
+    const hit: RawHit = { ...rec };
+    if (N > 0) {
+      hit.contextLines = { before: [...ringBefore], after: [] };
+      pending.push({ hit, after: hit.contextLines.after });
+    } else {
+      if (!emit(hit)) break;
+    }
+
+    if (N > 0) pushRing(ringBefore, rec.raw, N);
+  }
+
+  // Drain any pending hits whose after-windows didn't fill before EOF.
+  while (pending.length > 0) {
+    const h = pending.shift()!.hit;
+    if (!emit(h)) break;
+  }
+
+  if (args.cursor) {
+    persistCursor(cursorStore, args.cursor, stats);
+  }
+
+  const elapsedMs = Math.round(performance.now() - t0);
+  return {
+    summary: {
+      matched,
+      returned: out.length,
+      truncated,
+      scannedBytes: stats.scannedBytes,
+      scannedLines: stats.scannedLines,
+      droppedNonGameLines: stats.droppedNonGameLines,
+      elapsedMs,
+      window: { since: window.since.toISOString(), until: window.until.toISOString() },
+      cursor: args.cursor
+        ? {
+            name: args.cursor,
+            advanced: countAdvancedFiles(stats),
+            rolledOverFiles: stats.rolledOverFiles,
+          }
+        : undefined,
+    },
+    lines: out.map((h) => projectFields(h, args.fields)),
+  };
+
+  function emit(h: RawHit): boolean {
+    const projected = projectFields(h, args.fields);
+    const encoded = JSON.stringify(projected);
+    if (bytesEmitted + encoded.length > MAX_RESPONSE_BYTES) {
+      truncated = true;
+      return false;
+    }
+    out.push(h);
+    bytesEmitted += encoded.length + 1;
+    return true;
+  }
+}
+
+function buildMatcher(args: QueryRawLinesArgs): (line: string) => boolean {
+  if (!args.pattern) return () => true;
+  if (args.regex) {
+    const flags = args.case_sensitive ? '' : 'i';
+    const re = new RegExp(args.pattern, flags);
+    return (line) => re.test(line);
+  }
+  if (args.case_sensitive) {
+    const needle = args.pattern;
+    return (line) => line.includes(needle);
+  }
+  const needle = args.pattern.toLowerCase();
+  return (line) => line.toLowerCase().includes(needle);
+}
+
+function pushRing(ring: string[], line: string, max: number): void {
+  if (max <= 0) return;
+  ring.push(line);
+  while (ring.length > max) ring.shift();
+}
+
+function projectFields(
+  hit: RawHit,
+  fields: string[] | undefined,
+): Record<string, unknown> {
+  const full: Record<string, unknown> = {
+    ts: hit.ts.toISOString(),
+    source: hit.source,
+    file: hit.file,
+    line: hit.line,
+    raw: hit.raw,
+  };
+  if (hit.contextLines) full.contextLines = hit.contextLines;
+  if (!fields || fields.length === 0) return full;
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    if (f in full) out[f] = full[f];
+  }
+  return out;
+}

--- a/tools/MithrilLogMcp/src/util/time-windows.ts
+++ b/tools/MithrilLogMcp/src/util/time-windows.ts
@@ -79,6 +79,31 @@ function unitToMs(value: number, unit: string): number {
 }
 
 /**
+ * Center-and-radius window form. `at` is the center instant (ISO 8601 or a
+ * relative duration interpreted as `now - duration`); `around` is a duration
+ * (e.g. "30s", "1m") that becomes the half-width. The resolved window is
+ * `[at - around, at + around]`. Defaults to ±1m if `around` is omitted.
+ */
+export function resolveAtAround(
+  now: Date,
+  at: string,
+  around: string | undefined,
+): ResolvedWindow {
+  const center = parseInstant(at, now, { negative: true });
+  const radiusMs = parseDuration(around ?? '1m');
+  return {
+    since: new Date(center.getTime() - radiusMs),
+    until: new Date(center.getTime() + radiusMs),
+  };
+}
+
+function parseDuration(input: string): number {
+  const m = RELATIVE_RE.exec(input.trim());
+  if (!m) throw new Error(`Cannot parse duration: '${input}' (expected '30s', '1m', '5h', etc.)`);
+  return unitToMs(Number.parseInt(m[1] ?? '0', 10), (m[2] ?? 's').toLowerCase());
+}
+
+/**
  * Player.log per-line stamper.
  *
  * Lines carry only `[HH:MM:SS]` (local game time) — no date. The date


### PR DESCRIPTION
## Summary
New tool, `query_raw_lines`, gives the model direct access to **raw** game- and chat-log lines without falling back to `grep`. `query_events` only surfaces parser-recognised events; anything outside the catalog (e.g. one-off game messages a parser hasn't been written for) was previously invisible.

## Design

- **Sources**: `player`, `chat`, `all`. Mithril Serilog excluded — it's CompactJsonFormatter, already exposed via `query_events` as `mithril.*` types.
- **Prefix gate**: lines must start with `[HH:MM:SS]` (player) or `YY-MM-DD HH:MM:SS\t` (chat). Everything else (Unity boot, stack frames, GfxDevice banners) counts toward `summary.droppedNonGameLines` and drops out — that's the whole point.
- **Pattern**: optional substring (default case-insensitive) or regex (when `regex: true`).
- **Time-window** (pick one): `since`/`until`, `between`, or **`at` + `around`** (centered ± duration, defaults `around: 1m`). Mixing forms throws.
- **Cursors**: live in new `raw-player` / `raw-chat` slots — same cursor *name* as `query_events`, different byte offsets. Avoids the silent-skip footgun where one tool would advance past lines the other wanted.
- **Context lines**: optional `context: N` ring-buffer for before/after, mirroring `scanPlayerLog`.
- **Schema-safety**: only uses Zod constructs the shim handles correctly (post-#20 fix). Generated `inputSchema` validated below — `between` correctly emits `prefixItems`, no field collapses to `{}`.

## Generated inputSchema

```json
{
  "type": "object",
  "properties": {
    "source": { "type": "string", "enum": ["player", "chat", "all"] },
    "pattern": { "type": "string" },
    "case_sensitive": { "type": "boolean" },
    "regex": { "type": "boolean" },
    "since": { "type": "string" },
    "until": { "type": "string" },
    "between": { "type": "array", "prefixItems": [{ "type": "string" }, { "type": "string" }] },
    "at": { "type": "string" },
    "around": { "type": "string" },
    "cursor": { "type": "string" },
    "context": { "type": "number" },
    "limit": { "type": "number" },
    "offset": { "type": "number" },
    "fields": { "type": "array", "items": { "type": "string" } }
  }
}
```

## Test plan
- [x] `npm run build` clean
- [x] inputSchema validated against draft 2020-12 (uses `prefixItems`, no `{}` fields)
- [x] Smoke-test: `{ source: 'player', pattern: 'chest', since: '4h', limit: 20 }` against live Player.log → matched 380 lines, droppedNonGameLines: 372, 30ms
- [x] **Cursor isolation verified**: ran `query_events` then `query_raw_lines` under the same cursor name; `query_events` wrote only to `player` / `chat` / `mithril` slots, then `query_raw_lines` populated `raw-player` / `raw-chat` while leaving the parsed-event slots byte-identical. No cross-contamination.
- [ ] Reload Claude Code with rebuilt server and call `mcp__mithril-logs__query_raw_lines` end-to-end

## Follow-up issues surfaced during validation
- #23 — `Player-prev.log` (rolled-over previous session log) is invisible to mithril-logs; surfaced when an `EltibuleSecretChest` interaction couldn't be found via `query_raw_lines` because it lived in the prev log
- #24 — `PlayerLogTimestamper` constructs Date with the local-time constructor, but the game appears to write Player.log timestamps in UTC; events in non-UTC timezones are time-shifted by the user's TZ offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)