### PR TITLE
feat(elrond): replace MithrilDataGrid with ListBox + CollectionViewSource

### DIFF
--- a/src/Elrond.Module/Domain/ElrondSettings.cs
+++ b/src/Elrond.Module/Domain/ElrondSettings.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
-using Mithril.Shared.Wpf;
 
 namespace Elrond.Domain;
 
@@ -21,7 +20,19 @@ public sealed class ElrondSettings : INotifyPropertyChanged
         set => Set(ref _lastGoalLevel, value);
     }
 
-    public DataGridState RecipeGrid { get; set; } = new();
+    private string _sortKey = "EffectiveXp";
+    public string SortKey
+    {
+        get => _sortKey;
+        set => Set(ref _sortKey, value);
+    }
+
+    private bool _sortDescending = true;
+    public bool SortDescending
+    {
+        get => _sortDescending;
+        set => Set(ref _sortDescending, value);
+    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/src/Elrond.Module/Domain/ElrondSettings.cs
+++ b/src/Elrond.Module/Domain/ElrondSettings.cs
@@ -34,6 +34,13 @@ public sealed class ElrondSettings : INotifyPropertyChanged
         set => Set(ref _sortDescending, value);
     }
 
+    private string _viewMode = "Rows";
+    public string ViewMode
+    {
+        get => _viewMode;
+        set => Set(ref _viewMode, value);
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -37,9 +37,7 @@ public sealed class ElrondModule : IMithrilModule
         services.AddSingleton<LevelingSimulator>();
 
         services.AddSingleton<SkillAdvisorViewModel>();
-        services.AddSingleton<SkillAdvisorView>(sp => new SkillAdvisorView(
-            sp.GetRequiredService<ElrondSettings>(),
-            sp.GetRequiredService<SettingsAutoSaver<ElrondSettings>>())
+        services.AddSingleton<SkillAdvisorView>(sp => new SkillAdvisorView
         {
             DataContext = sp.GetRequiredService<SkillAdvisorViewModel>(),
         });

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -1,21 +1,36 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Elrond.Domain;
 using Elrond.Services;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
-using Mithril.Shared.Wpf;
 
 namespace Elrond.ViewModels;
 
+public sealed record SortOption(string Label, string Key);
+
 public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposable
 {
+    public IReadOnlyList<SortOption> SortOptions { get; } =
+    [
+        new("Recipe", "RecipeName"),
+        new("Lvl Req", "LevelRequired"),
+        new("Eff. XP", "EffectiveXp"),
+        new("To Level", "CompletionsToLevel"),
+    ];
+
     private readonly SkillAdvisorEngine _engine;
     private readonly LevelingSimulator _simulator;
     private readonly IActiveCharacterService _activeChar;
     private readonly IReferenceDataService _referenceData;
     private readonly ElrondSettings _settings;
+
+    private readonly ObservableCollection<RecipeAnalysis> _recipes = [];
+
+    public ICollectionView RecipesView { get; }
 
     public SkillAdvisorViewModel(
         SkillAdvisorEngine engine,
@@ -31,6 +46,14 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         _settings = settings;
 
         _goalLevel = settings.LastGoalLevel;
+        _sortKey = settings.SortKey;
+        _sortDescending = settings.SortDescending;
+
+        var view = (ListCollectionView)CollectionViewSource.GetDefaultView(_recipes);
+        view.Filter = item => MatchesFilter((RecipeAnalysis)item);
+        view.CurrentChanged += OnCurrentRecipeChanged;
+        RecipesView = view;
+        ApplySortDescriptions();
 
         _activeChar.ActiveCharacterChanged += OnActiveCharacterChanged;
         _activeChar.CharacterExportsChanged += OnActiveCharacterChanged;
@@ -49,9 +72,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
 
     [ObservableProperty]
     private SkillAnalysis? _analysis;
-
-    [ObservableProperty]
-    private IReadOnlyList<RecipeAnalysis> _filteredRecipes = [];
 
     [ObservableProperty]
     private RecipeAnalysis? _selectedRecipe;
@@ -77,7 +97,11 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
     [ObservableProperty]
     private SimulationResult? _simulationResult;
 
-    public DataGridState GridState => _settings.RecipeGrid;
+    [ObservableProperty]
+    private string _sortKey = "EffectiveXp";
+
+    [ObservableProperty]
+    private bool _sortDescending = true;
 
     // ── Property change handlers ─────────────────────────────────────────
 
@@ -95,10 +119,22 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         Reanalyze();
     }
 
-    partial void OnShowKnownOnlyChanged(bool value) => ApplyRecipeFilter();
-    partial void OnShowFirstTimeOnlyChanged(bool value) => ApplyRecipeFilter();
-    partial void OnShowCraftableOnlyChanged(bool value) => ApplyRecipeFilter();
+    partial void OnShowKnownOnlyChanged(bool value) => RecipesView.Refresh();
+    partial void OnShowFirstTimeOnlyChanged(bool value) => RecipesView.Refresh();
+    partial void OnShowCraftableOnlyChanged(bool value) => RecipesView.Refresh();
     partial void OnIncludeZeroXpChanged(bool value) => Reanalyze();
+
+    partial void OnSortKeyChanged(string value)
+    {
+        _settings.SortKey = value;
+        ApplySortDescriptions();
+    }
+
+    partial void OnSortDescendingChanged(bool value)
+    {
+        _settings.SortDescending = value;
+        ApplySortDescriptions();
+    }
 
     // ── Commands ─────────────────────────────────────────────────────────
 
@@ -121,13 +157,28 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         SimulationResult = _simulator.Simulate(SelectedSkill, active, goal);
     }
 
+    [RelayCommand]
+    private void ToggleSort(string? key)
+    {
+        if (string.IsNullOrEmpty(key)) return;
+        if (SortKey == key)
+        {
+            SortDescending = !SortDescending;
+        }
+        else
+        {
+            SortKey = key;
+            // Numeric metrics read top-down (largest first); names read alphabetically.
+            SortDescending = key != "RecipeName";
+        }
+    }
+
     // ── Private helpers ──────────────────────────────────────────────────
 
     private void ReloadSkills()
     {
         var skills = _engine.GetSkillsWithRecipes();
 
-        // If a character is selected, filter to skills the character has
         var active = _activeChar.ActiveCharacter;
         if (active is not null)
         {
@@ -135,8 +186,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         }
 
         AvailableSkills = new ObservableCollection<string>(skills);
-
-        // Restore last selection
         SelectedSkill = skills.Contains(_settings.LastSkill) ? _settings.LastSkill : skills.FirstOrDefault();
     }
 
@@ -146,21 +195,25 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         if (active is null)
         {
             Analysis = null;
+            _recipes.Clear();
             StatusMessage = "No active character — switch one from the shell header.";
             return;
         }
         if (string.IsNullOrEmpty(SelectedSkill))
         {
             Analysis = null;
+            _recipes.Clear();
             StatusMessage = $"{active.Name} on {active.Server} — select a skill.";
             return;
         }
 
         Analysis = _engine.Analyze(SelectedSkill, active, IncludeZeroXp, GoalLevel);
-        ApplyRecipeFilter();
 
+        _recipes.Clear();
         if (Analysis is not null)
         {
+            foreach (var r in Analysis.Recipes) _recipes.Add(r);
+            RecipesView.MoveCurrentToFirst();
             StatusMessage = $"{active.Name} on {active.Server} — exported {active.ExportedAt:g}";
         }
         else
@@ -169,75 +222,26 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         }
     }
 
-    public void ApplyRecipeFilter()
+    private bool MatchesFilter(RecipeAnalysis row)
     {
-        if (Analysis is null)
-        {
-            FilteredRecipes = [];
-            SelectedRecipe = null;
-            return;
-        }
-
-        IEnumerable<RecipeAnalysis> filtered = Analysis.Recipes;
-
-        // Existing checkbox filters
-        if (ShowKnownOnly) filtered = filtered.Where(r => r.IsKnown);
-        if (ShowFirstTimeOnly) filtered = filtered.Where(r => r.FirstTimeBonusAvailable);
-        if (ShowCraftableOnly) filtered = filtered.Where(r => r.LevelRequired <= Analysis.CurrentLevel);
-
-        // Per-column filters
-        foreach (var col in GridState.Columns)
-        {
-            if (string.IsNullOrEmpty(col.FilterText)) continue;
-            var filter = col.FilterText;
-            var key = col.Key;
-            filtered = filtered.Where(row =>
-                GetCellText(row, key).Contains(filter, StringComparison.OrdinalIgnoreCase));
-        }
-
-        // Sort
-        var sortCol = GridState.Columns.FirstOrDefault(c => c.SortDirection is not null);
-        if (sortCol is not null)
-        {
-            filtered = sortCol.SortDirection == "Ascending"
-                ? filtered.OrderBy(r => GetSortValue(r, sortCol.Key))
-                : filtered.OrderByDescending(r => GetSortValue(r, sortCol.Key));
-        }
-
-        var newList = filtered.ToList();
-        FilteredRecipes = newList;
-
-        var previousKey = SelectedRecipe?.RecipeKey;
-        SelectedRecipe = previousKey is null
-            ? newList.FirstOrDefault()
-            : newList.FirstOrDefault(r => r.RecipeKey == previousKey) ?? newList.FirstOrDefault();
+        if (Analysis is null) return false;
+        if (ShowKnownOnly && !row.IsKnown) return false;
+        if (ShowFirstTimeOnly && !row.FirstTimeBonusAvailable) return false;
+        if (ShowCraftableOnly && row.LevelRequired > Analysis.CurrentLevel) return false;
+        return true;
     }
 
-    private static string GetCellText(RecipeAnalysis row, string key) => key switch
+    private void ApplySortDescriptions()
     {
-        "RecipeName" => row.RecipeName,
-        "LevelRequired" => row.LevelRequired.ToString(),
-        "BaseXp" => row.BaseXp.ToString(),
-        "FirstTimeXp" => row.FirstTimeXp.ToString(),
-        "TimesCompleted" => row.TimesCompleted.ToString(),
-        "FirstTimeBonusAvailable" => row.FirstTimeBonusAvailable ? "Yes" : "No",
-        "EffectiveXp" => row.EffectiveXp.ToString(),
-        "CompletionsToLevel" => row.CompletionsToLevel?.ToString() ?? "",
-        _ => "",
-    };
+        var dir = SortDescending ? ListSortDirection.Descending : ListSortDirection.Ascending;
+        RecipesView.SortDescriptions.Clear();
+        RecipesView.SortDescriptions.Add(new SortDescription(SortKey, dir));
+    }
 
-    private static IComparable GetSortValue(RecipeAnalysis row, string key) => key switch
+    private void OnCurrentRecipeChanged(object? sender, EventArgs e)
     {
-        "RecipeName" => row.RecipeName,
-        "LevelRequired" => row.LevelRequired,
-        "BaseXp" => row.BaseXp,
-        "FirstTimeXp" => row.FirstTimeXp,
-        "TimesCompleted" => row.TimesCompleted,
-        "FirstTimeBonusAvailable" => row.FirstTimeBonusAvailable ? 1 : 0,
-        "EffectiveXp" => row.EffectiveXp,
-        "CompletionsToLevel" => row.CompletionsToLevel ?? int.MaxValue,
-        _ => "",
-    };
+        SelectedRecipe = RecipesView.CurrentItem as RecipeAnalysis;
+    }
 
     private void OnActiveCharacterChanged(object? sender, EventArgs e)
     {
@@ -259,5 +263,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         _activeChar.ActiveCharacterChanged -= OnActiveCharacterChanged;
         _activeChar.CharacterExportsChanged -= OnActiveCharacterChanged;
         _referenceData.FileUpdated -= OnReferenceUpdated;
+        RecipesView.CurrentChanged -= OnCurrentRecipeChanged;
     }
 }

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -48,6 +48,7 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         _goalLevel = settings.LastGoalLevel;
         _sortKey = settings.SortKey;
         _sortDescending = settings.SortDescending;
+        _viewMode = settings.ViewMode;
 
         var view = (ListCollectionView)CollectionViewSource.GetDefaultView(_recipes);
         view.Filter = item => MatchesFilter((RecipeAnalysis)item);
@@ -103,6 +104,9 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
     [ObservableProperty]
     private bool _sortDescending = true;
 
+    [ObservableProperty]
+    private string _viewMode = "Rows";
+
     // ── Property change handlers ─────────────────────────────────────────
 
     partial void OnSelectedSkillChanged(string? value)
@@ -136,6 +140,11 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         ApplySortDescriptions();
     }
 
+    partial void OnViewModeChanged(string value)
+    {
+        _settings.ViewMode = value;
+    }
+
     // ── Commands ─────────────────────────────────────────────────────────
 
     [RelayCommand]
@@ -155,6 +164,12 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         }
 
         SimulationResult = _simulator.Simulate(SelectedSkill, active, goal);
+    }
+
+    [RelayCommand]
+    private void SetViewMode(string? mode)
+    {
+        if (!string.IsNullOrEmpty(mode)) ViewMode = mode;
     }
 
     [RelayCommand]

--- a/src/Elrond.Module/Views/Converters.cs
+++ b/src/Elrond.Module/Views/Converters.cs
@@ -30,3 +30,40 @@ public sealed class BoolToVisibilityConverter : IValueConverter
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();
 }
+
+/// <summary>
+/// Resolves the active-sort indicator for a sort chip. Inputs (in order):
+/// current SortKey, current SortDescending, this chip's Key. Returns
+/// " ▼" (down arrow) when matching and descending, " ▲" (up
+/// arrow) when matching and ascending, empty string otherwise.
+/// </summary>
+public sealed class SortIndicatorConverter : IMultiValueConverter
+{
+    public static SortIndicatorConverter Instance { get; } = new();
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values is [string current, bool desc, string key] && current == key)
+            return desc ? " ▼" : " ▲";
+        return string.Empty;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Returns true when the current SortKey (first input) equals this chip's
+/// Key (second input). Drives the chip's active styling via Tag-based
+/// trigger.
+/// </summary>
+public sealed class IsActiveSortConverter : IMultiValueConverter
+{
+    public static IsActiveSortConverter Instance { get; } = new();
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+        => values is [string current, string key] && current == key;
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Elrond.Module/Views/Converters.cs
+++ b/src/Elrond.Module/Views/Converters.cs
@@ -67,3 +67,18 @@ public sealed class IsActiveSortConverter : IMultiValueConverter
     public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();
 }
+
+/// <summary>
+/// Returns Visible when the bound value (string) equals the converter
+/// parameter (string). Used to show/hide chrome based on view mode.
+/// </summary>
+public sealed class StringEqualsToVisConverter : IValueConverter
+{
+    public static StringEqualsToVisConverter Instance { get; } = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is string s && parameter is string p && s == p ? Visibility.Visible : Visibility.Collapsed;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -1,7 +1,55 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:views="clr-namespace:Elrond.Views">
+                    xmlns:views="clr-namespace:Elrond.Views"
+                    xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared">
     <views:BoolToCheckConverter x:Key="BoolToCheck"/>
     <views:NullableIntConverter x:Key="NullableInt"/>
     <views:BoolToVisibilityConverter x:Key="BoolToVisibility"/>
+
+    <!-- Recipe row template — column-aligned values for fast vertical scanning. -->
+    <DataTemplate x:Key="RecipeRowTemplate">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="50"/>
+                <ColumnDefinition Width="40"/>
+                <ColumnDefinition Width="80"/>
+                <ColumnDefinition Width="80"/>
+            </Grid.ColumnDefinitions>
+            <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="3" Text="{Binding EffectiveXp, StringFormat=N0}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+        </Grid>
+    </DataTemplate>
+
+    <!-- Recipe card template — bigger icon, stacked metadata pills, more breathing room. -->
+    <DataTemplate x:Key="RecipeCardTemplate">
+        <DockPanel>
+            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}" Width="36" Height="36" Margin="0,0,12,0" VerticalAlignment="Center"/>
+            <Border DockPanel.Dock="Right" Background="#33D4A847" CornerRadius="3" Padding="6,2" Margin="8,0,0,0" VerticalAlignment="Center"
+                    Visibility="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToVisibility}}">
+                <TextBlock Text="1st time" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeSmall}"/>
+            </Border>
+            <StackPanel VerticalAlignment="Center">
+                <TextBlock Text="{Binding RecipeName}" Foreground="#FFE8E8E8" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                        <Run Text="Lvl "/><Run Text="{Binding LevelRequired, Mode=OneWay}"/>
+                    </TextBlock>
+                    <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
+                    <TextBlock Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold">
+                        <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
+                        <Run Text=" eff XP"/>
+                    </TextBlock>
+                    <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
+                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                        <Run Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
+                        <Run Text=" to level"/>
+                    </TextBlock>
+                </StackPanel>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
 </ResourceDictionary>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Elrond.ViewModels"
+             xmlns:views="clr-namespace:Elrond.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -143,50 +144,160 @@
                                     <ColumnDefinition Width="2*" MinWidth="280"/>
                                 </Grid.ColumnDefinitions>
 
-                                <wpf:MithrilDataGrid Grid.Column="0" x:Name="RecipeGrid"
-                                                     ItemsSource="{Binding FilteredRecipes}"
-                                                     SelectedItem="{Binding SelectedRecipe, Mode=TwoWay}"
-                                                     SelectionMode="Single"
-                                                     SelectionUnit="FullRow"
-                                                     Mode="ReadOnly">
-                                    <wpf:MithrilDataGrid.Columns>
-                                        <DataGridTemplateColumn Header="Recipe" Width="*" MinWidth="120" SortMemberPath="RecipeName">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding RecipeName}"/>
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                        <DataGridTextColumn Header="Lvl Req" Binding="{Binding LevelRequired}" SortMemberPath="LevelRequired" Width="60">
-                                            <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                                </Style>
-                                            </DataGridTextColumn.ElementStyle>
-                                        </DataGridTextColumn>
-                                        <DataGridTextColumn Header="1st?" Binding="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" SortMemberPath="FirstTimeBonusAvailable" Width="40">
-                                            <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                                </Style>
-                                            </DataGridTextColumn.ElementStyle>
-                                        </DataGridTextColumn>
-                                        <DataGridTextColumn Header="Eff. XP" Binding="{Binding EffectiveXp}" SortMemberPath="EffectiveXp" Width="70">
-                                            <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                                </Style>
-                                            </DataGridTextColumn.ElementStyle>
-                                        </DataGridTextColumn>
-                                        <DataGridTextColumn Header="To Level" Binding="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" SortMemberPath="CompletionsToLevel" Width="70">
-                                            <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                                </Style>
-                                            </DataGridTextColumn.ElementStyle>
-                                        </DataGridTextColumn>
-                                    </wpf:MithrilDataGrid.Columns>
-                                </wpf:MithrilDataGrid>
+                                <DockPanel Grid.Column="0">
+                                    <!-- Sort chip row -->
+                                    <Border DockPanel.Dock="Top" Padding="0,0,0,6">
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="Sort by:" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                            <ItemsControl ItemsSource="{Binding SortOptions}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Button Command="{Binding DataContext.ToggleSortCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                CommandParameter="{Binding Key}"
+                                                                Margin="0,0,4,0" Padding="8,2"
+                                                                BorderThickness="1" Cursor="Hand">
+                                                            <Button.Tag>
+                                                                <MultiBinding Converter="{x:Static views:IsActiveSortConverter.Instance}">
+                                                                    <Binding Path="DataContext.SortKey" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
+                                                                    <Binding Path="Key"/>
+                                                                </MultiBinding>
+                                                            </Button.Tag>
+                                                            <Button.Style>
+                                                                <Style TargetType="Button">
+                                                                    <Setter Property="Background" Value="Transparent"/>
+                                                                    <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+                                                                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                                                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
+                                                                    <Setter Property="Template">
+                                                                        <Setter.Value>
+                                                                            <ControlTemplate TargetType="Button">
+                                                                                <Border x:Name="Bd" Background="{TemplateBinding Background}"
+                                                                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                                                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                                                                        Padding="{TemplateBinding Padding}"
+                                                                                        CornerRadius="3">
+                                                                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                                </Border>
+                                                                                <ControlTemplate.Triggers>
+                                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                                                                                    </Trigger>
+                                                                                </ControlTemplate.Triggers>
+                                                                            </ControlTemplate>
+                                                                        </Setter.Value>
+                                                                    </Setter>
+                                                                    <Style.Triggers>
+                                                                        <Trigger Property="Tag" Value="True">
+                                                                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                                                            <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                                                        </Trigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Button.Style>
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <TextBlock Text="{Binding Label}"/>
+                                                                <TextBlock>
+                                                                    <TextBlock.Text>
+                                                                        <MultiBinding Converter="{x:Static views:SortIndicatorConverter.Instance}">
+                                                                            <Binding Path="DataContext.SortKey" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
+                                                                            <Binding Path="DataContext.SortDescending" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
+                                                                            <Binding Path="Key"/>
+                                                                        </MultiBinding>
+                                                                    </TextBlock.Text>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <!-- Column header strip (mirrors the row template's column widths) -->
+                                    <Border DockPanel.Dock="Top" Background="#FF1E1E1E" BorderBrush="#22FFFFFF"
+                                            BorderThickness="0,0,0,1" Padding="8,4">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="50"/>
+                                                <ColumnDefinition Width="40"/>
+                                                <ColumnDefinition Width="80"/>
+                                                <ColumnDefinition Width="80"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="Recipe"
+                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="1" Text="Lvl" HorizontalAlignment="Center"
+                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="2" Text="1st?" HorizontalAlignment="Center"
+                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="3" Text="Eff. XP" HorizontalAlignment="Right"
+                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="4" Text="To Level" HorizontalAlignment="Right"
+                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                        </Grid>
+                                    </Border>
+
+                                    <!-- Recipe list -->
+                                    <ListBox ItemsSource="{Binding RecipesView}"
+                                             SelectedItem="{Binding SelectedRecipe, Mode=TwoWay}"
+                                             IsSynchronizedWithCurrentItem="True"
+                                             Background="Transparent" BorderThickness="0"
+                                             HorizontalContentAlignment="Stretch"
+                                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                             VirtualizingPanel.IsVirtualizing="True"
+                                             VirtualizingPanel.VirtualizationMode="Recycling">
+                                        <ListBox.ItemContainerStyle>
+                                            <Style TargetType="ListBoxItem">
+                                                <Setter Property="Padding" Value="8,5"/>
+                                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                                <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                                <Setter Property="Template">
+                                                    <Setter.Value>
+                                                        <ControlTemplate TargetType="ListBoxItem">
+                                                            <Border x:Name="Bd" Background="Transparent"
+                                                                    BorderBrush="#11FFFFFF" BorderThickness="0,0,0,1"
+                                                                    Padding="{TemplateBinding Padding}">
+                                                                <ContentPresenter/>
+                                                            </Border>
+                                                            <ControlTemplate.Triggers>
+                                                                <Trigger Property="IsMouseOver" Value="True">
+                                                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                                                                </Trigger>
+                                                                <Trigger Property="IsSelected" Value="True">
+                                                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentSoftBrush}"/>
+                                                                </Trigger>
+                                                            </ControlTemplate.Triggers>
+                                                        </ControlTemplate>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </ListBox.ItemContainerStyle>
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="50"/>
+                                                        <ColumnDefinition Width="40"/>
+                                                        <ColumnDefinition Width="80"/>
+                                                        <ColumnDefinition Width="80"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
+                                                    <TextBlock Grid.Column="1" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                    <TextBlock Grid.Column="2" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                    <TextBlock Grid.Column="3" Text="{Binding EffectiveXp, StringFormat=N0}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                                    <TextBlock Grid.Column="4" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+                                </DockPanel>
 
                                 <GridSplitter Grid.Column="1" Width="6" Background="#22FFFFFF"
                                               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -145,8 +145,85 @@
                                 </Grid.ColumnDefinitions>
 
                                 <DockPanel Grid.Column="0">
-                                    <!-- Sort chip row -->
-                                    <Border DockPanel.Dock="Top" Padding="0,0,0,6">
+                                    <!-- Sort chip row + view-mode toggle -->
+                                    <DockPanel DockPanel.Dock="Top" Margin="0,0,0,6" LastChildFill="False">
+                                        <!-- View-mode toggle (Rows / Cards) on the right -->
+                                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                            <TextBlock Text="View:" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                       VerticalAlignment="Center" Margin="12,0,6,0"/>
+                                            <Button Command="{Binding SetViewModeCommand}" CommandParameter="Rows"
+                                                    Margin="0,0,2,0" Padding="6,2" Cursor="Hand"
+                                                    ToolTip="Show recipes as compact rows with column-aligned values">
+                                                <Button.Style>
+                                                    <Style TargetType="Button">
+                                                        <Setter Property="Background" Value="Transparent"/>
+                                                        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+                                                        <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                                        <Setter Property="Template">
+                                                            <Setter.Value>
+                                                                <ControlTemplate TargetType="Button">
+                                                                    <Border x:Name="Bd" Background="{TemplateBinding Background}"
+                                                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                                                            BorderThickness="1" CornerRadius="3"
+                                                                            Padding="{TemplateBinding Padding}">
+                                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                    </Border>
+                                                                    <ControlTemplate.Triggers>
+                                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                                                                        </Trigger>
+                                                                    </ControlTemplate.Triggers>
+                                                                </ControlTemplate>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding ViewMode}" Value="Rows">
+                                                                <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                                                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Button.Style>
+                                                <icon:PackIconLucide Kind="List" Width="14" Height="14"/>
+                                            </Button>
+                                            <Button Command="{Binding SetViewModeCommand}" CommandParameter="Cards"
+                                                    Padding="6,2" Cursor="Hand"
+                                                    ToolTip="Show recipes as cards with bigger icons and inline metadata">
+                                                <Button.Style>
+                                                    <Style TargetType="Button">
+                                                        <Setter Property="Background" Value="Transparent"/>
+                                                        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+                                                        <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                                        <Setter Property="Template">
+                                                            <Setter.Value>
+                                                                <ControlTemplate TargetType="Button">
+                                                                    <Border x:Name="Bd" Background="{TemplateBinding Background}"
+                                                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                                                            BorderThickness="1" CornerRadius="3"
+                                                                            Padding="{TemplateBinding Padding}">
+                                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                                    </Border>
+                                                                    <ControlTemplate.Triggers>
+                                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                                                                        </Trigger>
+                                                                    </ControlTemplate.Triggers>
+                                                                </ControlTemplate>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding ViewMode}" Value="Cards">
+                                                                <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                                                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Button.Style>
+                                                <icon:PackIconLucide Kind="LayoutList" Width="14" Height="14"/>
+                                            </Button>
+                                        </StackPanel>
+
+                                        <!-- Sort chips on the left -->
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="Sort by:" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
                                                        VerticalAlignment="Center" Margin="0,0,8,0"/>
@@ -217,11 +294,12 @@
                                                 </ItemsControl.ItemTemplate>
                                             </ItemsControl>
                                         </StackPanel>
-                                    </Border>
+                                    </DockPanel>
 
-                                    <!-- Column header strip (mirrors the row template's column widths) -->
+                                    <!-- Column header strip (mirrors the row template's column widths) — only relevant in Rows mode -->
                                     <Border DockPanel.Dock="Top" Background="#FF1E1E1E" BorderBrush="#22FFFFFF"
-                                            BorderThickness="0,0,0,1" Padding="8,4">
+                                            BorderThickness="0,0,0,1" Padding="8,4"
+                                            Visibility="{Binding ViewMode, Converter={x:Static views:StringEqualsToVisConverter.Instance}, ConverterParameter=Rows}">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="*"/>
@@ -257,6 +335,7 @@
                                                 <Setter Property="Padding" Value="8,5"/>
                                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                                                 <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                                <Setter Property="ContentTemplate" Value="{StaticResource RecipeRowTemplate}"/>
                                                 <Setter Property="Template">
                                                     <Setter.Value>
                                                         <ControlTemplate TargetType="ListBoxItem">
@@ -276,26 +355,14 @@
                                                         </ControlTemplate>
                                                     </Setter.Value>
                                                 </Setter>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DataContext.ViewMode, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="Cards">
+                                                        <Setter Property="ContentTemplate" Value="{StaticResource RecipeCardTemplate}"/>
+                                                        <Setter Property="Padding" Value="12,10"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
                                             </Style>
                                         </ListBox.ItemContainerStyle>
-                                        <ListBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <Grid>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="50"/>
-                                                        <ColumnDefinition Width="40"/>
-                                                        <ColumnDefinition Width="80"/>
-                                                        <ColumnDefinition Width="80"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
-                                                    <TextBlock Grid.Column="1" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                    <TextBlock Grid.Column="2" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                    <TextBlock Grid.Column="3" Text="{Binding EffectiveXp, StringFormat=N0}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                                                    <TextBlock Grid.Column="4" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-                                                </Grid>
-                                            </DataTemplate>
-                                        </ListBox.ItemTemplate>
                                     </ListBox>
                                 </DockPanel>
 

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
@@ -1,20 +1,11 @@
 using System.Windows.Controls;
-using Elrond.Domain;
-using Elrond.ViewModels;
-using Mithril.Shared.Settings;
-using Mithril.Shared.Wpf;
 
 namespace Elrond.Views;
 
 public partial class SkillAdvisorView : UserControl
 {
-    public SkillAdvisorView(ElrondSettings settings, SettingsAutoSaver<ElrondSettings> saver)
+    public SkillAdvisorView()
     {
         InitializeComponent();
-        Loaded += (_, _) =>
-        {
-            if (DataContext is SkillAdvisorViewModel vm)
-                DataGridStateBinder.Bind(RecipeGrid, settings.RecipeGrid, vm.ApplyRecipeFilter, saver.Touch);
-        };
     }
 }


### PR DESCRIPTION
Closes #96.

Stacked on #95. Merges into `feat/elrond-master-detail` until #95 lands; once #95 merges, retarget this PR to `main` and rebase.

## Summary

- Replaces the recipe `MithrilDataGrid` with a virtualizing `ListBox` whose `ItemsSource` is an `ICollectionView` (the default view of an `ObservableCollection<RecipeAnalysis>`).
- Sort and filter become live: filter flag changes call `View.Refresh()`; sort changes mutate `SortDescriptions` in place. `ApplyRecipeFilter`'s manual list rebuild and the `previousKey` selection restore are gone.
- `SelectedRecipe` is now mirrored from `CVS.CurrentItem` via `CurrentChanged`; the ListBox uses `IsSynchronizedWithCurrentItem="True"`. Detail pane binding stays the same.
- New sort-trigger chip row above the list (Recipe / Lvl Req / Eff. XP / To Level), driven by a static `SortOptions` list on the VM. Active chip is highlighted in accent gold and shows ▲/▼ for sort direction. `ToggleSortCommand` cycles: same key → flip direction; different key → switch (numeric metrics default descending so the strongest values float to the top; `RecipeName` defaults ascending).
- Custom `ItemContainerStyle` on `ListBoxItem` → hover = `BgSurfaceHoverBrush`, selected = `AccentSoftBrush`. No more `DataGridRow` / `DataGridCell` brushes to override.
- A column-header strip with `ColumnDefinitions` matching the row template keeps values column-aligned across rows despite the ListBox lacking a built-in header concept.
- `ElrondSettings`: drops `RecipeGrid` (`DataGridState`); adds `SortKey` (string, default `\"EffectiveXp\"`) + `SortDescending` (bool, default `true`). `System.Text.Json` silently ignores the now-unknown `recipeGrid` field on existing settings files. Per-column filter text persistence is intentionally dropped (the UI surface for it is gone, and no one was relying on it for this view).
- `SkillAdvisorView` code-behind no longer needs `ElrondSettings` or `SettingsAutoSaver` injection (`DataGridStateBinder.Bind` was the only consumer); reverts to parameterless constructor and `ElrondModule` drops the matching factory args.

## Test plan

- [ ] `dotnet build Mithril.slnx` is clean.
- [ ] `dotnet test Mithril.slnx` is green (Elrond.Tests at 19/19).
- [ ] Pick a character + skill → list populates; first row auto-selected; detail pane shows the recipe.
- [ ] Hover a row → background goes hover gray; click → background goes accent blue. Confirm no leftover \"cell selection\" rectangle.
- [ ] Click each sort chip:
  - First click on a numeric chip (Lvl Req / Eff. XP / To Level) → sorts descending; chip turns gold with ▼.
  - Click same chip again → flips to ascending (▲).
  - Recipe chip first click → ascending (A→Z).
  - Switching chips → indicator and direction update; only one chip active at a time.
- [ ] Toggle filter checkboxes → list refilters live; selected row stays selected if still visible, or selection clears (and detail pane shows empty inner state).
- [ ] Switch skills → new list populates, first row auto-selected (sort survives), detail pane updates.
- [ ] Restart the app → last sort key and direction are restored from settings.
- [ ] Scroll a long list (e.g. cooking) → smooth virtualization, no lag.
- [ ] Resize the `GridSplitter` → list and detail pane resize, column header strip stays aligned with row contents.
- [ ] No regressions in Samwise / Arwen / Bilbo grids (still use `MithrilDataGrid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)