### PR TITLE
fix(di): wire SettingsAutoSaver in Smaug, Gandalf, IconSettings (#101)

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -131,9 +131,16 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<ICharacterPresenceService>()));
 
         services.AddSingleton<GandalfShellViewModel>();
-        services.AddSingleton<GandalfShellView>(sp => new GandalfShellView
+        services.AddSingleton<GandalfShellView>(sp =>
         {
-            DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
+            // Force the autosaver to instantiate so it subscribes to GandalfSettings.PropertyChanged.
+            // Same pattern as Celebrimbor/Elrond — the saver is registered but DI won't construct
+            // it unless something explicitly requests it.
+            _ = sp.GetRequiredService<SettingsAutoSaver<GandalfSettings>>();
+            return new GandalfShellView
+            {
+                DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
+            };
         });
 
         services.AddSingleton<GandalfSettingsViewModel>();

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -114,12 +114,19 @@ public static class ServiceCollectionExtensions
             .AddSingleton(sp =>
                 sp.GetRequiredService<ISettingsStore<IconSettings>>().Load())
             .AddSingleton<SettingsAutoSaver<IconSettings>>()
-            .AddSingleton<IIconCacheService>(sp => new IconCacheService(
-                cacheDirectory,
-                sp.GetRequiredService<HttpClient>(),
-                sp.GetRequiredService<IReferenceDataService>(),
-                sp.GetRequiredService<IDiagnosticsSink>(),
-                sp.GetRequiredService<IconSettings>()));
+            .AddSingleton<IIconCacheService>(sp =>
+            {
+                // Force the autosaver to instantiate so it subscribes to IconSettings.PropertyChanged.
+                // Same pattern as Celebrimbor/Elrond — the saver is registered but DI won't construct
+                // it unless something explicitly requests it.
+                _ = sp.GetRequiredService<SettingsAutoSaver<IconSettings>>();
+                return new IconCacheService(
+                    cacheDirectory,
+                    sp.GetRequiredService<HttpClient>(),
+                    sp.GetRequiredService<IReferenceDataService>(),
+                    sp.GetRequiredService<IDiagnosticsSink>(),
+                    sp.GetRequiredService<IconSettings>());
+            });
     }
 
     public static IServiceCollection AddMithrilHotkeys(this IServiceCollection services) =>

--- a/src/Smaug.Module/SmaugModule.cs
+++ b/src/Smaug.Module/SmaugModule.cs
@@ -56,6 +56,10 @@ public sealed class SmaugModule : IMithrilModule
 
         services.AddSingleton<SmaugView>(sp =>
         {
+            // Force the autosaver to instantiate so it subscribes to SmaugSettings.PropertyChanged.
+            // Same pattern as Celebrimbor/Elrond — the saver is registered but DI won't construct
+            // it unless something explicitly requests it.
+            _ = sp.GetRequiredService<SettingsAutoSaver<SmaugSettings>>();
             var view = new SmaugView();
             view.AddTab("Vendor Shop", new VendorShopTab { DataContext = sp.GetRequiredService<VendorShopViewModel>() });
             view.AddTab("Storage Sellback", new StorageSellbackTab { DataContext = sp.GetRequiredService<StorageSellbackViewModel>() });
@@ -65,9 +69,16 @@ public sealed class SmaugModule : IMithrilModule
             view.AddTab("Calibration", new CalibrationTab { DataContext = sp.GetRequiredService<CalibrationViewModel>() });
             return view;
         });
-        services.AddSingleton<SmaugSettingsView>(sp => new SmaugSettingsView
+        services.AddSingleton<SmaugSettingsView>(sp =>
         {
-            DataContext = sp.GetRequiredService<SmaugSettings>(),
+            // Same discard-resolve as the SmaugView factory — a user opening
+            // Settings without ever opening the main Smaug tab would otherwise
+            // never trigger the autosaver's construction.
+            _ = sp.GetRequiredService<SettingsAutoSaver<SmaugSettings>>();
+            return new SmaugSettingsView
+            {
+                DataContext = sp.GetRequiredService<SmaugSettings>(),
+            };
         });
 
         services.AddHostedService<VendorIngestionService>();


### PR DESCRIPTION
## Summary

- Audited every `SettingsAutoSaver<T>` registration; three sites had no resolution path (Smaug, Gandalf, IconSettings) — DI never constructed the saver, so `PropertyChanged` was never subscribed and settings never persisted across restarts.
- Apply the same discard-resolve pattern that PR #100 used for Elrond: each broken site now force-resolves the saver from the factory of a view it can't avoid creating.
- Smaug got the pattern in **both** `SmaugView` and `SmaugSettingsView` factories — a user can open the gear-icon Settings page without ever opening the main tab, so each entry point needs to trigger activation independently.

Tracked in: #101. Follows up on #100.

## What was broken

| Module | Symptom |
|---|---|
| Smaug | Calibration source / auto-refresh toggles in the Settings page reverted on every restart |
| Gandalf | Alarm volume + sound preferences reverted on every restart |
| IconSettings | Icon-cache preferences (cache size, etc.) reverted on every restart |

`PriceCalibrationData` (the observation log behind Smaug's Calibration **tab**) is unaffected — it persists via `PriceCalibrationService.Save()` directly, not through `SettingsAutoSaver`.

## Test plan

Manually verified by @arthur-conde:

- [x] Smaug — open Settings (gear icon) **without** opening the main tab first, change Calibration source, restart, confirm persistence.
- [x] Smaug — open main tab → Calibration tab path also still persists changes made via Settings.
- [ ] Gandalf — change alarm volume, restart, confirm persistence.
- [ ] IconSettings — change a property on `IconSettings`, restart, confirm `%LocalAppData%\Mithril\Icons\settings.json` reflects the change.
- [x] `dotnet build Mithril.slnx` — clean.
- [x] `dotnet test Mithril.slnx` — 1218 tests pass.

## Follow-up

Issue #101 also tracks a longer-term refactor: an `AddMithrilSettings<T>` helper that makes `SettingsAutoSaver<T>` itself an `IHostedService`, so Generic Host always activates it eagerly and the foot-gun is gone for any future module. Coming as a separate PR after this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)