### PR TITLE
feat(gandalf): shell refactor — TabControl with Dashboard / User / Quests / Loot tabs

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -22,7 +22,7 @@ public sealed class GandalfModule : IMithrilModule
     public string? IconUri => "pack://application:,,,/Gandalf.Module;component/Resources/gandalf.ico";
     public int SortOrder => 300;
     public ActivationMode DefaultActivation => ActivationMode.Eager;
-    public Type ViewType => typeof(TimerListView);
+    public Type ViewType => typeof(GandalfShellView);
     public Type? SettingsViewType => typeof(GandalfSettingsView);
 
     public void Register(IServiceCollection services)
@@ -65,9 +65,10 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<IActiveCharacterService>(),
             sp.GetRequiredService<ICharacterPresenceService>()));
 
-        services.AddSingleton<TimerListView>(sp => new TimerListView
+        services.AddSingleton<GandalfShellViewModel>();
+        services.AddSingleton<GandalfShellView>(sp => new GandalfShellView
         {
-            DataContext = sp.GetRequiredService<TimerListViewModel>(),
+            DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
         });
 
         services.AddSingleton<GandalfSettingsViewModel>();

--- a/src/Gandalf.Module/ViewModels/GandalfShellViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/GandalfShellViewModel.cs
@@ -1,0 +1,17 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Gandalf.ViewModels;
+
+public sealed partial class GandalfShellViewModel : ObservableObject
+{
+    public GandalfShellViewModel(TimerListViewModel userTab)
+    {
+        UserTab = userTab;
+    }
+
+    public TimerListViewModel UserTab { get; }
+
+    public string DashboardPlaceholder => "Coming soon";
+    public string QuestsPlaceholder => "Coming soon";
+    public string LootPlaceholder => "Coming soon";
+}

--- a/src/Gandalf.Module/Views/GandalfShellView.xaml
+++ b/src/Gandalf.Module/Views/GandalfShellView.xaml
@@ -1,0 +1,89 @@
+<UserControl x:Class="Gandalf.Views.GandalfShellView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Gandalf.ViewModels"
+             xmlns:views="clr-namespace:Gandalf.Views"
+             Background="#FF1A1A1A">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Gandalf.Module;component/Views/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:TimerListViewModel}">
+                <views:TimerListView/>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel Margin="12">
+        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,12">
+            <StackPanel Orientation="Horizontal">
+                <Image Source="pack://application:,,,/Gandalf.Module;component/Resources/gandalf.ico"
+                       Width="28" Height="28" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Gandalf · Timers"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeHero}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
+            </StackPanel>
+        </DockPanel>
+
+        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0">
+            <TabControl.Resources>
+                <Style TargetType="TabItem">
+                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
+                    <Setter Property="Padding" Value="14,6"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="TabItem">
+                                <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
+                                        BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
+                                    <ContentPresenter ContentSource="Header"/>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
+                                        <Setter Property="Foreground" Value="#FFE8E8E8"/>
+                                    </Trigger>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </TabControl.Resources>
+
+            <TabItem Header="Dashboard" Margin="0,8,0,0">
+                <Border>
+                    <TextBlock Text="{Binding DashboardPlaceholder}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHeader}"/>
+                </Border>
+            </TabItem>
+
+            <TabItem Header="User" Margin="0,8,0,0">
+                <ContentControl Content="{Binding UserTab}"/>
+            </TabItem>
+
+            <TabItem Header="Quests" Margin="0,8,0,0">
+                <Border>
+                    <TextBlock Text="{Binding QuestsPlaceholder}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHeader}"/>
+                </Border>
+            </TabItem>
+
+            <TabItem Header="Loot" Margin="0,8,0,0">
+                <Border>
+                    <TextBlock Text="{Binding LootPlaceholder}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHeader}"/>
+                </Border>
+            </TabItem>
+        </TabControl>
+    </DockPanel>
+</UserControl>

--- a/src/Gandalf.Module/Views/GandalfShellView.xaml.cs
+++ b/src/Gandalf.Module/Views/GandalfShellView.xaml.cs
@@ -1,0 +1,6 @@
+namespace Gandalf.Views;
+
+public partial class GandalfShellView : System.Windows.Controls.UserControl
+{
+    public GandalfShellView() { InitializeComponent(); }
+}

--- a/src/Gandalf.Module/Views/TimerListView.xaml
+++ b/src/Gandalf.Module/Views/TimerListView.xaml
@@ -12,26 +12,19 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <DockPanel Margin="12">
-        <!-- Header -->
-        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,12">
-            <StackPanel Orientation="Horizontal">
-                <Image Source="pack://application:,,,/Gandalf.Module;component/Resources/gandalf.ico"
-                       Width="28" Height="28" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBlock Text="Gandalf · Timers" FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeHero}" FontWeight="SemiBold"
-                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
-            </StackPanel>
-            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Content="Clear done" Padding="10,4" Margin="4,0"
-                        Command="{Binding ClearDoneCommand}"
-                        ToolTip="Reset progress on every finished timer (definitions untouched)"/>
-                <Button Content="Paste" Padding="10,4" Margin="4,0"
-                        Command="{Binding PasteTimersCommand}"
-                        ToolTip="Paste timers from clipboard (JSON)"/>
-                <Button Content="+ Add Timer" Padding="10,4"
-                        Command="{Binding AddTimerCommand}"/>
-            </StackPanel>
-        </DockPanel>
+    <DockPanel>
+        <!-- Action row -->
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Margin="0,0,0,12">
+            <Button Content="Clear done" Padding="10,4" Margin="4,0"
+                    Command="{Binding ClearDoneCommand}"
+                    ToolTip="Reset progress on every finished timer (definitions untouched)"/>
+            <Button Content="Paste" Padding="10,4" Margin="4,0"
+                    Command="{Binding PasteTimersCommand}"
+                    ToolTip="Paste timers from clipboard (JSON)"/>
+            <Button Content="+ Add Timer" Padding="10,4"
+                    Command="{Binding AddTimerCommand}"/>
+        </StackPanel>
 
         <!-- Timer List -->
         <Grid>


### PR DESCRIPTION
## Summary

- Replaces `GandalfModule.ViewType => typeof(TimerListView)` with a new `GandalfShellView` hosting a `TabControl` of four tabs: Dashboard, User, Quests, Loot.
- The User tab re-hosts the existing `TimerListViewModel` via `<ContentControl Content="{Binding UserTab}"/>` plus a `DataTemplate` that maps the VM to `TimerListView` — existing User-tab wiring (alarms, edit, restart, dismiss, reset, character-switch) is untouched.
- The other three tabs render a centered "Coming soon" `TextBlock`. No placeholder VMs — bound to literal strings on `GandalfShellViewModel`.
- Module hero header (icon + "Gandalf · Timers") moves up to `GandalfShellView`, so the embedded `TimerListView` no longer renders a duplicate hero. Action buttons (Clear done, Paste, + Add Timer) stay anchored at the top of the User tab body.
- Module identity (`Id`, `DisplayName`, icon) and the Settings view path are unchanged.

Foundational refactor for the derived-timer-sources plan tracked in [docs/agent-plans/gandalf-derived-timers.md](https://github.com/arthur-conde/project-gorgon/blob/main/docs/agent-plans/gandalf-derived-timers.md). `ITimerSource` (#61), past-anchored `Start` (#62), and the Quest/Loot/Dashboard sources (#63–#65) land in follow-up PRs.

Tracked in #59.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors; XamlResourceLint passes)
- [x] `dotnet test tests/Gandalf.Tests` — 36/36 passing
- [x] Mithril.exe launches and stays alive without crashing
- [ ] **Manual:** open Gandalf tab in app, switch through all four tabs (Dashboard / User / Quests / Loot). Confirm User tab still adds/edits/starts/restarts/deletes timers and that placeholder tabs show "Coming soon" centered. (Could not visually confirm from the agent shell — needs a quick eyeball before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)