### PR TITLE
fix(gandalf): Quests tab freeze — only materialize relevant rows

### DIFF
--- a/src/Gandalf.Module/Gandalf.Module.csproj
+++ b/src/Gandalf.Module/Gandalf.Module.csproj
@@ -15,6 +15,9 @@
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Gandalf.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <Resource Include="Resources\gandalf.ico" />
     <Resource Include="Resources\gandalf.jpg" />
   </ItemGroup>

--- a/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
@@ -13,12 +13,18 @@ namespace Gandalf.ViewModels;
 /// ViewModel for the Quests tab. Renders repeatable-quest cooldowns from the
 /// shared <see cref="QuestSource"/> and exposes the State filter chip
 /// (Pending / Cooling / Ready / All) plus bulk dismiss commands.
+///
+/// Materializes only the rows the player cares about: pending in journal, or
+/// cooling/done. The full catalog is ~2,000 entries — projecting it all into
+/// a non-virtualizing WrapPanel froze the UI thread.
 /// </summary>
 public sealed partial class QuestTimersViewModel : ObservableObject
 {
     private readonly QuestSource _source;
     private readonly DerivedTimerProgressService _derived;
     private readonly DispatcherTimer _refreshTimer;
+    private readonly Dictionary<string, TimerItemViewModel> _byKey = new(StringComparer.Ordinal);
+    private Dictionary<string, TimerCatalogEntry> _catalogByKey = new(StringComparer.Ordinal);
 
     [ObservableProperty] private QuestStateFilter _stateFilter = QuestStateFilter.All;
 
@@ -86,35 +92,81 @@ public sealed partial class QuestTimersViewModel : ObservableObject
 
     private bool IsPending(TimerItemViewModel vm)
     {
-        // Pending: in the player's journal but not currently cooling.
         if (vm.Catalog.SourceMetadata is not QuestCatalogPayload payload) return false;
         if (vm.State != TimerState.Idle) return false;
         return _source.PendingInternalNames.Contains(payload.Quest.InternalName);
     }
 
+    private static bool IsRelevant(TimerCatalogEntry entry, TimerProgressEntry? progress, IReadOnlySet<string> pending)
+    {
+        if (progress is { DismissedAt: null }) return true;
+        if (entry.SourceMetadata is QuestCatalogPayload payload &&
+            pending.Contains(payload.Quest.InternalName)) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Reconcile <see cref="Timers"/> against the source's relevant set. Diffs
+    /// in place — adds new rows, updates existing rows, removes gone rows —
+    /// instead of clearing the collection, which would thrash WPF's grouping.
+    /// </summary>
     private void Sync()
     {
-        Timers.Clear();
+        _catalogByKey = _source.Catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
         var progress = _source.Progress;
+        var pending = _source.PendingInternalNames;
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var entry in _source.Catalog)
         {
             progress.TryGetValue(entry.Key, out var p);
-            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p)));
+            if (!IsRelevant(entry, p, pending)) continue;
+
+            seen.Add(entry.Key);
+            if (_byKey.TryGetValue(entry.Key, out var vm))
+            {
+                vm.UpdateRow(new TimerRow(entry, p));
+            }
+            else
+            {
+                vm = new TimerItemViewModel(new TimerRow(entry, p));
+                _byKey[entry.Key] = vm;
+                Timers.Add(vm);
+            }
         }
+
+        for (var i = Timers.Count - 1; i >= 0; i--)
+        {
+            var vm = Timers[i];
+            if (seen.Contains(vm.Key)) continue;
+            Timers.RemoveAt(i);
+            _byKey.Remove(vm.Key);
+        }
+
         TimersView.Refresh();
     }
 
-    private void Tick()
+    /// <summary>
+    /// Per-second update of progress fractions and time labels. Per-item
+    /// <c>OnPropertyChanged</c> handles the bindings; only call
+    /// <see cref="ICollectionView.Refresh"/> when an item's <c>State</c>
+    /// transitioned (Running &harr; Done) — that changes filter / sort keys.
+    /// </summary>
+    internal void Tick()
     {
         var progress = _source.Progress;
-        var catalog = _source.Catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
-        foreach (var vm in Timers)
+        var stateChanged = false;
+
+        foreach (var vm in _byKey.Values)
         {
-            if (!catalog.TryGetValue(vm.Key, out var entry)) continue;
+            if (!_catalogByKey.TryGetValue(vm.Key, out var entry)) continue;
             progress.TryGetValue(vm.Key, out var p);
+            var prior = vm.State;
             vm.UpdateRow(new TimerRow(entry, p));
+            if (vm.State != prior) stateChanged = true;
         }
-        TimersView.Refresh();
+
+        if (stateChanged) TimersView.Refresh();
     }
 }
 

--- a/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
+++ b/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
@@ -1,0 +1,190 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Gandalf.ViewModels;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Verifies the Quests tab VM only materializes rows the player cares about
+/// (pending in journal or cooling/done) — not the full ~2,000 repeatable-quest
+/// catalog. The freeze bug was structural: a non-virtualizing WrapPanel asked
+/// to render every catalog row.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class QuestTimersViewModelTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _charactersDir;
+
+    public QuestTimersViewModelTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_quest_vm");
+        _charactersDir = Path.Combine(_dir, "characters");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private (QuestTimersViewModel vm, QuestSource src, DerivedTimerProgressService derived, ManualTime time)
+        Build(params QuestEntry[] quests)
+    {
+        var active = new FakeActiveCharacterService();
+        active.SetActiveCharacter("Arthur", "Kwatoxi");
+        var time = new ManualTime(new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc));
+
+        var derivedStore = new Mithril.Shared.Character.PerCharacterStore<DerivedProgress>(
+            _charactersDir, "gandalf-derived.json",
+            DerivedProgressJsonContext.Default.DerivedProgress);
+        var derivedView = new Mithril.Shared.Character.PerCharacterView<DerivedProgress>(active, derivedStore);
+        var derived = new DerivedTimerProgressService(derivedView, time);
+
+        var refData = new FakeReferenceData(quests);
+        var src = new QuestSource(derived, refData, time);
+        var vm = new QuestTimersViewModel(src, derived);
+        return (vm, src, derived, time);
+    }
+
+    [Fact]
+    public void Empty_state_does_not_materialize_full_catalog()
+    {
+        // Synthesize a ~500-quest catalog (still 100x larger than what should
+        // ever appear in the VM). Regression guard for the freeze bug.
+        var quests = Enumerable.Range(0, 500)
+            .Select(i => QuestEntryFactory.Repeatable($"k{i}", $"Q{i}", $"Quest {i}", TimeSpan.FromHours(1)))
+            .ToArray();
+
+        var (vm, src, derived, _) = Build(quests);
+        try
+        {
+            src.Catalog.Should().HaveCount(500);
+            vm.Timers.Should().BeEmpty();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Pending_quests_show_as_idle_rows()
+    {
+        var q1 = QuestEntryFactory.Repeatable("k1", "Q1", "Quest 1", TimeSpan.FromHours(1));
+        var q2 = QuestEntryFactory.Repeatable("k2", "Q2", "Quest 2", TimeSpan.FromHours(1));
+        var q3 = QuestEntryFactory.Repeatable("k3", "Q3", "Quest 3", TimeSpan.FromHours(1));
+
+        var (vm, src, derived, _) = Build(q1, q2, q3);
+        try
+        {
+            src.OnQuestLoaded("Q1");
+            src.OnQuestLoaded("Q3");
+
+            vm.Timers.Should().HaveCount(2);
+            vm.Timers.Should().OnlyContain(t => t.State == TimerState.Idle);
+            vm.Timers.Select(t => t.Name).Should().BeEquivalentTo(["Quest 1", "Quest 3"]);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Recently_completed_quest_appears_as_running()
+    {
+        var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(1));
+        var (vm, src, derived, _) = Build(q);
+        try
+        {
+            // StartedAt = now → 1h cooldown still ticking. State reads wall clock,
+            // so anchor on real `DateTime.UtcNow` rather than the injected provider.
+            src.OnQuestCompleted("Q1", DateTime.UtcNow);
+
+            vm.Timers.Should().HaveCount(1);
+            vm.Timers[0].State.Should().Be(TimerState.Running);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Quest_completed_long_ago_appears_as_done()
+    {
+        var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(1));
+        var (vm, src, derived, _) = Build(q);
+        try
+        {
+            // StartedAt = 2h ago → 1h cooldown elapsed → Done.
+            src.OnQuestCompleted("Q1", DateTime.UtcNow - TimeSpan.FromHours(2));
+
+            vm.Timers.Should().HaveCount(1);
+            vm.Timers[0].State.Should().Be(TimerState.Done);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Dismissed_row_disappears_from_visible_set()
+    {
+        var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(1));
+        var (vm, src, derived, time) = Build(q);
+        try
+        {
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
+            vm.Timers.Should().HaveCount(1);
+
+            derived.Dismiss(QuestSource.Id, QuestSource.QuestKey("Q1"));
+
+            vm.Timers.Should().BeEmpty();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Re_loading_a_dismissed_quest_re_adds_it_as_pending()
+    {
+        var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(1));
+        var (vm, src, derived, time) = Build(q);
+        try
+        {
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
+            derived.Dismiss(QuestSource.Id, QuestSource.QuestKey("Q1"));
+            vm.Timers.Should().BeEmpty();
+
+            src.OnQuestLoaded("Q1");
+
+            vm.Timers.Should().HaveCount(1);
+            vm.Timers[0].State.Should().Be(TimerState.Idle);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Tick_does_not_refresh_view_when_no_state_changed()
+    {
+        var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(10));
+        var (vm, src, derived, time) = Build(q);
+        try
+        {
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
+            var refreshes = 0;
+            ((System.ComponentModel.ICollectionView)vm.TimersView).CollectionChanged += (_, _) => refreshes++;
+
+            // Advance only seconds — still Running.
+            time.Advance(TimeSpan.FromSeconds(5));
+            vm.Tick();
+
+            refreshes.Should().Be(0, "no state transition means no Refresh() — the freeze bug came from doing this every second");
+            vm.Timers[0].State.Should().Be(TimerState.Running);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTime utcStart) => _now = new DateTimeOffset(utcStart, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #75. The Quests tab froze on activation because `QuestTimersViewModel.Sync()` projected the full ~2,000-entry repeatable-quest catalog into a `ListBox` whose `ItemsPanel` is a non-virtualizing `WrapPanel` — every row fully realized on the first layout pass.
- `Sync()` now only materializes quests that are pending in the journal or have a non-dismissed progress entry (cooling/done). Per-second `Tick()` updates rows in place via `OnPropertyChanged` and only calls `TimersView.Refresh()` when an item's `State` actually transitioned.
- Internal `_byKey` dictionary diff-updates the `ObservableCollection` instead of `Clear()` + rebuild — preserves WPF grouping state across progress events.

## Test plan

- [x] `dotnet build Mithril.slnx` clean.
- [x] `dotnet test Mithril.slnx` — 992 tests pass, including 7 new `QuestTimersViewModelTests` (500-quest regression guard, pending/completed/done/dismissed lifecycle, "tick without state change does not Refresh" guard).
- [ ] Manual smoke: launch shell, click Quests tab — should render instantly with empty state or only pending/cooling/done rows.
- [ ] Manual smoke: complete a repeatable quest in-game; row appears as Running with progress bar.
- [ ] Manual smoke: Loot tab still works (same XAML, small catalog — no behavior change expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)