### PR TITLE
tools/RefreshAndValidate: pre-merge CDN drift detector

### DIFF
--- a/.github/workflows/cdn-drift-check.yml
+++ b/.github/workflows/cdn-drift-check.yml
@@ -1,0 +1,35 @@
+name: CDN drift check
+
+# Daily scan of the Project Gorgon CDN to catch schema drift between the live
+# data and the bundled JSON our app ships with. The job is intentionally separate
+# from `Release` so a CDN drift failure doesn't block a tagged release; instead
+# it surfaces a red workflow that flags "Elder Game shipped a new discriminator
+# value, the model layer needs an update."
+#
+# See tools/RefreshAndValidate/Program.cs for the actual logic.
+
+on:
+  schedule:
+    # 08:00 UTC daily — quiet for the CDN, awake for both US and EU triagers.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh-and-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      # Don't `dotnet build Mithril.slnx` — it contains net10.0-windows projects
+      # (every *.Module.csproj plus Mithril.Shared) which won't build on Linux.
+      # `dotnet run --project tools/RefreshAndValidate` only restores/builds
+      # the tool and its single ProjectReference (Mithril.Reference, netstandard2.0).
+      - name: Run drift validator against live CDN
+        run: dotnet run --project tools/RefreshAndValidate --configuration Release

--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -17,6 +17,7 @@
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/XamlResourceLint/XamlResourceLint.csproj" />
+    <Project Path="tools/RefreshAndValidate/RefreshAndValidate.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Mithril.Reference.Tests/Mithril.Reference.Tests.csproj" />

--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -33,5 +33,6 @@
     <Project Path="tests/Smaug.Tests/Smaug.Tests.csproj" />
     <Project Path="tests/Celebrimbor.Tests/Celebrimbor.Tests.csproj" />
     <Project Path="tests/Palantir.Tests/Palantir.Tests.csproj" />
+    <Project Path="tests/RefreshAndValidate.Tests/RefreshAndValidate.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/mithril-reference-shape-quirks.md
+++ b/docs/mithril-reference-shape-quirks.md
@@ -271,3 +271,40 @@ abilities-debug pass, not just the parent field's `kind`. Costs ~10 lines,
 catches this class of bug before it hits the validation harness.
 
 ---
+
+## Operational notes
+
+### Pre-merge drift detection via `tools/RefreshAndValidate`
+
+The `BundledDataValidationTests` harness only gates the JSON checked into
+this repo. The Phase 6 `IDiagnosticsSink` instrumentation only fires *at
+runtime on a user's machine* — by then the broken model is already
+shipped. To close the gap, a daily GitHub Actions cron
+([cdn-drift-check.yml](../.github/workflows/cdn-drift-check.yml)) runs
+[tools/RefreshAndValidate](../tools/RefreshAndValidate/Program.cs) against
+the live CDN. The tool fetches every BundledData file from
+`https://cdn.projectgorgon.com/{version}/data/{file}.json` (version
+auto-detected, with `v469` as the fallback), runs every `IParserSpec`
+discovered in `Mithril.Reference` over them, and exits non-zero on any
+parse failure, sub-floor entry count, or unknown discriminator.
+
+A red `CDN drift check` workflow means **Elder Game shipped a new
+discriminator value the model layer hasn't been updated to recognise**.
+Resolution path:
+
+1. Click into the failing workflow run; the failing file and the new
+   `T`-value (or other discriminator) appear in the log.
+2. In `Mithril.Reference`, add a new concrete subclass for the new
+   discriminator value and an entry in the corresponding
+   `JsonSubTypes`/discriminator map.
+3. Run `dotnet test tests/Mithril.Reference.Tests` locally to confirm
+   the bundled gate still passes.
+4. Commit, PR, merge — the next cron run will go green.
+
+The tool can also be run locally (`dotnet run --project
+tools/RefreshAndValidate`) any time you want to refresh-and-check before
+bumping `src/Mithril.Shared/Reference/BundledData/`. It does not modify
+the bundled JSON; auto-bundled-data-refresh is a deferred follow-up
+([refresh-and-validate-tool.md "Out of scope"](agent-plans/refresh-and-validate-tool.md#out-of-scope-future-follow-ups-in-priority-order)).
+
+---

--- a/tests/RefreshAndValidate.Tests/CdnDriftValidatorTests.cs
+++ b/tests/RefreshAndValidate.Tests/CdnDriftValidatorTests.cs
@@ -1,0 +1,91 @@
+using System.Text;
+using FluentAssertions;
+using Mithril.Reference;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mithril.Tools.RefreshAndValidate.Tests;
+
+[Trait("Category", "FileIO")]
+public class CdnDriftValidatorTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CdnDriftValidatorTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task Validator_succeeds_against_bundled_data()
+    {
+        var specs = ParserRegistry.Discover();
+        var fetcher = new InMemoryFetcher(LoadBundledFiles(specs));
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        var exit = await CdnDriftValidator.RunAsync(
+            fetcher, "test-version", specs, new StringWriter(stdout), new StringWriter(stderr));
+
+        _output.WriteLine(stdout.ToString());
+        if (stderr.Length > 0) _output.WriteLine("--- STDERR ---\n" + stderr);
+
+        exit.Should().Be(0, "bundled data is the canonical fixture and must always pass");
+        stderr.ToString().Should().BeEmpty();
+        stdout.ToString().Should().Contain($"All {specs.Count} files validated against CDN test-version.");
+    }
+
+    [Fact]
+    public async Task Validator_fails_when_unknown_discriminator_injected()
+    {
+        var specs = ParserRegistry.Discover();
+        var bundled = LoadBundledFiles(specs).ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        // Surgical edit: pick the first quest with at least one Requirement and
+        // rewrite its [0].T to a value no QuestRequirement subclass discriminates.
+        const string SyntheticT = "NotARealRequirementType";
+        var quests = JObject.Parse(bundled["quests.json"]);
+        var (questId, _) = MutateFirstQuestRequirement(quests, SyntheticT);
+        bundled["quests.json"] = quests.ToString();
+
+        var fetcher = new InMemoryFetcher(bundled);
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        var exit = await CdnDriftValidator.RunAsync(
+            fetcher, "test-version", specs, new StringWriter(stdout), new StringWriter(stderr));
+
+        _output.WriteLine(stdout.ToString());
+        if (stderr.Length > 0) _output.WriteLine("--- STDERR ---\n" + stderr);
+
+        exit.Should().Be(1, $"injected unknown T='{SyntheticT}' into quest {questId} must trip the gate");
+        stdout.ToString().Should().Contain(SyntheticT);
+        stderr.ToString().Should().Contain("quests.json");
+    }
+
+    private static IReadOnlyDictionary<string, string> LoadBundledFiles(IReadOnlyList<IParserSpec> specs)
+    {
+        var dict = new Dictionary<string, string>(specs.Count, StringComparer.Ordinal);
+        foreach (var spec in specs)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "BundledData", spec.FileName);
+            File.Exists(path).Should().BeTrue(
+                $"missing fixture {path}. Is the Content link in RefreshAndValidate.Tests.csproj correct?");
+            dict[spec.FileName] = File.ReadAllText(path);
+        }
+        return dict;
+    }
+
+    private static (string QuestId, string PreviousT) MutateFirstQuestRequirement(JObject quests, string newT)
+    {
+        foreach (var prop in quests.Properties())
+        {
+            if (prop.Value is not JObject quest) continue;
+            if (quest["Requirements"] is not JArray reqs || reqs.Count == 0) continue;
+            if (reqs[0] is not JObject req || req["T"] is not JValue t) continue;
+
+            var prev = t.Value<string>() ?? "";
+            req["T"] = newT;
+            return (prop.Name, prev);
+        }
+        throw new InvalidOperationException("no quest with a Requirements[0].T value found in bundled quests.json");
+    }
+}

--- a/tests/RefreshAndValidate.Tests/HttpFetcherTests.cs
+++ b/tests/RefreshAndValidate.Tests/HttpFetcherTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace Mithril.Tools.RefreshAndValidate.Tests;
+
+public class HttpFetcherTests
+{
+    [Fact]
+    public async Task Retries_once_on_transient_failure_then_succeeds()
+    {
+        var handler = new ScriptedHandler(new[]
+        {
+            new ScriptedResponse(throwException: true),
+            new ScriptedResponse(content: "{\"ok\":true}"),
+        });
+        using var http = new HttpClient(handler);
+        var fetcher = new HttpFetcher(http, "https://example.test/", "v1", TimeSpan.Zero);
+
+        var body = await fetcher.FetchAsync("test.json");
+
+        body.Should().Be("{\"ok\":true}");
+        handler.CallCount.Should().Be(2, "transient failure should trigger exactly one retry");
+    }
+
+    [Fact]
+    public async Task Throws_aggregated_exception_when_both_attempts_fail()
+    {
+        var handler = new ScriptedHandler(new[]
+        {
+            new ScriptedResponse(throwException: true),
+            new ScriptedResponse(throwException: true),
+        });
+        using var http = new HttpClient(handler);
+        var fetcher = new HttpFetcher(http, "https://example.test/", "v1", TimeSpan.Zero);
+
+        var act = async () => await fetcher.FetchAsync("test.json");
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .Where(ex => ex.Message.Contains("Both attempts"));
+        handler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Single_success_on_first_attempt_does_not_retry()
+    {
+        var handler = new ScriptedHandler(new[]
+        {
+            new ScriptedResponse(content: "{\"ok\":true}"),
+        });
+        using var http = new HttpClient(handler);
+        var fetcher = new HttpFetcher(http, "https://example.test/", "v1", TimeSpan.Zero);
+
+        var body = await fetcher.FetchAsync("test.json");
+
+        body.Should().Be("{\"ok\":true}");
+        handler.CallCount.Should().Be(1);
+    }
+
+    private sealed record ScriptedResponse(string? content = null, bool throwException = false);
+
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly IReadOnlyList<ScriptedResponse> _responses;
+        public int CallCount { get; private set; }
+
+        public ScriptedHandler(IReadOnlyList<ScriptedResponse> responses) => _responses = responses;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var idx = CallCount++;
+            if (idx >= _responses.Count)
+                throw new InvalidOperationException($"unexpected extra fetch (call {idx + 1})");
+
+            var script = _responses[idx];
+            if (script.throwException)
+                throw new HttpRequestException("simulated transient failure");
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(script.content ?? ""),
+            });
+        }
+    }
+}

--- a/tests/RefreshAndValidate.Tests/InMemoryFetcher.cs
+++ b/tests/RefreshAndValidate.Tests/InMemoryFetcher.cs
@@ -1,0 +1,20 @@
+namespace Mithril.Tools.RefreshAndValidate.Tests;
+
+/// <summary>
+/// Test fetcher that returns JSON from a fixed dictionary. Throws
+/// <see cref="KeyNotFoundException"/> on missing files so a test which forgets
+/// to seed a spec sees an obvious failure rather than mysterious empty results.
+/// </summary>
+internal sealed class InMemoryFetcher : IFetcher
+{
+    private readonly IReadOnlyDictionary<string, string> _files;
+
+    public InMemoryFetcher(IReadOnlyDictionary<string, string> files) => _files = files;
+
+    public Task<string> FetchAsync(string fileName, CancellationToken ct = default)
+    {
+        if (!_files.TryGetValue(fileName, out var body))
+            throw new KeyNotFoundException($"InMemoryFetcher has no body for '{fileName}'.");
+        return Task.FromResult(body);
+    }
+}

--- a/tests/RefreshAndValidate.Tests/RefreshAndValidate.Tests.csproj
+++ b/tests/RefreshAndValidate.Tests/RefreshAndValidate.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.Tools.RefreshAndValidate.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <!-- Surgical edit of bundled JSON for the unknown-injection test. -->
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\RefreshAndValidate\RefreshAndValidate.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Reference\Mithril.Reference.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!--
+      Same content-link trick Mithril.Reference.Tests uses: link the bundled JSON
+      from src/Mithril.Shared so test fixtures track the canonical files on disk.
+    -->
+    <Content Include="..\..\src\Mithril.Shared\Reference\BundledData\*.json"
+             Exclude="..\..\src\Mithril.Shared\Reference\BundledData\*.meta.json"
+             Link="BundledData\%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tools/RefreshAndValidate/CdnDriftValidator.cs
+++ b/tools/RefreshAndValidate/CdnDriftValidator.cs
@@ -1,0 +1,112 @@
+using Mithril.Reference;
+
+namespace Mithril.Tools.RefreshAndValidate;
+
+/// <summary>
+/// Runs every <see cref="IParserSpec"/> over JSON pulled from <see cref="IFetcher"/>
+/// and prints a per-file summary plus a final pass/fail line. Returns the process
+/// exit code: 0 if every file parses, meets its <see cref="IParserSpec.MinimumEntryCount"/>
+/// floor, and yields zero <see cref="UnknownReport"/>s; 1 otherwise.
+/// </summary>
+public static class CdnDriftValidator
+{
+    public static async Task<int> RunAsync(
+        IFetcher fetcher,
+        string version,
+        IReadOnlyList<IParserSpec> specs,
+        TextWriter stdout,
+        TextWriter stderr,
+        CancellationToken ct = default)
+    {
+        // Fetch in parallel (small files, but be polite to the CDN — the test harness
+        // and live CDN both serve from the same origin).
+        var jsonByFile = await FetchAllAsync(fetcher, specs, ct);
+
+        // Validate sequentially so output ordering is stable and matches the
+        // alphabetical FileName order ParserRegistry.Discover guarantees.
+        var failures = new List<string>();
+        foreach (var spec in specs)
+        {
+            if (!jsonByFile.TryGetValue(spec.FileName, out var fetched))
+            {
+                failures.Add(spec.FileName);
+                stdout.WriteLine($"FAIL {spec.FileName,-40}      fetch failed (no body)");
+                continue;
+            }
+
+            if (fetched.Error is not null)
+            {
+                failures.Add(spec.FileName);
+                stdout.WriteLine($"FAIL {spec.FileName,-40}      fetch threw: {fetched.Error.GetType().Name}: {fetched.Error.Message}");
+                continue;
+            }
+
+            try
+            {
+                var parsed = spec.Parse(fetched.Body!);
+                var count = spec.CountEntries(parsed);
+                var unknowns = spec.EnumerateUnknowns(parsed).Take(20).ToList();
+
+                var pass = unknowns.Count == 0 && count >= spec.MinimumEntryCount;
+                var status = pass ? "OK  " : "FAIL";
+                stdout.WriteLine($"{status} {spec.FileName,-40} {count,8} entries  {unknowns.Count} unknowns");
+
+                if (!pass)
+                {
+                    failures.Add(spec.FileName);
+                    if (count < spec.MinimumEntryCount)
+                        stdout.WriteLine($"     count {count} < minimum {spec.MinimumEntryCount}");
+                    foreach (var u in unknowns)
+                        stdout.WriteLine($"     {u}");
+                }
+            }
+            catch (Exception ex)
+            {
+                failures.Add(spec.FileName);
+                stdout.WriteLine($"FAIL {spec.FileName,-40}      parse threw: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        stdout.WriteLine();
+        if (failures.Count == 0)
+        {
+            stdout.WriteLine($"All {specs.Count} files validated against CDN {version}.");
+            return 0;
+        }
+
+        stderr.WriteLine($"FAIL: {failures.Count}/{specs.Count} files failed validation against CDN {version}.");
+        stderr.WriteLine("Files: " + string.Join(", ", failures));
+        return 1;
+    }
+
+    private static async Task<Dictionary<string, FetchResult>> FetchAllAsync(
+        IFetcher fetcher,
+        IReadOnlyList<IParserSpec> specs,
+        CancellationToken ct)
+    {
+        // Cap concurrency at 4 — the CDN is small but there's no reason to hammer it,
+        // and a too-wide fanout occasionally trips CDN-side rate-limiting.
+        using var gate = new SemaphoreSlim(4);
+        var tasks = specs.Select(async spec =>
+        {
+            await gate.WaitAsync(ct);
+            try
+            {
+                var body = await fetcher.FetchAsync(spec.FileName, ct);
+                return (spec.FileName, new FetchResult(body, null));
+            }
+            catch (Exception ex)
+            {
+                return (spec.FileName, new FetchResult(null, ex));
+            }
+            finally
+            {
+                gate.Release();
+            }
+        });
+        var results = await Task.WhenAll(tasks);
+        return results.ToDictionary(r => r.FileName, r => r.Item2);
+    }
+
+    private readonly record struct FetchResult(string? Body, Exception? Error);
+}

--- a/tools/RefreshAndValidate/CdnVersionDetector.cs
+++ b/tools/RefreshAndValidate/CdnVersionDetector.cs
@@ -1,0 +1,40 @@
+using System.Net.Http;
+using System.Text.RegularExpressions;
+
+namespace Mithril.Tools.RefreshAndValidate;
+
+/// <summary>
+/// CDN root returns an HTML meta-refresh page rather than an HTTP redirect, e.g.
+/// <c>&lt;meta http-equiv="refresh" content="2; URL=http://cdn.projectgorgon.com/v469/data/index.html"&gt;</c>.
+/// We GET the body and regex out the version segment.
+/// <para>
+/// IMPORTANT: this is duplicated from <c>Mithril.Shared.Reference.CdnVersionDetector</c>
+/// because that project targets <c>net10.0-windows</c> (UseWPF=true) and this tool
+/// is cross-platform. <see cref="FallbackVersion"/> mirrors
+/// <c>Mithril.Shared.Reference.ReferenceDataService.FallbackCdnVersion</c> for the
+/// same reason. When bumping the fallback version, update both places.
+/// </para>
+/// </summary>
+internal static partial class CdnVersionDetector
+{
+    public const string FallbackVersion = "v469";
+
+    [GeneratedRegex(@"/(v\d+)/", RegexOptions.CultureInvariant)]
+    private static partial Regex VersionRx();
+
+    public static async Task<string?> TryDetectAsync(HttpClient http, string root, CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await http.GetAsync(root, ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            var m = VersionRx().Match(body);
+            return m.Success ? m.Groups[1].Value : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/tools/RefreshAndValidate/HttpFetcher.cs
+++ b/tools/RefreshAndValidate/HttpFetcher.cs
@@ -2,25 +2,57 @@ namespace Mithril.Tools.RefreshAndValidate;
 
 /// <summary>
 /// Production fetcher: pulls each BundledData file from
-/// <c>{cdnRoot}{version}/data/{fileName}</c>. A single transient retry is
-/// applied per fetch (slice 3 wires up the delay-injectable form for tests).
+/// <c>{cdnRoot}{version}/data/{fileName}</c>. One transient retry per file;
+/// the second failure is propagated to the validator and reported as a fetch
+/// failure. The retry delay is constructor-injectable so tests can pass
+/// <see cref="TimeSpan.Zero"/> instead of waiting on the wall clock.
 /// </summary>
 public sealed class HttpFetcher : IFetcher
 {
+    private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromSeconds(5);
+
     private readonly HttpClient _http;
     private readonly string _cdnRoot;
     private readonly string _version;
+    private readonly TimeSpan _retryDelay;
 
     public HttpFetcher(HttpClient http, string cdnRoot, string version)
+        : this(http, cdnRoot, version, DefaultRetryDelay) { }
+
+    internal HttpFetcher(HttpClient http, string cdnRoot, string version, TimeSpan retryDelay)
     {
         _http = http;
         _cdnRoot = cdnRoot.EndsWith('/') ? cdnRoot : cdnRoot + "/";
         _version = version;
+        _retryDelay = retryDelay;
     }
 
-    public Task<string> FetchAsync(string fileName, CancellationToken ct = default)
+    public async Task<string> FetchAsync(string fileName, CancellationToken ct = default)
     {
         var url = $"{_cdnRoot}{_version}/data/{fileName}";
-        return _http.GetStringAsync(url, ct);
+        try
+        {
+            return await _http.GetStringAsync(url, ct);
+        }
+        catch (Exception first) when (first is HttpRequestException or TaskCanceledException)
+        {
+            // CDN flake: one second-chance fetch after a short pause. CDN content
+            // is small enough that the latency cost is negligible compared to the
+            // false-positive cost of failing CI on a single TCP hiccup.
+            try { await Task.Delay(_retryDelay, ct); }
+            catch (TaskCanceledException) { throw; }
+
+            try
+            {
+                return await _http.GetStringAsync(url, ct);
+            }
+            catch (Exception second)
+            {
+                throw new HttpRequestException(
+                    $"Both attempts to fetch {url} failed. First: {first.GetType().Name}: {first.Message}. " +
+                    $"Second: {second.GetType().Name}: {second.Message}",
+                    second);
+            }
+        }
     }
 }

--- a/tools/RefreshAndValidate/HttpFetcher.cs
+++ b/tools/RefreshAndValidate/HttpFetcher.cs
@@ -1,0 +1,26 @@
+namespace Mithril.Tools.RefreshAndValidate;
+
+/// <summary>
+/// Production fetcher: pulls each BundledData file from
+/// <c>{cdnRoot}{version}/data/{fileName}</c>. A single transient retry is
+/// applied per fetch (slice 3 wires up the delay-injectable form for tests).
+/// </summary>
+public sealed class HttpFetcher : IFetcher
+{
+    private readonly HttpClient _http;
+    private readonly string _cdnRoot;
+    private readonly string _version;
+
+    public HttpFetcher(HttpClient http, string cdnRoot, string version)
+    {
+        _http = http;
+        _cdnRoot = cdnRoot.EndsWith('/') ? cdnRoot : cdnRoot + "/";
+        _version = version;
+    }
+
+    public Task<string> FetchAsync(string fileName, CancellationToken ct = default)
+    {
+        var url = $"{_cdnRoot}{_version}/data/{fileName}";
+        return _http.GetStringAsync(url, ct);
+    }
+}

--- a/tools/RefreshAndValidate/IFetcher.cs
+++ b/tools/RefreshAndValidate/IFetcher.cs
@@ -1,0 +1,11 @@
+namespace Mithril.Tools.RefreshAndValidate;
+
+/// <summary>
+/// Source of BundledData JSON for the validator. Production wraps an HttpClient;
+/// tests use an in-memory map so the suite is hermetic.
+/// </summary>
+public interface IFetcher
+{
+    /// <summary>Returns the JSON body for <paramref name="fileName"/> (e.g. "quests.json").</summary>
+    Task<string> FetchAsync(string fileName, CancellationToken ct = default);
+}

--- a/tools/RefreshAndValidate/Program.cs
+++ b/tools/RefreshAndValidate/Program.cs
@@ -1,0 +1,23 @@
+// Pre-merge CDN drift detector. Fetches every BundledData file from the live
+// Project Gorgon CDN, runs every IParserSpec from Mithril.Reference over the
+// fetched JSON, and exits non-zero if any unknown discriminator values appear
+// or any file falls below its MinimumEntryCount floor.
+//
+// Designed to run from CI on a daily cron — see .github/workflows/cdn-drift-check.yml.
+
+using Mithril.Reference;
+using Mithril.Tools.RefreshAndValidate;
+
+const string CdnRoot = "https://cdn.projectgorgon.com/";
+
+using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+http.DefaultRequestHeaders.UserAgent.ParseAdd("Mithril.RefreshAndValidate/1.0");
+
+var version = await CdnVersionDetector.TryDetectAsync(http, CdnRoot)
+              ?? CdnVersionDetector.FallbackVersion;
+Console.WriteLine($"CDN version: {version}");
+
+var fetcher = new HttpFetcher(http, CdnRoot, version);
+var specs = ParserRegistry.Discover();
+
+return await CdnDriftValidator.RunAsync(fetcher, version, specs, Console.Out, Console.Error);

--- a/tools/RefreshAndValidate/RefreshAndValidate.csproj
+++ b/tools/RefreshAndValidate/RefreshAndValidate.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Mithril.Tools.RefreshAndValidate</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Tool runs against the live CDN, not the runtime app — opt out of analyzers
+         tuned to the WPF shell (Windows-platform + VS-extension threading). -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <!--
+      Only ProjectReference Mithril.Reference: it's netstandard2.0 and contains every
+      IParserSpec we drive. Mithril.Shared targets net10.0-windows (UseWPF=true) and
+      can't be referenced from this cross-platform tool. CdnVersionDetector and the
+      fallback version literal are duplicated locally — see CdnVersionDetector.cs.
+    -->
+    <ProjectReference Include="..\..\src\Mithril.Reference\Mithril.Reference.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!--
+      Mithril.Reference declares Newtonsoft.Json + JsonSubTypes as PrivateAssets="all"
+      so consumers don't see them at compile time. The IParserSpec implementations
+      use Newtonsoft for deserialization, so we need the assemblies on disk at run
+      time. Restate them here.
+    -->
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="JsonSubTypes" />
+  </ItemGroup>
+</Project>

--- a/tools/RefreshAndValidate/RefreshAndValidate.csproj
+++ b/tools/RefreshAndValidate/RefreshAndValidate.csproj
@@ -20,6 +20,9 @@
     <ProjectReference Include="..\..\src\Mithril.Reference\Mithril.Reference.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="RefreshAndValidate.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <!--
       Mithril.Reference declares Newtonsoft.Json + JsonSubTypes as PrivateAssets="all"
       so consumers don't see them at compile time. The IParserSpec implementations


### PR DESCRIPTION
## Summary

A standalone .NET console tool at `tools/RefreshAndValidate/` that closes the gap between the `BundledDataValidationTests` harness (gates only the JSON checked into the repo) and the Phase 6 `IDiagnosticsSink` runtime instrumentation (only fires on a user's machine, after broken models have shipped).

The tool fetches every BundledData file from the live Project Gorgon CDN, runs every `IParserSpec` discovered in `Mithril.Reference` over them, and exits non-zero on any parse failure, sub-floor entry count, or unknown discriminator. A daily GitHub Actions cron at 08:00 UTC runs it; a red workflow means *Elder Game shipped a new discriminator value and the model layer needs an update*.

Per the design plan in [docs/agent-plans/refresh-and-validate-tool.md](https://github.com/arthur-conde/project-gorgon/blob/main/docs/agent-plans/refresh-and-validate-tool.md).

- Validated locally against CDN **v470** (one ahead of bundled v469): 29 files, zero unknowns. The tool already detected and validated against a CDN refresh the bundled JSON hasn't caught up to yet.
- 5 new tests covering the validator core (bundled-data smoke, unknown-injection failure) and the `HttpFetcher` (single-retry success, both-attempts-fail aggregation, no-retry-on-success).
- Existing 29 `Mithril.Reference.Tests` still green — no regressions.

## Implementation notes

- **Tool ProjectReferences only `Mithril.Reference`** (netstandard2.0). `Mithril.Shared` targets `net10.0-windows` (UseWPF=true) and can't be consumed cross-platform. `CdnVersionDetector` and the `FallbackVersion = \"v469\"` literal are duplicated locally with explicit \"keep in sync\" comments — the duplication is ~25 LOC; the alternative (extracting them into Mithril.Reference) is a public-API refactor outside this tool's scope.
- **`Newtonsoft.Json` and `JsonSubTypes` are restated as `PackageReference`** in the tool csproj. They're `PrivateAssets=\"all\"` inside Mithril.Reference's csproj so they don't transit to consumers; the tool needs them on disk at runtime for `IParserSpec.Parse`.
- **CI runs on `ubuntu-latest`**, not `windows-latest`. The tool is platform-neutral; ubuntu is faster and cheaper. `dotnet run --project tools/RefreshAndValidate` only restores/builds the tool and Mithril.Reference, so the `net10.0-windows` module projects in `Mithril.slnx` aren't an issue.

## What's deliberately out of scope (deferred follow-ups)

1. **Auto-bundled-data-refresh.** When the tool succeeds, copy the fetched JSON into `src/Mithril.Shared/Reference/BundledData/` and open a PR. Needs reviewer policy; defer.
2. **Field-coverage walker.** Walk raw `JObject`s during validation to flag any property name the JSON has that the POCO doesn't. Catches \"new field added to existing type\" — drift the discriminator-only check misses.
3. **Slack/email alerting.** Today's red workflow + GitHub Actions notifications is enough.
4. **Historical drift tracking.** Log per-run summary to a workflow artifact for visualization.

## Test plan

- [x] `dotnet test tests/RefreshAndValidate.Tests` — 5 passed.
- [x] `dotnet test tests/Mithril.Reference.Tests` — 29 passed (regression check).
- [x] `dotnet run --project tools/RefreshAndValidate` against live CDN — all 29 files OK against v470.
- [ ] After merge: `gh workflow run cdn-drift-check.yml` to manually dispatch the new workflow on `main` and confirm it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)