### PR TITLE
fix(mithril-log-mcp): replace z.tuple with z.array().length(2) for draft-2020-12

### DIFF
--- a/tools/MithrilLogMcp/src/tools/aggregate.ts
+++ b/tools/MithrilLogMcp/src/tools/aggregate.ts
@@ -29,7 +29,7 @@ export const AggregateInput = z.object({
   event_type: z.array(z.string()).optional(),
   since: z.string().optional(),
   until: z.string().optional(),
-  between: z.tuple([z.string(), z.string()]).optional(),
+  between: z.array(z.string()).length(2).optional(),
   last_session: z.boolean().optional(),
   character: z.string().optional(),
   cursor: z.string().optional(),

--- a/tools/MithrilLogMcp/src/tools/query-events.ts
+++ b/tools/MithrilLogMcp/src/tools/query-events.ts
@@ -21,7 +21,7 @@ export const QueryEventsInput = z.object({
   event_type: z.array(z.string()).optional(),
   since: z.string().optional(),
   until: z.string().optional(),
-  between: z.tuple([z.string(), z.string()]).optional(),
+  between: z.array(z.string()).length(2).optional(),
   last_session: z.boolean().optional(),
   character: z.string().optional(),
   cursor: z.string().optional(),

--- a/tools/MithrilLogMcp/src/tools/query-raw-lines.ts
+++ b/tools/MithrilLogMcp/src/tools/query-raw-lines.ts
@@ -35,7 +35,7 @@ export const QueryRawLinesInput = z
     // Window form 1: since/until/between (same vocabulary as query_events).
     since: z.string().optional(),
     until: z.string().optional(),
-    between: z.tuple([z.string(), z.string()]).optional(),
+    between: z.array(z.string()).length(2).optional(),
 
     // Window form 2: at/around (centered ± duration).
     at: z.string().optional(),

--- a/tools/MithrilLogMcp/src/util/time-windows.ts
+++ b/tools/MithrilLogMcp/src/util/time-windows.ts
@@ -20,16 +20,17 @@ export function resolveWindow(
   args: {
     since?: string | undefined;
     until?: string | undefined;
-    between?: [string, string] | undefined;
+    between?: string[] | undefined;
   },
 ): ResolvedWindow {
   if (args.between) {
-    const since = parseInstant(args.between[0], now);
-    const until = parseInstant(args.between[1], now);
+    const [start, end] = args.between as [string, string];
+    const since = parseInstant(start, now);
+    const until = parseInstant(end, now);
     if (since > until) {
       throw new Error(
-        `'between' range is reversed: '${args.between[0]}' (${since.toISOString()}) ` +
-        `is after '${args.between[1]}' (${until.toISOString()}). Pass [start, end].`,
+        `'between' range is reversed: '${start}' (${since.toISOString()}) ` +
+        `is after '${end}' (${until.toISOString()}). Pass [start, end].`,
       );
     }
     return { since, until };


### PR DESCRIPTION
## Summary

- Anthropic API now rejects tool input schemas that don't validate against JSON Schema draft 2020-12. `z.tuple([z.string(), z.string()])` compiles via `zod-to-json-schema` (target `jsonSchema7`) to `items: [<schema>, <schema>]` — the draft-7 tuple form. Draft 2020-12 requires `items` to be a single schema and moved tuple validation to `prefixItems`, so the API returns `tools.N.custom.input_schema: JSON schema is invalid`.
- Swapped `z.tuple([z.string(), z.string()])` for `z.array(z.string()).length(2)` on the optional `between` field of `query_events`, `aggregate`, and `query_raw_lines`. The new shape compiles to `{ type: "array", items: { type: "string" }, minItems: 2, maxItems: 2 }`, valid in every draft and semantically identical for two homogeneous strings.
- Updated `resolveWindow` helper signature to accept `string[]`, with a tuple cast at the destructure site (Zod's `.length(2)` guarantees the runtime invariant).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 86/86 pass
- [x] Captured `tools/list` over JSON-RPC and walked every input schema; no draft-2020-12 violations remain. Verified `query_events.between` now emits `{"type":"array","items":{"type":"string"},"minItems":2,"maxItems":2}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)