### PR TITLE
refactor(settings): AddMithrilSettings<T> helper closes #101 foot-gun

### DIFF
--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -38,11 +38,7 @@ public sealed class ArwenModule : IMithrilModule
         var settingsPath = Path.Combine(arwenDir, "settings.json");
 
         // Global preferences (just Calibration now that FavorStates has split into per-char arwen.json).
-        services.AddSingleton<ISettingsStore<ArwenSettings>>(_ =>
-            new JsonSettingsStore<ArwenSettings>(settingsPath, ArwenJsonContext.Default.ArwenSettings));
-        services.AddSingleton<ArwenSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<ArwenSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<ArwenSettings>>();
+        services.AddMithrilSettings<ArwenSettings>(settingsPath, ArwenJsonContext.Default.ArwenSettings);
 
         // Per-character favor state (exact favor values parsed from Player.log).
         services.AddPerCharacterModuleStore<ArwenFavorState>(Id, ArwenFavorStateJsonContext.Default.ArwenFavorState);

--- a/src/Bilbo.Module/BilboModule.cs
+++ b/src/Bilbo.Module/BilboModule.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Bilbo.Domain;
 using Bilbo.ViewModels;
 using Bilbo.Views;
+using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Wpf;
 using MahApps.Metro.IconPacks;
@@ -26,11 +27,7 @@ public sealed class BilboModule : IMithrilModule
         var localApp = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var settingsPath = Path.Combine(localApp, "Mithril", "Bilbo", "settings.json");
 
-        services.AddSingleton<ISettingsStore<BilboSettings>>(_ =>
-            new JsonSettingsStore<BilboSettings>(settingsPath, BilboSettingsJsonContext.Default.BilboSettings));
-        services.AddSingleton<BilboSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<BilboSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<BilboSettings>>();
+        services.AddMithrilSettings<BilboSettings>(settingsPath, BilboSettingsJsonContext.Default.BilboSettings);
 
         services.AddSingleton<StorageViewModel>();
         services.AddSingleton<StorageView>(sp => new StorageView(

--- a/src/Celebrimbor.Module/CelebrimborModule.cs
+++ b/src/Celebrimbor.Module/CelebrimborModule.cs
@@ -3,6 +3,7 @@ using Celebrimbor.Domain;
 using Celebrimbor.Services;
 using Celebrimbor.ViewModels;
 using Celebrimbor.Views;
+using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf;
@@ -27,11 +28,7 @@ public sealed class CelebrimborModule : IMithrilModule
         var localApp = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var settingsPath = Path.Combine(localApp, "Mithril", "Celebrimbor", "settings.json");
 
-        services.AddSingleton<ISettingsStore<CelebrimborSettings>>(_ =>
-            new JsonSettingsStore<CelebrimborSettings>(settingsPath, CelebrimborSettingsJsonContext.Default.CelebrimborSettings));
-        services.AddSingleton<CelebrimborSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<CelebrimborSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<CelebrimborSettings>>();
+        services.AddMithrilSettings<CelebrimborSettings>(settingsPath, CelebrimborSettingsJsonContext.Default.CelebrimborSettings);
 
         services.AddSingleton<RecipeAggregator>();
         services.AddSingleton<RecipeSearchIndex>();
@@ -44,23 +41,13 @@ public sealed class CelebrimborModule : IMithrilModule
         services.AddSingleton<CelebrimborShellViewModel>();
         services.AddSingleton<CelebrimborSettingsViewModel>();
 
-        services.AddSingleton<CelebrimborShellView>(sp =>
+        services.AddSingleton<CelebrimborShellView>(sp => new CelebrimborShellView
         {
-            // Resolve the auto-saver here so its INotifyPropertyChanged subscriptions are live
-            // as soon as the module view is built. DI singletons are otherwise lazy.
-            _ = sp.GetRequiredService<SettingsAutoSaver<CelebrimborSettings>>();
-            return new CelebrimborShellView
-            {
-                DataContext = sp.GetRequiredService<CelebrimborShellViewModel>(),
-            };
+            DataContext = sp.GetRequiredService<CelebrimborShellViewModel>(),
         });
-        services.AddSingleton<CelebrimborSettingsView>(sp =>
+        services.AddSingleton<CelebrimborSettingsView>(sp => new CelebrimborSettingsView
         {
-            _ = sp.GetRequiredService<SettingsAutoSaver<CelebrimborSettings>>();
-            return new CelebrimborSettingsView
-            {
-                DataContext = sp.GetRequiredService<CelebrimborSettingsViewModel>(),
-            };
+            DataContext = sp.GetRequiredService<CelebrimborSettingsViewModel>(),
         });
     }
 }

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -3,6 +3,7 @@ using Elrond.Domain;
 using Elrond.Services;
 using Elrond.ViewModels;
 using Elrond.Views;
+using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Modules;
 using MahApps.Metro.IconPacks;
 using Mithril.Shared.Settings;
@@ -27,28 +28,17 @@ public sealed class ElrondModule : IMithrilModule
         var elrondDir = Path.Combine(localApp, "Mithril", "Elrond");
         var settingsPath = Path.Combine(elrondDir, "settings.json");
 
-        services.AddSingleton<ISettingsStore<ElrondSettings>>(_ =>
-            new JsonSettingsStore<ElrondSettings>(settingsPath, ElrondSettingsJsonContext.Default.ElrondSettings));
-        services.AddSingleton<ElrondSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<ElrondSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<ElrondSettings>>();
+        services.AddMithrilSettings<ElrondSettings>(settingsPath, ElrondSettingsJsonContext.Default.ElrondSettings);
 
         services.AddSingleton<SkillAdvisorEngine>();
         services.AddSingleton<LevelingSimulator>();
 
-        services.AddSingleton<SkillAdvisorViewModel>(sp =>
-        {
-            // Force the autosaver to instantiate so it subscribes to ElrondSettings.PropertyChanged.
-            // Same pattern as Celebrimbor/Bilbo — the saver is registered but DI won't construct
-            // it unless something explicitly requests it.
-            _ = sp.GetRequiredService<SettingsAutoSaver<ElrondSettings>>();
-            return new SkillAdvisorViewModel(
-                sp.GetRequiredService<SkillAdvisorEngine>(),
-                sp.GetRequiredService<LevelingSimulator>(),
-                sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
-                sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
-                sp.GetRequiredService<ElrondSettings>());
-        });
+        services.AddSingleton<SkillAdvisorViewModel>(sp => new SkillAdvisorViewModel(
+            sp.GetRequiredService<SkillAdvisorEngine>(),
+            sp.GetRequiredService<LevelingSimulator>(),
+            sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
+            sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
+            sp.GetRequiredService<ElrondSettings>()));
         services.AddSingleton<SkillAdvisorView>(sp => new SkillAdvisorView
         {
             DataContext = sp.GetRequiredService<SkillAdvisorViewModel>(),

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -36,11 +36,7 @@ public sealed class GandalfModule : IMithrilModule
         var lootCatalogPath = Path.Combine(gandalfDir, "loot-catalog.json");
 
         // Global user preferences (alarm volume, sound picker, etc) stay app-wide.
-        services.AddSingleton<ISettingsStore<GandalfSettings>>(_ =>
-            new JsonSettingsStore<GandalfSettings>(settingsPath, GandalfSettingsJsonContext.Default.GandalfSettings));
-        services.AddSingleton<GandalfSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<GandalfSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<GandalfSettings>>();
+        services.AddMithrilSettings<GandalfSettings>(settingsPath, GandalfSettingsJsonContext.Default.GandalfSettings);
 
         // Global timer definitions — one file, shared across every character.
         services.AddSingleton<ISettingsStore<GandalfDefinitions>>(_ =>
@@ -131,16 +127,9 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<ICharacterPresenceService>()));
 
         services.AddSingleton<GandalfShellViewModel>();
-        services.AddSingleton<GandalfShellView>(sp =>
+        services.AddSingleton<GandalfShellView>(sp => new GandalfShellView
         {
-            // Force the autosaver to instantiate so it subscribes to GandalfSettings.PropertyChanged.
-            // Same pattern as Celebrimbor/Elrond — the saver is registered but DI won't construct
-            // it unless something explicitly requests it.
-            _ = sp.GetRequiredService<SettingsAutoSaver<GandalfSettings>>();
-            return new GandalfShellView
-            {
-                DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
-            };
+            DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
         });
 
         services.AddSingleton<GandalfSettingsViewModel>();

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
@@ -31,11 +32,7 @@ public sealed class LegolasModule : IMithrilModule
         var dir = Path.Combine(localApp, "Mithril", "Legolas");
         var settingsPath = Path.Combine(dir, "settings.json");
 
-        services.AddSingleton<ISettingsStore<LegolasSettings>>(_ =>
-            new JsonSettingsStore<LegolasSettings>(settingsPath, LegolasSettingsJsonContext.Default.LegolasSettings));
-        services.AddSingleton<LegolasSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<LegolasSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<LegolasSettings>>();
+        services.AddMithrilSettings<LegolasSettings>(settingsPath, LegolasSettingsJsonContext.Default.LegolasSettings);
         services.AddSingleton<InventoryGridSettings>(sp =>
             sp.GetRequiredService<LegolasSettings>().InventoryGrid);
 

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Net.Http;
 using System.Text.Json.Serialization.Metadata;
 using Mithril.Shared.Character;
@@ -105,28 +106,44 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<HttpClient>(),
                 sp.GetRequiredService<IDiagnosticsSink>()));
 
+    /// <summary>
+    /// Register a settings type for JSON persistence with debounced autosave on
+    /// every <see cref="INotifyPropertyChanged.PropertyChanged"/> event. Registers:
+    /// <list type="bullet">
+    /// <item><see cref="ISettingsStore{T}"/> backed by <see cref="JsonSettingsStore{T}"/> at <paramref name="settingsPath"/></item>
+    /// <item><typeparamref name="T"/> as a singleton, loaded from the store</item>
+    /// <item><see cref="SettingsAutoSaver{T}"/> as both singleton and <c>IHostedService</c>, so Generic Host always activates it eagerly at startup</item>
+    /// </list>
+    /// The hosted-service registration is what closes the silent-failure foot-gun
+    /// from #101: previously each module had to remember to inject the saver
+    /// somewhere or use a discard-resolve in a factory; now activation is automatic.
+    /// </summary>
+    public static IServiceCollection AddMithrilSettings<T>(
+        this IServiceCollection services,
+        string settingsPath,
+        JsonTypeInfo<T> typeInfo)
+        where T : class, INotifyPropertyChanged, new()
+    {
+        services.AddSingleton<ISettingsStore<T>>(_ =>
+            new JsonSettingsStore<T>(settingsPath, typeInfo));
+        services.AddSingleton<T>(sp =>
+            sp.GetRequiredService<ISettingsStore<T>>().Load());
+        services.AddSingleton<SettingsAutoSaver<T>>();
+        services.AddHostedService(sp => sp.GetRequiredService<SettingsAutoSaver<T>>());
+        return services;
+    }
+
     public static IServiceCollection AddMithrilIcons(this IServiceCollection services, string cacheDirectory)
     {
         var settingsPath = System.IO.Path.Combine(cacheDirectory, "settings.json");
-        return services
-            .AddSingleton<ISettingsStore<IconSettings>>(_ =>
-                new JsonSettingsStore<IconSettings>(settingsPath, IconSettingsJsonContext.Default.IconSettings))
-            .AddSingleton(sp =>
-                sp.GetRequiredService<ISettingsStore<IconSettings>>().Load())
-            .AddSingleton<SettingsAutoSaver<IconSettings>>()
-            .AddSingleton<IIconCacheService>(sp =>
-            {
-                // Force the autosaver to instantiate so it subscribes to IconSettings.PropertyChanged.
-                // Same pattern as Celebrimbor/Elrond — the saver is registered but DI won't construct
-                // it unless something explicitly requests it.
-                _ = sp.GetRequiredService<SettingsAutoSaver<IconSettings>>();
-                return new IconCacheService(
-                    cacheDirectory,
-                    sp.GetRequiredService<HttpClient>(),
-                    sp.GetRequiredService<IReferenceDataService>(),
-                    sp.GetRequiredService<IDiagnosticsSink>(),
-                    sp.GetRequiredService<IconSettings>());
-            });
+        services.AddMithrilSettings<IconSettings>(settingsPath, IconSettingsJsonContext.Default.IconSettings);
+        services.AddSingleton<IIconCacheService>(sp => new IconCacheService(
+            cacheDirectory,
+            sp.GetRequiredService<HttpClient>(),
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IDiagnosticsSink>(),
+            sp.GetRequiredService<IconSettings>()));
+        return services;
     }
 
     public static IServiceCollection AddMithrilHotkeys(this IServiceCollection services) =>

--- a/src/Mithril.Shared/Settings/SettingsAutoSaver.cs
+++ b/src/Mithril.Shared/Settings/SettingsAutoSaver.cs
@@ -1,9 +1,10 @@
 using System.ComponentModel;
 using System.Windows.Threading;
+using Microsoft.Extensions.Hosting;
 
 namespace Mithril.Shared.Settings;
 
-public sealed class SettingsAutoSaver<T> : IDisposable where T : class, INotifyPropertyChanged, new()
+public sealed class SettingsAutoSaver<T> : IHostedService, IDisposable where T : class, INotifyPropertyChanged, new()
 {
     private readonly ISettingsStore<T> _store;
     private readonly T _instance;
@@ -17,6 +18,18 @@ public sealed class SettingsAutoSaver<T> : IDisposable where T : class, INotifyP
         _timer = new DispatcherTimer { Interval = debounce ?? TimeSpan.FromMilliseconds(500) };
         _timer.Tick += OnTick;
         _instance.PropertyChanged += OnChanged;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>Flush any pending dirty state synchronously on graceful shutdown
+    /// — closes the small data-loss window where the user edits a setting and
+    /// closes the app within the debounce interval (500ms by default).</summary>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer.Stop();
+        FlushIfDirty();
+        return Task.CompletedTask;
     }
 
     private void OnChanged(object? sender, PropertyChangedEventArgs e)
@@ -36,6 +49,11 @@ public sealed class SettingsAutoSaver<T> : IDisposable where T : class, INotifyP
     private void OnTick(object? sender, EventArgs e)
     {
         _timer.Stop();
+        FlushIfDirty();
+    }
+
+    private void FlushIfDirty()
+    {
         if (!_dirty) return;
         _dirty = false;
         try { _store.Save(_instance); }
@@ -47,6 +65,5 @@ public sealed class SettingsAutoSaver<T> : IDisposable where T : class, INotifyP
         _timer.Stop();
         _timer.Tick -= OnTick;
         _instance.PropertyChanged -= OnChanged;
-        if (_dirty) try { _store.Save(_instance); } catch { }
     }
 }

--- a/src/Samwise.Module/SamwiseModule.cs
+++ b/src/Samwise.Module/SamwiseModule.cs
@@ -49,11 +49,7 @@ public sealed class SamwiseModule : IMithrilModule
         services.AddSingleton<AlarmService>();
 
         // Global preferences stay app-wide.
-        services.AddSingleton<ISettingsStore<SamwiseSettings>>(_ =>
-            new JsonSettingsStore<SamwiseSettings>(settingsPath, SamwiseSettingsJsonContext.Default.SamwiseSettings));
-        services.AddSingleton<SamwiseSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<SamwiseSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<SamwiseSettings>>();
+        services.AddMithrilSettings<SamwiseSettings>(settingsPath, SamwiseSettingsJsonContext.Default.SamwiseSettings);
 
         // Garden state is per-character; store each char's plot dict in its own file.
         services.AddPerCharacterModuleStore<GardenCharacterState>(Id,

--- a/src/Smaug.Module/SmaugModule.cs
+++ b/src/Smaug.Module/SmaugModule.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
@@ -29,11 +30,7 @@ public sealed class SmaugModule : IMithrilModule
         var localApp = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var settingsPath = Path.Combine(localApp, "Mithril", "Smaug", "settings.json");
 
-        services.AddSingleton<ISettingsStore<SmaugSettings>>(_ =>
-            new JsonSettingsStore<SmaugSettings>(settingsPath, SmaugJsonContext.Default.SmaugSettings));
-        services.AddSingleton<SmaugSettings>(sp =>
-            sp.GetRequiredService<ISettingsStore<SmaugSettings>>().Load());
-        services.AddSingleton<SettingsAutoSaver<SmaugSettings>>();
+        services.AddMithrilSettings<SmaugSettings>(settingsPath, SmaugJsonContext.Default.SmaugSettings);
 
         services.AddSingleton<VendorLogParser>();
         services.AddSingleton<VendorSellContext>();
@@ -56,10 +53,6 @@ public sealed class SmaugModule : IMithrilModule
 
         services.AddSingleton<SmaugView>(sp =>
         {
-            // Force the autosaver to instantiate so it subscribes to SmaugSettings.PropertyChanged.
-            // Same pattern as Celebrimbor/Elrond — the saver is registered but DI won't construct
-            // it unless something explicitly requests it.
-            _ = sp.GetRequiredService<SettingsAutoSaver<SmaugSettings>>();
             var view = new SmaugView();
             view.AddTab("Vendor Shop", new VendorShopTab { DataContext = sp.GetRequiredService<VendorShopViewModel>() });
             view.AddTab("Storage Sellback", new StorageSellbackTab { DataContext = sp.GetRequiredService<StorageSellbackViewModel>() });
@@ -69,16 +62,9 @@ public sealed class SmaugModule : IMithrilModule
             view.AddTab("Calibration", new CalibrationTab { DataContext = sp.GetRequiredService<CalibrationViewModel>() });
             return view;
         });
-        services.AddSingleton<SmaugSettingsView>(sp =>
+        services.AddSingleton<SmaugSettingsView>(sp => new SmaugSettingsView
         {
-            // Same discard-resolve as the SmaugView factory — a user opening
-            // Settings without ever opening the main Smaug tab would otherwise
-            // never trigger the autosaver's construction.
-            _ = sp.GetRequiredService<SettingsAutoSaver<SmaugSettings>>();
-            return new SmaugSettingsView
-            {
-                DataContext = sp.GetRequiredService<SmaugSettings>(),
-            };
+            DataContext = sp.GetRequiredService<SmaugSettings>(),
         });
 
         services.AddHostedService<VendorIngestionService>();

--- a/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
+++ b/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
@@ -13,13 +13,19 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
-    <!-- Module references exist solely so LogPatternCatalogParityTests can
-         reflect over [GeneratedRegex] attributes in module-level parsers. -->
+    <!-- Module references support both LogPatternCatalogParityTests (reflects over
+         [GeneratedRegex] attributes in module-level parsers) and
+         SettingsAutoSaverActivationTests (loops over every module's Register call
+         and asserts SettingsAutoSaver<T> resolves at the module gate). -->
     <ProjectReference Include="..\..\src\Samwise.Module\Samwise.Module.csproj" />
     <ProjectReference Include="..\..\src\Arwen.Module\Arwen.Module.csproj" />
     <ProjectReference Include="..\..\src\Smaug.Module\Smaug.Module.csproj" />
     <ProjectReference Include="..\..\src\Pippin.Module\Pippin.Module.csproj" />
     <ProjectReference Include="..\..\src\Saruman.Module\Saruman.Module.csproj" />
     <ProjectReference Include="..\..\src\Legolas.Module\Legolas.Module.csproj" />
+    <ProjectReference Include="..\..\src\Bilbo.Module\Bilbo.Module.csproj" />
+    <ProjectReference Include="..\..\src\Celebrimbor.Module\Celebrimbor.Module.csproj" />
+    <ProjectReference Include="..\..\src\Elrond.Module\Elrond.Module.csproj" />
+    <ProjectReference Include="..\..\src\Gandalf.Module\Gandalf.Module.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Mithril.Shared.Tests/Settings/SettingsAutoSaverActivationTests.cs
+++ b/tests/Mithril.Shared.Tests/Settings/SettingsAutoSaverActivationTests.cs
@@ -1,0 +1,153 @@
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Settings;
+
+/// <summary>
+/// Regression net for #101. The bug class: a module registers
+/// <see cref="SettingsAutoSaver{T}"/> as a singleton but nothing in the DI
+/// graph forces it to construct, so it never subscribes to PropertyChanged
+/// and settings silently fail to persist across restarts.
+///
+/// The helper <see cref="ServiceCollectionExtensions.AddMithrilSettings{T}"/>
+/// closes the gap by also registering the saver as an <see cref="IHostedService"/>.
+/// Generic Host eagerly activates every IHostedService, so the saver always
+/// constructs at startup. These tests assert that contract.
+/// </summary>
+public class SettingsAutoSaverActivationTests
+{
+    /// <summary>
+    /// Every module under test. Statically referenced so the assemblies are
+    /// loaded by the time xunit collects MemberData (AppDomain enumeration
+    /// doesn't see lazy-loaded module assemblies).
+    /// </summary>
+    public static IEnumerable<object[]> AllModules() => new IMithrilModule[]
+    {
+        new Samwise.SamwiseModule(),
+        new Arwen.ArwenModule(),
+        new Bilbo.BilboModule(),
+        new Celebrimbor.CelebrimborModule(),
+        new Elrond.ElrondModule(),
+        new Gandalf.GandalfModule(),
+        new Legolas.LegolasModule(),
+        new Smaug.SmaugModule(),
+        new Pippin.PippinModule(),
+        new Saruman.SarumanModule(),
+    }.Select(m => new object[] { m });
+
+    [Theory]
+    [MemberData(nameof(AllModules))]
+    public void Module_pairs_every_SettingsAutoSaver_with_an_IHostedService(IMithrilModule module)
+    {
+        var services = new ServiceCollection();
+        module.Register(services);
+
+        var saverTypes = services
+            .Where(d => d.ServiceType.IsGenericType
+                     && d.ServiceType.GetGenericTypeDefinition() == typeof(SettingsAutoSaver<>))
+            .Select(d => d.ServiceType)
+            .Distinct()
+            .ToList();
+
+        if (saverTypes.Count == 0) return;
+
+        var hostedFactories = services
+            .Where(d => d.ServiceType == typeof(IHostedService) && d.ImplementationFactory is not null)
+            .Select(d => d.ImplementationFactory!)
+            .ToList();
+
+        foreach (var saverType in saverTypes)
+        {
+            var settingsType = saverType.GetGenericArguments()[0];
+            var storeType = typeof(ISettingsStore<>).MakeGenericType(settingsType);
+
+            // Build a minimal sub-provider with just the saver's own dependencies.
+            // Avoids dragging in unrelated module deps (HttpClient, log streams, etc.).
+            IServiceCollection sub = new ServiceCollection();
+            foreach (var d in services)
+            {
+                if (d.ServiceType == saverType
+                 || d.ServiceType == settingsType
+                 || d.ServiceType == storeType)
+                {
+                    sub.Add(d);
+                }
+            }
+
+            using var sp = sub.BuildServiceProvider();
+            var saver = sp.GetRequiredService(saverType);
+
+            // Probe each hosted-service factory. The matching one is whichever
+            // returns the saver instance when handed the same sub-provider.
+            var matched = hostedFactories.Any(f =>
+            {
+                try { return ReferenceEquals(f(sp), saver); }
+                catch { return false; }
+            });
+
+            matched.Should().BeTrue(
+                $"{module.GetType().Name} registers {saverType.Name} as a singleton but " +
+                $"nothing forces it to activate. Use AddMithrilSettings<{settingsType.Name}> " +
+                $"so the saver is also registered as an IHostedService.");
+        }
+    }
+
+    [Fact]
+    public void AddMithrilSettings_registers_store_instance_saver_and_hosted_service()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"mithril-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddMithrilSettings<FakeSettings>(tempPath, FakeSettingsJsonContext.Default.FakeSettings);
+
+            using var sp = services.BuildServiceProvider();
+
+            sp.GetRequiredService<ISettingsStore<FakeSettings>>().Should().NotBeNull();
+            sp.GetRequiredService<FakeSettings>().Should().NotBeNull();
+
+            var saver = sp.GetRequiredService<SettingsAutoSaver<FakeSettings>>();
+            saver.Should().NotBeNull();
+
+            // The hosted service registration MUST resolve to the same instance —
+            // otherwise StopAsync's flush hits a different saver than the one the
+            // settings instance is subscribed to.
+            var hosted = sp.GetServices<IHostedService>().OfType<SettingsAutoSaver<FakeSettings>>().Single();
+            hosted.Should().BeSameAs(saver);
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+}
+
+public sealed class FakeSettings : INotifyPropertyChanged
+{
+    private string _value = "";
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            if (_value == value) return;
+            _value = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+        }
+    }
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+[System.Text.Json.Serialization.JsonSerializable(typeof(FakeSettings))]
+public partial class FakeSettingsJsonContext : System.Text.Json.Serialization.JsonSerializerContext;


### PR DESCRIPTION
## Summary

- Promotes `SettingsAutoSaver<T>` to `IHostedService` so Generic Host eagerly activates it at app startup. The saver always constructs and subscribes to `PropertyChanged` — no more silent failure when nothing in the DI graph happens to resolve it.
- Bundles store + instance + saver registration into one `AddMithrilSettings<T>(settingsPath, JsonTypeInfo<T>)` extension. All 9 settings registrations across the codebase collapse from 3 lines to 1.
- All 5 discard-resolves drop out as dead code (the 3 from #102 plus the pre-existing 2 in Celebrimbor and Elrond). Adding a new settings type is now a one-liner that **cannot** silently fail.

Closes #101. Follows up on #102 (the immediate hotfix).

## Behavioral changes

1. **Eager activation.** Lazy-module settings files (Bilbo, Celebrimbor, Elrond, Legolas, Smaug) now load at app startup instead of on first tab open. Cost is negligible — `JsonSettingsStore.Load` is `File.Exists` + `File.OpenRead` + `JsonSerializer.Deserialize`. One small upside: malformed JSON now throws at startup instead of mysteriously when a particular tab is opened.
2. **Graceful-shutdown flush.** `SettingsAutoSaver<T>.StopAsync` now flushes pending dirty state synchronously — closes the small data-loss window where the user edits a setting and closes the app within the 500ms debounce interval. Previously nothing called `Dispose` on the saver at shutdown, so the final-flush branch never ran.

## Constraint check

`AddMithrilSettings<T>` requires `T : class, INotifyPropertyChanged, new()`. Gandalf's two non-saver stores (`GandalfDefinitions`, `LootCatalogCache`) don't implement INPC, so the helper's signature won't accept them — they keep their existing manual registration. The constraint naturally distinguishes "auto-saved settings" from "load-only data files."

## Regression test

`SettingsAutoSaverActivationTests` loops over every `IMithrilModule` and asserts each `SettingsAutoSaver<T>` registration is paired with an `IHostedService` that resolves to the same instance. Catches the entire #101 bug class for any future module. Verified by temporarily reverting Bilbo to the old triple shape — test correctly fails with a precise error message naming the offending module and settings type.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean.
- [x] `dotnet test Mithril.slnx` — 1229 tests pass (was 1218, added 11 new ones: 10 per-module + 1 helper).
- [x] App launches cleanly, no exceptions in `%LocalAppData%\Mithril\logs\`.
- [x] PR #102's persistence wins (Smaug Settings, Gandalf alarm volume, IconSettings) still work.
- [x] Graceful-shutdown final-flush: edit a setting, close within 500ms, restart, change persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)