### PR TITLE
Legolas FSM: SurveyFlowController + MotherlodeFlowController

### DIFF
--- a/docs/agent-plans/legolas-state-machine.md
+++ b/docs/agent-plans/legolas-state-machine.md
@@ -1,0 +1,316 @@
+# Legolas state machine
+
+**Tracked in:** #4
+
+Refactor Legolas's session state into two explicit FSMs (Survey, Motherlode)
+plus a thin shell that picks between them. Prerequisite for the modernised
+UI (wizard for first-time users, condensed dashboard for experienced
+users) and for cleanly addressing the rest of issue #4.
+
+This is the *first* PR on the way to the new UI. The visible user-facing
+change after this PR lands is small — the existing panel keeps working —
+but every state mutation in the module flows through one controller per
+mode, so the wizard/dashboard split becomes a XAML problem instead of a
+"rewire five files" problem.
+
+## Why now
+
+Issue #4's last bullet ("maybe a discrete state machine?") is the unlock
+for the other four bullets:
+
+- **Splitting Survey/Motherlode** is naturally expressed as two
+  independent FSMs, not "toggle Visibility on a GroupBox at the bottom
+  of one giant scrollviewer".
+- **Consolidating the show-overlay buttons** is a side-effect of
+  entering `Listening`, not a button the user has to remember to click.
+- **Auto click-through on inventory** is a side-effect of the same
+  transition. One place, not three.
+- **Wizard UI** is an FSM rendered one step at a time. Without the FSM
+  it's a pile of `Visibility` bindings and stale flags.
+
+## Today's state model
+
+`SessionState` carries three independent fields that together describe
+"where in the workflow are we":
+
+- [`SessionMode Mode`](../../src/Legolas.Module/ViewModels/SessionState.cs#L64)
+  — `Survey | Motherlode`, orthogonal to phase.
+- [`SurveyPhase SurveyPhase`](../../src/Legolas.Module/ViewModels/SessionState.cs#L72)
+  — `Idle | Surveying | AwaitingPin`. Survey-only; Motherlode ignores it.
+- [`bool HasPlayerPosition`](../../src/Legolas.Module/ViewModels/SessionState.cs#L60)
+  — checked alongside `SurveyPhase` (e.g. `StartSession` picks Idle vs
+  Surveying based on this flag).
+
+Phase mutations happen in **four** places:
+
+| Where | What it does |
+|---|---|
+| [`ControlPanelViewModel.StartSession`](../../src/Legolas.Module/ViewModels/ControlPanelViewModel.cs#L86) | Clears surveys, sets phase to `Idle` or `Surveying` based on `HasPlayerPosition` |
+| [`ControlPanelViewModel.SetPlayerPosition`](../../src/Legolas.Module/ViewModels/ControlPanelViewModel.cs#L96) | Clears `PendingSurvey`, sets phase to `Idle` (so the next map click sets origin) |
+| [`MapOverlayViewModel.HandleMapClick`](../../src/Legolas.Module/ViewModels/MapOverlayViewModel.cs#L132) | `Idle` → set origin → `Surveying`; `AwaitingPin` → place pin → `Surveying` |
+| [`LogIngestionService.HandleSurveyDetected`](../../src/Legolas.Module/Services/LogIngestionService.cs#L91) | `Surveying` → store `PendingSurvey` → `AwaitingPin` (and a side-branch when ≥2 manual corrections exist that *bypasses* `AwaitingPin` entirely) |
+
+Plus an `AllCollected` event on the `Surveys` collection that fires when
+the last uncollected survey is marked, but doesn't flip a phase — only a
+settings flag (`AutoResetWhenAllCollected`) decides whether anything
+happens.
+
+Motherlode has its own progression — `RecordedPositions` 0→1→2→3, then
+`Distances.Count` 0→1→2→3 per slot, then trilateration kicks in — but
+it's all implicit in `MotherlodeViewModel`, with no named phase.
+
+This works, but the wizard can't bind to it: there's no single
+`CurrentStep` value to template-select on, and each transition's
+side-effects (auto-show overlay, auto-click-through, etc.) would have to
+be replicated at every mutation site.
+
+## The position-anchor constraint that shapes the design
+
+The game's chat log emits survey results as `[Status]` lines containing
+*relative* offsets ("X east, Y north") from the player's *current*
+position. **There is no absolute coordinate available.** The projector
+is anchored when the user clicks the map to set the player position,
+plus optionally refit by 2+ manual pin corrections.
+
+If the player moves and surveys again mid-session, the new offsets are
+relative to the new location but the projector still maps against the
+old anchor. We have no way to detect this — the chat log doesn't emit
+movement events, and a phantom pin at (50E, 30N) post-movement looks
+identical to a real new survey at (50E, 30N) from the original anchor.
+
+**Implication for the FSM:** a Survey session is bounded by one player
+position. Once the route is optimised and the player is walking, further
+`SurveyDetected` events are dropped with a diagnostic. Adding new
+targets mid-route requires an explicit Reset, which forces the user to
+re-anchor. This is not paranoia — it's the only safe contract given
+that we can't tell when the player has moved.
+
+## Proposed design: two controllers + one shell
+
+Two independent FSMs, one per mode, mirroring the prior-art shape of
+[GardenStateMachine](../../src/Samwise.Module/State/GardenStateMachine.cs#L22)
+(no FSM library; transition methods *are* the public API).
+
+A thin `LegolasShell` (just a property on `SessionState`, or a small
+sibling object — TBD during implementation) carries `ActiveMode = None |
+Survey | Motherlode`. `PickMode` is the only shell-level command;
+everything else delegates to whichever FSM is active.
+
+### Why two FSMs instead of one tagged enum
+
+- Survey and Motherlode share zero transitions. A unified enum would be
+  textual concatenation, not semantic unity.
+- The compiler enforces "you can't `OnSurveyDetected` on the Motherlode
+  controller" — the unified-enum version was a runtime no-op + diag,
+  which is the weaker version of the same check.
+- Tests partition naturally per controller; no cross-mode interference
+  cases.
+- "Mode-not-picked" stops being a state of either workflow — it's a
+  shell-level concern, which is where mode selection actually lives.
+- Maps directly onto #4 bullet 1 (split Survey/Motherlode views): two
+  FSMs → two wizards → no shared template gymnastics.
+
+### `SurveyFlowController`
+
+```
+SurveyFlowState:
+
+AwaitingPosition
+   │ ConfirmPlayerPosition(p)
+   ▼
+Listening ◄──────────────────┐
+   │ OnSurveyDetected(sd)    │ ConfirmPin(px)
+   ▼                          │
+AwaitingPin ──────────────────┘
+
+Listening: OptimizeRoute()
+   │
+   ▼
+Gathering          ← OnSurveyDetected here is IGNORED + diagnostic
+   │ MarkCollected(...)  — last one
+   ▼
+Done
+   │ Reset() (auto if AutoResetWhenAllCollected, else manual)
+   ▼
+AwaitingPosition
+```
+
+Linear, no back-edges across phases. The only cycle is the natural
+`Listening ⇄ AwaitingPin` loop while a survey is being placed.
+
+**Internal names** (`AwaitingPosition`, `Listening`, `AwaitingPin`,
+`Gathering`, `Done`) are technical and not user-facing. The wizard owns
+its own copy strings ("Click on the map where you are now", "Use a
+survey — we're listening", etc.) so naming the states precisely doesn't
+constrain UX vocabulary.
+
+### `MotherlodeFlowController`
+
+```
+MotherlodeFlowState:
+
+AwaitingPos1
+   │ RecordPosition(p1)
+   ▼
+AwaitingDist1
+   │ RecordDistance(d1)
+   ▼
+AwaitingPos2 → AwaitingDist2 → AwaitingPos3 → AwaitingDist3
+   │ (trilateration computed once Pos3+Dist3 land)
+   ▼
+Ready
+   │ OptimizeRoute()
+   ▼
+Optimized
+   │ MarkCollected (last)
+   ▼
+Done
+   │ Reset()
+   ▼
+AwaitingPos1
+```
+
+The position/distance progression is currently implicit in
+`MotherlodeViewModel`'s `Slots.Count` plumbing. Surfacing it as named
+states lets the wizard render distinct steps for "stand somewhere new"
+vs. "tell me the distance you're seeing".
+
+### Transition side-effects (bound to enter-state, not callsites)
+
+These hooks are why the FSMs exist. Each is one place after the
+refactor:
+
+| Transition | Side effect |
+|---|---|
+| `Survey: → AwaitingPosition` | `Surveys.Clear()`, `PendingSurvey = null`, fire setting-driven auto-show overlays |
+| `Survey: → Listening` | If `Settings.AutoClickThroughInventoryWhileGathering`, set `Settings.ClickThroughInventory = true`. (#4 bullet 4 — applies as soon as we're listening since that's when overlays go up) |
+| `Survey: → AwaitingPin` | Set `PendingSurvey`. View binds to render the "click here" prompt. |
+| `Survey: → Gathering` | Drop further `SurveyDetected` events with diagnostic. |
+| `Survey: → Done` | Fire `AllCollected`; if `Settings.AutoResetWhenAllCollected`, schedule `Reset()` via dispatcher post (avoids re-entrant transition). |
+| `Motherlode: → AwaitingDistN` | Increment `CurrentRound` exposed on the VM (decouples from `Slots.Count` plumbing). |
+
+### Single `Transitioned` post-event per controller
+
+```csharp
+public sealed record SurveyTransition(
+    SurveyFlowState From,
+    SurveyFlowState To,
+    string Trigger);
+
+public event Action<SurveyTransition>? Transitioned;
+```
+
+Fires after every successful state change. Two listeners benefit:
+
+1. **Diagnostics sink** — logs every transition in one place instead of
+   `_diag?.Transition(...)` sprinkled in every transition method.
+2. **Tests** — assert transition sequences directly
+   (`transitions.Should().Equal(...)`), more expressive than poking
+   final state.
+
+The VM doesn't need this event — it binds to `[ObservableProperty]
+SurveyFlowState _currentState` via `INotifyPropertyChanged` for wizard
+re-templating.
+
+**No pre-events / veto.** The controller is the only thing deciding
+whether a trigger is valid; nothing external should veto. Pre-events
+would be ceremony without payoff.
+
+### Where corrections fit
+
+The existing two-corrections-then-skip-pin path in
+[`HandleSurveyDetected`](../../src/Legolas.Module/Services/LogIngestionService.cs#L112)
+becomes part of `SurveyFlowController.OnSurveyDetected(sd)`: the
+controller decides internally whether to enter `AwaitingPin` or place
+the pin automatically. The decision logic doesn't change — just moves.
+This stays implicit (no dedicated state) — the user experience is "I've
+taught the projector enough, it just works now", which doesn't need its
+own wizard step.
+
+## Call-site map after the refactor
+
+| File | Today | After |
+|---|---|---|
+| `ControlPanelViewModel.cs` | Mutates `Session.SurveyPhase` directly | Calls `_surveyFlow.Reset()`, `_surveyFlow.RequestSetPlayerPosition()`, `_surveyFlow.MarkCurrentCollected()` |
+| `MapOverlayViewModel.HandleMapClick` | `switch` on `SurveyPhase`; mutates it | Calls `_surveyFlow.OnMapClicked(where)`; the controller decides what the click means |
+| `MapOverlayViewModel.PlacePendingPinAt` | Mutates `SurveyPhase`/`PendingSurvey` | Calls `_surveyFlow.ConfirmPin(where)`; placement helper stays pure |
+| `LogIngestionService.HandleSurveyDetected` | Mutates `SurveyPhase`/`PendingSurvey`; mode check | Calls `_shell.OnSurveyDetected(sd)` which routes to active controller (no-op if not Survey mode) |
+| `LogIngestionService.HandleMotherlodeDistance` | Calls VM command | Calls `_motherlodeFlow.RecordDistance(d)` |
+| `MotherlodeViewModel` commands | Mutate internal state directly | Call `_motherlodeFlow.RecordPosition()`, `_motherlodeFlow.RecordDistance(d)`, etc. The VM keeps the data; the controller owns transitions. |
+| `SessionState` | `[ObservableProperty] SurveyPhase`; `HasPlayerPosition` flag | Splits: shared bits (`PlayerPosition`, `LastLogEvent`, opacity, click-through) stay; `Surveys` and `PendingSurvey` move to a `SurveySession` data record co-owned by `SurveyFlowController`. `SessionMode` becomes `ActiveMode`, derived from "which controller is live". |
+
+## What stays out of scope for PR1
+
+These all build on the FSMs but are deliberately separate PRs:
+
+1. **Wizard view.** New `SurveyWizardView.xaml` and
+   `MotherlodeWizardView.xaml` with per-state `DataTemplate`s, gated by
+   a top-level `ContentControl` switching on `ActiveMode`. (#4
+   follow-up.)
+2. **Dashboard ("pro") shell.** Condensed status strip + contextual
+   action panel that swaps content based on each FSM's `CurrentState`.
+3. **`LegolasUiMode = Wizard | Dashboard` setting** with first-run
+   default and "skip wizard next time" toggle.
+4. **Configurable pin/marker colors.** Adds `LegolasColors` sub-settings
+   + `LegolasBrushes` VM that observes it. Sized for a small parallel
+   PR — not blocked on the FSM, but lands together with the wizard
+   since the wizard is what surfaces the new color picker UI.
+5. **Motherlode wizard polish** (the trilateration math is fine; only
+   the prompts change).
+6. **The Survey/Motherlode top-level split into separate panels** (#4
+   bullet 1). The two-FSM design enables it; the layout work is the
+   wizard PR.
+
+## Test strategy
+
+New `tests/Legolas.Tests/Flow/` directory with one file per controller.
+Pattern mirrors [`GardenStateMachineTests`](../../tests/Samwise.Tests/) —
+drive the controller through transition methods, assert state and
+transition sequences via the `Transitioned` event.
+
+**`SurveyFlowControllerTests`** covers at minimum:
+
+- Happy path: ConfirmPlayerPosition → OnSurveyDetected → ConfirmPin →
+  OptimizeRoute → MarkCollected ×N → Done.
+- Auto-reset: with `AutoResetWhenAllCollected = true`, `Done` →
+  `AwaitingPosition` (player position preserved).
+- Two-corrections short-circuit: third+ `OnSurveyDetected` after two
+  manual overrides skips `AwaitingPin`.
+- Post-Optimize survey drop: `OnSurveyDetected` while in `Gathering` is
+  a no-op + diagnostic, no state change, no new pin.
+- Illegal triggers (e.g. `ConfirmPin` while in `AwaitingPosition`) are
+  no-ops with a diagnostic — match Gandalf precedent.
+- `Transitioned` event fires once per real transition with correct
+  `(from, to, trigger)`.
+
+**`MotherlodeFlowControllerTests`** covers:
+
+- Happy path: 3× (RecordPosition → RecordDistance) → Ready →
+  OptimizeRoute → MarkCollected → Done.
+- Trilateration kicks in only after the third `(Pos, Dist)` pair lands.
+- Distance-before-position is a no-op (or whatever the existing VM
+  does — preserve current behaviour).
+
+**Shell-level test** (`LegolasShellTests` or similar): `PickMode`
+swaps which controller receives `OnSurveyDetected` /
+`OnMotherlodeDistance`; calling the wrong one is a silent no-op with a
+diagnostic.
+
+Existing tests in `tests/Legolas.Tests/` (parser, optimisers,
+trilateration) are untouched.
+
+## Open questions
+
+- **Where does shared state live?** `PlayerPosition`, `LastLogEvent`,
+  opacity, click-through — these aren't owned by either FSM but are
+  read by both. Two options: (a) keep them on `SessionState` and pass
+  it to both controllers, or (b) split into `SurveySession` /
+  `MotherlodeSession` with cross-references. Lean (a) for less
+  upheaval; revisit if it leaks.
+- **DI registration.** `SurveyFlowController` and
+  `MotherlodeFlowController` as singletons in `LegolasModule.Register`,
+  alongside the existing `SessionState`. Both get
+  `IDiagnosticsSink` injected to listen on their own `Transitioned`
+  events.
+- **Backwards compat.** No persisted state references `SurveyPhase`
+  (it's session-scoped, not in `LegolasSettings`). No migration needed.

--- a/src/Legolas.Module/Flow/MotherlodeFlowController.cs
+++ b/src/Legolas.Module/Flow/MotherlodeFlowController.cs
@@ -1,0 +1,92 @@
+using Legolas.ViewModels;
+
+namespace Legolas.Flow;
+
+/// <summary>
+/// Phase a Motherlode-mode session can be in. Simpler than <see cref="SurveyFlowState"/>
+/// because Motherlode distances are absolute — re-measuring after Optimize doesn't have
+/// the relative-offset hazard that Survey does. The wizard may later want finer-grained
+/// states (per-position / per-distance prompts); kept minimal here until that work lands.
+/// </summary>
+public enum MotherlodeFlowState
+{
+    Idle,
+    Measuring,
+    Optimized,
+}
+
+public sealed record MotherlodeTransition(
+    MotherlodeFlowState From,
+    MotherlodeFlowState To,
+    string Trigger);
+
+/// <summary>
+/// State machine for Motherlode mode. Owns transitions only; the
+/// <see cref="MotherlodeViewModel"/> still owns the position list, slot collection,
+/// and trilateration math.
+/// </summary>
+public sealed class MotherlodeFlowController
+{
+    private readonly SessionState _session;
+
+    public MotherlodeFlowController(SessionState session)
+    {
+        _session = session;
+    }
+
+    public MotherlodeFlowState CurrentState { get; private set; } = MotherlodeFlowState.Idle;
+
+    public event Action<MotherlodeTransition>? Transitioned;
+
+    /// <summary>True when a record-position / record-distance action would be accepted.</summary>
+    public bool CanMeasure => CurrentState is MotherlodeFlowState.Idle or MotherlodeFlowState.Measuring;
+
+    /// <summary>True when <see cref="OptimizeRoute"/> would do anything useful.</summary>
+    public bool CanOptimize => CurrentState == MotherlodeFlowState.Measuring;
+
+    /// <summary>
+    /// Notifies the controller that a position or distance was just recorded. Promotes
+    /// <c>Idle → Measuring</c>. From <c>Optimized</c>, demotes back to <c>Measuring</c>
+    /// — re-measuring after optimize is allowed because Motherlode distances are
+    /// absolute (no anchor invalidation).
+    /// </summary>
+    public void NoteMeasurement(string detail)
+    {
+        switch (CurrentState)
+        {
+            case MotherlodeFlowState.Idle:
+                TransitionTo(MotherlodeFlowState.Measuring, $"NoteMeasurement({detail})");
+                break;
+            case MotherlodeFlowState.Optimized:
+                TransitionTo(MotherlodeFlowState.Measuring, $"NoteMeasurement({detail}, re-measuring)");
+                break;
+            // Already Measuring: nothing to do.
+        }
+    }
+
+    /// <summary>Measuring → Optimized. Caller computes the route.</summary>
+    public void OptimizeRoute()
+    {
+        if (CurrentState != MotherlodeFlowState.Measuring)
+        {
+            _session.LastLogEvent = $"Motherlode OptimizeRoute ignored — state is {CurrentState}";
+            return;
+        }
+        TransitionTo(MotherlodeFlowState.Optimized, nameof(OptimizeRoute));
+    }
+
+    /// <summary>Reset to <c>Idle</c>. Caller is responsible for clearing data.</summary>
+    public void Reset()
+    {
+        if (CurrentState != MotherlodeFlowState.Idle)
+            TransitionTo(MotherlodeFlowState.Idle, nameof(Reset));
+    }
+
+    private void TransitionTo(MotherlodeFlowState next, string trigger)
+    {
+        var prev = CurrentState;
+        if (prev == next) return;
+        CurrentState = next;
+        Transitioned?.Invoke(new MotherlodeTransition(prev, next, trigger));
+    }
+}

--- a/src/Legolas.Module/Flow/MotherlodeFlowController.cs
+++ b/src/Legolas.Module/Flow/MotherlodeFlowController.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.ComponentModel;
 using Legolas.ViewModels;
 
 namespace Legolas.Flow;
@@ -25,7 +26,7 @@ public sealed record MotherlodeTransition(
 /// <see cref="MotherlodeViewModel"/> still owns the position list, slot collection,
 /// and trilateration math.
 /// </summary>
-public sealed class MotherlodeFlowController
+public sealed partial class MotherlodeFlowController : ObservableObject
 {
     private readonly SessionState _session;
 
@@ -34,7 +35,10 @@ public sealed class MotherlodeFlowController
         _session = session;
     }
 
-    public MotherlodeFlowState CurrentState { get; private set; } = MotherlodeFlowState.Idle;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanMeasure))]
+    [NotifyPropertyChangedFor(nameof(CanOptimize))]
+    private MotherlodeFlowState _currentState = MotherlodeFlowState.Idle;
 
     public event Action<MotherlodeTransition>? Transitioned;
 
@@ -86,7 +90,7 @@ public sealed class MotherlodeFlowController
     {
         var prev = CurrentState;
         if (prev == next) return;
-        CurrentState = next;
+        CurrentState = next; // generated setter fires PropertyChanged for state + dependents
         Transitioned?.Invoke(new MotherlodeTransition(prev, next, trigger));
     }
 }

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -1,0 +1,185 @@
+using Legolas.Domain;
+using Legolas.ViewModels;
+
+namespace Legolas.Flow;
+
+/// <summary>
+/// Phase a Survey-mode session can be in. See docs/agent-plans/legolas-state-machine.md
+/// for the full diagram and rationale (notably the post-Optimize "no new surveys" rule
+/// driven by the position-anchor constraint).
+/// </summary>
+public enum SurveyFlowState
+{
+    AwaitingPosition,
+    Listening,
+    AwaitingPin,
+    Gathering,
+    Done,
+}
+
+public sealed record SurveyTransition(
+    SurveyFlowState From,
+    SurveyFlowState To,
+    string Trigger);
+
+/// <summary>
+/// State machine for Survey mode. Methods are the public transition API; direct
+/// mutation of <see cref="SessionState.Surveys"/> / <see cref="SessionState.PendingSurvey"/>
+/// outside this class is no longer supported (still possible at the language level,
+/// but considered a bug — call a controller method instead).
+/// </summary>
+public sealed class SurveyFlowController
+{
+    private readonly SessionState _session;
+    private readonly LegolasSettings _settings;
+
+    public SurveyFlowController(SessionState session, LegolasSettings settings)
+    {
+        _session = session;
+        _settings = settings;
+        _session.AllCollected += OnAllCollected;
+    }
+
+    public SurveyFlowState CurrentState { get; private set; } = SurveyFlowState.AwaitingPosition;
+
+    /// <summary>Fires after every successful state change.</summary>
+    public event Action<SurveyTransition>? Transitioned;
+
+    /// <summary>True when <see cref="OnSurveyDetected"/> would be accepted.</summary>
+    public bool CanAcceptSurvey => CurrentState is SurveyFlowState.Listening or SurveyFlowState.AwaitingPin;
+
+    /// <summary>True when <see cref="OptimizeRoute"/> would be accepted.</summary>
+    public bool CanOptimize => CurrentState == SurveyFlowState.Listening && _session.Surveys.Count > 0;
+
+    /// <summary>
+    /// Confirms a player position has been set (caller has already updated the projector
+    /// and <see cref="SessionState.PlayerPosition"/>). Transitions <c>AwaitingPosition →
+    /// Listening</c>. No-op from other states.
+    /// </summary>
+    public void ConfirmPlayerPosition()
+    {
+        if (CurrentState != SurveyFlowState.AwaitingPosition)
+        {
+            _session.LastLogEvent = $"ConfirmPlayerPosition ignored — state is {CurrentState}";
+            return;
+        }
+        TransitionTo(SurveyFlowState.Listening, nameof(ConfirmPlayerPosition));
+    }
+
+    /// <summary>
+    /// Re-anchor request (e.g. user pressed "Set Player Position"). Goes back to
+    /// <c>AwaitingPosition</c> from any state. Preserves <see cref="SessionState.Surveys"/>
+    /// (their offsets remain valid; only the projector origin will change on the next
+    /// <see cref="ConfirmPlayerPosition"/>). Clears any pending pin.
+    /// </summary>
+    public void RequestSetPlayerPosition()
+    {
+        _session.PendingSurvey = null;
+        if (CurrentState == SurveyFlowState.AwaitingPosition) return;
+        TransitionTo(SurveyFlowState.AwaitingPosition, nameof(RequestSetPlayerPosition));
+    }
+
+    /// <summary>
+    /// A new <see cref="SurveyDetected"/> arrived. Sets <see cref="SessionState.PendingSurvey"/>
+    /// and transitions to <c>AwaitingPin</c> from <c>Listening</c> or <c>AwaitingPin</c>
+    /// (overwriting any prior pending — preserves pre-FSM behaviour). Dropped from
+    /// <c>Gathering</c>/<c>Done</c>/<c>AwaitingPosition</c> per the position-anchor
+    /// constraint (see plan doc).
+    /// </summary>
+    public void OnSurveyDetected(SurveyDetected sd)
+    {
+        if (!CanAcceptSurvey)
+        {
+            _session.LastLogEvent = $"Survey: {sd.Name} → ignored ({DescribeWhyDropped()})";
+            return;
+        }
+        _session.PendingSurvey = sd;
+        if (CurrentState != SurveyFlowState.AwaitingPin)
+            TransitionTo(SurveyFlowState.AwaitingPin, nameof(OnSurveyDetected));
+    }
+
+    /// <summary>
+    /// Caller has placed the pending pin (added it to <see cref="SessionState.Surveys"/>).
+    /// Clears <see cref="SessionState.PendingSurvey"/> and returns to <c>Listening</c>.
+    /// </summary>
+    public void ConfirmPin()
+    {
+        if (CurrentState != SurveyFlowState.AwaitingPin)
+        {
+            _session.LastLogEvent = $"ConfirmPin ignored — state is {CurrentState}";
+            return;
+        }
+        _session.PendingSurvey = null;
+        TransitionTo(SurveyFlowState.Listening, nameof(ConfirmPin));
+    }
+
+    /// <summary>
+    /// Survey came in with ≥2 corrections already on file → caller auto-placed the pin
+    /// without entering <c>AwaitingPin</c>. Stays in <c>Listening</c>; no transition.
+    /// Exists to keep symmetry with <see cref="OnSurveyDetected"/>: callers should
+    /// invoke exactly one of the two for every detected survey, so the controller has
+    /// a chance to log/diagnose.
+    /// </summary>
+    public void NoteAutoPlacedSurvey(SurveyDetected sd)
+    {
+        if (!CanAcceptSurvey)
+        {
+            _session.LastLogEvent = $"Survey: {sd.Name} → ignored ({DescribeWhyDropped()})";
+            return;
+        }
+        // No transition; the auto-placement happened directly in Listening.
+    }
+
+    /// <summary>Listening → Gathering. Caller is responsible for actually computing the route.</summary>
+    public void OptimizeRoute()
+    {
+        if (CurrentState != SurveyFlowState.Listening)
+        {
+            _session.LastLogEvent = $"OptimizeRoute ignored — state is {CurrentState}";
+            return;
+        }
+        TransitionTo(SurveyFlowState.Gathering, nameof(OptimizeRoute));
+    }
+
+    /// <summary>
+    /// Reset the session: clears surveys + pending pin, returns to either
+    /// <c>Listening</c> (if a player position is still set) or <c>AwaitingPosition</c>.
+    /// Preserves the projector anchor; caller is responsible for clearing the projector
+    /// if they want a hard reset.
+    /// </summary>
+    public void Reset()
+    {
+        _session.ClearSurveys();
+        _session.PendingSurvey = null;
+        var target = _session.HasPlayerPosition
+            ? SurveyFlowState.Listening
+            : SurveyFlowState.AwaitingPosition;
+        if (CurrentState != target)
+            TransitionTo(target, nameof(Reset));
+    }
+
+    private void OnAllCollected()
+    {
+        if (CurrentState is not (SurveyFlowState.Listening or SurveyFlowState.Gathering))
+            return;
+        TransitionTo(SurveyFlowState.Done, nameof(OnAllCollected));
+        if (_settings.AutoResetWhenAllCollected)
+            Reset();
+    }
+
+    private void TransitionTo(SurveyFlowState next, string trigger)
+    {
+        var prev = CurrentState;
+        if (prev == next) return;
+        CurrentState = next;
+        Transitioned?.Invoke(new SurveyTransition(prev, next, trigger));
+    }
+
+    private string DescribeWhyDropped() => CurrentState switch
+    {
+        SurveyFlowState.AwaitingPosition => "set player position first",
+        SurveyFlowState.Gathering => "route in progress; reset to start a new session",
+        SurveyFlowState.Done => "session done; reset to start a new session",
+        _ => $"state is {CurrentState}",
+    };
+}

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Legolas.Domain;
 using Legolas.ViewModels;
 
@@ -28,7 +30,7 @@ public sealed record SurveyTransition(
 /// outside this class is no longer supported (still possible at the language level,
 /// but considered a bug — call a controller method instead).
 /// </summary>
-public sealed class SurveyFlowController
+public sealed partial class SurveyFlowController : ObservableObject
 {
     private readonly SessionState _session;
     private readonly LegolasSettings _settings;
@@ -38,12 +40,34 @@ public sealed class SurveyFlowController
         _session = session;
         _settings = settings;
         _session.AllCollected += OnAllCollected;
+        _session.PropertyChanged += OnSessionPropertyChanged;
     }
 
-    public SurveyFlowState CurrentState { get; private set; } = SurveyFlowState.AwaitingPosition;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PhaseDescription))]
+    [NotifyPropertyChangedFor(nameof(CanAcceptSurvey))]
+    [NotifyPropertyChangedFor(nameof(CanOptimize))]
+    private SurveyFlowState _currentState = SurveyFlowState.AwaitingPosition;
 
     /// <summary>Fires after every successful state change.</summary>
     public event Action<SurveyTransition>? Transitioned;
+
+    /// <summary>
+    /// Human-readable description of the current state, suitable for the in-app
+    /// status strip. The wizard view (when it lands) will use richer per-state
+    /// templates; this is the dashboard-style fallback.
+    /// </summary>
+    public string PhaseDescription => CurrentState switch
+    {
+        SurveyFlowState.AwaitingPosition => "Click the map to set player position",
+        SurveyFlowState.Listening => "Listening for surveys",
+        SurveyFlowState.AwaitingPin when _session.PendingSurvey is { } p =>
+            $"Click the ping for: {p.Name}  ({p.Offset.East:0}E, {p.Offset.North:0}N)",
+        SurveyFlowState.AwaitingPin => "Click the ping on the map",
+        SurveyFlowState.Gathering => "Walk to each target — new surveys will be ignored until reset",
+        SurveyFlowState.Done => "All surveys collected",
+        _ => "",
+    };
 
     /// <summary>True when <see cref="OnSurveyDetected"/> would be accepted.</summary>
     public bool CanAcceptSurvey => CurrentState is SurveyFlowState.Listening or SurveyFlowState.AwaitingPin;
@@ -171,8 +195,16 @@ public sealed class SurveyFlowController
     {
         var prev = CurrentState;
         if (prev == next) return;
-        CurrentState = next;
+        CurrentState = next; // generated setter fires PropertyChanged for state + dependents
         Transitioned?.Invoke(new SurveyTransition(prev, next, trigger));
+    }
+
+    private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // PhaseDescription's AwaitingPin branch reads PendingSurvey. Forward the
+        // change so bound UI reflects updated pin prompts without an extra subscriber.
+        if (e.PropertyName == nameof(SessionState.PendingSurvey))
+            OnPropertyChanged(nameof(PhaseDescription));
     }
 
     private string DescribeWhyDropped() => CurrentState switch

--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -1,24 +1,21 @@
 using Mithril.Shared.Hotkeys;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.ViewModels;
 
 namespace Legolas.Hotkeys;
 
 public sealed class StartSessionCommand : IHotkeyCommand
 {
-    private readonly SessionState _session;
-    public StartSessionCommand(SessionState session) => _session = session;
+    private readonly SurveyFlowController _surveyFlow;
+    public StartSessionCommand(SurveyFlowController surveyFlow) => _surveyFlow = surveyFlow;
     public string Id => "legolas.session.start";
     public string DisplayName => "Start / Reset Session";
     public string? Category => "Legolas · Session";
     public HotkeyBinding? DefaultBinding => null;
     public Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        _session.ClearSurveys();
-        _session.PendingSurvey = null;
-        _session.SurveyPhase = _session.HasPlayerPosition
-            ? SurveyPhase.Surveying
-            : SurveyPhase.Idle;
+        _surveyFlow.Reset();
         return Task.CompletedTask;
     }
 }
@@ -44,16 +41,15 @@ public sealed class MarkCurrentCollectedCommand : IHotkeyCommand
 
 public sealed class SetPlayerPositionCommand : IHotkeyCommand
 {
-    private readonly SessionState _session;
-    public SetPlayerPositionCommand(SessionState session) => _session = session;
+    private readonly SurveyFlowController _surveyFlow;
+    public SetPlayerPositionCommand(SurveyFlowController surveyFlow) => _surveyFlow = surveyFlow;
     public string Id => "legolas.session.set_position";
     public string DisplayName => "Set Player Position";
     public string? Category => "Legolas · Session";
     public HotkeyBinding? DefaultBinding => null;
     public Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        _session.PendingSurvey = null;
-        _session.SurveyPhase = SurveyPhase.Idle;
+        _surveyFlow.RequestSetPlayerPosition();
         return Task.CompletedTask;
     }
 }

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -6,6 +6,7 @@ using Mithril.Shared.Modules;
 using MahApps.Metro.IconPacks;
 using Mithril.Shared.Settings;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.Hotkeys;
 using Legolas.Services;
 using Legolas.ViewModels;
@@ -46,8 +47,10 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<ITrilaterationSolver, TrilaterationSolver>();
         services.AddSingleton<ICoordinateProjector, CoordinateProjector>();
 
-        // Session + VMs
+        // Session + flow controllers + VMs
         services.AddSingleton<SessionState>();
+        services.AddSingleton<SurveyFlowController>();
+        services.AddSingleton<MotherlodeFlowController>();
         services.AddSingleton<LegolasPanelViewModel>();
         services.AddSingleton<ControlPanelViewModel>();
         services.AddSingleton<InventoryOverlayViewModel>();

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.ViewModels;
 using Microsoft.Extensions.Hosting;
 
@@ -22,6 +23,7 @@ public sealed class LogIngestionService : BackgroundService
     private readonly SessionState _session;
     private readonly ICoordinateProjector _projector;
     private readonly MotherlodeViewModel _motherlode;
+    private readonly SurveyFlowController _surveyFlow;
 
     public LogIngestionService(
         IChatLogStream stream,
@@ -30,7 +32,8 @@ public sealed class LogIngestionService : BackgroundService
         LegolasSettings settings,
         SessionState session,
         ICoordinateProjector projector,
-        MotherlodeViewModel motherlode)
+        MotherlodeViewModel motherlode,
+        SurveyFlowController surveyFlow)
     {
         _stream = stream;
         _parser = parser;
@@ -39,6 +42,7 @@ public sealed class LogIngestionService : BackgroundService
         _session = session;
         _projector = projector;
         _motherlode = motherlode;
+        _surveyFlow = surveyFlow;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -95,9 +99,10 @@ public sealed class LogIngestionService : BackgroundService
             _session.LastLogEvent = $"Survey: {sd.Name} → ignored (mode is Motherlode)";
             return;
         }
-        if (_session.SurveyPhase == SurveyPhase.Idle)
+        if (!_surveyFlow.CanAcceptSurvey)
         {
-            _session.LastLogEvent = $"Survey: {sd.Name} → ignored (press Start first)";
+            // Controller writes its own diagnostic to LastLogEvent.
+            _surveyFlow.OnSurveyDetected(sd);
             return;
         }
 
@@ -120,11 +125,11 @@ public sealed class LogIngestionService : BackgroundService
             var survey = Survey.Create(sd.Name, sd.Offset, gridIndex: index)
                 with { PixelPos = newPixel };
             _session.Surveys.Add(new SurveyItemViewModel(survey));
+            _surveyFlow.NoteAutoPlacedSurvey(sd);
             return;
         }
 
-        _session.PendingSurvey = sd;
-        _session.SurveyPhase = SurveyPhase.AwaitingPin;
+        _surveyFlow.OnSurveyDetected(sd);
     }
 
     private SurveyItemViewModel? FindDuplicate(string name, MetreOffset newOffset, double radiusMetres)

--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
+using Legolas.Flow;
 
 namespace Legolas.ViewModels;
 
@@ -9,17 +10,11 @@ public sealed partial class ControlPanelViewModel : ObservableObject
 {
     private readonly LegolasSettings _settings;
 
-    public ControlPanelViewModel(LegolasSettings settings, SessionState session)
+    public ControlPanelViewModel(LegolasSettings settings, SessionState session, SurveyFlowController surveyFlow)
     {
         _settings = settings;
         Session = session;
-        session.AllCollected += OnAllCollected;
-    }
-
-    private void OnAllCollected()
-    {
-        if (!_settings.AutoResetWhenAllCollected) return;
-        StartSession();
+        SurveyFlow = surveyFlow;
     }
 
     public bool AutoResetWhenAllCollected
@@ -35,6 +30,7 @@ public sealed partial class ControlPanelViewModel : ObservableObject
 
     public LegolasSettings Settings => _settings;
     public SessionState Session { get; }
+    public SurveyFlowController SurveyFlow { get; }
 
     public double SurveyDedupRadiusMetres
     {
@@ -83,21 +79,10 @@ public sealed partial class ControlPanelViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void StartSession()
-    {
-        Session.ClearSurveys();
-        Session.PendingSurvey = null;
-        Session.SurveyPhase = Session.HasPlayerPosition
-            ? SurveyPhase.Surveying
-            : SurveyPhase.Idle;
-    }
+    private void StartSession() => SurveyFlow.Reset();
 
     [RelayCommand]
-    private void SetPlayerPosition()
-    {
-        Session.PendingSurvey = null;
-        Session.SurveyPhase = SurveyPhase.Idle;
-    }
+    private void SetPlayerPosition() => SurveyFlow.RequestSetPlayerPosition();
 
     [RelayCommand]
     private void MarkCurrentCollected()

--- a/src/Legolas.Module/ViewModels/LegolasPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasPanelViewModel.cs
@@ -1,10 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Legolas.Flow;
 
 namespace Legolas.ViewModels;
 
 public sealed partial class LegolasPanelViewModel : ObservableObject
 {
     public LegolasPanelViewModel(SessionState session,
+                                 SurveyFlowController surveyFlow,
+                                 MotherlodeFlowController motherlodeFlow,
                                  InventoryOverlayViewModel inventoryOverlay,
                                  MapOverlayViewModel mapOverlay,
                                  InventoryGridSettingsViewModel gridSettings,
@@ -12,6 +15,8 @@ public sealed partial class LegolasPanelViewModel : ObservableObject
                                  MotherlodeViewModel motherlode)
     {
         Session = session;
+        SurveyFlow = surveyFlow;
+        MotherlodeFlow = motherlodeFlow;
         InventoryOverlay = inventoryOverlay;
         MapOverlay = mapOverlay;
         GridSettings = gridSettings;
@@ -20,6 +25,8 @@ public sealed partial class LegolasPanelViewModel : ObservableObject
     }
 
     public SessionState Session { get; }
+    public SurveyFlowController SurveyFlow { get; }
+    public MotherlodeFlowController MotherlodeFlow { get; }
     public InventoryOverlayViewModel InventoryOverlay { get; }
     public MapOverlayViewModel MapOverlay { get; }
     public InventoryGridSettingsViewModel GridSettings { get; }

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.Services;
 
 namespace Legolas.ViewModels;
@@ -16,15 +17,17 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     private readonly ICoordinateProjector _projector;
     private readonly IRouteOptimizer _optimizer;
     private readonly LegolasSettings? _settings;
+    private readonly SurveyFlowController _surveyFlow;
 
-    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer)
-        : this(session, projector, optimizer, settings: null) { }
+    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow)
+        : this(session, projector, optimizer, surveyFlow, settings: null) { }
 
-    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, LegolasSettings? settings)
+    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasSettings? settings)
     {
         _session = session;
         _projector = projector;
         _optimizer = optimizer;
+        _surveyFlow = surveyFlow;
         _settings = settings;
         if (_settings is not null)
         {
@@ -92,6 +95,8 @@ public sealed partial class MapOverlayViewModel : ObservableObject
 
     public SessionState Session => _session;
 
+    public SurveyFlowController SurveyFlow => _surveyFlow;
+
     public PixelPoint PlayerPosition
     {
         get => _session.PlayerPosition;
@@ -126,23 +131,22 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         _session.HasPlayerPosition = true;
         _projector.SetOrigin(where);
         ReprojectUncorrected();
+        _surveyFlow.ConfirmPlayerPosition();
     }
 
     [RelayCommand]
     public void HandleMapClick(PixelPoint where)
     {
-        switch (_session.SurveyPhase)
+        switch (_surveyFlow.CurrentState)
         {
-            case SurveyPhase.Idle:
+            case SurveyFlowState.AwaitingPosition:
                 SetPlayerPosition(where);
-                _session.SurveyPhase = SurveyPhase.Surveying;
                 break;
-            case SurveyPhase.Surveying:
-                // No-op: prevents accidental player re-set mid-session.
-                break;
-            case SurveyPhase.AwaitingPin when _session.PendingSurvey is { } pending:
+            case SurveyFlowState.AwaitingPin when _session.PendingSurvey is not null:
                 PlacePendingPinAt(where);
                 break;
+            // Listening / Gathering / Done: ignore map clicks (prevents accidental
+            // re-anchor mid-session). User must press Set Player Position to re-anchor.
         }
     }
 
@@ -153,11 +157,10 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     /// </summary>
     public SurveyItemViewModel? PlacePendingPinAt(PixelPoint where)
     {
-        if (_session.SurveyPhase != SurveyPhase.AwaitingPin) return null;
+        if (_surveyFlow.CurrentState != SurveyFlowState.AwaitingPin) return null;
         if (_session.PendingSurvey is not { } pending) return null;
         var placed = PlacePin(pending, where);
-        _session.PendingSurvey = null;
-        _session.SurveyPhase = SurveyPhase.Surveying;
+        _surveyFlow.ConfirmPin();
         return placed;
     }
 
@@ -247,6 +250,7 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             Surveys[src].UpdateModel(Surveys[src].Model with { RouteOrder = i });
         }
         RebuildRouteGeometry();
+        _surveyFlow.OptimizeRoute();
     }
 
     private void ReprojectUncorrected()

--- a/src/Legolas.Module/ViewModels/MotherlodeViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MotherlodeViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.Services;
 
 namespace Legolas.ViewModels;
@@ -16,14 +17,18 @@ public sealed partial class MotherlodeViewModel : ObservableObject
     private readonly ITrilaterationSolver _trilateration;
     private readonly IRouteOptimizer _optimizer;
     private readonly SessionState _session;
+    private readonly MotherlodeFlowController _flow;
     private readonly MotherlodeSession _state = new();
 
-    public MotherlodeViewModel(ITrilaterationSolver trilateration, IRouteOptimizer optimizer, SessionState session)
+    public MotherlodeViewModel(ITrilaterationSolver trilateration, IRouteOptimizer optimizer, SessionState session, MotherlodeFlowController flow)
     {
         _trilateration = trilateration;
         _optimizer = optimizer;
         _session = session;
+        _flow = flow;
     }
+
+    public MotherlodeFlowController Flow => _flow;
 
     public ObservableCollection<MotherlodeSlotViewModel> Slots { get; } = new();
 
@@ -39,6 +44,7 @@ public sealed partial class MotherlodeViewModel : ObservableObject
         _state.PlayerPositions.Add(_session.PlayerPosition);
         OnPropertyChanged(nameof(CurrentRound));
         OnPropertyChanged(nameof(RecordedPositions));
+        _flow.NoteMeasurement($"position{_state.PlayerPositions.Count}");
     }
 
     [RelayCommand]
@@ -69,6 +75,7 @@ public sealed partial class MotherlodeViewModel : ObservableObject
                 p3, slot.Distances[2]);
             slot.EstimatedPosition = estimate;
         }
+        _flow.NoteMeasurement($"distance{slot.Distances.Count}");
     }
 
     [RelayCommand]
@@ -91,6 +98,7 @@ public sealed partial class MotherlodeViewModel : ObservableObject
         {
             Slots[indices[order[i]]].RouteOrder = i;
         }
+        _flow.OptimizeRoute();
     }
 
     [RelayCommand]
@@ -103,6 +111,7 @@ public sealed partial class MotherlodeViewModel : ObservableObject
         DistanceInput = 0;
         OnPropertyChanged(nameof(CurrentRound));
         OnPropertyChanged(nameof(RecordedPositions));
+        _flow.Reset();
     }
 }
 

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -68,25 +68,10 @@ public sealed partial class SessionState : ObservableObject
     [ObservableProperty] private bool _isInventoryVisible;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(PhaseDescription))]
-    private SurveyPhase _surveyPhase = SurveyPhase.Idle;
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(PhaseDescription))]
     private SurveyDetected? _pendingSurvey;
 
     [ObservableProperty]
     private SurveyItemViewModel? _selectedSurvey;
-
-    public string PhaseDescription => SurveyPhase switch
-    {
-        SurveyPhase.Idle => "Click the map to set player position",
-        SurveyPhase.Surveying => "Surveying — waiting for next [Status] line",
-        SurveyPhase.AwaitingPin when PendingSurvey is { } p =>
-            $"Click the ping for: {p.Name}  ({p.Offset.East:0}E, {p.Offset.North:0}N)",
-        SurveyPhase.AwaitingPin => "Click the ping on the map",
-        _ => "",
-    };
 
     public void ClearSurveys()
     {
@@ -98,11 +83,4 @@ public enum SessionMode
 {
     Survey,
     Motherlode
-}
-
-public enum SurveyPhase
-{
-    Idle,
-    Surveying,
-    AwaitingPin,
 }

--- a/src/Legolas.Module/Views/LegolasPanelView.xaml
+++ b/src/Legolas.Module/Views/LegolasPanelView.xaml
@@ -55,7 +55,7 @@
                                 ToolTip="Manually mark the highlighted next-up survey as collected" />
                     </WrapPanel>
                     <Border Background="{StaticResource AccentSoftBrush}" CornerRadius="2" Padding="6,4" Margin="0,4,0,6">
-                        <TextBlock Text="{Binding Session.PhaseDescription}"
+                        <TextBlock Text="{Binding SurveyFlow.PhaseDescription}"
                                    Foreground="{StaticResource AccentSoftTextBrush}" TextWrapping="Wrap" />
                     </Border>
                     <CheckBox Content="Auto-reset when all surveys collected"

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using Mithril.Shared.Settings;
 using Legolas.Controls;
+using Legolas.Flow;
 using Legolas.ViewModels;
 using Legolas.Domain;
 
@@ -145,7 +146,7 @@ public partial class MapOverlayView : Window
 
         // AwaitingPin: place the pin and let the user keep dragging without
         // releasing the mouse — same gesture for placement and fine-tuning.
-        if (vm.Session.SurveyPhase == SurveyPhase.AwaitingPin
+        if (vm.SurveyFlow.CurrentState == SurveyFlowState.AwaitingPin
             && vm.Session.PendingSurvey is not null)
         {
             var placed = vm.PlacePendingPinAt(clickPoint);

--- a/tests/Legolas.Tests/Flow/MotherlodeFlowControllerTests.cs
+++ b/tests/Legolas.Tests/Flow/MotherlodeFlowControllerTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Legolas.Flow;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.Flow;
+
+public class MotherlodeFlowControllerTests
+{
+    private static (MotherlodeFlowController flow, SessionState session, List<MotherlodeTransition> transitions) BuildSut()
+    {
+        var session = new SessionState();
+        var flow = new MotherlodeFlowController(session);
+        var transitions = new List<MotherlodeTransition>();
+        flow.Transitioned += transitions.Add;
+        return (flow, session, transitions);
+    }
+
+    [Fact]
+    public void InitialState_is_Idle()
+    {
+        var (flow, _, _) = BuildSut();
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Idle);
+    }
+
+    [Fact]
+    public void NoteMeasurement_Idle_to_Measuring()
+    {
+        var (flow, _, transitions) = BuildSut();
+        flow.NoteMeasurement("position1");
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Measuring);
+        transitions.Should().ContainSingle()
+            .Which.From.Should().Be(MotherlodeFlowState.Idle);
+    }
+
+    [Fact]
+    public void NoteMeasurement_Measuring_no_self_transition()
+    {
+        var (flow, _, transitions) = BuildSut();
+        flow.NoteMeasurement("position1");
+        transitions.Clear();
+        flow.NoteMeasurement("distance1");
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Measuring);
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OptimizeRoute_Measuring_to_Optimized()
+    {
+        var (flow, _, _) = BuildSut();
+        flow.NoteMeasurement("position1");
+        flow.OptimizeRoute();
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Optimized);
+    }
+
+    [Fact]
+    public void OptimizeRoute_Idle_is_noop_with_diagnostic()
+    {
+        var (flow, session, transitions) = BuildSut();
+        flow.OptimizeRoute();
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Idle);
+        session.LastLogEvent.Should().Contain("OptimizeRoute ignored");
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NoteMeasurement_Optimized_demotes_to_Measuring()
+    {
+        // Re-measuring after Optimize is allowed for Motherlode (absolute distances,
+        // no anchor invalidation). Differs from Survey mode where Gathering drops
+        // new survey events.
+        var (flow, _, _) = BuildSut();
+        flow.NoteMeasurement("position1");
+        flow.OptimizeRoute();
+        flow.NoteMeasurement("distance4");
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Measuring);
+    }
+
+    [Fact]
+    public void Reset_returns_to_Idle()
+    {
+        var (flow, _, transitions) = BuildSut();
+        flow.NoteMeasurement("position1");
+        flow.OptimizeRoute();
+        transitions.Clear();
+        flow.Reset();
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Idle);
+        transitions.Should().ContainSingle()
+            .Which.Trigger.Should().Be("Reset");
+    }
+
+    [Fact]
+    public void Reset_from_Idle_is_noop()
+    {
+        var (flow, _, transitions) = BuildSut();
+        flow.Reset();
+        flow.CurrentState.Should().Be(MotherlodeFlowState.Idle);
+        transitions.Should().BeEmpty();
+    }
+}

--- a/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
+++ b/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
@@ -1,0 +1,277 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.Flow;
+
+public class SurveyFlowControllerTests
+{
+    private static readonly DateTime FixedTime = new(2026, 5, 6, 12, 0, 0, DateTimeKind.Utc);
+
+    private static (SurveyFlowController flow, SessionState session, LegolasSettings settings, List<SurveyTransition> transitions) BuildSut()
+    {
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var flow = new SurveyFlowController(session, settings);
+        var transitions = new List<SurveyTransition>();
+        flow.Transitioned += transitions.Add;
+        return (flow, session, settings, transitions);
+    }
+
+    private static SurveyDetected NewSurvey(string name = "Diamond", int east = 50, int north = 30) =>
+        new(FixedTime, name, new MetreOffset(east, north));
+
+    private static void Anchor(SurveyFlowController flow, SessionState session)
+    {
+        // Pretend the caller has set the projector + player position; controller only
+        // needs to know the player position is now valid.
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+    }
+
+    [Fact]
+    public void InitialState_is_AwaitingPosition()
+    {
+        var (flow, _, _, _) = BuildSut();
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
+    }
+
+    [Fact]
+    public void ConfirmPlayerPosition_AwaitingPosition_to_Listening()
+    {
+        var (flow, session, _, transitions) = BuildSut();
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        transitions.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new SurveyTransition(
+                SurveyFlowState.AwaitingPosition, SurveyFlowState.Listening, "ConfirmPlayerPosition"));
+    }
+
+    [Fact]
+    public void OnSurveyDetected_Listening_to_AwaitingPin_with_pending_set()
+    {
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        var sd = NewSurvey();
+        flow.OnSurveyDetected(sd);
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPin);
+        session.PendingSurvey.Should().Be(sd);
+    }
+
+    [Fact]
+    public void ConfirmPin_AwaitingPin_to_Listening_clears_pending()
+    {
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        flow.OnSurveyDetected(NewSurvey());
+        flow.ConfirmPin();
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        session.PendingSurvey.Should().BeNull();
+    }
+
+    [Fact]
+    public void OnSurveyDetected_AwaitingPin_overwrites_pending_no_double_transition()
+    {
+        var (flow, session, _, transitions) = BuildSut();
+        Anchor(flow, session);
+        flow.OnSurveyDetected(NewSurvey("Diamond"));
+        transitions.Clear();
+
+        var second = NewSurvey("Coal");
+        flow.OnSurveyDetected(second);
+
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPin);
+        session.PendingSurvey.Should().Be(second);
+        transitions.Should().BeEmpty(); // no AwaitingPin → AwaitingPin self-transition
+    }
+
+    [Fact]
+    public void OnSurveyDetected_AwaitingPosition_dropped_with_diagnostic()
+    {
+        var (flow, session, _, transitions) = BuildSut();
+        var sd = NewSurvey();
+        flow.OnSurveyDetected(sd);
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
+        session.PendingSurvey.Should().BeNull();
+        session.LastLogEvent.Should().Contain("ignored").And.Contain("set player position first");
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OptimizeRoute_Listening_to_Gathering_when_surveys_present()
+    {
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
+        flow.OptimizeRoute();
+        flow.CurrentState.Should().Be(SurveyFlowState.Gathering);
+    }
+
+    [Fact]
+    public void OptimizeRoute_Listening_with_no_surveys_still_transitions()
+    {
+        // The "are there surveys" check is exposed via CanOptimize; the transition
+        // method itself doesn't enforce — callers gate via CanOptimize. Documented
+        // shape so tests pin it.
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        flow.CanOptimize.Should().BeFalse();
+        flow.OptimizeRoute();
+        flow.CurrentState.Should().Be(SurveyFlowState.Gathering);
+    }
+
+    [Fact]
+    public void OnSurveyDetected_Gathering_dropped_per_position_anchor_constraint()
+    {
+        var (flow, session, _, transitions) = BuildSut();
+        Anchor(flow, session);
+        flow.OptimizeRoute();
+        transitions.Clear();
+
+        flow.OnSurveyDetected(NewSurvey());
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Gathering);
+        session.PendingSurvey.Should().BeNull();
+        session.LastLogEvent.Should().Contain("route in progress");
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RequestSetPlayerPosition_from_Listening_clears_pending_preserves_surveys()
+    {
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        flow.OnSurveyDetected(NewSurvey()); // sets PendingSurvey, goes to AwaitingPin
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 0)));
+
+        flow.RequestSetPlayerPosition();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
+        session.PendingSurvey.Should().BeNull();
+        session.Surveys.Should().HaveCount(1, "RequestSetPlayerPosition is a re-anchor, not a Reset");
+    }
+
+    [Fact]
+    public void Reset_clears_surveys_and_returns_to_Listening_when_position_known()
+    {
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
+        flow.OptimizeRoute();
+
+        flow.Reset();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening, "HasPlayerPosition is true");
+        session.Surveys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Reset_returns_to_AwaitingPosition_when_no_position()
+    {
+        var (flow, session, _, _) = BuildSut();
+        Anchor(flow, session);
+        session.HasPlayerPosition = false;
+
+        flow.Reset();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
+    }
+
+    [Fact]
+    public void AllCollected_Gathering_to_Done_then_AutoReset_back_to_Listening()
+    {
+        var (flow, session, settings, transitions) = BuildSut();
+        Anchor(flow, session);
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 1));
+        session.Surveys.Add(s1);
+        session.Surveys.Add(s2);
+        flow.OptimizeRoute();
+        transitions.Clear();
+        settings.AutoResetWhenAllCollected = true;
+
+        // Marking the last one fires SessionState.AllCollected → controller reacts.
+        s1.UpdateModel(s1.Model with { Collected = true });
+        s2.UpdateModel(s2.Model with { Collected = true });
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening, "auto-reset returned us to Listening");
+        session.Surveys.Should().BeEmpty();
+        transitions.Select(t => t.To).Should().ContainInOrder(
+            SurveyFlowState.Done, SurveyFlowState.Listening);
+    }
+
+    [Fact]
+    public void AllCollected_Gathering_to_Done_no_AutoReset_stays_Done()
+    {
+        var (flow, session, settings, _) = BuildSut();
+        Anchor(flow, session);
+        settings.AutoResetWhenAllCollected = false;
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        flow.OptimizeRoute();
+
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Done);
+        session.Surveys.Should().HaveCount(1, "no auto-reset, surveys retained for review");
+    }
+
+    [Fact]
+    public void AllCollected_from_Listening_also_transitions_to_Done()
+    {
+        // Mark-collected works in Listening too (via hotkey, before optimizing).
+        // Preserves pre-FSM behaviour: AllCollected fires a session reset regardless
+        // of whether the user optimized first.
+        var (flow, session, settings, transitions) = BuildSut();
+        Anchor(flow, session);
+        settings.AutoResetWhenAllCollected = false;
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        transitions.Clear();
+
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Done);
+    }
+
+    [Fact]
+    public void ConfirmPlayerPosition_from_Listening_is_noop()
+    {
+        var (flow, session, _, transitions) = BuildSut();
+        Anchor(flow, session);
+        transitions.Clear();
+        flow.ConfirmPlayerPosition();
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ConfirmPin_from_Listening_is_noop_with_diagnostic()
+    {
+        var (flow, session, _, transitions) = BuildSut();
+        Anchor(flow, session);
+        transitions.Clear();
+        flow.ConfirmPin();
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        session.LastLogEvent.Should().Contain("ConfirmPin ignored");
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NoteAutoPlacedSurvey_Listening_no_transition()
+    {
+        // ≥2-corrections shortcut: caller placed the pin directly without going through
+        // AwaitingPin. Controller stays in Listening; method exists for symmetry +
+        // potential future diagnostics.
+        var (flow, session, _, transitions) = BuildSut();
+        Anchor(flow, session);
+        transitions.Clear();
+
+        flow.NoteAutoPlacedSurvey(NewSurvey());
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        transitions.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces two state-machine controllers (one per Legolas mode) that own all phase transitions; replaces ad-hoc `SurveyPhase`/`HasPlayerPosition` mutation scattered across four files.
- Survey FSM is linear: `AwaitingPosition → Listening → AwaitingPin (cycle) → Gathering → Done`. New `SurveyDetected` events are dropped in `Gathering`/`Done` per the position-anchor constraint (game emits offsets relative to current position; movement silently invalidates the projector).
- Motherlode FSM is minimal (`Idle → Measuring ↔ Optimized`); kept permissive about re-measuring since absolute distances aren't anchor-sensitive.
- Each controller fires a single `Transitioned` post-event — used by tests today, available for diagnostics later.

## Why

Prerequisite for the Legolas wizard / dashboard UI rework (#4). Doing the FSM first means the wizard becomes a XAML problem (per-state `DataTemplate`s) instead of "rewire five files". Spec: [docs/agent-plans/legolas-state-machine.md](https://github.com/arthur-conde/project-gorgon/blob/legolas-fsm/docs/agent-plans/legolas-state-machine.md).

## Notable behavior change

Pre-FSM, a `SurveyDetected` arriving after `OptimizeRoute` would be added as a phantom pin (the projector still uses the original anchor; the new offsets are relative to wherever the player has walked to). The FSM enforces "one session = one player position" by dropping these events with a diagnostic. Re-surveying mid-route now requires an explicit Reset.

## Test plan

- [x] All 1481 tests pass (`dotnet test Mithril.slnx`).
- [x] 26 new tests in `tests/Legolas.Tests/Flow/` cover happy paths, illegal transitions, post-Optimize drop, two-corrections shortcut, AllCollected → Done auto-reset.
- [x] App launches, no DI errors, no exceptions in shell log.
- [ ] Smoke-test in-game (manual): set position → cast survey → place pin → optimize → walk + collect. Verify auto-reset still works.
- [ ] Smoke-test Motherlode: 3× position, 3× distance, optimize, reset.
- [ ] Verify the new `Gathering`-state copy ("Walk to each target — new surveys will be ignored until reset") doesn't surprise.

## What's deferred

Wizard view, dashboard shell, configurable colors, mode-toggle setting, top-level Survey/Motherlode panel split — all listed in the plan doc as separate PRs that build on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)