### PR TITLE
refactor: lift audio playback into Mithril.Shared

### DIFF
--- a/src/Gandalf.Module/Gandalf.Module.csproj
+++ b/src/Gandalf.Module/Gandalf.Module.csproj
@@ -9,12 +9,10 @@
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="NAudio" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
-    <ProjectReference Include="..\Samwise.Module\Samwise.Module.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\gandalf.ico" />

--- a/src/Gandalf.Module/Services/TimerAlarmService.cs
+++ b/src/Gandalf.Module/Services/TimerAlarmService.cs
@@ -1,12 +1,12 @@
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
 using Gandalf.Domain;
-using Samwise.Alarms;
+using Mithril.Shared.Audio;
+using Mithril.Shared.Wpf;
 
 namespace Gandalf.Services;
 
-public sealed partial class TimerAlarmService : IDisposable
+public sealed class TimerAlarmService : IDisposable
 {
     private readonly TimerProgressService _progress;
     private readonly GandalfSettings _settings;
@@ -52,12 +52,12 @@ public sealed partial class TimerAlarmService : IDisposable
         _firedIds.Add(id);
         Dispatch(() =>
         {
-            var handle = AlarmSoundPlayer.Play(_settings.SoundFilePath, (float)_settings.AlarmVolume, "gandalf");
+            var handle = AudioPlayer.Play(_settings.SoundFilePath, (float)_settings.AlarmVolume, "gandalf");
             _playback[id] = handle;
             if (_settings.FlashWindow)
             {
                 var win = Application.Current?.MainWindow;
-                if (win is not null) FlashWindow(win);
+                if (win is not null) WindowFlasher.Flash(win);
             }
         });
     }
@@ -78,33 +78,5 @@ public sealed partial class TimerAlarmService : IDisposable
     {
         foreach (var h in _playback.Values) h.Stop();
         _playback.Clear();
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct FLASHWINFO
-    {
-        public uint cbSize;
-        public IntPtr hwnd;
-        public uint dwFlags;
-        public uint uCount;
-        public uint dwTimeout;
-    }
-
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool FlashWindowEx(ref FLASHWINFO pwfi);
-
-    private static void FlashWindow(Window window)
-    {
-        var helper = new System.Windows.Interop.WindowInteropHelper(window);
-        var fi = new FLASHWINFO
-        {
-            cbSize = (uint)Marshal.SizeOf<FLASHWINFO>(),
-            hwnd = helper.Handle,
-            dwFlags = 0x0000000F,
-            uCount = 5,
-            dwTimeout = 0,
-        };
-        FlashWindowEx(ref fi);
     }
 }

--- a/src/Gandalf.Module/Views/GandalfSettingsView.xaml.cs
+++ b/src/Gandalf.Module/Views/GandalfSettingsView.xaml.cs
@@ -1,9 +1,9 @@
 using System.Windows;
 using Gandalf.Domain;
 using Gandalf.ViewModels;
+using Mithril.Shared.Audio;
 using Mithril.Shared.Settings;
 using Microsoft.Win32;
-using Samwise.Alarms;
 
 namespace Gandalf.Views;
 
@@ -24,7 +24,7 @@ public partial class GandalfSettingsView : System.Windows.Controls.UserControl
         var dlg = new OpenFileDialog
         {
             Title = "Choose an alarm sound",
-            Filter = AlarmSoundPlayer.OpenFileFilter,
+            Filter = AudioPlayer.OpenFileFilter,
         };
         if (dlg.ShowDialog() == true) settings.SoundFilePath = dlg.FileName;
     }
@@ -34,7 +34,7 @@ public partial class GandalfSettingsView : System.Windows.Controls.UserControl
         var s = CurrentSettings;
         if (s is null) return;
         _testHandle?.Stop();
-        _testHandle = AlarmSoundPlayer.Play(s.SoundFilePath, (float)s.AlarmVolume, "gandalf");
+        _testHandle = AudioPlayer.Play(s.SoundFilePath, (float)s.AlarmVolume, "gandalf");
     }
 
     private void ClearSound_Click(object sender, RoutedEventArgs e)

--- a/src/Mithril.Shared/Audio/AudioPlayer.cs
+++ b/src/Mithril.Shared/Audio/AudioPlayer.cs
@@ -4,20 +4,14 @@ using NAudio.MediaFoundation;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 
-namespace Samwise.Alarms;
+namespace Mithril.Shared.Audio;
 
-public interface IPlaybackHandle : IDisposable
-{
-    void Stop();
-    bool IsPlaying { get; }
-}
-
-public static class AlarmSoundPlayer
+public static class AudioPlayer
 {
     private static readonly object _lock = new();
     private static readonly List<PlaybackHandle> _active = new();
 
-    static AlarmSoundPlayer()
+    static AudioPlayer()
     {
         MediaFoundationApi.Startup();
     }

--- a/src/Mithril.Shared/Audio/IPlaybackHandle.cs
+++ b/src/Mithril.Shared/Audio/IPlaybackHandle.cs
@@ -1,0 +1,7 @@
+namespace Mithril.Shared.Audio;
+
+public interface IPlaybackHandle : IDisposable
+{
+    void Stop();
+    bool IsPlaying { get; }
+}

--- a/src/Mithril.Shared/Mithril.Shared.csproj
+++ b/src/Mithril.Shared/Mithril.Shared.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Formatting.Compact" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
+    <PackageReference Include="NAudio" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Reference\BundledData\**\*.json" />

--- a/src/Mithril.Shared/Wpf/WindowFlasher.cs
+++ b/src/Mithril.Shared/Wpf/WindowFlasher.cs
@@ -1,0 +1,36 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Mithril.Shared.Wpf;
+
+public static partial class WindowFlasher
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FLASHWINFO
+    {
+        public uint cbSize;
+        public IntPtr hwnd;
+        public uint dwFlags;
+        public uint uCount;
+        public uint dwTimeout;
+    }
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool FlashWindowEx(ref FLASHWINFO pwfi);
+
+    public static void Flash(Window window)
+    {
+        var helper = new WindowInteropHelper(window);
+        var fi = new FLASHWINFO
+        {
+            cbSize = (uint)Marshal.SizeOf<FLASHWINFO>(),
+            hwnd = helper.Handle,
+            dwFlags = 0x0000000F, // FLASHW_ALL | FLASHW_TIMERNOFG = 3 | 12
+            uCount = 5,
+            dwTimeout = 0,
+        };
+        FlashWindowEx(ref fi);
+    }
+}

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using Mithril.Shared.Audio;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Game;
@@ -18,7 +19,6 @@ using Mithril.Shell.ViewModels;
 using Mithril.Shell.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Samwise.Alarms;
 using Velopack;
 
 namespace Mithril.Shell;
@@ -222,12 +222,12 @@ public static class Program
             hk.Attach(hwnd);
             hk.ReloadFromBindings(shellSettings.HotkeyBindings.Values);
 
-            AlarmSoundPlayer.ConcurrentPlayback = audioSettings.ConcurrentAlarms;
+            AudioPlayer.ConcurrentPlayback = audioSettings.ConcurrentAlarms;
             audioSettings.PropertyChanged += (_, ev) =>
             {
                 if (ev.PropertyName == nameof(AudioSettings.ConcurrentAlarms))
                 {
-                    AlarmSoundPlayer.ConcurrentPlayback = audioSettings.ConcurrentAlarms;
+                    AudioPlayer.ConcurrentPlayback = audioSettings.ConcurrentAlarms;
                     shellSettings.ConcurrentAlarms = audioSettings.ConcurrentAlarms;
                 }
             };

--- a/src/Samwise.Module/Alarms/AlarmService.cs
+++ b/src/Samwise.Module/Alarms/AlarmService.cs
@@ -1,13 +1,14 @@
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
+using Mithril.Shared.Audio;
+using Mithril.Shared.Wpf;
 using Samwise.State;
 
 namespace Samwise.Alarms;
 
 public sealed record ActiveAlarm(string Key, string CharName, string CropType, DateTimeOffset Triggered);
 
-public sealed partial class AlarmService : IDisposable
+public sealed class AlarmService : IDisposable
 {
     private readonly GardenStateMachine _state;
     private readonly SamwiseSettings _settings;
@@ -77,13 +78,13 @@ public sealed partial class AlarmService : IDisposable
         Dispatch(() =>
         {
             StopPlayback(alarm.Key);
-            var handle = AlarmSoundPlayer.Play(soundFilePath, (float)_settings.Alarms.AlarmVolume, "samwise");
+            var handle = AudioPlayer.Play(soundFilePath, (float)_settings.Alarms.AlarmVolume, "samwise");
             _playback[alarm.Key] = handle;
 
             if (_settings.Alarms.FlashWindow)
             {
                 var win = Application.Current?.MainWindow;
-                if (win is not null) FlashWindow(win);
+                if (win is not null) WindowFlasher.Flash(win);
             }
 
             AlarmTriggered?.Invoke(this, alarm);
@@ -129,33 +130,5 @@ public sealed partial class AlarmService : IDisposable
     {
         foreach (var h in _playback.Values) h.Stop();
         _playback.Clear();
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct FLASHWINFO
-    {
-        public uint cbSize;
-        public IntPtr hwnd;
-        public uint dwFlags;
-        public uint uCount;
-        public uint dwTimeout;
-    }
-
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool FlashWindowEx(ref FLASHWINFO pwfi);
-
-    private static void FlashWindow(Window window)
-    {
-        var helper = new System.Windows.Interop.WindowInteropHelper(window);
-        var fi = new FLASHWINFO
-        {
-            cbSize = (uint)Marshal.SizeOf<FLASHWINFO>(),
-            hwnd = helper.Handle,
-            dwFlags = 0x0000000F, // FLASHW_ALL | FLASHW_TIMERNOFG = 3 | 12
-            uCount = 5,
-            dwTimeout = 0,
-        };
-        FlashWindowEx(ref fi);
     }
 }

--- a/src/Samwise.Module/Hotkeys/StopAllSoundsCommand.cs
+++ b/src/Samwise.Module/Hotkeys/StopAllSoundsCommand.cs
@@ -1,5 +1,5 @@
+using Mithril.Shared.Audio;
 using Mithril.Shared.Hotkeys;
-using Samwise.Alarms;
 
 namespace Samwise.Hotkeys;
 
@@ -12,7 +12,7 @@ public sealed class StopAllSoundsCommand : IHotkeyCommand
 
     public Task ExecuteAsync(CancellationToken ct)
     {
-        AlarmSoundPlayer.Stop();
+        AudioPlayer.Stop();
         return Task.CompletedTask;
     }
 }

--- a/src/Samwise.Module/Samwise.Module.csproj
+++ b/src/Samwise.Module/Samwise.Module.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="NAudio" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Samwise.Module/Views/SamwiseSettingsView.xaml.cs
+++ b/src/Samwise.Module/Views/SamwiseSettingsView.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Mithril.Shared.Audio;
 using Mithril.Shared.Settings;
 using Microsoft.Win32;
 using Samwise.Alarms;
@@ -19,7 +20,7 @@ public partial class SamwiseSettingsView : System.Windows.Controls.UserControl
         var dlg = new OpenFileDialog
         {
             Title = "Choose an alarm sound",
-            Filter = AlarmSoundPlayer.OpenFileFilter,
+            Filter = AudioPlayer.OpenFileFilter,
         };
         if (dlg.ShowDialog() == true) rule.SoundFilePath = dlg.FileName;
     }
@@ -30,7 +31,7 @@ public partial class SamwiseSettingsView : System.Windows.Controls.UserControl
             && DataContext is SamwiseSettings s)
         {
             _testHandle?.Stop();
-            _testHandle = AlarmSoundPlayer.Play(rule.SoundFilePath, (float)s.Alarms.AlarmVolume, "samwise");
+            _testHandle = AudioPlayer.Play(rule.SoundFilePath, (float)s.Alarms.AlarmVolume, "samwise");
         }
     }
 


### PR DESCRIPTION
## Summary

- Promotes `AlarmSoundPlayer` + `IPlaybackHandle` from `Samwise.Module` to a generic `Mithril.Shared.Audio.AudioPlayer`.
- Consolidates the duplicated `FlashWindowEx` P/Invoke (previously copy-pasted in `Samwise.AlarmService` and `Gandalf.TimerAlarmService`) into a single `Mithril.Shared.Wpf.WindowFlasher.Flash(Window)` helper.
- **Closes the shell→Samwise leak**: `Mithril.Shell/Program.cs` no longer carries `using Samwise.Alarms;`. The shell now imports the architecturally-correct `Mithril.Shared.Audio`.
- **Drops `Gandalf.Module`'s `<ProjectReference>` to `Samwise.Module`** — Gandalf was only depending on Samwise to reach the audio primitive. Gandalf is now a peer of Samwise, not a dependent.
- NAudio package reference moves from two module projects to one shared project; `Samwise.Module.csproj` and `Gandalf.Module.csproj` both drop their direct NAudio reference.

## Scope discipline

Pure refactor, no behavior change. `AlarmService` (Samwise) and `TimerAlarmService` (Gandalf) keep their domain coupling and are unchanged apart from the `using` swap and the `WindowFlasher.Flash` call replacing their inlined P/Invoke. No `IAudioPlayer` interface, no DI-ification, no notification/inbox subsystem — those are deliberate non-goals.

This refactor is independently justified, but also a precondition for the upcoming repeatable-quest-timer work in Gandalf, which needs to reuse the audio primitive without dragging Samwise along.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors (warnings-as-errors enforced).
- [x] `dotnet test Mithril.slnx` — all 12 test projects pass, 973 tests, 0 failures.
- [x] `using Samwise.Alarms` no longer appears in `Mithril.Shell/` or `Gandalf.Module/` (verified via grep).
- [x] Clean build of `Gandalf.Module.csproj` alone touches only `Mithril.Shared` and `Gandalf.Module` — confirms Samwise is fully out of Gandalf's dependency graph.
- [ ] Manual smoke-test in the running app: Test Sound buttons in both Samwise and Gandalf settings, alarm trigger + window flash, Stop-all-sounds hotkey, `ConcurrentAlarms` toggle live-flips `AudioPlayer.ConcurrentPlayback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)