### PR TITLE
fix(gandalf): close brackets on EndInteraction; suppress harvest AddItem

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -76,6 +76,8 @@ public sealed class GandalfModule : IMithrilModule
         // bosses.
         services.AddSingleton<ChestInteractionParser>();
         services.AddSingleton<ChestRejectionParser>();
+        services.AddSingleton<InteractionEndParser>();
+        services.AddSingleton<InteractionDelayLoopParser>();
         services.AddSingleton<BossKillCreditParser>();
         services.AddSingleton<DefeatCooldownParser>();
         services.AddSingleton<LootBracketTracker>();

--- a/src/Gandalf.Module/Parsing/InteractionDelayLoopParser.cs
+++ b/src/Gandalf.Module/Parsing/InteractionDelayLoopParser.cs
@@ -1,0 +1,36 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Gandalf.Parsing;
+
+/// <summary>
+/// Parses <c>LocalPlayer: ProcessDoDelayLoop(...)</c> into an
+/// <see cref="InteractionDelayLoopEvent"/>. The bracket tracker uses the
+/// <c>IsInteractorDelayLoop</c> trailing flag to discriminate harvest-style
+/// interactions (Gather "Collecting Fruit..." on a LemonTree) from chests:
+/// when set, the in-flight bracket is a harvest and the subsequent
+/// <c>ProcessAddItem</c> must not commit a chest row.
+///
+/// Sample shapes from live capture (#91):
+/// <c>ProcessDoDelayLoop(3, Gather, "Collecting Fruit...", 0, AbortIfAttacked, IsInteractorDelayLoop)</c> — harvest
+/// <c>ProcessDoDelayLoop(1.5, Eat, "Using Ranalon Salad", 5820, AbortIfAttacked)</c> — self-targeted, no flag
+/// <c>ProcessDoDelayLoop(10, UseTeleportationCircle, "Recalling Other Places", 3713, AbortIfAttacked)</c> — self-targeted, no flag
+/// </summary>
+public sealed partial class InteractionDelayLoopParser : ILogParser
+{
+    [GeneratedRegex(
+        """LocalPlayer:\s*ProcessDoDelayLoop\(\s*\d+(?:\.\d+)?\s*,\s*(?<verb>\w+)\s*,\s*"[^"]*"\s*,\s*-?\d+\s*,\s*\w+(?<flags>(?:\s*,\s*\w+)*)\s*\)""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex DelayLoopRx();
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (!line.Contains("ProcessDoDelayLoop(", StringComparison.Ordinal)) return null;
+        var m = DelayLoopRx().Match(line);
+        if (!m.Success) return null;
+
+        var verb = m.Groups["verb"].Value;
+        var isInteractor = m.Groups["flags"].Value.Contains("IsInteractorDelayLoop", StringComparison.Ordinal);
+        return new InteractionDelayLoopEvent(timestamp, verb, isInteractor);
+    }
+}

--- a/src/Gandalf.Module/Parsing/InteractionEndParser.cs
+++ b/src/Gandalf.Module/Parsing/InteractionEndParser.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Gandalf.Parsing;
+
+/// <summary>
+/// Parses <c>LocalPlayer: ProcessEndInteraction(id)</c> into an
+/// <see cref="InteractionEndEvent"/>. Symmetric close to the existing
+/// <c>ProcessEnableInteractors</c> handler in <c>LootBracketTracker</c>:
+/// portals (and other quick interactions) close via this signal instead.
+///
+/// Live capture (#91):
+/// <c>LocalPlayer: ProcessStartInteraction(-158, 8, 0, False, "Portal")</c>
+/// <c>LocalPlayer: ProcessEndInteraction(-158)</c>
+/// </summary>
+public sealed partial class InteractionEndParser : ILogParser
+{
+    [GeneratedRegex(
+        """LocalPlayer:\s*ProcessEndInteraction\((?<id>-?\d+)\)""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex EndRx();
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (!line.Contains("ProcessEndInteraction(", StringComparison.Ordinal)) return null;
+        var m = EndRx().Match(line);
+        if (!m.Success) return null;
+
+        if (!long.TryParse(m.Groups["id"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+            return null;
+        return new InteractionEndEvent(timestamp, id);
+    }
+}

--- a/src/Gandalf.Module/Parsing/LootEvents.cs
+++ b/src/Gandalf.Module/Parsing/LootEvents.cs
@@ -24,3 +24,27 @@ public sealed record InteractionStartEvent(DateTime Timestamp, long InteractorId
 /// </summary>
 public sealed record ChestCooldownObservedEvent(DateTime Timestamp, string ChestInternalName, TimeSpan Duration)
     : LogEvent(Timestamp);
+
+/// <summary>
+/// Player ended an interaction. Symmetric close to <c>ProcessEnableInteractors</c>:
+/// in live captures, portals close via <c>ProcessEndInteraction(id)</c> and
+/// chests close via <c>ProcessEnableInteractors([], [id,])</c>; the tracker
+/// needs to honor both so non-chest brackets don't sit InFlight long enough
+/// for an unrelated <c>ProcessAddItem</c> to commit them as a chest.
+/// </summary>
+public sealed record InteractionEndEvent(DateTime Timestamp, long InteractorId)
+    : LogEvent(Timestamp);
+
+/// <summary>
+/// Player started an action with a delay loop (gather fruit, eat food, recall
+/// to a teleport circle, distill, etc.). The discriminator for the loot
+/// tracker is <see cref="IsInteractor"/>: when set, the delay loop is bound
+/// to the in-flight interaction (e.g. <c>Gather, "Collecting Fruit..."</c> on
+/// a tree), and the subsequent <c>ProcessAddItem</c> is harvested loot, not a
+/// chest. Self-targeted delay loops (<c>Eat</c>, <c>Drink</c>, <c>UseItem</c>,
+/// <c>UseTeleportationCircle</c>) don't carry the flag and shouldn't poison
+/// an unrelated bracket. The verb is captured for diagnostics and so we can
+/// promote to an explicit allowlist if a chest ever emits one.
+/// </summary>
+public sealed record InteractionDelayLoopEvent(DateTime Timestamp, string Verb, bool IsInteractor)
+    : LogEvent(Timestamp);

--- a/src/Gandalf.Module/Services/LootBracketTracker.cs
+++ b/src/Gandalf.Module/Services/LootBracketTracker.cs
@@ -26,20 +26,27 @@ public sealed partial class LootBracketTracker
     private readonly LootSource _source;
     private readonly ChestInteractionParser _interactionParser;
     private readonly ChestRejectionParser _rejectionParser;
+    private readonly InteractionEndParser _endParser;
+    private readonly InteractionDelayLoopParser _delayLoopParser;
 
     private State _state = State.Idle;
     private string? _bracketName;
     private DateTime _bracketStartTimestamp;
     private long _bracketInteractorId;
+    private string? _bracketHarvestVerb;
 
     public LootBracketTracker(
         LootSource source,
         ChestInteractionParser interactionParser,
-        ChestRejectionParser rejectionParser)
+        ChestRejectionParser rejectionParser,
+        InteractionEndParser endParser,
+        InteractionDelayLoopParser delayLoopParser)
     {
         _source = source;
         _interactionParser = interactionParser;
         _rejectionParser = rejectionParser;
+        _endParser = endParser;
+        _delayLoopParser = delayLoopParser;
     }
 
     /// <summary>True iff the tracker is currently inside an interaction bracket.</summary>
@@ -76,6 +83,7 @@ public sealed partial class LootBracketTracker
             _bracketName = start.EntityName;
             _bracketStartTimestamp = start.Timestamp;
             _bracketInteractorId = start.InteractorId;
+            _bracketHarvestVerb = null;
             return;
         }
 
@@ -99,18 +107,48 @@ public sealed partial class LootBracketTracker
             return;
         }
 
-        // 4. AddItem inside bracket → confirmed loot. Commit the chest event.
+        // 4. Interactor-bound delay loop → bracket is a harvest (Gather "Collecting Fruit..."
+        // on a tree, etc.), not a chest. Stash the verb and let the bracket continue
+        // — its closing signal will reset state, and the AddItem step will see a
+        // non-null harvest verb and skip the chest commit. Self-targeted delay loops
+        // (Eat / Drink / UseItem / UseTeleportationCircle) don't carry the
+        // IsInteractorDelayLoop flag and shouldn't poison an unrelated bracket.
+        if (_state == State.InFlight
+            && _delayLoopParser.TryParse(line, timestamp) is InteractionDelayLoopEvent delay
+            && delay.IsInteractor)
+        {
+            _bracketHarvestVerb = delay.Verb;
+            return;
+        }
+
+        // 5. AddItem inside bracket → confirmed loot, *unless* a harvest verb has
+        // been stashed for this bracket. No chest in any captured log emits
+        // ProcessDoDelayLoop, so the discriminator is "delay-loop verb present →
+        // not a chest"; the verb itself is captured for diagnostics and so we
+        // can promote to an explicit allowlist if a chest ever shows up with one.
         if (_state == State.InFlight && AddItemRx().IsMatch(line) && _bracketName is not null)
         {
-            _source.OnChestInteraction(_bracketName, _bracketStartTimestamp);
+            if (_bracketHarvestVerb is null)
+                _source.OnChestInteraction(_bracketName, _bracketStartTimestamp);
             _state = State.Committed;
             return;
         }
 
-        // 5. EnableInteractors with matching id → bracket close.
+        // 6. EnableInteractors with matching id → bracket close.
         if (EnableInteractorsRx().Match(line) is { Success: true } m
             && long.TryParse(m.Groups["id"].Value, out var closingId)
             && closingId == _bracketInteractorId)
+        {
+            ResetIdle();
+            return;
+        }
+
+        // 7. EndInteraction with matching id → bracket close (symmetric to
+        // EnableInteractors). Portals close via this signal; without it the
+        // bracket would sit InFlight long enough for an unrelated AddItem
+        // to commit "Portal" as a chest.
+        if (_endParser.TryParse(line, timestamp) is InteractionEndEvent end
+            && end.InteractorId == _bracketInteractorId)
         {
             ResetIdle();
             return;
@@ -123,6 +161,7 @@ public sealed partial class LootBracketTracker
         _bracketName = null;
         _bracketStartTimestamp = default;
         _bracketInteractorId = 0;
+        _bracketHarvestVerb = null;
     }
 
     private enum State

--- a/tests/Gandalf.Tests/LootBracketTrackerTests.cs
+++ b/tests/Gandalf.Tests/LootBracketTrackerTests.cs
@@ -46,7 +46,12 @@ public class LootBracketTrackerTests : IDisposable
             LootCatalogCacheJsonContext.Default.LootCatalogCache);
         var cache = cacheStore.Load();
         var src = new LootSource(derived, cacheStore, cache, time);
-        var tracker = new LootBracketTracker(src, new ChestInteractionParser(), new ChestRejectionParser());
+        var tracker = new LootBracketTracker(
+            src,
+            new ChestInteractionParser(),
+            new ChestRejectionParser(),
+            new InteractionEndParser(),
+            new InteractionDelayLoopParser());
 
         return (src, tracker, derived);
     }
@@ -271,6 +276,130 @@ public class LootBracketTrackerTests : IDisposable
             tracker.Observe("LocalPlayer: ProcessAddItem(Pear(2), -1, True)", EventTime);
             // Still only one row — TestChest from the closed bracket.
             src.Progress.Should().HaveCount(1);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// #91 Mode A: Portal closes via ProcessEndInteraction(id), not
+    /// ProcessEnableInteractors. Without that close signal recognized, the
+    /// bracket sat InFlight and the next stray AddItem (a real chest, quest
+    /// reward, etc.) would commit "Portal" as a chest row.
+    /// </summary>
+    [Fact]
+    public void EndInteraction_with_matching_id_closes_bracket()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            // Portal interaction shape from live capture.
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-158, 8, 0, False, \"Portal\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessEndInteraction(-158)", EventTime);
+
+            tracker.IsInFlight.Should().BeFalse();
+
+            // A later, unrelated AddItem must not be attributed to "Portal".
+            tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", EventTime);
+            src.Progress.Should().BeEmpty();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// #91 Mode A: EndInteraction with non-matching id is a stale signal
+    /// (e.g. a prior interactor finishing late) and must not close the
+    /// current bracket.
+    /// </summary>
+    [Fact]
+    public void EndInteraction_with_non_matching_id_does_not_close_bracket()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("TestChest", TimeSpan.FromHours(1));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-200, 7, 0, False, \"TestChest\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessEndInteraction(-999)", EventTime);
+
+            tracker.IsInFlight.Should().BeTrue();
+            tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", EventTime);
+            src.Progress.Should().ContainKey(LootSource.ChestKey("TestChest"));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// #91 Mode A: SummonedFlower entities never emit a close signal at all
+    /// (no EndInteraction, no EnableInteractors). The next ProcessStartInteraction
+    /// must replace the stale bracket so an unrelated AddItem from somewhere
+    /// later in the log doesn't get committed under the flower's name.
+    /// </summary>
+    [Fact]
+    public void Stale_summoned_flower_bracket_is_replaced_by_next_start()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            // Flower interaction never closes — only emits an UpdateDescription.
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(10148077, 7, 0, False, \"SummonedFlower4\")", EventTime);
+            tracker.Observe("ProcessUpdateDescription(10148077, \"Growing Dahlia\", \"This dahlia is growing nicely.\", \"Check Dahlia\", UseItem, \"Flower4(Scale=0.75)\", 0)", EventTime);
+
+            // Real chest interaction takes over before any AddItem fires.
+            src.OnChestCooldownObserved("EltibuleSecretChest", TimeSpan.FromHours(3));
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-147, 5, 0, False, \"EltibuleSecretChest\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(PowerPotion2(1), -1, True)", EventTime);
+
+            src.Progress.Should().ContainKey(LootSource.ChestKey("EltibuleSecretChest"));
+            src.Progress.Should().NotContainKey(LootSource.ChestKey("SummonedFlower4"));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// #91 Mode B: LemonTree (and any harvestable tree / plant / node) emits
+    /// a real ProcessAddItem inside the bracket — picking fruit. The
+    /// ProcessDoDelayLoop with the IsInteractorDelayLoop flag distinguishes
+    /// it from a chest; the AddItem must not produce a chest row.
+    /// </summary>
+    [Fact]
+    public void Harvest_delay_loop_suppresses_chest_commit()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            // Verbatim shape from live capture (#91): LemonTree harvest sequence.
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(9902924, 7, 0, False, \"LemonTree\")", EventTime);
+            tracker.Observe("LocalPlayer: ProcessDoDelayLoop(3, Gather, \"Collecting Fruit...\", 0, AbortIfAttacked, IsInteractorDelayLoop)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(Lemon(115660438), -1, True)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessEndInteraction(9902924)", EventTime);
+
+            tracker.IsInFlight.Should().BeFalse();
+            src.Progress.Should().BeEmpty();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    /// <summary>
+    /// #91 Mode B guard: self-targeted delay loops (Eat / Drink / UseItem /
+    /// UseTeleportationCircle) don't carry the IsInteractorDelayLoop flag and
+    /// therefore must not poison an in-flight chest bracket. Sequence:
+    /// player opens a chest, eats food while it's open, then loots — the
+    /// chest commit must still fire.
+    /// </summary>
+    [Fact]
+    public void Self_targeted_delay_loop_does_not_suppress_chest_commit()
+    {
+        var (src, tracker, derived) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("EltibuleSecretChest", TimeSpan.FromHours(3));
+
+            tracker.Observe("LocalPlayer: ProcessStartInteraction(-147, 5, 0, False, \"EltibuleSecretChest\")", EventTime);
+            // Self-targeted "Eat" delay loop — no IsInteractorDelayLoop flag.
+            tracker.Observe("LocalPlayer: ProcessDoDelayLoop(1.5, Eat, \"Using Ranalon Salad\", 5820, AbortIfAttacked)", EventTime);
+            tracker.Observe("LocalPlayer: ProcessAddItem(PowerPotion2(1), -1, True)", EventTime);
+
+            src.Progress.Should().ContainKey(LootSource.ChestKey("EltibuleSecretChest"));
         }
         finally { src.Dispose(); derived.Dispose(); }
     }

--- a/tests/Gandalf.Tests/Parsing/InteractionDelayLoopParserTests.cs
+++ b/tests/Gandalf.Tests/Parsing/InteractionDelayLoopParserTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Gandalf.Parsing;
+using Xunit;
+
+namespace Gandalf.Tests.Parsing;
+
+public sealed class InteractionDelayLoopParserTests
+{
+    private readonly InteractionDelayLoopParser _parser = new();
+
+    [Fact]
+    public void Parses_harvest_with_interactor_flag()
+    {
+        // LemonTree fruit harvest — IsInteractorDelayLoop is the discriminator
+        // that tells the bracket tracker to suppress the chest commit.
+        var line = "[18:33:03] LocalPlayer: ProcessDoDelayLoop(3, Gather, \"Collecting Fruit...\", 0, AbortIfAttacked, IsInteractorDelayLoop)";
+        var evt = (InteractionDelayLoopEvent?)_parser.TryParse(line, DateTime.UtcNow);
+
+        evt.Should().NotBeNull();
+        evt!.Verb.Should().Be("Gather");
+        evt.IsInteractor.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("LocalPlayer: ProcessDoDelayLoop(1.5, Eat, \"Using Ranalon Salad\", 5820, AbortIfAttacked)", "Eat")]
+    [InlineData("LocalPlayer: ProcessDoDelayLoop(1.5, Drink, \"Using Grape Juice\", 5313, AbortIfAttacked)", "Drink")]
+    [InlineData("LocalPlayer: ProcessDoDelayLoop(3, UseItem, \"Distilling Phlogiston\", 5815, AbortIfAttacked)", "UseItem")]
+    [InlineData("LocalPlayer: ProcessDoDelayLoop(10, UseTeleportationCircle, \"Recalling Other Places\", 3713, AbortIfAttacked)", "UseTeleportationCircle")]
+    public void Parses_self_targeted_loops_without_interactor_flag(string line, string expectedVerb)
+    {
+        var evt = (InteractionDelayLoopEvent?)_parser.TryParse(line, DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.Verb.Should().Be(expectedVerb);
+        evt.IsInteractor.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Captures_timestamp_passed_in()
+    {
+        var ts = new DateTime(2026, 5, 1, 18, 33, 3, DateTimeKind.Utc);
+        var line = "LocalPlayer: ProcessDoDelayLoop(3, Gather, \"Collecting Fruit...\", 0, AbortIfAttacked, IsInteractorDelayLoop)";
+        var evt = (InteractionDelayLoopEvent)_parser.TryParse(line, ts)!;
+        evt.Timestamp.Should().Be(ts);
+    }
+
+    [Fact]
+    public void Returns_null_for_unrelated_line() =>
+        _parser.TryParse("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", DateTime.UtcNow).Should().BeNull();
+
+    [Fact]
+    public void Returns_null_for_empty_line() =>
+        _parser.TryParse("", DateTime.UtcNow).Should().BeNull();
+}

--- a/tests/Gandalf.Tests/Parsing/InteractionEndParserTests.cs
+++ b/tests/Gandalf.Tests/Parsing/InteractionEndParserTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Gandalf.Parsing;
+using Xunit;
+
+namespace Gandalf.Tests.Parsing;
+
+public sealed class InteractionEndParserTests
+{
+    private readonly InteractionEndParser _parser = new();
+
+    [Fact]
+    public void Parses_portal_end_sample()
+    {
+        // From live capture (#91): portal closes via ProcessEndInteraction(id).
+        var line = "[17:27:57] LocalPlayer: ProcessEndInteraction(-158)";
+        var evt = (InteractionEndEvent?)_parser.TryParse(line, DateTime.UtcNow);
+
+        evt.Should().NotBeNull();
+        evt!.InteractorId.Should().Be(-158);
+    }
+
+    [Fact]
+    public void Parses_positive_id()
+    {
+        var line = "LocalPlayer: ProcessEndInteraction(9902924)";
+        var evt = (InteractionEndEvent?)_parser.TryParse(line, DateTime.UtcNow);
+
+        evt.Should().NotBeNull();
+        evt!.InteractorId.Should().Be(9902924);
+    }
+
+    [Fact]
+    public void Captures_timestamp_passed_in()
+    {
+        var ts = new DateTime(2026, 5, 1, 18, 33, 6, DateTimeKind.Utc);
+        var evt = (InteractionEndEvent)_parser.TryParse("LocalPlayer: ProcessEndInteraction(9902924)", ts)!;
+        evt.Timestamp.Should().Be(ts);
+    }
+
+    [Fact]
+    public void Returns_null_for_start_interaction() =>
+        _parser.TryParse(
+            "LocalPlayer: ProcessStartInteraction(-158, 8, 0, False, \"Portal\")",
+            DateTime.UtcNow).Should().BeNull();
+
+    [Fact]
+    public void Returns_null_for_unrelated_line() =>
+        _parser.TryParse("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", DateTime.UtcNow).Should().BeNull();
+
+    [Fact]
+    public void Returns_null_for_empty_line() =>
+        _parser.TryParse("", DateTime.UtcNow).Should().BeNull();
+}


### PR DESCRIPTION
## Summary

Closes #91. Two false-positive modes were surfacing after #88 (first-loot-stamps-unverified-row):

- **Mode A** — Portal / SummonedFlower4 / SummonedFlower6 — `LootBracketTracker` only recognized `ProcessEnableInteractors` as a bracket close. Portal closes via `ProcessEndInteraction(id)`; SummonedFlowerX never closes at all. The bracket leaked InFlight until an unrelated `ProcessAddItem` (real chest's loot, quest reward, vendor pickup, harvest) committed it under the wrong name.
- **Mode B** — LemonTree (and any harvestable tree/plant/node) — the bracket *does* contain a genuine `ProcessAddItem` (picking fruit). The discriminator the tracker was missing is the `IsInteractorDelayLoop` flag on `ProcessDoDelayLoop`: harvests carry it, self-targeted actions (Eat / Drink / UseItem / UseTeleportationCircle) don't, and no chest in any captured log emits a delay loop at all.

## Changes

- New `InteractionEndParser` recognizing `LocalPlayer: ProcessEndInteraction(id)` → `InteractionEndEvent`.
- New `InteractionDelayLoopParser` extracting verb + `IsInteractorDelayLoop` flag → `InteractionDelayLoopEvent`.
- `LootBracketTracker` now:
  - Closes the bracket on `ProcessEndInteraction(id)` when `id` matches the in-flight interactor.
  - Stashes a `_bracketHarvestVerb` when a delay loop with the interactor flag fires inside a bracket; suppresses the chest commit on the subsequent `ProcessAddItem`.
- Anchoring (StartedAt = `ProcessStartInteraction` timestamp) and the existing chest / storage / NPC / cooldown-rejection paths are unchanged.

## Test plan

- [x] `dotnet test tests/Gandalf.Tests` — 180/180 pass (16 new, 164 pre-existing).
- [x] New `LootBracketTrackerTests` cover: Portal end-close, EndInteraction with non-matching id, SummonedFlower stale bracket replaced by next start, LemonTree harvest suppressed, self-targeted Eat delay loop does **not** suppress a real chest commit.
- [x] New parser tests cover `InteractionEndParser` (positive/negative ids, unrelated lines) and `InteractionDelayLoopParser` (Gather + interactor flag, Eat/Drink/UseItem/UseTeleportationCircle without flag).
- [x] Existing chest tests (EltibuleSecretChest, GoblinStaticChest1, multi-AddItem, EnableInteractors close, bracket replacement, AddItem-outside-bracket, TalkScreen-discarded brackets) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)