### PR TITLE
feat(shared): TabBadge attached property + MithrilTabItemStyle

### DIFF
--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -11,6 +11,7 @@ using Mithril.Shared.Inventory;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
+using Mithril.Shared.Wpf;
 using MahApps.Metro.IconPacks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -103,7 +104,10 @@ public sealed class ArwenModule : IMithrilModule
             view.AddTab("Gift Scanner", new GiftScannerTab { DataContext = sp.GetRequiredService<GiftScannerViewModel>() });
             view.AddTab("Item Lookup", new ItemLookupTab { DataContext = sp.GetRequiredService<ItemLookupViewModel>() });
             view.AddTab("Storage Gifts", new StorageGiftsTab { DataContext = sp.GetRequiredService<StorageGiftsViewModel>() });
-            view.AddTab("Calibration", new CalibrationTab { DataContext = sp.GetRequiredService<CalibrationViewModel>() });
+            var calibrationVm = sp.GetRequiredService<CalibrationViewModel>();
+            var calibrationTab = view.AddTab("Calibration", new CalibrationTab { DataContext = calibrationVm });
+            calibrationTab.SetBinding(TabBadge.CountProperty,
+                new System.Windows.Data.Binding(nameof(CalibrationViewModel.PendingCount)) { Source = calibrationVm });
             sp.GetRequiredService<FavorViewNavigatorHolder>().Inner = view;
             return view;
         });

--- a/src/Arwen.Module/Views/FavorView.xaml
+++ b/src/Arwen.Module/Views/FavorView.xaml
@@ -7,6 +7,14 @@
              mc:Ignorable="d"
              Background="#FF1A1A1A">
 
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
     <DockPanel Margin="12">
         <!-- Header -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,12">
@@ -18,33 +26,7 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0">
-        <TabControl.Resources>
-            <Style TargetType="TabItem">
-                <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
-                <Setter Property="Padding" Value="14,6"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="TabItem">
-                            <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                    BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
-                                <ContentPresenter ContentSource="Header"/>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
-                                    <Setter Property="Foreground" Value="#FFE8E8E8"/>
-                                </Trigger>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-        </TabControl.Resources>
-        </TabControl>
+        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"/>
     </DockPanel>
 </UserControl>

--- a/src/Arwen.Module/Views/FavorView.xaml.cs
+++ b/src/Arwen.Module/Views/FavorView.xaml.cs
@@ -12,18 +12,22 @@ public partial class FavorView : UserControl, IFavorViewNavigator
     }
 
     /// <summary>
-    /// Adds a tab with its DataContext already set.
-    /// Called by ArwenModule during DI registration so each tab
+    /// Adds a tab with its DataContext already set, and returns the created
+    /// <see cref="TabItem"/> so callers can attach a notification badge via
+    /// <c>Mithril.Shared.Wpf.TabBadge.SetCount(item, n)</c> or bind it to a VM
+    /// property. Called by ArwenModule during DI registration so each tab
     /// has its ViewModel before any bindings are evaluated.
     /// </summary>
-    public void AddTab(string header, UserControl content)
+    public TabItem AddTab(string header, UserControl content)
     {
-        Tabs.Items.Add(new TabItem
+        var tab = new TabItem
         {
             Header = header,
             Content = content,
             Margin = new System.Windows.Thickness(0, 8, 0, 0),
-        });
+        };
+        Tabs.Items.Add(tab);
+        return tab;
     }
 
     /// <summary>

--- a/src/Mithril.Shared/Wpf/Resources.xaml
+++ b/src/Mithril.Shared/Wpf/Resources.xaml
@@ -585,6 +585,50 @@
         <Setter Property="Padding"     Value="6,3"/>
     </Style>
 
+    <!-- ═══════════════════ MithrilTabItem ═══════════════════ -->
+
+    <!-- Themed TabItem with optional notification badge. Set
+         c:TabBadge.Count="<int>" on a TabItem to render a small accent pill
+         next to the header; the pill is hidden when Count <= 0. Apply via
+         <TabControl.ItemContainerStyle> or per-item Style. -->
+    <Style x:Key="MithrilTabItemStyle" TargetType="TabItem">
+        <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
+        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeMedium}"/>
+        <Setter Property="Padding"    Value="14,6"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TabItem">
+                    <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
+                            BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
+                        <StackPanel Orientation="Horizontal">
+                            <ContentPresenter ContentSource="Header" VerticalAlignment="Center"/>
+                            <Border x:Name="BadgePill" Margin="6,0,0,0" Padding="5,0"
+                                    MinWidth="16" Height="14" CornerRadius="7"
+                                    Background="{StaticResource AccentBrush}"
+                                    VerticalAlignment="Center"
+                                    Visibility="{Binding Path=(c:TabBadge.Count), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource PositiveIntToVis}}">
+                                <TextBlock Text="{Binding Path=(c:TabBadge.Count), RelativeSource={RelativeSource TemplatedParent}}"
+                                           Foreground="#FF1A1A1A" FontWeight="SemiBold"
+                                           FontSize="{DynamicResource AppFontSizeXSmall}"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </StackPanel>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- ═══════════════════ MithrilQueryBox ═══════════════════ -->
 
     <!-- Highlight brushes — reused by MithrilQueryBox when coloring tokens. -->

--- a/src/Mithril.Shared/Wpf/TabBadge.cs
+++ b/src/Mithril.Shared/Wpf/TabBadge.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Attached properties that paint a notification badge on a <see cref="TabItem"/>
+/// styled with <c>MithrilTabItemStyle</c>. The pill is hidden when
+/// <see cref="GetCount"/> &lt;= 0.
+/// </summary>
+public static class TabBadge
+{
+    public static readonly DependencyProperty CountProperty = DependencyProperty.RegisterAttached(
+        "Count", typeof(int), typeof(TabBadge),
+        new FrameworkPropertyMetadata(0));
+
+    public static int GetCount(DependencyObject obj) => (int)obj.GetValue(CountProperty);
+    public static void SetCount(DependencyObject obj, int value) => obj.SetValue(CountProperty, value);
+}


### PR DESCRIPTION
## Summary

- Promotes the per-`FavorView` inline `TabItem` chrome into a shared `MithrilTabItemStyle` in `Mithril.Shared/Wpf/Resources.xaml`.
- Adds a `TabBadge.Count` attached property; the style renders a small accent pill next to the tab header (hidden when `Count <= 0`).
- `FavorView.AddTab` now returns the created `TabItem` so modules can attach a badge.
- `ArwenModule` wires the badge on the **Calibration** tab to `CalibrationViewModel.PendingCount`, so the pending-observations count is visible without opening the tab.

## Test plan

- [ ] `dotnet build Mithril.slnx` is clean.
- [ ] `dotnet test Mithril.slnx` is green (no test changes; this is a UI-only addition).
- [ ] Open Arwen → confirm the Calibration tab shows a count pill when there are pending observations and hides it at zero.
- [ ] Confirm other Arwen tabs still render with the new shared style (no visual regression vs. the old inline style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)