### PR TITLE
feat(shell): in-game clock pill + resizable sidebar

### DIFF
--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Text.Json.Serialization.Metadata;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Game;
 using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Icons;
 using Mithril.Shared.Inventory;
@@ -23,6 +24,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddMithrilGameServices(this IServiceCollection services) =>
         services
+            .AddSingleton<IGameClock, GameClock>()
             .AddSingleton<IPlayerLogStream, PlayerLogStream>()
             .AddSingleton<IChatLogStream, ChatLogStream>()
             .AddSingleton<IActiveCharacterService>(sp => new ActiveCharacterService(

--- a/src/Mithril.Shared/Game/GameClock.cs
+++ b/src/Mithril.Shared/Game/GameClock.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Mithril.Shared.Game;
+
+/// <summary>
+/// In-game time-of-day for Project Gorgon. The game has a 24h day with AM/PM,
+/// no calendar, and time advances at 12× wall-clock (1 in-game hour = 5 real minutes).
+/// </summary>
+public interface IGameClock
+{
+    /// <summary>Current in-game time of day.</summary>
+    GameTimeOfDay GetCurrent();
+}
+
+/// <summary>
+/// In-game hour and minute (0–23, 0–59). The game UI exposes only the hour, so
+/// minute precision derives from the anchor + ratio rather than from observation.
+/// </summary>
+public readonly record struct GameTimeOfDay(int Hour, int Minute)
+{
+    public string ToString12Hour()
+    {
+        var h12 = Hour % 12;
+        if (h12 == 0) h12 = 12;
+        var ampm = Hour < 12 ? "AM" : "PM";
+        return $"{h12}:{Minute:D2} {ampm}";
+    }
+}
+
+public sealed class GameClock : IGameClock
+{
+    // Anchor sourced from https://pgemissary.com/api/game-clocks (all PG servers share
+    // the same in-game clock). Independently verified against a manual tick-flip
+    // capture on 2026-05-04 — agreed within ~8 real seconds. Re-anchor here if a
+    // future patch changes the day/night cycle.
+    private static readonly DateTime AnchorUtc =
+        new(2026, 3, 11, 1, 45, 1, 212, DateTimeKind.Utc);
+    private const int AnchorGameSeconds = 75600; // 9:00 PM
+
+    private const int Ratio = 12;
+    private const int SecondsPerGameDay = 86400;
+
+    private readonly TimeProvider _time;
+
+    public GameClock(TimeProvider? time = null)
+    {
+        _time = time ?? TimeProvider.System;
+    }
+
+    public GameTimeOfDay GetCurrent()
+    {
+        var elapsedReal = (_time.GetUtcNow().UtcDateTime - AnchorUtc).TotalSeconds;
+        var gameSecs = (AnchorGameSeconds + elapsedReal * Ratio) % SecondsPerGameDay;
+        if (gameSecs < 0) gameSecs += SecondsPerGameDay;
+        var total = (int)gameSecs;
+        return new GameTimeOfDay(total / 3600, total % 3600 / 60);
+    }
+}

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -201,6 +201,7 @@ public static class Program
             shell.Top = shellSettings.WindowTop;
             shell.Width = shellSettings.WindowWidth;
             shell.Height = shellSettings.WindowHeight;
+            shell.SidebarWidth = shellSettings.SidebarWidth;
             app.MainWindow = shell;
 
             Boot("calling shell.Show()");
@@ -214,6 +215,7 @@ public static class Program
                     shellSettings.WindowWidth = shell.Width;
                     shellSettings.WindowHeight = shell.Height;
                 }
+                shellSettings.SidebarWidth = shell.SidebarWidth;
             };
             Boot("shell shown");
 

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -38,6 +38,9 @@ public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPers
     public double WindowWidth { get => _windowWidth; set => Set(ref _windowWidth, value); }
     public double WindowHeight { get => _windowHeight; set => Set(ref _windowHeight, value); }
 
+    private double _sidebarWidth = 260.0;
+    public double SidebarWidth { get => _sidebarWidth; set => Set(ref _sidebarWidth, value); }
+
     public Dictionary<string, HotkeyBinding> HotkeyBindings { get; set; } = new();
     public Dictionary<string, bool> ModuleEagerOverrides { get; set; } = new();
 

--- a/src/Mithril.Shell/ViewModels/ShellViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/ShellViewModel.cs
@@ -1,9 +1,11 @@
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Character;
+using Mithril.Shared.Game;
 using Mithril.Shared.Modules;
 using Mithril.Shell.Updates;
 using MahApps.Metro.IconPacks;
@@ -47,9 +49,11 @@ public sealed partial class ShellViewModel : ObservableObject
     private readonly IUpdateStatusService _updateStatus;
     private readonly IUpdateApplier _updateApplier;
     private readonly IAttentionAggregator _attention;
+    private readonly IGameClock _gameClock;
     private readonly IReadOnlyList<IMithrilModule> _allModules;
 
     private readonly ModuleGates _gates;
+    private readonly DispatcherTimer _gameClockTimer;
 
     public ShellViewModel(
         IServiceProvider services,
@@ -59,7 +63,8 @@ public sealed partial class ShellViewModel : ObservableObject
         IActiveCharacterService activeChar,
         IUpdateStatusService updateStatus,
         IUpdateApplier updateApplier,
-        IAttentionAggregator attention)
+        IAttentionAggregator attention,
+        IGameClock gameClock)
     {
         _services = services;
         _settings = settings;
@@ -68,6 +73,7 @@ public sealed partial class ShellViewModel : ObservableObject
         _updateStatus = updateStatus;
         _updateApplier = updateApplier;
         _attention = attention;
+        _gameClock = gameClock;
         _allModules = modules.OrderBy(m => m.SortOrder).ToList();
         RebuildVisibleModules();
         var initial = Modules.FirstOrDefault(e => e.Module.Id == settings.ActiveModuleId)
@@ -82,6 +88,17 @@ public sealed partial class ShellViewModel : ObservableObject
         RefreshCharacter();
         RefreshUpdateStatus();
         RefreshAttentionSurface();
+
+        // 5 real seconds = 1 in-game minute (the smallest unit we display).
+        RefreshGameTime();
+        _gameClockTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+        _gameClockTimer.Tick += (_, _) => RefreshGameTime();
+        _gameClockTimer.Start();
+    }
+
+    private void RefreshGameTime()
+    {
+        GameTimeText = _gameClock.GetCurrent().ToString12Hour();
     }
 
     private void OnAttentionChanged(object? sender, AttentionChangedEventArgs e)
@@ -158,6 +175,8 @@ public sealed partial class ShellViewModel : ObservableObject
 
     [ObservableProperty] private System.Windows.Media.ImageSource? _attentionOverlayIcon;
     [ObservableProperty] private string _attentionTooltip = "Mithril";
+
+    [ObservableProperty] private string _gameTimeText = "";
 
     [RelayCommand]
     private void DismissUpdate() => _updateStatus.Dismiss();

--- a/src/Mithril.Shell/Views/ShellWindow.xaml
+++ b/src/Mithril.Shell/Views/ShellWindow.xaml
@@ -40,8 +40,14 @@
                 <TextBlock Text="{Binding StatusText}" Foreground="#88FFFFFF"/>
             </DockPanel>
         </Border>
-        <Border DockPanel.Dock="Left" Width="260" Background="#FF202020" BorderThickness="0,0,1,0" BorderBrush="#33FFFFFF">
-            <DockPanel>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="SidebarColumn" Width="260" MinWidth="180"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*" MinWidth="320"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" Background="#FF202020" BorderThickness="0,0,1,0" BorderBrush="#33FFFFFF">
+                <DockPanel>
                 <StackPanel DockPanel.Dock="Bottom" Margin="10">
                     <Button Margin="0,0,0,6" Padding="10,6" HorizontalContentAlignment="Left"
                             Command="{Binding OpenDiagnosticsCommand}">
@@ -135,6 +141,19 @@
                     </Border>
                 </Popup>
 
+                <Border DockPanel.Dock="Top" Margin="10,6,10,0" Padding="10,4"
+                        Background="#FF252525" CornerRadius="3"
+                        ToolTip="In-game time · 1 in-game hour = 5 real minutes">
+                    <StackPanel Orientation="Horizontal">
+                        <icon:PackIconLucide Kind="Clock" Width="14" Height="14"
+                                             VerticalAlignment="Center" Margin="0,0,8,0"
+                                             Foreground="#FFD4A847"/>
+                        <TextBlock Text="{Binding GameTimeText}"
+                                   FontSize="{DynamicResource AppFontSizeMedium}"
+                                   Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+
                 <ListBox ItemsSource="{Binding Modules}"
                          SelectedItem="{Binding SelectedModule, Mode=TwoWay}"
                          HorizontalContentAlignment="Stretch"
@@ -167,33 +186,38 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-            </DockPanel>
-        </Border>
-        <Border DockPanel.Dock="Top" Background="#FF4A3820" BorderBrush="#FFE8B04A" BorderThickness="0,0,0,1"
-                Padding="12,6" Visibility="{Binding IsUpdateAvailable, Converter={StaticResource BoolToVis}}">
-            <DockPanel LastChildFill="True">
-                <icon:PackIconLucide DockPanel.Dock="Left" Kind="TriangleAlert" Width="16" Height="16"
-                                     VerticalAlignment="Center" Margin="0,0,10,0"
-                                     Foreground="#FFE8B04A"/>
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0">
-                    <Button Padding="10,3" Margin="0,0,6,0"
-                            Background="#FFD4A847" Foreground="#FF1A1A1A"
-                            Command="{Binding ApplyUpdateCommand}">
-                        <StackPanel Orientation="Horizontal">
-                            <icon:PackIconLucide Kind="Download" Width="12" Height="12"
-                                                 VerticalAlignment="Center" Margin="0,0,4,0"/>
-                            <TextBlock Text="Install and restart" VerticalAlignment="Center"/>
+                </DockPanel>
+            </Border>
+            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                          Background="#33FFFFFF" ShowsPreview="False"/>
+            <DockPanel Grid.Column="2">
+                <Border DockPanel.Dock="Top" Background="#FF4A3820" BorderBrush="#FFE8B04A" BorderThickness="0,0,0,1"
+                        Padding="12,6" Visibility="{Binding IsUpdateAvailable, Converter={StaticResource BoolToVis}}">
+                    <DockPanel LastChildFill="True">
+                        <icon:PackIconLucide DockPanel.Dock="Left" Kind="TriangleAlert" Width="16" Height="16"
+                                             VerticalAlignment="Center" Margin="0,0,10,0"
+                                             Foreground="#FFE8B04A"/>
+                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0">
+                            <Button Padding="10,3" Margin="0,0,6,0"
+                                    Background="#FFD4A847" Foreground="#FF1A1A1A"
+                                    Command="{Binding ApplyUpdateCommand}">
+                                <StackPanel Orientation="Horizontal">
+                                    <icon:PackIconLucide Kind="Download" Width="12" Height="12"
+                                                         VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                    <TextBlock Text="Install and restart" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Padding="10,3"
+                                    Command="{Binding DismissUpdateCommand}">
+                                <TextBlock Text="Dismiss"/>
+                            </Button>
                         </StackPanel>
-                    </Button>
-                    <Button Padding="10,3"
-                            Command="{Binding DismissUpdateCommand}">
-                        <TextBlock Text="Dismiss"/>
-                    </Button>
-                </StackPanel>
-                <TextBlock Text="{Binding UpdateBannerText}" Foreground="#FFF3E1B8"
-                           VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                        <TextBlock Text="{Binding UpdateBannerText}" Foreground="#FFF3E1B8"
+                                   VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                    </DockPanel>
+                </Border>
+                <ContentPresenter Content="{Binding ActiveContent}"/>
             </DockPanel>
-        </Border>
-        <ContentPresenter Content="{Binding ActiveContent}"/>
+        </Grid>
     </DockPanel>
 </Window>

--- a/src/Mithril.Shell/Views/ShellWindow.xaml.cs
+++ b/src/Mithril.Shell/Views/ShellWindow.xaml.cs
@@ -34,6 +34,16 @@ public partial class ShellWindow : System.Windows.Window
         RefreshTray();
     }
 
+    public double SidebarWidth
+    {
+        get => SidebarColumn.ActualWidth > 0 ? SidebarColumn.ActualWidth : SidebarColumn.Width.Value;
+        set
+        {
+            if (value > 0 && !double.IsNaN(value) && !double.IsInfinity(value))
+                SidebarColumn.Width = new GridLength(value, GridUnitType.Pixel);
+        }
+    }
+
     private void OnAttentionPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName is nameof(IAttentionAggregator.TotalCount)

--- a/tests/Mithril.Shared.Tests/GameClockTests.cs
+++ b/tests/Mithril.Shared.Tests/GameClockTests.cs
@@ -1,0 +1,75 @@
+using System;
+using FluentAssertions;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Mithril.Shared.Tests;
+
+public class GameClockTests
+{
+    // Pgemissary's published anchor: 2026-03-11T01:45:01.212304Z = 9:00 PM (75600 sec).
+    // The tests below feed a TimeProvider so they don't depend on wall-clock time.
+    private static readonly DateTime PgEmissaryAnchorUtc =
+        new(2026, 3, 11, 1, 45, 1, 212, DateTimeKind.Utc);
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTimeProvider(DateTime utc) => _now = new DateTimeOffset(utc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    [Fact]
+    public void AtAnchor_Returns9PM()
+    {
+        var clock = new GameClock(new FixedTimeProvider(PgEmissaryAnchorUtc));
+        clock.GetCurrent().Should().Be(new GameTimeOfDay(21, 0));
+    }
+
+    [Fact]
+    public void FiveRealMinutesLater_AdvancesOneInGameHour()
+    {
+        var clock = new GameClock(new FixedTimeProvider(PgEmissaryAnchorUtc.AddMinutes(5)));
+        clock.GetCurrent().Should().Be(new GameTimeOfDay(22, 0));
+    }
+
+    [Fact]
+    public void TwoRealHoursLater_WrapsToSameTimeOfDay()
+    {
+        // 2 real hours = 24 in-game hours = full in-game day.
+        var clock = new GameClock(new FixedTimeProvider(PgEmissaryAnchorUtc.AddHours(2)));
+        clock.GetCurrent().Should().Be(new GameTimeOfDay(21, 0));
+    }
+
+    [Fact]
+    public void BeforeAnchor_HandlesNegativeElapsedWithoutNegativeMinutes()
+    {
+        // Elapsed is negative; the modulo bookkeeping should still produce 0–23.
+        var clock = new GameClock(new FixedTimeProvider(PgEmissaryAnchorUtc.AddMinutes(-5)));
+        clock.GetCurrent().Should().Be(new GameTimeOfDay(20, 0));
+    }
+
+    [Theory]
+    [InlineData(0, 0, "12:00 AM")]
+    [InlineData(0, 5, "12:05 AM")]
+    [InlineData(11, 59, "11:59 AM")]
+    [InlineData(12, 0, "12:00 PM")]
+    [InlineData(13, 7, "1:07 PM")]
+    [InlineData(23, 0, "11:00 PM")]
+    public void ToString12Hour_FormatsCorrectly(int hour, int minute, string expected)
+    {
+        new GameTimeOfDay(hour, minute).ToString12Hour().Should().Be(expected);
+    }
+
+    [Fact]
+    public void OurTickFlipObservation_AgreesWithinSeconds()
+    {
+        // On 2026-05-04T21:00:08.78Z we observed the in-game clock flip to 12:00 PM.
+        // Confirms pgemissary's anchor matches what we manually captured.
+        var clock = new GameClock(new FixedTimeProvider(
+            new DateTime(2026, 5, 4, 21, 0, 8, 780, DateTimeKind.Utc)));
+        var t = clock.GetCurrent();
+        t.Hour.Should().Be(12);
+        t.Minute.Should().BeInRange(0, 1); // ~1 min slop from cross-anchor drift
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an in-game time-of-day pill to the sidebar (below the character chip), anchored to pgemissary.com's published clock. The PG day cycle is 24 in-game hours per 2 real hours (12:1 ratio); the anchor was independently verified against a manual tick-flip capture and agreed within ~8 real seconds. Refreshes every 5 real seconds, the smallest in-game time unit (1 in-game minute) we can display.
- Sidebar refactored from fixed-width `DockPanel` to `Grid` + `GridSplitter`, so users can drag-resize it. Width persists to `ShellSettings.SidebarWidth`.
- New `IGameClock` / `GameClock` in `Mithril.Shared/Game/`, registered as singleton in `AddMithrilGameServices`. Takes an injected `TimeProvider` for testability.
- 11 new unit tests covering anchor, ratio, day-wrap, negative-elapsed handling, AM/PM formatting, and a cross-check against our manual tick observation.

The anchor is baked as `static readonly` constants. The pgemissary API at `/api/game-clocks` exists, but a startup HTTP dependency for two static numbers is more cost than benefit; if PG ever patches the day cycle, a one-line change here is fine.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean
- [x] `dotnet test tests/Mithril.Shared.Tests --filter GameClockTests` — 11/11 pass
- [x] Launch app, confirm pill renders below character chip with current in-game time and tooltip
- [ ] Drag the sidebar splitter; confirm width persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)