### PR TITLE
feat(elrond): master-detail recipe browser + split out Simulation tab

### DIFF
--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -54,6 +54,9 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
     private IReadOnlyList<RecipeAnalysis> _filteredRecipes = [];
 
     [ObservableProperty]
+    private RecipeAnalysis? _selectedRecipe;
+
+    [ObservableProperty]
     private bool _showKnownOnly = true;
 
     [ObservableProperty]
@@ -171,6 +174,7 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         if (Analysis is null)
         {
             FilteredRecipes = [];
+            SelectedRecipe = null;
             return;
         }
 
@@ -200,7 +204,13 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
                 : filtered.OrderByDescending(r => GetSortValue(r, sortCol.Key));
         }
 
-        FilteredRecipes = filtered.ToList();
+        var newList = filtered.ToList();
+        FilteredRecipes = newList;
+
+        var previousKey = SelectedRecipe?.RecipeKey;
+        SelectedRecipe = previousKey is null
+            ? newList.FirstOrDefault()
+            : newList.FirstOrDefault(r => r.RecipeKey == previousKey) ?? newList.FirstOrDefault();
     }
 
     private static string GetCellText(RecipeAnalysis row, string key) => key switch

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -222,9 +222,9 @@
 
                                                 <!-- XP breakdown -->
                                                 <Border Background="#FF1E1E1E" CornerRadius="2" Padding="8,6" Margin="0,0,0,10">
-                                                    <Grid>
+                                                    <Grid HorizontalAlignment="Left">
                                                         <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition Width="Auto"/>
                                                         </Grid.ColumnDefinitions>
                                                         <Grid.RowDefinitions>
@@ -236,26 +236,26 @@
                                                         </Grid.RowDefinitions>
 
                                                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Base XP" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
                                                             <Run Text="{Binding BaseXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
                                                         <TextBlock Grid.Row="1" Grid.Column="0" Text="First-time bonus XP" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="1" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                                                        <TextBlock Grid.Row="1" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
                                                             <Run Text="{Binding FirstTimeXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
                                                         <TextBlock Grid.Row="2" Grid.Column="0" Text="Times completed" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="2" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                        <TextBlock Grid.Row="2" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
                                                                    Text="{Binding TimesCompleted, Mode=OneWay}"/>
 
                                                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Effective XP per craft" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="3" Grid.Column="1" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold">
+                                                        <TextBlock Grid.Row="3" Grid.Column="1" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
                                                             <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
                                                         <TextBlock Grid.Row="4" Grid.Column="0" Text="Crafts to next level" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
                                                                    Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
                                                     </Grid>
                                                 </Border>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -28,7 +28,7 @@
             </StackPanel>
         </DockPanel>
 
-        <!-- Controls bar -->
+        <!-- Top control strip: refresh + skill picker (shared by both tabs) -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10">
             <Button DockPanel.Dock="Right" Padding="10,4" Margin="8,0,0,0"
                     Command="{Binding RefreshCharacterDataCommand}"
@@ -41,38 +41,9 @@
 
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Skill:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <ComboBox Width="180" Margin="0,0,16,0"
+                <ComboBox Width="180"
                           ItemsSource="{Binding AvailableSkills}"
                           SelectedItem="{Binding SelectedSkill}"/>
-
-                <TextBlock Text="Goal:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <TextBox Width="50" Margin="0,0,6,0"
-                         Text="{Binding GoalLevel, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
-                         ToolTip="Target level (leave empty for next level)"/>
-                <Button Padding="8,4" Margin="0,0,16,0"
-                        Command="{Binding SimulateCommand}"
-                        ToolTip="Calculate optimal crafting path to goal level">
-                    <StackPanel Orientation="Horizontal">
-                        <icon:PackIconLucide Kind="Route" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                        <TextBlock Text="Simulate" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Button>
-
-                <CheckBox Content="Known only" VerticalAlignment="Center"
-                          IsChecked="{Binding ShowKnownOnly}"
-                          ToolTip="Show only recipes the character has learned"
-                          Margin="0,0,12,0"/>
-                <CheckBox Content="1st time available" VerticalAlignment="Center"
-                          IsChecked="{Binding ShowFirstTimeOnly}"
-                          ToolTip="Show only recipes with a first-time bonus still available"
-                          Margin="0,0,12,0"/>
-                <CheckBox Content="Craftable only" VerticalAlignment="Center"
-                          IsChecked="{Binding ShowCraftableOnly}"
-                          ToolTip="Show only recipes whose level requirement is at or below your current skill level"
-                          Margin="0,0,12,0"/>
-                <CheckBox Content="Include 0 XP" VerticalAlignment="Center"
-                          IsChecked="{Binding IncludeZeroXp}"
-                          ToolTip="Include recipes that give 0 repeatable XP (first-time bonus only)"/>
             </StackPanel>
         </DockPanel>
 
@@ -106,7 +77,7 @@
 
             <!-- Analysis content -->
             <DockPanel Visibility="{Binding Analysis, Converter={x:Static vm:NullToVisConverter.Instance}}">
-                <!-- Summary panel -->
+                <!-- Skill summary panel (shared by both tabs) -->
                 <Border DockPanel.Dock="Top" Background="#FF252525" BorderBrush="#33FFFFFF"
                         BorderThickness="1" Padding="12" CornerRadius="3" Margin="0,0,0,10">
                     <StackPanel>
@@ -137,188 +108,286 @@
                     </StackPanel>
                 </Border>
 
-                <!-- Simulation results -->
-                <Border DockPanel.Dock="Top" Background="#FF252525" BorderBrush="#33D4A847"
-                        BorderThickness="1" Padding="12" CornerRadius="3" Margin="0,0,0,10"
-                        Visibility="{Binding SimulationResult, Converter={x:Static vm:NullToVisConverter.Instance}}">
-                    <StackPanel>
-                        <DockPanel Margin="0,0,0,8">
-                            <StackPanel Orientation="Horizontal">
-                                <icon:PackIconLucide Kind="Route" Width="14" Height="14" VerticalAlignment="Center" Foreground="#FFD4A847" Margin="0,0,6,0"/>
-                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeLarge}" Foreground="#FFD4A847">
-                                    <Run Text="Optimal Path"/>
-                                    <Run Text=" — "/>
-                                    <Run Text="{Binding SimulationResult.TotalCompletions, Mode=OneWay}"/>
-                                    <Run Text=" total crafts"/>
-                                </TextBlock>
-                            </StackPanel>
-                        </DockPanel>
-                        <ItemsControl ItemsSource="{Binding SimulationResult.Steps}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Border Background="#FF1E1E1E" CornerRadius="2" Padding="8,5" Margin="0,0,0,3">
-                                        <DockPanel>
-                                            <TextBlock DockPanel.Dock="Right" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
-                                                <Run Text="Lv "/>
-                                                <Run Text="{Binding LevelAtStart, Mode=OneWay}"/>
-                                                <Run Text=" &#x2192; "/>
-                                                <Run Text="{Binding LevelAtEnd, Mode=OneWay}"/>
-                                            </TextBlock>
-                                            <StackPanel Orientation="Horizontal">
-                                                <wpf:IconImage IconId="{Binding IconId}" Width="18" Height="18" Margin="0,0,6,0" VerticalAlignment="Center"/>
-                                                <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
-                                                    <Run Text="{Binding RecipeName, Mode=OneWay}"/>
-                                                </TextBlock>
-                                                <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
-                                                    <Run Text="x"/>
-                                                    <Run Text="{Binding Completions, Mode=OneWay}"/>
-                                                </TextBlock>
-                                                <Border Background="#44D4A847" CornerRadius="3" Padding="4,1" Margin="8,0,0,0"
-                                                        Visibility="{Binding UsesFirstTimeBonus, Converter={StaticResource BoolToVisibility}}">
-                                                    <TextBlock Text="1st time" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                <TabControl Background="Transparent" BorderThickness="0" Padding="0"
+                            ItemContainerStyle="{StaticResource MithrilTabItemStyle}">
+
+                    <!-- ── Recipes tab ────────────────────────────────────── -->
+                    <TabItem Header="Recipes">
+                        <DockPanel Margin="0,8,0,0">
+                            <!-- Filter bar -->
+                            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+                                <StackPanel Orientation="Horizontal">
+                                    <CheckBox Content="Known only" VerticalAlignment="Center"
+                                              IsChecked="{Binding ShowKnownOnly}"
+                                              ToolTip="Show only recipes the character has learned"
+                                              Margin="0,0,12,0"/>
+                                    <CheckBox Content="1st time available" VerticalAlignment="Center"
+                                              IsChecked="{Binding ShowFirstTimeOnly}"
+                                              ToolTip="Show only recipes with a first-time bonus still available"
+                                              Margin="0,0,12,0"/>
+                                    <CheckBox Content="Craftable only" VerticalAlignment="Center"
+                                              IsChecked="{Binding ShowCraftableOnly}"
+                                              ToolTip="Show only recipes whose level requirement is at or below your current skill level"
+                                              Margin="0,0,12,0"/>
+                                    <CheckBox Content="Include 0 XP" VerticalAlignment="Center"
+                                              IsChecked="{Binding IncludeZeroXp}"
+                                              ToolTip="Include recipes that give 0 repeatable XP (first-time bonus only)"/>
+                                </StackPanel>
+                            </DockPanel>
+
+                            <!-- Master-detail split -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*" MinWidth="320"/>
+                                    <ColumnDefinition Width="6"/>
+                                    <ColumnDefinition Width="2*" MinWidth="280"/>
+                                </Grid.ColumnDefinitions>
+
+                                <wpf:MithrilDataGrid Grid.Column="0" x:Name="RecipeGrid"
+                                                     ItemsSource="{Binding FilteredRecipes}"
+                                                     SelectedItem="{Binding SelectedRecipe, Mode=TwoWay}"
+                                                     SelectionMode="Single"
+                                                     SelectionUnit="FullRow"
+                                                     Mode="ReadOnly">
+                                    <wpf:MithrilDataGrid.Columns>
+                                        <DataGridTemplateColumn Header="Recipe" Width="*" MinWidth="120" SortMemberPath="RecipeName">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding RecipeName}"/>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTextColumn Header="Lvl Req" Binding="{Binding LevelRequired}" SortMemberPath="LevelRequired" Width="60">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="1st?" Binding="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" SortMemberPath="FirstTimeBonusAvailable" Width="40">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Eff. XP" Binding="{Binding EffectiveXp}" SortMemberPath="EffectiveXp" Width="70">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="To Level" Binding="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" SortMemberPath="CompletionsToLevel" Width="70">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="HorizontalAlignment" Value="Right"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                    </wpf:MithrilDataGrid.Columns>
+                                </wpf:MithrilDataGrid>
+
+                                <GridSplitter Grid.Column="1" Width="6" Background="#22FFFFFF"
+                                              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                              ShowsPreview="True"/>
+
+                                <!-- Detail pane -->
+                                <Border Grid.Column="2" Background="#FF252525" BorderBrush="#33FFFFFF"
+                                        BorderThickness="1" CornerRadius="3" Padding="12">
+                                    <Grid>
+                                        <!-- Empty inner state -->
+                                        <TextBlock Text="Select a recipe to view its ingredients, XP breakdown, and crafted outputs."
+                                                   Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                   TextWrapping="Wrap" TextAlignment="Center"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                   Visibility="{Binding SelectedRecipe, Converter={x:Static vm:NullToVisConverter.Instance}, ConverterParameter=invert}"/>
+
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                                                      Visibility="{Binding SelectedRecipe, Converter={x:Static vm:NullToVisConverter.Instance}}">
+                                            <StackPanel DataContext="{Binding SelectedRecipe}">
+                                                <!-- Recipe header -->
+                                                <DockPanel Margin="0,0,0,10">
+                                                    <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                                   Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
+                                                    <StackPanel VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding RecipeName}" FontWeight="Bold"
+                                                                   Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                                                        <TextBlock Foreground="#AAFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0">
+                                                            <Run Text="Level"/>
+                                                            <Run Text="{Binding LevelRequired, Mode=OneWay}"/>
+                                                        </TextBlock>
+                                                    </StackPanel>
+                                                </DockPanel>
+
+                                                <!-- XP breakdown -->
+                                                <Border Background="#FF1E1E1E" CornerRadius="2" Padding="8,6" Margin="0,0,0,10">
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                        </Grid.RowDefinitions>
+
+                                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Base XP" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                                                            <Run Text="{Binding BaseXp, Mode=OneWay, StringFormat=N0}"/>
+                                                        </TextBlock>
+
+                                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="First-time bonus XP" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="1" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                                                            <Run Text="{Binding FirstTimeXp, Mode=OneWay, StringFormat=N0}"/>
+                                                        </TextBlock>
+
+                                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Times completed" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="2" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                                   Text="{Binding TimesCompleted, Mode=OneWay}"/>
+
+                                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Effective XP per craft" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="3" Grid.Column="1" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold">
+                                                            <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
+                                                        </TextBlock>
+
+                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Crafts to next level" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                                   Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
+                                                    </Grid>
                                                 </Border>
-                                                <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
-                                                    <Run Text="{Binding TotalXpFromStep, Mode=OneWay, StringFormat=N0}"/>
-                                                    <Run Text=" XP"/>
+
+                                                <!-- Ingredients -->
+                                                <TextBlock Text="Ingredients" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                           FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                                <ItemsControl ItemsSource="{Binding Ingredients}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <StackPanel Orientation="Horizontal" Margin="0,1">
+                                                                <wpf:IconImage IconId="{Binding IconId}" Width="16" Height="16" Margin="0,0,4,0"/>
+                                                                <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                                                                    <Run Text="{Binding StackSize, Mode=OneWay, StringFormat='{}{0}x '}"/>
+                                                                </TextBlock>
+                                                                <TextBlock Text="{Binding Name}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                <TextBlock Text="{Binding ChanceToConsume, Mode=OneWay, StringFormat=' ({0:P0} chance)'}"
+                                                                           Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontStyle="Italic"
+                                                                           Visibility="{Binding ChanceToConsume, Converter={x:Static vm:NullToVisConverter.Instance}}"/>
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+
+                                                <!-- Crafted gear -->
+                                                <TextBlock Text="Crafted gear" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                           FontWeight="SemiBold" Margin="0,10,0,4"
+                                                           Visibility="{Binding CraftedOutputs.Count, Converter={x:Static vm:CountToVisConverter.Instance}}"/>
+                                                <ItemsControl ItemsSource="{Binding CraftedOutputs}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <StackPanel Orientation="Horizontal" Margin="0,1">
+                                                                <wpf:IconImage IconId="{Binding IconId}" Width="16" Height="16" Margin="0,0,4,0"/>
+                                                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" TextWrapping="Wrap"/>
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </StackPanel>
+                                        </ScrollViewer>
+                                    </Grid>
+                                </Border>
+                            </Grid>
+                        </DockPanel>
+                    </TabItem>
+
+                    <!-- ── Simulation tab ─────────────────────────────────── -->
+                    <TabItem Header="Simulation">
+                        <DockPanel Margin="0,8,0,0">
+                            <!-- Sim controls -->
+                            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Goal level:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <TextBox Width="60" Margin="0,0,6,0"
+                                             Text="{Binding GoalLevel, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
+                                             ToolTip="Target level (leave empty for next level)"/>
+                                    <Button Padding="8,4"
+                                            Command="{Binding SimulateCommand}"
+                                            ToolTip="Calculate optimal crafting path to goal level">
+                                        <StackPanel Orientation="Horizontal">
+                                            <icon:PackIconLucide Kind="Route" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                            <TextBlock Text="Simulate" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Button>
+                                </StackPanel>
+                            </DockPanel>
+
+                            <!-- Result or empty state -->
+                            <Grid>
+                                <TextBlock Text="Set a goal level and click Simulate to see an optimal crafting path."
+                                           Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" TextAlignment="Center"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="420"
+                                           Visibility="{Binding SimulationResult, Converter={x:Static vm:NullToVisConverter.Instance}, ConverterParameter=invert}"/>
+
+                                <Border Background="#FF252525" BorderBrush="#33D4A847"
+                                        BorderThickness="1" Padding="12" CornerRadius="3"
+                                        Visibility="{Binding SimulationResult, Converter={x:Static vm:NullToVisConverter.Instance}}">
+                                    <DockPanel>
+                                        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+                                            <StackPanel Orientation="Horizontal">
+                                                <icon:PackIconLucide Kind="Route" Width="14" Height="14" VerticalAlignment="Center" Foreground="#FFD4A847" Margin="0,0,6,0"/>
+                                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeLarge}" Foreground="#FFD4A847">
+                                                    <Run Text="Optimal Path"/>
+                                                    <Run Text=" — "/>
+                                                    <Run Text="{Binding SimulationResult.TotalCompletions, Mode=OneWay}"/>
+                                                    <Run Text=" total crafts"/>
                                                 </TextBlock>
                                             </StackPanel>
                                         </DockPanel>
-                                    </Border>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                </Border>
-
-                <!-- Recipe table -->
-                <wpf:MithrilDataGrid x:Name="RecipeGrid"
-                                    ItemsSource="{Binding FilteredRecipes}"
-                                    Mode="ReadOnly">
-                    <wpf:MithrilDataGrid.Columns>
-                        <DataGridTemplateColumn Header="Recipe" Width="*" MinWidth="120" SortMemberPath="RecipeName">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding RecipeName}"/>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
-                        <DataGridTextColumn Header="Lvl Req" Binding="{Binding LevelRequired}" SortMemberPath="LevelRequired" Width="60">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Base XP" Binding="{Binding BaseXp}" SortMemberPath="BaseXp" Width="65">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="1st Time" Binding="{Binding FirstTimeXp}" SortMemberPath="FirstTimeXp" Width="65">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Done" Binding="{Binding TimesCompleted}" SortMemberPath="TimesCompleted" Width="50">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="1st?" Binding="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" SortMemberPath="FirstTimeBonusAvailable" Width="40">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Eff. XP" Binding="{Binding EffectiveXp}" SortMemberPath="EffectiveXp" Width="60">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="To Level" Binding="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" SortMemberPath="CompletionsToLevel" Width="65">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                    </wpf:MithrilDataGrid.Columns>
-                    <wpf:MithrilDataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
-                            <Setter Property="ToolTip">
-                                <Setter.Value>
-                                    <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
-                                             Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                        <ToolTip.ContentTemplate>
-                                            <DataTemplate>
-                                                <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                                                        CornerRadius="4" Padding="10" MaxWidth="360">
-                                                    <StackPanel>
-                                                        <DockPanel Margin="0,0,0,6">
-                                                            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                                           Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
-                                                            <StackPanel VerticalAlignment="Center">
-                                                                <TextBlock Text="{Binding RecipeName}" FontWeight="Bold"
-                                                                           Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
-                                                                <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0">
-                                                                    <Run Text="Level"/>
-                                                                    <Run Text="{Binding LevelRequired, Mode=OneWay}"/>
-                                                                    <Run Text=" &#x2022; "/>
-                                                                    <Run Text="{Binding BaseXp, Mode=OneWay}"/>
-                                                                    <Run Text=" XP"/>
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                            <ItemsControl ItemsSource="{Binding SimulationResult.Steps}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Background="#FF1E1E1E" CornerRadius="2" Padding="8,5" Margin="0,0,0,3">
+                                                            <DockPanel>
+                                                                <TextBlock DockPanel.Dock="Right" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
+                                                                    <Run Text="Lv "/>
+                                                                    <Run Text="{Binding LevelAtStart, Mode=OneWay}"/>
+                                                                    <Run Text=" &#x2192; "/>
+                                                                    <Run Text="{Binding LevelAtEnd, Mode=OneWay}"/>
                                                                 </TextBlock>
-                                                            </StackPanel>
-                                                        </DockPanel>
-                                                        <TextBlock Text="Ingredients" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                                                                   FontWeight="SemiBold" Margin="0,0,0,4"/>
-                                                        <ItemsControl ItemsSource="{Binding Ingredients}">
-                                                            <ItemsControl.ItemTemplate>
-                                                                <DataTemplate>
-                                                                    <StackPanel Orientation="Horizontal" Margin="0,1">
-                                                                        <wpf:IconImage IconId="{Binding IconId}" Width="16" Height="16" Margin="0,0,4,0"/>
-                                                                        <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
-                                                                            <Run Text="{Binding StackSize, Mode=OneWay, StringFormat='{}{0}x '}"/>
-                                                                        </TextBlock>
-                                                                        <TextBlock Text="{Binding Name}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                                        <TextBlock Text="{Binding ChanceToConsume, Mode=OneWay, StringFormat=' ({0:P0} chance)'}"
-                                                                                   Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontStyle="Italic"
-                                                                                   Visibility="{Binding ChanceToConsume, Converter={x:Static vm:NullToVisConverter.Instance}}"/>
-                                                                    </StackPanel>
-                                                                </DataTemplate>
-                                                            </ItemsControl.ItemTemplate>
-                                                        </ItemsControl>
-                                                        <TextBlock Text="Crafted gear" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                                                                   FontWeight="SemiBold" Margin="0,8,0,4"
-                                                                   Visibility="{Binding CraftedOutputs.Count, Converter={x:Static vm:CountToVisConverter.Instance}}"/>
-                                                        <ItemsControl ItemsSource="{Binding CraftedOutputs}">
-                                                            <ItemsControl.ItemTemplate>
-                                                                <DataTemplate>
-                                                                    <StackPanel Orientation="Horizontal" Margin="0,1">
-                                                                        <wpf:IconImage IconId="{Binding IconId}" Width="16" Height="16" Margin="0,0,4,0"/>
-                                                                        <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                                    </StackPanel>
-                                                                </DataTemplate>
-                                                            </ItemsControl.ItemTemplate>
-                                                        </ItemsControl>
-                                                    </StackPanel>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ToolTip.ContentTemplate>
-                                    </ToolTip>
-                                </Setter.Value>
-                            </Setter>
-                        </Style>
-                    </wpf:MithrilDataGrid.RowStyle>
-                </wpf:MithrilDataGrid>
+                                                                <StackPanel Orientation="Horizontal">
+                                                                    <wpf:IconImage IconId="{Binding IconId}" Width="18" Height="18" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                                                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
+                                                                        <Run Text="{Binding RecipeName, Mode=OneWay}"/>
+                                                                    </TextBlock>
+                                                                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
+                                                                        <Run Text="x"/>
+                                                                        <Run Text="{Binding Completions, Mode=OneWay}"/>
+                                                                    </TextBlock>
+                                                                    <Border Background="#44D4A847" CornerRadius="3" Padding="4,1" Margin="8,0,0,0"
+                                                                            Visibility="{Binding UsesFirstTimeBonus, Converter={StaticResource BoolToVisibility}}">
+                                                                        <TextBlock Text="1st time" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                                                    </Border>
+                                                                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
+                                                                        <Run Text="{Binding TotalXpFromStep, Mode=OneWay, StringFormat=N0}"/>
+                                                                        <Run Text=" XP"/>
+                                                                    </TextBlock>
+                                                                </StackPanel>
+                                                            </DockPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </DockPanel>
+                                </Border>
+                            </Grid>
+                        </DockPanel>
+                    </TabItem>
+                </TabControl>
             </DockPanel>
         </Grid>
     </DockPanel>


### PR DESCRIPTION
## Summary

- Replaces Elrond's flat 8-column recipe grid + 40-line hover tooltip with a real master-detail layout: trimmed grid (Recipe / Lvl Req / 1st? / Eff. XP / To Level) on the left, persistent detail pane on the right showing icon, full XP breakdown, ingredients, and crafted gear.
- Splits the goal-driven simulator into its own **Simulation** tab so it stops competing for vertical space with the recipe grid.
- Adds `SelectedRecipe` to `SkillAdvisorViewModel`; `ApplyRecipeFilter` preserves selection across filter changes by `RecipeKey`, falling back to the first row.

**Note:** stacked on top of #94 (`feat/tab-badge`) which introduces `MithrilTabItemStyle`. Merge #94 first, then rebase this onto `main`.

## Test plan

- [ ] `dotnet build Mithril.slnx` is clean.
- [ ] `dotnet test Mithril.slnx` is green (Elrond.Tests at 19/19).
- [ ] Recipes tab — pick a skill → first row auto-selected → detail pane populated with icon, XP breakdown, ingredients, crafted gear.
- [ ] Click a different row → detail pane updates.
- [ ] Toggle a filter so the previously selected recipe is still in the list → selection persists.
- [ ] Toggle a filter so the previously selected recipe drops out → selection falls back to the first new row.
- [ ] Filter to zero rows → grid empty, detail pane shows the empty inner state.
- [ ] Drag the `GridSplitter` to verify the detail pane resizes; long ingredient lists scroll inside the pane.
- [ ] Simulation tab — set goal level + click Simulate → optimal path renders. Switch skill → result clears (existing VM behavior).
- [ ] No regressions in Samwise / Arwen / Bilbo grids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)