### PR TITLE
chore(gandalf): drop quest-requirement filter — the game is the authoritative gate

### DIFF
--- a/docs/agent-plans/quest-discovery-module.md
+++ b/docs/agent-plans/quest-discovery-module.md
@@ -1,0 +1,119 @@
+# Quest discovery module
+
+**Tracked in:** _no issue yet_
+
+A future module dedicated to "what can I do right now" — a quest browser /
+eligibility surface that's deliberately separate from Gandalf. Captured
+here so the design we hashed out during the 2026-04-30 chain-quest
+debugging doesn't get lost.
+
+## Why a separate module
+
+Gandalf is a *timer* module — it speaks the language of "this thing has a
+cooldown clock running, here's how long." Trying to also answer "what
+quests do I qualify for right now" inside Gandalf's Quests tab produced
+two pressures pulling in opposite directions:
+
+- **Cooldown awareness** wants the row visible only when the player has
+  observed a completion (otherwise the tab fills with irrelevant rows).
+- **Discovery** wants every takeable quest visible regardless of past
+  completions.
+
+Splitting the modules lets each surface stay narrow and honest. Per the
+[Mithril design principles](https://github.com/arthur-conde/project-gorgon/wiki/Mithril-Design-Principles)
+note, Gandalf does not re-evaluate eligibility — and a quest browser by
+definition has to. They're different jobs.
+
+## Scope sketch
+
+The discovery module owns:
+
+1. **Catalog projection.** Project `IReferenceDataService.Quests` into a
+   filterable view: by `FavorNpc`, `DisplayedLocation`, level range,
+   keywords, repeatable vs one-shot.
+2. **Eligibility evaluation.** Compute "can I take this right now" by
+   evaluating every requirement type the game uses
+   (`MinFavorLevel`, `MinSkillLevel`, `QuestCompleted`,
+   `QuestCompletedRecently`, `MinDelayAfterFirstCompletion*`,
+   `HasEffectKeyword`, `IsVampire`, etc.) against character state. This
+   IS authority-shopping, but that's the module's job. Stale conclusions
+   are tolerable here in a way they aren't for Gandalf.
+3. **Cross-link with Gandalf cooldowns.** When evaluating
+   `QuestCompletedRecently`, look at Gandalf's progress rows — the
+   `StartedAt` of the gating quest's row says when it last fired. Same
+   for the Reuse* clock on the candidate quest itself.
+4. **Chain awareness in the UI.** See "Stacked card rendering" below.
+
+What the discovery module does **not** own: per-character state mutation
+on observed completions (still Gandalf's responsibility — discovery
+*reads* Gandalf's progress, doesn't write to it).
+
+## Chain-card stacked-UI design
+
+Captured during the 2026-04-30 design conversation. Applies to the
+discovery module's renderer for repeatable quests; Gandalf's flat row
+list stays as-is.
+
+### Problem
+
+Chained dailies (e.g. Orrrilund's `KilltheDoctrineKeeperRepeat` ↔
+`KilltheDenMotherRepeat` pair, gated via `QuestCompletedRecently`) are
+one *gameplay loop* but two *quest entries*. Rendering them as two
+flat cards bloats the UI and obscures the cycle structure. Rendering
+them as a single fused row hides per-quest data (rewards, names, partial
+progress).
+
+### Approach: stacked cards with vertical-dot navigation
+
+For any chain (connected component on the `QuestCompletedRecently`
+graph), render a single visual *stack* in the layout, with:
+
+- **Top card:** the chain member with the most recent completion, ticking
+  down its own `Reuse*` cooldown.
+- **Stacked underneath:** the other chain members, peeking out enough at
+  the edges that the user knows there are more cards.
+- **Vertical dots on the left side:** one dot per card in the chain, the
+  active card's dot highlighted. Clickable to navigate; ready cards get
+  an accent (color or sparkle) so a takeable card under the stack
+  surfaces visually.
+
+### Data model
+
+`QuestCatalogPayload` (or its discovery-module equivalent) gains a
+`LinkedToInternalName` field projected from any `QuestCompletedRecently`
+requirement. Connected components computed once at catalog build time
+yield the chain membership.
+
+### Card-only-when-completed rule
+
+A chain card only renders when *at least one* member has a Gandalf
+progress row. Pure-discovery rendering (everything you qualify for, even
+unstarted chains) is a different filter, optionally toggle-able. The
+default cooldown view stays observation-driven.
+
+### Dashboard semantics
+
+Each chain contributes one tile. The tile shows the top card's
+`ReadyAt`. Title is the chain identity (`FavorNpc` +
+`DisplayedLocation` works — e.g. "Orrrilund — Ranalon Den"). No bloat.
+
+### Implementation cost (rough)
+
+- Data: small. `LinkedToInternalName` projection + connected-components
+  pass.
+- View-model: medium. `ChainRowViewModel { Cards, TopIndex,
+  SelectedIndex }`, top-card auto-reset on a chain member completing.
+- View (XAML): medium-to-large. Custom card-stack template with peek-out
+  edges, side dot strip with hit testing. Day-and-a-half ish if no
+  surprises.
+
+## Open questions
+
+- Does the chain abstraction also handle longer chains (3+ members)?
+  Mechanically yes (it's just a connected component); UX might need
+  tuning if real chains exist past length 2.
+- Should the discovery module duplicate Gandalf's Pending journal state
+  or read it as a foreign service? Probably read.
+- Is there an existing Project Gorgon equivalent surface we should
+  emulate (the in-game journal? a popular addon?), or are we
+  green-fielding the UX?

--- a/src/Gandalf.Module/Domain/TimerRow.cs
+++ b/src/Gandalf.Module/Domain/TimerRow.cs
@@ -9,6 +9,14 @@ namespace Gandalf.Domain;
 /// </summary>
 public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Progress)
 {
+    /// <summary>
+    /// Clock used to compute <see cref="State"/>, <see cref="Remaining"/>,
+    /// <see cref="CompletedAt"/>, and <see cref="Fraction"/>. Defaults to wall
+    /// clock; tests override with a controlled <see cref="TimeProvider"/> so
+    /// state assertions don't drift with real time.
+    /// </summary>
+    public TimeProvider Clock { get; init; } = TimeProvider.System;
+
     public string Key => Catalog.Key;
     public string Name => Catalog.DisplayName;
     public string? Region => Catalog.Region;
@@ -21,7 +29,7 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
         {
             if (Progress is null) return TimerState.Idle;
             if (Progress.DismissedAt is not null) return TimerState.Idle;
-            if (DateTimeOffset.UtcNow - Progress.StartedAt >= Catalog.Duration) return TimerState.Done;
+            if (Clock.GetUtcNow() - Progress.StartedAt >= Catalog.Duration) return TimerState.Done;
             return TimerState.Running;
         }
     }
@@ -31,7 +39,7 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
         get
         {
             if (Progress is null) return Catalog.Duration;
-            var left = Catalog.Duration - (DateTimeOffset.UtcNow - Progress.StartedAt);
+            var left = Catalog.Duration - (Clock.GetUtcNow() - Progress.StartedAt);
             return left < TimeSpan.Zero ? TimeSpan.Zero : left;
         }
     }
@@ -42,7 +50,7 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
         {
             if (Progress is null) return null;
             var stamped = Progress.StartedAt + Catalog.Duration;
-            return DateTimeOffset.UtcNow >= stamped ? stamped : null;
+            return Clock.GetUtcNow() >= stamped ? stamped : null;
         }
     }
 
@@ -52,7 +60,7 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
         {
             if (Progress is null) return 0.0;
             if (Catalog.Duration <= TimeSpan.Zero) return 1.0;
-            return Math.Clamp((DateTimeOffset.UtcNow - Progress.StartedAt) / Catalog.Duration, 0.0, 1.0);
+            return Math.Clamp((Clock.GetUtcNow() - Progress.StartedAt) / Catalog.Duration, 0.0, 1.0);
         }
     }
 }

--- a/src/Gandalf.Module/Services/QuestSource.cs
+++ b/src/Gandalf.Module/Services/QuestSource.cs
@@ -6,9 +6,15 @@ namespace Gandalf.Services;
 /// <summary>
 /// <see cref="ITimerSource"/> for repeatable-quest cooldowns. Catalog projects
 /// from <see cref="IReferenceDataService.Quests"/> filtered to entries with a
-/// <c>Reuse*</c> duration and no time-flavored requirement gate. Progress
-/// routes through <see cref="DerivedTimerProgressService"/> with sourceId
-/// <c>"gandalf.quest"</c>.
+/// <c>Reuse*</c> duration. Progress routes through
+/// <see cref="DerivedTimerProgressService"/> with sourceId <c>"gandalf.quest"</c>.
+///
+/// Eligibility gates (<c>QuestCompletedRecently</c>, <c>MinFavorLevel</c>,
+/// <c>MinSkillLevel</c>, …) are intentionally not re-evaluated here. The
+/// game is the authoritative gate: a <see cref="QuestCompletedEvent"/>
+/// observation already implies the server validated every requirement,
+/// so the cooldown can be stamped without local pre-checks. See the wiki
+/// note "Mithril does not re-evaluate game gates".
 ///
 /// "Pending" filter: tracks an in-memory set of currently-in-journal quests.
 /// <see cref="QuestJournalLoadedEvent"/> snapshot-replaces it on login;
@@ -18,12 +24,6 @@ namespace Gandalf.Services;
 public sealed class QuestSource : ITimerSource, IDisposable
 {
     public const string Id = "gandalf.quest";
-
-    private static readonly HashSet<string> TimeGatedRequirementTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "QuestCompletedRecently",
-    };
-    private static readonly string TimeGatedPrefix = "MinDelayAfterFirstCompletion";
 
     private readonly DerivedTimerProgressService _derived;
     private readonly IReferenceDataService _refData;
@@ -171,7 +171,6 @@ public sealed class QuestSource : ITimerSource, IDisposable
         var list = new List<TimerCatalogEntry>();
         foreach (var quest in _refData.Quests.Values)
         {
-            if (!IsRepeatableNonTimeGated(quest)) continue;
             var duration = ComputeDuration(quest);
             if (duration <= TimeSpan.Zero) continue;
 
@@ -184,24 +183,6 @@ public sealed class QuestSource : ITimerSource, IDisposable
         }
         return list;
     }
-
-    private static bool IsRepeatableNonTimeGated(QuestEntry quest)
-    {
-        if (HasReuse(quest) is false) return false;
-
-        // Drop quests gated by non-Reuse cooldowns — every cooldown shown must be
-        // one this source can compute correctly.
-        foreach (var req in quest.Requirements)
-        {
-            if (req.Type is null) continue;
-            if (TimeGatedRequirementTypes.Contains(req.Type)) return false;
-            if (req.Type.StartsWith(TimeGatedPrefix, StringComparison.OrdinalIgnoreCase)) return false;
-        }
-        return true;
-    }
-
-    private static bool HasReuse(QuestEntry q) =>
-        (q.ReuseMinutes ?? 0) > 0 || (q.ReuseHours ?? 0) > 0 || (q.ReuseDays ?? 0) > 0;
 
     private static TimeSpan ComputeDuration(QuestEntry q)
     {

--- a/src/Gandalf.Module/ViewModels/LootTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/LootTimersViewModel.cs
@@ -18,15 +18,17 @@ public sealed partial class LootTimersViewModel : ObservableObject
 {
     private readonly LootSource _source;
     private readonly DerivedTimerProgressService _derived;
+    private readonly TimeProvider _time;
     private readonly DispatcherTimer _refreshTimer;
 
     [ObservableProperty] private LootKindFilter _kindFilter = LootKindFilter.All;
     [ObservableProperty] private LootStateFilter _stateFilter = LootStateFilter.All;
 
-    public LootTimersViewModel(LootSource source, DerivedTimerProgressService derived)
+    public LootTimersViewModel(LootSource source, DerivedTimerProgressService derived, TimeProvider? time = null)
     {
         _source = source;
         _derived = derived;
+        _time = time ?? TimeProvider.System;
 
         _source.CatalogChanged += (_, _) => Sync();
         _source.ProgressChanged += (_, _) => Sync();
@@ -96,7 +98,7 @@ public sealed partial class LootTimersViewModel : ObservableObject
         foreach (var entry in _source.Catalog)
         {
             progress.TryGetValue(entry.Key, out var p);
-            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p)));
+            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p) { Clock = _time }));
         }
         TimersView.Refresh();
     }
@@ -109,7 +111,7 @@ public sealed partial class LootTimersViewModel : ObservableObject
         {
             if (!catalog.TryGetValue(vm.Key, out var entry)) continue;
             progress.TryGetValue(vm.Key, out var p);
-            vm.UpdateRow(new TimerRow(entry, p));
+            vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
         }
         TimersView.Refresh();
     }

--- a/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
@@ -22,16 +22,18 @@ public sealed partial class QuestTimersViewModel : ObservableObject
 {
     private readonly QuestSource _source;
     private readonly DerivedTimerProgressService _derived;
+    private readonly TimeProvider _time;
     private readonly DispatcherTimer _refreshTimer;
     private readonly Dictionary<string, TimerItemViewModel> _byKey = new(StringComparer.Ordinal);
     private Dictionary<string, TimerCatalogEntry> _catalogByKey = new(StringComparer.Ordinal);
 
     [ObservableProperty] private QuestStateFilter _stateFilter = QuestStateFilter.All;
 
-    public QuestTimersViewModel(QuestSource source, DerivedTimerProgressService derived)
+    public QuestTimersViewModel(QuestSource source, DerivedTimerProgressService derived, TimeProvider? time = null)
     {
         _source = source;
         _derived = derived;
+        _time = time ?? TimeProvider.System;
 
         _source.CatalogChanged += (_, _) => Sync();
         _source.ProgressChanged += (_, _) => Sync();
@@ -125,11 +127,11 @@ public sealed partial class QuestTimersViewModel : ObservableObject
             seen.Add(entry.Key);
             if (_byKey.TryGetValue(entry.Key, out var vm))
             {
-                vm.UpdateRow(new TimerRow(entry, p));
+                vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
             }
             else
             {
-                vm = new TimerItemViewModel(new TimerRow(entry, p));
+                vm = new TimerItemViewModel(new TimerRow(entry, p) { Clock = _time });
                 _byKey[entry.Key] = vm;
                 Timers.Add(vm);
             }
@@ -162,7 +164,7 @@ public sealed partial class QuestTimersViewModel : ObservableObject
             if (!_catalogByKey.TryGetValue(vm.Key, out var entry)) continue;
             progress.TryGetValue(vm.Key, out var p);
             var prior = vm.State;
-            vm.UpdateRow(new TimerRow(entry, p));
+            vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
             if (vm.State != prior) stateChanged = true;
         }
 

--- a/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
@@ -22,6 +22,7 @@ public sealed partial class TimerListViewModel : ObservableObject
     private readonly IDialogService? _dialogService;
     private readonly IActiveCharacterService? _active;
     private readonly ICharacterPresenceService? _presence;
+    private readonly TimeProvider _time;
     private readonly DispatcherTimer _refreshTimer;
 
     public TimerListViewModel(
@@ -31,7 +32,8 @@ public sealed partial class TimerListViewModel : ObservableObject
         TimerAlarmService? alarmService = null,
         IDialogService? dialogService = null,
         IActiveCharacterService? active = null,
-        ICharacterPresenceService? presence = null)
+        ICharacterPresenceService? presence = null,
+        TimeProvider? time = null)
     {
         _source = source;
         _defs = defs;
@@ -40,6 +42,7 @@ public sealed partial class TimerListViewModel : ObservableObject
         _dialogService = dialogService;
         _active = active;
         _presence = presence;
+        _time = time ?? TimeProvider.System;
 
         _source.CatalogChanged += (_, _) => { SyncFromState(); RefreshAutocomplete(); };
         _source.ProgressChanged += (_, _) => SyncFromState();
@@ -177,7 +180,7 @@ public sealed partial class TimerListViewModel : ObservableObject
         foreach (var entry in _source.Catalog)
         {
             progress.TryGetValue(entry.Key, out var p);
-            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p)));
+            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p) { Clock = _time }));
         }
 
         ApplyElapsedWhileAwayBadges();
@@ -201,7 +204,7 @@ public sealed partial class TimerListViewModel : ObservableObject
         var lastActive = _presence.GetLastActiveAt(name, server);
         if (lastActive is null) return;
 
-        var now = DateTimeOffset.UtcNow;
+        var now = _time.GetUtcNow();
         foreach (var vm in Timers)
         {
             if (vm.Row.Progress is null) continue;
@@ -246,7 +249,7 @@ public sealed partial class TimerListViewModel : ObservableObject
         {
             if (!catalog.TryGetValue(vm.Key, out var entry)) continue;
             progress.TryGetValue(vm.Key, out var p);
-            vm.UpdateRow(new TimerRow(entry, p));
+            vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
         }
     }
 }

--- a/tests/Gandalf.Tests/QuestSourceTests.cs
+++ b/tests/Gandalf.Tests/QuestSourceTests.cs
@@ -85,31 +85,26 @@ public class QuestSourceTests : IDisposable
     }
 
     [Fact]
-    public void Catalog_filter_drops_QuestCompletedRecently_gated_quests()
+    public void Catalog_admits_quests_with_any_requirement_type_when_Reuse_is_present()
     {
-        var gated = QuestEntryFactory.Repeatable("quest_g", "QG", "Gated", TimeSpan.FromHours(1),
+        // The game is the authoritative gate; QuestSource does not re-evaluate
+        // QuestCompletedRecently / MinDelayAfterFirstCompletion / etc. Any quest
+        // with a Reuse* duration is in the catalog and a future completion
+        // observation will stamp the cooldown row.
+        var recentlyGated = QuestEntryFactory.Repeatable("quest_a", "QA", "Recently-gated daily",
+            TimeSpan.FromHours(20),
             requirements: QuestEntryFactory.TimeGate("QuestCompletedRecently"));
-        var ok = QuestEntryFactory.Repeatable("quest_ok", "QOK", "Ungated", TimeSpan.FromHours(1));
-
-        var (src, derived, _, _) = Build(gated, ok);
-        try
-        {
-            src.Catalog.Should().HaveCount(1);
-            src.Catalog[0].DisplayName.Should().Be("Ungated");
-        }
-        finally { src.Dispose(); derived.Dispose(); }
-    }
-
-    [Fact]
-    public void Catalog_filter_drops_MinDelayAfterFirstCompletion_prefixed_requirements()
-    {
-        var gated = QuestEntryFactory.Repeatable("quest_g", "QG", "Gated", TimeSpan.FromHours(1),
+        var firstDelayGated = QuestEntryFactory.Repeatable("quest_b", "QB", "First-delay-gated daily",
+            TimeSpan.FromHours(20),
             requirements: QuestEntryFactory.TimeGate("MinDelayAfterFirstCompletion_Hours"));
+        var plain = QuestEntryFactory.Repeatable("quest_c", "QC", "Plain daily", TimeSpan.FromHours(20));
 
-        var (src, derived, _, _) = Build(gated);
+        var (src, derived, _, _) = Build(recentlyGated, firstDelayGated, plain);
         try
         {
-            src.Catalog.Should().BeEmpty();
+            src.Catalog.Should().HaveCount(3);
+            src.Catalog.Select(c => c.DisplayName).Should().BeEquivalentTo(
+                "Recently-gated daily", "First-delay-gated daily", "Plain daily");
         }
         finally { src.Dispose(); derived.Dispose(); }
     }

--- a/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
+++ b/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
@@ -48,7 +48,7 @@ public class QuestTimersViewModelTests : IDisposable
 
         var refData = new FakeReferenceData(quests);
         var src = new QuestSource(derived, refData, time);
-        var vm = new QuestTimersViewModel(src, derived);
+        var vm = new QuestTimersViewModel(src, derived, time);
         return (vm, src, derived, time);
     }
 
@@ -94,12 +94,11 @@ public class QuestTimersViewModelTests : IDisposable
     public void Recently_completed_quest_appears_as_running()
     {
         var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(1));
-        var (vm, src, derived, _) = Build(q);
+        var (vm, src, derived, time) = Build(q);
         try
         {
-            // StartedAt = now → 1h cooldown still ticking. State reads wall clock,
-            // so anchor on real `DateTime.UtcNow` rather than the injected provider.
-            src.OnQuestCompleted("Q1", DateTime.UtcNow);
+            // StartedAt = now → 1h cooldown still ticking.
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
 
             vm.Timers.Should().HaveCount(1);
             vm.Timers[0].State.Should().Be(TimerState.Running);
@@ -111,11 +110,11 @@ public class QuestTimersViewModelTests : IDisposable
     public void Quest_completed_long_ago_appears_as_done()
     {
         var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(1));
-        var (vm, src, derived, _) = Build(q);
+        var (vm, src, derived, time) = Build(q);
         try
         {
             // StartedAt = 2h ago → 1h cooldown elapsed → Done.
-            src.OnQuestCompleted("Q1", DateTime.UtcNow - TimeSpan.FromHours(2));
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime - TimeSpan.FromHours(2));
 
             vm.Timers.Should().HaveCount(1);
             vm.Timers[0].State.Should().Be(TimerState.Done);


### PR DESCRIPTION
## Summary

- **Drops `QuestSource`'s requirement-inspection filter.** The catalog previously excluded any repeatable quest with a `QuestCompletedRecently` or `MinDelayAfterFirstCompletion*` requirement, on the theory that we couldn't compute the cooldown correctly. The actual effect: legitimate completion observations on chained dailies (e.g. Orrrilund's Doctrine-Keeper ↔ Den Mother pair in the Ranalon Den) were silently dropped — no row stamped, no cooldown rendered. The fix collapses to the right rule: catalog admits anything with a `Reuse*` duration; if the game emitted `ProcessCompleteQuest`, every requirement was already satisfied server-side, and re-checking client-side is redundant authority-shopping.
- **Wiki:** new `Mithril-Design-Principles` page with "the game is the authoritative gate" recorded as the first cross-cutting principle, linked from Home.
- **Agent plan:** `docs/agent-plans/quest-discovery-module.md` captures the future quest-browser module design (eligibility evaluation, chain-card stacked UI with vertical-dot navigation, dashboard collapsing) so it isn't lost.
- **Bonus fix — time-dependent test flake.** `TimerRow.State` / `Remaining` / `Fraction` read `DateTimeOffset.UtcNow` directly. Tests using `ManualTime` to anchor `StartedAt` only passed when run within the anchor's wall-clock proximity; today's date drift broke them at midnight. `TimerRow` grows a `TimeProvider Clock { init; }` defaulting to `TimeProvider.System`. `QuestTimersViewModel`, `LootTimersViewModel`, and `TimerListViewModel` accept an optional `TimeProvider` and pass it through.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — 1116 passed, 0 failed
- [x] New test `Catalog_admits_quests_with_any_requirement_type_when_Reuse_is_present` covers the relaxed rule
- [x] `Tick_does_not_refresh_view_when_no_state_changed` and `Quest_completed_long_ago_appears_as_done` (previously time-dependent flakes) now anchor on the injected `TimeProvider`
- [ ] In-game verification — complete `KilltheDenMotherRepeat` (28505) and confirm a 20h row appears in the Quests tab (deferred to next play session)

## Out of scope (next PR)

- Boss-side equivalent: auto-discover defeat-cooldown bosses from the CombatInfo wisdom-credit signal + calibration overlay for durations, retiring `DefeatCatalogSeed.Bundled`.
- Stacked-card chain UI (lives in the future quest-discovery module per the agent plan).

## Wiki

[`abb0c6d`](https://github.com/arthur-conde/project-gorgon/wiki/Mithril-Design-Principles) — adds Mithril Design Principles page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)