### PR TITLE
feat(gandalf): first-loot stamps unverified chest row, rejection upgrades in place

### DIFF
--- a/src/Gandalf.Module/Domain/LootCatalogCache.cs
+++ b/src/Gandalf.Module/Domain/LootCatalogCache.cs
@@ -22,8 +22,24 @@ public sealed class LootCatalogCache
 
     public int SchemaVersion { get; set; } = Version;
 
-    /// <summary>Map keyed by chest internal name (e.g. <c>GoblinStaticChest1</c>).</summary>
+    /// <summary>
+    /// Verified chest cooldown durations learned from the game's re-loot
+    /// rejection screen text. Keyed by chest internal name (e.g.
+    /// <c>GoblinStaticChest1</c>). Membership here means the duration is
+    /// authoritative; rows in <see cref="LearnedChests"/> without a cache entry
+    /// fall back to <see cref="Services.LootSource.PlaceholderChestDuration"/>
+    /// and surface as <c>IsDurationVerified=false</c>.
+    /// </summary>
     public Dictionary<string, TimeSpan> ChestDurationByInternalName { get; set; } =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Chests the player has personally looted in any session. Discovered via
+    /// the bracket-tracker AddItem signal regardless of whether the duration is
+    /// known yet. Persisted so a chest's row reappears after restart even when
+    /// the cooldown is still anchored on a prior session's loot.
+    /// </summary>
+    public Dictionary<string, LearnedChest> LearnedChests { get; set; } =
         new(StringComparer.Ordinal);
 
     /// <summary>
@@ -35,6 +51,18 @@ public sealed class LootCatalogCache
     /// </summary>
     public Dictionary<string, LearnedDefeat> LearnedDefeats { get; set; } =
         new(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Per-chest bookkeeping for the auto-discovered catalog. Mirrors
+/// <see cref="LearnedDefeat"/>; the chest's duration lives in
+/// <see cref="LootCatalogCache.ChestDurationByInternalName"/> only once a
+/// rejection has confirmed it.
+/// </summary>
+public sealed class LearnedChest
+{
+    public DateTime FirstObservedAt { get; set; }
+    public DateTime LastObservedAt { get; set; }
 }
 
 /// <summary>

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -33,6 +33,15 @@ public sealed class LootSource : ITimerSource, IDisposable
     /// </summary>
     public static readonly TimeSpan PlaceholderDefeatDuration = TimeSpan.FromHours(3);
 
+    /// <summary>
+    /// Folklore-default cooldown for a chest looted before any rejection has
+    /// taught us the real duration. The chest's row appears immediately
+    /// anchored on the original loot timestamp; on the next rejection the
+    /// duration upgrades in place and <see cref="LootCatalogPayload.IsDurationVerified"/>
+    /// flips to <c>true</c> without resetting the clock.
+    /// </summary>
+    public static readonly TimeSpan PlaceholderChestDuration = TimeSpan.FromHours(3);
+
     private readonly DerivedTimerProgressService _derived;
     private readonly ISettingsStore<LootCatalogCache> _cacheStore;
     private readonly LootCatalogCache _cache;
@@ -70,24 +79,48 @@ public sealed class LootSource : ITimerSource, IDisposable
 
     /// <summary>
     /// Apply a chest interaction observation: stamp a cooldown row anchored on
-    /// the log timestamp. If the duration for this chest template is unknown
-    /// the row is skipped (we'll learn the duration on a future re-loot
-    /// rejection and backfill on the next interaction).
+    /// the log timestamp. If the chest's real duration hasn't been observed
+    /// yet (no rejection screen has fired for this template) the row is
+    /// stamped with <see cref="PlaceholderChestDuration"/> and surfaces as
+    /// <c>IsDurationVerified=false</c>; on a future rejection
+    /// <see cref="OnChestCooldownObserved"/> upgrades the duration without
+    /// resetting the row's <c>StartedAt</c>.
     /// </summary>
     public void OnChestInteraction(string chestInternalName, DateTime timestampUtc)
     {
         if (string.IsNullOrEmpty(chestInternalName)) return;
-        if (!_cache.ChestDurationByInternalName.TryGetValue(chestInternalName, out var duration))
-        {
-            // First-ever loot of this chest template — duration is unknown until
-            // a future re-loot rejection populates the catalog. Don't create a
-            // row with a guessed duration.
-            return;
-        }
 
+        var (duration, _) = ResolveChestDuration(chestInternalName);
         var key = ChestKey(chestInternalName);
         var prior = _derived.GetProgress(Id, key);
         var startedAt = new DateTimeOffset(timestampUtc, TimeSpan.Zero);
+
+        // Persist the discovery so the row survives across sessions even if
+        // the rejection screen never fires (placeholder behaviour mirrors the
+        // defeat-cooldown auto-learn path).
+        var learnedChanged = false;
+        lock (_catalogLock)
+        {
+            if (!_cache.LearnedChests.TryGetValue(chestInternalName, out var entry))
+            {
+                _cache.LearnedChests[chestInternalName] = new LearnedChest
+                {
+                    FirstObservedAt = timestampUtc,
+                    LastObservedAt = timestampUtc,
+                };
+                learnedChanged = true;
+            }
+            else if (timestampUtc > entry.LastObservedAt)
+            {
+                entry.LastObservedAt = timestampUtc;
+                learnedChanged = true;
+            }
+        }
+        if (learnedChanged)
+        {
+            try { _cacheStore.Save(_cache); } catch { /* best-effort */ }
+            EnsureCatalogReprojected();
+        }
 
         // Idempotency: matching StartedAt means this is a replay of the same
         // line. Skip regardless of DismissedAt — clearing DismissedAt would
@@ -101,8 +134,15 @@ public sealed class LootSource : ITimerSource, IDisposable
 
     /// <summary>
     /// Apply a chest rejection observation: cache the discovered duration
-    /// against the chest template name. Future first-loots of any chest of this
-    /// template will start with the right duration.
+    /// against the chest template name. Future loots of any chest of this
+    /// template will start with the verified duration.
+    ///
+    /// If a placeholder row is already in flight from an earlier loot, the
+    /// row's <c>StartedAt</c> is preserved (it's anchored on the original
+    /// <c>ProcessStartInteraction</c> timestamp). The catalog re-projection
+    /// upgrades the duration and flips <c>IsDurationVerified</c> to <c>true</c>;
+    /// if the new ready time has already elapsed,
+    /// <see cref="TimerReady"/> fires so downstream listeners notice.
     /// </summary>
     public void OnChestCooldownObserved(string chestInternalName, TimeSpan duration)
     {
@@ -121,6 +161,18 @@ public sealed class LootSource : ITimerSource, IDisposable
         {
             try { _cacheStore.Save(_cache); } catch { /* best-effort */ }
             EnsureCatalogReprojected();
+
+            // Re-fire ready for an in-flight row whose anchor + new duration
+            // has already elapsed. StartedAt stays put — only the duration
+            // upgrade matters.
+            var key = ChestKey(chestInternalName);
+            var prior = _derived.GetProgress(Id, key);
+            if (prior is not null && prior.DismissedAt is null)
+            {
+                FireReady(key, chestInternalName,
+                    durationOverride: duration,
+                    atUtc: prior.StartedAt + duration);
+            }
         }
     }
 
@@ -220,6 +272,13 @@ public sealed class LootSource : ITimerSource, IDisposable
         return (PlaceholderDefeatDuration, false);
     }
 
+    private (TimeSpan duration, bool verified) ResolveChestDuration(string internalName)
+    {
+        if (_cache.ChestDurationByInternalName.TryGetValue(internalName, out var d))
+            return (d, true);
+        return (PlaceholderChestDuration, false);
+    }
+
     private void OnDerivedProgressChanged(object? sender, EventArgs e) =>
         ProgressChanged?.Invoke(this, EventArgs.Empty);
 
@@ -236,17 +295,26 @@ public sealed class LootSource : ITimerSource, IDisposable
 
     private IReadOnlyList<TimerCatalogEntry> BuildCatalog()
     {
-        var list = new List<TimerCatalogEntry>(
-            _cache.ChestDurationByInternalName.Count + _cache.LearnedDefeats.Count);
+        // Union of every chest that's been looted (LearnedChests) and every
+        // chest whose duration has been observed via rejection
+        // (ChestDurationByInternalName) — covers the rejection-only walk-up
+        // case where the player saw the screen text without ever looting.
+        var chestNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in _cache.LearnedChests.Keys) chestNames.Add(name);
+        foreach (var name in _cache.ChestDurationByInternalName.Keys) chestNames.Add(name);
 
-        foreach (var (internalName, duration) in _cache.ChestDurationByInternalName)
+        var list = new List<TimerCatalogEntry>(chestNames.Count + _cache.LearnedDefeats.Count);
+
+        foreach (var internalName in chestNames)
         {
+            var (duration, verified) = ResolveChestDuration(internalName);
             list.Add(new TimerCatalogEntry(
                 Key: ChestKey(internalName),
                 DisplayName: internalName,
                 Region: "Chests",
                 Duration: duration,
-                SourceMetadata: new LootCatalogPayload(LootKind.Chest, internalName, Region: null)));
+                SourceMetadata: new LootCatalogPayload(
+                    LootKind.Chest, internalName, Region: null, IsDurationVerified: verified)));
         }
 
         foreach (var displayName in _cache.LearnedDefeats.Keys)

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -50,16 +50,24 @@ public class LootSourceTests : IDisposable
     }
 
     [Fact]
-    public void First_loot_of_unknown_chest_does_not_create_a_row()
+    public void First_loot_of_unknown_chest_creates_unverified_placeholder_row()
     {
         var (src, derived, _, time) = Build();
         try
         {
-            // Duration unknown until rejection observed — don't fabricate one.
-            src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
+            // No rejection observed yet → row stamps with PlaceholderChestDuration,
+            // catalog row flagged unverified. The user sees an immediate timer
+            // instead of silently losing the cooldown.
+            var lootTime = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("GoblinStaticChest1", lootTime);
 
-            src.Catalog.Should().BeEmpty();
-            src.Progress.Should().BeEmpty();
+            src.Catalog.Should().HaveCount(1);
+            src.Catalog[0].Duration.Should().Be(LootSource.PlaceholderChestDuration);
+            ((LootCatalogPayload)src.Catalog[0].SourceMetadata!).IsDurationVerified.Should().BeFalse();
+
+            src.Progress.Should().ContainKey(LootSource.ChestKey("GoblinStaticChest1"));
+            src.Progress[LootSource.ChestKey("GoblinStaticChest1")].StartedAt
+                .Should().Be(new DateTimeOffset(lootTime, TimeSpan.Zero));
         }
         finally
         {
@@ -68,7 +76,88 @@ public class LootSourceTests : IDisposable
     }
 
     [Fact]
-    public void Rejection_caches_duration_and_subsequent_loots_create_rows()
+    public void Rejection_after_placeholder_loot_upgrades_duration_and_preserves_StartedAt()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            // Loot at T0 with no prior rejection → placeholder row anchored at T0.
+            var lootTime = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("EltibuleSecretChest", lootTime);
+
+            var key = LootSource.ChestKey("EltibuleSecretChest");
+            var anchored = src.Progress[key].StartedAt;
+
+            // Rejection arrives later carrying the real duration. The row's
+            // anchor must remain at the original ProcessStartInteraction
+            // timestamp; only the catalog Duration upgrades.
+            time.Advance(TimeSpan.FromMinutes(45));
+            src.OnChestCooldownObserved("EltibuleSecretChest", TimeSpan.FromHours(6));
+
+            src.Progress[key].StartedAt.Should().Be(anchored,
+                "rejection learns the duration but the cooldown is still anchored on the original loot");
+
+            src.Catalog.Should().HaveCount(1);
+            src.Catalog[0].Duration.Should().Be(TimeSpan.FromHours(6));
+            ((LootCatalogPayload)src.Catalog[0].SourceMetadata!).IsDurationVerified.Should().BeTrue();
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Rejection_with_shorter_real_duration_fires_TimerReady_when_already_elapsed()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            var lootTime = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("GoblinStaticChest1", lootTime);
+
+            var fired = new List<TimerReadyEventArgs>();
+            src.TimerReady += (_, e) => fired.Add(e);
+
+            // Real duration (15 min) is shorter than the 3 h placeholder, and
+            // we've already advanced 30 min — the row is genuinely ready now.
+            time.Advance(TimeSpan.FromMinutes(30));
+            src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromMinutes(15));
+
+            fired.Should().ContainSingle()
+                .Which.Key.Should().Be(LootSource.ChestKey("GoblinStaticChest1"));
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Rejection_after_placeholder_loot_does_not_refire_when_still_cooling()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
+
+            var fired = new List<TimerReadyEventArgs>();
+            src.TimerReady += (_, e) => fired.Add(e);
+
+            // Real duration (6 h) is longer than the placeholder; the row is
+            // still cooling, no ready fire expected.
+            src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(6));
+
+            fired.Should().BeEmpty();
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Subsequent_loot_after_rejection_uses_verified_duration()
     {
         var (src, derived, _, time) = Build();
         try
@@ -76,13 +165,15 @@ public class LootSourceTests : IDisposable
             src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
             src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
 
-            src.Catalog.Should().HaveCount(1);
-            src.Catalog[0].Duration.Should().Be(TimeSpan.FromHours(3));
+            time.Advance(TimeSpan.FromHours(4));
+            var newLoot = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("GoblinStaticChest1", newLoot);
 
-            time.Advance(TimeSpan.FromMinutes(10));
-            src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
-
-            src.Progress.Should().ContainKey(LootSource.ChestKey("GoblinStaticChest1"));
+            var key = LootSource.ChestKey("GoblinStaticChest1");
+            src.Progress[key].StartedAt.Should().Be(new DateTimeOffset(newLoot, TimeSpan.Zero));
+            src.Catalog.Single(c => c.Key == key).Duration.Should().Be(TimeSpan.FromHours(3));
+            ((LootCatalogPayload)src.Catalog.Single(c => c.Key == key).SourceMetadata!)
+                .IsDurationVerified.Should().BeTrue();
         }
         finally
         {


### PR DESCRIPTION
Closes #88.

## Summary

- First loot of an unknown chest no longer drops silently. The row appears immediately anchored on the `ProcessStartInteraction` timestamp with `PlaceholderChestDuration` (3 h) and `IsDurationVerified=false`.
- When the rejection screen text fires later, `OnChestCooldownObserved` upgrades the cached duration and re-projects the catalog **without touching `StartedAt`** — the cooldown is still anchored on the original loot, so the ready time correctly becomes `original-loot-timestamp + verified-duration`.
- If the new ready time has already elapsed (e.g., placeholder 3 h was longer than real 15 min), `TimerReady` fires once so downstream listeners notice. If the new duration is still in the future, the row keeps cooling silently.
- Adds `LearnedChests` to `LootCatalogCache`, mirroring `LearnedDefeats` from #85. The catalog projection unions `LearnedChests` with `ChestDurationByInternalName`, so the rejection-only walk-up case still surfaces a verified row even before the player's first loot.

## Test plan

- [x] `First_loot_of_unknown_chest_creates_unverified_placeholder_row`
- [x] `Rejection_after_placeholder_loot_upgrades_duration_and_preserves_StartedAt`
- [x] `Rejection_with_shorter_real_duration_fires_TimerReady_when_already_elapsed`
- [x] `Rejection_after_placeholder_loot_does_not_refire_when_still_cooling`
- [x] `Subsequent_loot_after_rejection_uses_verified_duration`
- [x] Full `Gandalf.Tests` suite passes (161/161)
- [ ] Manual smoke: loot a never-before-seen chest in-game, confirm a row appears in the Loot tab with the unverified flag, then attempt to re-loot and confirm the row's duration upgrades while the original anchor is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)