### PR TITLE
feat(elrond): reusable sort/filter toolbar pattern in Mithril.Shared

### DIFF
--- a/src/Elrond.Module/Domain/ElrondSettings.cs
+++ b/src/Elrond.Module/Domain/ElrondSettings.cs
@@ -52,6 +52,30 @@ public sealed class ElrondSettings : INotifyPropertyChanged
         set => Set(ref _legacySortDescending, value);
     }
 
+    /// <summary>
+    /// Active filter Ids (resolved against the VM's AvailableFilters at load
+    /// time). Stored as plain strings so adding/renaming filters in code is
+    /// non-fatal: stale Ids are silently ignored.
+    /// </summary>
+    private List<string> _activeFilterIds = [];
+    public List<string> ActiveFilterIds
+    {
+        get => _activeFilterIds;
+        set => Set(ref _activeFilterIds, value ?? []);
+    }
+
+    /// <summary>
+    /// Distinguishes "never persisted" from "persisted as empty" — when false
+    /// the VM keeps its constructor-declared defaults; when true it mirrors
+    /// <see cref="ActiveFilterIds"/> verbatim (including the empty case).
+    /// </summary>
+    private bool _hasPersistedFilters;
+    public bool HasPersistedFilters
+    {
+        get => _hasPersistedFilters;
+        set => Set(ref _hasPersistedFilters, value);
+    }
+
     private string _viewMode = "Rows";
     public string ViewMode
     {
@@ -80,4 +104,5 @@ public sealed record PersistedSortEntry(string Id, System.ComponentModel.ListSor
 [JsonSerializable(typeof(ElrondSettings))]
 [JsonSerializable(typeof(PersistedSortEntry))]
 [JsonSerializable(typeof(List<PersistedSortEntry>))]
+[JsonSerializable(typeof(List<string>))]
 public partial class ElrondSettingsJsonContext : JsonSerializerContext { }

--- a/src/Elrond.Module/Domain/ElrondSettings.cs
+++ b/src/Elrond.Module/Domain/ElrondSettings.cs
@@ -20,18 +20,36 @@ public sealed class ElrondSettings : INotifyPropertyChanged
         set => Set(ref _lastGoalLevel, value);
     }
 
-    private string _sortKey = "EffectiveXp";
-    public string SortKey
+    /// <summary>
+    /// Active sort keys in precedence order. Each entry is a stable
+    /// <see cref="PersistedSortEntry.Id"/> (looked up against the VM's
+    /// AvailableSortKeys at load time) plus its current direction.
+    /// </summary>
+    private List<PersistedSortEntry> _activeSortKeys = [];
+    public List<PersistedSortEntry> ActiveSortKeys
     {
-        get => _sortKey;
-        set => Set(ref _sortKey, value);
+        get => _activeSortKeys;
+        set => Set(ref _activeSortKeys, value ?? []);
     }
 
-    private bool _sortDescending = true;
-    public bool SortDescending
+    /// <summary>
+    /// Legacy single-key sort field. Read on first launch after upgrade so the
+    /// new <see cref="ActiveSortKeys"/> is seeded with the user's previous
+    /// choice; ignored thereafter. Deserializer keeps this populated for
+    /// backwards compatibility — the migration runs on VM construction.
+    /// </summary>
+    private string? _legacySortKey;
+    public string? SortKey
     {
-        get => _sortDescending;
-        set => Set(ref _sortDescending, value);
+        get => _legacySortKey;
+        set => Set(ref _legacySortKey, value);
+    }
+
+    private bool? _legacySortDescending;
+    public bool? SortDescending
+    {
+        get => _legacySortDescending;
+        set => Set(ref _legacySortDescending, value);
     }
 
     private string _viewMode = "Rows";
@@ -51,6 +69,15 @@ public sealed class ElrondSettings : INotifyPropertyChanged
     }
 }
 
+/// <summary>
+/// One persisted entry in <see cref="ElrondSettings.ActiveSortKeys"/>.
+/// Stored as JSON (id + direction); the VM resolves <paramref name="Id"/> back
+/// to a typed <c>SortKey&lt;RecipeAnalysis&gt;</c> at load time.
+/// </summary>
+public sealed record PersistedSortEntry(string Id, System.ComponentModel.ListSortDirection Direction);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
 [JsonSerializable(typeof(ElrondSettings))]
+[JsonSerializable(typeof(PersistedSortEntry))]
+[JsonSerializable(typeof(List<PersistedSortEntry>))]
 public partial class ElrondSettingsJsonContext : JsonSerializerContext { }

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -36,7 +36,19 @@ public sealed class ElrondModule : IMithrilModule
         services.AddSingleton<SkillAdvisorEngine>();
         services.AddSingleton<LevelingSimulator>();
 
-        services.AddSingleton<SkillAdvisorViewModel>();
+        services.AddSingleton<SkillAdvisorViewModel>(sp =>
+        {
+            // Force the autosaver to instantiate so it subscribes to ElrondSettings.PropertyChanged.
+            // Same pattern as Celebrimbor/Bilbo — the saver is registered but DI won't construct
+            // it unless something explicitly requests it.
+            _ = sp.GetRequiredService<SettingsAutoSaver<ElrondSettings>>();
+            return new SkillAdvisorViewModel(
+                sp.GetRequiredService<SkillAdvisorEngine>(),
+                sp.GetRequiredService<LevelingSimulator>(),
+                sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
+                sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
+                sp.GetRequiredService<ElrondSettings>());
+        });
         services.AddSingleton<SkillAdvisorView>(sp => new SkillAdvisorView
         {
             DataContext = sp.GetRequiredService<SkillAdvisorViewModel>(),

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -7,20 +8,22 @@ using Elrond.Domain;
 using Elrond.Services;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Sorting;
 
 namespace Elrond.ViewModels;
 
-public sealed record SortOption(string Label, string Key);
-
-public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposable
+public sealed partial class SkillAdvisorViewModel
+    : ObservableObject, ISortableViewModel<RecipeAnalysis>, IDisposable
 {
-    public IReadOnlyList<SortOption> SortOptions { get; } =
+    public IReadOnlyList<SortKey<RecipeAnalysis>> AvailableSortKeys { get; } =
     [
-        new("Recipe", "RecipeName"),
-        new("Lvl Req", "LevelRequired"),
-        new("Eff. XP", "EffectiveXp"),
-        new("To Level", "CompletionsToLevel"),
+        new("RecipeName",         "Recipe",   "RecipeName"),
+        new("LevelRequired",      "Lvl Req",  "LevelRequired"),
+        new("EffectiveXp",        "Eff. XP",  "EffectiveXp",        DefaultDescending: true),
+        new("CompletionsToLevel", "To Level", "CompletionsToLevel", DefaultDescending: true),
     ];
+
+    public ObservableCollection<ActiveSortKey<RecipeAnalysis>> ActiveSortKeys { get; } = [];
 
     private readonly SkillAdvisorEngine _engine;
     private readonly LevelingSimulator _simulator;
@@ -46,14 +49,16 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         _settings = settings;
 
         _goalLevel = settings.LastGoalLevel;
-        _sortKey = settings.SortKey;
-        _sortDescending = settings.SortDescending;
         _viewMode = settings.ViewMode;
 
         var view = (ListCollectionView)CollectionViewSource.GetDefaultView(_recipes);
         view.Filter = item => MatchesFilter((RecipeAnalysis)item);
         view.CurrentChanged += OnCurrentRecipeChanged;
         RecipesView = view;
+
+        HydrateSortKeysFromSettings();
+        ActiveSortKeys.CollectionChanged += OnActiveSortKeysChanged;
+        foreach (var k in ActiveSortKeys) k.PropertyChanged += OnActiveSortKeyPropertyChanged;
         ApplySortDescriptions();
 
         _activeChar.ActiveCharacterChanged += OnActiveCharacterChanged;
@@ -99,12 +104,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
     private SimulationResult? _simulationResult;
 
     [ObservableProperty]
-    private string _sortKey = "EffectiveXp";
-
-    [ObservableProperty]
-    private bool _sortDescending = true;
-
-    [ObservableProperty]
     private string _viewMode = "Rows";
 
     // ── Property change handlers ─────────────────────────────────────────
@@ -127,18 +126,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
     partial void OnShowFirstTimeOnlyChanged(bool value) => RecipesView.Refresh();
     partial void OnShowCraftableOnlyChanged(bool value) => RecipesView.Refresh();
     partial void OnIncludeZeroXpChanged(bool value) => Reanalyze();
-
-    partial void OnSortKeyChanged(string value)
-    {
-        _settings.SortKey = value;
-        ApplySortDescriptions();
-    }
-
-    partial void OnSortDescendingChanged(bool value)
-    {
-        _settings.SortDescending = value;
-        ApplySortDescriptions();
-    }
 
     partial void OnViewModeChanged(string value)
     {
@@ -166,19 +153,80 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         SimulationResult = _simulator.Simulate(SelectedSkill, active, goal);
     }
 
-    [RelayCommand]
-    private void ToggleSort(string? key)
+    // ── Sort wiring ──────────────────────────────────────────────────────
+
+    private void HydrateSortKeysFromSettings()
     {
-        if (string.IsNullOrEmpty(key)) return;
-        if (SortKey == key)
+        var byId = AvailableSortKeys.ToDictionary(k => k.Id);
+
+        // 1. New persisted list — restore ordered entries, skipping any whose Id no
+        //    longer maps (renamed / removed).
+        foreach (var entry in _settings.ActiveSortKeys)
         {
-            SortDescending = !SortDescending;
+            if (byId.TryGetValue(entry.Id, out var key))
+                ActiveSortKeys.Add(new ActiveSortKey<RecipeAnalysis>(key, entry.Direction));
         }
-        else
+
+        // 2. Legacy single-key migration: SortKey + SortDescending from the pre-popup
+        //    schema, only honoured when the new list didn't contain anything resolvable.
+        if (ActiveSortKeys.Count == 0
+            && !string.IsNullOrEmpty(_settings.SortKey)
+            && byId.TryGetValue(_settings.SortKey, out var legacy))
         {
-            SortKey = key;
-            // Numeric metrics read top-down (largest first); names read alphabetically.
-            SortDescending = key != "RecipeName";
+            var dir = (_settings.SortDescending ?? legacy.DefaultDescending)
+                ? ListSortDirection.Descending
+                : ListSortDirection.Ascending;
+            ActiveSortKeys.Add(new ActiveSortKey<RecipeAnalysis>(legacy, dir));
+        }
+
+        // 3. Default seed: most-effective XP first.
+        if (ActiveSortKeys.Count == 0)
+        {
+            ActiveSortKeys.Add(new ActiveSortKey<RecipeAnalysis>(
+                byId["EffectiveXp"], ListSortDirection.Descending));
+        }
+
+        // Drop the legacy fields so they don't shadow the new list on next save.
+        _settings.SortKey = null;
+        _settings.SortDescending = null;
+    }
+
+    private void OnActiveSortKeysChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+            foreach (ActiveSortKey<RecipeAnalysis> k in e.OldItems)
+                k.PropertyChanged -= OnActiveSortKeyPropertyChanged;
+        if (e.NewItems is not null)
+            foreach (ActiveSortKey<RecipeAnalysis> k in e.NewItems)
+                k.PropertyChanged += OnActiveSortKeyPropertyChanged;
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+            foreach (var k in ActiveSortKeys)
+                k.PropertyChanged += OnActiveSortKeyPropertyChanged;
+
+        PersistAndApplySort();
+    }
+
+    private void OnActiveSortKeyPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ActiveSortKey<RecipeAnalysis>.Direction))
+            PersistAndApplySort();
+    }
+
+    private void PersistAndApplySort()
+    {
+        _settings.ActiveSortKeys = ActiveSortKeys
+            .Select(k => new PersistedSortEntry(k.Key.Id, k.Direction))
+            .ToList();
+        ApplySortDescriptions();
+    }
+
+    private void ApplySortDescriptions()
+    {
+        using (RecipesView.DeferRefresh())
+        {
+            RecipesView.SortDescriptions.Clear();
+            foreach (var k in ActiveSortKeys)
+                RecipesView.SortDescriptions.Add(new SortDescription(k.Key.SortMemberPath, k.Direction));
         }
     }
 
@@ -240,13 +288,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         return true;
     }
 
-    private void ApplySortDescriptions()
-    {
-        var dir = SortDescending ? ListSortDirection.Descending : ListSortDirection.Ascending;
-        RecipesView.SortDescriptions.Clear();
-        RecipesView.SortDescriptions.Add(new SortDescription(SortKey, dir));
-    }
-
     private void OnCurrentRecipeChanged(object? sender, EventArgs e)
     {
         SelectedRecipe = RecipesView.CurrentItem as RecipeAnalysis;
@@ -273,5 +314,7 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
         _activeChar.CharacterExportsChanged -= OnActiveCharacterChanged;
         _referenceData.FileUpdated -= OnReferenceUpdated;
         RecipesView.CurrentChanged -= OnCurrentRecipeChanged;
+        ActiveSortKeys.CollectionChanged -= OnActiveSortKeysChanged;
+        foreach (var k in ActiveSortKeys) k.PropertyChanged -= OnActiveSortKeyPropertyChanged;
     }
 }

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -10,12 +10,16 @@ using Elrond.Domain;
 using Elrond.Services;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Filtering;
 using Mithril.Shared.Wpf.Sorting;
 
 namespace Elrond.ViewModels;
 
 public sealed partial class SkillAdvisorViewModel
-    : ObservableObject, ISortableViewModel<RecipeAnalysis>, IDisposable
+    : ObservableObject,
+      ISortableViewModel<RecipeAnalysis>,
+      IFilterableViewModel<RecipeAnalysis>,
+      IDisposable
 {
     public IReadOnlyList<SortKey<RecipeAnalysis>> AvailableSortKeys { get; } =
     [
@@ -26,6 +30,8 @@ public sealed partial class SkillAdvisorViewModel
     ];
 
     public ObservableCollection<ActiveSortKey<RecipeAnalysis>> ActiveSortKeys { get; } = [];
+
+    public IReadOnlyList<FilterPredicate<RecipeAnalysis>> AvailableFilters { get; }
 
     private readonly SkillAdvisorEngine _engine;
     private readonly LevelingSimulator _simulator;
@@ -53,8 +59,20 @@ public sealed partial class SkillAdvisorViewModel
         _goalLevel = settings.LastGoalLevel;
         _viewMode = settings.ViewMode;
 
+        // Filters declared here so each closure captures `this` and reads live state
+        // (e.g. CraftableOnly compares against the current Analysis at predicate-call time).
+        // Labels read from the user's perspective: toggling on does what the label says.
+        AvailableFilters =
+        [
+            // Inverted: predicate r => r.IsKnown applies when IsActive=false; toggling ON reveals unknowns.
+            new("ShowUnknown",        "Show unknown",          r => r.IsKnown,                inverted: true,  isActive: false),
+            new("FirstTimeBonusOnly", "First Time Bonus Only", r => r.FirstTimeBonusAvailable, inverted: false, isActive: false),
+            new("CraftableOnly",      "Craftable only",        r => Analysis is { } a && r.LevelRequired <= a.CurrentLevel, inverted: false, isActive: true),
+            new("HideZeroXp",         "Hide 0 XP",             r => r.EffectiveXp > 0,         inverted: false, isActive: true),
+        ];
+
         var view = (ListCollectionView)CollectionViewSource.GetDefaultView(_recipes);
-        view.Filter = item => MatchesFilter((RecipeAnalysis)item);
+        view.Filter = item => MatchesActiveFilters((RecipeAnalysis)item);
         view.CurrentChanged += OnCurrentRecipeChanged;
         RecipesView = view;
 
@@ -62,6 +80,9 @@ public sealed partial class SkillAdvisorViewModel
         ActiveSortKeys.CollectionChanged += OnActiveSortKeysChanged;
         foreach (var k in ActiveSortKeys) k.PropertyChanged += OnActiveSortKeyPropertyChanged;
         ApplySortDescriptions();
+
+        HydrateFiltersFromSettings();
+        foreach (var f in AvailableFilters) f.PropertyChanged += OnFilterPropertyChanged;
 
         _activeChar.ActiveCharacterChanged += OnActiveCharacterChanged;
         _activeChar.CharacterExportsChanged += OnActiveCharacterChanged;
@@ -83,18 +104,6 @@ public sealed partial class SkillAdvisorViewModel
 
     [ObservableProperty]
     private RecipeAnalysis? _selectedRecipe;
-
-    [ObservableProperty]
-    private bool _showKnownOnly = true;
-
-    [ObservableProperty]
-    private bool _showFirstTimeOnly;
-
-    [ObservableProperty]
-    private bool _showCraftableOnly = true;
-
-    [ObservableProperty]
-    private bool _includeZeroXp;
 
     [ObservableProperty]
     private string _statusMessage = "Select a character export to begin.";
@@ -124,10 +133,11 @@ public sealed partial class SkillAdvisorViewModel
         Reanalyze();
     }
 
-    partial void OnShowKnownOnlyChanged(bool value) => RecipesView.Refresh();
-    partial void OnShowFirstTimeOnlyChanged(bool value) => RecipesView.Refresh();
-    partial void OnShowCraftableOnlyChanged(bool value) => RecipesView.Refresh();
-    partial void OnIncludeZeroXpChanged(bool value) => Reanalyze();
+    partial void OnAnalysisChanged(SkillAnalysis? value)
+    {
+        // CraftableOnly closes over Analysis.CurrentLevel — re-run the filter when it shifts.
+        RecipesView.Refresh();
+    }
 
     partial void OnViewModeChanged(string value)
     {
@@ -232,6 +242,43 @@ public sealed partial class SkillAdvisorViewModel
         }
     }
 
+    // ── Filter wiring ────────────────────────────────────────────────────
+
+    private void HydrateFiltersFromSettings()
+    {
+        // First launch (no persisted filters): keep the constructor-declared defaults.
+        // Otherwise, mirror the persisted set onto IsActive — Ids no longer in code
+        // are silently ignored.
+        if (_settings.ActiveFilterIds is { Count: 0 } && !_settings.HasPersistedFilters) return;
+
+        var persisted = new HashSet<string>(_settings.ActiveFilterIds);
+        foreach (var f in AvailableFilters)
+            f.IsActive = persisted.Contains(f.Id);
+    }
+
+    private void OnFilterPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(FilterPredicate<RecipeAnalysis>.IsActive)) return;
+
+        _settings.ActiveFilterIds = AvailableFilters
+            .Where(f => f.IsActive)
+            .Select(f => f.Id)
+            .ToList();
+        _settings.HasPersistedFilters = true;
+        RecipesView.Refresh();
+    }
+
+    private bool MatchesActiveFilters(RecipeAnalysis row)
+    {
+        if (Analysis is null) return false;
+        foreach (var f in AvailableFilters)
+        {
+            if (!f.ShouldApply) continue;
+            if (!f.Predicate(row)) return false;
+        }
+        return true;
+    }
+
     // ── Private helpers ──────────────────────────────────────────────────
 
     private void ReloadSkills()
@@ -266,7 +313,10 @@ public sealed partial class SkillAdvisorViewModel
             return;
         }
 
-        Analysis = _engine.Analyze(SelectedSkill, active, IncludeZeroXp, GoalLevel);
+        // Always include 0-XP recipes in the analysis result; the "Hide 0 XP" filter
+        // takes care of hiding them at the view level. Keeps engine output stable
+        // regardless of filter state.
+        Analysis = _engine.Analyze(SelectedSkill, active, includeZeroXp: true, GoalLevel);
 
         _recipes.Clear();
         if (Analysis is not null)
@@ -279,15 +329,6 @@ public sealed partial class SkillAdvisorViewModel
         {
             StatusMessage = $"No data for {SelectedSkill} on this character.";
         }
-    }
-
-    private bool MatchesFilter(RecipeAnalysis row)
-    {
-        if (Analysis is null) return false;
-        if (ShowKnownOnly && !row.IsKnown) return false;
-        if (ShowFirstTimeOnly && !row.FirstTimeBonusAvailable) return false;
-        if (ShowCraftableOnly && row.LevelRequired > Analysis.CurrentLevel) return false;
-        return true;
     }
 
     private void OnCurrentRecipeChanged(object? sender, EventArgs e)
@@ -337,5 +378,6 @@ public sealed partial class SkillAdvisorViewModel
         RecipesView.CurrentChanged -= OnCurrentRecipeChanged;
         ActiveSortKeys.CollectionChanged -= OnActiveSortKeysChanged;
         foreach (var k in ActiveSortKeys) k.PropertyChanged -= OnActiveSortKeyPropertyChanged;
+        foreach (var f in AvailableFilters) f.PropertyChanged -= OnFilterPropertyChanged;
     }
 }

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -1,7 +1,9 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Windows;
 using System.Windows.Data;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Elrond.Domain;
@@ -295,17 +297,36 @@ public sealed partial class SkillAdvisorViewModel
 
     private void OnActiveCharacterChanged(object? sender, EventArgs e)
     {
-        ReloadSkills();
-        Reanalyze();
+        OnUiThread(() =>
+        {
+            ReloadSkills();
+            Reanalyze();
+        });
     }
 
     private void OnReferenceUpdated(object? sender, string key)
     {
-        if (key is "recipes" or "skills" or "xptables")
+        if (key is not ("recipes" or "skills" or "xptables")) return;
+        OnUiThread(() =>
         {
             ReloadSkills();
             Reanalyze();
-        }
+        });
+    }
+
+    /// <summary>
+    /// Reanalyze mutates <see cref="_recipes"/>, which is observed by a
+    /// <see cref="ListCollectionView"/> that rejects changes off the
+    /// dispatcher thread. ReferenceData and ActiveCharacter events both fire
+    /// from background threads, so marshal here. Otherwise the view's
+    /// internal state desyncs and subsequent refreshes (e.g. a sort change)
+    /// surface zero items.
+    /// </summary>
+    private static void OnUiThread(Action action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess()) action();
+        else dispatcher.InvokeAsync(action, DispatcherPriority.Normal);
     }
 
     public void Dispose()

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -167,12 +167,6 @@ public sealed partial class SkillAdvisorViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
-    private void SetViewMode(string? mode)
-    {
-        if (!string.IsNullOrEmpty(mode)) ViewMode = mode;
-    }
-
-    [RelayCommand]
     private void ToggleSort(string? key)
     {
         if (string.IsNullOrEmpty(key)) return;

--- a/src/Elrond.Module/Views/Converters.cs
+++ b/src/Elrond.Module/Views/Converters.cs
@@ -32,43 +32,6 @@ public sealed class BoolToVisibilityConverter : IValueConverter
 }
 
 /// <summary>
-/// Resolves the active-sort indicator for a sort chip. Inputs (in order):
-/// current SortKey, current SortDescending, this chip's Key. Returns
-/// " ▼" (down arrow) when matching and descending, " ▲" (up
-/// arrow) when matching and ascending, empty string otherwise.
-/// </summary>
-public sealed class SortIndicatorConverter : IMultiValueConverter
-{
-    public static SortIndicatorConverter Instance { get; } = new();
-
-    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        if (values is [string current, bool desc, string key] && current == key)
-            return desc ? " ▼" : " ▲";
-        return string.Empty;
-    }
-
-    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
-}
-
-/// <summary>
-/// Returns true when the current SortKey (first input) equals this chip's
-/// Key (second input). Drives the chip's active styling via Tag-based
-/// trigger.
-/// </summary>
-public sealed class IsActiveSortConverter : IMultiValueConverter
-{
-    public static IsActiveSortConverter Instance { get; } = new();
-
-    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
-        => values is [string current, string key] && current == key;
-
-    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
-}
-
-/// <summary>
 /// Returns Visible when the bound value (string) equals the converter
 /// parameter (string). Used to show/hide chrome based on view mode.
 /// </summary>

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -2,6 +2,13 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:views="clr-namespace:Elrond.Views"
                     xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared">
+    <ResourceDictionary.MergedDictionaries>
+        <!-- Brought in so the StaticResource references below (TextPrimaryBrush
+             etc.) resolve when this dictionary is parsed standalone, not just
+             when it's merged into a view that already has the shared brushes. -->
+        <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+
     <views:BoolToCheckConverter x:Key="BoolToCheck"/>
     <views:NullableIntConverter x:Key="NullableInt"/>
     <views:BoolToVisibilityConverter x:Key="BoolToVisibility"/>

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -6,15 +6,24 @@
     <views:NullableIntConverter x:Key="NullableInt"/>
     <views:BoolToVisibilityConverter x:Key="BoolToVisibility"/>
 
+    <!-- Shared column widths for the recipe row template + the column-header strip
+         in SkillAdvisorView. Keep these in sync; both Grids reference the same keys
+         so the header always lines up with the rows below it. -->
+    <GridLength x:Key="RecipeColRecipe">*</GridLength>
+    <GridLength x:Key="RecipeColLvl">50</GridLength>
+    <GridLength x:Key="RecipeColFirst">40</GridLength>
+    <GridLength x:Key="RecipeColEffXp">80</GridLength>
+    <GridLength x:Key="RecipeColToLevel">80</GridLength>
+
     <!-- Recipe row template — column-aligned values for fast vertical scanning. -->
     <DataTemplate x:Key="RecipeRowTemplate">
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition Width="40"/>
-                <ColumnDefinition Width="80"/>
-                <ColumnDefinition Width="80"/>
+                <ColumnDefinition Width="{StaticResource RecipeColRecipe}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColLvl}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColFirst}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColEffXp}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColToLevel}"/>
             </Grid.ColumnDefinitions>
             <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
             <TextBlock Grid.Column="1" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
@@ -30,21 +39,21 @@
             <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}" Width="36" Height="36" Margin="0,0,12,0" VerticalAlignment="Center"/>
             <Border DockPanel.Dock="Right" Background="#33D4A847" CornerRadius="3" Padding="6,2" Margin="8,0,0,0" VerticalAlignment="Center"
                     Visibility="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToVisibility}}">
-                <TextBlock Text="1st time" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                <TextBlock Text="1st time" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeSmall}"/>
             </Border>
             <StackPanel VerticalAlignment="Center">
-                <TextBlock Text="{Binding RecipeName}" Foreground="#FFE8E8E8" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                <TextBlock Text="{Binding RecipeName}" Foreground="{StaticResource TextPrimaryBrush}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
                 <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                    <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
                         <Run Text="Lvl "/><Run Text="{Binding LevelRequired, Mode=OneWay}"/>
                     </TextBlock>
                     <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
-                    <TextBlock Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold">
+                    <TextBlock Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold">
                         <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
                         <Run Text=" eff XP"/>
                     </TextBlock>
                     <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
-                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                    <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
                         <Run Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
                         <Run Text=" to level"/>
                     </TextBlock>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -10,7 +10,7 @@
              xmlns:sort="clr-namespace:Mithril.Shared.Wpf.Sorting;assembly=Mithril.Shared"
              xmlns:filter="clr-namespace:Mithril.Shared.Wpf.Filtering;assembly=Mithril.Shared"
              mc:Ignorable="d"
-             Background="{StaticResource BgPrimaryBrush}">
+             Background="{DynamicResource BgPrimaryBrush}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -7,6 +7,7 @@
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared"
+             xmlns:sort="clr-namespace:Mithril.Shared.Wpf.Sorting;assembly=Mithril.Shared"
              mc:Ignorable="d"
              Background="#FF1A1A1A">
     <UserControl.Resources>
@@ -145,7 +146,7 @@
                                 </Grid.ColumnDefinitions>
 
                                 <DockPanel Grid.Column="0">
-                                    <!-- Sort chip row + view-mode toggle -->
+                                    <!-- Toolbar: Sort button (opens popup) + view-mode toggle -->
                                     <DockPanel DockPanel.Dock="Top" Margin="0,0,0,6" LastChildFill="False">
                                         <wpf:ViewModeToggle DockPanel.Dock="Right"
                                                             SelectedMode="{Binding ViewMode, Mode=TwoWay}">
@@ -159,77 +160,19 @@
                                             </wpf:ViewModeOption>
                                         </wpf:ViewModeToggle>
 
-                                        <!-- Sort chips on the left -->
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="Sort by:" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                            <ItemsControl ItemsSource="{Binding SortOptions}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <StackPanel Orientation="Horizontal"/>
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <Button Command="{Binding DataContext.ToggleSortCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                CommandParameter="{Binding Key}"
-                                                                Margin="0,0,4,0" Padding="8,2"
-                                                                BorderThickness="1" Cursor="Hand">
-                                                            <Button.Tag>
-                                                                <MultiBinding Converter="{x:Static views:IsActiveSortConverter.Instance}">
-                                                                    <Binding Path="DataContext.SortKey" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                                    <Binding Path="Key"/>
-                                                                </MultiBinding>
-                                                            </Button.Tag>
-                                                            <Button.Style>
-                                                                <Style TargetType="Button">
-                                                                    <Setter Property="Background" Value="Transparent"/>
-                                                                    <Setter Property="BorderBrush" Value="#33FFFFFF"/>
-                                                                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                                                                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
-                                                                    <Setter Property="Template">
-                                                                        <Setter.Value>
-                                                                            <ControlTemplate TargetType="Button">
-                                                                                <Border x:Name="Bd" Background="{TemplateBinding Background}"
-                                                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                                                                        Padding="{TemplateBinding Padding}"
-                                                                                        CornerRadius="3">
-                                                                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                                </Border>
-                                                                                <ControlTemplate.Triggers>
-                                                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
-                                                                                    </Trigger>
-                                                                                </ControlTemplate.Triggers>
-                                                                            </ControlTemplate>
-                                                                        </Setter.Value>
-                                                                    </Setter>
-                                                                    <Style.Triggers>
-                                                                        <Trigger Property="Tag" Value="True">
-                                                                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
-                                                                            <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
-                                                                        </Trigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </Button.Style>
-                                                            <StackPanel Orientation="Horizontal">
-                                                                <TextBlock Text="{Binding Label}"/>
-                                                                <TextBlock>
-                                                                    <TextBlock.Text>
-                                                                        <MultiBinding Converter="{x:Static views:SortIndicatorConverter.Instance}">
-                                                                            <Binding Path="DataContext.SortKey" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                                            <Binding Path="DataContext.SortDescending" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                                            <Binding Path="Key"/>
-                                                                        </MultiBinding>
-                                                                    </TextBlock.Text>
-                                                                </TextBlock>
-                                                            </StackPanel>
-                                                        </Button>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                        </StackPanel>
+                                        <Button x:Name="SortBtn"
+                                                Style="{StaticResource MithrilToolbarButtonStyle}"
+                                                Click="OnOpenSortPopup"
+                                                ToolTip="Manage the recipe list's sort keys">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="Sort"/>
+                                                <TextBlock Text="…" Margin="2,0,0,0"
+                                                           Foreground="{StaticResource TextTertiaryBrush}"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <sort:MithrilSortPopup x:Name="SortPopup"
+                                                               Source="{Binding}"
+                                                               PlacementTarget="{Binding ElementName=SortBtn}"/>
                                     </DockPanel>
 
                                     <!-- Column header strip (mirrors the row template's column widths) — only relevant in Rows mode -->

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -10,7 +10,7 @@
              xmlns:sort="clr-namespace:Mithril.Shared.Wpf.Sorting;assembly=Mithril.Shared"
              xmlns:filter="clr-namespace:Mithril.Shared.Wpf.Filtering;assembly=Mithril.Shared"
              mc:Ignorable="d"
-             Background="#FF1A1A1A">
+             Background="{StaticResource BgPrimaryBrush}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -27,7 +27,7 @@
                 <Image Source="pack://application:,,,/Elrond.Module;component/Resources/elrond.ico"
                        Width="28" Height="28" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBlock Text="Elrond · Skills" FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeHero}" FontWeight="SemiBold"
-                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                           Foreground="{StaticResource AccentBrush}" VerticalAlignment="Center"/>
             </StackPanel>
         </DockPanel>
 
@@ -43,7 +43,7 @@
             </Button>
 
             <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Skill:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBlock Text="Skill:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                 <ComboBox Width="180"
                           ItemsSource="{Binding AvailableSkills}"
                           SelectedItem="{Binding SelectedSkill}"/>
@@ -52,7 +52,7 @@
 
         <!-- Status bar -->
         <Border DockPanel.Dock="Bottom" Margin="0,8,0,0" Padding="4">
-            <TextBlock Text="{Binding StatusMessage}" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+            <TextBlock Text="{Binding StatusMessage}" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
         </Border>
 
         <!-- Main content -->
@@ -62,15 +62,15 @@
                         Visibility="{Binding Analysis, Converter={x:Static vm:NullToVisConverter.Instance}, ConverterParameter=invert}">
                 <icon:PackIconLucide Kind="BookOpen" Width="56" Height="56" HorizontalAlignment="Center" Foreground="#66D4A847" Margin="0,0,0,12"/>
                 <TextBlock Text="No skill selected" FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeHeader}"
-                           HorizontalAlignment="Center" Foreground="#FFE8E8E8" Margin="0,0,0,8"/>
-                <TextBlock TextWrapping="Wrap" TextAlignment="Center" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSize}" Margin="0,0,0,16">
+                           HorizontalAlignment="Center" Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                <TextBlock TextWrapping="Wrap" TextAlignment="Center" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSize}" Margin="0,0,0,16">
                     Select a character and skill above to see available recipes, XP rewards,
                     and how many completions are needed to reach the next level.
                 </TextBlock>
-                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1" Padding="12" CornerRadius="3">
+                <Border Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1" Padding="12" CornerRadius="3">
                     <StackPanel>
-                        <TextBlock Text="No character exports?" FontWeight="SemiBold" Foreground="#FFE8E8E8" Margin="0,0,0,4"/>
-                        <TextBlock FontSize="{DynamicResource AppFontSizeHint}" Foreground="#AAFFFFFF" TextWrapping="Wrap">
+                        <TextBlock Text="No character exports?" FontWeight="SemiBold" Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,4"/>
+                        <TextBlock FontSize="{DynamicResource AppFontSizeHint}" Foreground="{StaticResource TextSecondaryBrush}" TextWrapping="Wrap">
                             Run <Run Text="/exportcharacter" FontFamily="{DynamicResource AppMonoFontFamily}"/> in-game to create a character export file.
                             Then click Refresh to load it.
                         </TextBlock>
@@ -81,17 +81,17 @@
             <!-- Analysis content -->
             <DockPanel Visibility="{Binding Analysis, Converter={x:Static vm:NullToVisConverter.Instance}}">
                 <!-- Skill summary panel (shared by both tabs) -->
-                <Border DockPanel.Dock="Top" Background="#FF252525" BorderBrush="#33FFFFFF"
+                <Border DockPanel.Dock="Top" Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
                         BorderThickness="1" Padding="12" CornerRadius="3" Margin="0,0,0,10">
                     <StackPanel>
                         <DockPanel Margin="0,0,0,6">
-                            <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeXLarge}" Foreground="#FFE8E8E8">
+                            <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeXLarge}" Foreground="{StaticResource TextPrimaryBrush}">
                                 <Run Text="{Binding Analysis.SkillName, Mode=OneWay}"/>
                                 <Run Text=" Level "/>
                                 <Run Text="{Binding Analysis.CurrentLevel, Mode=OneWay}"/>
                             </TextBlock>
                             <TextBlock DockPanel.Dock="Right" HorizontalAlignment="Right"
-                                       Foreground="#AAFFFFFF" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
+                                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
                                 <Run Text="{Binding Analysis.CurrentXp, Mode=OneWay, StringFormat=N0}"/>
                                 <Run Text=" / "/>
                                 <Run Text="{Binding Analysis.XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
@@ -102,8 +102,8 @@
                                      Minimum="0"
                                      Maximum="{Binding Analysis.XpNeededForNextLevel, Mode=OneWay}"
                                      Value="{Binding Analysis.CurrentXp, Mode=OneWay}"
-                                     Foreground="#FFD4A847" Background="#FF333333"/>
-                        <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,4,0,0">
+                                     Foreground="{StaticResource AccentBrush}" Background="#FF333333"/>
+                        <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,4,0,0">
                             <Run Text="{Binding Analysis.XpRemaining, Mode=OneWay, StringFormat=N0}"/>
                             <Run Text=" XP remaining to "/>
                             <Run Text="{Binding Analysis.GoalLevel, Mode=OneWay, TargetNullValue='next level', StringFormat='level {0}'}"/>
@@ -170,27 +170,27 @@
                                     </DockPanel>
 
                                     <!-- Column header strip (mirrors the row template's column widths) — only relevant in Rows mode -->
-                                    <Border DockPanel.Dock="Top" Background="#FF1E1E1E" BorderBrush="#22FFFFFF"
+                                    <Border DockPanel.Dock="Top" Background="{StaticResource BgRecessedBrush}" BorderBrush="#22FFFFFF"
                                             BorderThickness="0,0,0,1" Padding="8,4"
                                             Visibility="{Binding ViewMode, Converter={x:Static views:StringEqualsToVisConverter.Instance}, ConverterParameter=Rows}">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="50"/>
-                                                <ColumnDefinition Width="40"/>
-                                                <ColumnDefinition Width="80"/>
-                                                <ColumnDefinition Width="80"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColRecipe}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColLvl}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColFirst}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColEffXp}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColToLevel}"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0" Text="Recipe"
-                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                             <TextBlock Grid.Column="1" Text="Lvl" HorizontalAlignment="Center"
-                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                             <TextBlock Grid.Column="2" Text="1st?" HorizontalAlignment="Center"
-                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                             <TextBlock Grid.Column="3" Text="Eff. XP" HorizontalAlignment="Right"
-                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                             <TextBlock Grid.Column="4" Text="To Level" HorizontalAlignment="Right"
-                                                       Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                         </Grid>
                                     </Border>
 
@@ -207,7 +207,7 @@
                                             <Style TargetType="ListBoxItem">
                                                 <Setter Property="Padding" Value="8,5"/>
                                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                                <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                                                <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
                                                 <Setter Property="ContentTemplate" Value="{StaticResource RecipeRowTemplate}"/>
                                                 <Setter Property="Template">
                                                     <Setter.Value>
@@ -244,12 +244,12 @@
                                               ShowsPreview="True"/>
 
                                 <!-- Detail pane -->
-                                <Border Grid.Column="2" Background="#FF252525" BorderBrush="#33FFFFFF"
+                                <Border Grid.Column="2" Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
                                         BorderThickness="1" CornerRadius="3" Padding="12">
                                     <Grid>
                                         <!-- Empty inner state -->
                                         <TextBlock Text="Select a recipe to view its ingredients, XP breakdown, and crafted outputs."
-                                                   Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                   Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
                                                    TextWrapping="Wrap" TextAlignment="Center"
                                                    HorizontalAlignment="Center" VerticalAlignment="Center"
                                                    Visibility="{Binding SelectedRecipe, Converter={x:Static vm:NullToVisConverter.Instance}, ConverterParameter=invert}"/>
@@ -263,8 +263,8 @@
                                                                    Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
                                                     <StackPanel VerticalAlignment="Center">
                                                         <TextBlock Text="{Binding RecipeName}" FontWeight="Bold"
-                                                                   Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
-                                                        <TextBlock Foreground="#AAFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0">
+                                                                   Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                                                        <TextBlock Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0">
                                                             <Run Text="Level"/>
                                                             <Run Text="{Binding LevelRequired, Mode=OneWay}"/>
                                                         </TextBlock>
@@ -272,7 +272,7 @@
                                                 </DockPanel>
 
                                                 <!-- XP breakdown -->
-                                                <Border Background="#FF1E1E1E" CornerRadius="2" Padding="8,6" Margin="0,0,0,10">
+                                                <Border Background="{StaticResource BgRecessedBrush}" CornerRadius="2" Padding="8,6" Margin="0,0,0,10">
                                                     <Grid HorizontalAlignment="Left">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>
@@ -286,45 +286,45 @@
                                                             <RowDefinition Height="Auto"/>
                                                         </Grid.RowDefinitions>
 
-                                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Base XP" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
+                                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Base XP" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="0" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
                                                             <Run Text="{Binding BaseXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="First-time bonus XP" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="1" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
+                                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="First-time bonus XP" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="1" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
                                                             <Run Text="{Binding FirstTimeXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Times completed" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="2" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
+                                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Times completed" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="2" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
                                                                    Text="{Binding TimesCompleted, Mode=OneWay}"/>
 
-                                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Effective XP per craft" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="3" Grid.Column="1" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
+                                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Effective XP per craft" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="3" Grid.Column="1" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
                                                             <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Crafts to next level" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
+                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Crafts to next level" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
                                                                    Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
                                                     </Grid>
                                                 </Border>
 
                                                 <!-- Ingredients -->
-                                                <TextBlock Text="Ingredients" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                <TextBlock Text="Ingredients" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
                                                            FontWeight="SemiBold" Margin="0,0,0,4"/>
                                                 <ItemsControl ItemsSource="{Binding Ingredients}">
                                                     <ItemsControl.ItemTemplate>
                                                         <DataTemplate>
                                                             <StackPanel Orientation="Horizontal" Margin="0,1">
                                                                 <wpf:IconImage IconId="{Binding IconId}" Width="16" Height="16" Margin="0,0,4,0"/>
-                                                                <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                                                                <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
                                                                     <Run Text="{Binding StackSize, Mode=OneWay, StringFormat='{}{0}x '}"/>
                                                                 </TextBlock>
-                                                                <TextBlock Text="{Binding Name}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                                <TextBlock Text="{Binding Name}" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
                                                                 <TextBlock Text="{Binding ChanceToConsume, Mode=OneWay, StringFormat=' ({0:P0} chance)'}"
-                                                                           Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" FontStyle="Italic"
+                                                                           Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontStyle="Italic"
                                                                            Visibility="{Binding ChanceToConsume, Converter={x:Static vm:NullToVisConverter.Instance}}"/>
                                                             </StackPanel>
                                                         </DataTemplate>
@@ -332,7 +332,7 @@
                                                 </ItemsControl>
 
                                                 <!-- Crafted gear -->
-                                                <TextBlock Text="Crafted gear" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                                <TextBlock Text="Crafted gear" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
                                                            FontWeight="SemiBold" Margin="0,10,0,4"
                                                            Visibility="{Binding CraftedOutputs.Count, Converter={x:Static vm:CountToVisConverter.Instance}}"/>
                                                 <ItemsControl ItemsSource="{Binding CraftedOutputs}">
@@ -340,7 +340,7 @@
                                                         <DataTemplate>
                                                             <StackPanel Orientation="Horizontal" Margin="0,1">
                                                                 <wpf:IconImage IconId="{Binding IconId}" Width="16" Height="16" Margin="0,0,4,0"/>
-                                                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}" TextWrapping="Wrap"/>
+                                                                <TextBlock Text="{Binding DisplayLine}" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" TextWrapping="Wrap"/>
                                                             </StackPanel>
                                                         </DataTemplate>
                                                     </ItemsControl.ItemTemplate>
@@ -359,7 +359,7 @@
                             <!-- Sim controls -->
                             <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10">
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="Goal level:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <TextBlock Text="Goal level:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                                     <TextBox Width="60" Margin="0,0,6,0"
                                              Text="{Binding GoalLevel, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
                                              ToolTip="Target level (leave empty for next level)"/>
@@ -377,19 +377,19 @@
                             <!-- Result or empty state -->
                             <Grid>
                                 <TextBlock Text="Set a goal level and click Simulate to see an optimal crafting path."
-                                           Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                           Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
                                            TextWrapping="Wrap" TextAlignment="Center"
                                            HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="420"
                                            Visibility="{Binding SimulationResult, Converter={x:Static vm:NullToVisConverter.Instance}, ConverterParameter=invert}"/>
 
-                                <Border Background="#FF252525" BorderBrush="#33D4A847"
+                                <Border Background="{StaticResource BgSurfaceBrush}" BorderBrush="#33D4A847"
                                         BorderThickness="1" Padding="12" CornerRadius="3"
                                         Visibility="{Binding SimulationResult, Converter={x:Static vm:NullToVisConverter.Instance}}">
                                     <DockPanel>
                                         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
                                             <StackPanel Orientation="Horizontal">
-                                                <icon:PackIconLucide Kind="Route" Width="14" Height="14" VerticalAlignment="Center" Foreground="#FFD4A847" Margin="0,0,6,0"/>
-                                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeLarge}" Foreground="#FFD4A847">
+                                                <icon:PackIconLucide Kind="Route" Width="14" Height="14" VerticalAlignment="Center" Foreground="{StaticResource AccentBrush}" Margin="0,0,6,0"/>
+                                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeLarge}" Foreground="{StaticResource AccentBrush}">
                                                     <Run Text="Optimal Path"/>
                                                     <Run Text=" — "/>
                                                     <Run Text="{Binding SimulationResult.TotalCompletions, Mode=OneWay}"/>
@@ -401,9 +401,9 @@
                                             <ItemsControl ItemsSource="{Binding SimulationResult.Steps}">
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
-                                                        <Border Background="#FF1E1E1E" CornerRadius="2" Padding="8,5" Margin="0,0,0,3">
+                                                        <Border Background="{StaticResource BgRecessedBrush}" CornerRadius="2" Padding="8,5" Margin="0,0,0,3">
                                                             <DockPanel>
-                                                                <TextBlock DockPanel.Dock="Right" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
+                                                                <TextBlock DockPanel.Dock="Right" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
                                                                     <Run Text="Lv "/>
                                                                     <Run Text="{Binding LevelAtStart, Mode=OneWay}"/>
                                                                     <Run Text=" &#x2192; "/>
@@ -411,18 +411,18 @@
                                                                 </TextBlock>
                                                                 <StackPanel Orientation="Horizontal">
                                                                     <wpf:IconImage IconId="{Binding IconId}" Width="18" Height="18" Margin="0,0,6,0" VerticalAlignment="Center"/>
-                                                                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
+                                                                    <TextBlock Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
                                                                         <Run Text="{Binding RecipeName, Mode=OneWay}"/>
                                                                     </TextBlock>
-                                                                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
+                                                                    <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
                                                                         <Run Text="x"/>
                                                                         <Run Text="{Binding Completions, Mode=OneWay}"/>
                                                                     </TextBlock>
                                                                     <Border Background="#44D4A847" CornerRadius="3" Padding="4,1" Margin="8,0,0,0"
                                                                             Visibility="{Binding UsesFirstTimeBonus, Converter={StaticResource BoolToVisibility}}">
-                                                                        <TextBlock Text="1st time" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                                                        <TextBlock Text="1st time" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeSmall}"/>
                                                                     </Border>
-                                                                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
+                                                                    <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center" Margin="8,0,0,0">
                                                                         <Run Text="{Binding TotalXpFromStep, Mode=OneWay, StringFormat=N0}"/>
                                                                         <Run Text=" XP"/>
                                                                     </TextBlock>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -147,81 +147,17 @@
                                 <DockPanel Grid.Column="0">
                                     <!-- Sort chip row + view-mode toggle -->
                                     <DockPanel DockPanel.Dock="Top" Margin="0,0,0,6" LastChildFill="False">
-                                        <!-- View-mode toggle (Rows / Cards) on the right -->
-                                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                                            <TextBlock Text="View:" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                                                       VerticalAlignment="Center" Margin="12,0,6,0"/>
-                                            <Button Command="{Binding SetViewModeCommand}" CommandParameter="Rows"
-                                                    Margin="0,0,2,0" Padding="6,2" Cursor="Hand"
-                                                    ToolTip="Show recipes as compact rows with column-aligned values">
-                                                <Button.Style>
-                                                    <Style TargetType="Button">
-                                                        <Setter Property="Background" Value="Transparent"/>
-                                                        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
-                                                        <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                                                        <Setter Property="Template">
-                                                            <Setter.Value>
-                                                                <ControlTemplate TargetType="Button">
-                                                                    <Border x:Name="Bd" Background="{TemplateBinding Background}"
-                                                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                                                            BorderThickness="1" CornerRadius="3"
-                                                                            Padding="{TemplateBinding Padding}">
-                                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                    </Border>
-                                                                    <ControlTemplate.Triggers>
-                                                                        <Trigger Property="IsMouseOver" Value="True">
-                                                                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
-                                                                        </Trigger>
-                                                                    </ControlTemplate.Triggers>
-                                                                </ControlTemplate>
-                                                            </Setter.Value>
-                                                        </Setter>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding ViewMode}" Value="Rows">
-                                                                <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
-                                                                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Button.Style>
+                                        <wpf:ViewModeToggle DockPanel.Dock="Right"
+                                                            SelectedMode="{Binding ViewMode, Mode=TwoWay}">
+                                            <wpf:ViewModeOption Id="Rows"
+                                                                ToolTipText="Show recipes as compact rows with column-aligned values">
                                                 <icon:PackIconLucide Kind="List" Width="14" Height="14"/>
-                                            </Button>
-                                            <Button Command="{Binding SetViewModeCommand}" CommandParameter="Cards"
-                                                    Padding="6,2" Cursor="Hand"
-                                                    ToolTip="Show recipes as cards with bigger icons and inline metadata">
-                                                <Button.Style>
-                                                    <Style TargetType="Button">
-                                                        <Setter Property="Background" Value="Transparent"/>
-                                                        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
-                                                        <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                                                        <Setter Property="Template">
-                                                            <Setter.Value>
-                                                                <ControlTemplate TargetType="Button">
-                                                                    <Border x:Name="Bd" Background="{TemplateBinding Background}"
-                                                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                                                            BorderThickness="1" CornerRadius="3"
-                                                                            Padding="{TemplateBinding Padding}">
-                                                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                    </Border>
-                                                                    <ControlTemplate.Triggers>
-                                                                        <Trigger Property="IsMouseOver" Value="True">
-                                                                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
-                                                                        </Trigger>
-                                                                    </ControlTemplate.Triggers>
-                                                                </ControlTemplate>
-                                                            </Setter.Value>
-                                                        </Setter>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding ViewMode}" Value="Cards">
-                                                                <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
-                                                                <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Button.Style>
+                                            </wpf:ViewModeOption>
+                                            <wpf:ViewModeOption Id="Cards"
+                                                                ToolTipText="Show recipes as cards with bigger icons and inline metadata">
                                                 <icon:PackIconLucide Kind="LayoutList" Width="14" Height="14"/>
-                                            </Button>
-                                        </StackPanel>
+                                            </wpf:ViewModeOption>
+                                        </wpf:ViewModeToggle>
 
                                         <!-- Sort chips on the left -->
                                         <StackPanel Orientation="Horizontal">

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -8,6 +8,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared"
              xmlns:sort="clr-namespace:Mithril.Shared.Wpf.Sorting;assembly=Mithril.Shared"
+             xmlns:filter="clr-namespace:Mithril.Shared.Wpf.Filtering;assembly=Mithril.Shared"
              mc:Ignorable="d"
              Background="#FF1A1A1A">
     <UserControl.Resources>
@@ -116,27 +117,6 @@
                     <!-- ── Recipes tab ────────────────────────────────────── -->
                     <TabItem Header="Recipes">
                         <DockPanel Margin="0,8,0,0">
-                            <!-- Filter bar -->
-                            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
-                                <StackPanel Orientation="Horizontal">
-                                    <CheckBox Content="Known only" VerticalAlignment="Center"
-                                              IsChecked="{Binding ShowKnownOnly}"
-                                              ToolTip="Show only recipes the character has learned"
-                                              Margin="0,0,12,0"/>
-                                    <CheckBox Content="1st time available" VerticalAlignment="Center"
-                                              IsChecked="{Binding ShowFirstTimeOnly}"
-                                              ToolTip="Show only recipes with a first-time bonus still available"
-                                              Margin="0,0,12,0"/>
-                                    <CheckBox Content="Craftable only" VerticalAlignment="Center"
-                                              IsChecked="{Binding ShowCraftableOnly}"
-                                              ToolTip="Show only recipes whose level requirement is at or below your current skill level"
-                                              Margin="0,0,12,0"/>
-                                    <CheckBox Content="Include 0 XP" VerticalAlignment="Center"
-                                              IsChecked="{Binding IncludeZeroXp}"
-                                              ToolTip="Include recipes that give 0 repeatable XP (first-time bonus only)"/>
-                                </StackPanel>
-                            </DockPanel>
-
                             <!-- Master-detail split -->
                             <Grid>
                                 <Grid.ColumnDefinitions>
@@ -170,9 +150,23 @@
                                                            Foreground="{StaticResource TextTertiaryBrush}"/>
                                             </StackPanel>
                                         </Button>
+                                        <Button x:Name="FilterBtn"
+                                                Style="{StaticResource MithrilToolbarButtonStyle}"
+                                                Margin="6,0,0,0"
+                                                Click="OnOpenFilterPopup"
+                                                ToolTip="Toggle filter predicates">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="Filter"/>
+                                                <TextBlock Text="…" Margin="2,0,0,0"
+                                                           Foreground="{StaticResource TextTertiaryBrush}"/>
+                                            </StackPanel>
+                                        </Button>
                                         <sort:MithrilSortPopup x:Name="SortPopup"
                                                                Source="{Binding}"
                                                                PlacementTarget="{Binding ElementName=SortBtn}"/>
+                                        <filter:MithrilFilterPopup x:Name="FilterPopup"
+                                                                   Source="{Binding}"
+                                                                   PlacementTarget="{Binding ElementName=FilterBtn}"/>
                                     </DockPanel>
 
                                     <!-- Column header strip (mirrors the row template's column widths) — only relevant in Rows mode -->

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
@@ -14,4 +14,9 @@ public partial class SkillAdvisorView : UserControl
     {
         SortPopup.IsOpen = !SortPopup.IsOpen;
     }
+
+    private void OnOpenFilterPopup(object sender, RoutedEventArgs e)
+    {
+        FilterPopup.IsOpen = !FilterPopup.IsOpen;
+    }
 }

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Elrond.Views;
@@ -7,5 +8,10 @@ public partial class SkillAdvisorView : UserControl
     public SkillAdvisorView()
     {
         InitializeComponent();
+    }
+
+    private void OnOpenSortPopup(object sender, RoutedEventArgs e)
+    {
+        SortPopup.IsOpen = !SortPopup.IsOpen;
     }
 }

--- a/src/Mithril.Shared/Wpf/Filtering/FilterPredicate.cs
+++ b/src/Mithril.Shared/Wpf/Filtering/FilterPredicate.cs
@@ -1,0 +1,35 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Mithril.Shared.Wpf.Filtering;
+
+/// <summary>
+/// One toggleable predicate exposed to the shared filter popup.
+/// </summary>
+/// <remarks>
+/// Predicates are always written positively (they describe "what passes"). When <see cref="Inverted"/>
+/// is <c>true</c> the predicate restricts the set in the *off* state, which lets a label like
+/// "Show unknown" read naturally — toggling on suppresses the predicate and reveals more rows.
+/// Consumers should combine via <c>filters.Where(f =&gt; f.ShouldApply).All(f =&gt; f.Predicate(item))</c>.
+/// </remarks>
+public sealed partial class FilterPredicate<T> : ObservableObject
+{
+    public FilterPredicate(string id, string displayName, Func<T, bool> predicate, bool inverted = false, bool isActive = false)
+    {
+        Id = id;
+        DisplayName = displayName;
+        Predicate = predicate;
+        Inverted = inverted;
+        _isActive = isActive;
+    }
+
+    public string Id { get; }
+    public string DisplayName { get; }
+    public Func<T, bool> Predicate { get; }
+    public bool Inverted { get; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShouldApply))]
+    private bool _isActive;
+
+    public bool ShouldApply => Inverted ? !IsActive : IsActive;
+}

--- a/src/Mithril.Shared/Wpf/Filtering/IFilterableViewModel.cs
+++ b/src/Mithril.Shared/Wpf/Filtering/IFilterableViewModel.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+
+namespace Mithril.Shared.Wpf.Filtering;
+
+/// <summary>
+/// Non-generic facet so the popup can bind without knowing <c>T</c>.
+/// </summary>
+public interface IFilterableViewModel
+{
+    IEnumerable AvailableFiltersUntyped { get; }
+}
+
+/// <summary>
+/// View-models expose this to participate in the shared filter popup.
+/// </summary>
+public interface IFilterableViewModel<T> : IFilterableViewModel
+{
+    IReadOnlyList<FilterPredicate<T>> AvailableFilters { get; }
+}

--- a/src/Mithril.Shared/Wpf/Filtering/IFilterableViewModel.cs
+++ b/src/Mithril.Shared/Wpf/Filtering/IFilterableViewModel.cs
@@ -12,8 +12,12 @@ public interface IFilterableViewModel
 
 /// <summary>
 /// View-models expose this to participate in the shared filter popup.
+/// Implementers only need to declare <see cref="AvailableFilters"/>; the
+/// non-generic facet is wired via default interface member.
 /// </summary>
 public interface IFilterableViewModel<T> : IFilterableViewModel
 {
     IReadOnlyList<FilterPredicate<T>> AvailableFilters { get; }
+
+    IEnumerable IFilterableViewModel.AvailableFiltersUntyped => AvailableFilters;
 }

--- a/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml
@@ -1,0 +1,57 @@
+<UserControl x:Class="Mithril.Shared.Wpf.Filtering.MithrilFilterPopup"
+             x:Name="Self"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Popup x:Name="Host"
+           IsOpen="{Binding IsOpen, ElementName=Self, Mode=TwoWay}"
+           PlacementTarget="{Binding PlacementTarget, ElementName=Self}"
+           Placement="Bottom"
+           StaysOpen="False"
+           AllowsTransparency="True"
+           PopupAnimation="Fade"
+           VerticalOffset="2">
+        <Border Background="{StaticResource BgSurfaceBrush}"
+                BorderBrush="{StaticResource BorderStrongBrush}"
+                BorderThickness="1"
+                CornerRadius="3"
+                Padding="10"
+                MinWidth="220"
+                SnapsToDevicePixels="True">
+            <Border.Effect>
+                <DropShadowEffect Color="Black" BlurRadius="10" ShadowDepth="2" Opacity="0.55"/>
+            </Border.Effect>
+
+            <DockPanel>
+                <TextBlock x:Name="EmptyHint"
+                           DockPanel.Dock="Top"
+                           Text="No filters available."
+                           Foreground="{StaticResource TextTertiaryBrush}"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           Visibility="Collapsed"/>
+
+                <ItemsControl x:Name="FiltersList"
+                              KeyboardNavigation.TabNavigation="Cycle">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Margin="0,3"
+                                      IsChecked="{Binding IsActive, Mode=TwoWay}"
+                                      Content="{Binding DisplayName}"
+                                      Foreground="{StaticResource TextPrimaryBrush}"
+                                      VerticalContentAlignment="Center"
+                                      Cursor="Hand"
+                                      Click="OnFilterToggleClick"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </DockPanel>
+        </Border>
+    </Popup>
+</UserControl>

--- a/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml
@@ -24,7 +24,8 @@
                 CornerRadius="3"
                 Padding="10"
                 MinWidth="220"
-                SnapsToDevicePixels="True">
+                SnapsToDevicePixels="True"
+                KeyDown="OnPopupKeyDown">
             <Border.Effect>
                 <DropShadowEffect Color="Black" BlurRadius="10" ShadowDepth="2" Opacity="0.55"/>
             </Border.Effect>

--- a/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml.cs
@@ -1,0 +1,86 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Mithril.Shared.Wpf.Filtering;
+
+/// <summary>
+/// Toolbar popup that toggles the active set of filter predicates over an
+/// <see cref="IFilterableViewModel"/>. Each predicate renders as a labeled
+/// checkbox bound two-way to <c>FilterPredicate&lt;T&gt;.IsActive</c>;
+/// authors of inverted filters (e.g. "Show unknown") use the predicate's
+/// <c>Inverted</c> flag so the on-state means "reveal more rows" while the
+/// underlying predicate stays positively expressed.
+/// </summary>
+public partial class MithrilFilterPopup : UserControl
+{
+    public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+        nameof(Source), typeof(IFilterableViewModel), typeof(MithrilFilterPopup),
+        new FrameworkPropertyMetadata(null, OnSourceChanged));
+
+    public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(
+        nameof(IsOpen), typeof(bool), typeof(MithrilFilterPopup),
+        new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnIsOpenChanged));
+
+    public static readonly DependencyProperty PlacementTargetProperty = DependencyProperty.Register(
+        nameof(PlacementTarget), typeof(UIElement), typeof(MithrilFilterPopup));
+
+    public IFilterableViewModel? Source
+    {
+        get => (IFilterableViewModel?)GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
+
+    public bool IsOpen
+    {
+        get => (bool)GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
+    }
+
+    public UIElement? PlacementTarget
+    {
+        get => (UIElement?)GetValue(PlacementTargetProperty);
+        set => SetValue(PlacementTargetProperty, value);
+    }
+
+    public MithrilFilterPopup()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var p = (MithrilFilterPopup)d;
+        // Bind via interface vtable rather than XAML: AvailableFiltersUntyped is a
+        // default-interface member, which WPF's reflection-based binding pipeline
+        // can't see on the runtime class.
+        if (e.NewValue is IFilterableViewModel src)
+            p.FiltersList.ItemsSource = src.AvailableFiltersUntyped;
+        p.RefreshEmptyHint();
+    }
+
+    private static void OnIsOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var p = (MithrilFilterPopup)d;
+        if ((bool)e.NewValue)
+        {
+            if (p.Source is { } src) p.FiltersList.ItemsSource = src.AvailableFiltersUntyped;
+            p.RefreshEmptyHint();
+        }
+    }
+
+    private void RefreshEmptyHint()
+    {
+        if (!IsLoaded) return;
+        var hasItems = false;
+        if (Source is { } src)
+            foreach (var _ in src.AvailableFiltersUntyped) { hasItems = true; break; }
+        EmptyHint.Visibility = hasItems ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    private void OnFilterToggleClick(object sender, RoutedEventArgs e)
+    {
+        // Stop the click bubbling — Popup.StaysOpen=False can dismiss the popup
+        // when a routed Click reaches an ancestor outside the popup's tree.
+        e.Handled = true;
+    }
+}

--- a/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Filtering/MithrilFilterPopup.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace Mithril.Shared.Wpf.Filtering;
 
@@ -65,7 +67,35 @@ public partial class MithrilFilterPopup : UserControl
         {
             if (p.Source is { } src) p.FiltersList.ItemsSource = src.AvailableFiltersUntyped;
             p.RefreshEmptyHint();
+            p.Dispatcher.BeginInvoke(new Action(p.FocusFirstCheckbox), DispatcherPriority.Input);
         }
+    }
+
+    private void FocusFirstCheckbox()
+    {
+        if (FiltersList.Items.Count == 0) return;
+        if (FiltersList.ItemContainerGenerator.ContainerFromIndex(0) is not FrameworkElement container) return;
+        var checkbox = FindChild<CheckBox>(container);
+        checkbox?.Focus();
+    }
+
+    private static T? FindChild<T>(DependencyObject root) where T : DependencyObject
+    {
+        for (int i = 0; i < System.Windows.Media.VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) return match;
+            var found = FindChild<T>(child);
+            if (found is not null) return found;
+        }
+        return null;
+    }
+
+    private void OnPopupKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Escape) return;
+        IsOpen = false;
+        e.Handled = true;
     }
 
     private void RefreshEmptyHint()

--- a/src/Mithril.Shared/Wpf/Resources.xaml
+++ b/src/Mithril.Shared/Wpf/Resources.xaml
@@ -41,6 +41,7 @@
 
     <!-- Palette — matches hand-authored colors in Samwise/Shell/Legolas views -->
     <SolidColorBrush x:Key="BgPrimaryBrush"      Color="#FF1A1A1A"/>
+    <SolidColorBrush x:Key="BgRecessedBrush"     Color="#FF1E1E1E"/>
     <SolidColorBrush x:Key="BgSurfaceBrush"      Color="#FF252525"/>
     <SolidColorBrush x:Key="BgSurfaceHoverBrush" Color="#FF303030"/>
     <SolidColorBrush x:Key="TextPrimaryBrush"    Color="#FFE8E8E8"/>
@@ -761,6 +762,140 @@
                             </Popup>
                         </Grid>
                     </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ═══════════════════ Toolbar (Sort / Filter / View) ═══════════════════ -->
+
+    <!-- Compact icon-with-label pill used by the Sort and Filter toolbar buttons.
+         Smaller than the default Button (MinHeight 22 vs 24, padding 8,2 vs 10,4)
+         so a row of these doesn't overpower the master list above which they sit. -->
+    <Style x:Key="MithrilToolbarButtonStyle" TargetType="Button">
+        <Setter Property="Background"  Value="Transparent"/>
+        <Setter Property="Foreground"  Value="{StaticResource TextSecondaryBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtleBrush}"/>
+        <Setter Property="Padding"     Value="8,2"/>
+        <Setter Property="MinHeight"   Value="22"/>
+        <Setter Property="Cursor"      Value="Hand"/>
+        <Setter Property="FontFamily"  Value="{DynamicResource AppFontFamily}"/>
+        <Setter Property="FontSize"    Value="{DynamicResource AppFontSizeHint}"/>
+        <Setter Property="Focusable"   Value="True"/>
+        <Setter Property="IsTabStop"   Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="3"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                          RecognizesAccessKey="True"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource BorderStrongBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentSoftBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ═══════════════════ ViewModeToggle ═══════════════════ -->
+
+    <!-- Segmented toggle backed by an internal ListBox. Each ListBoxItem renders a
+         ViewModeOption's Icon (and DisplayName when present); the selected segment
+         picks up AccentBrush on its border + foreground. ListBox.SelectedValuePath
+         points at ViewModeOption.Id so the host VM binds a plain string. -->
+    <Style TargetType="{x:Type c:ViewModeToggle}">
+        <Setter Property="Background"  Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtleBrush}"/>
+        <Setter Property="Focusable"   Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type c:ViewModeToggle}">
+                    <ListBox x:Name="PART_List"
+                             ItemsSource="{Binding Modes, RelativeSource={RelativeSource TemplatedParent}}"
+                             SelectedValue="{Binding SelectedMode, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                             SelectedValuePath="Id"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             Padding="0"
+                             KeyboardNavigation.TabNavigation="Once"
+                             SnapsToDevicePixels="True">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Margin" Value="0,0,2,0"/>
+                                <Setter Property="Padding" Value="6,2"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                                <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+                                <Setter Property="ToolTip" Value="{Binding ToolTipText}"/>
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ListBoxItem">
+                                            <Border x:Name="Bd"
+                                                    Background="Transparent"
+                                                    BorderBrush="{StaticResource BorderSubtleBrush}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="3"
+                                                    Padding="{TemplateBinding Padding}"
+                                                    SnapsToDevicePixels="True">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <ContentPresenter Content="{Binding Icon}"
+                                                                      VerticalAlignment="Center"
+                                                                      HorizontalAlignment="Center"/>
+                                                    <TextBlock Text="{Binding DisplayName}"
+                                                               Margin="4,0,0,0"
+                                                               VerticalAlignment="Center"
+                                                               Foreground="{TemplateBinding Foreground}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding DisplayName}" Value="">
+                                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                                                </Trigger>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                                    <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                                </Trigger>
+                                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Mithril.Shared/Wpf/Sorting/ActiveSortKey.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/ActiveSortKey.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Mithril.Shared.Wpf.Sorting;
+
+/// <summary>
+/// One entry in the ordered list of active sort keys. Wraps a <see cref="SortKey{T}"/>
+/// with a mutable <see cref="Direction"/> and a glyph for the popup tag.
+/// </summary>
+public sealed partial class ActiveSortKey<T> : ObservableObject
+{
+    public ActiveSortKey(SortKey<T> key, ListSortDirection direction)
+    {
+        Key = key;
+        _direction = direction;
+    }
+
+    public SortKey<T> Key { get; }
+
+    public string Id => Key.Id;
+
+    public string DisplayName => Key.DisplayName;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IndicatorGlyph))]
+    private ListSortDirection _direction;
+
+    public string IndicatorGlyph => Direction == ListSortDirection.Ascending ? "▲" : "▼";
+
+    public void FlipDirection() =>
+        Direction = Direction == ListSortDirection.Ascending
+            ? ListSortDirection.Descending
+            : ListSortDirection.Ascending;
+}

--- a/src/Mithril.Shared/Wpf/Sorting/ISortableViewModel.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/ISortableViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace Mithril.Shared.Wpf.Sorting;
 
@@ -18,9 +19,38 @@ public interface ISortableViewModel
 
 /// <summary>
 /// View-models expose this to participate in the shared sort popup.
+/// Implementers only need to declare <see cref="AvailableSortKeys"/> and
+/// <see cref="ActiveSortKeys"/>; the non-generic facets and mutation methods
+/// are wired via default interface members.
 /// </summary>
 public interface ISortableViewModel<T> : ISortableViewModel
 {
     IReadOnlyList<SortKey<T>> AvailableSortKeys { get; }
     ObservableCollection<ActiveSortKey<T>> ActiveSortKeys { get; }
+
+    IEnumerable ISortableViewModel.AvailableSortKeysUntyped => AvailableSortKeys;
+    IList ISortableViewModel.ActiveSortKeysUntyped => ActiveSortKeys;
+
+    void ISortableViewModel.AddSortKeyById(string id)
+    {
+        var key = AvailableSortKeys.FirstOrDefault(k => k.Id == id);
+        if (key is null) return;
+        if (ActiveSortKeys.Any(a => a.Key.Id == id)) return;
+        var dir = key.DefaultDescending ? ListSortDirection.Descending : ListSortDirection.Ascending;
+        ActiveSortKeys.Add(new ActiveSortKey<T>(key, dir));
+    }
+
+    void ISortableViewModel.RemoveSortKeyAt(int index)
+    {
+        if ((uint)index < (uint)ActiveSortKeys.Count)
+            ActiveSortKeys.RemoveAt(index);
+    }
+
+    void ISortableViewModel.MoveSortKey(int fromIndex, int toIndex)
+    {
+        if ((uint)fromIndex >= (uint)ActiveSortKeys.Count) return;
+        if ((uint)toIndex   >= (uint)ActiveSortKeys.Count) return;
+        if (fromIndex == toIndex) return;
+        ActiveSortKeys.Move(fromIndex, toIndex);
+    }
 }

--- a/src/Mithril.Shared/Wpf/Sorting/ISortableViewModel.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/ISortableViewModel.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+
+namespace Mithril.Shared.Wpf.Sorting;
+
+/// <summary>
+/// Non-generic facet so the popup can bind without knowing <c>T</c>.
+/// </summary>
+public interface ISortableViewModel
+{
+    IEnumerable AvailableSortKeysUntyped { get; }
+    IList ActiveSortKeysUntyped { get; }
+
+    void AddSortKeyById(string id);
+    void RemoveSortKeyAt(int index);
+    void MoveSortKey(int fromIndex, int toIndex);
+}
+
+/// <summary>
+/// View-models expose this to participate in the shared sort popup.
+/// </summary>
+public interface ISortableViewModel<T> : ISortableViewModel
+{
+    IReadOnlyList<SortKey<T>> AvailableSortKeys { get; }
+    ObservableCollection<ActiveSortKey<T>> ActiveSortKeys { get; }
+}

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -50,7 +50,7 @@
                     <Grid>
                         <!-- Centered placeholder, shown when there are no chips. -->
                         <TextBlock x:Name="EmptyPlaceholder"
-                                   Text="No sort applied · list shows source order"
+                                   Text="No sort applied · list shows the source's default order"
                                    Foreground="{StaticResource TextTertiaryBrush}"
                                    FontStyle="Italic"
                                    FontSize="{DynamicResource AppFontSizeHint}"

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -18,102 +18,190 @@
            StaysOpen="False"
            AllowsTransparency="True"
            PopupAnimation="Fade"
-           HorizontalOffset="0"
            VerticalOffset="2">
         <Border Background="{StaticResource BgSurfaceBrush}"
                 BorderBrush="{StaticResource BorderStrongBrush}"
                 BorderThickness="1"
                 CornerRadius="3"
-                Padding="8"
-                MinWidth="220"
+                Padding="10"
+                MinWidth="280"
                 SnapsToDevicePixels="True">
             <Border.Effect>
                 <DropShadowEffect Color="Black" BlurRadius="10" ShadowDepth="2" Opacity="0.55"/>
             </Border.Effect>
 
             <DockPanel>
-                <!-- Footer: "+ Add sort key" -->
-                <Button x:Name="AddBtn" DockPanel.Dock="Bottom"
-                        Style="{StaticResource MithrilToolbarButtonStyle}"
-                        HorizontalAlignment="Stretch"
-                        Margin="0,6,0,0"
-                        Click="OnAddSortKeyClick"
-                        ToolTip="Append another sort key">
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                        <TextBlock Text="+ " Foreground="{StaticResource AccentBrush}"/>
-                        <TextBlock Text="Add sort key"/>
-                    </StackPanel>
-                    <Button.ContextMenu>
-                        <ContextMenu x:Name="AddMenu" Placement="Bottom"/>
-                    </Button.ContextMenu>
-                </Button>
-
-                <!-- Empty-state hint -->
-                <TextBlock x:Name="EmptyHint"
-                           DockPanel.Dock="Top"
-                           Text="No sort keys active. Add one to start ordering the list."
+                <!-- Hint -->
+                <TextBlock DockPanel.Dock="Bottom"
+                           Text="Click a chip to flip direction. ✕ removes."
                            Foreground="{StaticResource TextTertiaryBrush}"
-                           FontSize="{DynamicResource AppFontSizeHint}"
-                           Padding="2,4"
-                           TextWrapping="Wrap"
-                           Visibility="Collapsed"/>
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           Margin="0,8,0,0"
+                           TextWrapping="Wrap"/>
 
-                <!-- Active sort keys, ordered top-to-bottom = precedence -->
-                <ItemsControl x:Name="TagsList"
-                              ItemsSource="{Binding Source.ActiveSortKeysUntyped, ElementName=Self}"
-                              KeyboardNavigation.TabNavigation="Cycle">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Grid Margin="0,2">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
+                <!-- Chip surface — looks like a TextBox; chips wrap inside -->
+                <Border BorderBrush="{StaticResource BorderSubtleBrush}"
+                        BorderThickness="1"
+                        CornerRadius="3"
+                        Background="{StaticResource BgRecessedBrush}"
+                        Padding="3"
+                        MinHeight="34">
+                    <ItemsControl x:Name="TagsList"
+                                  ItemsSource="{Binding Source.ActiveSortKeysUntyped, ElementName=Self}"
+                                  KeyboardNavigation.TabNavigation="Cycle">
+                        <ItemsControl.Template>
+                            <ControlTemplate TargetType="ItemsControl">
+                                <WrapPanel x:Name="ItemsHost"
+                                           Orientation="Horizontal"
+                                           IsItemsHost="True"/>
+                            </ControlTemplate>
+                        </ItemsControl.Template>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Margin="2" CornerRadius="10"
+                                        BorderBrush="{StaticResource BorderSubtleBrush}"
+                                        BorderThickness="1"
+                                        Background="{StaticResource BgSurfaceHoverBrush}"
+                                        SnapsToDevicePixels="True">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <!-- Tag body: glyph + label. Click flips direction. -->
+                                        <Button Click="OnTagBodyClick"
+                                                Cursor="Hand"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Padding="8,3"
+                                                Foreground="{StaticResource TextPrimaryBrush}"
+                                                ToolTip="Click to flip direction">
+                                            <Button.Template>
+                                                <ControlTemplate TargetType="Button">
+                                                    <Border Background="Transparent" Padding="{TemplateBinding Padding}">
+                                                        <ContentPresenter VerticalAlignment="Center"
+                                                                          HorizontalAlignment="Center"/>
+                                                    </Border>
+                                                </ControlTemplate>
+                                            </Button.Template>
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding IndicatorGlyph}"
+                                                           Foreground="{StaticResource AccentBrush}"
+                                                           FontWeight="SemiBold"
+                                                           Margin="0,0,5,0"/>
+                                                <TextBlock Text="{Binding DisplayName}"/>
+                                            </StackPanel>
+                                        </Button>
 
-                                <!-- Tag body: label + asc/desc indicator. Click flips direction. -->
-                                <Button Grid.Column="0"
-                                        Style="{StaticResource MithrilToolbarButtonStyle}"
-                                        HorizontalContentAlignment="Stretch"
-                                        Click="OnTagBodyClick"
-                                        ToolTip="Click to flip direction">
-                                    <DockPanel LastChildFill="False">
-                                        <TextBlock DockPanel.Dock="Right"
-                                                   Text="{Binding IndicatorGlyph}"
-                                                   Foreground="{StaticResource AccentBrush}"
-                                                   Margin="6,0,0,0"
-                                                   FontWeight="SemiBold"/>
-                                        <TextBlock Text="{Binding DisplayName}"
-                                                   Foreground="{StaticResource TextPrimaryBrush}"/>
-                                    </DockPanel>
-                                </Button>
+                                        <!-- × remove -->
+                                        <Button Click="OnRemoveClick"
+                                                Cursor="Hand"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Padding="4,3,7,3"
+                                                Foreground="{StaticResource TextTertiaryBrush}"
+                                                ToolTip="Remove sort key">
+                                            <Button.Template>
+                                                <ControlTemplate TargetType="Button">
+                                                    <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}">
+                                                        <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                                    </Border>
+                                                    <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                                        </Trigger>
+                                                    </ControlTemplate.Triggers>
+                                                </ControlTemplate>
+                                            </Button.Template>
+                                            <TextBlock Text="✕" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                        </Button>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
 
-                                <Button Grid.Column="1"
-                                        Style="{StaticResource MithrilToolbarButtonStyle}"
-                                        Margin="2,0,0,0" Padding="6,0"
-                                        Click="OnMoveUpClick"
-                                        ToolTip="Move up (higher precedence)">
-                                    <TextBlock Text="▲" FontSize="{DynamicResource AppFontSizeSmall}"/>
-                                </Button>
-                                <Button Grid.Column="2"
-                                        Style="{StaticResource MithrilToolbarButtonStyle}"
-                                        Margin="2,0,0,0" Padding="6,0"
-                                        Click="OnMoveDownClick"
-                                        ToolTip="Move down (lower precedence)">
-                                    <TextBlock Text="▼" FontSize="{DynamicResource AppFontSizeSmall}"/>
-                                </Button>
-                                <Button Grid.Column="3"
-                                        Style="{StaticResource MithrilToolbarButtonStyle}"
-                                        Margin="2,0,0,0" Padding="6,0"
-                                        Click="OnRemoveClick"
-                                        ToolTip="Remove sort key">
-                                    <TextBlock Text="✕" Foreground="{StaticResource TextSecondaryBrush}"/>
-                                </Button>
-                            </Grid>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
+                        <!-- Empty-state hint placeholder, rendered via the items-host's parent border -->
+                    </ItemsControl>
+                </Border>
+
+                <!-- + Add chip lives outside the surface (right-aligned) so it doesn't shift the chip flow -->
+                <DockPanel DockPanel.Dock="Bottom" Margin="0,6,0,0" LastChildFill="False">
+                    <TextBlock x:Name="EmptyHint"
+                               DockPanel.Dock="Left"
+                               Text="No sort keys active."
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               FontSize="{DynamicResource AppFontSizeSmall}"
+                               VerticalAlignment="Center"
+                               Visibility="Collapsed"/>
+                    <Button x:Name="AddBtn"
+                            DockPanel.Dock="Right"
+                            Style="{StaticResource MithrilToolbarButtonStyle}"
+                            Click="OnAddSortKeyClick"
+                            ToolTip="Add another sort key">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="+ " Foreground="{StaticResource AccentBrush}" FontWeight="SemiBold"/>
+                            <TextBlock Text="Add sort key"/>
+                        </StackPanel>
+                    </Button>
+                </DockPanel>
+
+                <!-- Themed sub-popup — replaces the unstyled ContextMenu. -->
+                <Popup x:Name="AddPopup"
+                       PlacementTarget="{Binding ElementName=AddBtn}"
+                       Placement="Bottom"
+                       StaysOpen="False"
+                       AllowsTransparency="True"
+                       PopupAnimation="Fade"
+                       VerticalOffset="2">
+                    <Border Background="{StaticResource BgSurfaceBrush}"
+                            BorderBrush="{StaticResource BorderStrongBrush}"
+                            BorderThickness="1"
+                            CornerRadius="3"
+                            Padding="2"
+                            SnapsToDevicePixels="True">
+                        <Border.Effect>
+                            <DropShadowEffect Color="Black" BlurRadius="8" ShadowDepth="2" Opacity="0.5"/>
+                        </Border.Effect>
+                        <ListBox x:Name="UnusedKeysList"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 MinWidth="160"
+                                 MaxHeight="240"
+                                 KeyboardNavigation.TabNavigation="Cycle"
+                                 SelectionChanged="OnUnusedKeysListSelectionChanged">
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="Padding" Value="8,4"/>
+                                    <Setter Property="Cursor" Value="Hand"/>
+                                    <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="ListBoxItem">
+                                                <Border x:Name="Bd"
+                                                        Background="Transparent"
+                                                        Padding="{TemplateBinding Padding}"
+                                                        SnapsToDevicePixels="True">
+                                                    <ContentPresenter VerticalAlignment="Center"/>
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource BgSurfaceHoverBrush}"/>
+                                                    </Trigger>
+                                                    <Trigger Property="IsSelected" Value="True">
+                                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentSoftBrush}"/>
+                                                        <Setter Property="Foreground" Value="{StaticResource AccentSoftTextBrush}"/>
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center"/>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Border>
+                </Popup>
             </DockPanel>
         </Border>
     </Popup>

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -47,8 +47,19 @@
                         Background="{StaticResource BgRecessedBrush}"
                         Padding="3"
                         MinHeight="34">
-                    <ItemsControl x:Name="TagsList"
-                                  KeyboardNavigation.TabNavigation="Cycle">
+                    <Grid>
+                        <!-- Centered placeholder, shown when there are no chips. -->
+                        <TextBlock x:Name="EmptyPlaceholder"
+                                   Text="No sort applied · list shows source order"
+                                   Foreground="{StaticResource TextTertiaryBrush}"
+                                   FontStyle="Italic"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   Margin="6,0"
+                                   Visibility="Collapsed"/>
+                        <ItemsControl x:Name="TagsList"
+                                      KeyboardNavigation.TabNavigation="Cycle">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <WrapPanel Orientation="Horizontal"/>
@@ -115,19 +126,12 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
 
-                        <!-- Empty-state hint placeholder, rendered via the items-host's parent border -->
-                    </ItemsControl>
+                        </ItemsControl>
+                    </Grid>
                 </Border>
 
                 <!-- + Add chip lives outside the surface (right-aligned) so it doesn't shift the chip flow -->
                 <DockPanel DockPanel.Dock="Bottom" Margin="0,6,0,0" LastChildFill="False">
-                    <TextBlock x:Name="EmptyHint"
-                               DockPanel.Dock="Left"
-                               Text="No sort keys active."
-                               Foreground="{StaticResource TextTertiaryBrush}"
-                               FontSize="{DynamicResource AppFontSizeSmall}"
-                               VerticalAlignment="Center"
-                               Visibility="Collapsed"/>
                     <Button x:Name="AddBtn"
                             DockPanel.Dock="Right"
                             Style="{StaticResource MithrilToolbarButtonStyle}"

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -47,7 +47,6 @@
                         Padding="3"
                         MinHeight="34">
                     <ItemsControl x:Name="TagsList"
-                                  ItemsSource="{Binding Source.ActiveSortKeysUntyped, ElementName=Self}"
                                   KeyboardNavigation.TabNavigation="Cycle">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -25,7 +25,8 @@
                 CornerRadius="3"
                 Padding="10"
                 MinWidth="280"
-                SnapsToDevicePixels="True">
+                SnapsToDevicePixels="True"
+                KeyDown="OnPopupKeyDown">
             <Border.Effect>
                 <DropShadowEffect Color="Black" BlurRadius="10" ShadowDepth="2" Opacity="0.55"/>
             </Border.Effect>
@@ -61,14 +62,15 @@
                                         Background="{StaticResource BgSurfaceHoverBrush}"
                                         SnapsToDevicePixels="True">
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <!-- Tag body: glyph + label. Click flips direction. -->
+                                        <!-- Tag body: glyph + label. Click flips; ↑/↓ reorder; Delete removes. -->
                                         <Button Click="OnTagBodyClick"
+                                                KeyDown="OnTagKeyDown"
                                                 Cursor="Hand"
                                                 Background="Transparent"
                                                 BorderThickness="0"
                                                 Padding="8,3"
                                                 Foreground="{StaticResource TextPrimaryBrush}"
-                                                ToolTip="Click to flip direction">
+                                                ToolTip="Click or Space/Enter to flip · ↑/↓ reorder · Delete removes">
                                             <Button.Template>
                                                 <ControlTemplate TargetType="Button">
                                                     <Border Background="Transparent" Padding="{TemplateBinding Padding}">

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -1,0 +1,120 @@
+<UserControl x:Class="Mithril.Shared.Wpf.Sorting.MithrilSortPopup"
+             x:Name="Self"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sort="clr-namespace:Mithril.Shared.Wpf.Sorting">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Popup x:Name="Host"
+           IsOpen="{Binding IsOpen, ElementName=Self, Mode=TwoWay}"
+           PlacementTarget="{Binding PlacementTarget, ElementName=Self}"
+           Placement="Bottom"
+           StaysOpen="False"
+           AllowsTransparency="True"
+           PopupAnimation="Fade"
+           HorizontalOffset="0"
+           VerticalOffset="2">
+        <Border Background="{StaticResource BgSurfaceBrush}"
+                BorderBrush="{StaticResource BorderStrongBrush}"
+                BorderThickness="1"
+                CornerRadius="3"
+                Padding="8"
+                MinWidth="220"
+                SnapsToDevicePixels="True">
+            <Border.Effect>
+                <DropShadowEffect Color="Black" BlurRadius="10" ShadowDepth="2" Opacity="0.55"/>
+            </Border.Effect>
+
+            <DockPanel>
+                <!-- Footer: "+ Add sort key" -->
+                <Button x:Name="AddBtn" DockPanel.Dock="Bottom"
+                        Style="{StaticResource MithrilToolbarButtonStyle}"
+                        HorizontalAlignment="Stretch"
+                        Margin="0,6,0,0"
+                        Click="OnAddSortKeyClick"
+                        ToolTip="Append another sort key">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Text="+ " Foreground="{StaticResource AccentBrush}"/>
+                        <TextBlock Text="Add sort key"/>
+                    </StackPanel>
+                    <Button.ContextMenu>
+                        <ContextMenu x:Name="AddMenu" Placement="Bottom"/>
+                    </Button.ContextMenu>
+                </Button>
+
+                <!-- Empty-state hint -->
+                <TextBlock x:Name="EmptyHint"
+                           DockPanel.Dock="Top"
+                           Text="No sort keys active. Add one to start ordering the list."
+                           Foreground="{StaticResource TextTertiaryBrush}"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Padding="2,4"
+                           TextWrapping="Wrap"
+                           Visibility="Collapsed"/>
+
+                <!-- Active sort keys, ordered top-to-bottom = precedence -->
+                <ItemsControl x:Name="TagsList"
+                              ItemsSource="{Binding Source.ActiveSortKeysUntyped, ElementName=Self}"
+                              KeyboardNavigation.TabNavigation="Cycle">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <!-- Tag body: label + asc/desc indicator. Click flips direction. -->
+                                <Button Grid.Column="0"
+                                        Style="{StaticResource MithrilToolbarButtonStyle}"
+                                        HorizontalContentAlignment="Stretch"
+                                        Click="OnTagBodyClick"
+                                        ToolTip="Click to flip direction">
+                                    <DockPanel LastChildFill="False">
+                                        <TextBlock DockPanel.Dock="Right"
+                                                   Text="{Binding IndicatorGlyph}"
+                                                   Foreground="{StaticResource AccentBrush}"
+                                                   Margin="6,0,0,0"
+                                                   FontWeight="SemiBold"/>
+                                        <TextBlock Text="{Binding DisplayName}"
+                                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                                    </DockPanel>
+                                </Button>
+
+                                <Button Grid.Column="1"
+                                        Style="{StaticResource MithrilToolbarButtonStyle}"
+                                        Margin="2,0,0,0" Padding="6,0"
+                                        Click="OnMoveUpClick"
+                                        ToolTip="Move up (higher precedence)">
+                                    <TextBlock Text="▲" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                </Button>
+                                <Button Grid.Column="2"
+                                        Style="{StaticResource MithrilToolbarButtonStyle}"
+                                        Margin="2,0,0,0" Padding="6,0"
+                                        Click="OnMoveDownClick"
+                                        ToolTip="Move down (lower precedence)">
+                                    <TextBlock Text="▼" FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                </Button>
+                                <Button Grid.Column="3"
+                                        Style="{StaticResource MithrilToolbarButtonStyle}"
+                                        Margin="2,0,0,0" Padding="6,0"
+                                        Click="OnRemoveClick"
+                                        ToolTip="Remove sort key">
+                                    <TextBlock Text="✕" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                </Button>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </DockPanel>
+        </Border>
+    </Popup>
+</UserControl>

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml
@@ -49,13 +49,11 @@
                     <ItemsControl x:Name="TagsList"
                                   ItemsSource="{Binding Source.ActiveSortKeysUntyped, ElementName=Self}"
                                   KeyboardNavigation.TabNavigation="Cycle">
-                        <ItemsControl.Template>
-                            <ControlTemplate TargetType="ItemsControl">
-                                <WrapPanel x:Name="ItemsHost"
-                                           Orientation="Horizontal"
-                                           IsItemsHost="True"/>
-                            </ControlTemplate>
-                        </ItemsControl.Template>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border Margin="2" CornerRadius="10"

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
@@ -48,8 +48,17 @@ public partial class MithrilSortPopup : UserControl
         InitializeComponent();
     }
 
-    private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) =>
-        ((MithrilSortPopup)d).RefreshEmptyHint();
+    private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var p = (MithrilSortPopup)d;
+        // Bind ItemsSource via direct interface call rather than XAML, because the
+        // non-generic facets (AvailableSortKeysUntyped / ActiveSortKeysUntyped) are
+        // default-interface members. WPF's reflection-based binding pipeline cannot
+        // see DIM-only properties on the runtime class — interface vtable dispatch
+        // here works regardless.
+        p.TagsList.ItemsSource = (e.NewValue as ISortableViewModel)?.ActiveSortKeysUntyped;
+        p.RefreshEmptyHint();
+    }
 
     private static void OnIsOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
@@ -1,0 +1,138 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Mithril.Shared.Wpf.Sorting;
+
+/// <summary>
+/// Toolbar popup that lets the user manage an ordered, multi-key sort over an
+/// <see cref="ISortableViewModel"/>. Each active key renders as a "tag" with a
+/// flip-direction body, ↑/↓ reorder buttons, and an × remove button. The footer
+/// Add button shows a context menu of currently-unused keys.
+/// </summary>
+public partial class MithrilSortPopup : UserControl
+{
+    public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
+        nameof(Source), typeof(ISortableViewModel), typeof(MithrilSortPopup),
+        new FrameworkPropertyMetadata(null, OnSourceChanged));
+
+    public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(
+        nameof(IsOpen), typeof(bool), typeof(MithrilSortPopup),
+        new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnIsOpenChanged));
+
+    public static readonly DependencyProperty PlacementTargetProperty = DependencyProperty.Register(
+        nameof(PlacementTarget), typeof(UIElement), typeof(MithrilSortPopup));
+
+    public ISortableViewModel? Source
+    {
+        get => (ISortableViewModel?)GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
+    }
+
+    public bool IsOpen
+    {
+        get => (bool)GetValue(IsOpenProperty);
+        set => SetValue(IsOpenProperty, value);
+    }
+
+    public UIElement? PlacementTarget
+    {
+        get => (UIElement?)GetValue(PlacementTargetProperty);
+        set => SetValue(PlacementTargetProperty, value);
+    }
+
+    public MithrilSortPopup()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) =>
+        ((MithrilSortPopup)d).RefreshEmptyHint();
+
+    private static void OnIsOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var p = (MithrilSortPopup)d;
+        if ((bool)e.NewValue) p.RefreshEmptyHint();
+    }
+
+    private void RefreshEmptyHint()
+    {
+        if (!IsLoaded) return;
+        var hasItems = Source?.ActiveSortKeysUntyped.Count > 0;
+        EmptyHint.Visibility = hasItems ? Visibility.Collapsed : Visibility.Visible;
+        TagsList.Visibility = hasItems ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void OnTagBodyClick(object sender, RoutedEventArgs e)
+    {
+        if (((FrameworkElement)sender).DataContext is { } dc)
+            ((dynamic)dc).FlipDirection();
+    }
+
+    private void OnMoveUpClick(object sender, RoutedEventArgs e) => Move(sender, -1);
+    private void OnMoveDownClick(object sender, RoutedEventArgs e) => Move(sender, +1);
+
+    private void Move(object sender, int delta)
+    {
+        if (Source is not { } src) return;
+        if (((FrameworkElement)sender).DataContext is not { } dc) return;
+        var from = src.ActiveSortKeysUntyped.IndexOf(dc);
+        var to = from + delta;
+        if (from < 0 || to < 0 || to >= src.ActiveSortKeysUntyped.Count) return;
+        src.MoveSortKey(from, to);
+    }
+
+    private void OnRemoveClick(object sender, RoutedEventArgs e)
+    {
+        if (Source is not { } src) return;
+        if (((FrameworkElement)sender).DataContext is not { } dc) return;
+        var index = src.ActiveSortKeysUntyped.IndexOf(dc);
+        if (index >= 0) src.RemoveSortKeyAt(index);
+        RefreshEmptyHint();
+    }
+
+    private void OnAddSortKeyClick(object sender, RoutedEventArgs e)
+    {
+        if (Source is not { } src) return;
+        AddMenu.Items.Clear();
+
+        var activeIds = new HashSet<string>();
+        foreach (var active in src.ActiveSortKeysUntyped)
+        {
+            if (active is null) continue;
+            activeIds.Add((string)((dynamic)active).Id);
+        }
+
+        var added = 0;
+        foreach (var key in src.AvailableSortKeysUntyped)
+        {
+            if (key is null) continue;
+            var id = (string)((dynamic)key).Id;
+            if (activeIds.Contains(id)) continue;
+            var displayName = (string)((dynamic)key).DisplayName;
+            var item = new MenuItem { Header = displayName, Tag = id };
+            item.Click += OnAddMenuItemClick;
+            AddMenu.Items.Add(item);
+            added++;
+        }
+
+        if (added == 0)
+        {
+            AddMenu.Items.Add(new MenuItem
+            {
+                Header = "All sort keys are already active",
+                IsEnabled = false,
+            });
+        }
+
+        AddMenu.PlacementTarget = AddBtn;
+        AddMenu.IsOpen = true;
+    }
+
+    private void OnAddMenuItemClick(object sender, RoutedEventArgs e)
+    {
+        if (Source is not { } src) return;
+        if (((FrameworkElement)sender).Tag is string id)
+            src.AddSortKeyById(id);
+        RefreshEmptyHint();
+    }
+}

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace Mithril.Shared.Wpf.Sorting;
 
@@ -70,11 +72,35 @@ public partial class MithrilSortPopup : UserControl
             // initial OnSourceChanged callback fired (or DIM resolution missed it).
             if (p.Source is { } src) p.TagsList.ItemsSource = src.ActiveSortKeysUntyped;
             p.RefreshEmptyHint();
+            // Focus the first chip when the popup pops, so keyboard users land
+            // somewhere actionable rather than on the popup root.
+            p.Dispatcher.BeginInvoke(new Action(p.FocusFirstChip), DispatcherPriority.Input);
         }
         else
         {
             p.AddPopup.IsOpen = false;
         }
+    }
+
+    private void FocusFirstChip()
+    {
+        if (TagsList.Items.Count == 0) { AddBtn.Focus(); return; }
+        if (TagsList.ItemContainerGenerator.ContainerFromIndex(0) is not FrameworkElement container) return;
+        // Walk to the inner Button (the chip body) so Space/Enter flips immediately.
+        var button = FindChild<Button>(container);
+        button?.Focus();
+    }
+
+    private static T? FindChild<T>(DependencyObject root) where T : DependencyObject
+    {
+        for (int i = 0; i < System.Windows.Media.VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) return match;
+            var found = FindChild<T>(child);
+            if (found is not null) return found;
+        }
+        return null;
     }
 
     private void RefreshEmptyHint()
@@ -100,6 +126,55 @@ public partial class MithrilSortPopup : UserControl
         var index = src.ActiveSortKeysUntyped.IndexOf(dc);
         if (index >= 0) src.RemoveSortKeyAt(index);
         RefreshEmptyHint();
+        e.Handled = true;
+    }
+
+    private void OnTagKeyDown(object sender, KeyEventArgs e)
+    {
+        if (Source is not { } src) return;
+        if (((FrameworkElement)sender).DataContext is not { } dc) return;
+        var index = src.ActiveSortKeysUntyped.IndexOf(dc);
+        if (index < 0) return;
+
+        switch (e.Key)
+        {
+            case Key.Up:
+                if (index > 0)
+                {
+                    src.MoveSortKey(index, index - 1);
+                    Dispatcher.BeginInvoke(() => FocusChipAt(index - 1), DispatcherPriority.Input);
+                }
+                e.Handled = true;
+                break;
+            case Key.Down:
+                if (index < src.ActiveSortKeysUntyped.Count - 1)
+                {
+                    src.MoveSortKey(index, index + 1);
+                    Dispatcher.BeginInvoke(() => FocusChipAt(index + 1), DispatcherPriority.Input);
+                }
+                e.Handled = true;
+                break;
+            case Key.Delete:
+                src.RemoveSortKeyAt(index);
+                RefreshEmptyHint();
+                Dispatcher.BeginInvoke(FocusFirstChip, DispatcherPriority.Input);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void FocusChipAt(int index)
+    {
+        if ((uint)index >= (uint)TagsList.Items.Count) return;
+        if (TagsList.ItemContainerGenerator.ContainerFromIndex(index) is not FrameworkElement container) return;
+        FindChild<Button>(container)?.Focus();
+    }
+
+    private void OnPopupKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Escape) return;
+        if (AddPopup.IsOpen) AddPopup.IsOpen = false;
+        else IsOpen = false;
         e.Handled = true;
     }
 

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
@@ -56,15 +56,25 @@ public partial class MithrilSortPopup : UserControl
         // default-interface members. WPF's reflection-based binding pipeline cannot
         // see DIM-only properties on the runtime class — interface vtable dispatch
         // here works regardless.
-        p.TagsList.ItemsSource = (e.NewValue as ISortableViewModel)?.ActiveSortKeysUntyped;
+        if (e.NewValue is ISortableViewModel src)
+            p.TagsList.ItemsSource = src.ActiveSortKeysUntyped;
         p.RefreshEmptyHint();
     }
 
     private static void OnIsOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var p = (MithrilSortPopup)d;
-        if ((bool)e.NewValue) p.RefreshEmptyHint();
-        else p.AddPopup.IsOpen = false;
+        if ((bool)e.NewValue)
+        {
+            // Re-bind on every open in case the consumer assigned Source after the
+            // initial OnSourceChanged callback fired (or DIM resolution missed it).
+            if (p.Source is { } src) p.TagsList.ItemsSource = src.ActiveSortKeysUntyped;
+            p.RefreshEmptyHint();
+        }
+        else
+        {
+            p.AddPopup.IsOpen = false;
+        }
     }
 
     private void RefreshEmptyHint()
@@ -78,6 +88,9 @@ public partial class MithrilSortPopup : UserControl
     {
         if (((FrameworkElement)sender).DataContext is { } dc)
             ((dynamic)dc).FlipDirection();
+        // Stop the click bubbling — Popup.StaysOpen=False can interpret a bubbling
+        // Click whose ancestor chain reaches outside the popup as "click outside".
+        e.Handled = true;
     }
 
     private void OnRemoveClick(object sender, RoutedEventArgs e)
@@ -87,6 +100,7 @@ public partial class MithrilSortPopup : UserControl
         var index = src.ActiveSortKeysUntyped.IndexOf(dc);
         if (index >= 0) src.RemoveSortKeyAt(index);
         RefreshEmptyHint();
+        e.Handled = true;
     }
 
     private void OnAddSortKeyClick(object sender, RoutedEventArgs e)

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
@@ -107,7 +107,7 @@ public partial class MithrilSortPopup : UserControl
     {
         if (!IsLoaded) return;
         var hasItems = Source?.ActiveSortKeysUntyped.Count > 0;
-        EmptyHint.Visibility = hasItems ? Visibility.Collapsed : Visibility.Visible;
+        EmptyPlaceholder.Visibility = hasItems ? Visibility.Collapsed : Visibility.Visible;
     }
 
     private void OnTagBodyClick(object sender, RoutedEventArgs e)

--- a/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/MithrilSortPopup.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -5,9 +6,11 @@ namespace Mithril.Shared.Wpf.Sorting;
 
 /// <summary>
 /// Toolbar popup that lets the user manage an ordered, multi-key sort over an
-/// <see cref="ISortableViewModel"/>. Each active key renders as a "tag" with a
-/// flip-direction body, ↑/↓ reorder buttons, and an × remove button. The footer
-/// Add button shows a context menu of currently-unused keys.
+/// <see cref="ISortableViewModel"/>. The popup interior reads as a TextBox-like
+/// surface holding sort-key chips: each chip is <c>[ ▼/▲ DisplayName ✕ ]</c>;
+/// clicking the body flips the direction, ✕ removes. A "+ Add sort key"
+/// button opens a themed sub-popup (not the system ContextMenu) listing the
+/// keys not currently active.
 /// </summary>
 public partial class MithrilSortPopup : UserControl
 {
@@ -52,6 +55,7 @@ public partial class MithrilSortPopup : UserControl
     {
         var p = (MithrilSortPopup)d;
         if ((bool)e.NewValue) p.RefreshEmptyHint();
+        else p.AddPopup.IsOpen = false;
     }
 
     private void RefreshEmptyHint()
@@ -59,26 +63,12 @@ public partial class MithrilSortPopup : UserControl
         if (!IsLoaded) return;
         var hasItems = Source?.ActiveSortKeysUntyped.Count > 0;
         EmptyHint.Visibility = hasItems ? Visibility.Collapsed : Visibility.Visible;
-        TagsList.Visibility = hasItems ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void OnTagBodyClick(object sender, RoutedEventArgs e)
     {
         if (((FrameworkElement)sender).DataContext is { } dc)
             ((dynamic)dc).FlipDirection();
-    }
-
-    private void OnMoveUpClick(object sender, RoutedEventArgs e) => Move(sender, -1);
-    private void OnMoveDownClick(object sender, RoutedEventArgs e) => Move(sender, +1);
-
-    private void Move(object sender, int delta)
-    {
-        if (Source is not { } src) return;
-        if (((FrameworkElement)sender).DataContext is not { } dc) return;
-        var from = src.ActiveSortKeysUntyped.IndexOf(dc);
-        var to = from + delta;
-        if (from < 0 || to < 0 || to >= src.ActiveSortKeysUntyped.Count) return;
-        src.MoveSortKey(from, to);
     }
 
     private void OnRemoveClick(object sender, RoutedEventArgs e)
@@ -93,7 +83,6 @@ public partial class MithrilSortPopup : UserControl
     private void OnAddSortKeyClick(object sender, RoutedEventArgs e)
     {
         if (Source is not { } src) return;
-        AddMenu.Items.Clear();
 
         var activeIds = new HashSet<string>();
         foreach (var active in src.ActiveSortKeysUntyped)
@@ -102,37 +91,29 @@ public partial class MithrilSortPopup : UserControl
             activeIds.Add((string)((dynamic)active).Id);
         }
 
-        var added = 0;
+        var unused = new List<object>();
         foreach (var key in src.AvailableSortKeysUntyped)
         {
             if (key is null) continue;
             var id = (string)((dynamic)key).Id;
-            if (activeIds.Contains(id)) continue;
-            var displayName = (string)((dynamic)key).DisplayName;
-            var item = new MenuItem { Header = displayName, Tag = id };
-            item.Click += OnAddMenuItemClick;
-            AddMenu.Items.Add(item);
-            added++;
+            if (!activeIds.Contains(id)) unused.Add(key);
         }
 
-        if (added == 0)
-        {
-            AddMenu.Items.Add(new MenuItem
-            {
-                Header = "All sort keys are already active",
-                IsEnabled = false,
-            });
-        }
-
-        AddMenu.PlacementTarget = AddBtn;
-        AddMenu.IsOpen = true;
+        UnusedKeysList.ItemsSource = unused;
+        UnusedKeysList.SelectedIndex = -1;
+        AddPopup.IsOpen = unused.Count > 0;
     }
 
-    private void OnAddMenuItemClick(object sender, RoutedEventArgs e)
+    private void OnUnusedKeysListSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (Source is not { } src) return;
-        if (((FrameworkElement)sender).Tag is string id)
-            src.AddSortKeyById(id);
+        if (UnusedKeysList.SelectedItem is not { } selected) return;
+
+        var id = (string)((dynamic)selected).Id;
+        src.AddSortKeyById(id);
+
+        AddPopup.IsOpen = false;
+        UnusedKeysList.SelectedIndex = -1;
         RefreshEmptyHint();
     }
 }

--- a/src/Mithril.Shared/Wpf/Sorting/SortFilterController.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/SortFilterController.cs
@@ -1,0 +1,107 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows.Data;
+using Mithril.Shared.Wpf.Filtering;
+
+namespace Mithril.Shared.Wpf.Sorting;
+
+/// <summary>
+/// Wires an <see cref="ICollectionView"/>'s <see cref="ICollectionView.SortDescriptions"/> and
+/// <see cref="ICollectionView.Filter"/> to the active sort/filter state owned by a view-model,
+/// so consumers don't have to write the boilerplate themselves.
+/// </summary>
+public sealed class SortFilterController<T> : IDisposable
+{
+    private readonly ICollectionView _view;
+    private readonly ObservableCollection<ActiveSortKey<T>> _activeSortKeys;
+    private readonly IReadOnlyList<FilterPredicate<T>> _filters;
+    private bool _disposed;
+
+    public SortFilterController(
+        ICollectionView view,
+        ObservableCollection<ActiveSortKey<T>> activeSortKeys,
+        IReadOnlyList<FilterPredicate<T>> filters)
+    {
+        _view = view ?? throw new ArgumentNullException(nameof(view));
+        _activeSortKeys = activeSortKeys ?? throw new ArgumentNullException(nameof(activeSortKeys));
+        _filters = filters ?? throw new ArgumentNullException(nameof(filters));
+
+        _view.Filter = MatchesActiveFilters;
+
+        _activeSortKeys.CollectionChanged += OnActiveSortKeysChanged;
+        foreach (var key in _activeSortKeys)
+            key.PropertyChanged += OnActiveSortKeyPropertyChanged;
+
+        foreach (var filter in _filters)
+            filter.PropertyChanged += OnFilterPropertyChanged;
+
+        RebuildSortDescriptions();
+    }
+
+    private bool MatchesActiveFilters(object item)
+    {
+        if (item is not T typed) return true;
+        foreach (var f in _filters)
+        {
+            if (!f.ShouldApply) continue;
+            if (!f.Predicate(typed)) return false;
+        }
+        return true;
+    }
+
+    private void OnActiveSortKeysChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+            foreach (ActiveSortKey<T> k in e.OldItems)
+                k.PropertyChanged -= OnActiveSortKeyPropertyChanged;
+
+        if (e.NewItems is not null)
+            foreach (ActiveSortKey<T> k in e.NewItems)
+                k.PropertyChanged += OnActiveSortKeyPropertyChanged;
+
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+            foreach (var k in _activeSortKeys)
+                k.PropertyChanged += OnActiveSortKeyPropertyChanged;
+
+        RebuildSortDescriptions();
+    }
+
+    private void OnActiveSortKeyPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ActiveSortKey<T>.Direction))
+            RebuildSortDescriptions();
+    }
+
+    private void OnFilterPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(FilterPredicate<T>.IsActive)
+            || e.PropertyName == nameof(FilterPredicate<T>.ShouldApply))
+            _view.Refresh();
+    }
+
+    private void RebuildSortDescriptions()
+    {
+        using (_view.DeferRefresh())
+        {
+            _view.SortDescriptions.Clear();
+            foreach (var key in _activeSortKeys)
+                _view.SortDescriptions.Add(new SortDescription(key.Key.SortMemberPath, key.Direction));
+        }
+    }
+
+    /// <summary>Re-evaluates filters without changing sort state. Call after closures' captured state changes (e.g. selecting a different skill).</summary>
+    public void RefreshFilters() => _view.Refresh();
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _activeSortKeys.CollectionChanged -= OnActiveSortKeysChanged;
+        foreach (var key in _activeSortKeys)
+            key.PropertyChanged -= OnActiveSortKeyPropertyChanged;
+        foreach (var filter in _filters)
+            filter.PropertyChanged -= OnFilterPropertyChanged;
+    }
+}

--- a/src/Mithril.Shared/Wpf/Sorting/SortFilterController.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/SortFilterController.cs
@@ -11,6 +11,13 @@ namespace Mithril.Shared.Wpf.Sorting;
 /// <see cref="ICollectionView.Filter"/> to the active sort/filter state owned by a view-model,
 /// so consumers don't have to write the boilerplate themselves.
 /// </summary>
+/// <remarks>
+/// <b>Empty-sort behaviour.</b> When <c>activeSortKeys</c> is empty,
+/// <see cref="ICollectionView.SortDescriptions"/> is empty too — items render in the underlying
+/// collection's iteration order. To keep that case meaningful (and reproducible), consumers
+/// should populate the source collection in a stable, considered default order rather than
+/// relying on dictionary or hash-set iteration.
+/// </remarks>
 public sealed class SortFilterController<T> : IDisposable
 {
     private readonly ICollectionView _view;

--- a/src/Mithril.Shared/Wpf/Sorting/SortKey.cs
+++ b/src/Mithril.Shared/Wpf/Sorting/SortKey.cs
@@ -1,0 +1,17 @@
+namespace Mithril.Shared.Wpf.Sorting;
+
+/// <summary>
+/// Declarative description of one property a collection can be sorted by.
+/// Authored once per consumer view-model; surfaced through <see cref="ISortableViewModel{T}"/>.
+/// </summary>
+/// <param name="Id">Stable identifier used for persistence and lookup. Must be unique within a single VM's <see cref="ISortableViewModel{T}.AvailableSortKeys"/>.</param>
+/// <param name="DisplayName">User-visible label shown in sort tags.</param>
+/// <param name="SortMemberPath">Property path passed to <see cref="System.ComponentModel.SortDescription"/>. Required because <see cref="System.Windows.Data.CollectionView.SortDescriptions"/> is path-based.</param>
+/// <param name="DefaultDescending">Direction used when this key is first added to the active list.</param>
+/// <param name="KeySelector">Optional in-memory key extractor for callers that want to sort outside a <see cref="System.Windows.Data.ICollectionView"/>.</param>
+public sealed record SortKey<T>(
+    string Id,
+    string DisplayName,
+    string SortMemberPath,
+    bool DefaultDescending = false,
+    Func<T, object?>? KeySelector = null);

--- a/src/Mithril.Shared/Wpf/ViewModeOption.cs
+++ b/src/Mithril.Shared/Wpf/ViewModeOption.cs
@@ -1,0 +1,50 @@
+using System.Windows;
+using System.Windows.Markup;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// One segment in a <see cref="ViewModeToggle"/>. <see cref="Id"/> is the value reflected in
+/// <see cref="ViewModeToggle.SelectedMode"/>; <see cref="Icon"/> is rendered through a
+/// <see cref="System.Windows.Controls.ContentPresenter"/> so consumers can pass any
+/// <c>FrameworkElement</c> (e.g. a <c>PackIconLucide</c>).
+/// </summary>
+[ContentProperty(nameof(Icon))]
+public sealed class ViewModeOption : DependencyObject
+{
+    public static readonly DependencyProperty IdProperty = DependencyProperty.Register(
+        nameof(Id), typeof(string), typeof(ViewModeOption), new PropertyMetadata(""));
+
+    public static readonly DependencyProperty DisplayNameProperty = DependencyProperty.Register(
+        nameof(DisplayName), typeof(string), typeof(ViewModeOption), new PropertyMetadata(""));
+
+    public static readonly DependencyProperty IconProperty = DependencyProperty.Register(
+        nameof(Icon), typeof(object), typeof(ViewModeOption));
+
+    public static readonly DependencyProperty ToolTipTextProperty = DependencyProperty.Register(
+        nameof(ToolTipText), typeof(string), typeof(ViewModeOption), new PropertyMetadata(""));
+
+    public string Id
+    {
+        get => (string)GetValue(IdProperty);
+        set => SetValue(IdProperty, value);
+    }
+
+    public string DisplayName
+    {
+        get => (string)GetValue(DisplayNameProperty);
+        set => SetValue(DisplayNameProperty, value);
+    }
+
+    public object? Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    public string? ToolTipText
+    {
+        get => (string?)GetValue(ToolTipTextProperty);
+        set => SetValue(ToolTipTextProperty, value);
+    }
+}

--- a/src/Mithril.Shared/Wpf/ViewModeToggle.cs
+++ b/src/Mithril.Shared/Wpf/ViewModeToggle.cs
@@ -1,0 +1,43 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Segmented two-or-more-way toggle for selecting a view mode (e.g. Rows / Cards).
+/// Internally a <see cref="ListBox"/> with one item per <see cref="ViewModeOption"/>;
+/// consumers bind <see cref="SelectedMode"/> two-way and declare options as inline
+/// children. Default style ships in <c>Mithril.Shared/Wpf/Resources.xaml</c>.
+/// </summary>
+[ContentProperty(nameof(Modes))]
+public sealed class ViewModeToggle : Control
+{
+    public static readonly DependencyProperty SelectedModeProperty = DependencyProperty.Register(
+        nameof(SelectedMode), typeof(string), typeof(ViewModeToggle),
+        new FrameworkPropertyMetadata("", FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+    public static readonly DependencyProperty ModesProperty = DependencyProperty.Register(
+        nameof(Modes), typeof(ObservableCollection<ViewModeOption>), typeof(ViewModeToggle));
+
+    static ViewModeToggle()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(typeof(ViewModeToggle),
+            new FrameworkPropertyMetadata(typeof(ViewModeToggle)));
+    }
+
+    public ViewModeToggle()
+    {
+        SetValue(ModesProperty, new ObservableCollection<ViewModeOption>());
+    }
+
+    public string SelectedMode
+    {
+        get => (string)GetValue(SelectedModeProperty);
+        set => SetValue(SelectedModeProperty, value);
+    }
+
+    public ObservableCollection<ViewModeOption> Modes =>
+        (ObservableCollection<ViewModeOption>)GetValue(ModesProperty);
+}

--- a/tests/Elrond.Tests/ElrondSettingsPersistenceTests.cs
+++ b/tests/Elrond.Tests/ElrondSettingsPersistenceTests.cs
@@ -1,0 +1,117 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Elrond.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace Elrond.Tests;
+
+public class ElrondSettingsPersistenceTests
+{
+    private static readonly JsonSerializerOptions Options =
+        new(ElrondSettingsJsonContext.Default.ElrondSettings.Options);
+
+    [Fact]
+    public void RoundTrip_PreservesActiveSortKeys()
+    {
+        var original = new ElrondSettings
+        {
+            LastSkill = "Cooking",
+            ActiveSortKeys =
+            [
+                new("EffectiveXp", ListSortDirection.Descending),
+                new("RecipeName",  ListSortDirection.Ascending),
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(original, ElrondSettingsJsonContext.Default.ElrondSettings);
+        var restored = JsonSerializer.Deserialize(json, ElrondSettingsJsonContext.Default.ElrondSettings);
+
+        restored.Should().NotBeNull();
+        restored!.ActiveSortKeys.Should().HaveCount(2);
+        restored.ActiveSortKeys[0].Id.Should().Be("EffectiveXp");
+        restored.ActiveSortKeys[0].Direction.Should().Be(ListSortDirection.Descending);
+        restored.ActiveSortKeys[1].Id.Should().Be("RecipeName");
+        restored.ActiveSortKeys[1].Direction.Should().Be(ListSortDirection.Ascending);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesActiveFilterIdsAndPersistenceFlag()
+    {
+        var original = new ElrondSettings
+        {
+            ActiveFilterIds = ["ShowUnknown", "CraftableOnly"],
+            HasPersistedFilters = true,
+        };
+
+        var json = JsonSerializer.Serialize(original, ElrondSettingsJsonContext.Default.ElrondSettings);
+        var restored = JsonSerializer.Deserialize(json, ElrondSettingsJsonContext.Default.ElrondSettings);
+
+        restored!.ActiveFilterIds.Should().Equal("ShowUnknown", "CraftableOnly");
+        restored.HasPersistedFilters.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RoundTrip_EmptyFilters_DistinguishedByPersistenceFlag()
+    {
+        // Empty list with HasPersistedFilters=true means the user intentionally
+        // disabled all filters — VM must respect that and not snap back to defaults.
+        var original = new ElrondSettings
+        {
+            ActiveFilterIds = [],
+            HasPersistedFilters = true,
+        };
+
+        var json = JsonSerializer.Serialize(original, ElrondSettingsJsonContext.Default.ElrondSettings);
+        var restored = JsonSerializer.Deserialize(json, ElrondSettingsJsonContext.Default.ElrondSettings);
+
+        restored!.ActiveFilterIds.Should().BeEmpty();
+        restored.HasPersistedFilters.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserializing_LegacySchema_LeavesNewFieldsAtDefaults()
+    {
+        // Pre-popup settings file (the schema seen on disk for #97-era users).
+        // It has "lastSkill" + "lastGoalLevel" only; no activeSortKeys / activeFilterIds.
+        const string legacyJson = """
+            {
+              "lastSkill": "Carpentry",
+              "lastGoalLevel": 15
+            }
+            """;
+
+        var restored = JsonSerializer.Deserialize(legacyJson, ElrondSettingsJsonContext.Default.ElrondSettings);
+
+        restored.Should().NotBeNull();
+        restored!.LastSkill.Should().Be("Carpentry");
+        restored.LastGoalLevel.Should().Be(15);
+        restored.ActiveSortKeys.Should().BeEmpty();
+        restored.ActiveFilterIds.Should().BeEmpty();
+        restored.HasPersistedFilters.Should().BeFalse();
+        restored.SortKey.Should().BeNull();
+        restored.SortDescending.Should().BeNull();
+        restored.ViewMode.Should().Be("Rows");
+    }
+
+    [Fact]
+    public void Deserializing_PreviousMigrationSchema_PreservesLegacySortFields()
+    {
+        // Mid-migration schema: an upgrading user's file with the old SortKey +
+        // SortDescending pair set, no ActiveSortKeys yet. The VM ctor consumes
+        // these on first launch and clears them.
+        const string mid = """
+            {
+              "lastSkill": "Cooking",
+              "sortKey": "EffectiveXp",
+              "sortDescending": true
+            }
+            """;
+
+        var restored = JsonSerializer.Deserialize(mid, ElrondSettingsJsonContext.Default.ElrondSettings);
+
+        restored!.SortKey.Should().Be("EffectiveXp");
+        restored.SortDescending.Should().BeTrue();
+        restored.ActiveSortKeys.Should().BeEmpty();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/SortFilterControllerTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/SortFilterControllerTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Data;
+using FluentAssertions;
+using Mithril.Shared.Wpf.Filtering;
+using Mithril.Shared.Wpf.Sorting;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+public class SortFilterControllerTests
+{
+    private sealed record Item(string Name, int Value);
+
+    private static (ListCollectionView View,
+                    ObservableCollection<Item> Source,
+                    ObservableCollection<ActiveSortKey<Item>> ActiveSortKeys,
+                    IReadOnlyList<FilterPredicate<Item>> Filters)
+        CreateRig(IEnumerable<Item> seed)
+    {
+        var coll = new ObservableCollection<Item>(seed);
+        var view = new ListCollectionView(coll);
+        var active = new ObservableCollection<ActiveSortKey<Item>>();
+        var filters = new List<FilterPredicate<Item>>();
+        return (view, coll, active, filters);
+    }
+
+    private static SortKey<Item> NameKey() => new("Name", "Name", "Name");
+    private static SortKey<Item> ValueKey() => new("Value", "Value", "Value", DefaultDescending: true);
+
+    [Fact]
+    public void TwoActiveSortKeys_YieldSortDescriptionsInOrder()
+    {
+        var (view, _, active, filters) = CreateRig([new("a", 2), new("b", 1)]);
+        active.Add(new(ValueKey(), ListSortDirection.Descending));
+        active.Add(new(NameKey(),  ListSortDirection.Ascending));
+
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        view.SortDescriptions.Should().HaveCount(2);
+        view.SortDescriptions[0].PropertyName.Should().Be("Value");
+        view.SortDescriptions[0].Direction.Should().Be(ListSortDirection.Descending);
+        view.SortDescriptions[1].PropertyName.Should().Be("Name");
+        view.SortDescriptions[1].Direction.Should().Be(ListSortDirection.Ascending);
+    }
+
+    [Fact]
+    public void FlippingDirection_RebuildsSortDescriptions()
+    {
+        var (view, _, active, filters) = CreateRig([]);
+        var entry = new ActiveSortKey<Item>(ValueKey(), ListSortDirection.Descending);
+        active.Add(entry);
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        entry.FlipDirection();
+
+        view.SortDescriptions.Single().Direction.Should().Be(ListSortDirection.Ascending);
+    }
+
+    [Fact]
+    public void RemovingActiveSortKey_RemovesSortDescription()
+    {
+        var (view, _, active, filters) = CreateRig([]);
+        active.Add(new(ValueKey(), ListSortDirection.Descending));
+        active.Add(new(NameKey(),  ListSortDirection.Ascending));
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        active.RemoveAt(0);
+
+        view.SortDescriptions.Should().ContainSingle()
+            .Which.PropertyName.Should().Be("Name");
+    }
+
+    [Fact]
+    public void MovingActiveSortKey_ReordersSortDescriptions()
+    {
+        var (view, _, active, filters) = CreateRig([]);
+        active.Add(new(ValueKey(), ListSortDirection.Descending));
+        active.Add(new(NameKey(),  ListSortDirection.Ascending));
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        active.Move(0, 1);
+
+        view.SortDescriptions[0].PropertyName.Should().Be("Name");
+        view.SortDescriptions[1].PropertyName.Should().Be("Value");
+    }
+
+    [Fact]
+    public void ActiveFilter_NarrowsTheView()
+    {
+        var items = new[] { new Item("a", 1), new Item("b", 2), new Item("c", 3) };
+        var (view, _, active, _) = CreateRig(items);
+        var filters = new List<FilterPredicate<Item>>
+        {
+            new("EvenValue", "Even", x => x.Value % 2 == 0, isActive: true),
+        };
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        view.Cast<Item>().Select(x => x.Name).Should().Equal("b");
+    }
+
+    [Fact]
+    public void InactiveFilter_DoesNotNarrow()
+    {
+        var items = new[] { new Item("a", 1), new Item("b", 2) };
+        var (view, _, active, _) = CreateRig(items);
+        var filters = new List<FilterPredicate<Item>>
+        {
+            new("Always", "Always false", _ => false, isActive: false),
+        };
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        view.Cast<Item>().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void TogglingIsActive_RefreshesView()
+    {
+        var items = new[] { new Item("a", 1), new Item("b", 2) };
+        var (view, _, active, _) = CreateRig(items);
+        var filter = new FilterPredicate<Item>("EvenValue", "Even", x => x.Value % 2 == 0, isActive: false);
+        var filters = new List<FilterPredicate<Item>> { filter };
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        view.Cast<Item>().Should().HaveCount(2);
+        filter.IsActive = true;
+        view.Cast<Item>().Should().HaveCount(1);
+        filter.IsActive = false;
+        view.Cast<Item>().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void InvertedFilter_AppliesWhenInactive()
+    {
+        // "Show unknown"-style predicate: r => r.Value > 0 means "value-bearing rows".
+        // Inverted=true → predicate applies when toggle is OFF (default), hiding zeros.
+        // Toggling ON suppresses the predicate, revealing zero-value rows too.
+        var items = new[] { new Item("a", 0), new Item("b", 1), new Item("c", 2) };
+        var (view, _, active, _) = CreateRig(items);
+        var filter = new FilterPredicate<Item>(
+            "ShowZeroes", "Show zeroes",
+            x => x.Value > 0,
+            inverted: true,
+            isActive: false);
+        var filters = new List<FilterPredicate<Item>> { filter };
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        // Off (default): predicate applies, zero hidden
+        view.Cast<Item>().Select(i => i.Name).Should().Equal("b", "c");
+
+        // On: predicate suppressed, all rows visible
+        filter.IsActive = true;
+        view.Cast<Item>().Select(i => i.Name).Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public void MultipleActiveFilters_AndCombine()
+    {
+        var items = new[]
+        {
+            new Item("a", 2), new Item("b", 4), new Item("aa", 4), new Item("bb", 6),
+        };
+        var (view, _, active, _) = CreateRig(items);
+        var filters = new List<FilterPredicate<Item>>
+        {
+            new("Even", "Even", x => x.Value % 2 == 0, isActive: true),
+            new("ShortName", "Single-char name", x => x.Name.Length == 1, isActive: true),
+        };
+        using var _c = new SortFilterController<Item>(view, active, filters);
+
+        view.Cast<Item>().Select(i => i.Name).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Dispose_StopsListening()
+    {
+        var (view, _, active, _) = CreateRig([]);
+        var entry = new ActiveSortKey<Item>(ValueKey(), ListSortDirection.Descending);
+        active.Add(entry);
+        var ctrl = new SortFilterController<Item>(view, active, new List<FilterPredicate<Item>>());
+
+        ctrl.Dispose();
+        entry.FlipDirection();
+        active.Add(new(NameKey(), ListSortDirection.Ascending));
+
+        // Direction flip + new key arrived after Dispose; SortDescriptions snapshot
+        // from before Dispose still has the original Descending Value.
+        view.SortDescriptions.Should().ContainSingle()
+            .Which.Direction.Should().Be(ListSortDirection.Descending);
+    }
+}


### PR DESCRIPTION
## Summary

Refines Elrond's recipe browser into a reusable sort+filter toolbar idiom that lives in `Mithril.Shared/Wpf` and that other modules (Arwen's tabs next, then Bilbo / Smaug) can adopt without rewriting the UI.

- **Sort button → popup** with an ordered tag-cloud of multi-key sort entries. Each chip is `[ ▼/▲ Label ✕ ]`; click body flips direction, ✕ removes, ↑/↓ keys reorder, Delete removes. A `+ Add sort key` chip opens a themed sub-popup (replacing an unstyled `ContextMenu`) listing currently-unused keys.
- **Filter button → popup** with a labelled checkbox per `FilterPredicate<T>`. The new `Inverted` flag lets a positively-expressed predicate drive a "Show X" label cleanly (e.g. `r => r.IsKnown` with `Inverted=true` → toggle ON reveals unknowns).
- **`ViewModeToggle`** as a first-class segmented control, replacing the hand-rolled inline `Button` pair.

The shared infra is exposed via `ISortableViewModel<T>` / `IFilterableViewModel<T>` with default interface members, so consumers only declare `AvailableSortKeys` / `ActiveSortKeys` / `AvailableFilters` and the popups bind through.

Filed [#99](https://github.com/arthur-conde/project-gorgon/issues/99) for the open design question — what to do when the user removes all sort keys.

### Latent bug fixed along the way

`IReferenceDataService.FileUpdated` and `IActiveCharacterService` events fire from background threads. The handlers in `SkillAdvisorViewModel` mutated `_recipes`, which a `ListCollectionView` observes; the view rejected the cross-thread changes and silently desynced. Symptoms: master list showed zero items after a `SortDescriptions` rebuild. All three handlers now marshal through the dispatcher.

### Tests

- `Mithril.Shared.Tests/Wpf/SortFilterControllerTests` (10 tests): multi-key order, flip/move/remove propagation, AND-combined active filters, `Inverted` semantics, `Dispose` stops listening
- `Elrond.Tests/ElrondSettingsPersistenceTests` (5 tests): JSON round-trip for `ActiveSortKeys` + `ActiveFilterIds` + `HasPersistedFilters`, legacy/mid-migration schema deserialisation

Total suite: 992 passing (up from 977).

## Test plan

- [ ] `dotnet build Mithril.slnx`
- [ ] `dotnet test Mithril.slnx`
- [ ] Run the shell, open Elrond → Skill Advisor:
  - [ ] Switch view modes via the new `ViewModeToggle`; restart, confirm persistence
  - [ ] Sort popup: flip a chip's direction; add a second key from the menu; remove via ✕; keyboard ↑/↓ reorders; Delete removes; Escape closes
  - [ ] Filter popup: toggle "Show unknown" on (unknowns appear), "Craftable only" off (over-level recipes appear); Escape closes
  - [ ] Restart and confirm sort + filter state survives
- [ ] First launch with a pre-popup `settings.json` (legacy schema with `lastSkill` + old `recipeGrid`) — defaults seed cleanly without a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)