### PR TITLE
feat(gandalf): Dashboard aggregator + Dashboard tab — final phase of the derived-timers plan

### DIFF
--- a/src/Gandalf.Module/Domain/TimerSummary.cs
+++ b/src/Gandalf.Module/Domain/TimerSummary.cs
@@ -1,0 +1,20 @@
+namespace Gandalf.Domain;
+
+/// <summary>
+/// Cross-source projection of one timer row, used by the Dashboard aggregator
+/// and (in the future) the shell-level inbox. Every <see cref="ITimerSource"/>
+/// maps its native shape into this uniform record so consumers don't need to
+/// pattern-match the source's metadata.
+///
+/// <see cref="ExpiresAt"/> is null for Idle rows (no active cooldown). For
+/// Cooling rows it's <c>StartedAt + Duration</c>; for Ready rows it's the same
+/// timestamp (already past). Ready/Idle/Cooling/Done are mapped directly from
+/// <see cref="TimerState"/>.
+/// </summary>
+public sealed record TimerSummary(
+    string SourceId,
+    string Key,
+    string DisplayName,
+    string? Region,
+    DateTimeOffset? ExpiresAt,
+    TimerState State);

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -96,10 +96,18 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<TimerDefinitionsService>();
         services.AddSingleton<TimerProgressService>();
         services.AddSingleton<UserTimerSource>();
-        // Same instance is registered as ITimerSource so the alarm service (and any
-        // future cross-source aggregator) can resolve it via the abstraction.
+        // Each source is registered both concretely and as ITimerSource so the
+        // alarm service and the dashboard aggregator can resolve them via the
+        // abstraction. AddSingleton<TInterface>(factory) appends to the
+        // IEnumerable<TInterface> resolution.
         services.AddSingleton<ITimerSource>(sp => sp.GetRequiredService<UserTimerSource>());
+        services.AddSingleton<ITimerSource>(sp => sp.GetRequiredService<QuestSource>());
+        services.AddSingleton<ITimerSource>(sp => sp.GetRequiredService<LootSource>());
         services.AddSingleton<TimerAlarmService>();
+
+        // Dashboard aggregator + VM — fans in every registered ITimerSource.
+        services.AddSingleton<DashboardAggregator>();
+        services.AddSingleton<DashboardViewModel>();
 
         services.AddSingleton<TimerListViewModel>(sp => new TimerListViewModel(
             sp.GetRequiredService<UserTimerSource>(),

--- a/src/Gandalf.Module/Services/DashboardAggregator.cs
+++ b/src/Gandalf.Module/Services/DashboardAggregator.cs
@@ -1,0 +1,95 @@
+using Gandalf.Domain;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Cross-source aggregator. Subscribes to every registered <see cref="ITimerSource"/>'s
+/// <c>CatalogChanged</c> / <c>ProgressChanged</c> events and recomputes a flat
+/// list of <see cref="TimerSummary"/> rows. The Dashboard tab consumes the
+/// aggregator's <see cref="Updated"/> event to refresh its three sections.
+///
+/// No caching beyond the projection itself — recomputation is cheap relative
+/// to the dashboard's 1Hz refresh budget. Driven by <c>TimeProvider</c> so
+/// tests can advance time deterministically.
+/// </summary>
+public sealed class DashboardAggregator : IDisposable
+{
+    private readonly IReadOnlyList<ITimerSource> _sources;
+    private readonly TimeProvider _time;
+    private readonly object _lock = new();
+    private IReadOnlyList<TimerSummary> _summaries = [];
+
+    public DashboardAggregator(IEnumerable<ITimerSource> sources, TimeProvider? time = null)
+    {
+        _sources = sources.ToArray();
+        _time = time ?? TimeProvider.System;
+
+        foreach (var source in _sources)
+        {
+            source.CatalogChanged += OnSourceChanged;
+            source.ProgressChanged += OnSourceChanged;
+        }
+
+        Recompute();
+    }
+
+    /// <summary>Fires whenever any source's catalog or progress changes.</summary>
+    public event EventHandler? Updated;
+
+    public IReadOnlyList<TimerSummary> Summaries
+    {
+        get { lock (_lock) return _summaries; }
+    }
+
+    /// <summary>
+    /// Recomputes <see cref="Summaries"/> using the current TimeProvider clock.
+    /// Called automatically on source events; call manually from the dashboard's
+    /// 1Hz tick so Cooling → Ready transitions show up without a source event.
+    /// </summary>
+    public void Recompute()
+    {
+        var now = _time.GetUtcNow();
+        var list = new List<TimerSummary>();
+        foreach (var source in _sources)
+        {
+            var progress = source.Progress;
+            foreach (var entry in source.Catalog)
+            {
+                progress.TryGetValue(entry.Key, out var p);
+                list.Add(BuildSummary(source.SourceId, entry, p, now));
+            }
+        }
+
+        lock (_lock) _summaries = list;
+        Updated?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static TimerSummary BuildSummary(
+        string sourceId,
+        TimerCatalogEntry entry,
+        TimerProgressEntry? progress,
+        DateTimeOffset now)
+    {
+        if (progress is null || progress.DismissedAt is not null)
+        {
+            return new TimerSummary(sourceId, entry.Key, entry.DisplayName, entry.Region,
+                ExpiresAt: null, State: TimerState.Idle);
+        }
+
+        var expiresAt = progress.StartedAt + entry.Duration;
+        var state = expiresAt <= now ? TimerState.Done : TimerState.Running;
+        return new TimerSummary(sourceId, entry.Key, entry.DisplayName, entry.Region,
+            ExpiresAt: expiresAt, State: state);
+    }
+
+    private void OnSourceChanged(object? sender, EventArgs e) => Recompute();
+
+    public void Dispose()
+    {
+        foreach (var source in _sources)
+        {
+            source.CatalogChanged -= OnSourceChanged;
+            source.ProgressChanged -= OnSourceChanged;
+        }
+    }
+}

--- a/src/Gandalf.Module/Services/TimerAlarmService.cs
+++ b/src/Gandalf.Module/Services/TimerAlarmService.cs
@@ -7,22 +7,23 @@ using Mithril.Shared.Wpf;
 namespace Gandalf.Services;
 
 /// <summary>
-/// Plays the alarm sound + flashes the window when a timer transitions to ready.
-/// Subscribes to <see cref="ITimerSource.TimerReady"/> rather than
-/// <c>TimerProgressService.TimerExpired</c> directly — the source-level event is
-/// the cross-source surface a future shell-level inbox will share. Today only the
-/// user feed is wired in; quest/loot sources will register the same way when those
-/// phases land.
+/// Plays the alarm sound + flashes the window when a user timer transitions to
+/// ready. Subscribes to <see cref="UserTimerSource"/> directly — quest and loot
+/// cooldowns ship through the cross-source <c>DashboardAggregator</c> instead;
+/// dragging derived rows into the user-tab alarm path would surface an audible
+/// alarm for every chest re-loot the player observes, which isn't the user's
+/// expressed preference. Cross-source notification belongs in a future shell
+/// inbox subsystem (see docs/gandalf-roadmap.md non-goals).
 /// </summary>
 public sealed class TimerAlarmService : IDisposable
 {
-    private readonly ITimerSource _source;
+    private readonly UserTimerSource _source;
     private readonly GandalfSettings _settings;
     private readonly HashSet<string> _firedKeys = new(StringComparer.Ordinal);
     private readonly Dictionary<string, DateTimeOffset> _snoozedUntil = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IPlaybackHandle> _playback = new(StringComparer.Ordinal);
 
-    public TimerAlarmService(ITimerSource source, GandalfSettings settings)
+    public TimerAlarmService(UserTimerSource source, GandalfSettings settings)
     {
         _source = source;
         _settings = settings;

--- a/src/Gandalf.Module/ViewModels/DashboardViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,146 @@
+using System.Collections.ObjectModel;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Gandalf.Domain;
+using Gandalf.Services;
+
+namespace Gandalf.ViewModels;
+
+/// <summary>
+/// Read-only home view that aggregates ready/cooling rows across every
+/// <see cref="ITimerSource"/>. Three sections — Ready Now, Coming Up, and a
+/// per-source count chip row. Click-through raises
+/// <see cref="NavigationRequested"/> so the shell can flip to the relevant
+/// tab and scroll the row into view.
+/// </summary>
+public sealed partial class DashboardViewModel : ObservableObject
+{
+    private const int ReadyNowMax = 20;
+    private const int ComingUpMax = 15;
+
+    private readonly DashboardAggregator _aggregator;
+    private readonly DispatcherTimer _refreshTimer;
+
+    public DashboardViewModel(DashboardAggregator aggregator)
+    {
+        _aggregator = aggregator;
+        _aggregator.Updated += (_, _) => Refresh();
+
+        _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        // 1Hz tick so Cooling → Ready transitions show up without a source
+        // event — pure time progression doesn't fire ProgressChanged.
+        _refreshTimer.Tick += (_, _) => { _aggregator.Recompute(); };
+        _refreshTimer.Start();
+
+        Refresh();
+    }
+
+    public ObservableCollection<DashboardRow> ReadyNow { get; } = [];
+    public ObservableCollection<DashboardRow> ComingUp { get; } = [];
+    public ObservableCollection<DashboardSourceChip> SourceChips { get; } = [];
+
+    public event EventHandler<DashboardNavigation>? NavigationRequested;
+
+    [RelayCommand]
+    private void Navigate(DashboardRow? row)
+    {
+        if (row is null) return;
+        NavigationRequested?.Invoke(this, new DashboardNavigation(row.SourceId, row.Key));
+    }
+
+    private void Refresh()
+    {
+        var summaries = _aggregator.Summaries;
+
+        ReadyNow.Clear();
+        var ready = summaries
+            .Where(s => s.State == TimerState.Done && s.ExpiresAt is not null)
+            .OrderByDescending(s => s.ExpiresAt)
+            .Take(ReadyNowMax);
+        foreach (var s in ready) ReadyNow.Add(DashboardRow.From(s));
+
+        ComingUp.Clear();
+        var cooling = summaries
+            .Where(s => s.State == TimerState.Running && s.ExpiresAt is not null)
+            .OrderBy(s => s.ExpiresAt)
+            .Take(ComingUpMax);
+        foreach (var s in cooling) ComingUp.Add(DashboardRow.From(s));
+
+        SourceChips.Clear();
+        var bySource = summaries.GroupBy(s => s.SourceId).OrderBy(g => g.Key);
+        foreach (var group in bySource)
+        {
+            var readyCount = group.Count(s => s.State == TimerState.Done);
+            var coolingCount = group.Count(s => s.State == TimerState.Running);
+            SourceChips.Add(new DashboardSourceChip(
+                SourceId: group.Key,
+                Label: FormatSourceLabel(group.Key, readyCount, coolingCount)));
+        }
+    }
+
+    private static string FormatSourceLabel(string sourceId, int ready, int cooling)
+    {
+        var name = FriendlyName(sourceId);
+        if (ready == 0 && cooling == 0) return $"{name}: idle";
+        var parts = new List<string>(2);
+        if (ready > 0) parts.Add($"{ready} ready");
+        if (cooling > 0) parts.Add($"{cooling} cooling");
+        return $"{name}: {string.Join(" · ", parts)}";
+    }
+
+    private static string FriendlyName(string sourceId) => sourceId switch
+    {
+        "gandalf.user" => "User",
+        "gandalf.quest" => "Quests",
+        "gandalf.loot" => "Loot",
+        _ => sourceId,
+    };
+}
+
+public sealed record DashboardRow(
+    string SourceId,
+    string Key,
+    string DisplayName,
+    string? Region,
+    DateTimeOffset? ExpiresAt,
+    string SourceLabel)
+{
+    public static DashboardRow From(TimerSummary s) => new(
+        SourceId: s.SourceId,
+        Key: s.Key,
+        DisplayName: s.DisplayName,
+        Region: s.Region,
+        ExpiresAt: s.ExpiresAt,
+        SourceLabel: FriendlySourceLabel(s.SourceId));
+
+    public string TimeDisplay
+    {
+        get
+        {
+            if (ExpiresAt is null) return "";
+            var delta = ExpiresAt.Value - DateTimeOffset.UtcNow;
+            if (delta <= TimeSpan.Zero) return Format(-delta) + " ago";
+            return "in " + Format(delta);
+        }
+    }
+
+    private static string Format(TimeSpan ts)
+    {
+        if (ts.TotalHours >= 1) return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+        if (ts.TotalMinutes >= 1) return $"{(int)ts.TotalMinutes}m";
+        return $"{ts.Seconds}s";
+    }
+
+    private static string FriendlySourceLabel(string sourceId) => sourceId switch
+    {
+        "gandalf.user" => "User",
+        "gandalf.quest" => "Quest",
+        "gandalf.loot" => "Loot",
+        _ => sourceId,
+    };
+}
+
+public sealed record DashboardSourceChip(string SourceId, string Label);
+
+public sealed record DashboardNavigation(string SourceId, string Key);

--- a/src/Gandalf.Module/ViewModels/GandalfShellViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/GandalfShellViewModel.cs
@@ -4,19 +4,33 @@ namespace Gandalf.ViewModels;
 
 public sealed partial class GandalfShellViewModel : ObservableObject
 {
+    [ObservableProperty] private int _selectedTabIndex;
+
     public GandalfShellViewModel(
+        DashboardViewModel dashboardTab,
         TimerListViewModel userTab,
         QuestTimersViewModel questsTab,
         LootTimersViewModel lootTab)
     {
+        DashboardTab = dashboardTab;
         UserTab = userTab;
         QuestsTab = questsTab;
         LootTab = lootTab;
+
+        DashboardTab.NavigationRequested += (_, n) => OnNavigationRequested(n.SourceId);
     }
 
+    public DashboardViewModel DashboardTab { get; }
     public TimerListViewModel UserTab { get; }
     public QuestTimersViewModel QuestsTab { get; }
     public LootTimersViewModel LootTab { get; }
 
-    public string DashboardPlaceholder => "Coming soon";
+    private void OnNavigationRequested(string sourceId) =>
+        SelectedTabIndex = sourceId switch
+        {
+            "gandalf.user" => 1,
+            "gandalf.quest" => 2,
+            "gandalf.loot" => 3,
+            _ => SelectedTabIndex,
+        };
 }

--- a/src/Gandalf.Module/Views/DashboardView.xaml
+++ b/src/Gandalf.Module/Views/DashboardView.xaml
@@ -1,0 +1,125 @@
+<UserControl x:Class="Gandalf.Views.DashboardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="#FF1A1A1A">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Gandalf.Module;component/Views/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="0,0,0,16">
+            <ItemsControl ItemsSource="{Binding SourceChips}" Margin="0,0,0,16">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                CornerRadius="12" Padding="10,4" Margin="0,0,8,8">
+                            <TextBlock Text="{Binding Label}" Foreground="#FFE8E8E8"
+                                       FontSize="{DynamicResource AppFontSizeHint}"/>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <TextBlock Text="Ready Now" FontFamily="{DynamicResource AppHeaderFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeHeader}" FontWeight="SemiBold"
+                       Foreground="#FFD4A847" Margin="0,0,0,8"/>
+            <ItemsControl ItemsSource="{Binding ReadyNow}" Margin="0,0,0,16">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                CornerRadius="6" Padding="10" Margin="0,0,0,4">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Grid.Column="0" Background="Transparent" BorderThickness="0"
+                                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                                        Cursor="Hand"
+                                        Command="{Binding DataContext.NavigateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding}">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
+                                                   Foreground="#FFE8E8E8"/>
+                                        <TextBlock Text="{Binding Region}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   Foreground="#88FFFFFF"/>
+                                    </StackPanel>
+                                </Button>
+                                <Border Grid.Column="1" Background="#3F66BB6A" BorderBrush="#7F66BB6A"
+                                        BorderThickness="1" CornerRadius="3" Padding="6,2"
+                                        VerticalAlignment="Center" Margin="0,0,8,0">
+                                    <TextBlock Text="{Binding SourceLabel}" Foreground="#FFE8E8E8"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               FontWeight="SemiBold"/>
+                                </Border>
+                                <TextBlock Grid.Column="2" Text="{Binding TimeDisplay}"
+                                           VerticalAlignment="Center" Foreground="#AAFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <TextBlock Text="Nothing ready"
+                       Visibility="{Binding ReadyNow.Count, Converter={StaticResource ZeroToVis}}"
+                       Foreground="#66FFFFFF" FontStyle="Italic" Margin="0,0,0,16"/>
+
+            <TextBlock Text="Coming Up" FontFamily="{DynamicResource AppHeaderFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeHeader}" FontWeight="SemiBold"
+                       Foreground="#FFD4A847" Margin="0,0,0,8"/>
+            <ItemsControl ItemsSource="{Binding ComingUp}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                CornerRadius="6" Padding="10" Margin="0,0,0,4">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Grid.Column="0" Background="Transparent" BorderThickness="0"
+                                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                                        Cursor="Hand"
+                                        Command="{Binding DataContext.NavigateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding}">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
+                                                   Foreground="#FFE8E8E8"/>
+                                        <TextBlock Text="{Binding Region}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   Foreground="#88FFFFFF"/>
+                                    </StackPanel>
+                                </Button>
+                                <Border Grid.Column="1" Background="#3F5b9bd5" BorderBrush="#7F5b9bd5"
+                                        BorderThickness="1" CornerRadius="3" Padding="6,2"
+                                        VerticalAlignment="Center" Margin="0,0,8,0">
+                                    <TextBlock Text="{Binding SourceLabel}" Foreground="#FFE8E8E8"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               FontWeight="SemiBold"/>
+                                </Border>
+                                <TextBlock Grid.Column="2" Text="{Binding TimeDisplay}"
+                                           VerticalAlignment="Center" Foreground="#AAFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <TextBlock Text="Nothing cooling"
+                       Visibility="{Binding ComingUp.Count, Converter={StaticResource ZeroToVis}}"
+                       Foreground="#66FFFFFF" FontStyle="Italic"/>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Gandalf.Module/Views/DashboardView.xaml.cs
+++ b/src/Gandalf.Module/Views/DashboardView.xaml.cs
@@ -1,0 +1,6 @@
+namespace Gandalf.Views;
+
+public partial class DashboardView : System.Windows.Controls.UserControl
+{
+    public DashboardView() { InitializeComponent(); }
+}

--- a/src/Gandalf.Module/Views/GandalfShellView.xaml
+++ b/src/Gandalf.Module/Views/GandalfShellView.xaml
@@ -20,6 +20,9 @@
             <DataTemplate DataType="{x:Type vm:LootTimersViewModel}">
                 <views:LootTimersView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:DashboardViewModel}">
+                <views:DashboardView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -35,7 +38,8 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0">
+        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0"
+                    SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
             <TabControl.Resources>
                 <Style TargetType="TabItem">
                     <Setter Property="Foreground" Value="#CCFFFFFF"/>
@@ -64,11 +68,7 @@
             </TabControl.Resources>
 
             <TabItem Header="Dashboard" Margin="0,8,0,0">
-                <Border>
-                    <TextBlock Text="{Binding DashboardPlaceholder}"
-                               HorizontalAlignment="Center" VerticalAlignment="Center"
-                               Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHeader}"/>
-                </Border>
+                <ContentControl Content="{Binding DashboardTab}"/>
             </TabItem>
 
             <TabItem Header="User" Margin="0,8,0,0">

--- a/tests/Gandalf.Tests/DashboardAggregatorTests.cs
+++ b/tests/Gandalf.Tests/DashboardAggregatorTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+public sealed class DashboardAggregatorTests
+{
+    private sealed class FakeSource : ITimerSource
+    {
+        public string SourceId { get; }
+        public IReadOnlyList<TimerCatalogEntry> Catalog { get; set; } = [];
+        public IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; set; } =
+            new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal);
+
+        public event EventHandler? CatalogChanged;
+        public event EventHandler? ProgressChanged;
+        public event EventHandler<TimerReadyEventArgs>? TimerReady;
+
+        public FakeSource(string sourceId) => SourceId = sourceId;
+
+        public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseTimerReady() =>
+            TimerReady?.Invoke(this, new TimerReadyEventArgs
+            {
+                SourceId = SourceId, Key = "_", DisplayName = "_", ReadyAt = DateTimeOffset.UtcNow,
+            });
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTime utcStart) => _now = new DateTimeOffset(utcStart, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+
+    private static readonly DateTime Origin = new(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Idle_rows_project_with_state_idle_and_null_expiresAt()
+    {
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null)],
+        };
+        var time = new ManualTime(Origin);
+
+        using var agg = new DashboardAggregator([src], time);
+        var summary = agg.Summaries.Single();
+        summary.State.Should().Be(TimerState.Idle);
+        summary.ExpiresAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Cooling_rows_carry_expiresAt_at_StartedAt_plus_Duration()
+    {
+        var time = new ManualTime(Origin);
+        var startedAt = time.GetUtcNow() - TimeSpan.FromMinutes(30);
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k1"] = new TimerProgressEntry("k1", startedAt, DismissedAt: null),
+            },
+        };
+
+        using var agg = new DashboardAggregator([src], time);
+        var summary = agg.Summaries.Single();
+        summary.State.Should().Be(TimerState.Running);
+        summary.ExpiresAt.Should().Be(startedAt + TimeSpan.FromHours(1));
+    }
+
+    [Fact]
+    public void Past_due_rows_project_as_Done()
+    {
+        var time = new ManualTime(Origin);
+        var startedAt = time.GetUtcNow() - TimeSpan.FromHours(2);
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k1"] = new TimerProgressEntry("k1", startedAt, DismissedAt: null),
+            },
+        };
+
+        using var agg = new DashboardAggregator([src], time);
+        var summary = agg.Summaries.Single();
+        summary.State.Should().Be(TimerState.Done);
+    }
+
+    [Fact]
+    public void Dismissed_rows_project_as_Idle_with_null_expiresAt()
+    {
+        var time = new ManualTime(Origin);
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k1"] = new TimerProgressEntry("k1",
+                    StartedAt: time.GetUtcNow() - TimeSpan.FromHours(2),
+                    DismissedAt: time.GetUtcNow() - TimeSpan.FromMinutes(5)),
+            },
+        };
+
+        using var agg = new DashboardAggregator([src], time);
+        var summary = agg.Summaries.Single();
+        summary.State.Should().Be(TimerState.Idle);
+        summary.ExpiresAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Aggregates_across_multiple_sources_with_source_id_preserved()
+    {
+        var time = new ManualTime(Origin);
+        var a = new FakeSource("gandalf.user")
+        {
+            Catalog = [new TimerCatalogEntry("u1", "User Timer", null, TimeSpan.FromMinutes(5), null)],
+        };
+        var b = new FakeSource("gandalf.quest")
+        {
+            Catalog = [new TimerCatalogEntry("q1", "Quest 1", "Serbule", TimeSpan.FromHours(20), null)],
+        };
+
+        using var agg = new DashboardAggregator([a, b], time);
+
+        agg.Summaries.Should().HaveCount(2);
+        agg.Summaries.Should().Contain(s => s.SourceId == "gandalf.user" && s.Key == "u1");
+        agg.Summaries.Should().Contain(s => s.SourceId == "gandalf.quest" && s.Key == "q1");
+    }
+
+    [Fact]
+    public void Updated_event_fires_when_a_source_raises_ProgressChanged()
+    {
+        var src = new FakeSource("gandalf.test");
+        var time = new ManualTime(Origin);
+
+        using var agg = new DashboardAggregator([src], time);
+        var fired = 0;
+        agg.Updated += (_, _) => fired++;
+
+        src.RaiseProgressChanged();
+        src.RaiseProgressChanged();
+
+        fired.Should().Be(2);
+    }
+
+    [Fact]
+    public void Updated_event_fires_when_a_source_raises_CatalogChanged()
+    {
+        var src = new FakeSource("gandalf.test");
+        var time = new ManualTime(Origin);
+
+        using var agg = new DashboardAggregator([src], time);
+        var fired = 0;
+        agg.Updated += (_, _) => fired++;
+
+        src.RaiseCatalogChanged();
+
+        fired.Should().Be(1);
+    }
+
+    [Fact]
+    public void Recompute_picks_up_time_progression_without_a_source_event()
+    {
+        var time = new ManualTime(Origin);
+        var startedAt = time.GetUtcNow();
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromMinutes(10), null)],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k1"] = new TimerProgressEntry("k1", startedAt, DismissedAt: null),
+            },
+        };
+
+        using var agg = new DashboardAggregator([src], time);
+        agg.Summaries.Single().State.Should().Be(TimerState.Running);
+
+        // Time advances past the cooldown — no source event, but Recompute()
+        // (called from the dashboard's 1Hz tick) reflects the transition.
+        time.Advance(TimeSpan.FromMinutes(15));
+        agg.Recompute();
+
+        agg.Summaries.Single().State.Should().Be(TimerState.Done);
+    }
+
+    [Fact]
+    public void Dispose_unsubscribes_so_aggregator_does_not_keep_sources_alive()
+    {
+        var src = new FakeSource("gandalf.test");
+        var time = new ManualTime(Origin);
+
+        var agg = new DashboardAggregator([src], time);
+        var fired = 0;
+        agg.Updated += (_, _) => fired++;
+
+        agg.Dispose();
+        src.RaiseProgressChanged();
+
+        fired.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

Ships **#65** — the final phase of the Gandalf derived-timers plan. A read-only Dashboard tab that fans in **every** registered `ITimerSource` (User + Quest + Loot today, future feeds plug in for free) and surfaces a single home view for "what's ready right now and what's coming up next".

### What landed

**[TimerSummary](src/Gandalf.Module/Domain/TimerSummary.cs)** — uniform cross-source row projection. Future shell-level inbox can index by the same `(SourceId, Key)` tuple.

**[DashboardAggregator](src/Gandalf.Module/Services/DashboardAggregator.cs)**:
- Subscribes to `CatalogChanged` + `ProgressChanged` on every `IEnumerable<ITimerSource>` resolved from DI.
- Recomputes the projection on each event; exposes a public `Recompute()` for passive time progression.
- `TimeProvider` injection so tests advance time deterministically.
- Disposes its subscriptions cleanly.

**[DashboardViewModel](src/Gandalf.Module/ViewModels/DashboardViewModel.cs) + [DashboardView](src/Gandalf.Module/Views/DashboardView.xaml)**:
- **Per-source chip row** at the top: `"User: 3 ready · Quests: 5 cooling · Loot: 2 ready"`.
- **Ready Now** (top 20, sorted by most-recently-ready descending) — green source badge + DisplayName + Region + relative time ("5m ago").
- **Coming Up** (top 15, sorted by `ExpiresAt` ascending) — blue source badge + same shape with "in 1h 30m" remaining.
- 1Hz `DispatcherTimer` drives `aggregator.Recompute()` so Cooling → Ready transitions render without a source event.
- Click-through raises `NavigationRequested(sourceId, key)`; `GandalfShellViewModel` flips `SelectedTabIndex` to the corresponding tab. (Per-row scroll-into-view is a follow-up; out of scope here.)

### DI changes (and the alarm-service knock-on)

`ITimerSource` is now registered three times (one for each source) so DI's `IEnumerable<ITimerSource>` resolution picks all three for the aggregator.

That breaks the existing `TimerAlarmService(ITimerSource source, ...)` — under MS DI's "last registration wins" semantics for non-IEnumerable resolution, it would silently switch from User to Loot. Fixed by switching `TimerAlarmService` to depend on `UserTimerSource` concretely. Quest/Loot cooldowns deliberately don't trigger alarms here:

- The user hasn't asked for an audible alarm on every chest re-loot or quest completion.
- Per [docs/gandalf-roadmap.md non-goals](docs/gandalf-roadmap.md), cross-source notification belongs in a future shell inbox subsystem, not the user-tab alarm path.
- The architecture stays inbox-ready: derived sources still fire `TimerReady`; the future inbox subscribes to that surface.

### Acceptance check

- [x] `DashboardAggregator` subscribes to all registered `ITimerSource` instances and emits `TimerSummary` projections.
- [x] Dashboard renders Ready Now, Coming Up, and per-source count sections.
- [x] Click-through navigates to the correct tab. (Row-scroll-into-view is a follow-up.)
- [x] Updates within 1s of a source's `ProgressChanged` event (event-driven) AND within 1s of pure time progression (1Hz tick).
- [x] No regressions on individual source tabs — 110/110 Gandalf tests pass, including all User / Quest / Loot suites.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — **1081/1081** passing solution-wide
- [x] `dotnet test tests/Gandalf.Tests` — **110/110** (101 pre-existing + 9 new aggregator tests covering Idle/Cooling/Done/Dismissed projections, multi-source aggregation, event bridging, time-progression-only Recompute, and Dispose unsubscription)
- [ ] **Manual:** open Gandalf → Dashboard. With at least one user timer running and one chest cooldown observed, confirm chip row counts, Ready Now / Coming Up sections populate, and click-through flips to the right tab.

## Plan complete

This PR closes the last open phase of [docs/agent-plans/gandalf-derived-timers.md](docs/agent-plans/gandalf-derived-timers.md):

```
#59 ✓  shell refactor (PR #66)
#61 ✓  ITimerSource abstraction (PR #68)
#62 ✓  past-anchored DerivedTimerProgressService (PR #69)
#63 ✓  Quest source (PR #71)
#64 ✓  Loot source (PR #70)
#65 ✓  Dashboard aggregation (this PR)
```

#60 (parser spike) carried forward as **Verification owed** markers in the Quest parsers + the boss "reduced rewards" cooldown line; capture-and-refine when a live session is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)