### PR TITLE
feat(pippin): share Gourmand progress (text, link, image)

### DIFF
--- a/src/Celebrimbor.Module/Services/CraftListFormat.cs
+++ b/src/Celebrimbor.Module/Services/CraftListFormat.cs
@@ -1,10 +1,9 @@
 using System.Globalization;
-using System.IO;
-using System.IO.Compression;
 using System.Text;
 using System.Text.RegularExpressions;
 using Celebrimbor.Domain;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Sharing;
 
 namespace Celebrimbor.Services;
 
@@ -88,33 +87,16 @@ public static partial class CraftListFormat
     // ---- Share-link encoding ------------------------------------------------
     //
     // mithril://list/<base64url> deep links embed a compressed copy of the plain-text share
-    // format. Format is: one version byte, then gzip(UTF-8 plain-text). v1 is the only version
-    // today; the prefix reserves room to swap the compression or switch formats later without
-    // invalidating existing pastes. Base64url keeps the URL free of the '+' and '/' characters
-    // that would otherwise need percent-encoding.
-    //
-    // Cap on decoded size: we refuse payloads that decompress past a sane ceiling so a
-    // pathological or malicious link can't pin the UI thread or blow the heap.
-
-    private const byte ShareLinkVersion = 1;
-    private const int MaxDecompressedBytes = 256 * 1024; // 256 KB of plain text is absurdly large
+    // format. The envelope (version byte + gzip + base64url) lives in
+    // <see cref="ShareCodec"/> so other modules (Pippin progress, …) share one
+    // implementation.
 
     /// <summary>
     /// Encodes a craft list into the base64url payload for a <c>mithril://list/…</c> deep link.
     /// Returns just the payload — callers prepend the scheme/host.
     /// </summary>
     public static string EncodeShareLink(IReadOnlyList<CraftListEntry> entries, DateTimeOffset? stampedAt = null)
-    {
-        var text = Serialize(entries, stampedAt);
-        var textBytes = Encoding.UTF8.GetBytes(text);
-
-        using var ms = new MemoryStream();
-        ms.WriteByte(ShareLinkVersion);
-        using (var gz = new GZipStream(ms, CompressionLevel.Optimal, leaveOpen: true))
-            gz.Write(textBytes, 0, textBytes.Length);
-
-        return Base64UrlEncode(ms.ToArray());
-    }
+        => ShareCodec.EncodePayload(Serialize(entries, stampedAt));
 
     /// <summary>
     /// Decodes a base64url deep-link payload into the plain-text share format, then parses it.
@@ -124,58 +106,9 @@ public static partial class CraftListFormat
     /// </summary>
     public static ParseResult DecodeShareLink(string base64UrlPayload, IReferenceDataService refData)
     {
-        if (string.IsNullOrWhiteSpace(base64UrlPayload))
-            return new ParseResult([], ["Share link is empty."]);
-
-        byte[] bytes;
-        try { bytes = Base64UrlDecode(base64UrlPayload); }
-        catch (FormatException)
-        {
-            return new ParseResult([], ["Share link is not valid base64url."]);
-        }
-
-        if (bytes.Length < 2)
-            return new ParseResult([], ["Share link payload is too short."]);
-        if (bytes[0] != ShareLinkVersion)
-            return new ParseResult([], [$"Share link version {bytes[0]} is not supported (expected {ShareLinkVersion})."]);
-
-        string text;
-        try
-        {
-            using var gz = new GZipStream(new MemoryStream(bytes, 1, bytes.Length - 1), CompressionMode.Decompress);
-            using var bounded = new MemoryStream();
-            var buf = new byte[4096];
-            int total = 0, n;
-            while ((n = gz.Read(buf, 0, buf.Length)) > 0)
-            {
-                total += n;
-                if (total > MaxDecompressedBytes)
-                    return new ParseResult([], ["Share link expands past the 256 KB safety cap."]);
-                bounded.Write(buf, 0, n);
-            }
-            text = Encoding.UTF8.GetString(bounded.ToArray());
-        }
-        catch (InvalidDataException)
-        {
-            return new ParseResult([], ["Share link is not valid gzip data."]);
-        }
-
+        if (!ShareCodec.TryDecodePayload(base64UrlPayload, out var text, out var error))
+            return new ParseResult([], [error!]);
         return Parse(text, refData);
-    }
-
-    private static string Base64UrlEncode(byte[] bytes) =>
-        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
-
-    private static byte[] Base64UrlDecode(string s)
-    {
-        var padded = s.Replace('-', '+').Replace('_', '/');
-        switch (padded.Length % 4)
-        {
-            case 2: padded += "=="; break;
-            case 3: padded += "="; break;
-            case 1: throw new FormatException("Invalid base64url length.");
-        }
-        return Convert.FromBase64String(padded);
     }
 
     [GeneratedRegex(@"^\s*(?<name>[^\d#].*?)\s*[x×X]\s*(?<qty>-?\d+)\s*$")]

--- a/src/Mithril.Shared/Icons/IIconCacheService.cs
+++ b/src/Mithril.Shared/Icons/IIconCacheService.cs
@@ -29,4 +29,30 @@ public interface IIconCacheService
     /// Reports progress as (completed, total).
     /// </summary>
     Task DownloadAllAsync(IProgress<(int completed, int total)> progress, CancellationToken ct = default);
+
+    /// <summary>
+    /// Synchronous cache-state check. Returns true if the icon is already in memory
+    /// or on disk and can be served immediately without a network round-trip. Never
+    /// triggers a fetch and does not load anything into memory.
+    /// </summary>
+    bool IsCached(int iconId);
+
+    /// <summary>
+    /// Filter <paramref name="iconIds"/> to the subset that aren't cached yet.
+    /// Useful for preload prompts (e.g. the share dialog's icon-preload banner).
+    /// Distinct, preserves first-seen order, drops non-positive ids.
+    /// </summary>
+    IReadOnlyList<int> GetUncachedIcons(IEnumerable<int> iconIds);
+
+    /// <summary>
+    /// Fetch the given subset, skipping any already cached or known-terminally-failed.
+    /// Completes when every requested icon is in cache or has failed; reports
+    /// <c>(completed, total)</c> progress per resolution. <paramref name="total"/> is
+    /// the count of icons that actually needed a download — already-cached ids are
+    /// excluded so the bar reflects real work.
+    /// </summary>
+    Task PreloadAsync(
+        IEnumerable<int> iconIds,
+        IProgress<(int completed, int total)>? progress = null,
+        CancellationToken ct = default);
 }

--- a/src/Mithril.Shared/Icons/IconCacheService.cs
+++ b/src/Mithril.Shared/Icons/IconCacheService.cs
@@ -99,6 +99,65 @@ public sealed class IconCacheService : IIconCacheService
         ScanCache();
     }
 
+    public bool IsCached(int iconId)
+    {
+        if (iconId <= 0) return false;
+        if (_memCache.ContainsKey(iconId)) return true;
+        return File.Exists(GetDiskPath(iconId));
+    }
+
+    public IReadOnlyList<int> GetUncachedIcons(IEnumerable<int> iconIds)
+    {
+        var seen = new HashSet<int>();
+        var result = new List<int>();
+        foreach (var id in iconIds)
+        {
+            if (id <= 0) continue;
+            if (!seen.Add(id)) continue;
+            if (IsCached(id)) continue;
+            result.Add(id);
+        }
+        return result;
+    }
+
+    public async Task PreloadAsync(
+        IEnumerable<int> iconIds,
+        IProgress<(int completed, int total)>? progress = null,
+        CancellationToken ct = default)
+    {
+        // Snapshot the subset that actually needs work — already-cached and known-failed
+        // ids are dropped so the progress bar reflects real downloads, not no-ops.
+        var needed = new List<int>();
+        var seen = new HashSet<int>();
+        lock (_failed)
+        {
+            foreach (var id in iconIds)
+            {
+                if (id <= 0) continue;
+                if (!seen.Add(id)) continue;
+                if (IsCached(id)) continue;
+                if (_failed.Contains(id)) continue;
+                needed.Add(id);
+            }
+        }
+
+        var total = needed.Count;
+        progress?.Report((0, total));
+        if (total == 0) return;
+
+        var completed = 0;
+        var tasks = needed.Select(async iconId =>
+        {
+            ct.ThrowIfCancellationRequested();
+            await DownloadSingleAsync(iconId, ct).ConfigureAwait(false);
+            var c = Interlocked.Increment(ref completed);
+            progress?.Report((c, total));
+        });
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        ScanCache();
+    }
+
     public async Task DownloadAllAsync(IProgress<(int completed, int total)> progress, CancellationToken ct = default)
     {
         var allIconIds = _refData.Items.Values

--- a/src/Mithril.Shared/Modules/DeepLinkRouter.cs
+++ b/src/Mithril.Shared/Modules/DeepLinkRouter.cs
@@ -10,6 +10,8 @@ namespace Mithril.Shared.Modules;
 ///   <item><c>mithril://item/&lt;internalName&gt;</c> — opens <see cref="IItemDetailPresenter"/>.</item>
 ///   <item><c>mithril://list/&lt;base64url&gt;</c> — hands the payload to
 ///         <see cref="ICraftListImportTarget"/> (Celebrimbor).</item>
+///   <item><c>mithril://pippin/&lt;base64url&gt;</c> — hands the payload to
+///         <see cref="IPippinShareImportTarget"/> (Pippin shared progress).</item>
 /// </list>
 /// Each action defines its own payload grammar so item names stay strict while the craft-list
 /// payload can hold a much longer base64url blob. Unknown actions are logged and dropped.
@@ -22,22 +24,26 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
     // we refuse anything that could confuse downstream lookups or smuggle separators.
     private static readonly Regex ItemPayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
 
-    // mithril://list carries a base64url-encoded gzip payload. Base64url uses [A-Za-z0-9_-];
-    // cap length well above any plausible compressed craft-list (~8KB url) so we fail fast on
-    // anything pathological rather than handing it to the decoder.
+    // mithril://list and mithril://pippin both carry a base64url-encoded gzip payload.
+    // Base64url uses [A-Za-z0-9_-]; cap length well above any plausible compressed payload
+    // so we fail fast on anything pathological rather than handing it to the decoder.
     private static readonly Regex ListPayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
+    private static readonly Regex PippinPayloadPattern = new("^[A-Za-z0-9_-]{1,16384}$", RegexOptions.Compiled);
 
     private readonly IItemDetailPresenter _itemDetail;
     private readonly ICraftListImportTarget? _listImport;
+    private readonly IPippinShareImportTarget? _pippinImport;
     private readonly IDiagnosticsSink? _diag;
 
     public DeepLinkRouter(
         IItemDetailPresenter itemDetail,
         ICraftListImportTarget? listImport = null,
+        IPippinShareImportTarget? pippinImport = null,
         IDiagnosticsSink? diag = null)
     {
         _itemDetail = itemDetail;
         _listImport = listImport;
+        _pippinImport = pippinImport;
         _diag = diag;
     }
 
@@ -82,6 +88,20 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
                     return false;
                 }
                 _listImport.ImportFromLinkPayload(payload);
+                return true;
+
+            case "pippin":
+                if (!PippinPayloadPattern.IsMatch(payload))
+                {
+                    _diag?.Info("DeepLink", $"Rejected: pippin payload (len={payload.Length}) failed validation.");
+                    return false;
+                }
+                if (_pippinImport is null)
+                {
+                    _diag?.Info("DeepLink", "Rejected: no pippin import target registered.");
+                    return false;
+                }
+                _pippinImport.ImportFromLinkPayload(payload);
                 return true;
 
             default:

--- a/src/Mithril.Shared/Modules/IPippinShareImportTarget.cs
+++ b/src/Mithril.Shared/Modules/IPippinShareImportTarget.cs
@@ -1,0 +1,18 @@
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Optional target that handles <c>mithril://pippin/&lt;payload&gt;</c> deep links.
+/// Implemented by Pippin to decode the share payload, activate its tab, and present a
+/// read-only view of another player's Gourmand progress. The router treats it as
+/// optional — if no module has registered a handler, pippin links are logged and
+/// dropped.
+/// </summary>
+public interface IPippinShareImportTarget
+{
+    /// <summary>
+    /// Decodes <paramref name="base64UrlPayload"/> (the path segment from the deep link)
+    /// and shows the read-only progress view. All errors are logged and swallowed —
+    /// callers are OS activation handlers that mustn't throw.
+    /// </summary>
+    void ImportFromLinkPayload(string base64UrlPayload);
+}

--- a/src/Mithril.Shared/Sharing/ShareCodec.cs
+++ b/src/Mithril.Shared/Sharing/ShareCodec.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Mithril.Shared.Sharing;
+
+/// <summary>
+/// Compact, version-prefixed binary envelope used by <c>mithril://*</c> deep links to
+/// embed module-specific payloads in URLs. The envelope is one version byte followed by
+/// gzip-compressed UTF-8 text; the whole thing is base64url-encoded so the result is
+/// URL-safe without any percent-escaping.
+///
+/// Originally lived in Celebrimbor for craft-list sharing; lifted to Mithril.Shared so
+/// other modules (Pippin progress, future…) can share one implementation.
+/// </summary>
+public static class ShareCodec
+{
+    private const byte EnvelopeVersion = 1;
+
+    /// <summary>
+    /// Hard upper bound on the decompressed payload. Pathological or malicious links
+    /// won't pin the UI thread or blow the heap.
+    /// </summary>
+    public const int MaxDecompressedBytes = 256 * 1024;
+
+    /// <summary>
+    /// Encodes <paramref name="text"/> into the base64url envelope payload for a deep
+    /// link. Callers prepend the scheme/host (e.g. <c>mithril://pippin/</c>).
+    /// </summary>
+    public static string EncodePayload(string text)
+    {
+        var textBytes = Encoding.UTF8.GetBytes(text ?? string.Empty);
+
+        using var ms = new MemoryStream();
+        ms.WriteByte(EnvelopeVersion);
+        using (var gz = new GZipStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+            gz.Write(textBytes, 0, textBytes.Length);
+
+        return Base64UrlEncode(ms.ToArray());
+    }
+
+    /// <summary>
+    /// Decodes <paramref name="base64UrlPayload"/> back to its plain-text form. Returns
+    /// false (with a human-readable <paramref name="error"/>) for any malformed input —
+    /// callers are deep-link handlers that mustn't throw.
+    /// </summary>
+    public static bool TryDecodePayload(string? base64UrlPayload, out string text, out string? error)
+    {
+        text = string.Empty;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(base64UrlPayload))
+        {
+            error = "Share link is empty.";
+            return false;
+        }
+
+        byte[] bytes;
+        try { bytes = Base64UrlDecode(base64UrlPayload); }
+        catch (FormatException)
+        {
+            error = "Share link is not valid base64url.";
+            return false;
+        }
+
+        if (bytes.Length < 2)
+        {
+            error = "Share link payload is too short.";
+            return false;
+        }
+        if (bytes[0] != EnvelopeVersion)
+        {
+            error = $"Share link version {bytes[0]} is not supported (expected {EnvelopeVersion}).";
+            return false;
+        }
+
+        try
+        {
+            using var gz = new GZipStream(new MemoryStream(bytes, 1, bytes.Length - 1), CompressionMode.Decompress);
+            using var bounded = new MemoryStream();
+            var buf = new byte[4096];
+            int total = 0, n;
+            while ((n = gz.Read(buf, 0, buf.Length)) > 0)
+            {
+                total += n;
+                if (total > MaxDecompressedBytes)
+                {
+                    error = "Share link expands past the 256 KB safety cap.";
+                    return false;
+                }
+                bounded.Write(buf, 0, n);
+            }
+            text = Encoding.UTF8.GetString(bounded.ToArray());
+            return true;
+        }
+        catch (InvalidDataException)
+        {
+            error = "Share link is not valid gzip data.";
+            return false;
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string s)
+    {
+        var padded = s.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+            case 1: throw new FormatException("Invalid base64url length.");
+        }
+        return Convert.FromBase64String(padded);
+    }
+}

--- a/src/Mithril.Shared/Wpf/MithrilDataGrid.cs
+++ b/src/Mithril.Shared/Wpf/MithrilDataGrid.cs
@@ -172,6 +172,17 @@ public class MithrilDataGrid : DataGrid
             return;
         }
 
+        // Defensive: if we're already attached when Loaded fires (which WPF can do on its
+        // own — e.g. when a child Window with Owner=this window is closed and the visual
+        // tree re-templates), detach first so we re-capture the *VM's* filter rather than
+        // the composite filter we previously installed. Without this, repeated attach
+        // cycles wrap the composite around itself, preserving stale query predicates that
+        // outlive the QueryBox text being cleared.
+        if (_attachedView is not null)
+        {
+            DetachFromSource();
+        }
+
         _itemType = InferItemType(ItemsSource);
         if (_itemType is not null)
         {

--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -76,12 +76,13 @@ public static class ShellServiceCollectionExtensions
         services
             .AddSingleton<IItemDetailPresenter, ItemDetailPresenter>()
             .AddSingleton<IModuleActivator, ShellModuleActivator>()
-            // Factory form so ICraftListImportTarget and IDiagnosticsSink stay optional —
+            // Factory form so module-side import targets and IDiagnosticsSink stay optional —
             // modules register them at their discretion, and the router degrades gracefully
             // (deep links to absent handlers are logged + dropped, never thrown).
             .AddSingleton<IDeepLinkRouter>(sp => new DeepLinkRouter(
                 sp.GetRequiredService<IItemDetailPresenter>(),
                 sp.GetService<ICraftListImportTarget>(),
+                sp.GetService<IPippinShareImportTarget>(),
                 sp.GetService<IDiagnosticsSink>()));
 
     public static IServiceCollection AddMithrilIngredientSources(this IServiceCollection services) =>

--- a/src/Pippin.Module/Domain/FoodCatalog.cs
+++ b/src/Pippin.Module/Domain/FoodCatalog.cs
@@ -1,16 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Mithril.Shared.Reference;
 
 namespace Pippin.Domain;
 
 /// <summary>
-/// Builds a lookup of all edible foods from the CDN item catalog.
-/// Keyed by display name (matching the in-game Foods Consumed report).
+/// Builds a lookup of all edible foods from the CDN item catalog. Exposes both
+/// display-name and InternalName indices: the in-game Foods Consumed report only
+/// gives display names, but persisted state and share payloads key by InternalName
+/// so they survive renames and CDN drift.
 /// </summary>
 public sealed partial class FoodCatalog
 {
     private readonly IReferenceDataService _refData;
     private Dictionary<string, FoodEntry> _byName = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, FoodEntry> _byInternalName = new(StringComparer.Ordinal);
 
     [GeneratedRegex(@"^Level\s+(\d+)\s+(.+)$")]
     private static partial Regex FoodDescRx();
@@ -19,15 +23,35 @@ public sealed partial class FoodCatalog
     {
         _refData = refData;
         Build();
-        _refData.FileUpdated += (_, _) => Build();
+        _refData.FileUpdated += (_, _) =>
+        {
+            Build();
+            CatalogChanged?.Invoke(this, EventArgs.Empty);
+        };
     }
 
     public IReadOnlyDictionary<string, FoodEntry> ByName => _byName;
-    public int TotalCount => _byName.Count;
+    public IReadOnlyDictionary<string, FoodEntry> ByInternalName => _byInternalName;
+    public int TotalCount => _byInternalName.Count;
+
+    /// <summary>True once at least one food entry has been resolved from reference data.</summary>
+    public bool IsReady => _byInternalName.Count > 0;
+
+    /// <summary>Fires after each <see cref="Build"/> completes — both initial load and CDN refreshes.</summary>
+    public event EventHandler? CatalogChanged;
+
+    /// <summary>Resolve a display name (case-insensitive) to its catalog entry.</summary>
+    public bool TryGetByName(string name, [MaybeNullWhen(false)] out FoodEntry entry)
+        => _byName.TryGetValue(name, out entry);
+
+    /// <summary>Resolve an InternalName (case-sensitive) to its catalog entry.</summary>
+    public bool TryGetByInternalName(string internalName, [MaybeNullWhen(false)] out FoodEntry entry)
+        => _byInternalName.TryGetValue(internalName, out entry);
 
     private void Build()
     {
-        var result = new Dictionary<string, FoodEntry>(600, StringComparer.OrdinalIgnoreCase);
+        var byName = new Dictionary<string, FoodEntry>(600, StringComparer.OrdinalIgnoreCase);
+        var byInternal = new Dictionary<string, FoodEntry>(600, StringComparer.Ordinal);
 
         foreach (var item in _refData.Items.Values)
         {
@@ -45,11 +69,13 @@ public sealed partial class FoodCatalog
 
             var dietaryTags = ExtractDietaryTags(item.Keywords);
 
-            var entry = new FoodEntry(item.Id, item.Name, item.IconId, foodType, foodLevel, gourmandReq, dietaryTags);
-            result[item.Name] = entry;
+            var entry = new FoodEntry(item.Id, item.InternalName, item.Name, item.IconId, foodType, foodLevel, gourmandReq, dietaryTags);
+            byName[item.Name] = entry;
+            byInternal[item.InternalName] = entry;
         }
 
-        _byName = result;
+        _byName = byName;
+        _byInternalName = byInternal;
     }
 
     private static IReadOnlyList<string> ExtractDietaryTags(IReadOnlyList<ItemKeyword> keywords)

--- a/src/Pippin.Module/Domain/FoodEntry.cs
+++ b/src/Pippin.Module/Domain/FoodEntry.cs
@@ -5,6 +5,7 @@ namespace Pippin.Domain;
 /// </summary>
 public sealed record FoodEntry(
     long ItemId,
+    string InternalName,
     string Name,
     int IconId,
     string FoodType,

--- a/src/Pippin.Module/Domain/GourmandState.cs
+++ b/src/Pippin.Module/Domain/GourmandState.cs
@@ -6,20 +6,76 @@ namespace Pippin.Domain;
 /// <summary>
 /// Persistence model for the Gourmand module — one file per character, written under
 /// <c>characters/{slug}/pippin.json</c>.
+///
+/// Schema v2: the eaten-foods dictionary now keys by item <c>InternalName</c> instead of
+/// display name, so persisted progress survives CDN renames and matches the cross-module
+/// convention used by Celebrimbor. Foods that don't resolve to a catalog entry are kept
+/// in <see cref="UnknownByName"/> so we don't lose data when the player has eaten
+/// something the bundled CDN snapshot doesn't yet know about.
+///
+/// Migration is two-phase: <see cref="Migrate"/> moves any v1 <c>EatenFoods</c> dict into
+/// <see cref="PendingLegacyByName"/> (data resolution requires the catalog, which isn't
+/// guaranteed to be ready at load time). <c>GourmandStateService</c> drains
+/// <see cref="PendingLegacyByName"/> once the catalog reports ready.
 /// </summary>
 public sealed class GourmandState : IVersionedState<GourmandState>
 {
-    public const int Version = 1;
+    public const int Version = 2;
     public static int CurrentVersion => Version;
-    public static GourmandState Migrate(GourmandState loaded) => loaded;
+
+    public static GourmandState Migrate(GourmandState loaded)
+    {
+        // v1 → v2: the legacy "eatenFoods" dict was deserialized into the back-compat
+        // property below. Park it for the catalog-aware resolution step.
+        if (loaded.EatenFoods is { Count: > 0 } legacy)
+        {
+            loaded.PendingLegacyByName ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in legacy)
+                loaded.PendingLegacyByName[kv.Key] = kv.Value;
+        }
+        loaded.EatenFoods = null;
+        return loaded;
+    }
 
     public int SchemaVersion { get; set; } = Version;
 
-    /// <summary>Food display name → times eaten.</summary>
-    public Dictionary<string, int> EatenFoods { get; set; } = new();
+    /// <summary>
+    /// Foods the player has eaten, keyed by item <c>InternalName</c>. Stable across CDN
+    /// renames and localization changes — the display name is recovered at view time
+    /// by joining against <c>FoodCatalog</c>.
+    /// </summary>
+    public Dictionary<string, int> EatenFoodsByInternalName { get; set; } =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Foods that came in from a Foods Consumed report but failed to resolve to any
+    /// catalog entry — kept by display name so they still surface in the UI as "Unknown"
+    /// rows and don't silently disappear if the player is ahead of the bundled CDN.
+    /// </summary>
+    public Dictionary<string, int> UnknownByName { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>When the last Foods Consumed report was parsed from the log.</summary>
     public DateTimeOffset? LastReportTime { get; set; }
+
+    /// <summary>
+    /// Display-name-keyed entries inherited from a v1 file that the catalog hasn't yet
+    /// resolved into <see cref="EatenFoodsByInternalName"/> + <see cref="UnknownByName"/>.
+    /// Drained by <c>GourmandStateService.PromoteLegacyIfReady</c> once the catalog is
+    /// populated. Persisted across sessions until the catalog can complete the join, so
+    /// the data isn't lost if the user closes Mithril before the CDN finishes loading.
+    /// </summary>
+    public Dictionary<string, int>? PendingLegacyByName { get; set; }
+
+    /// <summary>
+    /// Back-compat surface for v1's <c>"eatenFoods"</c> JSON key. The setter accepts the
+    /// inbound v1 dict; the getter returns null in v2 so the property is omitted from
+    /// new files (per <see cref="JsonIgnoreCondition.WhenWritingNull"/>). Modules must
+    /// not read or write this — use <see cref="EatenFoodsByInternalName"/> instead.
+    /// </summary>
+    [JsonPropertyName("eatenFoods")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, int>? EatenFoods { get; set; }
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Pippin.Module/PippinModule.cs
+++ b/src/Pippin.Module/PippinModule.cs
@@ -1,12 +1,15 @@
 using System.IO;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Icons;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Dialogs;
 using MahApps.Metro.IconPacks;
 using Microsoft.Extensions.DependencyInjection;
 using Pippin.Domain;
 using Pippin.Parsing;
+using Pippin.Sharing;
 using Pippin.State;
 using Pippin.ViewModels;
 using Pippin.Views;
@@ -49,12 +52,26 @@ public sealed class PippinModule : IMithrilModule
         services.AddSingleton<GourmandViewModel>(sp => new GourmandViewModel(
             sp.GetRequiredService<GourmandStateMachine>(),
             sp.GetRequiredService<FoodCatalog>(),
-            sp.GetService<IActiveCharacterService>()));
+            sp.GetService<IActiveCharacterService>(),
+            sp.GetService<IDialogService>(),
+            sp.GetService<PippinShareCardRenderer>(),
+            sp.GetService<IIconCacheService>()));
         services.AddSingleton<GourmandView>(sp => new GourmandView
         {
             DataContext = sp.GetRequiredService<GourmandViewModel>(),
         });
         services.AddSingleton<PippinSettingsView>(_ => new PippinSettingsView());
+
+        // Sharing — mithril://pippin/<payload> import target
+        services.AddSingleton<IPippinShareImportTarget>(sp => new PippinShareImportTarget(
+            sp.GetRequiredService<FoodCatalog>(),
+            sp.GetService<IModuleActivator>(),
+            sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
+
+        // Sharing — image export renderer (round 3)
+        services.AddSingleton<PippinShareCardRenderer>(sp => new PippinShareCardRenderer(
+            sp.GetRequiredService<FoodCatalog>(),
+            sp.GetRequiredService<IIconCacheService>()));
 
         // Background ingestion
         services.AddHostedService<GourmandIngestionService>();

--- a/src/Pippin.Module/Sharing/PippinFullGridView.xaml
+++ b/src/Pippin.Module/Sharing/PippinFullGridView.xaml
@@ -1,0 +1,89 @@
+<UserControl x:Class="Pippin.Sharing.PippinFullGridView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Pippin.Sharing"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:PippinFullGridViewModel}"
+             Width="1200"
+             Background="#FF1A1A1A"
+             FontFamily="Segoe UI"
+             UseLayoutRounding="True"
+             SnapsToDevicePixels="True">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <DockPanel Margin="20">
+        <!-- Header strip -->
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,16">
+            <StackPanel Orientation="Horizontal">
+                <Image Source="pack://application:,,,/Pippin.Module;component/Resources/pippin.ico"
+                       Width="28" Height="28" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding CharacterTitle}" FontSize="22" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                <TextBlock Text="  ·  Pippin · Gourmand" FontSize="14" Foreground="#88FFFFFF"
+                           VerticalAlignment="Bottom" Margin="0,0,0,3"
+                           Visibility="{Binding HasIdentity, Converter={StaticResource BoolToVis}}"/>
+            </StackPanel>
+            <TextBlock Text="{Binding StatsLine}" FontSize="14" Foreground="#CCFFFFFF" Margin="0,4,0,0"/>
+            <TextBlock Text="{Binding LastSyncText}" FontSize="12" Foreground="#88FFFFFF" Margin="0,2,0,0"
+                       Visibility="{Binding LastSyncText, Converter={StaticResource NullOrEmptyToVis}}"/>
+        </StackPanel>
+
+        <!-- Column header row -->
+        <Grid DockPanel.Dock="Top" Height="36" Background="#FF222222">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="32"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="60"/>
+                <ColumnDefinition Width="50"/>
+                <ColumnDefinition Width="60"/>
+                <ColumnDefinition Width="180"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="" />
+            <TextBlock Grid.Column="1" Text="Name"  Margin="8,0,0,0" Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2" Text="Type"  Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="3" Text="Level" Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" Text="Req"   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="5" Text="Count" Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="6" Text="Tags"  Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+        </Grid>
+
+        <!-- Rows -->
+        <ItemsControl ItemsSource="{Binding Rows}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Grid Height="32" Background="#FF1E1E1E">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="32"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="60"/>
+                            <ColumnDefinition Width="50"/>
+                            <ColumnDefinition Width="60"/>
+                            <ColumnDefinition Width="180"/>
+                        </Grid.ColumnDefinitions>
+                        <CheckBox Grid.Column="0" IsChecked="{Binding IsEaten, Mode=OneWay}"
+                                  IsEnabled="False" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="8,0,0,0">
+                            <Image Source="{Binding Icon}" Width="20" Height="20" VerticalAlignment="Center" Margin="0,0,8,0"
+                                   Visibility="{Binding HasIcon, Converter={StaticResource BoolToVis}}"/>
+                            <TextBlock Text="{Binding Name}" Foreground="#FFE8E8E8" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <TextBlock Grid.Column="2" Text="{Binding FoodType}"         Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="3" Text="{Binding FoodLevel}"        Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="4" Text="{Binding GourmandLevelReq}" Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="5" Text="{Binding EatenCount}"       Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="6" Text="{Binding DietaryTags}"      Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                    </Grid>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </DockPanel>
+</UserControl>

--- a/src/Pippin.Module/Sharing/PippinFullGridView.xaml.cs
+++ b/src/Pippin.Module/Sharing/PippinFullGridView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Pippin.Sharing;
+
+public partial class PippinFullGridView : UserControl
+{
+    public PippinFullGridView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pippin.Module/Sharing/PippinFullGridViewModel.cs
+++ b/src/Pippin.Module/Sharing/PippinFullGridViewModel.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using System.Windows.Media.Imaging;
+using Mithril.Shared.Icons;
+using Pippin.Domain;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// View model for the archival full-grid PNG export. Materializes every food row
+/// (catalog ∪ orphan-unknowns ∪ sender-only InternalNames) with its bitmap icon
+/// pre-resolved through the cache, so the off-screen render in
+/// <see cref="PippinShareCardRenderer"/> doesn't depend on the IconImage Loaded
+/// lifecycle.
+/// </summary>
+public sealed class PippinFullGridViewModel
+{
+    public const double Width = 1200;
+    public const double HeaderHeight = 36;
+    public const double RowHeight = 32;
+
+    public PippinFullGridViewModel(
+        PippinSharePayload payload,
+        FoodCatalog catalog,
+        int gourmandLevel,
+        IIconCacheService iconCache)
+    {
+        CharacterTitle = string.IsNullOrWhiteSpace(payload.CharacterName)
+            ? "Pippin · Gourmand"
+            : payload.CharacterName!;
+        HasIdentity = !string.IsNullOrWhiteSpace(payload.CharacterName);
+
+        var eatenCount = payload.EatenFoodsByInternalName.Count + (payload.UnknownByName?.Count ?? 0);
+        var totalCount = catalog.TotalCount > 0 ? catalog.TotalCount : eatenCount;
+        var pct = totalCount > 0 ? 100.0 * eatenCount / totalCount : 0.0;
+
+        StatsLine = string.Format(CultureInfo.InvariantCulture,
+            "{0} / {1}  ·  {2:0.#}%  ·  {3}",
+            eatenCount, totalCount,
+            pct,
+            gourmandLevel > 0 ? $"Gourmand Lv {gourmandLevel}" : "Gourmand");
+
+        LastSyncText = payload.LastReportTime is { } t
+            ? $"Synced {t.LocalDateTime:g}"
+            : "";
+
+        // Build rows: catalog + sender-only InternalNames + sender-only display-name
+        // unknowns. Mirror the live GourmandViewModel ordering so the image looks like
+        // the live grid.
+        var rows = new List<PippinFullGridRow>(catalog.TotalCount + (payload.UnknownByName?.Count ?? 0) + 16);
+
+        var eaten = payload.EatenFoodsByInternalName;
+        foreach (var food in catalog.ByInternalName.Values)
+        {
+            var hasCount = eaten.TryGetValue(food.InternalName, out var count);
+            var icon = food.IconId > 0 ? iconCache.GetOrLoadIcon(food.IconId) : null;
+            rows.Add(new PippinFullGridRow(
+                food.Name, food.FoodType, food.FoodLevel, food.GourmandLevelReq,
+                hasCount ? count : 0, hasCount, FormatTags(food.DietaryTags), icon));
+        }
+
+        if (payload.UnknownByName is { } unknowns)
+        {
+            foreach (var (name, count) in unknowns)
+                rows.Add(new PippinFullGridRow(name, "Unknown", 0, 0, count, true, "", null));
+        }
+
+        foreach (var (internalName, count) in eaten)
+        {
+            if (catalog.TryGetByInternalName(internalName, out _)) continue;
+            rows.Add(new PippinFullGridRow(internalName, "Unknown", 0, 0, count, true, "", null));
+        }
+
+        rows.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        Rows = rows;
+
+        TotalHeight = HeaderHeight + Rows.Count * RowHeight + 80; // header strip + footer pad
+    }
+
+    public string CharacterTitle { get; }
+    public bool HasIdentity { get; }
+    public string StatsLine { get; }
+    public string LastSyncText { get; }
+    public IReadOnlyList<PippinFullGridRow> Rows { get; }
+
+    /// <summary>Computed pixel height needed to fit every row + header + footer.</summary>
+    public double TotalHeight { get; }
+
+    private static string FormatTags(IReadOnlyList<string> tags) => string.Join(", ", tags);
+}
+
+public sealed record PippinFullGridRow(
+    string Name,
+    string FoodType,
+    int FoodLevel,
+    int GourmandLevelReq,
+    int EatenCount,
+    bool IsEaten,
+    string DietaryTags,
+    BitmapImage? Icon)
+{
+    public bool HasIcon => Icon is not null;
+}

--- a/src/Pippin.Module/Sharing/PippinShareCardRenderer.cs
+++ b/src/Pippin.Module/Sharing/PippinShareCardRenderer.cs
@@ -1,0 +1,67 @@
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Mithril.Shared.Icons;
+using Pippin.Domain;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// Renders a <see cref="PippinSharePayload"/> to a <see cref="BitmapSource"/> off-screen
+/// via <see cref="RenderTargetBitmap"/>. Two outputs:
+/// <list type="bullet">
+///   <item><see cref="RenderCard"/> — fixed 1000×400 social card.</item>
+///   <item><see cref="RenderFullGrid"/> — fixed-width tall grid for archival.</item>
+/// </list>
+/// Renderer never touches the live <c>GourmandViewModel</c> or the live grid; it
+/// constructs a fresh control tree, lays it out off-screen, and snapshots it. Icons
+/// must be cached locally before render — see
+/// <c>IIconCacheService.PreloadAsync</c> and the share dialog's preload banner.
+/// </summary>
+public sealed class PippinShareCardRenderer
+{
+    private readonly FoodCatalog _catalog;
+    private readonly IIconCacheService _iconCache;
+
+    public PippinShareCardRenderer(FoodCatalog catalog, IIconCacheService iconCache)
+    {
+        _catalog = catalog;
+        _iconCache = iconCache;
+    }
+
+    /// <summary>1000×400 social card.</summary>
+    public BitmapSource RenderCard(PippinSharePayload payload, int gourmandLevel)
+    {
+        var vm = new PippinShareCardViewModel(payload, _catalog, gourmandLevel, _iconCache);
+        var view = new PippinShareCardView { DataContext = vm };
+        return RenderControl(view, PippinShareCardViewModel.CardWidth, PippinShareCardViewModel.CardHeight);
+    }
+
+    /// <summary>Tall PNG with header strip + every food row.</summary>
+    public BitmapSource RenderFullGrid(PippinSharePayload payload, int gourmandLevel)
+    {
+        var vm = new PippinFullGridViewModel(payload, _catalog, gourmandLevel, _iconCache);
+        var view = new PippinFullGridView { DataContext = vm };
+        return RenderControl(view, PippinFullGridViewModel.Width, vm.TotalHeight);
+    }
+
+    private static BitmapSource RenderControl(FrameworkElement control, double width, double height)
+    {
+        // Force a layout pass so every binding resolves before the render. Without the
+        // explicit Measure/Arrange/UpdateLayout dance, a never-parented FrameworkElement
+        // has zero size and RenderTargetBitmap captures nothing.
+        control.Width = width;
+        control.Height = height;
+        control.Measure(new Size(width, height));
+        control.Arrange(new Rect(0, 0, width, height));
+        control.UpdateLayout();
+
+        var bitmap = new RenderTargetBitmap(
+            (int)Math.Ceiling(width),
+            (int)Math.Ceiling(height),
+            96, 96, PixelFormats.Pbgra32);
+        bitmap.Render(control);
+        bitmap.Freeze();
+        return bitmap;
+    }
+}

--- a/src/Pippin.Module/Sharing/PippinShareCardView.xaml
+++ b/src/Pippin.Module/Sharing/PippinShareCardView.xaml
@@ -1,0 +1,93 @@
+<UserControl x:Class="Pippin.Sharing.PippinShareCardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Pippin.Sharing"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:PippinShareCardViewModel}"
+             Width="1000" Height="400"
+             Background="#FF1A1A1A"
+             FontFamily="Segoe UI"
+             UseLayoutRounding="True"
+             SnapsToDevicePixels="True">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Border BorderBrush="#33D4A847" BorderThickness="1" CornerRadius="8" Padding="32">
+        <DockPanel>
+            <!-- Header -->
+            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,20">
+                <StackPanel Orientation="Horizontal">
+                    <Image Source="pack://application:,,,/Pippin.Module;component/Resources/pippin.ico"
+                           Width="40" Height="40" VerticalAlignment="Center" Margin="0,0,14,0"/>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding CharacterTitle}" FontSize="32" FontWeight="SemiBold"
+                                   Foreground="#FFD4A847"/>
+                        <TextBlock Text="Pippin · Gourmand" FontSize="14" Foreground="#88FFFFFF"
+                                   Visibility="{Binding HasIdentity, Converter={StaticResource BoolToVis}}"/>
+                    </StackPanel>
+                    <Border Margin="20,0,0,0" Padding="10,4" VerticalAlignment="Center"
+                            Background="#33D4A847" CornerRadius="4">
+                        <TextBlock Text="{Binding GourmandLevelText}" Foreground="#FFD4A847"
+                                   FontSize="14" FontWeight="SemiBold"/>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Footer (last sync) -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding LastSyncText}"
+                       Foreground="#66FFFFFF" FontSize="12" HorizontalAlignment="Right" Margin="0,16,0,0"/>
+
+            <!-- Top eaten chips -->
+            <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">
+                <TextBlock Text="Most eaten" Foreground="#66FFFFFF" FontSize="12" Margin="0,0,0,6"/>
+                <ItemsControl ItemsSource="{Binding TopEaten}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="#FF222222" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                    CornerRadius="4" Padding="8,4" Margin="0,0,8,0">
+                                <StackPanel Orientation="Horizontal">
+                                    <Image Source="{Binding Icon}" Width="20" Height="20" VerticalAlignment="Center"
+                                           Margin="0,0,6,0"
+                                           Visibility="{Binding HasIcon, Converter={StaticResource BoolToVis}}"/>
+                                    <TextBlock Text="{Binding Name}" Foreground="#FFE8E8E8" FontSize="13"
+                                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <TextBlock Text="{Binding CountText}" Foreground="#FFD4A847"
+                                               FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- Hero: completion bar -->
+            <StackPanel VerticalAlignment="Center">
+                <TextBlock Text="{Binding CompletionText}" FontSize="44" FontWeight="SemiBold"
+                           Foreground="#FFE8E8E8" HorizontalAlignment="Center"/>
+                <Grid Margin="0,16,0,0" Height="22">
+                    <Border Background="#FF202020" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="11"/>
+                    <Border HorizontalAlignment="Left" Margin="2"
+                            Width="{Binding BarFillPixelWidth}" CornerRadius="9">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                                <GradientStop Color="#FFD4A847" Offset="0"/>
+                                <GradientStop Color="#FFE8C977" Offset="1"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/Pippin.Module/Sharing/PippinShareCardView.xaml.cs
+++ b/src/Pippin.Module/Sharing/PippinShareCardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Pippin.Sharing;
+
+public partial class PippinShareCardView : UserControl
+{
+    public PippinShareCardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pippin.Module/Sharing/PippinShareCardViewModel.cs
+++ b/src/Pippin.Module/Sharing/PippinShareCardViewModel.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+using System.Windows.Media.Imaging;
+using Mithril.Shared.Icons;
+using Pippin.Domain;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// View model for the social-card share image. Built from a <see cref="PippinSharePayload"/>
+/// joined against the local <see cref="FoodCatalog"/>; bitmap icons are resolved through
+/// <see cref="IIconCacheService"/> at construction time so the off-screen render in
+/// <see cref="PippinShareCardRenderer"/> doesn't depend on the IconImage Loaded
+/// lifecycle (which doesn't fire for unparented visuals).
+/// </summary>
+public sealed class PippinShareCardViewModel
+{
+    public const double CardWidth = 1000;
+    public const double CardHeight = 400;
+    private const double BarMaxPixelWidth = 928; // 1000 - 32 padding × 2 - 4 (border + margin)
+
+    public PippinShareCardViewModel(
+        PippinSharePayload payload,
+        FoodCatalog catalog,
+        int gourmandLevel,
+        IIconCacheService iconCache)
+    {
+        CharacterTitle = string.IsNullOrWhiteSpace(payload.CharacterName) ? "Pippin · Gourmand" : payload.CharacterName!;
+        HasIdentity = !string.IsNullOrWhiteSpace(payload.CharacterName);
+
+        var eatenCount = payload.EatenFoodsByInternalName.Count + (payload.UnknownByName?.Count ?? 0);
+        var totalCount = catalog.TotalCount > 0 ? catalog.TotalCount : eatenCount;
+        var pct = totalCount > 0 ? 100.0 * eatenCount / totalCount : 0.0;
+
+        EatenCount = eatenCount;
+        TotalCount = totalCount;
+        CompletionText = string.Format(CultureInfo.InvariantCulture,
+            "{0} / {1}  ·  {2:0.#}%", eatenCount, totalCount, pct);
+        CompletionRatio = totalCount > 0 ? Math.Clamp((double)eatenCount / totalCount, 0, 1) : 0;
+        BarFillPixelWidth = CompletionRatio * BarMaxPixelWidth;
+
+        GourmandLevelText = gourmandLevel > 0 ? $"Gourmand Lv {gourmandLevel}" : "Gourmand";
+
+        LastSyncText = payload.LastReportTime is { } t
+            ? $"Synced {t.LocalDateTime:g}"
+            : "Sync time not available";
+
+        // Top 5 by count, joined against the recipient's catalog so display names
+        // reflect what's actually rendered in the local UI.
+        TopEaten = payload.EatenFoodsByInternalName
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+            .Take(5)
+            .Select(kv =>
+            {
+                var name = kv.Key;
+                BitmapImage? icon = null;
+                if (catalog.TryGetByInternalName(kv.Key, out var entry))
+                {
+                    name = entry.Name;
+                    if (entry.IconId > 0)
+                        icon = iconCache.GetOrLoadIcon(entry.IconId);
+                }
+                return new TopEatenItem(name, kv.Value, icon);
+            })
+            .ToList();
+    }
+
+    public string CharacterTitle { get; }
+    public bool HasIdentity { get; }
+    public int EatenCount { get; }
+    public int TotalCount { get; }
+    public string CompletionText { get; }
+    public double CompletionRatio { get; }
+    public double BarFillPixelWidth { get; }
+    public string GourmandLevelText { get; }
+    public string LastSyncText { get; }
+    public IReadOnlyList<TopEatenItem> TopEaten { get; }
+}
+
+public sealed record TopEatenItem(string Name, int Count, BitmapImage? Icon)
+{
+    public string CountText => $"×{Count}";
+    public bool HasIcon => Icon is not null;
+}

--- a/src/Pippin.Module/Sharing/PippinShareDialog.xaml
+++ b/src/Pippin.Module/Sharing/PippinShareDialog.xaml
@@ -6,7 +6,7 @@
              xmlns:vm="clr-namespace:Pippin.Sharing"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance vm:PippinShareDialogViewModel}"
-             MinWidth="540" MaxWidth="640">
+             MinWidth="500" MaxWidth="520">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/Pippin.Module/Sharing/PippinShareDialog.xaml
+++ b/src/Pippin.Module/Sharing/PippinShareDialog.xaml
@@ -1,0 +1,145 @@
+<UserControl x:Class="Pippin.Sharing.PippinShareDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Pippin.Sharing"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:PippinShareDialogViewModel}"
+             MinWidth="540" MaxWidth="640">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <StackPanel>
+        <TextBlock TextWrapping="Wrap" Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSize}" Margin="0,0,0,10"
+                   Text="Share your Gourmand progress with another player. The link opens a read-only view in their Pippin tab; the JSON or summary work for Discord, forums, or anywhere a link won't."/>
+
+        <CheckBox Content="Include character name" IsChecked="{Binding IncludeCharacterName}"
+                  IsEnabled="{Binding HasCharacterName}"
+                  Foreground="#CCFFFFFF" Margin="0,0,0,12"/>
+
+        <TextBlock Text="Share link (mithril://pippin/…)" Foreground="#88FFFFFF"
+                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+        <Grid Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox Grid.Column="0" Text="{Binding ShareLink, Mode=OneWay}" IsReadOnly="True"
+                     FontFamily="Consolas,Cascadia Mono,Courier New" FontSize="11"
+                     Background="#FF151515" Foreground="#FFB0E0A0" BorderBrush="#FF333333"
+                     TextWrapping="NoWrap" HorizontalScrollBarVisibility="Auto"
+                     Padding="6,4" Margin="0,0,8,0"/>
+            <Button Grid.Column="1" Content="Copy" Command="{Binding CopyLinkCommand}"
+                    Padding="12,6" Background="#FFD4A847" Foreground="#FF1A1A1A" FontWeight="SemiBold"/>
+        </Grid>
+
+        <TextBlock Text="JSON payload" Foreground="#88FFFFFF"
+                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+        <TextBox Text="{Binding JsonPayload, Mode=OneWay}" IsReadOnly="True"
+                 Height="160" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
+                 FontFamily="Consolas,Cascadia Mono,Courier New" FontSize="11"
+                 Background="#FF151515" Foreground="#FFB0E0A0" BorderBrush="#FF333333"
+                 TextWrapping="NoWrap"/>
+        <StackPanel Orientation="Horizontal" Margin="0,6,0,12">
+            <Button Content="Copy JSON" Command="{Binding CopyJsonCommand}"
+                    Padding="10,4" Margin="0,0,8,0"
+                    Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"/>
+            <Button Content="Save JSON…" Command="{Binding SaveJsonCommand}"
+                    Padding="10,4"
+                    Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"/>
+        </StackPanel>
+
+        <TextBlock Text="Human-readable summary" Foreground="#88FFFFFF"
+                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+        <TextBox Text="{Binding Summary, Mode=OneWay}" IsReadOnly="True"
+                 Height="120" VerticalScrollBarVisibility="Auto"
+                 FontFamily="Consolas,Cascadia Mono,Courier New" FontSize="11"
+                 Background="#FF151515" Foreground="#CCFFFFFF" BorderBrush="#FF333333"
+                 TextWrapping="Wrap"/>
+        <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+            <Button Content="Copy summary" Command="{Binding CopySummaryCommand}"
+                    Padding="10,4"
+                    Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"/>
+        </StackPanel>
+
+        <!-- ── Image export (round 3) ─────────────────────────────────── -->
+        <Separator Margin="0,16,0,8" Background="#33FFFFFF"/>
+        <TextBlock Text="Image" Foreground="#88FFFFFF"
+                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8"/>
+
+        <!-- Icon-preload banner: only when count > 0 -->
+        <Border Background="#FF2A2A2A" BorderBrush="#33D4A847" BorderThickness="1"
+                CornerRadius="4" Padding="10,8" Margin="0,0,0,10"
+                Visibility="{Binding UncachedIconCount, Converter={StaticResource PositiveIntToVis}}">
+            <StackPanel>
+                <TextBlock Foreground="#CCFFFFFF" TextWrapping="Wrap">
+                    <Run Text="ⓘ"/>
+                    <Run Text="{Binding UncachedIconCount, Mode=OneWay}"/>
+                    <Run Text="icons aren't downloaded yet — share will use placeholders for those."/>
+                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <Button Content="Load icons now" Command="{Binding LoadIconsCommand}"
+                            Padding="10,4" Margin="0,0,8,0"
+                            Background="#FFD4A847" Foreground="#FF1A1A1A" FontWeight="SemiBold"/>
+                    <ProgressBar Width="160" Height="14" VerticalAlignment="Center"
+                                 Minimum="0" Maximum="1" Value="{Binding PrefetchProgress, Mode=OneWay}"
+                                 Visibility="{Binding IsPrefetching, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding PrefetchProgressLabel}" Foreground="#88FFFFFF"
+                               VerticalAlignment="Center" Margin="8,0,0,0"
+                               Visibility="{Binding IsPrefetching, Converter={StaticResource BoolToVis}}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Card image row -->
+        <Grid Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="Card image" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                <TextBlock Text="1000×400 — Discord-friendly summary" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                <Button Content="Copy" Command="{Binding CopyCardCommand}"
+                        Padding="12,6" Margin="0,0,8,0"
+                        Background="#FFD4A847" Foreground="#FF1A1A1A" FontWeight="SemiBold"/>
+                <Button Content="Save…" Command="{Binding SaveCardCommand}"
+                        Padding="10,6"
+                        Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Full-grid image row -->
+        <Grid Margin="0,0,0,4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="Full grid" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                <TextBlock Text="Tall PNG with every row — archival" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                <Button Content="Save…" Command="{Binding SaveFullGridCommand}"
+                        Padding="12,6" Margin="0,0,8,0"
+                        Background="#FFD4A847" Foreground="#FF1A1A1A" FontWeight="SemiBold"/>
+                <Button Content="Copy" Command="{Binding CopyFullGridCommand}"
+                        Padding="10,6"
+                        Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"/>
+            </StackPanel>
+        </Grid>
+
+        <TextBlock Text="{Binding StatusMessage}" Foreground="#FF7AB880"
+                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,10,0,0"
+                   Visibility="{Binding StatusMessage, Converter={StaticResource NullOrEmptyToVis}}"/>
+    </StackPanel>
+</UserControl>

--- a/src/Pippin.Module/Sharing/PippinShareDialog.xaml.cs
+++ b/src/Pippin.Module/Sharing/PippinShareDialog.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Pippin.Sharing;
+
+public partial class PippinShareDialog : UserControl
+{
+    public PippinShareDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Pippin.Module/Sharing/PippinShareDialogViewModel.cs
+++ b/src/Pippin.Module/Sharing/PippinShareDialogViewModel.cs
@@ -1,0 +1,245 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Sharing;
+using Mithril.Shared.Wpf.Dialogs;
+using Pippin.Domain;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// Dialog for sharing the active character's Gourmand progress. Surfaces five outputs
+/// that target disjoint audiences:
+/// <list type="bullet">
+///   <item><description><b>Share link</b> — <c>mithril://pippin/&lt;base64url&gt;</c>.
+///         Click-to-import for other Mithril users; opens a read-only progress view in
+///         the recipient's Pippin tab.</description></item>
+///   <item><description><b>JSON</b> — the raw <see cref="PippinSharePayload"/> for paste
+///         into bug reports, archival, or non-Mithril tooling.</description></item>
+///   <item><description><b>Summary</b> — human-readable Discord/forum prose, generated
+///         from the sender's catalog snapshot.</description></item>
+///   <item><description><b>Card image</b> — 1000×400 social PNG. Defaults to clipboard
+///         (paste straight into Discord); save-to-file as secondary.</description></item>
+///   <item><description><b>Full grid image</b> — tall archival PNG. Defaults to file
+///         save; clipboard as secondary.</description></item>
+/// </list>
+/// "Include character name" toggles whether the sender's name is embedded; defaults on
+/// per the share-progress design call. Off = anonymous payload labeled "Shared progress".
+///
+/// When the icon cache is missing entries for the catalog, an inline preload banner
+/// offers <i>Load icons now</i> instead of warning passively. Card/grid images render
+/// with whatever icons the cache holds at click-time — placeholders for the rest.
+/// </summary>
+public sealed partial class PippinShareDialogViewModel : DialogViewModelBase
+{
+    private readonly Func<bool, PippinSharePayload> _buildPayload;
+    private readonly Func<PippinSharePayload, string> _buildSummary;
+    private readonly Func<int> _getGourmandLevel;
+    private readonly PippinShareCardRenderer _renderer;
+    private readonly IIconCacheService _iconCache;
+    private readonly IReadOnlyList<int> _catalogIconIds;
+    private readonly string? _activeCharacterName;
+
+    public PippinShareDialogViewModel(
+        Func<bool, PippinSharePayload> buildPayload,
+        Func<PippinSharePayload, string> buildSummary,
+        Func<int> getGourmandLevel,
+        PippinShareCardRenderer renderer,
+        IIconCacheService iconCache,
+        IReadOnlyList<int> catalogIconIds,
+        string? activeCharacterName)
+    {
+        _buildPayload = buildPayload;
+        _buildSummary = buildSummary;
+        _getGourmandLevel = getGourmandLevel;
+        _renderer = renderer;
+        _iconCache = iconCache;
+        _catalogIconIds = catalogIconIds;
+        _activeCharacterName = activeCharacterName;
+        _includeCharacterName = !string.IsNullOrEmpty(activeCharacterName);
+        Refresh();
+        RefreshUncachedIconCount();
+    }
+
+    public override string Title => "Share Pippin Progress";
+    public override string PrimaryButtonText => "Close";
+    public override string? SecondaryButtonText => null;
+
+    public bool HasCharacterName => !string.IsNullOrEmpty(_activeCharacterName);
+
+    [ObservableProperty]
+    private bool _includeCharacterName;
+
+    [ObservableProperty]
+    private string _shareLink = "";
+
+    [ObservableProperty]
+    private string _jsonPayload = "";
+
+    [ObservableProperty]
+    private string _summary = "";
+
+    [ObservableProperty]
+    private string _statusMessage = "";
+
+    [ObservableProperty]
+    private int _uncachedIconCount;
+
+    [ObservableProperty]
+    private bool _isPrefetching;
+
+    [ObservableProperty]
+    private double _prefetchProgress;
+
+    [ObservableProperty]
+    private string _prefetchProgressLabel = "";
+
+    partial void OnIncludeCharacterNameChanged(bool value) => Refresh();
+
+    private void Refresh()
+    {
+        var payload = _buildPayload(IncludeCharacterName && HasCharacterName);
+        JsonPayload = JsonSerializer.Serialize(payload, PippinShareJsonContext.Default.PippinSharePayload);
+        ShareLink = "mithril://pippin/" + ShareCodec.EncodePayload(JsonPayload);
+        Summary = _buildSummary(payload);
+    }
+
+    private void RefreshUncachedIconCount()
+        => UncachedIconCount = _iconCache.GetUncachedIcons(_catalogIconIds).Count;
+
+    [RelayCommand] private void CopyLink() => CopyText(ShareLink, "Share link copied to clipboard.");
+    [RelayCommand] private void CopyJson() => CopyText(JsonPayload, "JSON copied to clipboard.");
+    [RelayCommand] private void CopySummary() => CopyText(Summary, "Summary copied to clipboard.");
+
+    [RelayCommand]
+    private void SaveJson()
+    {
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save Pippin Progress",
+            Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+            DefaultExt = "json",
+            FileName = $"pippin-progress-{DateTimeOffset.UtcNow:yyyyMMdd-HHmm}.json",
+        };
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, JsonPayload, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            StatusMessage = $"Saved to {dialog.FileName}";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Save failed: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private async Task LoadIconsAsync()
+    {
+        if (IsPrefetching) return;
+        IsPrefetching = true;
+        PrefetchProgress = 0;
+        PrefetchProgressLabel = "";
+        StatusMessage = "";
+
+        var progress = new Progress<(int completed, int total)>(p =>
+        {
+            PrefetchProgress = p.total > 0 ? (double)p.completed / p.total : 1.0;
+            PrefetchProgressLabel = $"{p.completed} / {p.total}";
+        });
+
+        try
+        {
+            await _iconCache.PreloadAsync(_catalogIconIds, progress).ConfigureAwait(true);
+            RefreshUncachedIconCount();
+            StatusMessage = UncachedIconCount == 0
+                ? "Icons downloaded."
+                : $"Downloaded what we could; {UncachedIconCount} still unavailable.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Icon download failed: {ex.Message}";
+        }
+        finally
+        {
+            IsPrefetching = false;
+        }
+    }
+
+    [RelayCommand] private void CopyCard()      => CopyImage(BuildCard(), "Card image copied to clipboard.");
+    [RelayCommand] private void SaveCard()      => SaveImage(BuildCard(), "card");
+    [RelayCommand] private void CopyFullGrid()  => CopyImage(BuildFullGrid(), "Full grid copied to clipboard.");
+    [RelayCommand] private void SaveFullGrid()  => SaveImage(BuildFullGrid(), "full");
+
+    private BitmapSource BuildCard()
+    {
+        var payload = _buildPayload(IncludeCharacterName && HasCharacterName);
+        return _renderer.RenderCard(payload, _getGourmandLevel());
+    }
+
+    private BitmapSource BuildFullGrid()
+    {
+        var payload = _buildPayload(IncludeCharacterName && HasCharacterName);
+        return _renderer.RenderFullGrid(payload, _getGourmandLevel());
+    }
+
+    private void CopyText(string text, string okMessage)
+    {
+        try
+        {
+            Clipboard.SetDataObject(new DataObject(DataFormats.UnicodeText, text), copy: true);
+            StatusMessage = okMessage;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Could not copy to clipboard: {ex.Message}";
+        }
+    }
+
+    private void CopyImage(BitmapSource image, string okMessage)
+    {
+        try
+        {
+            // copy: true persists the bitmap on the clipboard past Mithril's process
+            // lifetime — the user can copy → close Mithril → paste in Discord.
+            Clipboard.SetDataObject(new DataObject(DataFormats.Bitmap, image), copy: true);
+            StatusMessage = okMessage;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Could not copy image: {ex.Message}";
+        }
+    }
+
+    private void SaveImage(BitmapSource image, string variant)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save Pippin Progress Image",
+            Filter = "PNG image (*.png)|*.png|All files (*.*)|*.*",
+            DefaultExt = "png",
+            FileName = $"pippin-progress-{variant}-{DateTimeOffset.UtcNow:yyyyMMdd-HHmm}.png",
+        };
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            using var fs = File.Create(dialog.FileName);
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(image));
+            encoder.Save(fs);
+            StatusMessage = $"Saved to {dialog.FileName}";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Save failed: {ex.Message}";
+        }
+    }
+}

--- a/src/Pippin.Module/Sharing/PippinShareImportTarget.cs
+++ b/src/Pippin.Module/Sharing/PippinShareImportTarget.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using System.Windows;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Sharing;
+using Pippin.Domain;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// Pippin's implementation of <see cref="IPippinShareImportTarget"/>. Decodes the deep
+/// link's base64url payload, deserializes a <see cref="PippinSharePayload"/>, brings
+/// the Pippin tab to the foreground, and opens a non-modal
+/// <see cref="SharedProgressWindow"/> with the sender's data joined against the local
+/// catalog.
+/// </summary>
+public sealed class PippinShareImportTarget : IPippinShareImportTarget
+{
+    private readonly FoodCatalog _catalog;
+    private readonly IModuleActivator? _activator;
+    private readonly IDiagnosticsSink? _diag;
+
+    public PippinShareImportTarget(
+        FoodCatalog catalog,
+        IModuleActivator? activator = null,
+        IDiagnosticsSink? diag = null)
+    {
+        _catalog = catalog;
+        _activator = activator;
+        _diag = diag;
+    }
+
+    public void ImportFromLinkPayload(string base64UrlPayload)
+    {
+        if (!ShareCodec.TryDecodePayload(base64UrlPayload, out var json, out var error))
+        {
+            _diag?.Info("Pippin", $"Share link decode failed: {error}");
+            return;
+        }
+
+        PippinSharePayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize(json, PippinShareJsonContext.Default.PippinSharePayload);
+        }
+        catch (JsonException ex)
+        {
+            _diag?.Info("Pippin", $"Share link payload is not valid PippinSharePayload JSON: {ex.Message}");
+            return;
+        }
+        if (payload is null)
+        {
+            _diag?.Info("Pippin", "Share link payload deserialized to null.");
+            return;
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            Show(payload);
+        else
+            dispatcher.InvokeAsync(() => Show(payload));
+    }
+
+    private void Show(PippinSharePayload payload)
+    {
+        if (_activator is not null && !_activator.Activate("pippin"))
+            _diag?.Info("Pippin", "Deep-link import: module activator could not find 'pippin'.");
+
+        var vm = new SharedProgressViewModel(payload, _catalog);
+        var window = new SharedProgressWindow(vm)
+        {
+            Owner = Application.Current?.MainWindow,
+        };
+        window.Show();
+    }
+}

--- a/src/Pippin.Module/Sharing/PippinSharePayload.cs
+++ b/src/Pippin.Module/Sharing/PippinSharePayload.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// Wire format for sharing a player's Gourmand progress. Carried inside a
+/// <c>mithril://pippin/&lt;base64url&gt;</c> deep link or pasted as JSON. Keys by
+/// <c>InternalName</c> so the sender's CDN snapshot doesn't have to match the
+/// recipient's — the recipient rejoins display-name metadata against their own
+/// <c>FoodCatalog</c> at render time.
+/// </summary>
+public sealed class PippinSharePayload
+{
+    public const int CurrentVersion = 2;
+
+    public int SchemaVersion { get; set; } = CurrentVersion;
+
+    /// <summary>
+    /// Sender's character name. Null when the sender opted out of sharing identity in
+    /// the share dialog. The shared-progress view labels itself "Shared progress" in
+    /// that case.
+    /// </summary>
+    public string? CharacterName { get; set; }
+
+    /// <summary>Foods eaten, keyed by item <c>InternalName</c> → times eaten.</summary>
+    public Dictionary<string, int> EatenFoodsByInternalName { get; set; } =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Foods the sender has eaten that didn't resolve in their catalog snapshot,
+    /// kept by display name. Recipient renders them in the same "Unknown" group as
+    /// the live view. Optional — omitted when empty.
+    /// </summary>
+    public Dictionary<string, int>? UnknownByName { get; set; }
+
+    /// <summary>When the sender's last Foods Consumed report was parsed.</summary>
+    public DateTimeOffset? LastReportTime { get; set; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(PippinSharePayload))]
+public partial class PippinShareJsonContext : JsonSerializerContext { }

--- a/src/Pippin.Module/Sharing/SharedProgressViewModel.cs
+++ b/src/Pippin.Module/Sharing/SharedProgressViewModel.cs
@@ -1,0 +1,104 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Windows.Data;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Pippin.Domain;
+using Pippin.ViewModels;
+
+namespace Pippin.Sharing;
+
+/// <summary>
+/// View model for the read-only "shared progress" surface — populated from a
+/// <see cref="PippinSharePayload"/> received via a <c>mithril://pippin/…</c> deep link.
+/// Joins the sender's <c>InternalName</c> keys against the recipient's local
+/// <see cref="FoodCatalog"/> for display metadata, so a sender on an older CDN
+/// snapshot still renders correctly on a recipient who's caught up.
+/// </summary>
+public sealed partial class SharedProgressViewModel : ObservableObject
+{
+    private readonly FoodCatalog _catalog;
+    private readonly ICollectionView _foodsView;
+
+    public SharedProgressViewModel(PippinSharePayload payload, FoodCatalog catalog)
+    {
+        _catalog = catalog;
+        Foods = new ObservableCollection<FoodItemViewModel>();
+        _foodsView = CollectionViewSource.GetDefaultView(Foods);
+        _foodsView.Filter = PassesComboFilters;
+
+        Title = string.IsNullOrWhiteSpace(payload.CharacterName)
+            ? "Shared progress"
+            : $"Shared progress · {payload.CharacterName}";
+
+        SyncedLabel = payload.LastReportTime is { } t
+            ? $"Synced {t.LocalDateTime.ToString("g", CultureInfo.CurrentCulture)}"
+            : "Sync time not available";
+
+        Rebuild(payload);
+    }
+
+    public string Title { get; }
+    public string SyncedLabel { get; }
+
+    [ObservableProperty] private string _foodTypeFilter = "All";
+    [ObservableProperty] private string _eatenFilter = "All";
+
+    [ObservableProperty] private int _eatenCount;
+    [ObservableProperty] private int _totalCount;
+    [ObservableProperty] private double _completionPercent;
+
+    public ObservableCollection<FoodItemViewModel> Foods { get; }
+
+    partial void OnFoodTypeFilterChanged(string value) => _foodsView.Refresh();
+    partial void OnEatenFilterChanged(string value) => _foodsView.Refresh();
+
+    private void Rebuild(PippinSharePayload payload)
+    {
+        var unknown = payload.UnknownByName ?? new Dictionary<string, int>();
+        var list = new List<FoodItemViewModel>(_catalog.TotalCount + unknown.Count);
+
+        foreach (var food in _catalog.ByInternalName.Values)
+        {
+            var isEaten = payload.EatenFoodsByInternalName.TryGetValue(food.InternalName, out var count);
+            list.Add(new FoodItemViewModel(food, isEaten, isEaten ? count : 0));
+        }
+
+        // Sender had foods we don't recognize — show them in the same orphan section
+        // the live view uses for unknowns.
+        foreach (var (name, count) in unknown)
+            list.Add(new FoodItemViewModel(name, count));
+
+        // Sender is on a newer CDN than us: their InternalName isn't in our catalog.
+        // Surface it as a best-effort orphan keyed by InternalName.
+        foreach (var (internalName, count) in payload.EatenFoodsByInternalName)
+        {
+            if (_catalog.TryGetByInternalName(internalName, out _)) continue;
+            list.Add(new FoodItemViewModel(internalName, count));
+        }
+
+        list.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+        Foods.Clear();
+        foreach (var vm in list) Foods.Add(vm);
+        _foodsView.Refresh();
+
+        EatenCount = payload.EatenFoodsByInternalName.Count + unknown.Count;
+        TotalCount = _catalog.TotalCount;
+        CompletionPercent = TotalCount > 0 ? Math.Round(100.0 * EatenCount / TotalCount, 1) : 0;
+    }
+
+    private bool PassesComboFilters(object obj)
+    {
+        if (obj is not FoodItemViewModel vm) return false;
+
+        if (FoodTypeFilter != "All" &&
+            !vm.FoodType.Equals(FoodTypeFilter, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (EatenFilter == "Eaten" && !vm.IsEaten) return false;
+        if (EatenFilter == "Uneaten" && vm.IsEaten) return false;
+
+        return true;
+    }
+}

--- a/src/Pippin.Module/Sharing/SharedProgressWindow.xaml
+++ b/src/Pippin.Module/Sharing/SharedProgressWindow.xaml
@@ -1,0 +1,104 @@
+<Window x:Class="Pippin.Sharing.SharedProgressWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:Pippin.Sharing"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance vm:SharedProgressViewModel}"
+        Title="{Binding Title}"
+        Width="900" Height="640"
+        Background="#FF1A1A1A"
+        WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <DockPanel Margin="16">
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                <icon:PackIconLucide Kind="Share2" Width="22" Height="22" Foreground="#FFD4A847"
+                                     VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="{Binding Title}" FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeHero}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <WrapPanel Margin="0,0,0,4">
+                <TextBlock Margin="0,0,20,0">
+                    <Run Text="{Binding EatenCount, Mode=OneWay}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                    <Run Text="/" Foreground="#88FFFFFF"/>
+                    <Run Text="{Binding TotalCount, Mode=OneWay}" Foreground="#88FFFFFF"/>
+                    <Run Text=" eaten" Foreground="#88FFFFFF"/>
+                </TextBlock>
+                <TextBlock Margin="0,0,20,0">
+                    <Run Text="{Binding CompletionPercent, Mode=OneWay, StringFormat={}{0:0.#}}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                    <Run Text="%" Foreground="#88FFFFFF"/>
+                </TextBlock>
+                <TextBlock Foreground="#88FFFFFF" Text="{Binding SyncedLabel}"/>
+            </WrapPanel>
+        </StackPanel>
+
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <wpf:MithrilQueryBox Grid.Column="0"
+                                    Grid="{Binding ElementName=FoodsGrid}"
+                                    QueryText="{Binding ElementName=FoodsGrid, Path=QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    Watermark="filter shared progress"
+                                    Margin="0,0,12,0"/>
+                <ComboBox Grid.Column="1" SelectedItem="{Binding FoodTypeFilter}" Width="130" Margin="0,0,12,0">
+                    <ComboBoxItem Content="All" IsSelected="True"/>
+                    <ComboBoxItem Content="Meal"/>
+                    <ComboBoxItem Content="Snack"/>
+                    <ComboBoxItem Content="Instant Snack"/>
+                </ComboBox>
+                <ComboBox Grid.Column="2" SelectedItem="{Binding EatenFilter}" Width="110">
+                    <ComboBoxItem Content="All" IsSelected="True"/>
+                    <ComboBoxItem Content="Eaten"/>
+                    <ComboBoxItem Content="Uneaten"/>
+                </ComboBox>
+            </Grid>
+        </StackPanel>
+
+        <wpf:MithrilDataGrid x:Name="FoodsGrid"
+                            ItemsSource="{Binding Foods}"
+                            Mode="ReadOnly"
+                            GridLinesVisibility="None"
+                            EnableRowVirtualization="True"
+                            EnableColumnVirtualization="True"
+                            VirtualizingPanel.IsVirtualizing="True"
+                            VirtualizingPanel.VirtualizationMode="Recycling"
+                            VirtualizingPanel.ScrollUnit="Pixel"
+                            ScrollViewer.CanContentScroll="True">
+            <wpf:MithrilDataGrid.Columns>
+                <DataGridCheckBoxColumn Header="" Binding="{Binding IsEaten, Mode=OneWay}"
+                                        Width="32" IsReadOnly="True"
+                                        wpf:MithrilDataGrid.QueryName="IsEaten"/>
+                <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name" SortDirection="Ascending"
+                                        wpf:MithrilDataGrid.QueryName="Name">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Type" Binding="{Binding FoodType}" Width="110"/>
+                <DataGridTextColumn Header="Level" Binding="{Binding FoodLevel}" Width="60"/>
+                <DataGridTextColumn Header="Req" Binding="{Binding GourmandLevelReq}" Width="50"/>
+                <DataGridTextColumn Header="Count" Binding="{Binding EatenCount}" Width="60"/>
+                <DataGridTextColumn Header="Tags" Binding="{Binding DietaryTags}" Width="140"/>
+            </wpf:MithrilDataGrid.Columns>
+        </wpf:MithrilDataGrid>
+    </DockPanel>
+</Window>

--- a/src/Pippin.Module/Sharing/SharedProgressWindow.xaml.cs
+++ b/src/Pippin.Module/Sharing/SharedProgressWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Pippin.Sharing;
+
+public partial class SharedProgressWindow : Window
+{
+    public SharedProgressWindow(SharedProgressViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+}

--- a/src/Pippin.Module/State/GourmandLegacyMigration.cs
+++ b/src/Pippin.Module/State/GourmandLegacyMigration.cs
@@ -40,7 +40,12 @@ public sealed class GourmandLegacyMigration : ILegacyMigration<GourmandState>
             using var stream = File.OpenRead(_legacyPath);
             var loaded = JsonSerializer.Deserialize(stream, _typeInfo);
             if (loaded is null) return false;
-            migrated = loaded;
+
+            // PerCharacterStore.Load takes a fast path on legacy migration that bumps
+            // SchemaVersion straight to CurrentVersion without invoking Migrate. Run the
+            // v1→v2 structural step here so PendingLegacyByName captures the legacy dict
+            // before it's discarded.
+            migrated = GourmandState.Migrate(loaded);
             return true;
         }
         catch

--- a/src/Pippin.Module/State/GourmandStateMachine.cs
+++ b/src/Pippin.Module/State/GourmandStateMachine.cs
@@ -6,11 +6,16 @@ namespace Pippin.State;
 /// <summary>
 /// Maintains the set of foods the player has eaten.
 /// Authoritative source: the in-game Foods Consumed report parsed from the log.
+///
+/// Entries are kept by item <c>InternalName</c>; the in-game report only emits display
+/// names, so reports are joined against <see cref="FoodCatalog"/> on ingest. Names that
+/// fail to resolve are kept in <see cref="UnknownByName"/> so the UI can still show them.
 /// </summary>
 public sealed class GourmandStateMachine
 {
     private readonly FoodCatalog _catalog;
-    private readonly Dictionary<string, int> _eatenFoods = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, int> _eatenByInternalName = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _unknownByName = new(StringComparer.OrdinalIgnoreCase);
     private DateTimeOffset? _lastReportTime;
 
     public event EventHandler? StateChanged;
@@ -20,11 +25,16 @@ public sealed class GourmandStateMachine
         _catalog = catalog;
     }
 
-    public IReadOnlyDictionary<string, int> EatenFoods => _eatenFoods;
+    public IReadOnlyDictionary<string, int> EatenFoodsByInternalName => _eatenByInternalName;
+    public IReadOnlyDictionary<string, int> UnknownByName => _unknownByName;
     public DateTimeOffset? LastReportTime => _lastReportTime;
-    public int EatenCount => _eatenFoods.Count;
+
+    /// <summary>
+    /// Distinct foods eaten — unique <c>InternalName</c> entries plus orphan unknowns.
+    /// </summary>
+    public int EatenCount => _eatenByInternalName.Count + _unknownByName.Count;
     public int TotalFoodCount => _catalog.TotalCount;
-    public bool HasData => _eatenFoods.Count > 0;
+    public bool HasData => EatenCount > 0;
 
     public void Apply(GourmandEvent evt)
     {
@@ -41,17 +51,78 @@ public sealed class GourmandStateMachine
     /// </summary>
     public void Hydrate(GourmandState persisted)
     {
-        _eatenFoods.Clear();
-        foreach (var (name, count) in persisted.EatenFoods)
-            _eatenFoods[name] = count;
+        _eatenByInternalName.Clear();
+        foreach (var (internalName, count) in persisted.EatenFoodsByInternalName)
+            _eatenByInternalName[internalName] = count;
+
+        _unknownByName.Clear();
+        foreach (var (name, count) in persisted.UnknownByName)
+            _unknownByName[name] = count;
+
         _lastReportTime = persisted.LastReportTime;
+    }
+
+    /// <summary>
+    /// Re-resolve any unknown-by-name entries against the catalog. Called after the catalog
+    /// completes a build so foods the player ate before the CDN snapshot caught up are
+    /// promoted out of the unknown bucket without waiting for the next in-game report.
+    /// </summary>
+    public bool ReconcileUnknowns()
+    {
+        if (_unknownByName.Count == 0) return false;
+
+        var resolved = new List<string>();
+        foreach (var (name, count) in _unknownByName)
+        {
+            if (!_catalog.TryGetByName(name, out var food)) continue;
+            _eatenByInternalName[food.InternalName] = Math.Max(
+                count,
+                _eatenByInternalName.TryGetValue(food.InternalName, out var existing) ? existing : 0);
+            resolved.Add(name);
+        }
+
+        if (resolved.Count == 0) return false;
+
+        foreach (var name in resolved) _unknownByName.Remove(name);
+        StateChanged?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    /// <summary>
+    /// Drain a v1 display-name dict into the resolved/unknown buckets. Used by the
+    /// schema migration once the catalog is ready. Returns true if any entries were
+    /// applied (and therefore the persisted state should be flushed).
+    /// </summary>
+    public bool ApplyLegacyByName(IReadOnlyDictionary<string, int> legacy)
+    {
+        if (legacy.Count == 0) return false;
+
+        foreach (var (name, count) in legacy)
+        {
+            if (_catalog.TryGetByName(name, out var food))
+                _eatenByInternalName[food.InternalName] = count;
+            else
+                _unknownByName[name] = count;
+        }
+
+        _lastReportTime ??= DateTimeOffset.UtcNow;
+        StateChanged?.Invoke(this, EventArgs.Empty);
+        return true;
     }
 
     private void HandleReport(FoodsConsumedReport report)
     {
-        _eatenFoods.Clear();
+        _eatenByInternalName.Clear();
+        _unknownByName.Clear();
+
         foreach (var food in report.Foods)
-            _eatenFoods[food.Name] = food.Count;
+        {
+            if (_catalog.TryGetByName(food.Name, out var entry))
+                _eatenByInternalName[entry.InternalName] = food.Count;
+            else
+                _unknownByName[food.Name] = food.Count;
+        }
+
         _lastReportTime = DateTimeOffset.UtcNow;
         StateChanged?.Invoke(this, EventArgs.Empty);
     }

--- a/src/Pippin.Module/State/GourmandStateService.cs
+++ b/src/Pippin.Module/State/GourmandStateService.cs
@@ -8,23 +8,34 @@ namespace Pippin.State;
 /// On character switch, hydrates the machine from the new character's file. On state
 /// changes, snapshots the machine back into <see cref="PerCharacterView{T}.Current"/>
 /// and writes to disk with a 500 ms debounce.
+///
+/// Also drives the second phase of the v1→v2 schema migration: when a hydrated state
+/// has a non-empty <see cref="GourmandState.PendingLegacyByName"/> and the catalog
+/// reports ready, the legacy display-name dict is resolved through the catalog into
+/// <see cref="GourmandState.EatenFoodsByInternalName"/> + <see cref="GourmandState.UnknownByName"/>.
 /// </summary>
 public sealed class GourmandStateService : IDisposable
 {
     private readonly GourmandStateMachine _state;
     private readonly PerCharacterView<GourmandState> _view;
+    private readonly FoodCatalog _catalog;
     private readonly System.Timers.Timer _debounce;
     private bool _dirty;
     private bool _hydrating;
 
-    public GourmandStateService(GourmandStateMachine state, PerCharacterView<GourmandState> view)
+    public GourmandStateService(
+        GourmandStateMachine state,
+        PerCharacterView<GourmandState> view,
+        FoodCatalog catalog)
     {
         _state = state;
         _view = view;
+        _catalog = catalog;
         _debounce = new System.Timers.Timer(500) { AutoReset = false };
         _debounce.Elapsed += (_, _) => Flush();
         _state.StateChanged += OnChanged;
         _view.CurrentChanged += OnCurrentChanged;
+        _catalog.CatalogChanged += OnCatalogChanged;
     }
 
     /// <summary>
@@ -47,6 +58,15 @@ public sealed class GourmandStateService : IDisposable
 
     private void OnCurrentChanged(object? sender, EventArgs e) => HydrateFromCurrent();
 
+    private void OnCatalogChanged(object? sender, EventArgs e)
+    {
+        // Catalog (re)built — try to drain any pending legacy data and reconcile previously
+        // unknown foods now that we have more reference data on hand.
+        var promoted = PromoteLegacyIfReady();
+        var reconciled = _state.ReconcileUnknowns();
+        if (promoted || reconciled) MarkDirty();
+    }
+
     private void HydrateFromCurrent()
     {
         var current = _view.Current;
@@ -59,13 +79,45 @@ public sealed class GourmandStateService : IDisposable
         {
             _hydrating = false;
         }
+
+        // Try to finish a deferred v1→v2 migration if the catalog is already ready.
+        PromoteLegacyIfReady();
+    }
+
+    /// <summary>
+    /// Drain <see cref="GourmandState.PendingLegacyByName"/> through the catalog.
+    /// No-op when the catalog isn't ready, when there's no pending data, or when no
+    /// character is active. Returns true when state was modified.
+    /// </summary>
+    private bool PromoteLegacyIfReady()
+    {
+        var current = _view.Current;
+        if (current is null) return false;
+        if (current.PendingLegacyByName is not { Count: > 0 } pending) return false;
+        if (!_catalog.IsReady) return false;
+
+        _hydrating = true;
+        try
+        {
+            _state.ApplyLegacyByName(pending);
+        }
+        finally
+        {
+            _hydrating = false;
+        }
+
+        current.PendingLegacyByName = null;
+        SyncSnapshotToView();
+        MarkDirty();
+        return true;
     }
 
     private void SyncSnapshotToView()
     {
         var current = _view.Current;
         if (current is null) return;
-        current.EatenFoods = new Dictionary<string, int>(_state.EatenFoods, StringComparer.OrdinalIgnoreCase);
+        current.EatenFoodsByInternalName = new Dictionary<string, int>(_state.EatenFoodsByInternalName, StringComparer.Ordinal);
+        current.UnknownByName = new Dictionary<string, int>(_state.UnknownByName, StringComparer.OrdinalIgnoreCase);
         current.LastReportTime = _state.LastReportTime;
     }
 
@@ -87,6 +139,7 @@ public sealed class GourmandStateService : IDisposable
     {
         _state.StateChanged -= OnChanged;
         _view.CurrentChanged -= OnCurrentChanged;
+        _catalog.CatalogChanged -= OnCatalogChanged;
         _debounce.Stop();
         _debounce.Dispose();
         Flush();

--- a/src/Pippin.Module/ViewModels/GourmandViewModel.cs
+++ b/src/Pippin.Module/ViewModels/GourmandViewModel.cs
@@ -1,9 +1,15 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
+using System.Text;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Character;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Wpf.Dialogs;
 using Pippin.Domain;
+using Pippin.Sharing;
 using Pippin.State;
 
 namespace Pippin.ViewModels;
@@ -13,16 +19,25 @@ public sealed partial class GourmandViewModel : ObservableObject
     private readonly GourmandStateMachine _state;
     private readonly FoodCatalog _catalog;
     private readonly IActiveCharacterService? _activeChar;
+    private readonly IDialogService? _dialogs;
+    private readonly PippinShareCardRenderer? _shareRenderer;
+    private readonly IIconCacheService? _iconCache;
     private readonly ICollectionView _foodsView;
 
     public GourmandViewModel(
         GourmandStateMachine state,
         FoodCatalog catalog,
-        IActiveCharacterService? characterData = null)
+        IActiveCharacterService? characterData = null,
+        IDialogService? dialogs = null,
+        PippinShareCardRenderer? shareRenderer = null,
+        IIconCacheService? iconCache = null)
     {
         _state = state;
         _catalog = catalog;
         _activeChar = characterData;
+        _dialogs = dialogs;
+        _shareRenderer = shareRenderer;
+        _iconCache = iconCache;
 
         Foods = new ObservableCollection<FoodItemViewModel>();
         _foodsView = CollectionViewSource.GetDefaultView(Foods);
@@ -30,6 +45,7 @@ public sealed partial class GourmandViewModel : ObservableObject
         _foodsView.Filter = PassesComboFilters;
 
         _state.StateChanged += (_, _) => Rebuild();
+        _catalog.CatalogChanged += (_, _) => Rebuild();
         if (_activeChar is not null)
         {
             _activeChar.ActiveCharacterChanged += (_, _) =>
@@ -68,21 +84,19 @@ public sealed partial class GourmandViewModel : ObservableObject
 
     private void Rebuild()
     {
-        var eaten = _state.EatenFoods;
+        var eaten = _state.EatenFoodsByInternalName;
+        var unknown = _state.UnknownByName;
 
         // Build the full list off the bound collection, then swap in a single Reset
         // to avoid per-item CollectionChanged notifications on large catalogs.
-        var list = new List<FoodItemViewModel>(_catalog.TotalCount + eaten.Count);
-        foreach (var food in _catalog.ByName.Values)
+        var list = new List<FoodItemViewModel>(_catalog.TotalCount + unknown.Count);
+        foreach (var food in _catalog.ByInternalName.Values)
         {
-            var isEaten = eaten.TryGetValue(food.Name, out var count);
+            var isEaten = eaten.TryGetValue(food.InternalName, out var count);
             list.Add(new FoodItemViewModel(food, isEaten, isEaten ? count : 0));
         }
-        foreach (var (name, count) in eaten)
-        {
-            if (!_catalog.ByName.ContainsKey(name))
-                list.Add(new FoodItemViewModel(name, count));
-        }
+        foreach (var (name, count) in unknown)
+            list.Add(new FoodItemViewModel(name, count));
         list.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
 
         Foods.Clear();
@@ -90,7 +104,7 @@ public sealed partial class GourmandViewModel : ObservableObject
             Foods.Add(vm);
         _foodsView.Refresh();
 
-        EatenCount = eaten.Count;
+        EatenCount = _state.EatenCount;
         TotalCount = _catalog.TotalCount;
         CompletionPercent = TotalCount > 0 ? Math.Round(100.0 * EatenCount / TotalCount, 1) : 0;
         HasData = _state.HasData;
@@ -121,5 +135,85 @@ public sealed partial class GourmandViewModel : ObservableObject
         if (EatenFilter == "Uneaten" && vm.IsEaten) return false;
 
         return true;
+    }
+
+    [RelayCommand]
+    private void ShareProgress()
+    {
+        if (_dialogs is null || _shareRenderer is null || _iconCache is null) return;
+        var catalogIconIds = _catalog.ByInternalName.Values
+            .Select(f => f.IconId)
+            .Where(id => id > 0)
+            .Distinct()
+            .ToList();
+        var vm = new PippinShareDialogViewModel(
+            BuildPayload,
+            BuildSummary,
+            () => GourmandLevel,
+            _shareRenderer,
+            _iconCache,
+            catalogIconIds,
+            _activeChar?.ActiveCharacterName);
+        _dialogs.ShowDialog(vm, new PippinShareDialog());
+    }
+
+    /// <summary>Snapshot the live state into a <see cref="PippinSharePayload"/>.</summary>
+    public PippinSharePayload BuildPayload(bool includeCharacterName)
+    {
+        var payload = new PippinSharePayload
+        {
+            CharacterName = includeCharacterName ? _activeChar?.ActiveCharacterName : null,
+            EatenFoodsByInternalName = new Dictionary<string, int>(_state.EatenFoodsByInternalName, StringComparer.Ordinal),
+            LastReportTime = _state.LastReportTime,
+        };
+        if (_state.UnknownByName.Count > 0)
+            payload.UnknownByName = new Dictionary<string, int>(_state.UnknownByName, StringComparer.OrdinalIgnoreCase);
+        return payload;
+    }
+
+    /// <summary>
+    /// Build a Discord-friendly summary from a snapshot payload, joined against the
+    /// sender's catalog so display names (and the top-foods list) reflect what the
+    /// sender sees.
+    /// </summary>
+    public string BuildSummary(PippinSharePayload payload)
+    {
+        var sb = new StringBuilder();
+        var eatenCount = payload.EatenFoodsByInternalName.Count + (payload.UnknownByName?.Count ?? 0);
+        var totalCount = _catalog.TotalCount > 0 ? _catalog.TotalCount : eatenCount;
+        var pct = totalCount > 0 ? 100.0 * eatenCount / totalCount : 0;
+
+        var prefix = string.IsNullOrEmpty(payload.CharacterName)
+            ? "Gourmand"
+            : $"{payload.CharacterName} · Gourmand";
+        if (GourmandLevel > 0) sb.Append(prefix).Append(" Lv ").Append(GourmandLevel).Append(" · ");
+        else sb.Append(prefix).Append(" · ");
+        sb.Append(eatenCount).Append(" / ").Append(totalCount)
+          .Append(" foods (").Append(pct.ToString("0.#", CultureInfo.InvariantCulture)).AppendLine("%)");
+
+        if (payload.LastReportTime is { } t)
+            sb.Append("Last synced: ").AppendLine(FormatAgo(DateTimeOffset.UtcNow - t));
+
+        var top = payload.EatenFoodsByInternalName
+            .OrderByDescending(kv => kv.Value)
+            .Take(5)
+            .Select(kv =>
+            {
+                var name = _catalog.TryGetByInternalName(kv.Key, out var food) ? food.Name : kv.Key;
+                return $"{name} ×{kv.Value}";
+            })
+            .ToList();
+        if (top.Count > 0)
+            sb.Append("Top: ").AppendLine(string.Join(", ", top));
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatAgo(TimeSpan ago)
+    {
+        if (ago.TotalMinutes < 1) return "just now";
+        if (ago.TotalHours < 1) return $"{(int)ago.TotalMinutes}m ago";
+        if (ago.TotalDays < 1) return $"{(int)ago.TotalHours}h ago";
+        return $"{(int)ago.TotalDays}d ago";
     }
 }

--- a/src/Pippin.Module/Views/GourmandView.xaml
+++ b/src/Pippin.Module/Views/GourmandView.xaml
@@ -28,26 +28,36 @@
                            Foreground="#FFD4A847" VerticalAlignment="Center"/>
             </StackPanel>
 
-            <WrapPanel Margin="0,0,0,4">
-                <TextBlock Margin="0,0,20,0">
-                    <Run Text="{Binding EatenCount, Mode=OneWay}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
-                    <Run Text="/" Foreground="#88FFFFFF"/>
-                    <Run Text="{Binding TotalCount, Mode=OneWay}" Foreground="#88FFFFFF"/>
-                    <Run Text=" eaten" Foreground="#88FFFFFF"/>
-                </TextBlock>
-                <TextBlock Margin="0,0,20,0">
-                    <Run Text="{Binding CompletionPercent, Mode=OneWay, StringFormat={}{0:0.#}}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
-                    <Run Text="%" Foreground="#88FFFFFF"/>
-                </TextBlock>
-                <TextBlock Margin="0,0,20,0">
-                    <Run Text="Gourmand Lv " Foreground="#88FFFFFF"/>
-                    <Run Text="{Binding GourmandLevel, Mode=OneWay}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
-                </TextBlock>
-                <TextBlock Foreground="#88FFFFFF">
-                    <Run Text="Synced: "/>
-                    <Run Text="{Binding LastSyncLabel, Mode=OneWay}" Foreground="#CCFFFFFF"/>
-                </TextBlock>
-            </WrapPanel>
+            <Grid Margin="0,0,0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <WrapPanel Grid.Column="0">
+                    <TextBlock Margin="0,0,20,0">
+                        <Run Text="{Binding EatenCount, Mode=OneWay}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                        <Run Text="/" Foreground="#88FFFFFF"/>
+                        <Run Text="{Binding TotalCount, Mode=OneWay}" Foreground="#88FFFFFF"/>
+                        <Run Text=" eaten" Foreground="#88FFFFFF"/>
+                    </TextBlock>
+                    <TextBlock Margin="0,0,20,0">
+                        <Run Text="{Binding CompletionPercent, Mode=OneWay, StringFormat={}{0:0.#}}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                        <Run Text="%" Foreground="#88FFFFFF"/>
+                    </TextBlock>
+                    <TextBlock Margin="0,0,20,0">
+                        <Run Text="Gourmand Lv " Foreground="#88FFFFFF"/>
+                        <Run Text="{Binding GourmandLevel, Mode=OneWay}" Foreground="#FFE8E8E8" FontWeight="SemiBold"/>
+                    </TextBlock>
+                    <TextBlock Foreground="#88FFFFFF">
+                        <Run Text="Synced: "/>
+                        <Run Text="{Binding LastSyncLabel, Mode=OneWay}" Foreground="#CCFFFFFF"/>
+                    </TextBlock>
+                </WrapPanel>
+                <Button Grid.Column="1" Command="{Binding ShareProgressCommand}"
+                        Content="Share…" Padding="12,4" VerticalAlignment="Center"
+                        Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"
+                        ToolTip="Share progress as a link, JSON, or summary"/>
+            </Grid>
         </StackPanel>
 
         <!-- ── Filters ── -->

--- a/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
+++ b/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
@@ -1,0 +1,173 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using FluentAssertions;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Icons;
+
+[Trait("Category", "FileIO")]
+public sealed class IconCachePreloadTests : IDisposable
+{
+    private readonly string _cacheDir;
+
+    public IconCachePreloadTests()
+    {
+        _cacheDir = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-icon-cache");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_cacheDir, recursive: true); } catch { }
+    }
+
+    private IconCacheService CreateService(HttpMessageHandler? handler = null)
+    {
+        var http = new HttpClient(handler ?? new RecordingHandler(_ => MakeOkPng()));
+        var refData = new EmptyReferenceData();
+        var settings = new IconSettings();
+        return new IconCacheService(_cacheDir, http, refData, diag: null, settings);
+    }
+
+    [Fact]
+    public void IsCached_returns_false_for_nonpositive_ids()
+    {
+        var svc = CreateService();
+        svc.IsCached(0).Should().BeFalse();
+        svc.IsCached(-1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCached_returns_false_for_unknown_id()
+        => CreateService().IsCached(42).Should().BeFalse();
+
+    [Fact]
+    public void IsCached_returns_true_when_file_already_on_disk()
+    {
+        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_99.png"), MakePngBytes());
+        CreateService().IsCached(99).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetUncachedIcons_filters_dedupes_and_drops_nonpositive()
+    {
+        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_10.png"), MakePngBytes());
+        var svc = CreateService();
+
+        var result = svc.GetUncachedIcons(new[] { 10, 20, 20, 30, 0, -5, 10 });
+
+        result.Should().Equal(20, 30);
+    }
+
+    [Fact]
+    public async Task PreloadAsync_with_empty_input_reports_zero_total()
+    {
+        var svc = CreateService();
+        var seen = new List<(int completed, int total)>();
+        await svc.PreloadAsync(Array.Empty<int>(), new TestProgress(seen));
+
+        seen.Should().ContainSingle().Which.Should().Be((0, 0));
+    }
+
+    [Fact]
+    public async Task PreloadAsync_skips_already_cached_ids()
+    {
+        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_10.png"), MakePngBytes());
+        var requests = new List<int>();
+        var handler = new RecordingHandler(req =>
+        {
+            // Record the requested icon id from the URL path
+            var id = int.Parse(System.IO.Path.GetFileNameWithoutExtension(req.RequestUri!.AbsolutePath).Replace("icon_", ""));
+            requests.Add(id);
+            return MakeOkPng();
+        });
+
+        var svc = CreateService(handler);
+        await svc.PreloadAsync(new[] { 10 }); // already cached
+
+        requests.Should().BeEmpty("ids already on disk must not trigger a network round-trip");
+    }
+
+    [Fact]
+    public async Task PreloadAsync_downloads_missing_ids_and_reports_progress()
+    {
+        var handler = new RecordingHandler(_ => MakeOkPng());
+        var svc = CreateService(handler);
+
+        var seen = new List<(int completed, int total)>();
+        await svc.PreloadAsync(new[] { 11, 12, 13 }, new TestProgress(seen));
+
+        File.Exists(Path.Combine(_cacheDir, "icon_11.png")).Should().BeTrue();
+        File.Exists(Path.Combine(_cacheDir, "icon_12.png")).Should().BeTrue();
+        File.Exists(Path.Combine(_cacheDir, "icon_13.png")).Should().BeTrue();
+
+        // First report is (0, 3), final is (3, 3); intermediate counts can arrive in any order
+        seen.First().Should().Be((0, 3));
+        seen.Last().Should().Be((3, 3));
+    }
+
+    private static HttpResponseMessage MakeOkPng() => new(HttpStatusCode.OK)
+    {
+        Content = new ByteArrayContent(MakePngBytes()),
+    };
+
+    /// <summary>1×1 transparent PNG header — enough to satisfy WriteAllBytes; never decoded by the cache during PreloadAsync.</summary>
+    private static byte[] MakePngBytes() =>
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+        0x42, 0x60, 0x82,
+    ];
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(_respond(request));
+    }
+
+    private sealed class TestProgress : IProgress<(int completed, int total)>
+    {
+        private readonly List<(int, int)> _list;
+        public TestProgress(List<(int, int)> list) => _list = list;
+        public void Report((int completed, int total) value)
+        {
+            lock (_list) _list.Add(value);
+        }
+    }
+
+    private sealed class EmptyReferenceData : IReferenceDataService
+    {
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public event EventHandler<string>? FileUpdated;
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        private void Suppress() => FileUpdated?.Invoke(this, "");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
@@ -122,6 +122,56 @@ public class DeepLinkRouterTests
         listTarget.LastPayload.Should().BeNull();
     }
 
+    // ---- mithril://pippin/… branch ------------------------------------------
+
+    [Fact]
+    public void PippinUri_Dispatched_WithBase64UrlPayload()
+    {
+        var presenter = new RecordingPresenter();
+        var pippinTarget = new RecordingPippinTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: pippinTarget);
+
+        var handled = router.Handle("mithril://pippin/AB-_abcXYZ123");
+
+        handled.Should().BeTrue();
+        pippinTarget.LastPayload.Should().Be("AB-_abcXYZ123");
+    }
+
+    [Fact]
+    public void PippinUri_WithoutRegisteredTarget_IsDropped()
+    {
+        var presenter = new RecordingPresenter();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null);
+
+        router.Handle("mithril://pippin/AB-_abcXYZ123").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("mithril://pippin/has.dot")]
+    [InlineData("mithril://pippin/has space")]
+    [InlineData("mithril://pippin/")]
+    public void PippinUri_MalformedPayload_IsRejected(string uri)
+    {
+        var presenter = new RecordingPresenter();
+        var pippinTarget = new RecordingPippinTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: pippinTarget);
+
+        router.Handle(uri).Should().BeFalse();
+        pippinTarget.LastPayload.Should().BeNull();
+    }
+
+    [Fact]
+    public void PippinUri_PayloadOverLengthCap_IsRejected()
+    {
+        var presenter = new RecordingPresenter();
+        var pippinTarget = new RecordingPippinTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: pippinTarget);
+
+        var tooLong = new string('A', 16_385);
+        router.Handle($"mithril://pippin/{tooLong}").Should().BeFalse();
+        pippinTarget.LastPayload.Should().BeNull();
+    }
+
     private sealed class RecordingPresenter : IItemDetailPresenter
     {
         public string? LastShown { get; private set; }
@@ -131,6 +181,12 @@ public class DeepLinkRouterTests
     }
 
     private sealed class RecordingListTarget : ICraftListImportTarget
+    {
+        public string? LastPayload { get; private set; }
+        public void ImportFromLinkPayload(string base64UrlPayload) => LastPayload = base64UrlPayload;
+    }
+
+    private sealed class RecordingPippinTarget : IPippinShareImportTarget
     {
         public string? LastPayload { get; private set; }
         public void ImportFromLinkPayload(string base64UrlPayload) => LastPayload = base64UrlPayload;

--- a/tests/Mithril.Shared.Tests/Sharing/ShareCodecTests.cs
+++ b/tests/Mithril.Shared.Tests/Sharing/ShareCodecTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Mithril.Shared.Sharing;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Sharing;
+
+public class ShareCodecTests
+{
+    [Theory]
+    [InlineData("a")]
+    [InlineData("hello")]
+    [InlineData("the quick brown fox jumps over the lazy dog")]
+    [InlineData("{\"schemaVersion\":2,\"eatenFoodsByInternalName\":{\"FoodBacon\":3}}")]
+    public void EncodeDecode_round_trips(string text)
+    {
+        var encoded = ShareCodec.EncodePayload(text);
+        var ok = ShareCodec.TryDecodePayload(encoded, out var decoded, out var error);
+
+        ok.Should().BeTrue();
+        error.Should().BeNull();
+        decoded.Should().Be(text);
+    }
+
+    [Fact]
+    public void Encoded_output_is_url_safe_base64url()
+    {
+        var encoded = ShareCodec.EncodePayload("the quick brown fox jumps over the lazy dog");
+
+        encoded.Should().NotContain("+");
+        encoded.Should().NotContain("/");
+        encoded.Should().NotContain("=");
+        encoded.Should().MatchRegex("^[A-Za-z0-9_-]+$");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Empty_input_is_rejected(string? input)
+    {
+        var ok = ShareCodec.TryDecodePayload(input, out _, out var error);
+        ok.Should().BeFalse();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Garbage_base64url_is_rejected()
+    {
+        // Length 1 is unrecoverable in base64url — should surface a format error rather
+        // than throw.
+        var ok = ShareCodec.TryDecodePayload("a", out _, out var error);
+        ok.Should().BeFalse();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Wrong_version_byte_is_rejected()
+    {
+        // Build a version-99 envelope manually (still valid base64url, still gzip data
+        // after the prefix) and confirm the codec refuses it instead of attempting to
+        // decompress garbage.
+        using var ms = new System.IO.MemoryStream();
+        ms.WriteByte(99);
+        using (var gz = new System.IO.Compression.GZipStream(ms, System.IO.Compression.CompressionLevel.Optimal, leaveOpen: true))
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes("hello");
+            gz.Write(bytes, 0, bytes.Length);
+        }
+        var b64url = Convert.ToBase64String(ms.ToArray()).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        var ok = ShareCodec.TryDecodePayload(b64url, out _, out var error);
+        ok.Should().BeFalse();
+        error.Should().Contain("99");
+    }
+
+    [Fact]
+    public void Decompressed_payload_above_safety_cap_is_rejected()
+    {
+        // Encode 257 KB of repeating 'a' — gzip compresses heavily so the encoded URL is
+        // tiny, but decompression must trip the 256 KB safety cap.
+        var huge = new string('a', ShareCodec.MaxDecompressedBytes + 1024);
+        var encoded = ShareCodec.EncodePayload(huge);
+
+        var ok = ShareCodec.TryDecodePayload(encoded, out _, out var error);
+        ok.Should().BeFalse();
+        error.Should().Contain("256 KB");
+    }
+
+    [Fact]
+    public void Realistic_completionist_payload_fits_url_budget()
+    {
+        // 614 distinct foods is the rough Project Gorgon completionist count; force the
+        // upper bound on internal-name length so the test is honest about worst case.
+        var sb = new System.Text.StringBuilder();
+        sb.Append("{\"schemaVersion\":2,\"eatenFoodsByInternalName\":{");
+        for (var i = 0; i < 614; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append('"').Append("FoodOverlyLongInternalNameForStressTesting").Append(i.ToString("D3")).Append("\":99");
+        }
+        sb.Append("},\"lastReportTime\":\"2026-04-01T12:00:00+00:00\"}");
+
+        var encoded = ShareCodec.EncodePayload(sb.ToString());
+        encoded.Length.Should().BeLessThan(16_384, "fits inside the deep-link router's pippin payload cap");
+    }
+}

--- a/tests/Pippin.Tests/GourmandStateMachineTests.cs
+++ b/tests/Pippin.Tests/GourmandStateMachineTests.cs
@@ -9,11 +9,14 @@ namespace Pippin.Tests;
 
 public class GourmandStateMachineTests
 {
-    private static FoodCatalog CreateEmptyCatalog()
+    private static FoodCatalog CreateEmptyCatalog() => new(new StubReferenceDataService([]));
+
+    private static FoodCatalog CreateCatalog(params (long Id, string InternalName, string Name)[] foods)
     {
-        // Create a minimal mock reference data service
-        var refData = new StubReferenceDataService();
-        return new FoodCatalog(refData);
+        var dict = new Dictionary<long, ItemEntry>();
+        foreach (var (id, internalName, name) in foods)
+            dict[id] = new ItemEntry(id, name, internalName, 1, 0, [], FoodDesc: "Level 0 Snack");
+        return new FoodCatalog(new StubReferenceDataService(dict));
     }
 
     private static FoodsConsumedReport MakeReport(params (string Name, int Count)[] foods)
@@ -24,27 +27,47 @@ public class GourmandStateMachineTests
     }
 
     [Fact]
-    public void Apply_populates_eaten_foods()
+    public void Apply_resolves_known_foods_to_internal_name()
     {
-        var sm = new GourmandStateMachine(CreateEmptyCatalog());
+        var sm = new GourmandStateMachine(CreateCatalog(
+            (1, "FoodAppleJuice", "Apple Juice"),
+            (2, "FoodBacon", "Bacon")));
+
         sm.Apply(MakeReport(("Apple Juice", 5), ("Bacon", 2)));
 
-        sm.EatenFoods.Should().HaveCount(2);
-        sm.EatenFoods["Apple Juice"].Should().Be(5);
-        sm.EatenFoods["Bacon"].Should().Be(2);
+        sm.EatenFoodsByInternalName.Should().HaveCount(2);
+        sm.EatenFoodsByInternalName["FoodAppleJuice"].Should().Be(5);
+        sm.EatenFoodsByInternalName["FoodBacon"].Should().Be(2);
+        sm.UnknownByName.Should().BeEmpty();
         sm.HasData.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_with_unknown_food_buckets_into_UnknownByName()
+    {
+        var sm = new GourmandStateMachine(CreateCatalog((1, "FoodBacon", "Bacon")));
+
+        sm.Apply(MakeReport(("Bacon", 2), ("Mystery Stew", 1)));
+
+        sm.EatenFoodsByInternalName.Should().ContainKey("FoodBacon").WhoseValue.Should().Be(2);
+        sm.UnknownByName.Should().ContainKey("Mystery Stew").WhoseValue.Should().Be(1);
+        sm.EatenCount.Should().Be(2, "unique foods include both resolved and unknown buckets");
     }
 
     [Fact]
     public void Second_report_replaces_first()
     {
-        var sm = new GourmandStateMachine(CreateEmptyCatalog());
+        var sm = new GourmandStateMachine(CreateCatalog(
+            (1, "FoodAppleJuice", "Apple Juice"),
+            (2, "FoodBacon", "Bacon"),
+            (3, "FoodGrapes", "Grapes")));
+
         sm.Apply(MakeReport(("Apple Juice", 5), ("Bacon", 2)));
         sm.Apply(MakeReport(("Grapes", 3)));
 
-        sm.EatenFoods.Should().HaveCount(1);
-        sm.EatenFoods.Should().ContainKey("Grapes");
-        sm.EatenFoods.Should().NotContainKey("Apple Juice");
+        sm.EatenFoodsByInternalName.Should().HaveCount(1);
+        sm.EatenFoodsByInternalName.Should().ContainKey("FoodGrapes");
+        sm.EatenFoodsByInternalName.Should().NotContainKey("FoodAppleJuice");
     }
 
     [Fact]
@@ -56,12 +79,14 @@ public class GourmandStateMachineTests
 
         sm.Hydrate(new GourmandState
         {
-            EatenFoods = new Dictionary<string, int> { ["Bacon"] = 1 },
+            EatenFoodsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal) { ["FoodBacon"] = 1 },
+            UnknownByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["Mystery Stew"] = 4 },
             LastReportTime = DateTimeOffset.UtcNow,
         });
 
         eventFired.Should().BeFalse();
-        sm.EatenFoods.Should().ContainKey("Bacon");
+        sm.EatenFoodsByInternalName.Should().ContainKey("FoodBacon");
+        sm.UnknownByName.Should().ContainKey("Mystery Stew");
     }
 
     [Fact]
@@ -76,13 +101,69 @@ public class GourmandStateMachineTests
         eventFired.Should().BeTrue();
     }
 
-    /// <summary>Minimal stub so FoodCatalog can be constructed without real CDN data.</summary>
+    [Fact]
+    public void ApplyLegacyByName_resolves_through_catalog()
+    {
+        var sm = new GourmandStateMachine(CreateCatalog(
+            (1, "FoodAppleJuice", "Apple Juice"),
+            (2, "FoodBacon", "Bacon")));
+
+        var changed = sm.ApplyLegacyByName(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Apple Juice"] = 8,
+            ["Bacon"] = 2,
+            ["Mystery Stew"] = 1, // not in catalog → unknown
+        });
+
+        changed.Should().BeTrue();
+        sm.EatenFoodsByInternalName["FoodAppleJuice"].Should().Be(8);
+        sm.EatenFoodsByInternalName["FoodBacon"].Should().Be(2);
+        sm.UnknownByName.Should().ContainKey("Mystery Stew").WhoseValue.Should().Be(1);
+    }
+
+    [Fact]
+    public void ReconcileUnknowns_promotes_entries_when_catalog_catches_up()
+    {
+        var stub = new StubReferenceDataService(new Dictionary<long, ItemEntry>
+        {
+            [1] = new(1, "Bacon", "FoodBacon", 1, 0, [], FoodDesc: "Level 0 Snack"),
+        });
+        var catalog = new FoodCatalog(stub);
+        var sm = new GourmandStateMachine(catalog);
+
+        // Sender ate Mystery Stew before our CDN snapshot knew about it.
+        sm.Hydrate(new GourmandState
+        {
+            UnknownByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["Mystery Stew"] = 4 },
+        });
+        sm.UnknownByName.Should().HaveCount(1);
+
+        // CDN refresh adds the food to the catalog and rebuilds.
+        stub.Add(new ItemEntry(2, "Mystery Stew", "FoodMysteryStew", 1, 0, [], FoodDesc: "Level 5 Meal"));
+        stub.RaiseFileUpdated();
+
+        sm.ReconcileUnknowns().Should().BeTrue();
+        sm.UnknownByName.Should().BeEmpty();
+        sm.EatenFoodsByInternalName.Should().ContainKey("FoodMysteryStew").WhoseValue.Should().Be(4);
+    }
+
+    /// <summary>Minimal stub so FoodCatalog can be constructed with controllable contents.</summary>
     private sealed class StubReferenceDataService : IReferenceDataService
     {
+        private readonly Dictionary<long, ItemEntry> _items;
+
+        public StubReferenceDataService(Dictionary<long, ItemEntry> items)
+        {
+            _items = items;
+        }
+
+        public void Add(ItemEntry item) => _items[item.Id] = item;
+        public void RaiseFileUpdated() => FileUpdated?.Invoke(this, "items");
+
         public IReadOnlyList<string> Keys { get; } = [];
-        public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
+        public IReadOnlyDictionary<long, ItemEntry> Items => _items;
         public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
-        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
         public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
@@ -100,6 +181,5 @@ public class GourmandStateMachineTests
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
         public void BeginBackgroundRefresh() { }
-        private void SuppressWarning() => FileUpdated?.Invoke(this, ""); // suppress CS0067
     }
 }

--- a/tests/Pippin.Tests/GourmandStateServiceMigrationTests.cs
+++ b/tests/Pippin.Tests/GourmandStateServiceMigrationTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using FluentAssertions;
 using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
 using Pippin.Domain;
 using Pippin.State;
 using Xunit;
@@ -31,17 +32,17 @@ public sealed class GourmandStateServiceMigrationTests : IDisposable
     }
 
     [Fact]
-    public void First_load_migrates_legacy_flat_file_into_active_character_directory()
+    public void First_load_migrates_legacy_flat_file_into_active_character_directory_with_pending_data()
     {
-        // Seed the pre-per-character flat file.
+        // Seed the pre-per-character flat file, written in the v1 shape (display-name keys).
         var legacyFile = Path.Combine(_legacyDir, "gourmand-state.json");
-        File.WriteAllText(legacyFile, JsonSerializer.Serialize(
-            new GourmandState
+        File.WriteAllText(legacyFile, """
             {
-                EatenFoods = new Dictionary<string, int> { ["Bacon"] = 3, ["Apple Juice"] = 7 },
-                LastReportTime = DateTimeOffset.UtcNow,
-            },
-            GourmandStateJsonContext.Default.GourmandState));
+                "schemaVersion": 1,
+                "eatenFoods": { "Bacon": 3, "Apple Juice": 7 },
+                "lastReportTime": "2026-04-01T12:00:00+00:00"
+            }
+            """);
 
         var migration = new GourmandLegacyMigration(_legacyDir, GourmandStateJsonContext.Default.GourmandState);
         var store = new PerCharacterStore<GourmandState>(
@@ -51,9 +52,14 @@ public sealed class GourmandStateServiceMigrationTests : IDisposable
 
         var loaded = store.Load("Arthur", "Kwatoxi");
 
-        loaded.EatenFoods.Should().ContainKey("Bacon").WhoseValue.Should().Be(3);
-        loaded.EatenFoods.Should().ContainKey("Apple Juice").WhoseValue.Should().Be(7);
+        // After Phase 1 (no catalog yet), the legacy display-name dict is parked for later
+        // resolution rather than being placed into the InternalName dict.
         loaded.SchemaVersion.Should().Be(GourmandState.CurrentVersion);
+        loaded.EatenFoodsByInternalName.Should().BeEmpty();
+        loaded.UnknownByName.Should().BeEmpty();
+        loaded.PendingLegacyByName.Should().NotBeNull();
+        loaded.PendingLegacyByName!.Should().ContainKey("Bacon").WhoseValue.Should().Be(3);
+        loaded.PendingLegacyByName.Should().ContainKey("Apple Juice").WhoseValue.Should().Be(7);
 
         File.Exists(Path.Combine(_charactersRoot, "Arthur_Kwatoxi", "pippin.json"))
             .Should().BeTrue("the per-character file should exist after migration");
@@ -62,12 +68,51 @@ public sealed class GourmandStateServiceMigrationTests : IDisposable
     }
 
     [Fact]
+    public void Phase2_promote_resolves_legacy_through_catalog_and_clears_pending()
+    {
+        var legacyFile = Path.Combine(_legacyDir, "gourmand-state.json");
+        File.WriteAllText(legacyFile, """
+            {
+                "schemaVersion": 1,
+                "eatenFoods": { "Bacon": 3, "Apple Juice": 7, "Mystery Stew": 1 }
+            }
+            """);
+
+        var migration = new GourmandLegacyMigration(_legacyDir, GourmandStateJsonContext.Default.GourmandState);
+        var store = new PerCharacterStore<GourmandState>(
+            _charactersRoot, "pippin.json",
+            GourmandStateJsonContext.Default.GourmandState,
+            migration);
+
+        var loaded = store.Load("Arthur", "Kwatoxi");
+        loaded.PendingLegacyByName.Should().NotBeNull();
+
+        // Now simulate the catalog being available: drain the pending dict through it
+        // exactly the way GourmandStateService does. Bacon + Apple Juice resolve;
+        // Mystery Stew falls through to UnknownByName.
+        var refData = new StubRefData(new Dictionary<long, ItemEntry>
+        {
+            [1] = new(1, "Apple Juice", "FoodAppleJuice", 1, 0, [], FoodDesc: "Level 0 Snack"),
+            [2] = new(2, "Bacon", "FoodBacon", 1, 0, [], FoodDesc: "Level 0 Snack"),
+        });
+        var catalog = new FoodCatalog(refData);
+        var sm = new GourmandStateMachine(catalog);
+        sm.Hydrate(loaded);
+        sm.ApplyLegacyByName(loaded.PendingLegacyByName!);
+
+        sm.EatenFoodsByInternalName.Should().HaveCount(2);
+        sm.EatenFoodsByInternalName["FoodAppleJuice"].Should().Be(7);
+        sm.EatenFoodsByInternalName["FoodBacon"].Should().Be(3);
+        sm.UnknownByName.Should().ContainKey("Mystery Stew").WhoseValue.Should().Be(1);
+    }
+
+    [Fact]
     public void Second_character_after_migration_starts_with_fresh_state()
     {
         var legacyFile = Path.Combine(_legacyDir, "gourmand-state.json");
-        File.WriteAllText(legacyFile, JsonSerializer.Serialize(
-            new GourmandState { EatenFoods = new Dictionary<string, int> { ["Bacon"] = 3 } },
-            GourmandStateJsonContext.Default.GourmandState));
+        File.WriteAllText(legacyFile, """
+            { "schemaVersion": 1, "eatenFoods": { "Bacon": 3 } }
+            """);
 
         var migration = new GourmandLegacyMigration(_legacyDir, GourmandStateJsonContext.Default.GourmandState);
         var store = new PerCharacterStore<GourmandState>(
@@ -80,7 +125,9 @@ public sealed class GourmandStateServiceMigrationTests : IDisposable
         // Second character: legacy already consumed + deleted, so this is a clean slate.
         var second = store.Load("Bilbo", "Kwatoxi");
 
-        second.EatenFoods.Should().BeEmpty();
+        second.EatenFoodsByInternalName.Should().BeEmpty();
+        second.UnknownByName.Should().BeEmpty();
+        second.PendingLegacyByName.Should().BeNull();
         second.SchemaVersion.Should().Be(GourmandState.CurrentVersion);
     }
 
@@ -95,7 +142,67 @@ public sealed class GourmandStateServiceMigrationTests : IDisposable
 
         var loaded = store.Load("Arthur", "Kwatoxi");
 
-        loaded.EatenFoods.Should().BeEmpty();
+        loaded.EatenFoodsByInternalName.Should().BeEmpty();
+        loaded.UnknownByName.Should().BeEmpty();
+        loaded.PendingLegacyByName.Should().BeNull();
         loaded.SchemaVersion.Should().Be(GourmandState.CurrentVersion);
+    }
+
+    [Fact]
+    public void V2_file_round_trips_without_back_compat_property_in_output()
+    {
+        var path = Path.Combine(_charactersRoot, "Arthur_Kwatoxi", "pippin.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        // Write a v2 file by serializing the current shape.
+        var state = new GourmandState
+        {
+            EatenFoodsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal) { ["FoodBacon"] = 3 },
+            UnknownByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["Mystery Stew"] = 1 },
+            LastReportTime = DateTimeOffset.UtcNow,
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(state, GourmandStateJsonContext.Default.GourmandState));
+
+        File.ReadAllText(path).Should().NotContain("\"eatenFoods\"",
+            "v2 output must not write the back-compat eatenFoods key");
+
+        var store = new PerCharacterStore<GourmandState>(
+            _charactersRoot, "pippin.json",
+            GourmandStateJsonContext.Default.GourmandState,
+            null);
+        var loaded = store.Load("Arthur", "Kwatoxi");
+
+        loaded.SchemaVersion.Should().Be(GourmandState.CurrentVersion);
+        loaded.EatenFoodsByInternalName.Should().ContainKey("FoodBacon").WhoseValue.Should().Be(3);
+        loaded.UnknownByName.Should().ContainKey("Mystery Stew").WhoseValue.Should().Be(1);
+        loaded.PendingLegacyByName.Should().BeNull();
+    }
+
+    private sealed class StubRefData : IReferenceDataService
+    {
+        public StubRefData(Dictionary<long, ItemEntry> items) { Items = items; }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; }
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public event EventHandler<string>? FileUpdated;
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        private void Suppress() => FileUpdated?.Invoke(this, "");
     }
 }

--- a/tests/Pippin.Tests/PippinShareRoundTripTests.cs
+++ b/tests/Pippin.Tests/PippinShareRoundTripTests.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using FluentAssertions;
+using Mithril.Shared.Sharing;
+using Pippin.Sharing;
+using Xunit;
+
+namespace Pippin.Tests;
+
+public class PippinShareRoundTripTests
+{
+    [Fact]
+    public void Payload_round_trips_through_codec()
+    {
+        var payload = new PippinSharePayload
+        {
+            CharacterName = "Argothian",
+            EatenFoodsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["FoodApplePie"] = 5,
+                ["FoodBacon"] = 12,
+            },
+            UnknownByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Mystery Stew"] = 1,
+            },
+            LastReportTime = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero),
+        };
+
+        var json = JsonSerializer.Serialize(payload, PippinShareJsonContext.Default.PippinSharePayload);
+        var encoded = ShareCodec.EncodePayload(json);
+        ShareCodec.TryDecodePayload(encoded, out var decodedJson, out _).Should().BeTrue();
+        var decoded = JsonSerializer.Deserialize(decodedJson, PippinShareJsonContext.Default.PippinSharePayload);
+
+        decoded.Should().NotBeNull();
+        decoded!.CharacterName.Should().Be("Argothian");
+        decoded.EatenFoodsByInternalName.Should().HaveCount(2);
+        decoded.EatenFoodsByInternalName["FoodApplePie"].Should().Be(5);
+        decoded.EatenFoodsByInternalName["FoodBacon"].Should().Be(12);
+        decoded.UnknownByName.Should().NotBeNull();
+        decoded.UnknownByName!.Should().ContainKey("Mystery Stew").WhoseValue.Should().Be(1);
+        decoded.LastReportTime.Should().Be(payload.LastReportTime);
+    }
+
+    [Fact]
+    public void Payload_without_character_name_omits_field_from_json()
+    {
+        var payload = new PippinSharePayload
+        {
+            CharacterName = null,
+            EatenFoodsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal) { ["FoodBacon"] = 1 },
+        };
+
+        var json = JsonSerializer.Serialize(payload, PippinShareJsonContext.Default.PippinSharePayload);
+
+        json.Should().NotContain("characterName",
+            "opt-out path should produce an anonymous payload with no character-name field");
+    }
+
+    [Fact]
+    public void Empty_unknown_dictionary_is_omitted_from_json()
+    {
+        var payload = new PippinSharePayload
+        {
+            EatenFoodsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal) { ["FoodBacon"] = 1 },
+            // UnknownByName left null
+        };
+
+        var json = JsonSerializer.Serialize(payload, PippinShareJsonContext.Default.PippinSharePayload);
+
+        json.Should().NotContain("unknownByName");
+    }
+
+    [Fact]
+    public void Realistic_completionist_payload_fits_url_budget()
+    {
+        var payload = new PippinSharePayload
+        {
+            CharacterName = "ArgothianTheLongNamed",
+            LastReportTime = DateTimeOffset.UtcNow,
+        };
+        for (var i = 0; i < 614; i++)
+            payload.EatenFoodsByInternalName[$"FoodOverlyLongInternalName{i:D3}"] = 99;
+
+        var json = JsonSerializer.Serialize(payload, PippinShareJsonContext.Default.PippinSharePayload);
+        var encoded = ShareCodec.EncodePayload(json);
+
+        encoded.Length.Should().BeLessThan(16_384,
+            "fits inside the deep-link router's pippin payload cap");
+    }
+}

--- a/tests/Pippin.Tests/Sharing/PippinShareViewModelTests.cs
+++ b/tests/Pippin.Tests/Sharing/PippinShareViewModelTests.cs
@@ -1,0 +1,228 @@
+using System.Windows.Media.Imaging;
+using FluentAssertions;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Reference;
+using Pippin.Domain;
+using Pippin.Sharing;
+using Xunit;
+
+namespace Pippin.Tests.Sharing;
+
+/// <summary>
+/// Pure-data tests for the share-card and full-grid view models. Exercises the data
+/// composition path (payload + catalog + cache) without invoking
+/// <c>RenderTargetBitmap</c> — the actual bitmap render needs a WPF Dispatcher and
+/// is verified manually per the plan.
+/// </summary>
+public class PippinShareViewModelTests
+{
+    private static FoodCatalog CreateCatalog(params (long Id, string InternalName, string Name, int IconId)[] foods)
+    {
+        var dict = new Dictionary<long, ItemEntry>();
+        foreach (var (id, internalName, name, iconId) in foods)
+            dict[id] = new ItemEntry(id, name, internalName, 1, iconId, [], FoodDesc: "Level 0 Snack");
+        return new FoodCatalog(new StubReferenceData(dict));
+    }
+
+    private static PippinSharePayload BuildPayload(
+        string? characterName = "Argothian",
+        Dictionary<string, int>? eaten = null,
+        Dictionary<string, int>? unknown = null) => new()
+    {
+        CharacterName = characterName,
+        EatenFoodsByInternalName = new Dictionary<string, int>(eaten ?? new(), StringComparer.Ordinal),
+        UnknownByName = unknown,
+        LastReportTime = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero),
+    };
+
+    // ---- Card VM ------------------------------------------------------------
+
+    [Fact]
+    public void Card_named_payload_uses_character_name_as_title()
+    {
+        var catalog = CreateCatalog((1, "FoodApple", "Apple", 0));
+        var vm = new PippinShareCardViewModel(BuildPayload("Argothian"), catalog, gourmandLevel: 33, new NoopIconCache());
+
+        vm.CharacterTitle.Should().Be("Argothian");
+        vm.HasIdentity.Should().BeTrue();
+        vm.GourmandLevelText.Should().Be("Gourmand Lv 33");
+    }
+
+    [Fact]
+    public void Card_anonymous_payload_falls_back_to_module_title()
+    {
+        var catalog = CreateCatalog((1, "FoodApple", "Apple", 0));
+        var vm = new PippinShareCardViewModel(BuildPayload(characterName: null), catalog, gourmandLevel: 0, new NoopIconCache());
+
+        vm.CharacterTitle.Should().Be("Pippin · Gourmand");
+        vm.HasIdentity.Should().BeFalse();
+        vm.GourmandLevelText.Should().Be("Gourmand", "level 0 hides the level number");
+    }
+
+    [Fact]
+    public void Card_completion_text_includes_count_total_and_percent()
+    {
+        var catalog = CreateCatalog(
+            (1, "FoodApple", "Apple", 0),
+            (2, "FoodBacon", "Bacon", 0),
+            (3, "FoodCake",  "Cake",  0),
+            (4, "FoodDate",  "Date",  0));
+        var payload = BuildPayload(eaten: new Dictionary<string, int> { ["FoodApple"] = 5 });
+
+        var vm = new PippinShareCardViewModel(payload, catalog, gourmandLevel: 10, new NoopIconCache());
+
+        vm.EatenCount.Should().Be(1);
+        vm.TotalCount.Should().Be(4);
+        vm.CompletionText.Should().Contain("1 / 4").And.Contain("25%");
+        vm.CompletionRatio.Should().Be(0.25);
+        vm.BarFillPixelWidth.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Card_top_eaten_picks_highest_counts_and_resolves_names()
+    {
+        var catalog = CreateCatalog(
+            (1, "FoodApple", "Apple Pie",      0),
+            (2, "FoodBacon", "Bacon",          0),
+            (3, "FoodCake",  "Steamed Cake",   0));
+        var payload = BuildPayload(eaten: new Dictionary<string, int>
+        {
+            ["FoodApple"] = 5,
+            ["FoodBacon"] = 12,
+            ["FoodCake"]  = 3,
+        });
+
+        var vm = new PippinShareCardViewModel(payload, catalog, gourmandLevel: 0, new NoopIconCache());
+
+        vm.TopEaten.Should().HaveCount(3);
+        vm.TopEaten[0].Name.Should().Be("Bacon");
+        vm.TopEaten[0].Count.Should().Be(12);
+        vm.TopEaten[1].Name.Should().Be("Apple Pie");
+        vm.TopEaten[2].Name.Should().Be("Steamed Cake");
+    }
+
+    [Fact]
+    public void Card_top_eaten_falls_back_to_internal_name_when_catalog_missing_entry()
+    {
+        var catalog = CreateCatalog((1, "FoodApple", "Apple", 0));
+        var payload = BuildPayload(eaten: new Dictionary<string, int>
+        {
+            ["FoodMystery"] = 7,
+        });
+
+        var vm = new PippinShareCardViewModel(payload, catalog, gourmandLevel: 0, new NoopIconCache());
+
+        vm.TopEaten.Should().ContainSingle()
+          .Which.Name.Should().Be("FoodMystery", "no catalog match → render the internal name verbatim");
+    }
+
+    // ---- Full-grid VM -------------------------------------------------------
+
+    [Fact]
+    public void FullGrid_includes_catalog_rows_unknowns_and_sender_only_internal_names()
+    {
+        var catalog = CreateCatalog(
+            (1, "FoodApple", "Apple", 0),
+            (2, "FoodBacon", "Bacon", 0));
+        var payload = BuildPayload(
+            eaten: new Dictionary<string, int>
+            {
+                ["FoodBacon"]   = 2,
+                ["FoodMystery"] = 1, // sender-only InternalName, recipient catalog doesn't know it
+            },
+            unknown: new Dictionary<string, int> { ["Mystery Stew"] = 4 });
+
+        var vm = new PippinFullGridViewModel(payload, catalog, gourmandLevel: 33, new NoopIconCache());
+
+        vm.Rows.Should().HaveCount(4, "two catalog rows + one orphan + one sender-only InternalName");
+        vm.Rows.Select(r => r.Name).Should().Contain(new[] { "Apple", "Bacon", "Mystery Stew", "FoodMystery" });
+    }
+
+    [Fact]
+    public void FullGrid_marks_eaten_rows_and_count()
+    {
+        var catalog = CreateCatalog(
+            (1, "FoodApple", "Apple", 0),
+            (2, "FoodBacon", "Bacon", 0));
+        var payload = BuildPayload(eaten: new Dictionary<string, int> { ["FoodBacon"] = 7 });
+
+        var vm = new PippinFullGridViewModel(payload, catalog, gourmandLevel: 0, new NoopIconCache());
+
+        var apple = vm.Rows.Single(r => r.Name == "Apple");
+        var bacon = vm.Rows.Single(r => r.Name == "Bacon");
+        apple.IsEaten.Should().BeFalse();
+        apple.EatenCount.Should().Be(0);
+        bacon.IsEaten.Should().BeTrue();
+        bacon.EatenCount.Should().Be(7);
+    }
+
+    [Fact]
+    public void FullGrid_total_height_grows_with_row_count()
+    {
+        var smallCatalog = CreateCatalog((1, "FoodA", "A", 0));
+        var bigCatalog = CreateCatalog(
+            Enumerable.Range(1, 50)
+                .Select(i => ((long)i, $"Food{i}", $"Name{i}", 0))
+                .ToArray());
+
+        var small = new PippinFullGridViewModel(BuildPayload(), smallCatalog, 0, new NoopIconCache());
+        var big   = new PippinFullGridViewModel(BuildPayload(), bigCatalog, 0, new NoopIconCache());
+
+        big.TotalHeight.Should().BeGreaterThan(small.TotalHeight);
+    }
+
+    [Fact]
+    public void FullGrid_anonymous_payload_omits_identity_subtitle()
+    {
+        var catalog = CreateCatalog((1, "FoodApple", "Apple", 0));
+        var vm = new PippinFullGridViewModel(BuildPayload(characterName: null), catalog, 0, new NoopIconCache());
+
+        vm.HasIdentity.Should().BeFalse();
+        vm.CharacterTitle.Should().Be("Pippin · Gourmand");
+    }
+
+    // ---- Stubs --------------------------------------------------------------
+
+    /// <summary>Returns null icons; the VM tolerates them and the off-screen renderer would draw blanks.</summary>
+    private sealed class NoopIconCache : IIconCacheService
+    {
+        public BitmapImage GetOrLoadIcon(int iconId) => new();
+        public event EventHandler<int>? IconReady;
+        public int CachedCount => 0;
+        public long CacheSizeBytes => 0;
+        public Task ClearCacheAsync() => Task.CompletedTask;
+        public Task DownloadAllAsync(IProgress<(int completed, int total)> progress, CancellationToken ct = default) => Task.CompletedTask;
+        public bool IsCached(int iconId) => false;
+        public IReadOnlyList<int> GetUncachedIcons(IEnumerable<int> iconIds) => iconIds.Where(i => i > 0).Distinct().ToList();
+        public Task PreloadAsync(IEnumerable<int> iconIds, IProgress<(int completed, int total)>? progress = null, CancellationToken ct = default) => Task.CompletedTask;
+        private void Suppress() => IconReady?.Invoke(this, 0);
+    }
+
+    private sealed class StubReferenceData : IReferenceDataService
+    {
+        public StubReferenceData(Dictionary<long, ItemEntry> items) { Items = items; }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; }
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public event EventHandler<string>? FileUpdated;
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        private void Suppress() => FileUpdated?.Invoke(this, "");
+    }
+}


### PR DESCRIPTION
## Summary

Three share affordances for Pippin's Gourmand progress, plus a v2 schema migration to make persisted state survive CDN drift. Tracks #105 (and surfaced #104 along the way).

- **Plain text + JSON** — clipboard-copy share link, JSON payload, human-readable summary; Save JSON for archival.
- **`mithril://pippin/<base64url>` deep link** — recipient's Pippin opens a non-modal `SharedProgressWindow` showing sender's data joined against the recipient's local `FoodCatalog` by `InternalName`, so cross-CDN-version shares still label foods correctly.
- **Image export** — 1000×400 social card (clipboard primary, file secondary) + tall full-grid PNG (file primary, clipboard secondary). Inline icon-preload banner that calls `IIconCacheService.PreloadAsync` rather than warning passively.

## Schema and infrastructure

- `GourmandState` bumped to v2: keys by item `InternalName` instead of display name, with separate `UnknownByName` for catalog-orphan foods. Two-phase migration (`Migrate` parks v1 `EatenFoods` into a transient `PendingLegacyByName`; `GourmandStateService` drains it through the catalog once `IsReady`).
- `ShareCodec` lifted from Celebrimbor to `Mithril.Shared.Sharing` (gzip + base64url + version byte); `CraftListFormat` delegates.
- `IIconCacheService` gains `IsCached` / `GetUncachedIcons` / `PreloadAsync` for subset preload before off-screen render.
- `DeepLinkRouter` routes `mithril://pippin/<payload>`.
- Defensive `MithrilDataGrid.AttachToSource` guard against re-attach without paired detach (root cause of #104 filter-stacking; full cleanup tracked separately).

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — all 1,252 tests pass (Pippin: 30→39, Mithril.Shared: 615→622)
- [x] **Manual:** open Pippin, click Share → all three "Copy" buttons populate clipboard; "Save JSON" writes valid file
- [x] **Manual:** copy `mithril://pippin/...` link, paste into browser → second Mithril instance opens read-only `SharedProgressWindow`
- [x] **Manual:** Card image → Copy to clipboard → paste into Discord (works ✅)
- [x] **Manual:** Full grid image → Copy to clipboard (works ✅)
- [x] **Manual:** v1 → v2 schema migration via `PendingLegacyByName` resolves foods correctly once catalog is ready
- [ ] **Manual TODO post-merge:** verify icon-preload banner appears for fresh installs (icons not yet downloaded) and `Load icons now` button drains them

## Known follow-ups (separate issues)

- **#104** — `MithrilDataGrid` filter-stacking cleanup. Defensive guard shipped here; underlying capture-and-overwrite pattern needs a `VmFilter` DependencyProperty refactor.
- **STA-aware test harness** — would let us assert `RenderTargetBitmap.Render` produces non-empty bitmaps. Render path is verified manually for now; VM-level tests cover everything below the bitmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)