### PR TITLE
ci: fetch full history for cdn-drift-check so NBGV can compute version

### DIFF
--- a/.github/workflows/cdn-drift-check.yml
+++ b/.github/workflows/cdn-drift-check.yml
@@ -23,6 +23,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Nerdbank.GitVersioning (wired in via Directory.Build.targets) needs
+          # full history to compute build height; default fetch-depth: 1 fails
+          # the build. Same reason release.yml does this.
+          fetch-depth: 0
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
The first run of `cdn-drift-check.yml` (PR #31, just merged) failed because Nerdbank.GitVersioning — wired into every build via `Directory.Build.targets` — couldn't compute commit height from the shallow clone that `actions/checkout@v4` does by default.

Add `fetch-depth: 0` to the checkout step. Same fix `release.yml` already has, same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)