### PR TITLE
mithril-log-mcp: UTC stamping + read rolled-over Player-prev.log

### DIFF
--- a/tools/MithrilLogMcp/src/sources/multi-source-raw.ts
+++ b/tools/MithrilLogMcp/src/sources/multi-source-raw.ts
@@ -55,7 +55,7 @@ export async function* scanMultiSourceRaw(
       path: config.playerLogPath,
       since: query.since,
       until: query.until,
-      prevCursor: query.cursors?.['raw-player']?.perFile?.[config.playerLogPath],
+      prevCursors: query.cursors?.['raw-player']?.perFile,
     }, playerStats)[Symbol.asyncIterator](),
     scanChatLogsRaw({
       dir: config.chatLogDir,
@@ -110,7 +110,7 @@ async function* singleSource(
         path: config.playerLogPath,
         since: query.since,
         until: query.until,
-        prevCursor: query.cursors?.['raw-player']?.perFile?.[config.playerLogPath],
+        prevCursors: query.cursors?.['raw-player']?.perFile,
       }, sub);
       stats.scannedBytes = sub.scannedBytes;
       stats.scannedLines = sub.scannedLines;

--- a/tools/MithrilLogMcp/src/sources/multi-source.ts
+++ b/tools/MithrilLogMcp/src/sources/multi-source.ts
@@ -4,7 +4,7 @@ import { scanMithrilSerilog, type MithrilSerilogScanStats } from './mithril-seri
 import type { Catalog } from '../parsing/catalog.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { ServerConfig } from '../config.js';
-import type { CursorState, FileCursor } from '../state/cursors.js';
+import type { CursorState } from '../state/cursors.js';
 
 export type SourceName = 'player' | 'chat' | 'mithril' | 'all';
 
@@ -61,7 +61,7 @@ export async function* scanMultiSource(
       path: config.playerLogPath,
       since: query.since,
       until: query.until,
-      prevCursor: cursorEntryFor(query.cursors?.player, config.playerLogPath),
+      prevCursors: query.cursors?.player?.perFile,
       context: query.context,
     }, playerStats)[Symbol.asyncIterator](),
     scanChatLogs(catalog, {
@@ -129,7 +129,7 @@ async function* singleSource(
         path: config.playerLogPath,
         since: query.since,
         until: query.until,
-        prevCursor: cursorEntryFor(query.cursors?.player, config.playerLogPath),
+        prevCursors: query.cursors?.player?.perFile,
         context: query.context,
       }, sub);
       stats.scannedBytes = sub.scannedBytes;
@@ -174,10 +174,6 @@ async function* singleSource(
 
 function makeSubStats(): PlayerLogScanStats & ChatScanStats & MithrilSerilogScanStats {
   return { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
-}
-
-function cursorEntryFor(state: CursorState | undefined, file: string): FileCursor | undefined {
-  return state?.perFile[file];
 }
 
 export function emptyMultiSourceStats(): MultiSourceStats {

--- a/tools/MithrilLogMcp/src/sources/player-log-discovery.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log-discovery.ts
@@ -1,0 +1,46 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Player.log gets rotated between sessions: when the game starts, the
+ * previous run's contents move to `Player-prev.log` in the same directory.
+ * The MCP scanner used to only open the current Player.log, leaving every
+ * pre-rotation event invisible to `since: 7d` windows. {@link discoverPlayerLogPaths}
+ * returns both files (when present) in oldest-first order so the scanner
+ * can stream them as one logical timeline.
+ *
+ * `oldPlayer.log` is intentionally NOT probed — it isn't produced by the
+ * game's own rotation, only by manual renames during debugging.
+ */
+
+export interface DiscoveredPlayerLog {
+  path: string;
+  stat: fs.Stats;
+}
+
+/**
+ * Returns existing Player.log files (current + previous rotation) sorted
+ * by mtime ascending.
+ *
+ * No cross-file dedupe: the two probed paths are distinct by construction,
+ * and game rotation never produces two paths with overlapping bytes (a
+ * rename moves all bytes, leaving the source empty). Per-file cursor
+ * invalidation via `rolloverDetected` already handles the
+ * file-identity-changed case at its own layer.
+ */
+export function discoverPlayerLogPaths(currentPath: string): DiscoveredPlayerLog[] {
+  const dir = path.dirname(currentPath);
+  const candidates = [
+    path.join(dir, 'Player-prev.log'),
+    currentPath,
+  ];
+
+  const found: DiscoveredPlayerLog[] = [];
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    found.push({ path: candidate, stat: fs.statSync(candidate) });
+  }
+
+  found.sort((a, b) => a.stat.mtimeMs - b.stat.mtimeMs);
+  return found;
+}

--- a/tools/MithrilLogMcp/src/sources/player-log-raw.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log-raw.ts
@@ -2,24 +2,30 @@ import * as fs from 'node:fs';
 import { lineStream, scannedBytes } from '../util/file-streams.js';
 import { countPlayerLogCrossings, PlayerLogTimestamper } from '../util/time-windows.js';
 import { rolloverDetected, type FileCursor } from '../state/cursors.js';
+import { discoverPlayerLogPaths, type DiscoveredPlayerLog } from './player-log-discovery.js';
 
 /**
- * Raw counterpart to `scanPlayerLog`. Streams Player.log forward and yields
- * every line with a `[HH:MM:SS]` prefix — the gameplay-event marker — within
- * the requested time window. Lines without that prefix (Unity boot output,
- * stack-trace addresses, GfxDevice banners, fallback-backend chatter) are
- * counted as `droppedNonGameLines` and dropped silently.
+ * Raw counterpart to `scanPlayerLog`. Streams every Player.log file
+ * (current + Player-prev.log) in age order and yields every line with a
+ * `[HH:MM:SS]` prefix — the gameplay-event marker — within the requested
+ * time window. Lines without that prefix (Unity boot output, stack-trace
+ * addresses, GfxDevice banners, fallback-backend chatter) are counted as
+ * `droppedNonGameLines` and dropped silently.
  *
- * Cursor handling, mtime-anchored date stamping, and rollover detection
- * mirror `scanPlayerLog` — but the catalog/parser/active-character machinery
- * is dropped because raw streaming has no use for typed events.
+ * Cursor handling, mtime-anchored date stamping, rollover detection, and
+ * multi-file discovery mirror `scanPlayerLog` — but the catalog/parser/
+ * active-character machinery is dropped because raw streaming has no use
+ * for typed events.
  */
 
 export interface PlayerLogRawQuery {
+  /** Path to the *current* Player.log. Sibling Player-prev.log is read
+   *  automatically when present. */
   path: string;
   since: Date;
   until: Date;
-  prevCursor?: FileCursor | undefined;
+  /** Per-file cursor map (same shape as `CursorState.perFile`). */
+  prevCursors?: Record<string, FileCursor> | undefined;
 }
 
 export interface PlayerLogRawScanStats {
@@ -43,32 +49,46 @@ export async function* scanPlayerLogRaw(
   query: PlayerLogRawQuery,
   stats: PlayerLogRawScanStats,
 ): AsyncGenerator<RawLineRecord, void, void> {
-  if (!fs.existsSync(query.path)) return;
+  const files = discoverPlayerLogPaths(query.path);
+  if (files.length === 0) return;
 
-  const stat = fs.statSync(query.path);
+  for (const file of files) {
+    yield* scanSinglePlayerFileRaw(file, query, stats);
+  }
+}
+
+async function* scanSinglePlayerFileRaw(
+  file: DiscoveredPlayerLog,
+  query: PlayerLogRawQuery,
+  stats: PlayerLogRawScanStats,
+): AsyncGenerator<RawLineRecord, void, void> {
+  const stat = file.stat;
+  const filePath = file.path;
+  const prev = query.prevCursors?.[filePath];
+
   let startOffset = 0;
-  if (query.prevCursor) {
-    if (rolloverDetected(query.prevCursor, stat)) {
-      stats.rolledOverFiles.push(query.path);
+  if (prev) {
+    if (rolloverDetected(prev, stat)) {
+      stats.rolledOverFiles.push(filePath);
       startOffset = 0;
     } else {
-      startOffset = Math.min(query.prevCursor.byteOffset, stat.size);
+      startOffset = Math.min(prev.byteOffset, stat.size);
     }
   }
 
   stats.scannedBytes += scannedBytes(stat, startOffset);
-  stats.endOffsets[query.path] = startOffset;
+  stats.endOffsets[filePath] = startOffset;
 
   // Anchor the start-of-file date the same way scanPlayerLog does: count
   // midnight crossings, then walk back from mtime UTC date by that many days.
-  const crossings = await countPlayerLogCrossings(lineStream(query.path, { start: startOffset }));
+  const crossings = await countPlayerLogCrossings(lineStream(filePath, { start: startOffset }));
   const startDate = new Date(stat.mtime);
   startDate.setUTCDate(startDate.getUTCDate() - crossings);
   const stamper = new PlayerLogTimestamper(startDate);
 
-  for await (const rec of lineStream(query.path, { start: startOffset })) {
+  for await (const rec of lineStream(filePath, { start: startOffset })) {
     stats.scannedLines += 1;
-    stats.endOffsets[query.path] = rec.byteOffset + rec.byteLength;
+    stats.endOffsets[filePath] = rec.byteOffset + rec.byteLength;
 
     if (!PlayerLogTimestamper.TIME_RE.test(rec.line)) {
       stats.droppedNonGameLines += 1;
@@ -82,7 +102,7 @@ export async function* scanPlayerLogRaw(
     yield {
       ts,
       source: 'player',
-      file: query.path,
+      file: filePath,
       line: rec.lineNo,
       raw: rec.line,
       byteOffset: rec.byteOffset,

--- a/tools/MithrilLogMcp/src/sources/player-log.ts
+++ b/tools/MithrilLogMcp/src/sources/player-log.ts
@@ -5,15 +5,19 @@ import { PlayerLineParser } from '../parsing/player-parser.js';
 import { ActiveCharacterTracker } from '../parsing/active-character-tracker.js';
 import { rolloverDetected, type FileCursor } from '../state/cursors.js';
 import { findActiveCharacterAt } from '../state/character-resolver.js';
+import { discoverPlayerLogPaths, type DiscoveredPlayerLog } from './player-log-discovery.js';
 import type { ParsedEvent } from '../parsing/types.js';
 import type { Catalog } from '../parsing/catalog.js';
 
 export interface PlayerLogQuery {
+  /** Path to the *current* Player.log. The scanner discovers Player-prev.log
+   *  beside it automatically and reads both in chronological order. */
   path: string;
   since: Date;
   until: Date;
-  /** Cursor entry for this file, if any. Honoured when not stale. */
-  prevCursor?: FileCursor | undefined;
+  /** Per-file cursor map (same shape as `CursorState.perFile`). Each file's
+   *  entry is honoured independently; missing entries restart from byte 0. */
+  prevCursors?: Record<string, FileCursor> | undefined;
   /**
    * Number of raw lines of surrounding context to attach to each emitted
    * event as `contextLines: { before, after }`. 0 disables (default).
@@ -33,32 +37,55 @@ export interface PlayerLogScanStats {
 }
 
 /**
- * Streams Player.log forward, yielding parsed events within the requested
- * time window. If `prevCursor` is supplied and still valid (no rollover),
- * scanning starts at its byteOffset; otherwise from byte 0. The final reached
- * byte offset is recorded in `stats.endOffsets[path]` so callers can persist
- * it as the next cursor.
+ * Streams every Player.log file in age order (oldest first), yielding parsed
+ * events within the requested time window. Discovers `Player-prev.log` next
+ * to the current `Player.log` so a multi-day query window catches events
+ * from the previous session. Each file gets its own cursor lookup; the
+ * `ActiveCharacterTracker` is shared across files so a `ProcessAddPlayer`
+ * in `Player-prev.log` keeps tagging events in `Player.log`.
+ *
+ * Ordering invariant for the multi-source merge: rotation guarantees the
+ * last line of `Player-prev.log` precedes the first line of `Player.log`,
+ * so streaming oldest-first preserves global ascending `ts`.
  */
 export async function* scanPlayerLog(
   catalog: Catalog,
   query: PlayerLogQuery,
   stats: PlayerLogScanStats,
 ): AsyncGenerator<ParsedEvent, void, void> {
-  if (!fs.existsSync(query.path)) return;
+  const files = discoverPlayerLogPaths(query.path);
+  if (files.length === 0) return;
 
-  const stat = fs.statSync(query.path);
+  const tracker = new ActiveCharacterTracker();
+
+  for (const file of files) {
+    yield* scanSinglePlayerFile(catalog, file, query, stats, tracker);
+  }
+}
+
+async function* scanSinglePlayerFile(
+  catalog: Catalog,
+  file: DiscoveredPlayerLog,
+  query: PlayerLogQuery,
+  stats: PlayerLogScanStats,
+  tracker: ActiveCharacterTracker,
+): AsyncGenerator<ParsedEvent, void, void> {
+  const stat = file.stat;
+  const filePath = file.path;
+  const prev = query.prevCursors?.[filePath];
+
   let startOffset = 0;
-  if (query.prevCursor) {
-    if (rolloverDetected(query.prevCursor, stat)) {
-      stats.rolledOverFiles.push(query.path);
+  if (prev) {
+    if (rolloverDetected(prev, stat)) {
+      stats.rolledOverFiles.push(filePath);
       startOffset = 0;
     } else {
-      startOffset = Math.min(query.prevCursor.byteOffset, stat.size);
+      startOffset = Math.min(prev.byteOffset, stat.size);
     }
   }
 
   stats.scannedBytes += scannedBytes(stat, startOffset);
-  stats.endOffsets[query.path] = startOffset;
+  stats.endOffsets[filePath] = startOffset;
 
   const parser = new PlayerLineParser(catalog);
 
@@ -67,18 +94,19 @@ export async function* scanPlayerLog(
   // forward scan then advances the date as it sees its own crossings, so the
   // last line of the file ends up stamped at the mtime UTC date — the only
   // value we know for certain.
-  const crossings = await countPlayerLogCrossings(lineStream(query.path, { start: startOffset }));
+  const crossings = await countPlayerLogCrossings(lineStream(filePath, { start: startOffset }));
   const startDate = new Date(stat.mtime);
   startDate.setUTCDate(startDate.getUTCDate() - crossings);
   const stamper = new PlayerLogTimestamper(startDate);
 
   // Seed the active-character tracker from a backward scan when resuming
   // mid-stream — without it, every event before the next ProcessAddPlayer
-  // would be unstamped and dropped by `character: "X"` filters.
-  const initialActive = startOffset > 0
-    ? findActiveCharacterAt(query.path, startOffset, catalog)
-    : null;
-  const tracker = new ActiveCharacterTracker(initialActive ?? undefined);
+  // would be unstamped and dropped by `character: "X"` filters. Skip when
+  // the tracker already has a value carried over from an earlier file.
+  if (startOffset > 0 && !tracker.active) {
+    const initialActive = findActiveCharacterAt(filePath, startOffset, catalog);
+    if (initialActive) tracker.set(initialActive);
+  }
 
   const N = query.context ?? 0;
   const ringBefore: string[] = [];
@@ -86,7 +114,7 @@ export async function* scanPlayerLog(
   // mutates the event's own array — no second pass needed at yield time.
   const pending: Array<{ ev: ParsedEvent; after: string[] }> = [];
 
-  for await (const rec of lineStream(query.path, { start: startOffset })) {
+  for await (const rec of lineStream(filePath, { start: startOffset })) {
     // Feed this line as after-context to events still waiting; yield any
     // whose after-window is now full.
     if (N > 0) {
@@ -99,7 +127,7 @@ export async function* scanPlayerLog(
     }
 
     stats.scannedLines += 1;
-    stats.endOffsets[query.path] = rec.byteOffset + rec.byteLength;
+    stats.endOffsets[filePath] = rec.byteOffset + rec.byteLength;
     const ts = stamper.stamp(rec.line, stat.mtime);
     if (ts < query.since) {
       if (N > 0) pushRing(ringBefore, rec.line, N);
@@ -107,7 +135,7 @@ export async function* scanPlayerLog(
     }
     if (ts > query.until) break;
 
-    for (const ev of parser.parse(rec.line, ts, query.path, rec.lineNo, rec.byteOffset)) {
+    for (const ev of parser.parse(rec.line, ts, filePath, rec.lineNo, rec.byteOffset)) {
       tracker.observe(ev);
       if (tracker.active) ev.activeCharacter = tracker.active;
       if (N > 0) {

--- a/tools/MithrilLogMcp/src/tools/server-info.ts
+++ b/tools/MithrilLogMcp/src/tools/server-info.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { ServerConfig } from '../config.js';
+import { discoverPlayerLogPaths } from '../sources/player-log-discovery.js';
 
 export const ServerInfoInput = z.object({});
 
@@ -30,6 +31,11 @@ export function runServerInfo(
       characterRoot: config.characterRoot,
       shellSettingsPath: config.shellSettingsPath,
     },
+    playerLogFiles: discoverPlayerLogPaths(config.playerLogPath).map((f) => ({
+      path: f.path,
+      sizeBytes: f.stat.size,
+      mtime: f.stat.mtime.toISOString(),
+    })),
   };
 }
 

--- a/tools/MithrilLogMcp/src/util/time-windows.ts
+++ b/tools/MithrilLogMcp/src/util/time-windows.ts
@@ -106,17 +106,17 @@ function parseDuration(input: string): number {
 /**
  * Player.log per-line stamper.
  *
- * Lines carry only `[HH:MM:SS]` (local game time) — no date. The date
- * anchor for the *first* line is supplied by the caller (typically computed
- * by {@link countPlayerLogCrossings}: the file's mtime UTC date, walked back
+ * Lines carry only `[HH:MM:SS]` (UTC) — no date. The date anchor for the
+ * *first* line is supplied by the caller (typically computed by
+ * {@link countPlayerLogCrossings}: the file's mtime UTC date, walked back
  * one day per midnight crossing detected in the file). As we stream forward,
  * a backward jump in HH:MM:SS of more than ~1 minute is taken as a midnight
  * crossing and the running date advances by one day.
  *
- * Times are constructed with the *local* Date constructor on purpose — the
- * game writes wall-clock time in the user's timezone, and the resulting
- * Date object's UTC instant is what callers compare against `since`/`until`
- * windows (also UTC instants).
+ * The game writes Player.log timestamps in UTC (cross-checked against
+ * ChatLogs/ entries, which are local-TZ — see issue #24). Times are
+ * constructed with `Date.UTC(...)` so the resulting instant matches the
+ * `since`/`until` window without a TZ-offset shift.
  */
 export class PlayerLogTimestamper {
   static readonly TIME_RE = /^\[(\d{2}):(\d{2}):(\d{2})\]\s/;
@@ -147,12 +147,12 @@ export class PlayerLogTimestamper {
     }
     this.prevSeconds = seconds;
 
-    return new Date(
+    return new Date(Date.UTC(
       this.currentDate.getUTCFullYear(),
       this.currentDate.getUTCMonth(),
       this.currentDate.getUTCDate(),
       h, min, s,
-    );
+    ));
   }
 }
 

--- a/tools/MithrilLogMcp/test/player-log-rollover.test.ts
+++ b/tools/MithrilLogMcp/test/player-log-rollover.test.ts
@@ -1,0 +1,190 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadCatalog } from '../src/parsing/catalog.js';
+import { scanPlayerLog } from '../src/sources/player-log.js';
+import { runQueryEvents, QueryEventsInput } from '../src/tools/query-events.js';
+import { CursorStore } from '../src/state/cursors.js';
+import type { ParsedEvent } from '../src/parsing/types.js';
+
+/**
+ * Player.log rotates when the game starts: the previous run's contents move
+ * to Player-prev.log next to the current Player.log. These tests verify the
+ * scanner discovers Player-prev.log automatically and reads both files in
+ * chronological order.
+ */
+
+interface RolloverFixture {
+  root: string;
+  playerLogPath: string;
+  prevLogPath: string;
+}
+
+function makeFixture(): RolloverFixture {
+  const root = path.join(os.tmpdir(), `mithril-rollover-${Date.now()}-${Math.random()}`);
+  fs.mkdirSync(root);
+  return {
+    root,
+    playerLogPath: path.join(root, 'Player.log'),
+    prevLogPath: path.join(root, 'Player-prev.log'),
+  };
+}
+
+function writeLog(p: string, lines: string[], mtime: Date): void {
+  fs.writeFileSync(p, lines.join('\n') + '\n');
+  fs.utimesSync(p, mtime, mtime);
+}
+
+function makeConfig(playerLogPath: string) {
+  return {
+    playerLogPath,
+    chatLogDir: '',
+    mithrilLogDir: '',
+    characterRoot: '',
+    shellSettingsPath: '',
+  };
+}
+
+function tmpCursorFile(): string {
+  return path.join(os.tmpdir(), `mithril-cursors-${Date.now()}-${Math.random()}.json`);
+}
+
+async function collect(gen: AsyncGenerator<ParsedEvent>): Promise<ParsedEvent[]> {
+  const out: ParsedEvent[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+describe('Player.log rollover discovery', () => {
+  it('A: Player-prev.log + Player.log both stream in chronological order', async () => {
+    const fix = makeFixture();
+    try {
+      const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000);
+      const yesterday = new Date(Date.now() - 86_400_000);
+      writeLog(fix.prevLogPath, [
+        '[10:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+        '[10:00:02] LocalPlayer: ProcessSetPetOwner(33, 44)',
+      ], twoDaysAgo);
+      writeLog(fix.playerLogPath, [
+        '[10:00:01] LocalPlayer: ProcessSetPetOwner(55, 66)',
+        '[10:00:02] LocalPlayer: ProcessSetPetOwner(77, 88)',
+      ], yesterday);
+
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
+      const events = await collect(scanPlayerLog(loadCatalog(), {
+        path: fix.playerLogPath,
+        since: new Date(0),
+        until: new Date('2099-01-01'),
+      }, stats));
+
+      const ids = events
+        .filter((e) => e.type === 'samwise.SetPetOwner')
+        .map((e) => e.data.entityId);
+      assert.deepEqual(ids, ['11', '33', '55', '77'],
+        'expected events from Player-prev.log first, then Player.log');
+
+      // Each file should appear in endOffsets independently.
+      assert.ok(fix.prevLogPath in stats.endOffsets);
+      assert.ok(fix.playerLogPath in stats.endOffsets);
+    } finally {
+      fs.rmSync(fix.root, { recursive: true });
+    }
+  });
+
+  it('B: only Player.log present — no rollover sibling — works as before', async () => {
+    const fix = makeFixture();
+    try {
+      const yesterday = new Date(Date.now() - 86_400_000);
+      writeLog(fix.playerLogPath, [
+        '[10:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      ], yesterday);
+
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
+      const events = await collect(scanPlayerLog(loadCatalog(), {
+        path: fix.playerLogPath,
+        since: new Date(0),
+        until: new Date('2099-01-01'),
+      }, stats));
+
+      const setPetOwners = events.filter((e) => e.type === 'samwise.SetPetOwner');
+      assert.equal(setPetOwners.length, 1);
+      assert.equal(setPetOwners[0]!.data.entityId, '11');
+      assert.deepEqual(Object.keys(stats.endOffsets), [fix.playerLogPath]);
+    } finally {
+      fs.rmSync(fix.root, { recursive: true });
+    }
+  });
+
+  it('D: cursor resume — second scan does not re-emit Player-prev.log lines', async () => {
+    const fix = makeFixture();
+    const cursorFile = tmpCursorFile();
+    const store = new CursorStore(cursorFile);
+    try {
+      // Both mtimes safely in the past relative to `now`, but distinct so
+      // discoverPlayerLogPaths sorts them deterministically (prev before
+      // current). runQueryEvents clips with `until: now`, so picking
+      // mtime = "now - 1h" can flake when the test runs before 10:00 UTC.
+      const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000);
+      const yesterday = new Date(Date.now() - 86_400_000);
+      writeLog(fix.prevLogPath, [
+        '[10:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      ], twoDaysAgo);
+      writeLog(fix.playerLogPath, [
+        '[10:00:01] LocalPlayer: ProcessSetPetOwner(55, 66)',
+      ], yesterday);
+
+      const args = QueryEventsInput.parse({
+        source: 'player',
+        cursor: 'rollover-resume',
+        limit: 100,
+      });
+      const first = await runQueryEvents(args, makeConfig(fix.playerLogPath), store);
+      assert.equal(first.events.length, 2,
+        `expected 2 events on first call, got ${first.events.length}`);
+
+      // Append a fresh event to Player.log only; keep mtime in the past.
+      fs.appendFileSync(fix.playerLogPath,
+        '[10:00:02] LocalPlayer: ProcessSetPetOwner(99, 100)\n');
+      fs.utimesSync(fix.playerLogPath, yesterday, yesterday);
+
+      const second = await runQueryEvents(args, makeConfig(fix.playerLogPath), store);
+      assert.equal(second.events.length, 1,
+        `expected only the 1 new event, got ${second.events.length}`);
+      assert.equal(second.events[0]!.data.entityId, '99');
+    } finally {
+      fs.rmSync(fix.root, { recursive: true });
+      if (fs.existsSync(cursorFile)) fs.unlinkSync(cursorFile);
+    }
+  });
+
+  it('F: ProcessAddPlayer in Player-prev.log keeps tagging events in Player.log', async () => {
+    const fix = makeFixture();
+    try {
+      const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000);
+      const yesterday = new Date(Date.now() - 86_400_000);
+      // ProcessAddPlayer in the old file, regular events in the new.
+      writeLog(fix.prevLogPath, [
+        '[10:00:01] LocalPlayer: ProcessAddPlayer(-1, 1, "PlayerWolf", "Frodo", "")',
+      ], twoDaysAgo);
+      writeLog(fix.playerLogPath, [
+        '[10:00:01] LocalPlayer: ProcessSetPetOwner(11, 22)',
+      ], yesterday);
+
+      const stats = { scannedBytes: 0, scannedLines: 0, endOffsets: {}, rolledOverFiles: [] };
+      const events = await collect(scanPlayerLog(loadCatalog(), {
+        path: fix.playerLogPath,
+        since: new Date(0),
+        until: new Date('2099-01-01'),
+      }, stats));
+
+      const petEvent = events.find((e) => e.type === 'samwise.SetPetOwner');
+      assert.ok(petEvent, 'expected SetPetOwner event');
+      assert.equal(petEvent!.activeCharacter, 'Frodo',
+        'tracker state from Player-prev.log should carry into Player.log');
+    } finally {
+      fs.rmSync(fix.root, { recursive: true });
+    }
+  });
+});

--- a/tools/MithrilLogMcp/test/time-windows.test.ts
+++ b/tools/MithrilLogMcp/test/time-windows.test.ts
@@ -59,8 +59,8 @@ describe('PlayerLogTimestamper', () => {
     const a = t.stamp('[10:00:00] foo', new Date(0));
     const b = t.stamp('[10:00:01] foo', new Date(0));
     const c = t.stamp('[10:00:02] foo', new Date(0));
-    assert.equal(a.getDate(), b.getDate());
-    assert.equal(b.getDate(), c.getDate());
+    assert.equal(a.getUTCDate(), b.getUTCDate());
+    assert.equal(b.getUTCDate(), c.getUTCDate());
     assert.ok(a < b && b < c);
   });
 
@@ -70,7 +70,7 @@ describe('PlayerLogTimestamper', () => {
     const firstAfter = t.stamp('[00:00:05] foo', new Date(0));
     // Different calendar dates, and firstAfter > lastBefore.
     assert.ok(firstAfter.getTime() > lastBefore.getTime());
-    assert.notEqual(lastBefore.getDate(), firstAfter.getDate());
+    assert.notEqual(lastBefore.getUTCDate(), firstAfter.getUTCDate());
   });
 
   it('returns the fallback for lines without a timestamp prefix', () => {
@@ -78,6 +78,14 @@ describe('PlayerLogTimestamper', () => {
     const fallback = new Date('2026-04-27T05:00:00Z');
     const got = t.stamp('Some Unity startup chatter without brackets', fallback);
     assert.equal(got.getTime(), fallback.getTime());
+  });
+
+  it('stamps [HH:MM:SS] as a UTC instant regardless of process TZ', () => {
+    // Game writes Player.log in UTC. The stamper must produce the same
+    // absolute instant whether the process runs in UTC, BST, or EST.
+    const t = new PlayerLogTimestamper(utcDay(2026, 4, 27));
+    const got = t.stamp('[12:34:56] foo', new Date(0));
+    assert.equal(got.toISOString(), '2026-04-27T12:34:56.000Z');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `mithril-log-mcp` that together make `query_events` /
`query_raw_lines` miss data near rotation boundaries.

- **#24** Player.log timestamps were being constructed with the local
  `Date(...)` constructor, but the game writes `[HH:MM:SS]` in UTC. Every
  emitted `ts` was shifted by the user's TZ offset, breaking
  `source: 'all'` merges against ChatLogs (which is local-TZ, correctly
  parsed). Fix: switch to `Date.UTC(...)` (already used for the
  start-of-file anchor a few lines above) and rewrite the comment block
  that was justifying the wrong behaviour.

- **#23** The scanner only opened the current `Player.log`, so any window
  that crossed the rotation boundary silently missed the prior session
  in `Player-prev.log`. Fix: add `discoverPlayerLogPaths` to find both
  files (sorted by mtime, oldest first), refactor `scanPlayerLog` and
  `scanPlayerLogRaw` into per-file inner + multi-file outer generators,
  and lift `ActiveCharacterTracker` to the outer wrapper so a
  `ProcessAddPlayer` in `Player-prev.log` keeps tagging events that
  appear in `Player.log` without a fresh login marker. Cursor wiring
  changes from a single `prevCursor` to a path-keyed `prevCursors` map;
  `CursorState` storage shape is unchanged.

`server_info` now reports the discovered files as `playerLogFiles` so
MCP clients can verify what's being scanned.

`oldPlayer.log` is intentionally not probed — that name is a
manual-debugging artefact, not produced by game rotation.

## Test plan

- [x] `npm test` in `tools/MithrilLogMcp/` (86 passing, 5/5 clean reruns)
- [x] `npm run build` clean
- [x] New `time-windows.test.ts` case asserts `[HH:MM:SS]` stamps to a UTC
      instant regardless of process TZ
- [x] New `player-log-rollover.test.ts` covers: chronological multi-file
      stream, only Player.log present, cursor resume not re-emitting
      prev events, and `ProcessAddPlayer` state bleeding across files
- [ ] Manual repro of the issue's chest event: `query_raw_lines` with
      `since: 7d` should now find the EltibuleSecretChest line that
      was in `Player-prev.log`
- [ ] Confirm in BST that the chest rejection event from Player.log
      and ChatLogs reconcile to the same UTC instant under
      `source: 'all'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)