### PR TITLE
fix(gandalf): replace chest naming heuristic with signal-driven loot detection

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -72,6 +72,7 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<ChestInteractionParser>();
         services.AddSingleton<ChestRejectionParser>();
         services.AddSingleton<DefeatRewardParser>();
+        services.AddSingleton<LootBracketTracker>();
         services.AddSingleton(sp => DefeatCatalogSeed.Bundled);
         services.AddSingleton<LootSource>(sp => new LootSource(
             sp.GetRequiredService<DerivedTimerProgressService>(),

--- a/src/Gandalf.Module/Parsing/ChestInteractionParser.cs
+++ b/src/Gandalf.Module/Parsing/ChestInteractionParser.cs
@@ -1,25 +1,27 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Mithril.Shared.Logging;
 
 namespace Gandalf.Parsing;
 
 /// <summary>
-/// Parses <c>ProcessStartInteraction</c> lines for static-chest interactions.
-/// Per the wiki page Player-Log-Signals (Static treasure chests):
-/// <c>LocalPlayer: ProcessStartInteraction(-162, 7, 0, False, "GoblinStaticChest1")</c>
-/// where the trailing quoted token is the chest's prefab name. The integer
-/// interactor id is reused across static interactors, so we key off the prefab
-/// name only.
+/// Parses any <c>ProcessStartInteraction</c> line into an
+/// <see cref="InteractionStartEvent"/>. The parser is intentionally broad —
+/// loot vs storage vs NPC discrimination happens downstream in
+/// <c>LootBracketTracker</c> based on which other signals fire inside the
+/// bracket (<c>ProcessAddItem</c> = loot, <c>ProcessTalkScreen</c> = UI dialog).
 ///
-/// v1 emits an event for *every* StartInteraction whose entity name ends with
-/// "StaticChest" (the convention observed in samples). Refines later if other
-/// chest naming patterns surface — the catalog cache absorbs the discovery
-/// either way.
+/// #64 v1 used a <c>Contains("StaticChest")</c> name filter, which silently
+/// dropped real loot prefabs like <c>EltibuleSecretChest</c>; live-log
+/// verification under #73 moved the filter from naming to signal.
+///
+/// Wiki sample:
+/// <c>LocalPlayer: ProcessStartInteraction(-162, 7, 0, False, "GoblinStaticChest1")</c>
 /// </summary>
 public sealed partial class ChestInteractionParser : ILogParser
 {
     [GeneratedRegex(
-        """LocalPlayer:\s*ProcessStartInteraction\(-?\d+,\s*\d+,\s*\d+,\s*(?:True|False),\s*"(?<name>[^"]+)"\)""",
+        """LocalPlayer:\s*ProcessStartInteraction\((?<id>-?\d+),\s*\d+,\s*\d+,\s*(?:True|False),\s*"(?<name>[^"]+)"\)""",
         RegexOptions.CultureInvariant)]
     private static partial Regex InteractionRx();
 
@@ -29,12 +31,8 @@ public sealed partial class ChestInteractionParser : ILogParser
         var m = InteractionRx().Match(line);
         if (!m.Success) return null;
 
-        var name = m.Groups["name"].Value;
-        // Static chests follow the "<Theme>StaticChest<N>" convention in observed
-        // samples (GoblinStaticChest1). Filter to that prefix shape so we don't
-        // create timers for vendor interactions, NPC dialog, etc.
-        if (!name.Contains("StaticChest", StringComparison.Ordinal)) return null;
-
-        return new ChestInteractionEvent(timestamp, name);
+        if (!long.TryParse(m.Groups["id"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+            return null;
+        return new InteractionStartEvent(timestamp, id, m.Groups["name"].Value);
     }
 }

--- a/src/Gandalf.Module/Parsing/LootEvents.cs
+++ b/src/Gandalf.Module/Parsing/LootEvents.cs
@@ -3,16 +3,24 @@ using Mithril.Shared.Logging;
 namespace Gandalf.Parsing;
 
 /// <summary>
-/// Player opened (started interaction with) a static chest. Anchor for the
-/// cooldown clock — <c>StartedAt</c> on the resulting timer is this Timestamp.
+/// Player started any interaction (chest, vendor, storage vault, NPC dialog).
+/// The bracket discriminator — loot vs storage vs NPC — is signal-driven in
+/// <c>LootBracketTracker</c>: <c>ProcessAddItem</c> inside the bracket means
+/// loot; <c>ProcessTalkScreen</c> means UI dialog (storage / NPC); the bracket
+/// closes on <c>ProcessEnableInteractors</c>. The parser is intentionally
+/// broad — naming heuristics like "*StaticChest*" silently dropped legitimate
+/// loot prefabs (e.g. EltibuleSecretChest), so the filter moved from the
+/// parser to the state machine.
 /// </summary>
-public sealed record ChestInteractionEvent(DateTime Timestamp, string ChestInternalName)
+public sealed record InteractionStartEvent(DateTime Timestamp, long InteractorId, string EntityName)
     : LogEvent(Timestamp);
 
 /// <summary>
 /// Player tried a chest already on cooldown — game emits the duration in the
 /// rejection screen text. Updates the catalog cache so future first-time loots
-/// of the same template start with the right duration.
+/// of the same template start with the right duration. The chest's internal
+/// name isn't carried on the rejection line itself; the bracket tracker
+/// correlates the rejection to the in-flight interaction.
 /// </summary>
 public sealed record ChestCooldownObservedEvent(DateTime Timestamp, string ChestInternalName, TimeSpan Duration)
     : LogEvent(Timestamp);

--- a/src/Gandalf.Module/Services/LootBracketTracker.cs
+++ b/src/Gandalf.Module/Services/LootBracketTracker.cs
@@ -1,0 +1,134 @@
+using System.Text.RegularExpressions;
+using Gandalf.Parsing;
+using Mithril.Shared.Logging;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Signal-driven state machine that distinguishes a loot-chest interaction
+/// from a storage-vault or NPC-dialog interaction. Replaces the v1 substring
+/// heuristic that filtered chest prefab names by <c>Contains("StaticChest")</c>
+/// — that filter silently dropped <c>EltibuleSecretChest</c> and would
+/// regress on every game patch that introduces a new chest theme.
+///
+/// Bracket shapes (verified against captured Player.log):
+/// <list type="bullet">
+/// <item><b>Loot chest:</b> <c>ProcessStartInteraction → ProcessAddItem(...) → ProcessEnableInteractors([],[id,])</c></item>
+/// <item><b>Storage / NPC:</b> <c>ProcessStartInteraction → ProcessPreTalkScreen → ProcessTalkScreen</c></item>
+/// <item><b>Cooldown rejection:</b> <c>ProcessStartInteraction → ProcessScreenText("You've already looted...")</c></item>
+/// </list>
+/// The tracker maintains a tiny three-state machine and routes confirmed loot
+/// events into <see cref="LootSource"/>; storage / NPC interactions are
+/// silently discarded.
+/// </summary>
+public sealed partial class LootBracketTracker
+{
+    private readonly LootSource _source;
+    private readonly ChestInteractionParser _interactionParser;
+    private readonly ChestRejectionParser _rejectionParser;
+
+    private State _state = State.Idle;
+    private string? _bracketName;
+    private DateTime _bracketStartTimestamp;
+    private long _bracketInteractorId;
+
+    public LootBracketTracker(
+        LootSource source,
+        ChestInteractionParser interactionParser,
+        ChestRejectionParser rejectionParser)
+    {
+        _source = source;
+        _interactionParser = interactionParser;
+        _rejectionParser = rejectionParser;
+    }
+
+    /// <summary>True iff the tracker is currently inside an interaction bracket.</summary>
+    public bool IsInFlight => _state != State.Idle;
+
+    [GeneratedRegex(
+        """LocalPlayer:\s*Process(?:Pre)?TalkScreen\(""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex TalkScreenRx();
+
+    [GeneratedRegex(
+        """LocalPlayer:\s*ProcessAddItem\(""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex AddItemRx();
+
+    [GeneratedRegex(
+        """LocalPlayer:\s*ProcessEnableInteractors\(\[\],\s*\[(?<id>-?\d+),\]\)""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex EnableInteractorsRx();
+
+    /// <summary>
+    /// Feed one raw log line through the state machine. Idempotent for
+    /// unrelated lines — the common case is a quick set of substring checks
+    /// that don't touch state.
+    /// </summary>
+    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp);
+
+    public void Observe(string line, DateTime timestamp)
+    {
+        // 1. Interaction start — always begins a fresh bracket, replacing any prior.
+        if (_interactionParser.TryParse(line, timestamp) is InteractionStartEvent start)
+        {
+            _state = State.InFlight;
+            _bracketName = start.EntityName;
+            _bracketStartTimestamp = start.Timestamp;
+            _bracketInteractorId = start.InteractorId;
+            return;
+        }
+
+        // Below this point, only events relevant when a bracket is in flight.
+        if (_state == State.Idle) return;
+
+        // 2. TalkScreen / PreTalkScreen → storage UI / NPC dialog. Discard.
+        if (TalkScreenRx().IsMatch(line))
+        {
+            ResetIdle();
+            return;
+        }
+
+        // 3. Cooldown rejection screen text → cache the duration, close bracket.
+        if (_state == State.InFlight
+            && _rejectionParser.TryParse(line, timestamp) is ChestCooldownObservedEvent rejection
+            && _bracketName is not null)
+        {
+            _source.OnChestCooldownObserved(_bracketName, rejection.Duration);
+            ResetIdle();
+            return;
+        }
+
+        // 4. AddItem inside bracket → confirmed loot. Commit the chest event.
+        if (_state == State.InFlight && AddItemRx().IsMatch(line) && _bracketName is not null)
+        {
+            _source.OnChestInteraction(_bracketName, _bracketStartTimestamp);
+            _state = State.Committed;
+            return;
+        }
+
+        // 5. EnableInteractors with matching id → bracket close.
+        if (EnableInteractorsRx().Match(line) is { Success: true } m
+            && long.TryParse(m.Groups["id"].Value, out var closingId)
+            && closingId == _bracketInteractorId)
+        {
+            ResetIdle();
+            return;
+        }
+    }
+
+    private void ResetIdle()
+    {
+        _state = State.Idle;
+        _bracketName = null;
+        _bracketStartTimestamp = default;
+        _bracketInteractorId = 0;
+    }
+
+    private enum State
+    {
+        Idle,
+        InFlight,
+        Committed,
+    }
+}

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -7,36 +7,33 @@ namespace Gandalf.Services;
 
 /// <summary>
 /// Subscribes to <see cref="IPlayerLogStream"/> and routes loot-related events
-/// into <see cref="LootSource"/>. No <c>ModuleGate</c> wait — Gandalf is eager;
-/// derived-source log replay must run as soon as the host starts.
+/// into <see cref="LootSource"/>. Chest detection delegates to
+/// <see cref="LootBracketTracker"/> — a signal-driven state machine that
+/// distinguishes loot chests from storage vaults / NPC dialog without a
+/// naming heuristic. Defeat parsing runs as a parallel path because kill
+/// credits don't share the interaction-bracket envelope.
 ///
-/// Chest interaction + rejection are correlated: the rejection screen text
-/// doesn't carry the chest name, but per the wiki it only fires inside an
-/// interaction bracket, so the most-recent chest interaction is the one being
-/// rejected. We track the last chest name in-process and pair on rejection.
+/// No <c>ModuleGate</c> wait — Gandalf is eager; derived-source log replay
+/// must run as soon as the host starts.
 /// </summary>
 public sealed class LootIngestionService : BackgroundService
 {
     private readonly IPlayerLogStream _stream;
-    private readonly ChestInteractionParser _chestInteraction;
-    private readonly ChestRejectionParser _chestRejection;
+    private readonly LootBracketTracker _bracket;
     private readonly DefeatRewardParser _defeatReward;
     private readonly LootSource _source;
     private readonly IDiagnosticsSink? _diag;
-    private string? _lastChestInternalName;
     private bool _firstObservationLogged;
 
     public LootIngestionService(
         IPlayerLogStream stream,
-        ChestInteractionParser chestInteraction,
-        ChestRejectionParser chestRejection,
+        LootBracketTracker bracket,
         DefeatRewardParser defeatReward,
         LootSource source,
         IDiagnosticsSink? diag = null)
     {
         _stream = stream;
-        _chestInteraction = chestInteraction;
-        _chestRejection = chestRejection;
+        _bracket = bracket;
         _defeatReward = defeatReward;
         _source = source;
         _diag = diag;
@@ -53,26 +50,7 @@ public sealed class LootIngestionService : BackgroundService
 
     private void Dispatch(RawLogLine raw)
     {
-        if (_chestInteraction.TryParse(raw.Line, raw.Timestamp) is ChestInteractionEvent chest)
-        {
-            _lastChestInternalName = chest.ChestInternalName;
-            _source.OnChestInteraction(chest.ChestInternalName, chest.Timestamp);
-            FirstObservation();
-            return;
-        }
-
-        if (_chestRejection.TryParse(raw.Line, raw.Timestamp) is ChestCooldownObservedEvent rejection)
-        {
-            // Rejection screen text doesn't carry the chest name — pair it to the
-            // most recent chest interaction we observed inside this bracket.
-            if (string.IsNullOrEmpty(_lastChestInternalName))
-            {
-                _diag?.Warn("Gandalf.Loot", "ChestRejection without preceding interaction — skipped");
-                return;
-            }
-            _source.OnChestCooldownObserved(_lastChestInternalName, rejection.Duration);
-            return;
-        }
+        _bracket.Observe(raw);
 
         if (_defeatReward.TryParse(raw.Line, raw.Timestamp) is DefeatRewardEvent defeat)
         {

--- a/tests/Gandalf.Tests/LootBracketTrackerTests.cs
+++ b/tests/Gandalf.Tests/LootBracketTrackerTests.cs
@@ -1,0 +1,285 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Parsing;
+using Gandalf.Services;
+using Mithril.Shared.Character;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class LootBracketTrackerTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _charactersDir;
+    private readonly string _cachePath;
+
+    public LootBracketTrackerTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_bracket_tracker");
+        _charactersDir = Path.Combine(_dir, "characters");
+        _cachePath = Path.Combine(_dir, "loot-catalog.json");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private (LootSource src, LootBracketTracker tracker, DerivedTimerProgressService derived)
+        Build(IEnumerable<DefeatCatalogEntry>? defeats = null)
+    {
+        var active = new FakeActiveCharacterService();
+        active.SetActiveCharacter("Arthur", "Kwatoxi");
+        var time = new ManualTime(new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc));
+
+        var derivedStore = new PerCharacterStore<DerivedProgress>(_charactersDir, "gandalf-derived.json",
+            DerivedProgressJsonContext.Default.DerivedProgress);
+        var derivedView = new PerCharacterView<DerivedProgress>(active, derivedStore);
+        var derived = new DerivedTimerProgressService(derivedView, time);
+
+        var cacheStore = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+            LootCatalogCacheJsonContext.Default.LootCatalogCache);
+        var cache = cacheStore.Load();
+        var src = new LootSource(derived, cacheStore, cache, defeats ?? [], time);
+        var tracker = new LootBracketTracker(src, new ChestInteractionParser(), new ChestRejectionParser());
+
+        return (src, tracker, derived);
+    }
+
+    private static readonly DateTime EventTime = new(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Live capture: EltibuleSecretChest bracket. v1's substring filter
+    /// (Contains("StaticChest")) silently dropped this chest entirely. The
+    /// signal-driven tracker correctly identifies it as loot via the AddItem
+    /// inside the bracket.
+    /// </summary>
+    [Fact]
+    public void Loot_chest_with_AddItem_creates_progress_row_and_caches_duration()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            // Seed cache so first interaction creates a row (otherwise it's the
+            // first-loot-of-unknown-chest case which is correctly skipped).
+            src.OnChestCooldownObserved("EltibuleSecretChest", TimeSpan.FromHours(3));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-147, 5, 0, False, \"EltibuleSecretChest\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(PowerPotion2(113863546), -1, True)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(ThentreeSkirt(113863548), -1, True)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessEnableInteractors([], [-147,])", EventTime);
+
+            src.Progress.Should().ContainKey(LootSource.ChestKey("EltibuleSecretChest"));
+            tracker.IsInFlight.Should().BeFalse();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// Storage chest bracket — opens a TalkScreen UI dialog, no AddItem, no
+    /// row should be created. This is the case the substring filter handled
+    /// accidentally; the signal-driven tracker handles it intentionally.
+    /// </summary>
+    [Fact]
+    public void Storage_chest_with_TalkScreen_creates_no_row()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            // Even with a duration cached, a TalkScreen-discriminated bracket
+            // must not produce a chest interaction event.
+            src.OnChestCooldownObserved("SerbuleCommunityChest", TimeSpan.FromHours(3));
+            // (the cache write itself populates the catalog, but no progress row)
+            src.Progress.Should().BeEmpty();
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(31190, 7, 0, False, \"SerbuleCommunityChest\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessPreTalkScreen(31190, PreTalkScreenInfo)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessTalkScreen(31190, \"Serbule Dynamic Safebox\", \"...\", \"\", [-1701,1,10,], System.String[], 0, Generic)", EventTime);
+
+            src.Progress.Should().BeEmpty();
+            tracker.IsInFlight.Should().BeFalse();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// NPC dialog interaction (vendor, quest-giver, etc.) — same shape as
+    /// storage from the bracket's perspective: TalkScreen, no AddItem.
+    /// </summary>
+    [Fact]
+    public void NPC_dialog_creates_no_row()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("NpcMaxine", TimeSpan.FromHours(1));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(42, 0, 0, False, \"NpcMaxine\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessTalkScreen(42, \"Maxine\", \"How may I help you?\", \"\", [], System.String[], 0, Generic)", EventTime);
+
+            src.Progress.Should().BeEmpty();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// Cooldown rejection inside the bracket — no AddItem (loot was suppressed),
+    /// instead a screen-text rejection carrying the duration. Must update the
+    /// catalog cache without creating a progress row.
+    /// </summary>
+    [Fact]
+    public void Rejection_inside_bracket_caches_duration_without_creating_row()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-162, 7, 0, False, \"GoblinStaticChest1\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessScreenText(GeneralInfo, \"You've already looted this chest! (It will refill 3 hours after you looted it.)\")", EventTime);
+
+            // Catalog should now know the duration even though no row was created.
+            src.Catalog.Should().Contain(c => c.DisplayName == "GoblinStaticChest1");
+            src.Progress.Should().BeEmpty();
+            tracker.IsInFlight.Should().BeFalse();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// AddItem outside any bracket (e.g., quest reward, vendor purchase fired
+    /// after a TalkScreen-discarded bracket) must not create a chest row.
+    /// </summary>
+    [Fact]
+    public void AddItem_outside_bracket_creates_no_row()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
+
+            // Bare AddItem with no preceding StartInteraction.
+            tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1234), -1, True)", EventTime);
+            // TalkScreen-discarded bracket then AddItem (e.g., quest reward).
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(42, 0, 0, False, \"NpcQuestGiver\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessTalkScreen(42, \"Quest\", \"Done!\", \"\", [], System.String[], 0, Generic)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(QuestReward(5678), -1, True)", EventTime);
+
+            src.Progress.Should().BeEmpty();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// New StartInteraction replaces an in-flight bracket without committing
+    /// the prior — covers the case where the player walks away from one
+    /// interaction into another without explicitly closing.
+    /// </summary>
+    [Fact]
+    public void New_Start_replaces_in_flight_bracket()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("ChestA", TimeSpan.FromHours(1));
+            src.OnChestCooldownObserved("ChestB", TimeSpan.FromHours(2));
+
+            // Open ChestA, then immediately open ChestB, then loot ChestB.
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-100, 7, 0, False, \"ChestA\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-101, 7, 0, False, \"ChestB\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(Apple(9999), -1, True)", EventTime);
+
+            // Only ChestB should have a progress row.
+            src.Progress.Should().ContainKey(LootSource.ChestKey("ChestB"));
+            src.Progress.Should().NotContainKey(LootSource.ChestKey("ChestA"));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// Multiple AddItems from the same chest don't fire the chest-interaction
+    /// event multiple times — only the first commits.
+    /// </summary>
+    [Fact]
+    public void Multiple_AddItems_in_one_bracket_only_commit_once()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("EltibuleSecretChest", TimeSpan.FromHours(3));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-147, 5, 0, False, \"EltibuleSecretChest\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(PowerPotion2(1), -1, True)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(ThentreeSkirt(2), -1, True)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(GoldenLockpick(3), -1, True)", EventTime);
+
+            // The progress entry should reflect a single committed cooldown
+            // anchored at the bracket's StartedAt. (Multiple commits would
+            // overwrite StartedAt, but they'd be safely the same value.)
+            src.Progress[LootSource.ChestKey("EltibuleSecretChest")]
+                .StartedAt.Should().Be(new DateTimeOffset(EventTime, TimeSpan.Zero));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// EnableInteractors with non-matching id leaves the bracket open —
+    /// stale events from earlier interactors shouldn't close the current one.
+    /// </summary>
+    [Fact]
+    public void EnableInteractors_with_non_matching_id_does_not_close_bracket()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("TestChest", TimeSpan.FromHours(1));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-200, 7, 0, False, \"TestChest\")", EventTime);
+            // EnableInteractors for a different id — must not close this bracket.
+            tracker.Observe("LocalPlayer: ProcessEnableInteractors([], [-999,])", EventTime);
+
+            tracker.IsInFlight.Should().BeTrue();
+
+            // Loot still confirms.
+            tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", EventTime);
+            src.Progress.Should().ContainKey(LootSource.ChestKey("TestChest"));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// EnableInteractors with matching id closes the bracket cleanly.
+    /// </summary>
+    [Fact]
+    public void EnableInteractors_with_matching_id_closes_bracket()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("TestChest", TimeSpan.FromHours(1));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-200, 7, 0, False, \"TestChest\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessEnableInteractors([], [-200,])", EventTime);
+
+            tracker.IsInFlight.Should().BeFalse();
+
+            // A subsequent AddItem outside the bracket creates no row.
+            tracker.Observe("LocalPlayer: ProcessAddItem(Pear(2), -1, True)", EventTime);
+            // Still only one row — TestChest from the closed bracket.
+            src.Progress.Should().HaveCount(1);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTime utcStart) => _now = new DateTimeOffset(utcStart, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Gandalf.Tests/Parsing/ChestInteractionParserTests.cs
+++ b/tests/Gandalf.Tests/Parsing/ChestInteractionParserTests.cs
@@ -15,8 +15,38 @@ public sealed class ChestInteractionParserTests
         var line = "[18:22:02] LocalPlayer: ProcessStartInteraction(-162, 7, 0, False, \"GoblinStaticChest1\")";
         var evt = _parser.TryParse(line, DateTime.UtcNow);
 
-        evt.Should().BeOfType<ChestInteractionEvent>();
-        ((ChestInteractionEvent)evt!).ChestInternalName.Should().Be("GoblinStaticChest1");
+        evt.Should().BeOfType<InteractionStartEvent>();
+        var start = (InteractionStartEvent)evt!;
+        start.EntityName.Should().Be("GoblinStaticChest1");
+        start.InteractorId.Should().Be(-162);
+    }
+
+    [Fact]
+    public void Parses_EltibuleSecretChest_sample()
+    {
+        // Live capture: this loot chest was missed by the v1 substring filter
+        // (Contains("StaticChest")) — the bug #73 fixes by moving filtering
+        // from the parser's name heuristic to the bracket state machine.
+        var line = "[03:41:37] LocalPlayer: ProcessStartInteraction(-147, 5, 0, False, \"EltibuleSecretChest\")";
+        var start = (InteractionStartEvent?)_parser.TryParse(line, DateTime.UtcNow);
+
+        start.Should().NotBeNull();
+        start!.EntityName.Should().Be("EltibuleSecretChest");
+        start.InteractorId.Should().Be(-147);
+    }
+
+    [Fact]
+    public void Emits_event_for_non_chest_interaction()
+    {
+        // After #73, the parser is intentionally broad — discriminates loot
+        // from storage/NPC happens downstream in LootBracketTracker. The
+        // parser now emits for *all* ProcessStartInteraction lines.
+        var line = "LocalPlayer: ProcessStartInteraction(31190, 7, 0, False, \"SerbuleCommunityChest\")";
+        var start = (InteractionStartEvent?)_parser.TryParse(line, DateTime.UtcNow);
+
+        start.Should().NotBeNull();
+        start!.EntityName.Should().Be("SerbuleCommunityChest");
+        start.InteractorId.Should().Be(31190);
     }
 
     [Fact]
@@ -24,24 +54,14 @@ public sealed class ChestInteractionParserTests
     {
         var ts = new DateTime(2026, 4, 30, 18, 22, 2, DateTimeKind.Utc);
         var line = "LocalPlayer: ProcessStartInteraction(-162, 7, 0, False, \"GoblinStaticChest1\")";
-        var evt = (ChestInteractionEvent)_parser.TryParse(line, ts)!;
+        var evt = (InteractionStartEvent)_parser.TryParse(line, ts)!;
 
         evt.Timestamp.Should().Be(ts);
     }
 
     [Fact]
-    public void Returns_null_for_non_chest_interaction()
-    {
-        // NPC vendor interaction shape — same line family, different name (no "StaticChest").
-        var line = "LocalPlayer: ProcessStartInteraction(42, 0, 0, False, \"NpcMaxine\")";
-        _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
-    }
-
-    [Fact]
-    public void Returns_null_for_unrelated_line()
-    {
+    public void Returns_null_for_unrelated_line() =>
         _parser.TryParse("LocalPlayer: ProcessAddItem(Apple(1234), -1, True)", DateTime.UtcNow).Should().BeNull();
-    }
 
     [Fact]
     public void Returns_null_for_empty_line() =>


### PR DESCRIPTION
## Summary

Closes **#73**. PR #70's [ChestInteractionParser](src/Gandalf.Module/Parsing/ChestInteractionParser.cs) used `name.Contains(\"StaticChest\")` to filter loot chests from storage vaults / NPC interactions. Live-log verification surfaced two problems:

- **False negative for `EltibuleSecretChest`** — a real loot chest the player has opened (verified: `ProcessAddItem(PowerPotion2(...))` + `ProcessAddItem(ThentreeSkirt(...))` follow the bracket). The naming heuristic silently dropped it.
- **Brittle**: loot chests use varying themes (`*StaticChest*`, `*SecretChest*`, probably more); storage uses `*CommunityChest*` / `*Vault*` / `*Storage*` / named-NPC vaults that defy any pattern. Every game patch can regress the filter.

### What landed

**Bracket shapes verified against captured `Player.log`:**

```
Loot chest    : Start → AddItem(s) → EnableInteractors([],[id,])
Storage / NPC : Start → PreTalkScreen → TalkScreen
Cooldown      : Start → ScreenText(\"You've already looted...\")
```

**Replace naming heuristic with signal-driven state machine:**

- [ChestInteractionParser](src/Gandalf.Module/Parsing/ChestInteractionParser.cs) drops the substring filter; emits `InteractionStartEvent` (renamed from `ChestInteractionEvent` — the parser is no longer chest-specific) for every `ProcessStartInteraction`. Now also captures `InteractorId` for bracket-close matching.
- New [LootBracketTracker](src/Gandalf.Module/Services/LootBracketTracker.cs) holds the three-state machine (`Idle → InFlight → Committed`) and routes confirmed loot interactions / cooldown rejections to `LootSource`. Storage / NPC interactions discriminated by `ProcessTalkScreen` appearing inside the bracket — they never produce a chest event. Bracket closes on `ProcessEnableInteractors([], [<sameId>,])`.
- [LootIngestionService](src/Gandalf.Module/Services/LootIngestionService.cs) becomes a thin shim around the tracker plus the parallel defeat-reward path.

### Acceptance check

- [x] `LootIngestionService` tracks an in-flight chest interaction bracket; emits `OnChestInteraction` only when `ProcessAddItem` confirms loot delivery.
- [x] Refill screen text inside the bracket still routes to `OnChestCooldownObserved` and updates `LootCatalogCache`.
- [x] `ChestInteractionParser`'s naming heuristic is removed (parser emits all `ProcessStartInteraction` matches; ingestion does the loot/storage distinction via signal).
- [x] New unit tests using captured fixtures:
  - **Positive:** `EltibuleSecretChest` bracket (`ProcessStartInteraction` + `ProcessAddItem`) creates a timer row.
  - **Positive:** `GoblinStaticChest1` bracket with refill rejection updates the catalog cache.
  - **Negative:** `SerbuleCommunityChest` bracket without `ProcessAddItem` creates no row.
  - **Negative:** `ProcessStartInteraction` for a non-chest interactor (NPC dialog, etc.) creates no row.

### Tests

8 new in [LootBracketTrackerTests](tests/Gandalf.Tests/LootBracketTrackerTests.cs) + 2 expanded in [ChestInteractionParserTests](tests/Gandalf.Tests/Parsing/ChestInteractionParserTests.cs):

- `EltibuleSecretChest` (positive) — full loot bracket creates a row.
- `SerbuleCommunityChest` (negative) — TalkScreen-discriminated bracket creates no row.
- NPC dialog — same TalkScreen path, no row.
- Cooldown rejection inside bracket — caches duration, no row.
- AddItem outside any bracket — no row.
- New Start replaces in-flight bracket — only the latest commits.
- Multiple AddItems in one bracket — only first commits.
- EnableInteractors id matching — non-matching keeps bracket open, matching closes.

### Connection to crowdsourced calibration

Signal-driven detection is the **observation engine that grows the local `LootCatalogCache`**, regardless of naming. Future PRs (separate issues) can publish observed `(chestInternalName, duration)` pairs upstream to `mithril-calibration/chests.json` so the community catalog grows organically:

```
ProcessStartInteraction + ProcessAddItem  →  bracket detection notices a loot chest
                                          →  LootSource creates timer row
ProcessScreenText(\"refill X after...\")    →  LootCatalogCache learns duration locally
                                          →  (future) upload pipeline → mithril-calibration
                                          →  (future) merged chests.json
                                          →  every player gets the catalog without
                                             retrying every chest themselves
```

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — **1092/1092** passing solution-wide
- [x] `dotnet test tests/Gandalf.Tests` — **120/120** (110 pre-existing + 10 new/expanded)
- [ ] **Manual:** open Gandalf → Loot tab. Open `EltibuleSecretChest` (or any non-`*StaticChest*` named loot chest); confirm a row appears (it would not have on `main`). Open `SerbuleCommunityChest`; confirm no row appears. Open and retry a `GoblinStaticChest1`; confirm the cooldown still caches and rows still appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)