### PR TITLE
fix(gandalf): replay must preserve user's dismissal (#86)

### DIFF
--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -89,10 +89,10 @@ public sealed class LootSource : ITimerSource, IDisposable
         var prior = _derived.GetProgress(Id, key);
         var startedAt = new DateTimeOffset(timestampUtc, TimeSpan.Zero);
 
-        // Idempotency: if we already track this chest with the same StartedAt,
-        // skip the redundant write so we don't churn the persistence layer on
-        // log replay.
-        if (prior is not null && prior.StartedAt == startedAt && prior.DismissedAt is null) return;
+        // Idempotency: matching StartedAt means this is a replay of the same
+        // line. Skip regardless of DismissedAt — clearing DismissedAt would
+        // silently resurrect a row the user explicitly X'd out.
+        if (prior is not null && prior.StartedAt == startedAt) return;
 
         _derived.Start(Id, key, startedAt);
         EnsureCatalogReprojected();
@@ -170,9 +170,11 @@ public sealed class LootSource : ITimerSource, IDisposable
             EnsureCatalogReprojected();
         }
 
-        // Idempotency: identical timestamp + still-active row → no churn.
+        // Idempotency: matching StartedAt means this is a replay of the same
+        // wisdom-credit line. Skip regardless of DismissedAt — clearing
+        // DismissedAt would silently resurrect a row the user X'd out.
         var prior = _derived.GetProgress(Id, key);
-        if (prior is not null && prior.StartedAt == startedAt && prior.DismissedAt is null) return;
+        if (prior is not null && prior.StartedAt == startedAt) return;
 
         _derived.Start(Id, key, startedAt);
         FireReady(key, displayName, durationOverride: duration, atUtc: startedAt + duration);

--- a/src/Gandalf.Module/Services/QuestSource.cs
+++ b/src/Gandalf.Module/Services/QuestSource.cs
@@ -120,7 +120,10 @@ public sealed class QuestSource : ITimerSource, IDisposable
         var key = QuestKey(questInternalName);
         var startedAt = new DateTimeOffset(timestampUtc, TimeSpan.Zero);
         var prior = _derived.GetProgress(Id, key);
-        if (prior is not null && prior.StartedAt == startedAt && prior.DismissedAt is null) return;
+        // Idempotency: matching StartedAt means this is a replay of the same
+        // ProcessCompleteQuest line. Skip regardless of DismissedAt —
+        // clearing DismissedAt would silently resurrect a row the user X'd out.
+        if (prior is not null && prior.StartedAt == startedAt) return;
 
         _derived.Start(Id, key, startedAt);
 

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -217,6 +217,82 @@ public class LootSourceTests : IDisposable
     }
 
     [Fact]
+    public void Replay_of_dismissed_boss_kill_preserves_dismissal()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            var killTime = time.GetUtcNow().UtcDateTime;
+            src.OnBossKillCredit("Megaspider", killTime);
+
+            var key = LootSource.DefeatKey("Megaspider");
+            derived.Dismiss(LootSource.Id, key);
+            src.Progress[key].DismissedAt.Should().NotBeNull();
+
+            // Same line replays (e.g. Mithril restarts mid-session and
+            // PlayerLogStream re-feeds the wisdom-credit line). Dismissal
+            // must survive.
+            src.OnBossKillCredit("Megaspider", killTime);
+            src.Progress[key].DismissedAt.Should().NotBeNull(
+                "replay of the same StartedAt must not undo the user's dismissal");
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Genuine_re_kill_after_dismissal_resurrects_the_row()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnBossKillCredit("Megaspider", time.GetUtcNow().UtcDateTime);
+
+            var key = LootSource.DefeatKey("Megaspider");
+            derived.Dismiss(LootSource.Id, key);
+
+            // A *new* kill (different timestamp) is not a replay — the player
+            // legitimately re-killed the boss after the cooldown elapsed and
+            // the row should resurrect with a fresh clock.
+            time.Advance(TimeSpan.FromHours(4));
+            var newKill = time.GetUtcNow().UtcDateTime;
+            src.OnBossKillCredit("Megaspider", newKill);
+
+            src.Progress[key].StartedAt.Should().Be(time.GetUtcNow());
+            src.Progress[key].DismissedAt.Should().BeNull();
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Replay_of_dismissed_chest_loot_preserves_dismissal()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
+            var lootTime = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("GoblinStaticChest1", lootTime);
+
+            var key = LootSource.ChestKey("GoblinStaticChest1");
+            derived.Dismiss(LootSource.Id, key);
+
+            // Same chest line replays — dismissal must survive.
+            src.OnChestInteraction("GoblinStaticChest1", lootTime);
+            src.Progress[key].DismissedAt.Should().NotBeNull();
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
     public void DefeatCooldownActive_is_diagnostic_only_does_not_mutate_progress()
     {
         var (src, derived, _, time) = Build();

--- a/tests/Gandalf.Tests/QuestSourceTests.cs
+++ b/tests/Gandalf.Tests/QuestSourceTests.cs
@@ -132,6 +132,51 @@ public class QuestSourceTests : IDisposable
     }
 
     [Fact]
+    public void Replay_of_dismissed_quest_completion_preserves_dismissal()
+    {
+        var quest = QuestEntryFactory.Repeatable("quest_1", "Q1", "Daily", TimeSpan.FromHours(20));
+        var (src, derived, _, time) = Build(quest);
+        try
+        {
+            var completedAt = time.GetUtcNow().UtcDateTime;
+            src.OnQuestCompleted("Q1", completedAt);
+
+            var key = QuestSource.QuestKey("Q1");
+            derived.Dismiss(QuestSource.Id, key);
+            src.Progress[key].DismissedAt.Should().NotBeNull();
+
+            // Same line replays (PlayerLogStream re-feeds the
+            // ProcessCompleteQuest line on next launch). Dismissal must survive.
+            src.OnQuestCompleted("Q1", completedAt);
+            src.Progress[key].DismissedAt.Should().NotBeNull(
+                "replay of the same StartedAt must not undo the user's dismissal");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Genuine_re_completion_after_dismissal_resurrects_the_row()
+    {
+        var quest = QuestEntryFactory.Repeatable("quest_1", "Q1", "Daily", TimeSpan.FromHours(20));
+        var (src, derived, _, time) = Build(quest);
+        try
+        {
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
+            var key = QuestSource.QuestKey("Q1");
+            derived.Dismiss(QuestSource.Id, key);
+
+            // A genuine re-completion after the cooldown — different timestamp,
+            // not a replay. The row should resurrect with a fresh clock.
+            time.Advance(TimeSpan.FromHours(21));
+            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
+
+            src.Progress[key].StartedAt.Should().Be(time.GetUtcNow());
+            src.Progress[key].DismissedAt.Should().BeNull();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
     public void OnQuestCompleted_drops_quest_from_pending()
     {
         var quest = QuestEntryFactory.Repeatable("quest_1", "Q1", "Daily", TimeSpan.FromHours(20));


### PR DESCRIPTION
## Summary

When the user clicks X on a Loot- or Quest-tab row, `DismissedAt` is set so the UI hides it. The row stays in storage so a future fresh observation can resurrect it — that's the cross-source "ready and unacked" model. But `PlayerLogStream` seeks to the most recent `ProcessAddPlayer(` on attach and replays everything from there, so within a single game session the same kill / completion line gets re-emitted every Mithril launch.

The replay guard in three ingestion paths — `LootSource.OnBossKillCredit`, `LootSource.OnChestInteraction`, `QuestSource.OnQuestCompleted` — included `&& prior.DismissedAt is null`, so it only skipped *un-dismissed* matching rows. A dismissed row's replay fell through to `_derived.Start(...)`, which clears `DismissedAt = null`. Result: dismissals were silently undone on the next launch.

Drops the trailing clause from each guard. The rule is now purely "matching `StartedAt` = replay, skip", regardless of dismissal state. Genuine fresh observations have a different `StartedAt` and still fall through, correctly resurrecting the row with a fresh clock.

## Resolves

- #86 — replay clobbers dismissed rows.
- Backwards-compat: any row dismissed before this PR will start sticking dismissed-after the fix lands; no data migration needed.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — 1130 passed, 0 failed (Gandalf 153 → 158 with 5 new tests)
- [x] `Replay_of_dismissed_boss_kill_preserves_dismissal` — same line replays, `DismissedAt` survives
- [x] `Genuine_re_kill_after_dismissal_resurrects_the_row` — new timestamp clears dismissal
- [x] `Replay_of_dismissed_chest_loot_preserves_dismissal` — same coverage on the chest path
- [x] `Replay_of_dismissed_quest_completion_preserves_dismissal` — same on the Quest path
- [x] `Genuine_re_completion_after_dismissal_resurrects_the_row` — Quest path resurrection
- [ ] In-game verification — dismiss a row, restart Mithril mid-session, confirm the row stays hidden (deferred to next play session)

## Companion changes

- **wiki:** [`ebb165d`](https://github.com/arthur-conde/project-gorgon/wiki/Log-Service#3-replay-must-preserve-dismissal) drops the "Verification owed" note from the Log Service page now that the gap is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)