### PR TITLE
mithril-log-mcp: emit strict JSON Schema for tool inputs

### DIFF
--- a/tools/MithrilLogMcp/package-lock.json
+++ b/tools/MithrilLogMcp/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "mithril-log-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-log-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.20.2",
-        "zod": "3.25.76"
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.25.2"
       },
       "bin": {
-        "mithril-log-mcp": "dist/server.js"
+        "mithril-log-mcp": "dist/src/server.js"
       },
       "devDependencies": {
         "@types/node": "22.18.13",

--- a/tools/MithrilLogMcp/package.json
+++ b/tools/MithrilLogMcp/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.20.2",
-    "zod": "3.25.76"
+    "zod": "3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@types/node": "22.18.13",

--- a/tools/MithrilLogMcp/src/server.ts
+++ b/tools/MithrilLogMcp/src/server.ts
@@ -6,6 +6,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { zodToJsonSchema as zodToJsonSchemaLib } from 'zod-to-json-schema';
 
 import { loadConfig } from './config.js';
 import {
@@ -218,59 +219,21 @@ function errorResult(message: string) {
 }
 
 /**
- * Minimal Zod -> JSON Schema bridge — the MCP SDK accepts plain JSON Schema
- * for `inputSchema`. A full library (zod-to-json-schema) would be more
- * accurate, but this server's schemas are simple enough that the Zod parser
- * does the real validation at call time and the JSON Schema is just a
- * description for the client.
+ * Zod -> JSON Schema bridge. Delegates to `zod-to-json-schema` so every Zod
+ * construct (refine/effects, literal, nullable, discriminatedUnion, …) maps
+ * to a strictly-valid JSON Schema. `target: 'jsonSchema7'` matches what MCP
+ * clients (Claude Code, Continue.dev, etc.) expect; `$refStrategy: 'none'`
+ * inlines everything so a single tool's inputSchema is self-contained.
  */
 function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
-  return describeSchema(schema);
-}
-
-function describeSchema(schema: z.ZodType): Record<string, unknown> {
-  const def = (schema as any)._def;
-  if (!def) return { type: 'object' };
-
-  switch (def.typeName) {
-    case 'ZodObject': {
-      const shape = def.shape();
-      const properties: Record<string, unknown> = {};
-      const required: string[] = [];
-      for (const [k, v] of Object.entries(shape)) {
-        const child = v as z.ZodType;
-        properties[k] = describeSchema(child);
-        if (!isOptional(child)) required.push(k);
-      }
-      return { type: 'object', properties, ...(required.length ? { required } : {}) };
-    }
-    case 'ZodArray':
-      return { type: 'array', items: describeSchema(def.type) };
-    case 'ZodTuple':
-      return { type: 'array', prefixItems: def.items.map((i: z.ZodType) => describeSchema(i)) };
-    case 'ZodEnum':
-      return { type: 'string', enum: def.values };
-    case 'ZodString':
-      return { type: 'string' };
-    case 'ZodNumber':
-      return { type: 'number' };
-    case 'ZodBoolean':
-      return { type: 'boolean' };
-    case 'ZodOptional':
-    case 'ZodDefault':
-      return describeSchema(def.innerType);
-    case 'ZodUnion':
-      return { anyOf: def.options.map((o: z.ZodType) => describeSchema(o)) };
-    case 'ZodRecord':
-      return { type: 'object', additionalProperties: describeSchema(def.valueType) };
-    default:
-      return {};
-  }
-}
-
-function isOptional(schema: z.ZodType): boolean {
-  const def = (schema as any)._def;
-  return def?.typeName === 'ZodOptional' || def?.typeName === 'ZodDefault';
+  const out = zodToJsonSchemaLib(schema, {
+    target: 'jsonSchema7',
+    $refStrategy: 'none',
+  }) as Record<string, unknown>;
+  // Strip the top-level $schema marker — MCP clients don't need it and some
+  // strict validators reject unknown keys at the inputSchema root.
+  delete out.$schema;
+  return out;
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- The hand-rolled Zod->JSON Schema bridge in `server.ts` had no case for `ZodEffects`, so any `.refine()`-wrapped schema (currently just `query_raw_lines`) emitted `{}` with no `type: "object"` at the root.
- Continue.dev validates `inputSchema` strictly and refused to load any tool from the server (`Invalid input: expected "object"` at `tools[3].inputSchema.type`); Claude Code happens to be lenient and accepted it.
- Swap the bridge for [`zod-to-json-schema`](https://www.npmjs.com/package/zod-to-json-schema) (`target: 'jsonSchema7'`, `$refStrategy: 'none'`) so every Zod construct — effects, literal, nullable, discriminatedUnion, etc. — maps to strictly-valid JSON Schema 7. This removes a future-trap where adding a new Zod feature would silently re-break clients.

## Verification
- `npm run build` — clean.
- `npm test` — all 86 tests pass.
- Drove the rebuilt server end-to-end via stdio (`initialize` + `tools/list`); confirmed all 8 tools now expose `type: "object"` at the root.

## Test plan
- [ ] Restart Continue.dev's MCP connection and confirm the Mithril server loads with all 8 tools visible.
- [ ] Sanity-check Claude Code still calls each tool successfully (no behavioral change expected — the schemas describe the same shapes, just with proper JSON Schema framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)