### PR TITLE
fix(inventory): guard HandleAddItem against re-emission pulses

### DIFF
--- a/src/Mithril.Shared/Inventory/InventoryService.cs
+++ b/src/Mithril.Shared/Inventory/InventoryService.cs
@@ -273,6 +273,19 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
         {
             DrainPendingStale();
 
+            // Re-emission pulse (zone change / server resync) for an already-tracked
+            // InstanceId. Carries no size information, so we must not touch StackSize,
+            // SizeConfirmed, _pendingChat, or _pendingAdd — otherwise a confirmed N
+            // gets silently clobbered to (1, unconfirmed) and a queued chat slot is
+            // burned on the wrong id. See issue #10.
+            if (_map.TryGetValue(instanceId, out var existing) && !existing.Deleted)
+            {
+                _map[instanceId] = existing with { Timestamp = timestamp };
+                _diag?.Trace("Inventory",
+                    $"Add-reemit id={instanceId} name={existing.InternalName} size={existing.StackSize} confirmed={existing.SizeConfirmed}");
+                return;
+            }
+
             // Try the pending-chat queue first — chat may have arrived ahead of us.
             int size = 1;
             bool seeded = false;

--- a/tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs
+++ b/tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs
@@ -312,6 +312,135 @@ public sealed class InventoryServiceStackSizeTests
         _ = run;
     }
 
+    [Fact]
+    public async Task AddItem_ReEmit_AfterUpdateCode_PreservesStackSize()
+    {
+        // Issue #10 — the 108233134 shape: AddItem-True → UpdateCode→2 → AddItem-False ×3 → Delete.
+        // Each AddItem-False is a server resync pulse that carries no size; without the re-emit guard
+        // the second-onwards AddItem clobbers the confirmed size 2 back to (1, unconfirmed) and the
+        // Deleted event reports stack 1 instead of 2.
+        var stream = new ScriptedPlayerStream(
+            "[00:43:15] LocalPlayer: ProcessAddItem(HumanSkull(108233134), -1, True)",
+            "[00:52:48] LocalPlayer: ProcessUpdateItemCode(108233134, 66683, True)", // size 2
+            "[00:56:27] LocalPlayer: ProcessAddItem(HumanSkull(108233134), -1, False)",
+            "[01:06:03] LocalPlayer: ProcessAddItem(HumanSkull(108233134), -1, False)",
+            "[01:48:58] LocalPlayer: ProcessAddItem(HumanSkull(108233134), -1, False)",
+            "[01:52:45] LocalPlayer: ProcessDeleteItem(108233134)");
+        var svc = new InventoryService(stream);
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add);
+        await RunAsync(svc, stream);
+
+        var deleted = events.Single(e => e.Kind == InventoryEventKind.Deleted);
+        deleted.StackSize.Should().Be(2);
+        deleted.SizeConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AddItem_ReEmit_DoesNotConsumePendingChat()
+    {
+        // A re-emit must not dequeue from _pendingChat — chat correlation must remain
+        // available for the next genuine new-stack AddItem of the same InternalName.
+        var ts = new DateTime(2026, 4, 25, 14, 10, 48, DateTimeKind.Utc);
+        var playerStream = new ScriptedPlayerStream();
+        var chatStream = new ScriptedPlayerStream();
+        var refData = new FakeRefData(("HumanSkull", "Human Skull"));
+        var svc = new InventoryService(playerStream, diag: null, chatStream: chatStream, refData: refData);
+        var run = svc.StartAsync(CancellationToken.None);
+
+        // Chat-first establishes id=100 at confirmed size 2 via the pending-chat path,
+        // which leaves _pendingAdd empty (avoids the "chat back-fills the still-queued
+        // original AddItem" interaction unrelated to this test).
+        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Human Skull x2 added to inventory."));
+        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        playerStream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)"));
+        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        svc.TryGetStackSize(100, out var seedSize).Should().BeTrue();
+        seedSize.Should().Be(2);
+
+        // Queue a chat count of 7 for the *next* HumanSkull pickup.
+        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:49\t[Status] Human Skull x7 added to inventory."));
+        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+
+        // Re-emit pulse for id=100 — must NOT dequeue the queued 7 from _pendingChat.
+        playerStream.Push(new RawLogLine(ts, "[14:10:50] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)"));
+        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        svc.TryGetStackSize(100, out var afterReemit).Should().BeTrue();
+        afterReemit.Should().Be(2);
+
+        // Genuinely new AddItem (different id) — should consume the queued 7.
+        playerStream.Push(new RawLogLine(ts, "[14:10:51] LocalPlayer: ProcessAddItem(HumanSkull(200), -1, True)"));
+        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+
+        svc.TryGetStackSize(200, out var newSize).Should().BeTrue();
+        newSize.Should().Be(7);
+
+        await svc.StopAsync(CancellationToken.None);
+        _ = run;
+    }
+
+    [Fact]
+    public async Task AddItem_ReEmit_FiresNoStackChangedOrAddedEvents()
+    {
+        // Subscribers should see exactly one Added (from the original new-stack AddItem)
+        // and one StackChanged (from UpdateCode); the re-emit pulses must be silent.
+        var stream = new ScriptedPlayerStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 201920, True)", // size 4
+            "[00:00:03] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)",
+            "[00:00:04] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)");
+        var svc = new InventoryService(stream);
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add);
+        await RunAsync(svc, stream);
+
+        events.Should().HaveCount(2);
+        events[0].Kind.Should().Be(InventoryEventKind.Added);
+        events[0].StackSize.Should().Be(1);
+        events[1].Kind.Should().Be(InventoryEventKind.StackChanged);
+        events[1].StackSize.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task AddItem_AfterDelete_TreatsAsNewStack()
+    {
+        // The re-emit guard skips entries marked Deleted — the game can reuse an InstanceId
+        // for a fresh stack after the original was deleted, and that legitimately needs a
+        // new Added event.
+        var stream = new ScriptedPlayerStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessDeleteItem(100)",
+            "[00:00:03] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)");
+        var svc = new InventoryService(stream);
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add);
+        await RunAsync(svc, stream);
+
+        events.Should().HaveCount(3);
+        events[0].Kind.Should().Be(InventoryEventKind.Added);
+        events[1].Kind.Should().Be(InventoryEventKind.Deleted);
+        events[2].Kind.Should().Be(InventoryEventKind.Added);
+    }
+
+    [Fact]
+    public async Task AddItem_GenuineSize1_ReEmitDoesNotChangeBehaviour()
+    {
+        // Issue's 108363377 shape: a stack that really is size 1, AddItem-True followed by
+        // AddItem-False pulses, then Delete. Reported size stays 1 (unchanged behaviour).
+        var stream = new ScriptedPlayerStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(HumanSkull(108363377), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessAddItem(HumanSkull(108363377), -1, False)",
+            "[00:00:03] LocalPlayer: ProcessAddItem(HumanSkull(108363377), -1, False)",
+            "[00:00:04] LocalPlayer: ProcessDeleteItem(108363377)");
+        var svc = new InventoryService(stream);
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add);
+        await RunAsync(svc, stream);
+
+        var deleted = events.Single(e => e.Kind == InventoryEventKind.Deleted);
+        deleted.StackSize.Should().Be(1);
+    }
+
     private static async Task RunAsync(InventoryService svc, ScriptedPlayerStream stream)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
## Summary
- `InventoryService.HandleAddItem` now early-returns when the InstanceId is already tracked and not deleted, refreshing only `Timestamp` and emitting a distinct `Add-reemit` trace.
- Eliminates the silent `(StackSize=N, SizeConfirmed=true)` → `(1, false)` clobber that fires on every zone-change/server-resync `ProcessAddItem(..., -1, False)` pulse.
- Pending chat correlation is no longer consumed on the wrong instance id.

Fixes #10.

## Root cause
The previous `HandleAddItem` always wrote `_map[instanceId] = new MapEntry(...)` at the end of the method, regardless of whether the id was already tracked. Re-emission pulses carry no size payload, so each one downgraded a confirmed entry to the unconfirmed default.

The fix is a presence-in-map check at the top of the method — more robust than parsing the third bool argument of `ProcessAddItem`, since session-replay of an original `True` is also effectively a re-emit relative to live state.

## Test plan
- [x] `dotnet test tests/Mithril.Shared.Tests --filter "FullyQualifiedName~InventoryServiceStackSizeTests"` — 18/18 pass (5 new regression tests + 13 existing).
- [x] `dotnet test Mithril.slnx` — full suite green across all module test projects.
- New tests cover:
  - Issue's `108233134` shape — AddItem-True → UpdateCode→2 → AddItem-False ×3 → Delete; Deleted event reports `StackSize=2, SizeConfirmed=true`.
  - Re-emit does not consume `_pendingChat`; the queued count back-fills the next genuinely-new id instead.
  - Re-emit fires no `Added`/`StackChanged` events.
  - AddItem after a Delete on the same id is treated as a new stack (re-emit guard skips `Deleted` entries).
  - Genuine size-1 items (`108363377` shape) report unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)