### PR TITLE
gandalf: cite spike findings in parser comments

### DIFF
--- a/src/Gandalf.Module/Parsing/DefeatRewardParser.cs
+++ b/src/Gandalf.Module/Parsing/DefeatRewardParser.cs
@@ -8,12 +8,16 @@ namespace Gandalf.Parsing;
 /// (Scripted-event bosses). Sample line:
 /// <c>LocalPlayer: ProcessScreenText(CombatInfo, "You earned 12 Combat Wisdom: Killed Olugax the Ever-Pudding")</c>
 ///
-/// **Verification owed.** Per the wiki, the kill-credit line fires on every kill
-/// regardless of cooldown state — both rewarded and cooldown-suppressed kills
-/// produce identical lines. The "reduced rewards" log line that distinguishes
-/// the two has not been pinned down. Until it is, v1 anchors the cooldown on
-/// the kill itself and lets <c>LootSource</c>'s in-flight check suppress
-/// duplicate triggers within the cooldown window.
+/// Correct for the **scripted-event class** (Olugax) — kill-credit fires on
+/// every kill regardless of cooldown; <c>LootSource</c>'s in-flight check
+/// suppresses duplicates within the cooldown window. The "reduced rewards"
+/// signal that would distinguish rewarded from cooldown-suppressed kills in
+/// this class is still verification-owed.
+///
+/// Wrong for the **defeat-cooldown class** (Megaspider) — the spike (#60)
+/// confirmed the game suppresses the kill-credit line entirely on a
+/// within-cooldown re-kill, and emits a parseable rejection text instead. A
+/// dedicated <c>DefeatCooldownParser</c> for that class is tracked in #79.
 /// </summary>
 public sealed partial class DefeatRewardParser : ILogParser
 {

--- a/src/Gandalf.Module/Parsing/LootEvents.cs
+++ b/src/Gandalf.Module/Parsing/LootEvents.cs
@@ -26,10 +26,11 @@ public sealed record ChestCooldownObservedEvent(DateTime Timestamp, string Chest
     : LogEvent(Timestamp);
 
 /// <summary>
-/// Player earned a kill credit on a reward-cooldown creature. v1 anchors the
-/// cooldown on this line; the "reduced rewards" line that distinguishes a
-/// rewarded kill from a cooldown-suppressed one is **Verification owed** per the
-/// wiki and will refine this trigger when captured.
+/// Player earned a kill credit on a scripted-event boss (Olugax class — the
+/// kill-credit line fires regardless of cooldown). The defeat-cooldown class
+/// (Megaspider) does not produce this event because the game suppresses the
+/// credit line within-cooldown; a dedicated event for that class is tracked
+/// in #79.
 /// </summary>
 public sealed record DefeatRewardEvent(DateTime Timestamp, string NpcDisplayName)
     : LogEvent(Timestamp);

--- a/src/Gandalf.Module/Parsing/QuestCompletedParser.cs
+++ b/src/Gandalf.Module/Parsing/QuestCompletedParser.cs
@@ -8,9 +8,10 @@ namespace Gandalf.Parsing;
 /// turned in. Anchors the cooldown clock on this Timestamp so log-replay
 /// produces the right elapsed time.
 ///
-/// **Verification owed.** Same caveat as <see cref="QuestLoadedParser"/> —
-/// regex is a plausible <c>LocalPlayer: ProcessXxx("InternalName"...)</c>
-/// match pending real captures. Refines once samples land.
+/// Captured shape (wiki Player-Log-Signals § Quest signals): two integer
+/// args — <c>ProcessCompleteQuest(&lt;charEntityId&gt;, &lt;questId&gt;)</c> — not
+/// the quoted-string form this regex matches. Real-shape rewrite tracked in
+/// #77; until that lands the parser silently no-ops on every real line.
 /// </summary>
 public sealed partial class QuestCompletedParser : ILogParser
 {

--- a/src/Gandalf.Module/Parsing/QuestLoadedParser.cs
+++ b/src/Gandalf.Module/Parsing/QuestLoadedParser.cs
@@ -4,13 +4,15 @@ using Mithril.Shared.Logging;
 namespace Gandalf.Parsing;
 
 /// <summary>
-/// Parses <c>ProcessLoadQuest</c> lines emitted when a quest enters the
-/// player's journal (login replay or fresh acceptance).
+/// Originally intended to parse a per-quest "loaded" line. The spike (#60)
+/// confirmed no such line exists in <c>Player.log</c>: login emits a single
+/// bulk <c>ProcessLoadQuests</c> (plural) carrying two ID lists, and per-quest
+/// acceptance is signalled via <c>ProcessAddQuest</c> + companion
+/// <c>ProcessBook("New Quest: &lt;&lt;&lt;quest_NNNNN_Name&gt;&gt;&gt;", …)</c>.
+/// See wiki Player-Log-Signals § Quest signals.
 ///
-/// **Verification owed.** The exact line shape was deferred from the parser
-/// spike (#60). The regex below is a plausible match against the
-/// <c>LocalPlayer: ProcessXxx(...)</c> family — first quoted argument is the
-/// quest's InternalName. Refines once captured samples land in the wiki.
+/// Redesign (rebuild as bulk-load + accept parsers, or drop) tracked in #78.
+/// Until that lands the parser silently no-ops on every real line.
 /// </summary>
 public sealed partial class QuestLoadedParser : ILogParser
 {

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -9,10 +9,10 @@ namespace Gandalf.Services;
 /// learns them from rejection screen text); defeat catalog is bundled
 /// + overlaid from <c>mithril-calibration/defeats.json</c> when shipped.
 ///
-/// Verification owed: v1 keys on chest internal name only (no area). The wiki
-/// caveat under "Static treasure chests § Per-instance vs per-template state"
-/// notes two GoblinStaticChest1 spawns in one zone may share state; refine when
-/// the parser spike captures area-disambiguating signals.
+/// Per-template chest keying (no per-instance disambiguation) was verified
+/// correct in #73: interactor IDs reshuffle across sessions and the 3h
+/// cooldown spans relogs, so two same-template spawns in one zone share
+/// state in practice.
 /// </summary>
 public sealed class LootSource : ITimerSource, IDisposable
 {
@@ -124,9 +124,11 @@ public sealed class LootSource : ITimerSource, IDisposable
         var prior = _derived.GetProgress(Id, key);
         var startedAt = new DateTimeOffset(timestampUtc, TimeSpan.Zero);
 
-        // Verification owed: the kill-credit line fires on every kill regardless
-        // of cooldown state. Suppress repeats while the cooldown is still
-        // active so a within-window kill doesn't reset the clock locally.
+        // Scripted-event-class behaviour (Olugax): the kill-credit line fires on
+        // every kill regardless of cooldown. Suppress repeats while the cooldown
+        // is still active so a within-window kill doesn't reset the clock locally.
+        // The defeat-cooldown class (Megaspider) is suppressed by the game itself
+        // and reaches this method via a different parser path — tracked in #79.
         if (prior is not null
             && prior.DismissedAt is null
             && _time.GetUtcNow() < prior.StartedAt + entry.RewardCooldown)


### PR DESCRIPTION
## Summary

- Comment-only cleanup. The #60 parser spike is now closed and the wiki has the captured signal shapes.
- Replaces speculative `// Verification owed:` markers with concrete pointers — either to the wiki section (where the marker is fully resolved) or to a follow-up issue (where the redesign work is now scoped).
- Pointer table:

| File | Old marker | Now points at |
|---|---|---|
| `QuestCompletedParser.cs` | regex shape unknown | #77 — real shape is `ProcessCompleteQuest(<int>, <int>)`, parser rewrite |
| `QuestLoadedParser.cs` | regex shape unknown | #78 — no per-quest line exists, parser redesign or removal |
| `DefeatRewardParser.cs` | "reduced rewards" line not pinned down | #79 — split into scripted-event (Olugax) vs defeat-cooldown (Megaspider) classes |
| `LootEvents.cs` `DefeatRewardEvent` | same as above | #79 |
| `LootSource.cs` (header) | per-instance/per-template chest keying | resolved by #73 — marker removed |
| `LootSource.cs` (in-flight check) | "kill-credit fires regardless of cooldown" | #79 — true for scripted-event class only |

No behavioural change.

## Test plan

- [x] `dotnet build src/Gandalf.Module/Gandalf.Module.csproj` — clean (0 warnings, 0 errors).
- [ ] Comment-only diff; no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)