### PR TITLE
feat(gandalf): DerivedTimerProgressService with past-anchored Start/Restart/Dismiss

### DIFF
--- a/src/Gandalf.Module/Domain/DerivedProgress.cs
+++ b/src/Gandalf.Module/Domain/DerivedProgress.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+using Mithril.Shared.Character;
+
+namespace Gandalf.Domain;
+
+/// <summary>
+/// Per-row derived-source progress: log-anchored <c>StartedAt</c> (the moment of the
+/// quest completion or chest loot, not when Mithril observed it), plus optional
+/// <c>DismissedAt</c> for the "row hidden until next observation" model. No
+/// <c>CompletedAt</c> — derived rows compute readiness from <c>StartedAt + Duration</c>
+/// so the timestamp is tick-order-independent.
+/// </summary>
+public sealed class DerivedTimerProgress
+{
+    public DateTimeOffset StartedAt { get; set; }
+    public DateTimeOffset? DismissedAt { get; set; }
+}
+
+/// <summary>
+/// Per-character derived-source progress. One file per character —
+/// <c>characters/{slug}/gandalf-derived.json</c> — holds entries from every derived
+/// source (Quest, Loot, future ...), namespaced by <see cref="ITimerSource.SourceId"/>
+/// to keep cross-source key collisions impossible. User timers stay in
+/// <see cref="GandalfProgress"/>; their lifecycle (manual Start, no DismissedAt,
+/// CompletedAt for fire-once alarm bookkeeping) is materially different.
+/// </summary>
+public sealed class DerivedProgress : IVersionedState<DerivedProgress>
+{
+    public const int Version = 1;
+
+    public static int CurrentVersion => Version;
+
+    public static DerivedProgress Migrate(DerivedProgress loaded)
+    {
+        if (loaded.SchemaVersion < Version)
+        {
+            loaded.BySource.Clear();
+            loaded.SchemaVersion = Version;
+        }
+        return loaded;
+    }
+
+    public int SchemaVersion { get; set; } = Version;
+
+    /// <summary>Outer dict keyed by <see cref="ITimerSource.SourceId"/>; inner by row key.</summary>
+    public Dictionary<string, Dictionary<string, DerivedTimerProgress>> BySource { get; set; } =
+        new(StringComparer.Ordinal);
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(DerivedProgress))]
+public partial class DerivedProgressJsonContext : JsonSerializerContext { }

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -49,6 +49,13 @@ public sealed class GandalfModule : IMithrilModule
         // Per-character timer progress (StartedAt / CompletedAt keyed by timer id).
         services.AddPerCharacterModuleStore<GandalfProgress>(Id, GandalfProgressJsonContext.Default.GandalfProgress);
 
+        // Per-character derived-source progress — log-anchored StartedAt + DismissedAt.
+        // Sibling to GandalfProgress; lives in characters/{slug}/gandalf-derived.json.
+        // Quest/Loot sources route through DerivedTimerProgressService exclusively.
+        services.AddPerCharacterModuleStore<DerivedProgress>("gandalf-derived",
+            DerivedProgressJsonContext.Default.DerivedProgress);
+        services.AddSingleton<DerivedTimerProgressService>();
+
         // One-shot startup fanout: split the old combined per-char gandalf.json into the
         // global definitions file + per-char progress files. Runs before module gates open.
         services.AddHostedService<GandalfSplitMigration>();

--- a/src/Gandalf.Module/Services/DerivedTimerProgressService.cs
+++ b/src/Gandalf.Module/Services/DerivedTimerProgressService.cs
@@ -1,0 +1,187 @@
+using Gandalf.Domain;
+using Mithril.Shared.Character;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Per-character progress store for derived (log-observed) timer sources — Quest,
+/// Loot, and any future feed where the cooldown clock anchors on the *log-line
+/// timestamp* rather than user-click-time. <see cref="Start(string,string,DateTimeOffset)"/>
+/// takes an explicit <c>startedAt</c> so log-replay produces correct elapsed times
+/// (a chest looted 90 minutes ago should not show a freshly-restarted 3-hour
+/// cooldown).
+///
+/// Sibling to <see cref="TimerProgressService"/> — derived rows have different
+/// lifecycle semantics (DismissedAt instead of CompletedAt; domain-string keys
+/// instead of GUIDs; GC'd on catalog removal instead of persisting forever) so
+/// they live in their own per-character file with their own service instance.
+/// </summary>
+public sealed class DerivedTimerProgressService : IDisposable
+{
+    private readonly PerCharacterView<DerivedProgress> _view;
+    private readonly TimeProvider _time;
+    private readonly System.Timers.Timer _debounce;
+    private readonly Lock _flushLock = new();
+    private bool _dirty;
+
+    public DerivedTimerProgressService(
+        PerCharacterView<DerivedProgress> view,
+        TimeProvider? time = null)
+    {
+        _view = view;
+        _time = time ?? TimeProvider.System;
+        _view.CurrentChanged += OnCurrentChanged;
+        _debounce = new System.Timers.Timer(500) { AutoReset = false };
+        _debounce.Elapsed += (_, _) => Flush();
+    }
+
+    public event EventHandler? ProgressChanged;
+
+    /// <summary>
+    /// Per-source row state for the active character. Returns an empty map when no
+    /// character is active or the source has never written a row.
+    /// </summary>
+    public IReadOnlyDictionary<string, DerivedTimerProgress> SnapshotFor(string sourceId)
+    {
+        var current = _view.Current;
+        if (current is null) return EmptyMap;
+        return current.BySource.TryGetValue(sourceId, out var inner)
+            ? inner
+            : EmptyMap;
+    }
+
+    public DerivedTimerProgress? GetProgress(string sourceId, string key)
+    {
+        var current = _view.Current;
+        if (current is null) return null;
+        return current.BySource.TryGetValue(sourceId, out var inner)
+               && inner.TryGetValue(key, out var p)
+            ? p
+            : null;
+    }
+
+    /// <summary>
+    /// Stamp <c>StartedAt = startedAt</c> (a log-line timestamp, typically in the
+    /// past) and clear any prior <c>DismissedAt</c>. Re-observation overwrites — a
+    /// re-loot or quest re-completion replaces the previous cooldown clock.
+    /// </summary>
+    public void Start(string sourceId, string key, DateTimeOffset startedAt)
+    {
+        var current = _view.Current;
+        if (current is null) return;
+        var inner = EnsureSourceMap(current, sourceId);
+        if (!inner.TryGetValue(key, out var progress))
+        {
+            progress = new DerivedTimerProgress();
+            inner[key] = progress;
+        }
+        progress.StartedAt = startedAt;
+        progress.DismissedAt = null;
+        SaveNow();
+        ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Alias for <see cref="Start"/>. Derived sources don't distinguish
+    /// "first start" from "restart after done" the way the user feed does — every
+    /// observation is the same operation, semantically. Provided for symmetry with
+    /// <see cref="TimerProgressService"/>.
+    /// </summary>
+    public void Restart(string sourceId, string key, DateTimeOffset startedAt) =>
+        Start(sourceId, key, startedAt);
+
+    /// <summary>
+    /// Stamp <c>DismissedAt = now</c> (TimeProvider clock). The row stays in
+    /// storage so the next observation can resurrect it with a fresh cooldown
+    /// — that's the cross-source "ready and unacked" model.
+    /// </summary>
+    public void Dismiss(string sourceId, string key)
+    {
+        var current = _view.Current;
+        if (current is null) return;
+        if (!current.BySource.TryGetValue(sourceId, out var inner)) return;
+        if (!inner.TryGetValue(key, out var progress)) return;
+        progress.DismissedAt = _time.GetUtcNow();
+        SaveNow();
+        ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Drop progress entries whose key is no longer in the live catalog. Called by
+    /// each source on <c>CatalogChanged</c> so removed quests/chests don't leak
+    /// progress rows forever.
+    /// </summary>
+    public void GarbageCollect(string sourceId, IEnumerable<string> validKeys)
+    {
+        var current = _view.Current;
+        if (current is null) return;
+        if (!current.BySource.TryGetValue(sourceId, out var inner)) return;
+
+        var keep = new HashSet<string>(validKeys, StringComparer.Ordinal);
+        var changed = false;
+        foreach (var key in inner.Keys.ToArray())
+        {
+            if (keep.Contains(key)) continue;
+            inner.Remove(key);
+            changed = true;
+        }
+        if (!changed) return;
+        MarkDirty();
+        ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnCurrentChanged(object? sender, EventArgs e) =>
+        ProgressChanged?.Invoke(this, EventArgs.Empty);
+
+    private static Dictionary<string, DerivedTimerProgress> EnsureSourceMap(
+        DerivedProgress current, string sourceId)
+    {
+        if (!current.BySource.TryGetValue(sourceId, out var inner))
+        {
+            inner = new Dictionary<string, DerivedTimerProgress>(StringComparer.Ordinal);
+            current.BySource[sourceId] = inner;
+        }
+        return inner;
+    }
+
+    private void MarkDirty()
+    {
+        _dirty = true;
+        _debounce.Stop();
+        _debounce.Start();
+    }
+
+    /// <summary>Immediate save — bypasses debounce so derived progress survives a crash.</summary>
+    private void SaveNow()
+    {
+        _debounce.Stop();
+        _dirty = false;
+        FlushCore();
+    }
+
+    private void Flush()
+    {
+        lock (_flushLock)
+        {
+            if (!_dirty) return;
+            _dirty = false;
+            FlushCore();
+        }
+    }
+
+    private void FlushCore()
+    {
+        try { _view.Save(); } catch { /* best-effort */ }
+    }
+
+    public void Dispose()
+    {
+        _view.CurrentChanged -= OnCurrentChanged;
+        _debounce.Stop();
+        _debounce.Dispose();
+        if (_dirty) { try { FlushCore(); } catch { } }
+    }
+
+    private static readonly IReadOnlyDictionary<string, DerivedTimerProgress> EmptyMap =
+        new Dictionary<string, DerivedTimerProgress>(StringComparer.Ordinal);
+}

--- a/tests/Gandalf.Tests/DerivedTimerProgressServiceTests.cs
+++ b/tests/Gandalf.Tests/DerivedTimerProgressServiceTests.cs
@@ -1,0 +1,242 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Character;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class DerivedTimerProgressServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _charactersDir;
+
+    public DerivedTimerProgressServiceTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_derived");
+        _charactersDir = Path.Combine(_dir, "characters");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private (DerivedTimerProgressService svc, PerCharacterView<DerivedProgress> view, FakeActiveCharacterService active, ManualTimeProvider time)
+        BuildService()
+    {
+        var active = new FakeActiveCharacterService();
+        var store = new PerCharacterStore<DerivedProgress>(_charactersDir, "gandalf-derived.json",
+            DerivedProgressJsonContext.Default.DerivedProgress);
+        var view = new PerCharacterView<DerivedProgress>(active, store);
+        var time = new ManualTimeProvider(new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc));
+        var svc = new DerivedTimerProgressService(view, time);
+        return (svc, view, active, time);
+    }
+
+    [Fact]
+    public void Start_with_past_timestamp_anchors_StartedAt_to_log_line_time()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            var ninetyMinAgo = time.GetUtcNow() - TimeSpan.FromMinutes(90);
+            svc.Start("gandalf.loot", "GoblinDungeon:GoblinStaticChest1", ninetyMinAgo);
+
+            var p = svc.GetProgress("gandalf.loot", "GoblinDungeon:GoblinStaticChest1");
+            p.Should().NotBeNull();
+            p!.StartedAt.Should().Be(ninetyMinAgo);
+            p.DismissedAt.Should().BeNull();
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Past_anchored_start_yields_correct_remaining_against_a_fixed_clock()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            var duration = TimeSpan.FromHours(3);
+            var ninetyMinAgo = time.GetUtcNow() - TimeSpan.FromMinutes(90);
+            svc.Start("gandalf.loot", "k1", ninetyMinAgo);
+
+            var p = svc.GetProgress("gandalf.loot", "k1")!;
+            // Compute remaining the way TimerRow does: Duration - (now - StartedAt).
+            var remaining = duration - (time.GetUtcNow() - p.StartedAt);
+
+            remaining.Should().Be(TimeSpan.FromMinutes(90));
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Restart_overwrites_StartedAt_and_clears_dismissal()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            svc.Start("gandalf.loot", "k1", time.GetUtcNow() - TimeSpan.FromHours(2));
+            svc.Dismiss("gandalf.loot", "k1");
+            svc.GetProgress("gandalf.loot", "k1")!.DismissedAt.Should().NotBeNull();
+
+            // Re-loot observed — fresh past-anchored stamp, dismissal cleared.
+            var freshLoot = time.GetUtcNow() - TimeSpan.FromMinutes(5);
+            svc.Restart("gandalf.loot", "k1", freshLoot);
+
+            var p = svc.GetProgress("gandalf.loot", "k1")!;
+            p.StartedAt.Should().Be(freshLoot);
+            p.DismissedAt.Should().BeNull();
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Dismiss_keeps_row_alive_so_next_observation_resurrects_it()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            svc.Start("gandalf.loot", "k1", time.GetUtcNow() - TimeSpan.FromHours(4));
+            svc.Dismiss("gandalf.loot", "k1");
+
+            // Dismissed but not deleted — the row is still queryable.
+            svc.GetProgress("gandalf.loot", "k1").Should().NotBeNull();
+            svc.GetProgress("gandalf.loot", "k1")!.DismissedAt.Should().Be(time.GetUtcNow());
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Dismiss_uses_TimeProvider_clock_not_DateTimeOffset_UtcNow()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+            svc.Start("gandalf.loot", "k1", time.GetUtcNow() - TimeSpan.FromHours(1));
+
+            time.Advance(TimeSpan.FromMinutes(5));
+            svc.Dismiss("gandalf.loot", "k1");
+
+            // DismissedAt should match the advanced clock, not wall time.
+            svc.GetProgress("gandalf.loot", "k1")!.DismissedAt.Should().Be(time.GetUtcNow());
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Sources_are_namespaced_so_keys_dont_collide()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            // Same key string in two sources — must be tracked independently.
+            svc.Start("gandalf.quest", "k1", time.GetUtcNow() - TimeSpan.FromMinutes(30));
+            svc.Start("gandalf.loot", "k1", time.GetUtcNow() - TimeSpan.FromMinutes(10));
+
+            svc.GetProgress("gandalf.quest", "k1")!.StartedAt
+                .Should().Be(time.GetUtcNow() - TimeSpan.FromMinutes(30));
+            svc.GetProgress("gandalf.loot", "k1")!.StartedAt
+                .Should().Be(time.GetUtcNow() - TimeSpan.FromMinutes(10));
+
+            svc.SnapshotFor("gandalf.quest").Should().HaveCount(1);
+            svc.SnapshotFor("gandalf.loot").Should().HaveCount(1);
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GarbageCollect_drops_keys_no_longer_in_catalog()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            svc.Start("gandalf.quest", "alive", time.GetUtcNow() - TimeSpan.FromHours(1));
+            svc.Start("gandalf.quest", "removed", time.GetUtcNow() - TimeSpan.FromHours(1));
+
+            svc.GarbageCollect("gandalf.quest", new[] { "alive" });
+
+            svc.GetProgress("gandalf.quest", "alive").Should().NotBeNull();
+            svc.GetProgress("gandalf.quest", "removed").Should().BeNull();
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Progress_persists_across_service_restart()
+    {
+        var active = new FakeActiveCharacterService();
+        active.SetActiveCharacter("Arthur", "Kwatoxi");
+        var time = new ManualTimeProvider(new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc));
+        var anchored = time.GetUtcNow() - TimeSpan.FromHours(2);
+
+        // First run — write.
+        var store1 = new PerCharacterStore<DerivedProgress>(_charactersDir, "gandalf-derived.json",
+            DerivedProgressJsonContext.Default.DerivedProgress);
+        var view1 = new PerCharacterView<DerivedProgress>(active, store1);
+        var svc1 = new DerivedTimerProgressService(view1, time);
+        svc1.Start("gandalf.loot", "k1", anchored);
+        svc1.Dispose(); view1.Dispose();
+
+        // Second run — read.
+        var store2 = new PerCharacterStore<DerivedProgress>(_charactersDir, "gandalf-derived.json",
+            DerivedProgressJsonContext.Default.DerivedProgress);
+        var view2 = new PerCharacterView<DerivedProgress>(active, store2);
+        var svc2 = new DerivedTimerProgressService(view2, time);
+        try
+        {
+            svc2.GetProgress("gandalf.loot", "k1")!.StartedAt.Should().Be(anchored);
+        }
+        finally
+        {
+            svc2.Dispose(); view2.Dispose();
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTimeProvider(DateTime utcStart) =>
+            _now = new DateTimeOffset(utcStart, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the past-anchored `Start(sourceId, key, startedAt)` entrypoint that derived timer sources (Quest, Loot) need so log-replay on subscribe produces correct elapsed times — a chest looted 90 minutes ago shows a 90-minute-elapsed cooldown, not a freshly-restarted 3-hour one.

### Decision: (b) sibling service, not an overload on `TimerProgressService`

Per the issue's open question and the plan's lean. Derived rows have materially different lifecycle semantics from user rows:

| | User feed | Derived feed |
|---|---|---|
| Identity | GUID per timer def | Domain string `(sourceId, {area}:{internalName})` |
| Mutation trigger | Manual button click (now) | Parser observation (past log timestamp) |
| Acknowledgment | Reset clears the row | Dismiss stamps `DismissedAt`, row stays alive |
| Bookkeeping | `CompletedAt` for fire-once alarms | None — readiness computed from `StartedAt + Duration` |
| GC | Persist forever | GC'd when catalog removes the key |

Mixing storage would invite conditional logic on every code path. Sibling service it is.

### What landed

- **[DerivedTimerProgress + DerivedProgress](src/Gandalf.Module/Domain/DerivedProgress.cs)** — per-row state + per-character store shape. `BySource: Dictionary<sourceId, Dictionary<key, DerivedTimerProgress>>` namespaces sources so `(quest \"k1\")` and `(loot \"k1\")` can't collide. Versioned migration via `IVersionedState<DerivedProgress>`, source-generated JSON contexts (no reflection).
- **[DerivedTimerProgressService](src/Gandalf.Module/Services/DerivedTimerProgressService.cs)** — `Start(sourceId, key, startedAt)`, `Restart(sourceId, key, startedAt)` (alias — derived sources don't distinguish first-start from restart-after-done), `Dismiss(sourceId, key)` (uses `TimeProvider.GetUtcNow()`, not `DateTimeOffset.UtcNow`), `GetProgress`, `SnapshotFor`, `GarbageCollect(sourceId, validKeys)`. Persisted at `characters/{slug}/gandalf-derived.json` via the existing `AddPerCharacterModuleStore<T>` infrastructure. SaveNow on Start/Restart/Dismiss so cooldowns survive a crash; debounced flush on GC.
- **`TimeProvider` injection** rather than a new `IClock` interface — matches the codebase's existing pattern in `TtlList`, `InventoryService`, `ChatLogStream`, `GardenStateMachine`. Tests use the same `ManualTimeProvider` shape Mithril.Shared.Tests already established.
- **DI registration** in `GandalfModule` adds the per-character store + the service; `TimerProgressService` and the user-feed wiring are untouched.

### Acceptance check

- [x] `Start(id, startedAt)` overload exists with `startedAt` honored — the derived service's `Start(sourceId, key, startedAt)` is the past-anchored equivalent.
- [x] Existing `TimerProgressService.Start(id)` call sites unchanged. (Plan's recommended (b) means user feed never gets the past-anchored shape; user clicks are always now-anchored.)
- [x] Same treatment for `Restart` — `DerivedTimerProgressService.Restart(sourceId, key, startedAt)` is an alias for `Start`.
- [x] Persistence layer for derived progress decided + implemented: per-character `gandalf-derived.json`, source-namespaced.
- [x] Test demonstrates past-anchored Start produces correct elapsed time relative to a `ManualTimeProvider`.

### Tests

8 new in `DerivedTimerProgressServiceTests`:

1. Start with past timestamp anchors `StartedAt` to the log-line time, not `UtcNow`.
2. Past-anchored Start + fixed clock → exact remaining-time math.
3. Restart overwrites `StartedAt` and clears prior dismissal (re-loot resurrects).
4. Dismiss keeps the row alive (queryable, not deleted) so next observation can resurrect.
5. Dismiss uses the injected `TimeProvider`, not wall time.
6. Sources are namespaced — same key in two sources tracked independently.
7. `GarbageCollect(sourceId, validKeys)` drops orphaned keys.
8. Progress survives service restart (write → dispose → re-instantiate → read).

Tracked in #62. Foundational for #63 (Quest source) and #64 (Loot source) — both will route every observation through this service.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — 1009/1009 passing across all modules
- [x] `dotnet test tests/Gandalf.Tests` — 56/56 (48 pre-existing + 8 new)
- [ ] **No manual test required.** This PR adds a service that's not yet wired into the UI; the consuming sources (#63, #64) will be where the manual smoke test lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)