### PR TITLE
feat(pippin): cards view + card-grid PNG export with async render

### DIFF
--- a/src/Mithril.Shared/Wpf/IconImage.cs
+++ b/src/Mithril.Shared/Wpf/IconImage.cs
@@ -27,10 +27,16 @@ public sealed class IconImage : Image
         set => SetValue(IconIdProperty, value);
     }
 
+    static IconImage()
+    {
+        // DP metadata defaults (24×24) so that consumers can still override Width/Height
+        // in XAML without contending with constructor-time local DP writes.
+        WidthProperty.OverrideMetadata(typeof(IconImage), new FrameworkPropertyMetadata(24.0));
+        HeightProperty.OverrideMetadata(typeof(IconImage), new FrameworkPropertyMetadata(24.0));
+    }
+
     public IconImage()
     {
-        Width = 24;
-        Height = 24;
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
     }

--- a/src/Mithril.Shared/Wpf/MithrilVirtualizingWrapPanel.cs
+++ b/src/Mithril.Shared/Wpf/MithrilVirtualizingWrapPanel.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 namespace Mithril.Shared.Wpf;
 
@@ -35,6 +36,27 @@ public class MithrilVirtualizingWrapPanel : VirtualizingPanel, IScrollInfo
     private Point _offset;
     private ScrollViewer? _owner;
     private int _firstVisibleIndex;
+
+    public MithrilVirtualizingWrapPanel()
+    {
+        // When the panel transitions from Collapsed → Visible (e.g. inside a view-mode
+        // toggle), the first measure pass can run before the ScrollViewer has wired up
+        // ScrollOwner / its viewport. Items get generated against a stale viewport and
+        // the panel paints blank until the user scrolls. Re-measure on every visibility
+        // gain, deferred to ContextIdle so it lands AFTER the ScrollViewer's first pass.
+        IsVisibleChanged += (_, e) =>
+        {
+            if (e.NewValue is true)
+            {
+                InvalidateMeasure();
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    InvalidateMeasure();
+                    _owner?.InvalidateScrollInfo();
+                }), DispatcherPriority.ContextIdle);
+            }
+        };
+    }
 
     protected override Size MeasureOverride(Size availableSize)
     {

--- a/src/Mithril.Shared/Wpf/Resources.xaml
+++ b/src/Mithril.Shared/Wpf/Resources.xaml
@@ -39,6 +39,11 @@
     <sys:Double x:Key="AppFontSizeTitle">20</sys:Double>
     <sys:Double x:Key="AppFontSizeHero">22</sys:Double>
 
+    <!-- State opacities for cards / list items.
+         Eaten = "done, de-emphasised"; Locked = "out of reach, even more de-emphasised". -->
+    <sys:Double x:Key="EatenOpacityKey">0.6</sys:Double>
+    <sys:Double x:Key="LockedOpacityKey">0.45</sys:Double>
+
     <!-- Palette — matches hand-authored colors in Samwise/Shell/Legolas views -->
     <SolidColorBrush x:Key="BgPrimaryBrush"      Color="#FF1A1A1A"/>
     <SolidColorBrush x:Key="BgRecessedBrush"     Color="#FF1E1E1E"/>

--- a/src/Pippin.Module/Domain/PippinSettings.cs
+++ b/src/Pippin.Module/Domain/PippinSettings.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+
+namespace Pippin.Domain;
+
+public sealed class PippinSettings : INotifyPropertyChanged
+{
+    private string _viewMode = "Grid";
+    public string ViewMode
+    {
+        get => _viewMode;
+        set => Set(ref _viewMode, value);
+    }
+
+    private bool _hideLocked;
+    public bool HideLocked
+    {
+        get => _hideLocked;
+        set => Set(ref _hideLocked, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(PippinSettings))]
+public partial class PippinSettingsJsonContext : JsonSerializerContext { }

--- a/src/Pippin.Module/PippinModule.cs
+++ b/src/Pippin.Module/PippinModule.cs
@@ -31,6 +31,10 @@ public sealed class PippinModule : IMithrilModule
     {
         var localApp = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var legacyPippinDir = Path.Combine(localApp, "Mithril", "Pippin");
+        var settingsPath = Path.Combine(localApp, "Mithril", "pippin-settings.json");
+
+        // App-level UI prefs (view mode, hide-locked toggle).
+        services.AddMithrilSettings<PippinSettings>(settingsPath, PippinSettingsJsonContext.Default.PippinSettings);
 
         // Per-character persistence with a one-shot migration from the legacy flat file.
         services.AddSingleton<ILegacyMigration<GourmandState>>(_ =>
@@ -52,6 +56,7 @@ public sealed class PippinModule : IMithrilModule
         services.AddSingleton<GourmandViewModel>(sp => new GourmandViewModel(
             sp.GetRequiredService<GourmandStateMachine>(),
             sp.GetRequiredService<FoodCatalog>(),
+            sp.GetRequiredService<PippinSettings>(),
             sp.GetService<IActiveCharacterService>(),
             sp.GetService<IDialogService>(),
             sp.GetService<PippinShareCardRenderer>(),

--- a/src/Pippin.Module/Sharing/PippinFullGridView.xaml
+++ b/src/Pippin.Module/Sharing/PippinFullGridView.xaml
@@ -2,11 +2,12 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Pippin.Sharing"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance vm:PippinFullGridViewModel}"
-             Width="1200"
+             Width="960"
              Background="#FF1A1A1A"
              FontFamily="Segoe UI"
              UseLayoutRounding="True"
@@ -35,53 +36,113 @@
                        Visibility="{Binding LastSyncText, Converter={StaticResource NullOrEmptyToVis}}"/>
         </StackPanel>
 
-        <!-- Column header row -->
-        <Grid DockPanel.Dock="Top" Height="36" Background="#FF222222">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="32"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="120"/>
-                <ColumnDefinition Width="60"/>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition Width="60"/>
-                <ColumnDefinition Width="180"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Text="" />
-            <TextBlock Grid.Column="1" Text="Name"  Margin="8,0,0,0" Foreground="#88FFFFFF" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="2" Text="Type"  Foreground="#88FFFFFF" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="3" Text="Level" Foreground="#88FFFFFF" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="4" Text="Req"   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="5" Text="Count" Foreground="#88FFFFFF" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="6" Text="Tags"  Foreground="#88FFFFFF" VerticalAlignment="Center"/>
-        </Grid>
-
-        <!-- Rows -->
+        <!-- Card grid — same visual language as the in-app cards mode. Locked state is
+             omitted: shared payloads don't carry the sender's Gourmand level, so we'd
+             have nothing to gate against. Plain WrapPanel (not virtualizing) because the
+             off-screen renderer needs every card laid out at once. -->
         <ItemsControl ItemsSource="{Binding Rows}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Grid Height="32" Background="#FF1E1E1E">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="32"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="120"/>
-                            <ColumnDefinition Width="60"/>
-                            <ColumnDefinition Width="50"/>
-                            <ColumnDefinition Width="60"/>
-                            <ColumnDefinition Width="180"/>
-                        </Grid.ColumnDefinitions>
-                        <CheckBox Grid.Column="0" IsChecked="{Binding IsEaten, Mode=OneWay}"
-                                  IsEnabled="False" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="8,0,0,0">
-                            <Image Source="{Binding Icon}" Width="20" Height="20" VerticalAlignment="Center" Margin="0,0,8,0"
-                                   Visibility="{Binding HasIcon, Converter={StaticResource BoolToVis}}"/>
-                            <TextBlock Text="{Binding Name}" Foreground="#FFE8E8E8" VerticalAlignment="Center"/>
-                        </StackPanel>
-                        <TextBlock Grid.Column="2" Text="{Binding FoodType}"         Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
-                        <TextBlock Grid.Column="3" Text="{Binding FoodLevel}"        Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
-                        <TextBlock Grid.Column="4" Text="{Binding GourmandLevelReq}" Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
-                        <TextBlock Grid.Column="5" Text="{Binding EatenCount}"       Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
-                        <TextBlock Grid.Column="6" Text="{Binding DietaryTags}"      Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
-                    </Grid>
+                    <Border Width="288" Height="130" Margin="6"
+                            CornerRadius="6" Padding="10"
+                            Background="#FF252525">
+                        <Border.Style>
+                            <!-- Three-state visual mirrored from the in-app cards: eaten gets gold
+                                 accent border + dim, locked gets heavier dim, available is default. -->
+                            <Style TargetType="Border">
+                                <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+                                <Setter Property="BorderThickness" Value="1"/>
+                                <Setter Property="Opacity" Value="1"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsEaten}" Value="True">
+                                        <Setter Property="BorderBrush" Value="#FFD4A847"/>
+                                        <Setter Property="BorderThickness" Value="2"/>
+                                        <Setter Property="Opacity" Value="0.6"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsLocked}" Value="True">
+                                        <Setter Property="Opacity" Value="0.45"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <DockPanel LastChildFill="True">
+                            <!-- Icon + state badge (check for eaten, lock for locked) -->
+                            <Grid DockPanel.Dock="Left" Width="64" Height="64" Margin="0,0,10,0" VerticalAlignment="Top">
+                                <Image Source="{Binding Icon}" Width="64" Height="64"
+                                       Visibility="{Binding HasIcon, Converter={StaticResource BoolToVis}}"/>
+                                <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                                        Width="20" Height="20" CornerRadius="10"
+                                        Background="#FFD4A847" BorderBrush="#FF1A1A1A" BorderThickness="1"
+                                        Visibility="{Binding IsEaten, Converter={StaticResource BoolToVis}}">
+                                    <icon:PackIconLucide Kind="Check" Width="13" Height="13"
+                                                         Foreground="#FF1A1A1A"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                                <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                                        Width="20" Height="20" CornerRadius="10"
+                                        Background="#FF1A1A1A" BorderBrush="#FFD4A847" BorderThickness="1"
+                                        Visibility="{Binding IsLocked, Converter={StaticResource BoolToVis}}">
+                                    <icon:PackIconLucide Kind="Lock" Width="11" Height="11"
+                                                         Foreground="#FFD4A847"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                            </Grid>
+                            <!-- Name + REQ chip -->
+                            <Grid DockPanel.Dock="Top" Margin="0,0,0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"
+                                           Foreground="#FFD4A847" FontSize="13"
+                                           TextTrimming="CharacterEllipsis"/>
+                                <Border Grid.Column="1" CornerRadius="3" Padding="5,1" Margin="6,0,0,0"
+                                        Background="#FF1E1E1E" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                        Visibility="{Binding GourmandLevelReq, Converter={StaticResource PositiveIntToVis}}">
+                                    <TextBlock Foreground="#CCFFFFFF" FontSize="9">
+                                        <Run Text="REQ"/>
+                                        <Run Text="{Binding GourmandLevelReq, Mode=OneWay}"/>
+                                    </TextBlock>
+                                </Border>
+                            </Grid>
+                            <!-- Type + Progress -->
+                            <Grid DockPanel.Dock="Top" Margin="0,0,0,4">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{Binding FoodType}"
+                                           Foreground="#CCFFFFFF" FontSize="11"/>
+                                <TextBlock Grid.Column="1" Foreground="#88FFFFFF" FontSize="11">
+                                    <Run Text="Progress:"/>
+                                    <Run Text="{Binding EatenCount, Mode=OneWay}" Foreground="#FFE8E8E8"/>
+                                    <Run Text="/1"/>
+                                </TextBlock>
+                            </Grid>
+                            <!-- Dietary tag chips -->
+                            <ItemsControl ItemsSource="{Binding DietaryTags}" VerticalAlignment="Bottom">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border CornerRadius="3" Padding="5,1" Margin="0,2,4,0"
+                                                Background="#FF1E1E1E" BorderBrush="#33FFFFFF" BorderThickness="1">
+                                            <TextBlock Text="{Binding}"
+                                                       Foreground="#CCFFFFFF" FontSize="9"/>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </DockPanel>
+                    </Border>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/src/Pippin.Module/Sharing/PippinFullGridViewModel.cs
+++ b/src/Pippin.Module/Sharing/PippinFullGridViewModel.cs
@@ -14,9 +14,12 @@ namespace Pippin.Sharing;
 /// </summary>
 public sealed class PippinFullGridViewModel
 {
-    public const double Width = 1200;
-    public const double HeaderHeight = 36;
-    public const double RowHeight = 32;
+    // 960px wide exports cleanly fit 3 × 300px card cells inside the 20px DockPanel
+    // margin (920 inner). Larger widths waste right-edge whitespace because the
+    // WrapPanel left-aligns and won't stretch cards. Height is measure-driven —
+    // the renderer reads <see cref="System.Windows.FrameworkElement.DesiredSize"/>
+    // after a layout pass, so the image auto-sizes to wrap content exactly.
+    public const double Width = 960;
 
     public PippinFullGridViewModel(
         PippinSharePayload payload,
@@ -53,27 +56,28 @@ public sealed class PippinFullGridViewModel
         {
             var hasCount = eaten.TryGetValue(food.InternalName, out var count);
             var icon = food.IconId > 0 ? iconCache.GetOrLoadIcon(food.IconId) : null;
+            // For the sender's own export the gourmandLevel is known, so locked items
+            // render with the same lock-badge + dim treatment as the in-app cards.
+            var isLocked = !hasCount && food.GourmandLevelReq > 0 && gourmandLevel < food.GourmandLevelReq;
             rows.Add(new PippinFullGridRow(
                 food.Name, food.FoodType, food.FoodLevel, food.GourmandLevelReq,
-                hasCount ? count : 0, hasCount, FormatTags(food.DietaryTags), icon));
+                hasCount ? count : 0, hasCount, isLocked, food.DietaryTags, icon));
         }
 
         if (payload.UnknownByName is { } unknowns)
         {
             foreach (var (name, count) in unknowns)
-                rows.Add(new PippinFullGridRow(name, "Unknown", 0, 0, count, true, "", null));
+                rows.Add(new PippinFullGridRow(name, "Unknown", 0, 0, count, true, false, Array.Empty<string>(), null));
         }
 
         foreach (var (internalName, count) in eaten)
         {
             if (catalog.TryGetByInternalName(internalName, out _)) continue;
-            rows.Add(new PippinFullGridRow(internalName, "Unknown", 0, 0, count, true, "", null));
+            rows.Add(new PippinFullGridRow(internalName, "Unknown", 0, 0, count, true, false, Array.Empty<string>(), null));
         }
 
         rows.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
         Rows = rows;
-
-        TotalHeight = HeaderHeight + Rows.Count * RowHeight + 80; // header strip + footer pad
     }
 
     public string CharacterTitle { get; }
@@ -81,11 +85,6 @@ public sealed class PippinFullGridViewModel
     public string StatsLine { get; }
     public string LastSyncText { get; }
     public IReadOnlyList<PippinFullGridRow> Rows { get; }
-
-    /// <summary>Computed pixel height needed to fit every row + header + footer.</summary>
-    public double TotalHeight { get; }
-
-    private static string FormatTags(IReadOnlyList<string> tags) => string.Join(", ", tags);
 }
 
 public sealed record PippinFullGridRow(
@@ -95,7 +94,8 @@ public sealed record PippinFullGridRow(
     int GourmandLevelReq,
     int EatenCount,
     bool IsEaten,
-    string DietaryTags,
+    bool IsLocked,
+    IReadOnlyList<string> DietaryTags,
     BitmapImage? Icon)
 {
     public bool HasIcon => Icon is not null;

--- a/src/Pippin.Module/Sharing/PippinShareCardRenderer.cs
+++ b/src/Pippin.Module/Sharing/PippinShareCardRenderer.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -29,36 +31,100 @@ public sealed class PippinShareCardRenderer
         _iconCache = iconCache;
     }
 
-    /// <summary>1000×400 social card.</summary>
-    public BitmapSource RenderCard(PippinSharePayload payload, int gourmandLevel)
+    /// <summary>1000×400 social card. Async — renders on a background STA worker thread
+    /// so the UI stays responsive while WPF lays out the visual tree.</summary>
+    public Task<BitmapSource> RenderCardAsync(PippinSharePayload payload, int gourmandLevel)
+        => RenderOnStaWorker(() =>
+        {
+            var vm = new PippinShareCardViewModel(payload, _catalog, gourmandLevel, _iconCache);
+            var view = new PippinShareCardView { DataContext = vm };
+            return RenderControl(view, PippinShareCardViewModel.CardWidth, PippinShareCardViewModel.CardHeight);
+        });
+
+    /// <summary>PNG sized to the card grid's natural height — width fixed to a column-count
+    /// constraint, height read from the laid-out WrapPanel via <see cref="FrameworkElement.DesiredSize"/>.
+    /// Async — renders on a background STA worker so the dialog stays responsive while
+    /// hundreds of card containers are laid out.</summary>
+    public Task<BitmapSource> RenderFullGridAsync(PippinSharePayload payload, int gourmandLevel)
+        => RenderOnStaWorker(() =>
+        {
+            var vm = new PippinFullGridViewModel(payload, _catalog, gourmandLevel, _iconCache);
+            var view = new PippinFullGridView { DataContext = vm };
+            return RenderControl(view, PippinFullGridViewModel.Width, height: null);
+        });
+
+    /// <summary>
+    /// Runs <paramref name="render"/> on a fresh STA thread. RenderTargetBitmap requires
+    /// the rendering visual to live on an STA-apartment thread with a Dispatcher, but
+    /// nothing requires that thread to be the main UI thread; a worker STA does fine.
+    /// The returned <see cref="BitmapSource"/> is <c>.Freeze()</c>'d inside
+    /// <see cref="RenderControl"/>, so it crosses threads safely.
+    /// Catalog / icon-cache reads from the worker are safe: <c>FoodCatalog.ByInternalName</c>
+    /// is reassigned atomically; <c>IconCacheService</c> uses ConcurrentDictionary and
+    /// freezes every BitmapImage it returns.
+    /// </summary>
+    private static Task<BitmapSource> RenderOnStaWorker(Func<BitmapSource> render)
     {
-        var vm = new PippinShareCardViewModel(payload, _catalog, gourmandLevel, _iconCache);
-        var view = new PippinShareCardView { DataContext = vm };
-        return RenderControl(view, PippinShareCardViewModel.CardWidth, PippinShareCardViewModel.CardHeight);
+        var tcs = new TaskCompletionSource<BitmapSource>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var result = render();
+                tcs.SetResult(result);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "PippinShareRender",
+        };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return tcs.Task;
     }
 
-    /// <summary>Tall PNG with header strip + every food row.</summary>
-    public BitmapSource RenderFullGrid(PippinSharePayload payload, int gourmandLevel)
-    {
-        var vm = new PippinFullGridViewModel(payload, _catalog, gourmandLevel, _iconCache);
-        var view = new PippinFullGridView { DataContext = vm };
-        return RenderControl(view, PippinFullGridViewModel.Width, vm.TotalHeight);
-    }
-
-    private static BitmapSource RenderControl(FrameworkElement control, double width, double height)
+    /// <summary>
+    /// Lays out <paramref name="control"/> at <paramref name="width"/> and renders to a bitmap.
+    /// When <paramref name="height"/> is null, the control's natural height (post-Measure)
+    /// is used — which lets card-grid layouts auto-size to their wrapped content instead
+    /// of relying on a manually-computed TotalHeight.
+    /// </summary>
+    private static BitmapSource RenderControl(FrameworkElement control, double width, double? height)
     {
         // Force a layout pass so every binding resolves before the render. Without the
         // explicit Measure/Arrange/UpdateLayout dance, a never-parented FrameworkElement
         // has zero size and RenderTargetBitmap captures nothing.
         control.Width = width;
-        control.Height = height;
-        control.Measure(new Size(width, height));
-        control.Arrange(new Rect(0, 0, width, height));
-        control.UpdateLayout();
+        if (height is { } fixedHeight)
+        {
+            control.Height = fixedHeight;
+            control.Measure(new Size(width, fixedHeight));
+            control.Arrange(new Rect(0, 0, width, fixedHeight));
+            control.UpdateLayout();
+        }
+        else
+        {
+            // Measure-driven height: WrapPanel + ItemsControl don't fully materialise their
+            // children on a single Measure pass when we hand it infinite height. We need a
+            // Measure → Arrange → UpdateLayout → Measure round-trip so the second Measure
+            // sees fully realized item containers and reports the true DesiredSize.
+            control.Measure(new Size(width, double.PositiveInfinity));
+            control.Arrange(new Rect(0, 0, width, control.DesiredSize.Height));
+            control.UpdateLayout();
+            control.Measure(new Size(width, double.PositiveInfinity));
+            var natural = control.DesiredSize.Height;
+            control.Arrange(new Rect(0, 0, width, natural));
+            control.UpdateLayout();
+            fixedHeight = natural;
+        }
 
         var bitmap = new RenderTargetBitmap(
             (int)Math.Ceiling(width),
-            (int)Math.Ceiling(height),
+            (int)Math.Ceiling(fixedHeight),
             96, 96, PixelFormats.Pbgra32);
         bitmap.Render(control);
         bitmap.Freeze();

--- a/src/Pippin.Module/Sharing/PippinShareDialogViewModel.cs
+++ b/src/Pippin.Module/Sharing/PippinShareDialogViewModel.cs
@@ -95,6 +95,9 @@ public sealed partial class PippinShareDialogViewModel : DialogViewModelBase
     private bool _isPrefetching;
 
     [ObservableProperty]
+    private bool _isRendering;
+
+    [ObservableProperty]
     private double _prefetchProgress;
 
     [ObservableProperty]
@@ -173,21 +176,43 @@ public sealed partial class PippinShareDialogViewModel : DialogViewModelBase
         }
     }
 
-    [RelayCommand] private void CopyCard()      => CopyImage(BuildCard(), "Card image copied to clipboard.");
-    [RelayCommand] private void SaveCard()      => SaveImage(BuildCard(), "card");
-    [RelayCommand] private void CopyFullGrid()  => CopyImage(BuildFullGrid(), "Full grid copied to clipboard.");
-    [RelayCommand] private void SaveFullGrid()  => SaveImage(BuildFullGrid(), "full");
+    [RelayCommand] private Task CopyCardAsync()     => RenderThen(BuildCardAsync,     image => CopyImage(image, "Card image copied to clipboard."));
+    [RelayCommand] private Task SaveCardAsync()     => RenderThen(BuildCardAsync,     image => SaveImage(image, "card"));
+    [RelayCommand] private Task CopyFullGridAsync() => RenderThen(BuildFullGridAsync, image => CopyImage(image, "Full grid copied to clipboard."));
+    [RelayCommand] private Task SaveFullGridAsync() => RenderThen(BuildFullGridAsync, image => SaveImage(image, "full"));
 
-    private BitmapSource BuildCard()
+    private Task<BitmapSource> BuildCardAsync()
     {
         var payload = _buildPayload(IncludeCharacterName && HasCharacterName);
-        return _renderer.RenderCard(payload, _getGourmandLevel());
+        return _renderer.RenderCardAsync(payload, _getGourmandLevel());
     }
 
-    private BitmapSource BuildFullGrid()
+    private Task<BitmapSource> BuildFullGridAsync()
     {
         var payload = _buildPayload(IncludeCharacterName && HasCharacterName);
-        return _renderer.RenderFullGrid(payload, _getGourmandLevel());
+        return _renderer.RenderFullGridAsync(payload, _getGourmandLevel());
+    }
+
+    /// <summary>Render off the UI thread, surface progress via <see cref="IsRendering"/>,
+    /// then dispatch the bitmap on the UI thread (clipboard / save dialog calls require it).</summary>
+    private async Task RenderThen(Func<Task<BitmapSource>> build, Action<BitmapSource> dispatchOnUi)
+    {
+        if (IsRendering) return;
+        IsRendering = true;
+        StatusMessage = "Rendering image…";
+        try
+        {
+            var image = await build().ConfigureAwait(true);
+            dispatchOnUi(image);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Render failed: {ex.Message}";
+        }
+        finally
+        {
+            IsRendering = false;
+        }
     }
 
     private void CopyText(string text, string okMessage)

--- a/src/Pippin.Module/Sharing/SharedProgressViewModel.cs
+++ b/src/Pippin.Module/Sharing/SharedProgressViewModel.cs
@@ -58,10 +58,13 @@ public sealed partial class SharedProgressViewModel : ObservableObject
         var unknown = payload.UnknownByName ?? new Dictionary<string, int>();
         var list = new List<FoodItemViewModel>(_catalog.TotalCount + unknown.Count);
 
+        // Shared payloads don't include the sender's Gourmand level, and "locked" is a
+        // viewer-relative state (what *I* can't eat yet), not a sender-relative one.
+        // Pass int.MaxValue so nothing on a remote progress view renders as locked.
         foreach (var food in _catalog.ByInternalName.Values)
         {
             var isEaten = payload.EatenFoodsByInternalName.TryGetValue(food.InternalName, out var count);
-            list.Add(new FoodItemViewModel(food, isEaten, isEaten ? count : 0));
+            list.Add(new FoodItemViewModel(food, isEaten, isEaten ? count : 0, int.MaxValue));
         }
 
         // Sender had foods we don't recognize — show them in the same orphan section

--- a/src/Pippin.Module/ViewModels/FoodItemViewModel.cs
+++ b/src/Pippin.Module/ViewModels/FoodItemViewModel.cs
@@ -5,16 +5,18 @@ namespace Pippin.ViewModels;
 
 public sealed partial class FoodItemViewModel : ObservableObject
 {
-    public FoodItemViewModel(FoodEntry catalog, bool isEaten, int eatenCount)
+    public FoodItemViewModel(FoodEntry catalog, bool isEaten, int eatenCount, int playerGourmandLevel)
     {
         Name = catalog.Name;
         FoodType = catalog.FoodType;
         FoodLevel = catalog.FoodLevel;
         GourmandLevelReq = catalog.GourmandLevelReq;
+        DietaryTagList = catalog.DietaryTags;
         DietaryTags = string.Join(", ", catalog.DietaryTags);
         IconId = catalog.IconId;
         IsEaten = isEaten;
         EatenCount = eatenCount;
+        IsLocked = !isEaten && GourmandLevelReq > 0 && playerGourmandLevel < GourmandLevelReq;
     }
 
     /// <summary>For foods eaten that don't appear in the CDN catalog.</summary>
@@ -22,6 +24,7 @@ public sealed partial class FoodItemViewModel : ObservableObject
     {
         Name = name;
         FoodType = "Unknown";
+        DietaryTagList = Array.Empty<string>();
         DietaryTags = "";
         IsEaten = true;
         EatenCount = eatenCount;
@@ -32,7 +35,10 @@ public sealed partial class FoodItemViewModel : ObservableObject
     public int FoodLevel { get; }
     public int GourmandLevelReq { get; }
     public string DietaryTags { get; }
+    public IReadOnlyList<string> DietaryTagList { get; }
     public int IconId { get; }
+    public bool IsLocked { get; }
+    public string? LockedReason => IsLocked ? $"Requires Gourmand {GourmandLevelReq}" : null;
 
     [ObservableProperty] private bool _isEaten;
     [ObservableProperty] private int _eatenCount;

--- a/src/Pippin.Module/ViewModels/GourmandViewModel.cs
+++ b/src/Pippin.Module/ViewModels/GourmandViewModel.cs
@@ -2,7 +2,9 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using System.Windows;
 using System.Windows.Data;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Character;
@@ -18,15 +20,18 @@ public sealed partial class GourmandViewModel : ObservableObject
 {
     private readonly GourmandStateMachine _state;
     private readonly FoodCatalog _catalog;
+    private readonly PippinSettings? _settings;
     private readonly IActiveCharacterService? _activeChar;
     private readonly IDialogService? _dialogs;
     private readonly PippinShareCardRenderer? _shareRenderer;
     private readonly IIconCacheService? _iconCache;
     private readonly ICollectionView _foodsView;
+    private readonly Dispatcher _dispatcher;
 
     public GourmandViewModel(
         GourmandStateMachine state,
         FoodCatalog catalog,
+        PippinSettings? settings = null,
         IActiveCharacterService? characterData = null,
         IDialogService? dialogs = null,
         PippinShareCardRenderer? shareRenderer = null,
@@ -34,34 +39,75 @@ public sealed partial class GourmandViewModel : ObservableObject
     {
         _state = state;
         _catalog = catalog;
+        _settings = settings;
         _activeChar = characterData;
         _dialogs = dialogs;
         _shareRenderer = shareRenderer;
         _iconCache = iconCache;
+        _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        if (settings is not null)
+        {
+            _viewMode = settings.ViewMode;
+            _hideLocked = settings.HideLocked;
+        }
 
         Foods = new ObservableCollection<FoodItemViewModel>();
         _foodsView = CollectionViewSource.GetDefaultView(Foods);
         // Grid composes its QueryText predicate on top of this combo-level filter.
         _foodsView.Filter = PassesComboFilters;
 
-        _state.StateChanged += (_, _) => Rebuild();
-        _catalog.CatalogChanged += (_, _) => Rebuild();
+        // Marshal every event-driven Rebuild to the UI thread. CDN refreshes (which
+        // fire CatalogChanged) and Player.log parsing (which fires StateChanged) both
+        // run on background threads; Foods is bound to a WPF ICollectionView that
+        // throws on cross-thread SourceCollection mutations, leaving Foods in a
+        // half-cleared state and the filter pipeline corrupted until app restart.
+        _state.StateChanged += (_, _) => DispatchRebuild();
+        _catalog.CatalogChanged += (_, _) => DispatchRebuild();
         if (_activeChar is not null)
         {
             _activeChar.ActiveCharacterChanged += (_, _) =>
             {
-                OnPropertyChanged(nameof(GourmandLevel));
-                Rebuild();
+                _dispatcher.BeginInvoke(() =>
+                {
+                    OnPropertyChanged(nameof(GourmandLevel));
+                    Rebuild();
+                });
             };
-            _activeChar.CharacterExportsChanged += (_, _) => OnPropertyChanged(nameof(GourmandLevel));
+            // Only rebuild on export refresh if the Gourmand level actually changed —
+            // otherwise we churn Foods every few seconds for no benefit.
+            _activeChar.CharacterExportsChanged += (_, _) =>
+            {
+                _dispatcher.BeginInvoke(() =>
+                {
+                    var newLevel = GourmandLevel;
+                    if (newLevel != _lastObservedLevel)
+                    {
+                        _lastObservedLevel = newLevel;
+                        OnPropertyChanged(nameof(GourmandLevel));
+                        Rebuild();
+                    }
+                });
+            };
+            _lastObservedLevel = GourmandLevel;
         }
         Rebuild();
+    }
+
+    private int _lastObservedLevel;
+
+    private void DispatchRebuild()
+    {
+        if (_dispatcher.CheckAccess()) Rebuild();
+        else _dispatcher.BeginInvoke(Rebuild);
     }
 
     public ObservableCollection<FoodItemViewModel> Foods { get; }
 
     [ObservableProperty] private string _foodTypeFilter = "All";
     [ObservableProperty] private string _eatenFilter = "All";
+    [ObservableProperty] private string _viewMode = "Grid";
+    [ObservableProperty] private bool _hideLocked;
 
     [ObservableProperty] private int _eatenCount;
     [ObservableProperty] private int _totalCount;
@@ -79,8 +125,22 @@ public sealed partial class GourmandViewModel : ObservableObject
         }
     }
 
+    public bool IsGridView => ViewMode == "Grid";
+    public bool IsCardView => ViewMode == "Cards";
+
     partial void OnFoodTypeFilterChanged(string value) => _foodsView.Refresh();
     partial void OnEatenFilterChanged(string value) => _foodsView.Refresh();
+    partial void OnHideLockedChanged(bool value)
+    {
+        _foodsView.Refresh();
+        if (_settings is not null) _settings.HideLocked = value;
+    }
+    partial void OnViewModeChanged(string value)
+    {
+        OnPropertyChanged(nameof(IsGridView));
+        OnPropertyChanged(nameof(IsCardView));
+        if (_settings is not null) _settings.ViewMode = value;
+    }
 
     private void Rebuild()
     {
@@ -89,11 +149,12 @@ public sealed partial class GourmandViewModel : ObservableObject
 
         // Build the full list off the bound collection, then swap in a single Reset
         // to avoid per-item CollectionChanged notifications on large catalogs.
+        var playerLevel = GourmandLevel;
         var list = new List<FoodItemViewModel>(_catalog.TotalCount + unknown.Count);
         foreach (var food in _catalog.ByInternalName.Values)
         {
             var isEaten = eaten.TryGetValue(food.InternalName, out var count);
-            list.Add(new FoodItemViewModel(food, isEaten, isEaten ? count : 0));
+            list.Add(new FoodItemViewModel(food, isEaten, isEaten ? count : 0, playerLevel));
         }
         foreach (var (name, count) in unknown)
             list.Add(new FoodItemViewModel(name, count));
@@ -133,6 +194,8 @@ public sealed partial class GourmandViewModel : ObservableObject
 
         if (EatenFilter == "Eaten" && !vm.IsEaten) return false;
         if (EatenFilter == "Uneaten" && vm.IsEaten) return false;
+
+        if (HideLocked && vm.IsLocked) return false;
 
         return true;
     }

--- a/src/Pippin.Module/Views/GourmandView.xaml
+++ b/src/Pippin.Module/Views/GourmandView.xaml
@@ -60,9 +60,9 @@
             </Grid>
         </StackPanel>
 
-        <!-- ── Filters ── -->
+        <!-- ── Filters + view-mode toggle ── -->
         <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12">
-            <Grid>
+            <Grid Margin="0,0,0,6">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
@@ -85,10 +85,31 @@
                     <ComboBoxItem Content="Uneaten"/>
                 </ComboBox>
             </Grid>
-            <TextBlock Text="{Binding ElementName=FoodsGrid, Path=QueryError}"
-                       Foreground="#FFCC6666" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,4,0,0"
-                       Visibility="{Binding ElementName=FoodsGrid, Path=QueryError,
-                           Converter={StaticResource NullOrEmptyToVis}}"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <CheckBox Grid.Column="0" IsChecked="{Binding HideLocked}" VerticalAlignment="Center"
+                          Content="Hide locked"
+                          ToolTip="Hide foods whose Gourmand requirement exceeds your current skill level"/>
+                <TextBlock Grid.Column="1" Text="{Binding ElementName=FoodsGrid, Path=QueryError}"
+                           Foreground="#FFCC6666" FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="12,0,12,0" VerticalAlignment="Center"
+                           Visibility="{Binding ElementName=FoodsGrid, Path=QueryError,
+                               Converter={StaticResource NullOrEmptyToVis}}"/>
+                <wpf:ViewModeToggle Grid.Column="2" SelectedMode="{Binding ViewMode, Mode=TwoWay}">
+                    <wpf:ViewModeOption Id="Grid"
+                                        ToolTipText="Show foods in a sortable table">
+                        <icon:PackIconLucide Kind="List" Width="14" Height="14"/>
+                    </wpf:ViewModeOption>
+                    <wpf:ViewModeOption Id="Cards"
+                                        ToolTipText="Show foods as cards with icons and dietary tags">
+                        <icon:PackIconLucide Kind="LayoutGrid" Width="14" Height="14"/>
+                    </wpf:ViewModeOption>
+                </wpf:ViewModeToggle>
+            </Grid>
         </StackPanel>
 
         <!-- ── Empty state ── -->
@@ -103,69 +124,245 @@
                        MaxWidth="360" TextAlignment="Center"/>
         </StackPanel>
 
-        <!-- ── Food grid ── -->
-        <wpf:MithrilDataGrid x:Name="FoodsGrid"
-                            ItemsSource="{Binding Foods}"
-                            Visibility="{Binding HasData, Converter={StaticResource BoolToVis}}"
-                            Mode="ReadOnly"
-                            GridLinesVisibility="None"
-                            EnableRowVirtualization="True"
-                            EnableColumnVirtualization="True"
-                            VirtualizingPanel.IsVirtualizing="True"
-                            VirtualizingPanel.VirtualizationMode="Recycling"
-                            VirtualizingPanel.ScrollUnit="Pixel"
-                            ScrollViewer.CanContentScroll="True">
-            <wpf:MithrilDataGrid.Columns>
-                <DataGridCheckBoxColumn Header="" Binding="{Binding IsEaten, Mode=OneWay}"
-                                        Width="32" IsReadOnly="True"
-                                        wpf:MithrilDataGrid.QueryName="IsEaten"/>
-                <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name" SortDirection="Ascending"
-                                        wpf:MithrilDataGrid.QueryName="Name">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTextColumn Header="Type" Binding="{Binding FoodType}" Width="110"/>
-                <DataGridTextColumn Header="Level" Binding="{Binding FoodLevel}" Width="60"/>
-                <DataGridTextColumn Header="Req" Binding="{Binding GourmandLevelReq}" Width="50"/>
-                <DataGridTextColumn Header="Count" Binding="{Binding EatenCount}" Width="60"/>
-                <DataGridTextColumn Header="Tags" Binding="{Binding DietaryTags}" Width="140"/>
-            </wpf:MithrilDataGrid.Columns>
-            <wpf:MithrilDataGrid.RowStyle>
-                <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
-                    <Setter Property="ToolTip">
-                        <Setter.Value>
-                            <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
-                                     Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <ToolTip.ContentTemplate>
-                                    <DataTemplate>
-                                        <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                                                CornerRadius="4" Padding="10" MaxWidth="320">
-                                            <DockPanel>
-                                                <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                               Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
-                                                <StackPanel>
-                                                    <TextBlock Text="{Binding Name}" FontWeight="Bold"
-                                                               Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
-                                                    <TextBlock Text="{Binding FoodType}" Foreground="#CCFFFFFF"
-                                                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"/>
-                                                </StackPanel>
-                                            </DockPanel>
-                                        </Border>
-                                    </DataTemplate>
-                                </ToolTip.ContentTemplate>
-                            </ToolTip>
-                        </Setter.Value>
-                    </Setter>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsEaten}" Value="True">
-                            <Setter Property="Opacity" Value="0.6"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </wpf:MithrilDataGrid.RowStyle>
-        </wpf:MithrilDataGrid>
+        <!-- ── Food grid / cards ── -->
+        <Grid Visibility="{Binding HasData, Converter={StaticResource BoolToVis}}">
+            <wpf:MithrilDataGrid x:Name="FoodsGrid"
+                                ItemsSource="{Binding Foods}"
+                                Visibility="{Binding IsGridView, Converter={StaticResource BoolToVis}}"
+                                Mode="ReadOnly"
+                                GridLinesVisibility="None"
+                                EnableRowVirtualization="True"
+                                EnableColumnVirtualization="True"
+                                VirtualizingPanel.IsVirtualizing="True"
+                                VirtualizingPanel.VirtualizationMode="Recycling"
+                                VirtualizingPanel.ScrollUnit="Pixel"
+                                ScrollViewer.CanContentScroll="True">
+                <wpf:MithrilDataGrid.Columns>
+                    <DataGridCheckBoxColumn Header="" Binding="{Binding IsEaten, Mode=OneWay}"
+                                            Width="32" IsReadOnly="True"
+                                            wpf:MithrilDataGrid.QueryName="IsEaten"/>
+                    <DataGridTemplateColumn Header="Name" Width="*" SortMemberPath="Name" SortDirection="Ascending"
+                                            wpf:MithrilDataGrid.QueryName="Name">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTextColumn Header="Type" Binding="{Binding FoodType}" Width="110"/>
+                    <DataGridTextColumn Header="Level" Binding="{Binding FoodLevel}" Width="60"/>
+                    <DataGridTextColumn Header="Req" Binding="{Binding GourmandLevelReq}" Width="50"/>
+                    <DataGridTextColumn Header="Count" Binding="{Binding EatenCount}" Width="60"/>
+                    <DataGridTextColumn Header="Tags" Binding="{Binding DietaryTags}" Width="140"/>
+                </wpf:MithrilDataGrid.Columns>
+                <wpf:MithrilDataGrid.RowStyle>
+                    <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
+                                         Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                    <ToolTip.ContentTemplate>
+                                        <DataTemplate>
+                                            <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
+                                                    CornerRadius="4" Padding="10" MaxWidth="320">
+                                                <DockPanel>
+                                                    <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                                   Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="Bold"
+                                                                   Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                                                        <TextBlock Text="{Binding FoodType}" Foreground="#CCFFFFFF"
+                                                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"/>
+                                                        <TextBlock Text="{Binding LockedReason}" Foreground="#FFCC6666"
+                                                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"
+                                                                   Visibility="{Binding IsLocked, Converter={StaticResource BoolToVis}}"/>
+                                                    </StackPanel>
+                                                </DockPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ToolTip.ContentTemplate>
+                                </ToolTip>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsEaten}" Value="True">
+                                <Setter Property="Opacity" Value="{StaticResource EatenOpacityKey}"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsLocked}" Value="True">
+                                <Setter Property="Opacity" Value="{StaticResource LockedOpacityKey}"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </wpf:MithrilDataGrid.RowStyle>
+            </wpf:MithrilDataGrid>
+
+            <ListBox x:Name="FoodsCards"
+                     ItemsSource="{Binding Foods}"
+                     Visibility="{Binding IsCardView, Converter={StaticResource BoolToVis}}"
+                     Background="Transparent" BorderThickness="0"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     ScrollViewer.CanContentScroll="True"
+                     VirtualizingPanel.IsVirtualizing="True"
+                     VirtualizingPanel.VirtualizationMode="Recycling">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <wpf:MithrilVirtualizingWrapPanel ItemWidth="330" ItemHeight="130"/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="Padding" Value="0"/>
+                        <Setter Property="Margin" Value="0"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="Focusable" Value="False"/>
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                        <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListBoxItem">
+                                    <ContentPresenter/>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Border x:Name="CardRoot" Margin="6" Padding="10" CornerRadius="6"
+                                Background="{StaticResource BgSurfaceBrush}">
+                            <Border.Style>
+                                <!-- Three-state visual: default (uneaten), eaten (accent border + check
+                                     badge + slight dim), locked (subtle border + heavy dim + lock badge).
+                                     BorderBrush / BorderThickness / Opacity are owned by the Style so
+                                     triggers can override them — local attribute values would otherwise
+                                     beat trigger setters per WPF DP precedence. -->
+                                <Style TargetType="Border">
+                                    <Setter Property="BorderBrush" Value="{StaticResource BorderSubtleBrush}"/>
+                                    <Setter Property="BorderThickness" Value="1"/>
+                                    <Setter Property="Opacity" Value="1"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsEaten}" Value="True">
+                                            <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                            <Setter Property="BorderThickness" Value="2"/>
+                                            <Setter Property="Opacity" Value="{StaticResource EatenOpacityKey}"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding IsLocked}" Value="True">
+                                            <Setter Property="Opacity" Value="{StaticResource LockedOpacityKey}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <Border.ToolTip>
+                                <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
+                                         Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                    <ToolTip.ContentTemplate>
+                                        <DataTemplate>
+                                            <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
+                                                    CornerRadius="4" Padding="10" MaxWidth="320">
+                                                <DockPanel>
+                                                    <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                                   Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="Bold"
+                                                                   Foreground="{StaticResource AccentBrush}"
+                                                                   FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                                                        <TextBlock Text="{Binding FoodType}"
+                                                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"/>
+                                                        <TextBlock Text="{Binding LockedReason}" Foreground="#FFCC6666"
+                                                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"
+                                                                   Visibility="{Binding IsLocked, Converter={StaticResource BoolToVis}}"/>
+                                                    </StackPanel>
+                                                </DockPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ToolTip.ContentTemplate>
+                                </ToolTip>
+                            </Border.ToolTip>
+                            <DockPanel LastChildFill="True">
+                                <!-- Icon + state badge overlay (lock for locked, check for eaten) -->
+                                <Grid DockPanel.Dock="Left" Width="64" Height="64" Margin="0,0,10,0" VerticalAlignment="Top">
+                                    <wpf:IconImage IconId="{Binding IconId}" Width="64" Height="64"/>
+                                    <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                                            Width="20" Height="20" CornerRadius="10"
+                                            Background="#FF1A1A1A" BorderBrush="{StaticResource AccentBrush}" BorderThickness="1"
+                                            Visibility="{Binding IsLocked, Converter={StaticResource BoolToVis}}">
+                                        <icon:PackIconLucide Kind="Lock" Width="11" Height="11"
+                                                             Foreground="{StaticResource AccentBrush}"
+                                                             HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                    <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                                            Width="20" Height="20" CornerRadius="10"
+                                            Background="{StaticResource AccentBrush}" BorderBrush="#FF1A1A1A" BorderThickness="1"
+                                            Visibility="{Binding IsEaten, Converter={StaticResource BoolToVis}}">
+                                        <icon:PackIconLucide Kind="Check" Width="13" Height="13"
+                                                             Foreground="#FF1A1A1A"
+                                                             HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                </Grid>
+                                <!-- Name + REQ chip -->
+                                <Grid DockPanel.Dock="Top" Margin="0,0,0,2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold"
+                                               Foreground="{StaticResource AccentBrush}"
+                                               FontSize="{DynamicResource AppFontSizeMedium}"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <Border Grid.Column="1" CornerRadius="3" Padding="5,1" Margin="6,0,0,0"
+                                            Background="{StaticResource BgRecessedBrush}"
+                                            BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
+                                            Visibility="{Binding GourmandLevelReq, Converter={StaticResource PositiveIntToVis}}">
+                                        <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeXSmall}">
+                                            <Run Text="REQ"/>
+                                            <Run Text="{Binding GourmandLevelReq, Mode=OneWay}"/>
+                                        </TextBlock>
+                                    </Border>
+                                </Grid>
+                                <!-- Type + Progress -->
+                                <Grid DockPanel.Dock="Top" Margin="0,0,0,4">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding FoodType}"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="{DynamicResource AppFontSizeHint}"/>
+                                    <TextBlock Grid.Column="1"
+                                               Foreground="{StaticResource TextTertiaryBrush}"
+                                               FontSize="{DynamicResource AppFontSizeHint}">
+                                        <Run Text="Progress:"/>
+                                        <Run Text="{Binding EatenCount, Mode=OneWay}" Foreground="{StaticResource TextPrimaryBrush}"/>
+                                        <Run Text="/1"/>
+                                    </TextBlock>
+                                </Grid>
+                                <!-- Dietary tag chips -->
+                                <ItemsControl ItemsSource="{Binding DietaryTagList}" VerticalAlignment="Bottom">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border CornerRadius="3" Padding="5,1" Margin="0,2,4,0"
+                                                    Background="{StaticResource BgRecessedBrush}"
+                                                    BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1">
+                                                <TextBlock Text="{Binding}"
+                                                           Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeXSmall}"/>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </DockPanel>
+                        </Border>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Grid>
     </DockPanel>
 </UserControl>

--- a/src/Pippin.Module/Views/GourmandView.xaml.cs
+++ b/src/Pippin.Module/Views/GourmandView.xaml.cs
@@ -1,8 +1,23 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Pippin.Views;
 
 public partial class GourmandView : UserControl
 {
-    public GourmandView() => InitializeComponent();
+    public GourmandView()
+    {
+        InitializeComponent();
+        // Virtualizing panels that start out collapsed don't run their initial measure with
+        // a real viewport — first show paints blank until the user scrolls. Force a fresh
+        // layout pass each time the cards ListBox becomes visible.
+        FoodsCards.IsVisibleChanged += (_, e) =>
+        {
+            if (e.NewValue is true)
+            {
+                FoodsCards.InvalidateMeasure();
+                FoodsCards.UpdateLayout();
+            }
+        };
+    }
 }

--- a/tests/Pippin.Tests/GourmandFilterRepro.cs
+++ b/tests/Pippin.Tests/GourmandFilterRepro.cs
@@ -1,0 +1,119 @@
+using System.Collections.ObjectModel;
+using System.Windows.Data;
+using FluentAssertions;
+using Mithril.Shared.Wpf.Query;
+using Pippin.Domain;
+using Pippin.ViewModels;
+using Xunit;
+
+namespace Pippin.Tests;
+
+/// <summary>
+/// Repro for the "filter hides everything in the cards/grid view" report.
+/// Verifies the QueryCompiler + ColumnBindingHelper combo against actual
+/// FoodItemViewModel instances.
+/// </summary>
+public class GourmandFilterRepro
+{
+    private static FoodItemViewModel MakeFood(string name, string foodType, int level, int gourmandReq, bool eaten, int playerLevel = 33)
+    {
+        var entry = new FoodEntry(
+            ItemId: 1,
+            InternalName: name.Replace(" ", ""),
+            Name: name,
+            IconId: 100,
+            FoodType: foodType,
+            FoodLevel: level,
+            GourmandLevelReq: gourmandReq,
+            DietaryTags: new List<string> { "Vegetarian" });
+        return new FoodItemViewModel(entry, eaten, eaten ? 1 : 0, playerLevel);
+    }
+
+    [Fact]
+    public void Name_contains_cake_should_match_cakes()
+    {
+        var foods = new List<FoodItemViewModel>
+        {
+            MakeFood("3-Year Steamed Cake", "Meal", 30, 0, eaten: false),
+            MakeFood("4-Year Steamed Cake", "Meal", 40, 0, eaten: false),
+            MakeFood("Apple Juice", "Snack", 5, 0, eaten: true),
+            MakeFood("Almonds", "Snack", 10, 0, eaten: true),
+        };
+
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(FoodItemViewModel));
+        var predicate = QueryCompiler.Compile("Name CONTAINS \"cake\"", columns);
+
+        predicate.Should().NotBeNull();
+        var matches = foods.Where(f => predicate!(f)).ToList();
+        matches.Should().HaveCount(2);
+        matches.Select(f => f.Name).Should().BeEquivalentTo(new[] { "3-Year Steamed Cake", "4-Year Steamed Cake" });
+    }
+
+    [Fact]
+    public void IsLocked_equals_true_should_match_locked_items()
+    {
+        var foods = new List<FoodItemViewModel>
+        {
+            MakeFood("Low Req", "Meal", 30, 10, eaten: false, playerLevel: 33), // not locked (req 10 <= 33)
+            MakeFood("High Req", "Meal", 60, 60, eaten: false, playerLevel: 33), // LOCKED (req 60 > 33)
+            MakeFood("Eaten High Req", "Meal", 60, 60, eaten: true, playerLevel: 33), // not locked (eaten)
+        };
+
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(FoodItemViewModel));
+        var predicate = QueryCompiler.Compile("IsLocked = TRUE", columns);
+
+        predicate.Should().NotBeNull();
+        var matches = foods.Where(f => predicate!(f)).ToList();
+        matches.Should().ContainSingle().Which.Name.Should().Be("High Req");
+    }
+
+    [Fact]
+    public void Empty_query_returns_null_predicate()
+    {
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(FoodItemViewModel));
+        var predicate = QueryCompiler.Compile("", columns);
+        predicate.Should().BeNull();
+    }
+
+    [Fact]
+    public void CollectionView_filter_pipeline_applies_predicate()
+    {
+        // Reproduce the GourmandViewModel + DataGrid filter composition end-to-end.
+        var foods = new ObservableCollection<FoodItemViewModel>
+        {
+            MakeFood("3-Year Steamed Cake", "Meal", 30, 0, eaten: false),
+            MakeFood("Apple Juice", "Snack", 5, 0, eaten: true),
+            MakeFood("Almonds", "Snack", 10, 0, eaten: true),
+        };
+
+        var view = CollectionViewSource.GetDefaultView(foods);
+
+        // Step 1: VM-level filter (PassesComboFilters with default settings — always true)
+        Predicate<object> vmFilter = _ => true;
+        view.Filter = vmFilter;
+
+        // Step 2: DataGrid composes query predicate over vmFilter
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(FoodItemViewModel));
+        var queryPredicate = QueryCompiler.Compile("Name CONTAINS \"cake\"", columns);
+
+        view.Filter = item =>
+        {
+            if (!vmFilter(item)) return false;
+            if (queryPredicate is not null && !queryPredicate(item)) return false;
+            return true;
+        };
+
+        var visible = view.Cast<FoodItemViewModel>().ToList();
+        visible.Should().ContainSingle().Which.Name.Should().Be("3-Year Steamed Cake");
+
+        // Step 3: clear query — composite should fall back to vmFilter only (all pass)
+        view.Filter = item =>
+        {
+            if (!vmFilter(item)) return false;
+            return true;
+        };
+
+        var visibleAfterClear = view.Cast<FoodItemViewModel>().ToList();
+        visibleAfterClear.Should().HaveCount(3);
+    }
+}

--- a/tests/Pippin.Tests/Sharing/PippinShareViewModelTests.cs
+++ b/tests/Pippin.Tests/Sharing/PippinShareViewModelTests.cs
@@ -157,21 +157,6 @@ public class PippinShareViewModelTests
     }
 
     [Fact]
-    public void FullGrid_total_height_grows_with_row_count()
-    {
-        var smallCatalog = CreateCatalog((1, "FoodA", "A", 0));
-        var bigCatalog = CreateCatalog(
-            Enumerable.Range(1, 50)
-                .Select(i => ((long)i, $"Food{i}", $"Name{i}", 0))
-                .ToArray());
-
-        var small = new PippinFullGridViewModel(BuildPayload(), smallCatalog, 0, new NoopIconCache());
-        var big   = new PippinFullGridViewModel(BuildPayload(), bigCatalog, 0, new NoopIconCache());
-
-        big.TotalHeight.Should().BeGreaterThan(small.TotalHeight);
-    }
-
-    [Fact]
     public void FullGrid_anonymous_payload_omits_identity_subtitle()
     {
         var catalog = CreateCatalog((1, "FoodApple", "Apple", 0));


### PR DESCRIPTION
## Summary

- **Cards view in-app** — alternate to the existing DataGrid, toggleable via `ViewModeToggle`. Renders three distinct states (eaten / available / locked) using gold accent border + check badge for eaten, lock badge + dim for items above the player's Gourmand level, default for available. View-mode and "Hide locked" toggle persist to `%LocalAppData%/Mithril/pippin-settings.json`.
- **Cross-thread filter fix** — `FoodCatalog.CatalogChanged` and `GourmandStateMachine.StateChanged` fire on background threads; mutating `Foods` (the bound source) from those threads threw `"This type of CollectionView does not support changes to its SourceCollection from a thread different from the Dispatcher thread"`, the exception was swallowed inside `IReferenceDataService`'s refresh loop, and `Foods` ended up half-cleared with the QueryBox filter pipeline corrupted until app restart. All event-driven `Rebuild()` calls now marshal via `Dispatcher.BeginInvoke`.
- **Card-grid PNG export** — replaces the row-based full-grid export with the same card layout used in-app (icons, check / lock badges, dietary tag chips). Width dropped to 960px (3 × 300px cells), height now measure-driven via `DesiredSize` round-trip rather than a hand-computed `TotalHeight`. Render runs on a dedicated STA worker `Thread` so the dialog stays responsive — eliminates the multi-second UI freeze when exporting.

## Test plan

- [ ] Open Pippin tab, toggle Grid ↔ Cards. Three states visible: eaten cards have gold border + check badge, locked cards have lock badge + heavy dim, available cards are default.
- [ ] Type `IsLocked = TRUE` in the QueryBox — only locked items show. Clear it — all items return.
- [ ] Type `Name CONTAINS \"cake\"` — only cakes show.
- [ ] Toggle "Hide locked" — locked cards disappear; toggle off, they return.
- [ ] Restart the app — view mode, hide-locked, and combo filter state restore.
- [ ] Wait for a CDN refresh (or trigger one), then type in QueryBox — filter still works (regression test for cross-thread fix).
- [ ] Open the Share dialog, click "Copy" / "Save…" on the full grid — UI stays responsive while rendering, no multi-second freeze.
- [ ] Saved PNG: 3 cards per row, no wasted right-edge whitespace, eaten / locked items rendered with the correct badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)