### PR TITLE
feat(arwen): Storage Gifts tab — cross-reference storage with gift recipients

### DIFF
--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -87,7 +87,13 @@ public sealed class ArwenModule : IMithrilModule
         services.AddSingleton<FavorCalculatorViewModel>();
         services.AddSingleton<GiftScannerViewModel>();
         services.AddSingleton<ItemLookupViewModel>();
+        services.AddSingleton<StorageGiftsViewModel>();
         services.AddSingleton<CalibrationViewModel>();
+
+        // Holder is constructed early; .Inner is wired below once FavorView exists.
+        // VMs depend on IFavorViewNavigator (the holder) so DI doesn't loop back into FavorView.
+        services.AddSingleton<FavorViewNavigatorHolder>();
+        services.AddSingleton<IFavorViewNavigator>(sp => sp.GetRequiredService<FavorViewNavigatorHolder>());
 
         services.AddSingleton<FavorView>(sp =>
         {
@@ -96,7 +102,9 @@ public sealed class ArwenModule : IMithrilModule
             view.AddTab("Favor Calculator", new FavorCalculatorTab { DataContext = sp.GetRequiredService<FavorCalculatorViewModel>() });
             view.AddTab("Gift Scanner", new GiftScannerTab { DataContext = sp.GetRequiredService<GiftScannerViewModel>() });
             view.AddTab("Item Lookup", new ItemLookupTab { DataContext = sp.GetRequiredService<ItemLookupViewModel>() });
+            view.AddTab("Storage Gifts", new StorageGiftsTab { DataContext = sp.GetRequiredService<StorageGiftsViewModel>() });
             view.AddTab("Calibration", new CalibrationTab { DataContext = sp.GetRequiredService<CalibrationViewModel>() });
+            sp.GetRequiredService<FavorViewNavigatorHolder>().Inner = view;
             return view;
         });
         services.AddSingleton<ArwenSettingsView>(sp => new ArwenSettingsView

--- a/src/Arwen.Module/Domain/GiftFilter.cs
+++ b/src/Arwen.Module/Domain/GiftFilter.cs
@@ -1,0 +1,63 @@
+using Mithril.Shared.Storage;
+
+namespace Arwen.Domain;
+
+/// <summary>
+/// Verifies that a real inventory item passes every filter-style keyword
+/// across all matched NPC preferences. CDN template matching is over-inclusive
+/// for filter keywords like MinRarity / MinValue / Rarity / Crafted — those are
+/// checked against the actual <see cref="StorageItem"/> properties here.
+/// </summary>
+public static class GiftFilter
+{
+    public static bool Passes(StorageItem item, IReadOnlyList<MatchedPreference> matchedPrefs)
+    {
+        foreach (var pref in matchedPrefs)
+        {
+            foreach (var kw in pref.Keywords)
+            {
+                if (!PassesSingleFilter(item, kw)) return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool PassesSingleFilter(StorageItem item, string kw)
+    {
+        if (kw.StartsWith("MinRarity:", StringComparison.Ordinal))
+        {
+            var required = kw["MinRarity:".Length..];
+            return RarityRank(item.Rarity) >= RarityRank(required);
+        }
+
+        if (kw.StartsWith("Rarity:", StringComparison.Ordinal))
+        {
+            var required = kw["Rarity:".Length..];
+            if (required == "Common")
+                return item.Rarity is null;
+            return string.Equals(item.Rarity, required, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (kw.StartsWith("MinValue:", StringComparison.Ordinal))
+        {
+            if (int.TryParse(kw.AsSpan("MinValue:".Length), out var minVal))
+                return item.Value >= minVal;
+        }
+
+        if (kw == "Crafted:y")
+            return item.IsCrafted;
+
+        return true;
+    }
+
+    private static int RarityRank(string? rarity) => rarity switch
+    {
+        null => 0,           // Common (no rarity field)
+        "Uncommon" => 1,
+        "Rare" => 2,
+        "Exceptional" => 3,
+        "Epic" => 4,
+        "Legendary" => 5,
+        _ => 0,
+    };
+}

--- a/src/Arwen.Module/Domain/StorageGiftCards.cs
+++ b/src/Arwen.Module/Domain/StorageGiftCards.cs
@@ -1,0 +1,43 @@
+namespace Arwen.Domain;
+
+/// <summary>
+/// One item in storage that has at least one accepting NPC. Carries its own
+/// pre-projected recipient list so the detail pane is instant on selection.
+/// </summary>
+public sealed record StorageItemCard(
+    int TypeId,
+    int IconId,
+    string Name,
+    int StackSize,
+    string Vault,
+    int RecipientCount,
+    bool HasLove,
+    IReadOnlyList<RecipientCard> AllRecipients);
+
+/// <summary>
+/// One NPC who would accept a particular item. Mirrors the favor-projection
+/// shape used by <see cref="ViewModels.GiftScannerRow"/> so the same
+/// "Favor After Gift" XAML pattern renders both views.
+/// </summary>
+public sealed record RecipientCard(
+    string NpcKey,
+    string NpcName,
+    string NpcArea,
+    string Desire,
+    double RelativeScore,
+    // Favor projection (null when calibration data is unavailable):
+    double? EstimatedFavor,        // per-stack total favor
+    string? EstimateSource,        // calibration tier (Item / Signature / NPC / Global)
+    int EstimateSamples,
+    double? CurrentFavor,           // null when player hasn't met the NPC
+    double? ProjectedFavor,
+    FavorTier CurrentTier,
+    FavorTier ProjectedTier,
+    double CurrentTierCeiling,
+    double CurrentProgressFraction,
+    double ProjectedProgressFraction);
+
+/// <summary>Detail-pane group: all recipients in a single NPC area.</summary>
+public sealed record RecipientAreaGroup(
+    string Area,
+    IReadOnlyList<RecipientCard> Recipients);

--- a/src/Arwen.Module/ViewModels/GiftScannerViewModel.cs
+++ b/src/Arwen.Module/ViewModels/GiftScannerViewModel.cs
@@ -154,7 +154,7 @@ public sealed partial class GiftScannerViewModel : ObservableObject
             // multiple NPC preferences; each preference's filter-type keywords (MinRarity, Rarity,
             // MinValue, Crafted) must pass for the item to qualify.
             var allPrefs = _giftIndex.MatchAllPreferencesForItem(match.ItemId, SelectedNpc.NpcKey);
-            if (!PassesStorageFilters(item, allPrefs)) continue;
+            if (!GiftFilter.Passes(item, allPrefs)) continue;
 
             var location = StorageReportLoader.NormalizeLocation(item.StorageVault, item.IsInInventory);
             var estimate = _calibration.EstimateFavor(match, SelectedNpc.NpcKey);
@@ -216,60 +216,4 @@ public sealed partial class GiftScannerViewModel : ObservableObject
         StatusMessage = $"Found {rows.Count:N0} giftable items{calibratedSuffix}";
     }
 
-    /// <summary>
-    /// Checks whether a real inventory item passes every filter-style keyword across all
-    /// matched NPC preferences. CDN template matching is over-inclusive for filter keywords
-    /// like MinRarity/MinValue/Rarity — the scanner verifies against actual inventory item
-    /// properties. All filter checks must pass.
-    /// </summary>
-    private static bool PassesStorageFilters(StorageItem item, IReadOnlyList<MatchedPreference> allPrefs)
-    {
-        foreach (var pref in allPrefs)
-        {
-            foreach (var kw in pref.Keywords)
-            {
-                if (!PassesSingleFilter(item, kw)) return false;
-            }
-        }
-        return true;
-    }
-
-    private static bool PassesSingleFilter(StorageItem item, string kw)
-    {
-        if (kw.StartsWith("MinRarity:", StringComparison.Ordinal))
-        {
-            var required = kw["MinRarity:".Length..];
-            return RarityRank(item.Rarity) >= RarityRank(required);
-        }
-
-        if (kw.StartsWith("Rarity:", StringComparison.Ordinal))
-        {
-            var required = kw["Rarity:".Length..];
-            if (required == "Common")
-                return item.Rarity is null;
-            return string.Equals(item.Rarity, required, StringComparison.OrdinalIgnoreCase);
-        }
-
-        if (kw.StartsWith("MinValue:", StringComparison.Ordinal))
-        {
-            if (int.TryParse(kw.AsSpan("MinValue:".Length), out var minVal))
-                return item.Value >= minVal;
-        }
-
-        if (kw == "Crafted:y")
-            return item.IsCrafted;
-
-        return true;
-    }
-
-    private static int RarityRank(string? rarity) => rarity switch
-    {
-        null => 0,           // Common (no rarity field)
-        "Uncommon" => 1,
-        "Rare" => 2,
-        "Exceptional" => 3,
-        "Epic" => 4,
-        "Legendary" => 5,
-        _ => 0,
-    };
 }

--- a/src/Arwen.Module/ViewModels/IFavorViewNavigator.cs
+++ b/src/Arwen.Module/ViewModels/IFavorViewNavigator.cs
@@ -1,0 +1,26 @@
+namespace Arwen.ViewModels;
+
+/// <summary>
+/// Lets a child tab ask Arwen's <c>FavorView</c> to switch tabs and (optionally)
+/// hand off context to the destination tab. Implemented by the view that owns
+/// the TabControl; injected into VMs that need cross-tab navigation.
+/// </summary>
+public interface IFavorViewNavigator
+{
+    /// <summary>Switch to the Gift Scanner tab and select <paramref name="npcKey"/> there.</summary>
+    void OpenInGiftScanner(string npcKey);
+}
+
+/// <summary>
+/// Late-bound forwarder for <see cref="IFavorViewNavigator"/>. Registered as a
+/// singleton so VMs can take a stable dependency at construction time, while the
+/// real navigator (Arwen's <c>FavorView</c>) is wired in via <see cref="Inner"/>
+/// once it finishes building. Without this indirection, injecting <c>FavorView</c>
+/// into VMs that <c>FavorView</c> itself constructs creates a DI cycle.
+/// </summary>
+public sealed class FavorViewNavigatorHolder : IFavorViewNavigator
+{
+    public IFavorViewNavigator? Inner { get; set; }
+
+    public void OpenInGiftScanner(string npcKey) => Inner?.OpenInGiftScanner(npcKey);
+}

--- a/src/Arwen.Module/ViewModels/StorageGiftsViewModel.cs
+++ b/src/Arwen.Module/ViewModels/StorageGiftsViewModel.cs
@@ -1,0 +1,277 @@
+using System.Collections.ObjectModel;
+using Arwen.Domain;
+using Arwen.State;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
+
+namespace Arwen.ViewModels;
+
+/// <summary>
+/// "Storage Gifts" tab: cross-reference everything in the active character's
+/// storage with the NPCs who would accept it as a gift. Master pane shows
+/// items grouped by vault; detail pane shows recipients grouped by NPC area
+/// with calibrated favor projections per stack.
+/// </summary>
+public sealed partial class StorageGiftsViewModel : ObservableObject
+{
+    private readonly GiftIndex _giftIndex;
+    private readonly IActiveCharacterService _activeChar;
+    private readonly IReferenceDataService _refData;
+    private readonly CalibrationService _calibration;
+    private readonly FavorStateService _state;
+    private readonly IFavorViewNavigator _navigator;
+
+    /// <summary>Backing list for all giftable items, before search/love-only filtering.</summary>
+    private List<StorageItemCard> _allItems = [];
+
+    public StorageGiftsViewModel(
+        GiftIndex giftIndex,
+        IActiveCharacterService activeChar,
+        IReferenceDataService refData,
+        CalibrationService calibration,
+        FavorStateService state,
+        IFavorViewNavigator navigator)
+    {
+        _giftIndex = giftIndex;
+        _activeChar = activeChar;
+        _refData = refData;
+        _calibration = calibration;
+        _state = state;
+        _navigator = navigator;
+
+        _activeChar.ActiveCharacterChanged += (_, _) => DispatchReload();
+        _activeChar.StorageReportsChanged += (_, _) => DispatchReload();
+        _giftIndex.Rebuilt += (_, _) => DispatchReload();
+        _state.StateChanged += (_, _) => DispatchReload();
+
+        Reload();
+    }
+
+    /// <summary>Flat, post-filter list of giftable items. WPF groups by Vault for the master pane.</summary>
+    public ObservableCollection<StorageItemCard> Items { get; } = [];
+
+    [ObservableProperty]
+    private StorageItemCard? _selectedItem;
+
+    /// <summary>Recipients of <see cref="SelectedItem"/>, regrouped by NPC area for the detail pane.</summary>
+    [ObservableProperty]
+    private IReadOnlyList<RecipientAreaGroup> _recipients = [];
+
+    [ObservableProperty]
+    private string _searchText = "";
+
+    [ObservableProperty]
+    private bool _loveOnly;
+
+    [ObservableProperty]
+    private bool _hasStorage;
+
+    [ObservableProperty]
+    private string _statusMessage = "";
+
+    partial void OnSelectedItemChanged(StorageItemCard? value) => RefreshRecipients();
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+
+    partial void OnLoveOnlyChanged(bool value) => ApplyFilter();
+
+    [RelayCommand]
+    private void OpenInGiftScanner(string? npcKey)
+    {
+        if (!string.IsNullOrEmpty(npcKey))
+            _navigator.OpenInGiftScanner(npcKey);
+    }
+
+    private void DispatchReload()
+    {
+        var d = System.Windows.Application.Current?.Dispatcher;
+        if (d is null || d.CheckAccess()) Reload();
+        else d.InvokeAsync(Reload);
+    }
+
+    private void Reload()
+    {
+        var report = _activeChar.ActiveStorageContents;
+        if (report is null)
+        {
+            _allItems = [];
+            HasStorage = false;
+            StatusMessage = "No storage export for the active character — run /exportstorage in-game.";
+            ApplyFilter();
+            return;
+        }
+
+        HasStorage = true;
+        var built = new List<StorageItemCard>(report.Items.Count);
+
+        foreach (var item in report.Items)
+        {
+            if (item.StackSize <= 0) continue;
+
+            var npcMatches = _giftIndex.GetNpcsForItem(item.TypeID);
+            if (npcMatches.Count == 0) continue;
+
+            var recipients = new List<RecipientCard>(npcMatches.Count);
+            foreach (var nm in npcMatches)
+            {
+                if (nm.Match.Desire is "Hate" or "Dislike") continue;
+
+                // Verify rarity/value/crafted filters against the actual inventory item.
+                var allPrefs = _giftIndex.MatchAllPreferencesForItem(item.TypeID, nm.NpcKey);
+                if (!GiftFilter.Passes(item, allPrefs)) continue;
+
+                recipients.Add(BuildRecipient(nm, item.StackSize));
+            }
+
+            if (recipients.Count == 0) continue;
+
+            // Sort recipients within the item: Love before Like, then by score desc.
+            recipients.Sort(RecipientComparer);
+
+            var vault = StorageReportLoader.NormalizeLocation(item.StorageVault, item.IsInInventory);
+            var hasLove = recipients.Any(r => r.Desire == "Love");
+
+            built.Add(new StorageItemCard(
+                TypeId: item.TypeID,
+                IconId: TryGetIconId(item.TypeID),
+                Name: item.Name,
+                StackSize: item.StackSize,
+                Vault: vault,
+                RecipientCount: recipients.Count,
+                HasLove: hasLove,
+                AllRecipients: recipients));
+        }
+
+        // Order: vault asc, then item name asc — ListBox grouping preserves insertion order.
+        built.Sort((a, b) =>
+        {
+            var v = string.Compare(a.Vault, b.Vault, StringComparison.OrdinalIgnoreCase);
+            if (v != 0) return v;
+            return string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+        });
+
+        _allItems = built;
+        ApplyFilter();
+    }
+
+    private void ApplyFilter()
+    {
+        var prevKey = SelectedItem is { } s ? (s.TypeId, s.Vault) : ((int, string)?)null;
+        var search = SearchText?.Trim() ?? "";
+        var loveOnly = LoveOnly;
+
+        var filtered = _allItems.Where(card =>
+        {
+            if (loveOnly && !card.HasLove) return false;
+            if (search.Length > 0 && !card.Name.Contains(search, StringComparison.OrdinalIgnoreCase)) return false;
+            return true;
+        }).ToList();
+
+        // Mutate the ObservableCollection in place so CollectionViewSource grouping in XAML stays stable.
+        Items.Clear();
+        foreach (var c in filtered) Items.Add(c);
+
+        // Restore selection if the previously-selected item is still visible.
+        SelectedItem = prevKey is { } pk
+            ? filtered.FirstOrDefault(c => c.TypeId == pk.Item1 && c.Vault == pk.Item2)
+            : null;
+
+        StatusMessage = HasStorage
+            ? $"{filtered.Count:N0} giftable item(s) across {_allItems.Select(c => c.Vault).Distinct().Count()} vault(s)"
+            : StatusMessage;
+    }
+
+    private void RefreshRecipients()
+    {
+        if (SelectedItem is null)
+        {
+            Recipients = [];
+            return;
+        }
+
+        Recipients = SelectedItem.AllRecipients
+            .GroupBy(r => string.IsNullOrEmpty(r.NpcArea) ? "Unknown" : r.NpcArea, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new RecipientAreaGroup(g.Key, g.OrderBy(r => r, RecipientComparer).ToList()))
+            .ToList();
+    }
+
+    private RecipientCard BuildRecipient(NpcGiftMatch nm, int stackSize)
+    {
+        var npcEntry = _refData.Npcs.TryGetValue(nm.NpcKey, out var npc) ? npc : null;
+        var name = npcEntry?.Name ?? nm.NpcKey.Replace("NPC_", "");
+        var area = npcEntry?.Area ?? "";
+
+        var favorEntry = _state.Entries.FirstOrDefault(e => e.NpcKey == nm.NpcKey);
+        var currentFavor = favorEntry?.ExactFavor
+            ?? (favorEntry?.IsKnown == true ? (double?)FavorTiers.FloorOf(favorEntry.CurrentTier) : null);
+
+        var estimate = _calibration.EstimateFavor(nm.Match, nm.NpcKey);
+        var estimatedTotal = estimate is not null ? estimate.Value * stackSize : (double?)null;
+
+        // Mirror GiftScannerViewModel's projection math so the same XAML cell template renders both.
+        double? projectedFavor = null;
+        var currentTier = favorEntry?.CurrentTier ?? FavorTier.Neutral;
+        var projectedTier = currentTier;
+        var currentFrac = 0.0;
+        var projectedFrac = 0.0;
+        var tierCeiling = (double)(FavorTiers.CeilingOf(currentTier) ?? FavorTiers.FloorOf(currentTier));
+
+        if (currentFavor.HasValue)
+        {
+            currentTier = FavorTiers.TierForFavor(currentFavor.Value);
+            tierCeiling = (double)(FavorTiers.CeilingOf(currentTier) ?? currentFavor.Value);
+            var cFrac = FavorTiers.ProgressInTier(currentFavor.Value, currentTier);
+            currentFrac = double.IsNaN(cFrac) ? 0.0 : cFrac;
+
+            if (estimatedTotal.HasValue)
+            {
+                var proj = currentFavor.Value + estimatedTotal.Value;
+                projectedFavor = proj;
+                projectedTier = FavorTiers.TierForFavor(proj);
+                var pFrac = projectedTier == currentTier
+                    ? FavorTiers.ProgressInTier(proj, currentTier)
+                    : 1.0;
+                projectedFrac = double.IsNaN(pFrac) ? 0.0 : pFrac;
+            }
+        }
+
+        return new RecipientCard(
+            NpcKey: nm.NpcKey,
+            NpcName: name,
+            NpcArea: area,
+            Desire: nm.Match.Desire,
+            RelativeScore: nm.Match.RelativeScore,
+            EstimatedFavor: estimatedTotal,
+            EstimateSource: estimate?.Tier,
+            EstimateSamples: estimate?.SampleCount ?? 0,
+            CurrentFavor: currentFavor,
+            ProjectedFavor: projectedFavor,
+            CurrentTier: currentTier,
+            ProjectedTier: projectedTier,
+            CurrentTierCeiling: tierCeiling,
+            CurrentProgressFraction: currentFrac,
+            ProjectedProgressFraction: projectedFrac);
+    }
+
+    private int TryGetIconId(int itemTypeId) =>
+        _refData.Items.TryGetValue(itemTypeId, out var entry) ? entry.IconId : 0;
+
+    private static readonly IComparer<RecipientCard> RecipientComparer =
+        Comparer<RecipientCard>.Create((a, b) =>
+        {
+            var d = DesireRank(a.Desire).CompareTo(DesireRank(b.Desire));
+            if (d != 0) return d;
+            return b.RelativeScore.CompareTo(a.RelativeScore);
+        });
+
+    private static int DesireRank(string desire) => desire switch
+    {
+        "Love" => 0,
+        "Like" => 1,
+        _ => 2,
+    };
+}

--- a/src/Arwen.Module/Views/FavorView.xaml.cs
+++ b/src/Arwen.Module/Views/FavorView.xaml.cs
@@ -1,8 +1,10 @@
+using System.Windows;
 using System.Windows.Controls;
+using Arwen.ViewModels;
 
 namespace Arwen.Views;
 
-public partial class FavorView : UserControl
+public partial class FavorView : UserControl, IFavorViewNavigator
 {
     public FavorView()
     {
@@ -22,5 +24,27 @@ public partial class FavorView : UserControl
             Content = content,
             Margin = new System.Windows.Thickness(0, 8, 0, 0),
         });
+    }
+
+    /// <summary>
+    /// Switches to the Gift Scanner tab and tells its VM to focus the given NPC.
+    /// Silent no-op if the tab isn't registered or the NPC isn't in the dropdown
+    /// (player hasn't met them yet).
+    /// </summary>
+    public void OpenInGiftScanner(string npcKey)
+    {
+        foreach (TabItem tab in Tabs.Items)
+        {
+            if (tab.Header is not string header || header != "Gift Scanner") continue;
+
+            Tabs.SelectedItem = tab;
+
+            if (tab.Content is FrameworkElement fe && fe.DataContext is GiftScannerViewModel vm)
+            {
+                var entry = vm.NpcList.FirstOrDefault(e => e.NpcKey == npcKey);
+                if (entry is not null) vm.SelectedNpc = entry;
+            }
+            return;
+        }
     }
 }

--- a/src/Arwen.Module/Views/StorageGiftsTab.xaml
+++ b/src/Arwen.Module/Views/StorageGiftsTab.xaml
@@ -1,0 +1,466 @@
+<UserControl x:Class="Arwen.Views.StorageGiftsTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Arwen.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:StorageGiftsViewModel}"
+             Background="#FF1A1A1A">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Items grouped by vault for the master pane. -->
+            <CollectionViewSource x:Key="ItemsView" Source="{Binding Items}">
+                <CollectionViewSource.GroupDescriptions>
+                    <PropertyGroupDescription PropertyName="Vault"/>
+                </CollectionViewSource.GroupDescriptions>
+            </CollectionViewSource>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel Margin="12">
+
+        <!-- Header strip: search + love-only + status -->
+        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <CheckBox DockPanel.Dock="Right" Content="Love only"
+                      IsChecked="{Binding LoveOnly, Mode=TwoWay}"
+                      Foreground="#CCFFFFFF" VerticalAlignment="Center"
+                      FontSize="{DynamicResource AppFontSize}"
+                      Margin="12,0,0,0"/>
+            <TextBlock DockPanel.Dock="Right" Text="{Binding StatusMessage}"
+                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSize}"
+                       VerticalAlignment="Center" Margin="12,0,0,0"/>
+            <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged, Delay=150}"
+                     Width="280" HorizontalAlignment="Left"
+                     FontSize="{DynamicResource AppFontSizeMedium}"
+                     Background="#FF2A2A2A" Foreground="#FFE8E8E8"
+                     BorderBrush="#FF444444" Padding="6,3"/>
+        </DockPanel>
+
+        <!-- Two-column master / detail -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="320"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="3*" MinWidth="320"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- ═══════════════ MASTER PANE: items grouped by vault ═══════════════ -->
+            <Border Grid.Column="0" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="3">
+                <Grid>
+                    <!-- Empty state: no storage export at all -->
+                    <TextBlock Text="No storage export for the active character.&#x0a;Run /exportstorage in-game to populate this view."
+                               Foreground="#66FFFFFF" TextAlignment="Center" TextWrapping="Wrap"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Padding="20">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasStorage}" Value="False">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- Empty state: storage exists but nothing in it is giftable -->
+                    <TextBlock Text="Nothing in storage matches any NPC's gift preferences."
+                               Foreground="#66FFFFFF" TextAlignment="Center" TextWrapping="Wrap"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Padding="20">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding HasStorage}" Value="True"/>
+                                            <Condition Binding="{Binding Items.Count}" Value="0"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- Vault accordion: ListBox with grouping + WrapPanel of card items -->
+                    <ListBox ItemsSource="{Binding Source={StaticResource ItemsView}}"
+                             SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                             Background="Transparent" BorderThickness="0"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             HorizontalContentAlignment="Stretch"
+                             VirtualizingPanel.IsVirtualizing="True"
+                             VirtualizingPanel.VirtualizationMode="Recycling"
+                             VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                             VirtualizingPanel.ScrollUnit="Pixel"
+                             VirtualizingPanel.CacheLengthUnit="Page"
+                             VirtualizingPanel.CacheLength="1,2">
+                        <ListBox.Style>
+                            <Style TargetType="ListBox">
+                                <Style.Triggers>
+                                    <!-- Hide the ListBox itself when an empty-state message is showing -->
+                                    <DataTrigger Binding="{Binding HasStorage}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ListBox.Style>
+
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel Orientation="Vertical"/>
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+
+                        <!-- Vault-section template: collapsible Expander per vault. -->
+                        <ListBox.GroupStyle>
+                            <GroupStyle>
+                                <GroupStyle.ContainerStyle>
+                                    <Style TargetType="GroupItem">
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="GroupItem">
+                                                    <Expander IsExpanded="True" Margin="4,4,4,0"
+                                                              Background="Transparent"
+                                                              Foreground="#FFE8E8E8">
+                                                        <Expander.Header>
+                                                            <DockPanel>
+                                                                <TextBlock Text="{Binding ItemCount, StringFormat='{}{0} ★'}"
+                                                                           DockPanel.Dock="Right"
+                                                                           Foreground="#FFD4A847" FontWeight="SemiBold"
+                                                                           VerticalAlignment="Center" Margin="8,0,4,0"/>
+                                                                <TextBlock Text="{Binding Name}"
+                                                                           FontSize="{DynamicResource AppFontSizeMedium}"
+                                                                           FontWeight="SemiBold" Foreground="#FFE8E8E8"
+                                                                           VerticalAlignment="Center"/>
+                                                            </DockPanel>
+                                                        </Expander.Header>
+                                                        <ItemsPresenter Margin="0,4,0,4"/>
+                                                    </Expander>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Style>
+                                </GroupStyle.ContainerStyle>
+                            </GroupStyle>
+                        </ListBox.GroupStyle>
+
+                        <!-- Per-card container: gold ring on selection, hover affordance. -->
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="Margin" Value="0"/>
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ListBoxItem">
+                                            <Border x:Name="CardOuter" CornerRadius="6" Margin="3"
+                                                    Background="#FF252525"
+                                                    BorderBrush="#33FFFFFF" BorderThickness="1">
+                                                <ContentPresenter/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter TargetName="CardOuter" Property="BorderBrush" Value="#FFD4A847"/>
+                                                    <Setter TargetName="CardOuter" Property="BorderThickness" Value="2"/>
+                                                    <Setter TargetName="CardOuter" Property="Background" Value="#1A1E3A5F"/>
+                                                </Trigger>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="CardOuter" Property="BorderBrush" Value="#88FFFFFF"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+
+                        <!-- Item row card: large icon left, full name center (wraps if long), stack + recipient count right. -->
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Height="56" MinWidth="260">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Border Grid.Column="0" Background="#FF1A1A1A" CornerRadius="4"
+                                            Padding="2" Margin="6,4" VerticalAlignment="Center">
+                                        <wpf:IconImage IconId="{Binding IconId}" Width="40" Height="40"/>
+                                    </Border>
+                                    <TextBlock Grid.Column="1" Text="{Binding Name}"
+                                               VerticalAlignment="Center"
+                                               TextWrapping="Wrap" TextTrimming="CharacterEllipsis"
+                                               Margin="4,0,8,0"
+                                               FontSize="{DynamicResource AppFontSize}"
+                                               Foreground="#FFE8E8E8"/>
+                                    <StackPanel Grid.Column="2" Orientation="Horizontal"
+                                                VerticalAlignment="Center" Margin="0,0,10,0">
+                                        <TextBlock Text="{Binding StackSize, StringFormat='×{0}'}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   Foreground="#88FFFFFF" VerticalAlignment="Center"
+                                                   MinWidth="34" TextAlignment="Right"/>
+                                        <TextBlock Text="★" FontSize="{DynamicResource AppFontSizeMedium}"
+                                                   Foreground="#FFD4A847" VerticalAlignment="Center"
+                                                   Margin="12,0,2,0"/>
+                                        <TextBlock Text="{Binding RecipientCount}"
+                                                   FontSize="{DynamicResource AppFontSize}"
+                                                   FontWeight="SemiBold" Foreground="#FFD4A847"
+                                                   VerticalAlignment="Center" MinWidth="22"/>
+                                    </StackPanel>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch"
+                          Background="Transparent"
+                          ShowsPreview="False"/>
+
+            <!-- ═══════════════ DETAIL PANE: recipients grouped by area ═══════════════ -->
+            <Border Grid.Column="2" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="3">
+                <Grid>
+                    <!-- Empty state: nothing selected -->
+                    <TextBlock Text="Select an item on the left to see who would accept it as a gift."
+                               Foreground="#66FFFFFF" TextWrapping="Wrap" TextAlignment="Center"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" Padding="20">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedItem}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- Item header + recipient sections -->
+                    <DockPanel>
+                        <DockPanel.Style>
+                            <Style TargetType="DockPanel">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedItem}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DockPanel.Style>
+
+                        <!-- Header: large icon + name + meta -->
+                        <Border DockPanel.Dock="Top" Padding="10" Margin="0,0,0,4"
+                                BorderBrush="#33FFFFFF" BorderThickness="0,0,0,1">
+                            <DockPanel>
+                                <Border DockPanel.Dock="Left" Background="#FF1A1A1A" CornerRadius="4"
+                                        Padding="2" Margin="0,0,12,0">
+                                    <wpf:IconImage IconId="{Binding SelectedItem.IconId}" Width="40" Height="40"/>
+                                </Border>
+                                <StackPanel VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding SelectedItem.Name}" FontWeight="SemiBold"
+                                               FontSize="{DynamicResource AppFontSizeLarge}"
+                                               Foreground="#FFD4A847"/>
+                                    <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                        <TextBlock Text="{Binding SelectedItem.StackSize, StringFormat='× {0}'}"
+                                                   Foreground="#CCFFFFFF"
+                                                   FontSize="{DynamicResource AppFontSize}"/>
+                                        <TextBlock Text="  ·  " Foreground="#44FFFFFF"
+                                                   FontSize="{DynamicResource AppFontSize}"/>
+                                        <TextBlock Text="{Binding SelectedItem.Vault}"
+                                                   Foreground="#88FFFFFF"
+                                                   FontSize="{DynamicResource AppFontSize}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </DockPanel>
+                        </Border>
+
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <ItemsControl ItemsSource="{Binding Recipients}" Margin="6">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="2,6">
+                                            <!-- Area section header -->
+                                            <DockPanel Margin="6,2,6,4">
+                                                <TextBlock Text="{Binding Recipients.Count, StringFormat='{}{0}'}"
+                                                           DockPanel.Dock="Right"
+                                                           Foreground="#66FFFFFF"
+                                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                                           VerticalAlignment="Bottom" Margin="6,0,0,1"/>
+                                                <TextBlock Text="{Binding Area}"
+                                                           FontSize="{DynamicResource AppFontSizeMedium}"
+                                                           FontWeight="SemiBold" Foreground="#CCFFFFFF"/>
+                                            </DockPanel>
+
+                                            <!-- Full-width recipient rows. Click jumps to Gift Scanner. -->
+                                            <ItemsControl ItemsSource="{Binding Recipients}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Button Margin="0,2"
+                                                                HorizontalAlignment="Stretch"
+                                                                HorizontalContentAlignment="Stretch"
+                                                                Command="{Binding DataContext.OpenInGiftScannerCommand,
+                                                                    RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"
+                                                                CommandParameter="{Binding NpcKey}"
+                                                                ToolTip="Open this NPC in Gift Scanner">
+                                                            <Button.Template>
+                                                                <ControlTemplate TargetType="Button">
+                                                                    <Border x:Name="CardBorder"
+                                                                            Background="#FF252525"
+                                                                            BorderBrush="#33FFFFFF"
+                                                                            BorderThickness="1"
+                                                                            CornerRadius="6"
+                                                                            Padding="10,6">
+                                                                        <ContentPresenter/>
+                                                                    </Border>
+                                                                    <ControlTemplate.Triggers>
+                                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                                            <Setter TargetName="CardBorder" Property="Background" Value="#FF2E2E2E"/>
+                                                                            <Setter TargetName="CardBorder" Property="BorderBrush" Value="#88FFFFFF"/>
+                                                                        </Trigger>
+                                                                        <Trigger Property="IsPressed" Value="True">
+                                                                            <Setter TargetName="CardBorder" Property="Background" Value="#FF1E3A5F"/>
+                                                                        </Trigger>
+                                                                    </ControlTemplate.Triggers>
+                                                                </ControlTemplate>
+                                                            </Button.Template>
+
+                                                            <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                                                    <ColumnDefinition Width="Auto"/>
+                                                                    <ColumnDefinition Width="*"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <!-- Col 0: NPC name -->
+                                                                <TextBlock Grid.Column="0" Text="{Binding NpcName}"
+                                                                           FontWeight="SemiBold" Foreground="#FFE8E8E8"
+                                                                           FontSize="{DynamicResource AppFontSize}"
+                                                                           VerticalAlignment="Center"
+                                                                           TextTrimming="CharacterEllipsis"/>
+
+                                                                <!-- Col 1: desire badge -->
+                                                                <Border Grid.Column="1" CornerRadius="3"
+                                                                        Padding="6,1" Margin="10,0,0,0"
+                                                                        VerticalAlignment="Center">
+                                                                    <Border.Style>
+                                                                        <Style TargetType="Border">
+                                                                            <Setter Property="Background" Value="#33FFFFFF"/>
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding Desire}" Value="Love">
+                                                                                    <Setter Property="Background" Value="#3FE8C97A"/>
+                                                                                </DataTrigger>
+                                                                                <DataTrigger Binding="{Binding Desire}" Value="Like">
+                                                                                    <Setter Property="Background" Value="#3F7AB880"/>
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </Border.Style>
+                                                                    <TextBlock Text="{Binding Desire}"
+                                                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                                                               FontWeight="SemiBold">
+                                                                        <TextBlock.Style>
+                                                                            <Style TargetType="TextBlock">
+                                                                                <Setter Property="Foreground" Value="#FFE8E8E8"/>
+                                                                                <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding Desire}" Value="Love">
+                                                                                        <Setter Property="Foreground" Value="#FFE8C97A"/>
+                                                                                    </DataTrigger>
+                                                                                    <DataTrigger Binding="{Binding Desire}" Value="Like">
+                                                                                        <Setter Property="Foreground" Value="#FF7AB880"/>
+                                                                                    </DataTrigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </TextBlock.Style>
+                                                                    </TextBlock>
+                                                                </Border>
+
+                                                                <!-- Col 2: favor projection (bar + text) OR "calibration needed" placeholder -->
+                                                                <Grid Grid.Column="2" Margin="16,0,0,0">
+                                                                    <!-- Calibrated: bar + numeric -->
+                                                                    <StackPanel HorizontalAlignment="Right"
+                                                                                VerticalAlignment="Center">
+                                                                        <StackPanel.Style>
+                                                                            <Style TargetType="StackPanel">
+                                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                                <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding EstimatedFavor}" Value="{x:Null}">
+                                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                    </DataTrigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </StackPanel.Style>
+
+                                                                        <Grid Height="14" Width="220" HorizontalAlignment="Right">
+                                                                            <Border Background="#FF333333" CornerRadius="3"/>
+                                                                            <Border Background="#FF7AB880" CornerRadius="3"
+                                                                                    HorizontalAlignment="Left"
+                                                                                    Width="{Binding ProjectedProgressFraction,
+                                                                                        Converter={StaticResource ProgressToWidthConverter},
+                                                                                        ConverterParameter=220, FallbackValue=0}"/>
+                                                                            <Border Background="#FFD4A847" CornerRadius="3"
+                                                                                    HorizontalAlignment="Left"
+                                                                                    Width="{Binding CurrentProgressFraction,
+                                                                                        Converter={StaticResource ProgressToWidthConverter},
+                                                                                        ConverterParameter=220, FallbackValue=0}"/>
+                                                                        </Grid>
+                                                                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0"
+                                                                                    HorizontalAlignment="Right">
+                                                                            <TextBlock Text="{Binding CurrentFavor, StringFormat=F0, TargetNullValue='?'}"
+                                                                                       Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text=" → " Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text="{Binding ProjectedFavor, StringFormat=F0, TargetNullValue='?'}"
+                                                                                       Foreground="#FF7AB880" FontWeight="SemiBold"
+                                                                                       FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text="  /  " Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text="{Binding CurrentTierCeiling, StringFormat=F0}"
+                                                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text="  (" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text="{Binding ProjectedTier, Converter={StaticResource TierToDisplayNameConverter}}"
+                                                                                       Foreground="#FF7AB880" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                            <TextBlock Text=")" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                        </StackPanel>
+                                                                    </StackPanel>
+
+                                                                    <!-- Uncalibrated: invitation to gift this combo -->
+                                                                    <TextBlock Text="Calibration needed — gift this in-game to learn the rate"
+                                                                               FontStyle="Italic" Foreground="#66FFFFFF"
+                                                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                                                               HorizontalAlignment="Right" VerticalAlignment="Center">
+                                                                        <TextBlock.Style>
+                                                                            <Style TargetType="TextBlock">
+                                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                                                <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding EstimatedFavor}" Value="{x:Null}">
+                                                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                                                    </DataTrigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </TextBlock.Style>
+                                                                    </TextBlock>
+                                                                </Grid>
+                                                            </Grid>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </DockPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/src/Arwen.Module/Views/StorageGiftsTab.xaml.cs
+++ b/src/Arwen.Module/Views/StorageGiftsTab.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Arwen.Views;
+
+public partial class StorageGiftsTab : UserControl
+{
+    public StorageGiftsTab()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a 6th Arwen tab — **Storage Gifts** — answering the inverse of the existing Gift Scanner: *"for everything in my storage, who would accept it as a gift?"*. Useful for cleaning out vaults, planning a favor-grinding trip, or deciding what to keep vs. sell.

- **Master-detail card view.** Vault sections (collapsible Expanders) with full-width item rows on the left; on selection, recipient rows grouped by NPC area on the right.
- **Calibrated favor projection per recipient.** Same `current → projected / ceiling (tier)` cell template Gift Scanner uses, computed per stack via `CalibrationService.EstimateFavor`. Falls back to *"Calibration needed — gift this in-game to learn the rate"* when no estimate exists.
- **Click-through to Gift Scanner.** Each recipient row is a button that switches tabs and pre-selects that NPC in Gift Scanner. New `IFavorViewNavigator` interface; `FavorViewNavigatorHolder` indirection breaks the DI cycle that would otherwise form.
- **Shared `GiftFilter` helper.** `PassesStorageFilters` (rarity / value / crafted preference checks) extracted from `GiftScannerViewModel` into `Arwen.Domain.GiftFilter` so both tabs verify identically; correctness coupling that previously had to be kept in sync by hand.
- **No changes to Bilbo or Mithril.Shared** — the design discussion concluded that storage contracts should stay in Mithril.Shared (consumed by Bilbo, Arwen, Celebrimbor, Smaug for orthogonal reasons) and that no `IGiftLookupService` extraction is needed yet since Arwen owns both the view and the underlying `GiftIndex`.

Plan: \`C:\Users\arthu\.claude\plans\expose-an-interface-to-keen-eich.md\` (local).

## Test plan

- [ ] Build clean — \`dotnet build Mithril.slnx\` ✓ (verified locally)
- [ ] All tests green — \`dotnet test Mithril.slnx\` ✓ (1133 passed, 0 failed)
- [ ] Launch shell with an active character that has a recent \`*_items_*.json\` storage export
- [ ] Open Arwen → **Storage Gifts** tab
- [ ] Verify vault Expanders populate; click an item card → recipient pane fills with NPC cards grouped by area
- [ ] Verify favor projection matches Gift Scanner's bar/numerics for the same (item, NPC) combination
- [ ] Verify recipients without calibration data show the *"Calibration needed"* placeholder
- [ ] Click a recipient row → focus jumps to **Gift Scanner** with that NPC selected
- [ ] Verify Search box and Love-only toggle filter the master pane live
- [ ] Verify switching active characters re-populates the view
- [ ] Trigger a storage report change (drop/pickup an item in-game) → tab refreshes without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)