### PR TITLE
feat(gandalf): ITimerSource abstraction with catalog/progress split

### DIFF
--- a/src/Gandalf.Module/Domain/ITimerSource.cs
+++ b/src/Gandalf.Module/Domain/ITimerSource.cs
@@ -1,0 +1,61 @@
+namespace Gandalf.Domain;
+
+/// <summary>
+/// Read-only feed of timer rows, common to every Gandalf source — user-curated,
+/// quest cooldowns, loot cooldowns. The catalog is the universe of timers a source
+/// knows about; the progress map is the per-character runtime state for whichever
+/// of those timers the player has interacted with. The split mirrors the natural
+/// separation of derived sources: catalogs are computed from CDN/calibration data
+/// (shared global), progress is observed from logs (per-character).
+///
+/// Forward-compat: <see cref="TimerReady"/> is the canonical signal a row finished
+/// cooling. <see cref="Services.TimerAlarmService"/> consumes it today; a future
+/// shell-level inbox / notification center will subscribe to the same surface to
+/// fan in ready-but-unacked rows across every module. Sources must NOT fire alarms
+/// directly — they emit, services consume.
+/// </summary>
+public interface ITimerSource
+{
+    /// <summary>
+    /// Stable wire identifier. Strings are used (not enums) because future external
+    /// consumers — a shell inbox, an export format — index by this tuple alongside
+    /// the row key.
+    /// </summary>
+    string SourceId { get; }
+
+    IReadOnlyList<TimerCatalogEntry> Catalog { get; }
+
+    /// <summary>
+    /// Per-row runtime state, keyed by <see cref="TimerCatalogEntry.Key"/>. A row
+    /// missing from this map is idle (catalog-known, never started). A row whose
+    /// <see cref="TimerProgressEntry.DismissedAt"/> is non-null is "active but
+    /// hidden" — keep the row, don't delete it; the next observation resurrects
+    /// it with a fresh cooldown.
+    /// </summary>
+    IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; }
+
+    event EventHandler? CatalogChanged;
+    event EventHandler? ProgressChanged;
+    event EventHandler<TimerReadyEventArgs>? TimerReady;
+}
+
+public sealed record TimerCatalogEntry(
+    string Key,
+    string DisplayName,
+    string? Region,
+    TimeSpan Duration,
+    object? SourceMetadata);
+
+public sealed record TimerProgressEntry(
+    string Key,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? DismissedAt);
+
+public sealed class TimerReadyEventArgs : EventArgs
+{
+    public required string SourceId { get; init; }
+    public required string Key { get; init; }
+    public required string DisplayName { get; init; }
+    public required DateTimeOffset ReadyAt { get; init; }
+    public object? SourceMetadata { get; init; }
+}

--- a/src/Gandalf.Module/Domain/TimerRow.cs
+++ b/src/Gandalf.Module/Domain/TimerRow.cs
@@ -1,0 +1,58 @@
+namespace Gandalf.Domain;
+
+/// <summary>
+/// Generic join of one <see cref="TimerCatalogEntry"/> with the matching
+/// <see cref="TimerProgressEntry"/> (or null if the row has never been started).
+/// The cross-source render path consumes this — the User-feed-specific
+/// <see cref="TimerView"/> remains in use inside <c>UserTimerSource</c> and
+/// <c>TimerProgressService</c> for User-only state-machine checks.
+/// </summary>
+public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Progress)
+{
+    public string Key => Catalog.Key;
+    public string Name => Catalog.DisplayName;
+    public string? Region => Catalog.Region;
+    public TimeSpan Duration => Catalog.Duration;
+    public string GroupKey => Catalog.Region ?? "";
+
+    public TimerState State
+    {
+        get
+        {
+            if (Progress is null) return TimerState.Idle;
+            if (Progress.DismissedAt is not null) return TimerState.Idle;
+            if (DateTimeOffset.UtcNow - Progress.StartedAt >= Catalog.Duration) return TimerState.Done;
+            return TimerState.Running;
+        }
+    }
+
+    public TimeSpan Remaining
+    {
+        get
+        {
+            if (Progress is null) return Catalog.Duration;
+            var left = Catalog.Duration - (DateTimeOffset.UtcNow - Progress.StartedAt);
+            return left < TimeSpan.Zero ? TimeSpan.Zero : left;
+        }
+    }
+
+    public DateTimeOffset? CompletedAt
+    {
+        get
+        {
+            if (Progress is null) return null;
+            var stamped = Progress.StartedAt + Catalog.Duration;
+            return DateTimeOffset.UtcNow >= stamped ? stamped : null;
+        }
+    }
+
+    public double Fraction
+    {
+        get
+        {
+            if (Progress is null) return 0.0;
+            if (Catalog.Duration <= TimeSpan.Zero) return 1.0;
+            return Math.Clamp((DateTimeOffset.UtcNow - Progress.StartedAt) / Catalog.Duration, 0.0, 1.0);
+        }
+    }
+}

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -55,9 +55,14 @@ public sealed class GandalfModule : IMithrilModule
 
         services.AddSingleton<TimerDefinitionsService>();
         services.AddSingleton<TimerProgressService>();
+        services.AddSingleton<UserTimerSource>();
+        // Same instance is registered as ITimerSource so the alarm service (and any
+        // future cross-source aggregator) can resolve it via the abstraction.
+        services.AddSingleton<ITimerSource>(sp => sp.GetRequiredService<UserTimerSource>());
         services.AddSingleton<TimerAlarmService>();
 
         services.AddSingleton<TimerListViewModel>(sp => new TimerListViewModel(
+            sp.GetRequiredService<UserTimerSource>(),
             sp.GetRequiredService<TimerDefinitionsService>(),
             sp.GetRequiredService<TimerProgressService>(),
             sp.GetRequiredService<TimerAlarmService>(),

--- a/src/Gandalf.Module/Services/TimerAlarmService.cs
+++ b/src/Gandalf.Module/Services/TimerAlarmService.cs
@@ -6,54 +6,62 @@ using Mithril.Shared.Wpf;
 
 namespace Gandalf.Services;
 
+/// <summary>
+/// Plays the alarm sound + flashes the window when a timer transitions to ready.
+/// Subscribes to <see cref="ITimerSource.TimerReady"/> rather than
+/// <c>TimerProgressService.TimerExpired</c> directly — the source-level event is
+/// the cross-source surface a future shell-level inbox will share. Today only the
+/// user feed is wired in; quest/loot sources will register the same way when those
+/// phases land.
+/// </summary>
 public sealed class TimerAlarmService : IDisposable
 {
-    private readonly TimerProgressService _progress;
+    private readonly ITimerSource _source;
     private readonly GandalfSettings _settings;
-    private readonly HashSet<string> _firedIds = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _firedKeys = new(StringComparer.Ordinal);
     private readonly Dictionary<string, DateTimeOffset> _snoozedUntil = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IPlaybackHandle> _playback = new(StringComparer.Ordinal);
 
-    public TimerAlarmService(TimerProgressService progress, GandalfSettings settings)
+    public TimerAlarmService(ITimerSource source, GandalfSettings settings)
     {
-        _progress = progress;
+        _source = source;
         _settings = settings;
-        _progress.TimerExpired += OnTimerExpired;
+        _source.TimerReady += OnTimerReady;
     }
 
     public void SnoozeAll()
     {
         var until = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(_settings.SnoozeMinutes);
-        foreach (var id in _firedIds.ToArray()) _snoozedUntil[id] = until;
-        _firedIds.Clear();
+        foreach (var key in _firedKeys.ToArray()) _snoozedUntil[key] = until;
+        _firedKeys.Clear();
         StopAllPlayback();
     }
 
     public void DismissAll()
     {
-        _firedIds.Clear();
+        _firedKeys.Clear();
         StopAllPlayback();
     }
 
-    public void Dismiss(string id)
+    public void Dismiss(string key)
     {
-        _firedIds.Remove(id);
-        if (_playback.Remove(id, out var handle))
+        _firedKeys.Remove(key);
+        if (_playback.Remove(key, out var handle))
             handle.Stop();
     }
 
-    private void OnTimerExpired(object? sender, TimerExpiredEventArgs e)
+    private void OnTimerReady(object? sender, TimerReadyEventArgs e)
     {
         if (!_settings.AlarmEnabled) return;
-        var id = e.Def.Id;
-        if (_firedIds.Contains(id)) return;
-        if (_snoozedUntil.TryGetValue(id, out var until) && until > DateTimeOffset.UtcNow) return;
+        var key = e.Key;
+        if (_firedKeys.Contains(key)) return;
+        if (_snoozedUntil.TryGetValue(key, out var until) && until > DateTimeOffset.UtcNow) return;
 
-        _firedIds.Add(id);
+        _firedKeys.Add(key);
         Dispatch(() =>
         {
             var handle = AudioPlayer.Play(_settings.SoundFilePath, (float)_settings.AlarmVolume, "gandalf");
-            _playback[id] = handle;
+            _playback[key] = handle;
             if (_settings.FlashWindow)
             {
                 var win = Application.Current?.MainWindow;
@@ -70,7 +78,7 @@ public sealed class TimerAlarmService : IDisposable
 
     public void Dispose()
     {
-        _progress.TimerExpired -= OnTimerExpired;
+        _source.TimerReady -= OnTimerReady;
         StopAllPlayback();
     }
 

--- a/src/Gandalf.Module/Services/UserTimerSource.cs
+++ b/src/Gandalf.Module/Services/UserTimerSource.cs
@@ -1,0 +1,98 @@
+using Gandalf.Domain;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// <see cref="ITimerSource"/> adapter for the user-curated timer feed. Wraps
+/// <see cref="TimerDefinitionsService"/> (catalog) and <see cref="TimerProgressService"/>
+/// (progress) and bridges <c>TimerExpired</c> into the cross-source <c>TimerReady</c>
+/// surface. User-tab mutation commands route through the underlying services as
+/// before — Quest/Loot sources will own their own analogues when those phases land.
+/// </summary>
+public sealed class UserTimerSource : ITimerSource, IDisposable
+{
+    public const string Id = "gandalf.user";
+
+    private readonly TimerDefinitionsService _defs;
+    private readonly TimerProgressService _progress;
+    private IReadOnlyList<TimerCatalogEntry> _catalog;
+    private IReadOnlyDictionary<string, TimerProgressEntry> _progressMap;
+
+    public UserTimerSource(TimerDefinitionsService defs, TimerProgressService progress)
+    {
+        _defs = defs;
+        _progress = progress;
+        _catalog = ProjectCatalog(defs);
+        _progressMap = ProjectProgress(defs, progress);
+
+        _defs.DefinitionsChanged += OnDefinitionsChanged;
+        _progress.ProgressChanged += OnProgressChanged;
+        _progress.TimerExpired += OnTimerExpired;
+    }
+
+    public string SourceId => Id;
+    public IReadOnlyList<TimerCatalogEntry> Catalog => _catalog;
+    public IReadOnlyDictionary<string, TimerProgressEntry> Progress => _progressMap;
+
+    public event EventHandler? CatalogChanged;
+    public event EventHandler? ProgressChanged;
+    public event EventHandler<TimerReadyEventArgs>? TimerReady;
+
+    private void OnDefinitionsChanged(object? sender, EventArgs e)
+    {
+        _catalog = ProjectCatalog(_defs);
+        // A definition swap can orphan progress entries; reproject so consumers see a
+        // consistent (catalog, progress) snapshot.
+        _progressMap = ProjectProgress(_defs, _progress);
+        CatalogChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnProgressChanged(object? sender, EventArgs e)
+    {
+        _progressMap = ProjectProgress(_defs, _progress);
+        ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnTimerExpired(object? sender, TimerExpiredEventArgs e)
+    {
+        TimerReady?.Invoke(this, new TimerReadyEventArgs
+        {
+            SourceId = Id,
+            Key = e.Def.Id,
+            DisplayName = e.Def.Name,
+            ReadyAt = e.Progress.CompletedAt ?? DateTimeOffset.UtcNow,
+            SourceMetadata = e.Def,
+        });
+    }
+
+    private static IReadOnlyList<TimerCatalogEntry> ProjectCatalog(TimerDefinitionsService defs) =>
+        defs.Definitions
+            .Select(d => new TimerCatalogEntry(
+                Key: d.Id,
+                DisplayName: d.Name,
+                Region: d.GroupKey,
+                Duration: d.Duration,
+                SourceMetadata: d))
+            .ToArray();
+
+    private static IReadOnlyDictionary<string, TimerProgressEntry> ProjectProgress(
+        TimerDefinitionsService defs,
+        TimerProgressService progress)
+    {
+        var map = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal);
+        foreach (var def in defs.Definitions)
+        {
+            var p = progress.GetProgress(def.Id);
+            if (p?.StartedAt is null) continue;
+            map[def.Id] = new TimerProgressEntry(def.Id, p.StartedAt.Value, DismissedAt: null);
+        }
+        return map;
+    }
+
+    public void Dispose()
+    {
+        _defs.DefinitionsChanged -= OnDefinitionsChanged;
+        _progress.ProgressChanged -= OnProgressChanged;
+        _progress.TimerExpired -= OnTimerExpired;
+    }
+}

--- a/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
@@ -26,7 +26,8 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
     public override string PrimaryButtonText => _isEditing ? "Update" : "Save";
 
     public TimerDialogViewModel(
-        TimerView? existing,
+        GandalfTimerDef? existing,
+        bool isIdleOnActive,
         IReadOnlyList<string> knownRegions,
         IReadOnlyList<string> knownMaps)
     {
@@ -40,14 +41,14 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
             // changing Duration mid-run would reinterpret remaining time. Other characters
             // with in-flight progress for the same def accept the new duration on their
             // next render (rare corner case; users can Restart).
-            _isDurationEditable = existing.State == TimerState.Idle;
-            _name = existing.Def.Name;
-            _hours = existing.Def.Duration.Hours > 0 || existing.Def.Duration.Days > 0
-                ? ((int)existing.Def.Duration.TotalHours).ToString() : "";
-            _minutes = existing.Def.Duration.Minutes > 0 ? existing.Def.Duration.Minutes.ToString() : "";
-            _seconds = existing.Def.Duration.Seconds > 0 ? existing.Def.Duration.Seconds.ToString() : "";
-            _region = existing.Def.Region;
-            _map = existing.Def.Map;
+            _isDurationEditable = isIdleOnActive;
+            _name = existing.Name;
+            _hours = existing.Duration.Hours > 0 || existing.Duration.Days > 0
+                ? ((int)existing.Duration.TotalHours).ToString() : "";
+            _minutes = existing.Duration.Minutes > 0 ? existing.Duration.Minutes.ToString() : "";
+            _seconds = existing.Duration.Seconds > 0 ? existing.Duration.Seconds.ToString() : "";
+            _region = existing.Region;
+            _map = existing.Map;
         }
         else
         {

--- a/src/Gandalf.Module/ViewModels/TimerItemViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerItemViewModel.cs
@@ -5,36 +5,35 @@ namespace Gandalf.ViewModels;
 
 public sealed partial class TimerItemViewModel : ObservableObject
 {
-    private TimerView _view;
+    private TimerRow _row;
 
     [ObservableProperty] private bool _elapsedWhileAway;
 
-    public TimerItemViewModel(TimerView view) => _view = view;
+    public TimerItemViewModel(TimerRow row) => _row = row;
 
-    public TimerView View => _view;
+    public TimerRow Row => _row;
+    public TimerCatalogEntry Catalog => _row.Catalog;
 
-    public string Id => _view.Def.Id;
-    public string Name => _view.Def.Name;
-    public string Region => _view.Def.Region;
-    public string Map => _view.Def.Map;
-    public string GroupKey => _view.GroupKey;
+    public string Key => _row.Key;
+    public string Name => _row.Name;
+    public string GroupKey => _row.GroupKey;
 
-    public TimerState State => _view.State;
+    public TimerState State => _row.State;
     public bool IsIdle => State == TimerState.Idle;
     public bool IsRunning => State == TimerState.Running;
     public bool IsDone => State == TimerState.Done;
 
-    public double Fraction => _view.Fraction;
+    public double Fraction => _row.Fraction;
 
     public string TimeDisplay => State switch
     {
-        TimerState.Idle => FormatDuration(_view.Def.Duration),
-        TimerState.Done when _view.Progress.CompletedAt is { } completed =>
+        TimerState.Idle => FormatDuration(_row.Duration),
+        TimerState.Done when _row.CompletedAt is { } completed =>
             (DateTimeOffset.UtcNow - completed).TotalMinutes < 1
                 ? "done!"
                 : $"done {FormatDuration(DateTimeOffset.UtcNow - completed)} ago",
         TimerState.Done => "done!",
-        _ => FormatDuration(_view.Remaining) + " remaining",
+        _ => FormatDuration(_row.Remaining) + " remaining",
     };
 
     public string StatusColor => State switch
@@ -53,24 +52,22 @@ public sealed partial class TimerItemViewModel : ObservableObject
         _ => "?",
     };
 
-    public string DurationLabel => FormatDuration(_view.Def.Duration);
+    public string DurationLabel => FormatDuration(_row.Duration);
 
     public bool ShowStartButton => IsIdle;
     public bool ShowRestartButton => IsDone;
     public bool ShowProgressBar => IsRunning || IsDone;
 
-    /// <summary>Swap in a fresh view (new def + progress snapshot) and re-fire bindings.</summary>
-    public void UpdateView(TimerView view)
+    /// <summary>Swap in a fresh row (new catalog + progress snapshot) and re-fire bindings.</summary>
+    public void UpdateRow(TimerRow row)
     {
-        _view = view;
+        _row = row;
         Refresh();
     }
 
     public void Refresh()
     {
         OnPropertyChanged(nameof(Name));
-        OnPropertyChanged(nameof(Region));
-        OnPropertyChanged(nameof(Map));
         OnPropertyChanged(nameof(GroupKey));
         OnPropertyChanged(nameof(State));
         OnPropertyChanged(nameof(IsIdle));

--- a/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
@@ -15,22 +15,25 @@ namespace Gandalf.ViewModels;
 
 public sealed partial class TimerListViewModel : ObservableObject
 {
-    private readonly TimerDefinitionsService _defs;
-    private readonly TimerProgressService _progress;
-    private readonly TimerAlarmService _alarmService;
-    private readonly IDialogService _dialogService;
-    private readonly IActiveCharacterService _active;
-    private readonly ICharacterPresenceService _presence;
+    private readonly ITimerSource _source;
+    private readonly TimerDefinitionsService? _defs;
+    private readonly TimerProgressService? _progress;
+    private readonly TimerAlarmService? _alarmService;
+    private readonly IDialogService? _dialogService;
+    private readonly IActiveCharacterService? _active;
+    private readonly ICharacterPresenceService? _presence;
     private readonly DispatcherTimer _refreshTimer;
 
     public TimerListViewModel(
-        TimerDefinitionsService defs,
-        TimerProgressService progress,
-        TimerAlarmService alarmService,
-        IDialogService dialogService,
-        IActiveCharacterService active,
-        ICharacterPresenceService presence)
+        ITimerSource source,
+        TimerDefinitionsService? defs = null,
+        TimerProgressService? progress = null,
+        TimerAlarmService? alarmService = null,
+        IDialogService? dialogService = null,
+        IActiveCharacterService? active = null,
+        ICharacterPresenceService? presence = null)
     {
+        _source = source;
         _defs = defs;
         _progress = progress;
         _alarmService = alarmService;
@@ -38,8 +41,8 @@ public sealed partial class TimerListViewModel : ObservableObject
         _active = active;
         _presence = presence;
 
-        _defs.DefinitionsChanged += (_, _) => { SyncFromState(); RefreshAutocomplete(); };
-        _progress.ProgressChanged += (_, _) => SyncFromState();
+        _source.CatalogChanged += (_, _) => { SyncFromState(); RefreshAutocomplete(); };
+        _source.ProgressChanged += (_, _) => SyncFromState();
 
         TimersView = CollectionViewSource.GetDefaultView(Timers);
         TimersView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(TimerItemViewModel.GroupKey)));
@@ -64,7 +67,8 @@ public sealed partial class TimerListViewModel : ObservableObject
     [RelayCommand]
     private void AddTimer()
     {
-        var vm = new TimerDialogViewModel(existing: null, KnownRegions, KnownMaps);
+        if (_defs is null || _dialogService is null) return;
+        var vm = new TimerDialogViewModel(existing: null, isIdleOnActive: true, KnownRegions, KnownMaps);
         var content = new TimerDialogContent();
 
         if (_dialogService.ShowDialog(vm, content) != true) return;
@@ -81,15 +85,15 @@ public sealed partial class TimerListViewModel : ObservableObject
     [RelayCommand]
     private void EditTimer(TimerItemViewModel? item)
     {
-        if (item is null) return;
+        if (item is null || _defs is null || _dialogService is null) return;
+        if (item.Catalog.SourceMetadata is not GandalfTimerDef existing) return;
 
-        var vm = new TimerDialogViewModel(item.View, KnownRegions, KnownMaps);
+        var isIdleOnActive = item.State == TimerState.Idle;
+        var vm = new TimerDialogViewModel(existing, isIdleOnActive, KnownRegions, KnownMaps);
         var content = new TimerDialogContent();
 
         if (_dialogService.ShowDialog(vm, content) != true) return;
-
-        var isIdleOnActive = item.State == TimerState.Idle;
-        _defs.Update(item.Id, d =>
+        _defs.Update(item.Key, d =>
         {
             d.Name = vm.ResultName;
             d.Region = vm.ResultRegion;
@@ -106,41 +110,46 @@ public sealed partial class TimerListViewModel : ObservableObject
     [RelayCommand]
     private void StartTimer(TimerItemViewModel? vm)
     {
-        if (vm is null) return;
+        if (vm is null || _progress is null) return;
         vm.ElapsedWhileAway = false;
-        _progress.Start(vm.Id);
+        _progress.Start(vm.Key);
     }
 
     [RelayCommand]
     private void RestartTimer(TimerItemViewModel? vm)
     {
-        if (vm is null) return;
+        if (vm is null || _progress is null) return;
         vm.ElapsedWhileAway = false;
-        _progress.Restart(vm.Id);
+        _progress.Restart(vm.Key);
     }
 
     [RelayCommand]
     private void DeleteTimer(TimerItemViewModel? vm)
     {
-        if (vm is null) return;
+        if (vm is null || _defs is null) return;
         vm.ElapsedWhileAway = false;
-        _defs.Remove(vm.Id);
+        _defs.Remove(vm.Key);
     }
 
     [RelayCommand]
-    private void ClearDone() => _progress.ClearAllDoneOnActive();
+    private void ClearDone()
+    {
+        _progress?.ClearAllDoneOnActive();
+    }
 
     [RelayCommand]
     private void CopyTimer(TimerItemViewModel? vm)
     {
         if (vm is null) return;
-        var json = TimerClipboard.Serialize([vm.View.Def]);
+        if (vm.Catalog.SourceMetadata is not GandalfTimerDef def) return;
+        var json = TimerClipboard.Serialize([def]);
         try { Clipboard.SetText(json); } catch { }
     }
 
     [RelayCommand]
     private void PasteTimers()
     {
+        if (_defs is null) return;
         string text;
         try { text = Clipboard.GetText(); } catch { return; }
         if (string.IsNullOrWhiteSpace(text)) return;
@@ -156,18 +165,19 @@ public sealed partial class TimerListViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void SnoozeAll() => _alarmService.SnoozeAll();
+    private void SnoozeAll() => _alarmService?.SnoozeAll();
 
     [RelayCommand]
-    private void DismissAll() => _alarmService.DismissAll();
+    private void DismissAll() => _alarmService?.DismissAll();
 
     private void SyncFromState()
     {
         Timers.Clear();
-        foreach (var def in _defs.Definitions)
+        var progress = _source.Progress;
+        foreach (var entry in _source.Catalog)
         {
-            var progress = _progress.GetProgress(def.Id) ?? new TimerProgress();
-            Timers.Add(new TimerItemViewModel(new TimerView(def, progress)));
+            progress.TryGetValue(entry.Key, out var p);
+            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p)));
         }
 
         ApplyElapsedWhileAwayBadges();
@@ -183,6 +193,7 @@ public sealed partial class TimerListViewModel : ObservableObject
     /// </summary>
     private void ApplyElapsedWhileAwayBadges()
     {
+        if (_active is null || _presence is null) return;
         var name = _active.ActiveCharacterName;
         var server = _active.ActiveServer;
         if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(server)) return;
@@ -193,16 +204,19 @@ public sealed partial class TimerListViewModel : ObservableObject
         var now = DateTimeOffset.UtcNow;
         foreach (var vm in Timers)
         {
-            if (ElapsedWhileAwayClassifier.IsElapsedWhileAway(
-                vm.View.Progress, vm.View.Def.Duration, lastActive, now))
-            {
+            if (vm.Row.Progress is null) continue;
+            // Bridge the source-shape progress into the classifier's TimerProgress shape.
+            var progress = new TimerProgress { StartedAt = vm.Row.Progress.StartedAt };
+            if (ElapsedWhileAwayClassifier.IsElapsedWhileAway(progress, vm.Row.Duration, lastActive, now))
                 vm.ElapsedWhileAway = true;
-            }
         }
     }
 
     private void RefreshAutocomplete()
     {
+        // Autocomplete still reads the user-specific def list (Region+Map are user-only fields).
+        if (_defs is null) return;
+
         var regions = _defs.Definitions
             .Select(d => d.Region)
             .Where(r => !string.IsNullOrWhiteSpace(r))
@@ -224,14 +238,15 @@ public sealed partial class TimerListViewModel : ObservableObject
 
     private void Tick()
     {
-        _progress.CheckExpirations();
+        _progress?.CheckExpirations();
         // Re-join with latest progress in case CheckExpirations stamped a CompletedAt.
+        var progress = _source.Progress;
+        var catalog = _source.Catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
         foreach (var vm in Timers)
         {
-            var def = _defs.Definitions.FirstOrDefault(d => d.Id == vm.Id);
-            if (def is null) continue;
-            var progress = _progress.GetProgress(def.Id) ?? new TimerProgress();
-            vm.UpdateView(new TimerView(def, progress));
+            if (!catalog.TryGetValue(vm.Key, out var entry)) continue;
+            progress.TryGetValue(vm.Key, out var p);
+            vm.UpdateRow(new TimerRow(entry, p));
         }
     }
 }

--- a/tests/Gandalf.Tests/FakeTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/FakeTimerSourceTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.ViewModels;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Demonstrates that <see cref="ITimerSource"/> is an open contract — a non-user
+/// implementation can drive the same row-rendering pipeline (<see cref="TimerRow"/>
+/// → <see cref="TimerItemViewModel"/>) the User feed uses, with no coupling to
+/// <c>UserTimerSource</c> or its underlying services.
+///
+/// The full <see cref="TimerListViewModel"/> requires a WPF Dispatcher
+/// (DispatcherTimer + CollectionViewSource); we exercise the projection path it
+/// drives instead — that's where the cross-source contract actually applies.
+/// </summary>
+public class FakeTimerSourceTests
+{
+    private sealed class FakeTimerSource : ITimerSource
+    {
+        public string SourceId { get; }
+        public IReadOnlyList<TimerCatalogEntry> Catalog { get; set; } = [];
+        public IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; set; } =
+            new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal);
+
+        public event EventHandler? CatalogChanged;
+        public event EventHandler? ProgressChanged;
+        public event EventHandler<TimerReadyEventArgs>? TimerReady;
+
+        public FakeTimerSource(string sourceId = "tests.fake") => SourceId = sourceId;
+
+        public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseTimerReady(TimerReadyEventArgs e) => TimerReady?.Invoke(this, e);
+    }
+
+    [Fact]
+    public void Catalog_only_row_projects_to_idle_state()
+    {
+        var source = new FakeTimerSource
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Chest", "Goblin Dungeon", TimeSpan.FromHours(3), SourceMetadata: null)],
+        };
+
+        var row = BuildRow(source, "k1");
+        var vm = new TimerItemViewModel(row);
+
+        vm.State.Should().Be(TimerState.Idle);
+        vm.Name.Should().Be("Chest");
+        vm.GroupKey.Should().Be("Goblin Dungeon");
+        vm.ShowStartButton.Should().BeTrue();
+        vm.ShowProgressBar.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Running_row_reports_remaining_and_fraction()
+    {
+        var source = new FakeTimerSource
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Olugax", "Sun Vale", TimeSpan.FromHours(2), SourceMetadata: null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k1"] = new TimerProgressEntry("k1", DateTimeOffset.UtcNow - TimeSpan.FromHours(1), DismissedAt: null),
+            },
+        };
+
+        var row = BuildRow(source, "k1");
+        var vm = new TimerItemViewModel(row);
+
+        vm.State.Should().Be(TimerState.Running);
+        vm.Fraction.Should().BeApproximately(0.5, 0.01);
+        vm.ShowStartButton.Should().BeFalse();
+        vm.ShowProgressBar.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Past_due_row_reports_done()
+    {
+        var source = new FakeTimerSource
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Quest", "Serbule", TimeSpan.FromMinutes(30), SourceMetadata: null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k1"] = new TimerProgressEntry("k1", DateTimeOffset.UtcNow - TimeSpan.FromHours(1), DismissedAt: null),
+            },
+        };
+
+        var row = BuildRow(source, "k1");
+        var vm = new TimerItemViewModel(row);
+
+        vm.State.Should().Be(TimerState.Done);
+        vm.Fraction.Should().Be(1.0);
+        vm.ShowRestartButton.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dismissed_row_reads_idle_so_it_hides_from_default_view()
+    {
+        var source = new FakeTimerSource
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Chest", "Goblin Dungeon", TimeSpan.FromHours(3), SourceMetadata: null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                // StartedAt set + DismissedAt set = "active row, hidden until next observation"
+                ["k1"] = new TimerProgressEntry("k1",
+                    DateTimeOffset.UtcNow - TimeSpan.FromMinutes(10),
+                    DismissedAt: DateTimeOffset.UtcNow - TimeSpan.FromMinutes(5)),
+            },
+        };
+
+        var row = BuildRow(source, "k1");
+        var vm = new TimerItemViewModel(row);
+
+        vm.State.Should().Be(TimerState.Idle);
+    }
+
+    [Fact]
+    public void Source_metadata_is_carried_through_for_consumers_to_pattern_match()
+    {
+        var meta = new { Zone = "Goblin Dungeon", Internal = "GoblinStaticChest1" };
+        var source = new FakeTimerSource
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Chest", "Goblin Dungeon", TimeSpan.FromHours(3), SourceMetadata: meta)],
+        };
+
+        var row = BuildRow(source, "k1");
+        row.Catalog.SourceMetadata.Should().BeSameAs(meta);
+    }
+
+    [Fact]
+    public void TimerReady_event_carries_source_id_and_metadata()
+    {
+        var source = new FakeTimerSource(sourceId: "tests.fake");
+        var captured = new List<TimerReadyEventArgs>();
+        source.TimerReady += (_, e) => captured.Add(e);
+
+        source.RaiseTimerReady(new TimerReadyEventArgs
+        {
+            SourceId = source.SourceId,
+            Key = "k1",
+            DisplayName = "Chest",
+            ReadyAt = DateTimeOffset.UtcNow,
+            SourceMetadata = "anything",
+        });
+
+        captured.Should().HaveCount(1);
+        captured[0].SourceId.Should().Be("tests.fake");
+        captured[0].Key.Should().Be("k1");
+        captured[0].SourceMetadata.Should().Be("anything");
+    }
+
+    private static TimerRow BuildRow(ITimerSource source, string key)
+    {
+        var entry = source.Catalog.Single(c => c.Key == key);
+        source.Progress.TryGetValue(key, out var p);
+        return new TimerRow(entry, p);
+    }
+}

--- a/tests/Gandalf.Tests/UserTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/UserTimerSourceTests.cs
@@ -1,0 +1,176 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Character;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class UserTimerSourceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _defsPath;
+    private readonly string _charactersDir;
+
+    public UserTimerSourceTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_user_source");
+        _defsPath = Path.Combine(_dir, "definitions.json");
+        _charactersDir = Path.Combine(_dir, "characters");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private (UserTimerSource source, TimerDefinitionsService defs, TimerProgressService progress, FakeActiveCharacterService active)
+        BuildServices()
+    {
+        var defStore = new JsonSettingsStore<GandalfDefinitions>(_defsPath,
+            GandalfDefinitionsJsonContext.Default.GandalfDefinitions);
+        var defs = defStore.Load();
+        var defsSvc = new TimerDefinitionsService(defStore, defs);
+
+        var active = new FakeActiveCharacterService();
+        var store = new PerCharacterStore<GandalfProgress>(_charactersDir, "gandalf.json",
+            GandalfProgressJsonContext.Default.GandalfProgress);
+        var view = new PerCharacterView<GandalfProgress>(active, store);
+        var progressSvc = new TimerProgressService(view, defsSvc,
+            new PerCharacterStoreOptions { CharactersRootDir = _charactersDir });
+
+        var source = new UserTimerSource(defsSvc, progressSvc);
+        return (source, defsSvc, progressSvc, active);
+    }
+
+    [Fact]
+    public void SourceId_is_stable_wire_identifier()
+    {
+        var (source, defs, progress, _) = BuildServices();
+        try
+        {
+            source.SourceId.Should().Be("gandalf.user");
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Catalog_projects_definitions_with_groupkey_as_region()
+    {
+        var (source, defs, progress, _) = BuildServices();
+        try
+        {
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "Chest", Duration = TimeSpan.FromHours(3),
+                Region = "Goblin Dungeon", Map = "Lower",
+            });
+
+            source.Catalog.Should().HaveCount(1);
+            source.Catalog[0].DisplayName.Should().Be("Chest");
+            source.Catalog[0].Region.Should().Be("Goblin Dungeon > Lower");
+            source.Catalog[0].Duration.Should().Be(TimeSpan.FromHours(3));
+            source.Catalog[0].SourceMetadata.Should().BeOfType<GandalfTimerDef>();
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Idle_timer_has_no_progress_entry()
+    {
+        var (source, defs, progress, active) = BuildServices();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+            defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1) });
+
+            source.Progress.Should().BeEmpty();
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Started_timer_appears_in_progress_with_started_at()
+    {
+        var (source, defs, progress, active) = BuildServices();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+            defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1) });
+            var id = defs.Definitions[0].Id;
+
+            progress.Start(id);
+
+            source.Progress.Should().ContainKey(id);
+            source.Progress[id].StartedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(2));
+            source.Progress[id].DismissedAt.Should().BeNull();
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DefinitionsChanged_raises_CatalogChanged()
+    {
+        var (source, defs, progress, _) = BuildServices();
+        try
+        {
+            var fired = 0;
+            source.CatalogChanged += (_, _) => fired++;
+
+            defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1) });
+
+            fired.Should().Be(1);
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void TimerExpired_bridges_to_TimerReady_with_source_id()
+    {
+        var (source, defs, progress, active) = BuildServices();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+            defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromMilliseconds(1) });
+            var id = defs.Definitions[0].Id;
+
+            var captured = new List<TimerReadyEventArgs>();
+            source.TimerReady += (_, e) => captured.Add(e);
+
+            progress.Start(id);
+            // Definitively past-due — well above the 1ms duration, no flake risk.
+            System.Threading.Thread.Sleep(20);
+            progress.CheckExpirations();
+
+            captured.Should().HaveCount(1);
+            captured[0].SourceId.Should().Be("gandalf.user");
+            captured[0].Key.Should().Be(id);
+            captured[0].DisplayName.Should().Be("Chest");
+            captured[0].SourceMetadata.Should().BeOfType<GandalfTimerDef>();
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Lifts the read surface of Gandalf's user-curated timers behind an `ITimerSource` interface so the same render path will serve the upcoming Quest/Loot/Dashboard sources without per-source branches in the VM or alarm service. Pure refactor — no behaviour changes in the User tab.

### What landed

- **`ITimerSource` + records** ([ITimerSource.cs](src/Gandalf.Module/Domain/ITimerSource.cs)) — `SourceId` (stable wire string, not an enum, per the forward-compat note), `IReadOnlyList<TimerCatalogEntry>` catalog, `IReadOnlyDictionary<string, TimerProgressEntry>` progress, plus `CatalogChanged` / `ProgressChanged` / `TimerReady` events. `SourceMetadata` is a typed `object?` so each source can attach its native record (`GandalfTimerDef`, future `QuestEntry`, `LootCatalogEntry`).
- **`TimerRow`** ([TimerRow.cs](src/Gandalf.Module/Domain/TimerRow.cs)) — universal join of catalog entry + optional progress entry, with `State` / `Remaining` / `Fraction` / `CompletedAt` derived. The User-only `TimerView` stays in place for `TimerProgressService` internal state-machine checks.
- **`UserTimerSource`** ([UserTimerSource.cs](src/Gandalf.Module/Services/UserTimerSource.cs)) — `SourceId = "gandalf.user"`. Wraps `TimerDefinitionsService` + `TimerProgressService`, projects definitions → catalog (Region carries the existing `GroupKey` so grouping is preserved), filters Progress to started rows only, and bridges `TimerProgressService.TimerExpired` into a cross-source `TimerReady` event.
- **`TimerAlarmService`** ([TimerAlarmService.cs](src/Gandalf.Module/Services/TimerAlarmService.cs)) — now subscribes to `ITimerSource.TimerReady`. A future `INotificationCenter` can subscribe to the same surface; sources emit, services consume.
- **`TimerListViewModel`** ([TimerListViewModel.cs](src/Gandalf.Module/ViewModels/TimerListViewModel.cs)) — takes an `ITimerSource` for reads. Underlying user services stay injected for User-only mutations (Add/Edit/Delete/Paste/Start/Restart/ClearDone) and are nullable so a fake source can drive render-only tests without dragging in user wiring.
- **`TimerItemViewModel`** ([TimerItemViewModel.cs](src/Gandalf.Module/ViewModels/TimerItemViewModel.cs)) + **`TimerDialogViewModel`** — migrated to consume `TimerRow` / `GandalfTimerDef` directly. The dialog stays User-feed-specific (Region/Map are User-only fields).

### Acceptance check

- [x] `ITimerSource` defined with catalog/progress records in `Gandalf.Module/Domain/`.
- [x] User feed implements `ITimerSource` via the `UserTimerSource` adapter; existing behaviour preserved.
- [x] `TimerListViewModel` consumes `ITimerSource` rather than `TimerDefinitionsService` directly for reads. (User-only mutation methods still route through the underlying services as before — that's User-tab logic that won't translate to Quest/Loot tabs, which will get their own VMs in #63/#64.)
- [x] No regressions: all 36 pre-existing Gandalf tests still pass.
- [x] `FakeTimerSourceTests` demonstrates a non-user implementation drives the `TimerRow` → `TimerItemViewModel` projection (idle / running / done / dismissed states + `TimerReady` event payload). Plus `UserTimerSourceTests` covers the adapter projection and `TimerExpired` → `TimerReady` bridging.

### Forward-compat hooks (per plan §"forward-compat")

- `(SourceId, Key)` is the cross-source identity tuple, exposed on every catalog/progress row and on `TimerReadyEventArgs` — the future shell inbox indexes by this.
- `TimerReady` is the canonical readiness event surface. `TimerAlarmService` is one subscriber today; the inbox will join later without further wiring changes.
- `TimerProgressEntry.DismissedAt` is on the contract from day one; User feed always writes `null` (User's Reset clears the row entirely), but Quest/Loot will use it to keep the row alive across re-observations.
- Shell stays decoupled: `ITimerSource` lives in `Gandalf.Module/Domain/`, not `Mithril.Shared`. Lift to `Mithril.Shared.Notifications` happens when the inbox lands, not before.

Tracked in #61. Foundational for #63 (Quest source), #64 (Loot source), #65 (Dashboard).

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — 1001/1001 passing across all modules
- [x] `dotnet test tests/Gandalf.Tests` — 48/48 (36 pre-existing + 12 new)
- [ ] **Manual:** verify User tab still works end-to-end (add, edit, start, restart, delete, paste, alarms fire on done, character-switch reloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)