### PR TITLE
Legolas: configurable marker colors + auto inventory click-through

### DIFF
--- a/src/Legolas.Module/Controls/BoolToVisibilityConverter.cs
+++ b/src/Legolas.Module/Controls/BoolToVisibilityConverter.cs
@@ -14,16 +14,3 @@ public sealed class BoolToVisibilityConverter : IValueConverter
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();
 }
-
-public sealed class CorrectedToBrushConverter : IValueConverter
-{
-    public static readonly CorrectedToBrushConverter Instance = new();
-
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => value is true
-            ? System.Windows.Media.Brushes.Red    // finalized / user-corrected
-            : System.Windows.Media.Brushes.Cyan;  // pending / projector-suggested (high contrast on outdoor map palettes)
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
-}

--- a/src/Legolas.Module/Domain/LegolasColors.cs
+++ b/src/Legolas.Module/Domain/LegolasColors.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// User-configurable map overlay marker colors. Stored as ARGB hex strings
+/// (e.g. <c>#FFFF0000</c>) for JSON friendliness and AlphA support (the bearing
+/// wedges need translucency). Manual <see cref="INotifyPropertyChanged"/> for
+/// the same reason as <see cref="InventoryGridSettings"/> — the CommunityToolkit
+/// + STJ source generators race on partial properties and silently drop fields.
+/// </summary>
+public sealed class LegolasColors : INotifyPropertyChanged
+{
+    /// <summary>Pin shown for an uncorrected (projector-suggested) survey target.</summary>
+    private string _pinPending = "#FF00FFFF"; // cyan
+    public string PinPending
+    {
+        get => _pinPending;
+        set => SetHex(ref _pinPending, value);
+    }
+
+    /// <summary>Pin shown for a manually-corrected (finalized) survey target.</summary>
+    private string _pinFinalized = "#FFFF0000"; // red
+    public string PinFinalized
+    {
+        get => _pinFinalized;
+        set => SetHex(ref _pinFinalized, value);
+    }
+
+    /// <summary>Centre dot of the player position marker.</summary>
+    private string _playerMarker = "#FF4CAF50"; // green
+    public string PlayerMarker
+    {
+        get => _playerMarker;
+        set => SetHex(ref _playerMarker, value);
+    }
+
+    /// <summary>Optimised route polyline.</summary>
+    private string _routeLine = "#FFFFD700"; // gold
+    public string RouteLine
+    {
+        get => _routeLine;
+        set => SetHex(ref _routeLine, value);
+    }
+
+    /// <summary>Fill of each bearing-uncertainty wedge. Should be translucent.</summary>
+    private string _bearingWedgeFill = "#33FFFF80";
+    public string BearingWedgeFill
+    {
+        get => _bearingWedgeFill;
+        set => SetHex(ref _bearingWedgeFill, value);
+    }
+
+    /// <summary>Outline of each bearing-uncertainty wedge.</summary>
+    private string _bearingWedgeStroke = "#55FFFF80";
+    public string BearingWedgeStroke
+    {
+        get => _bearingWedgeStroke;
+        set => SetHex(ref _bearingWedgeStroke, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetHex(ref string field, string? value, [CallerMemberName] string? name = null)
+    {
+        var normalized = Normalize(value);
+        if (string.Equals(field, normalized, StringComparison.OrdinalIgnoreCase)) return;
+        field = normalized;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    /// <summary>
+    /// Coerces input to a canonical 8-digit ARGB hex string. Accepts either
+    /// 6-digit (RGB; alpha defaults to FF) or 8-digit (ARGB) forms with or
+    /// without a leading '#'. Invalid strings fall back to opaque magenta so
+    /// the bug is visible rather than silently transparent.
+    /// </summary>
+    public static string Normalize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return "#FFFF00FF";
+        var s = input.Trim();
+        if (s.StartsWith("#")) s = s.Substring(1);
+        return s.Length switch
+        {
+            6 when IsHex(s) => "#FF" + s.ToUpperInvariant(),
+            8 when IsHex(s) => "#" + s.ToUpperInvariant(),
+            _ => "#FFFF00FF",
+        };
+    }
+
+    private static bool IsHex(string s)
+    {
+        foreach (var c in s)
+        {
+            if (!Uri.IsHexDigit(c)) return false;
+        }
+        return true;
+    }
+}

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -33,6 +33,7 @@ public sealed class LegolasSettings : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public InventoryGridSettings InventoryGrid { get; set; } = new();
+    public LegolasColors Colors { get; set; } = new();
     public WindowLayout MapOverlay { get; set; } = new() { Width = 800, Height = 600 };
     public WindowLayout InventoryOverlay { get; set; } = new() { Width = 540, Height = 440 };
     public double MapOpacity { get; set; } = 1.0;
@@ -75,6 +76,18 @@ public sealed class LegolasSettings : INotifyPropertyChanged
             if (_autoResetWhenAllCollected == value) return;
             _autoResetWhenAllCollected = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AutoResetWhenAllCollected)));
+        }
+    }
+
+    private bool _autoClickThroughInventoryDuringSession = true;
+    public bool AutoClickThroughInventoryDuringSession
+    {
+        get => _autoClickThroughInventoryDuringSession;
+        set
+        {
+            if (_autoClickThroughInventoryDuringSession == value) return;
+            _autoClickThroughInventoryDuringSession = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AutoClickThroughInventoryDuringSession)));
         }
     }
 }

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -36,6 +36,9 @@ public sealed class LegolasModule : IMithrilModule
         services.AddMithrilSettings<LegolasSettings>(settingsPath, LegolasSettingsJsonContext.Default.LegolasSettings);
         services.AddSingleton<InventoryGridSettings>(sp =>
             sp.GetRequiredService<LegolasSettings>().InventoryGrid);
+        services.AddSingleton<LegolasColors>(sp =>
+            sp.GetRequiredService<LegolasSettings>().Colors);
+        services.AddSingleton<LegolasBrushes>();
 
         // Core services
         services.AddSingleton<IChatLogParser, ChatLogParser>();
@@ -84,6 +87,7 @@ public sealed class LegolasModule : IMithrilModule
 
         // Overlay lifecycle
         services.AddHostedService<OverlayController>();
+        services.AddHostedService<AutoOverlayCoordinator>();
 
         // Hotkey commands (shell auto-collects via IEnumerable<IHotkeyCommand>)
         services.AddSingleton<IHotkeyCommand, StartSessionCommand>();

--- a/src/Legolas.Module/Services/AutoOverlayCoordinator.cs
+++ b/src/Legolas.Module/Services/AutoOverlayCoordinator.cs
@@ -1,0 +1,126 @@
+using System.ComponentModel;
+using System.Windows;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.ViewModels;
+using Mithril.Shared.Modules;
+using Microsoft.Extensions.Hosting;
+
+namespace Legolas.Services;
+
+/// <summary>
+/// Issue #4 bullets 2 + 4: when the inventory overlay is visible AND a survey
+/// session is in progress, auto-flip <see cref="LegolasSettings.ClickThroughInventory"/>
+/// so map clicks pass through to the game window. Opt out via
+/// <see cref="LegolasSettings.AutoClickThroughInventoryDuringSession"/>.
+/// </summary>
+/// <remarks>
+/// We never flip click-through OFF here. The user can still toggle it back
+/// manually mid-session if they need to interact with the overlay; on the next
+/// state transition we will re-enable it. This is the cheapest contract that
+/// matches "automatic" without fighting the user.
+/// </remarks>
+public sealed class AutoOverlayCoordinator : IHostedService
+{
+    private readonly ModuleGates _gates;
+    private readonly LegolasSettings _settings;
+    private readonly SessionState _session;
+    private readonly SurveyFlowController _surveyFlow;
+    private readonly CancellationTokenSource _stopCts = new();
+    private Task? _activationTask;
+    private bool _subscribed;
+
+    public AutoOverlayCoordinator(
+        ModuleGates gates,
+        LegolasSettings settings,
+        SessionState session,
+        SurveyFlowController surveyFlow)
+    {
+        _gates = gates;
+        _settings = settings;
+        _session = session;
+        _surveyFlow = surveyFlow;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _activationTask = Task.Run(async () =>
+        {
+            try
+            {
+                await _gates.For("legolas").WaitAsync(_stopCts.Token).ConfigureAwait(false);
+                if (Application.Current?.Dispatcher is { } dispatcher)
+                {
+                    await dispatcher.InvokeAsync(Initialize);
+                }
+                else
+                {
+                    Initialize();
+                }
+            }
+            catch (OperationCanceledException) { }
+        }, _stopCts.Token);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _stopCts.Cancel();
+        if (_activationTask is not null) { try { await _activationTask.ConfigureAwait(false); } catch { } }
+        if (Application.Current?.Dispatcher is { } dispatcher)
+        {
+            await dispatcher.InvokeAsync(Teardown);
+        }
+        else
+        {
+            Teardown();
+        }
+    }
+
+    /// <summary>
+    /// Begin observing flow + session and apply the auto-click-through rule once.
+    /// Public for testability — the hosted-service path calls this after the module
+    /// gate opens.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_subscribed) return;
+        _session.PropertyChanged += OnSessionPropertyChanged;
+        _surveyFlow.PropertyChanged += OnFlowPropertyChanged;
+        _subscribed = true;
+        Evaluate();
+    }
+
+    /// <summary>Stop observing. Public for symmetry with <see cref="Initialize"/>.</summary>
+    public void Teardown()
+    {
+        if (!_subscribed) return;
+        _session.PropertyChanged -= OnSessionPropertyChanged;
+        _surveyFlow.PropertyChanged -= OnFlowPropertyChanged;
+        _subscribed = false;
+    }
+
+    private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SessionState.IsInventoryVisible))
+            Evaluate();
+    }
+
+    private void OnFlowPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SurveyFlowController.CurrentState))
+            Evaluate();
+    }
+
+    private void Evaluate()
+    {
+        if (!_settings.AutoClickThroughInventoryDuringSession) return;
+        if (!_session.IsInventoryVisible) return;
+        if (!IsActiveSession(_surveyFlow.CurrentState)) return;
+        if (_settings.ClickThroughInventory) return;
+        _settings.ClickThroughInventory = true;
+    }
+
+    private static bool IsActiveSession(SurveyFlowState state) =>
+        state != SurveyFlowState.AwaitingPosition;
+}

--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -78,6 +78,17 @@ public sealed partial class ControlPanelViewModel : ObservableObject
         }
     }
 
+    public bool AutoClickThroughInventoryDuringSession
+    {
+        get => _settings.AutoClickThroughInventoryDuringSession;
+        set
+        {
+            if (_settings.AutoClickThroughInventoryDuringSession == value) return;
+            _settings.AutoClickThroughInventoryDuringSession = value;
+            OnPropertyChanged();
+        }
+    }
+
     [RelayCommand]
     private void StartSession() => SurveyFlow.Reset();
 

--- a/src/Legolas.Module/ViewModels/LegolasBrushes.cs
+++ b/src/Legolas.Module/ViewModels/LegolasBrushes.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Windows.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Legolas.Domain;
+
+namespace Legolas.ViewModels;
+
+/// <summary>
+/// View-model wrapper around <see cref="LegolasColors"/> exposing pre-built
+/// <see cref="SolidColorBrush"/> instances for XAML bindings. WPF resource
+/// dictionaries don't observe POCO settings cleanly, so views bind through
+/// this object instead and we re-emit a fresh brush whenever the underlying
+/// hex changes.
+/// </summary>
+public sealed class LegolasBrushes : ObservableObject
+{
+    private readonly LegolasColors _colors;
+
+    public LegolasBrushes(LegolasColors colors)
+    {
+        _colors = colors;
+        _colors.PropertyChanged += OnColorsPropertyChanged;
+    }
+
+    public SolidColorBrush PinPending => Build(_colors.PinPending);
+    public SolidColorBrush PinFinalized => Build(_colors.PinFinalized);
+    public SolidColorBrush PlayerMarker => Build(_colors.PlayerMarker);
+    public SolidColorBrush RouteLine => Build(_colors.RouteLine);
+    public SolidColorBrush BearingWedgeFill => Build(_colors.BearingWedgeFill);
+    public SolidColorBrush BearingWedgeStroke => Build(_colors.BearingWedgeStroke);
+
+    private static SolidColorBrush Build(string hex)
+    {
+        var brush = new SolidColorBrush(Parse(hex));
+        brush.Freeze();
+        return brush;
+    }
+
+    /// <summary>
+    /// Parse the canonical 8-digit ARGB hex written by <see cref="LegolasColors.Normalize"/>.
+    /// Falls back to opaque magenta on malformed input — the same fail-loud
+    /// fallback as the settings layer, so a bad value is visible everywhere.
+    /// </summary>
+    public static Color Parse(string hex)
+    {
+        var normalized = LegolasColors.Normalize(hex);
+        var s = normalized.Substring(1); // strip '#'
+        var a = byte.Parse(s.Substring(0, 2), System.Globalization.NumberStyles.HexNumber);
+        var r = byte.Parse(s.Substring(2, 2), System.Globalization.NumberStyles.HexNumber);
+        var g = byte.Parse(s.Substring(4, 2), System.Globalization.NumberStyles.HexNumber);
+        var b = byte.Parse(s.Substring(6, 2), System.Globalization.NumberStyles.HexNumber);
+        return Color.FromArgb(a, r, g, b);
+    }
+
+    private void OnColorsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // Forward each color property → matching brush property notification.
+        // Names line up 1:1, so re-emit the same name and bound views re-fetch.
+        if (!string.IsNullOrEmpty(e.PropertyName))
+            OnPropertyChanged(e.PropertyName);
+    }
+}

--- a/src/Legolas.Module/ViewModels/LegolasPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasPanelViewModel.cs
@@ -1,4 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Legolas.Domain;
 using Legolas.Flow;
 
 namespace Legolas.ViewModels;
@@ -12,7 +14,9 @@ public sealed partial class LegolasPanelViewModel : ObservableObject
                                  MapOverlayViewModel mapOverlay,
                                  InventoryGridSettingsViewModel gridSettings,
                                  ControlPanelViewModel controlPanel,
-                                 MotherlodeViewModel motherlode)
+                                 MotherlodeViewModel motherlode,
+                                 LegolasColors colors,
+                                 LegolasBrushes brushes)
     {
         Session = session;
         SurveyFlow = surveyFlow;
@@ -22,6 +26,14 @@ public sealed partial class LegolasPanelViewModel : ObservableObject
         GridSettings = gridSettings;
         ControlPanel = controlPanel;
         Motherlode = motherlode;
+        Colors = colors;
+        Brushes = brushes;
+
+        Session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(SessionState.IsMapVisible) or nameof(SessionState.IsInventoryVisible))
+                OnPropertyChanged(nameof(OverlaysVisible));
+        };
     }
 
     public SessionState Session { get; }
@@ -32,4 +44,33 @@ public sealed partial class LegolasPanelViewModel : ObservableObject
     public InventoryGridSettingsViewModel GridSettings { get; }
     public ControlPanelViewModel ControlPanel { get; }
     public MotherlodeViewModel Motherlode { get; }
+    public LegolasColors Colors { get; }
+    public LegolasBrushes Brushes { get; }
+
+    /// <summary>True if either overlay is visible. Setter flips both together.</summary>
+    public bool OverlaysVisible
+    {
+        get => Session.IsMapVisible || Session.IsInventoryVisible;
+        set
+        {
+            Session.IsMapVisible = value;
+            Session.IsInventoryVisible = value;
+            OnPropertyChanged();
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleOverlays() => OverlaysVisible = !OverlaysVisible;
+
+    [RelayCommand]
+    private void ResetColorsToDefaults()
+    {
+        var defaults = new LegolasColors();
+        Colors.PinPending = defaults.PinPending;
+        Colors.PinFinalized = defaults.PinFinalized;
+        Colors.PlayerMarker = defaults.PlayerMarker;
+        Colors.RouteLine = defaults.RouteLine;
+        Colors.BearingWedgeFill = defaults.BearingWedgeFill;
+        Colors.BearingWedgeStroke = defaults.BearingWedgeStroke;
+    }
 }

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -18,16 +18,18 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     private readonly IRouteOptimizer _optimizer;
     private readonly LegolasSettings? _settings;
     private readonly SurveyFlowController _surveyFlow;
+    private readonly LegolasBrushes _brushes;
 
-    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow)
-        : this(session, projector, optimizer, surveyFlow, settings: null) { }
+    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes)
+        : this(session, projector, optimizer, surveyFlow, brushes, settings: null) { }
 
-    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasSettings? settings)
+    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes, LegolasSettings? settings)
     {
         _session = session;
         _projector = projector;
         _optimizer = optimizer;
         _surveyFlow = surveyFlow;
+        _brushes = brushes;
         _settings = settings;
         if (_settings is not null)
         {
@@ -96,6 +98,8 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     public SessionState Session => _session;
 
     public SurveyFlowController SurveyFlow => _surveyFlow;
+
+    public LegolasBrushes Brushes => _brushes;
 
     public PixelPoint PlayerPosition
     {

--- a/src/Legolas.Module/Views/LegolasPanelView.xaml
+++ b/src/Legolas.Module/Views/LegolasPanelView.xaml
@@ -24,8 +24,19 @@
 
             <!-- Overlay visibility -->
             <WrapPanel Margin="0,0,0,12">
-                <Button Content="Inventory Overlay" Click="ShowInventory_Click" Padding="10,4" Margin="0,0,8,8" />
-                <Button Content="Map Overlay" Click="ShowMap_Click" Padding="10,4" Margin="0,0,8,8" />
+                <Button Padding="10,4" Margin="0,0,8,8"
+                        Command="{Binding ToggleOverlaysCommand}">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Content" Value="Show Overlays" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding OverlaysVisible}" Value="True">
+                                    <Setter Property="Content" Value="Hide Overlays" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
             </WrapPanel>
 
             <!-- Mode -->
@@ -131,9 +142,74 @@
                     <CheckBox Content="Map overlay" Margin="0,0,0,4"
                               IsChecked="{Binding ControlPanel.ClickThroughMap}"
                               ToolTip="Mouse clicks pass through the map overlay" />
-                    <CheckBox Content="Inventory overlay"
+                    <CheckBox Content="Inventory overlay" Margin="0,0,0,4"
                               IsChecked="{Binding ControlPanel.ClickThroughInventory}"
                               ToolTip="Mouse clicks pass through the inventory overlay" />
+                    <CheckBox Content="Auto-enable inventory click-through during a survey session"
+                              IsChecked="{Binding ControlPanel.AutoClickThroughInventoryDuringSession}"
+                              ToolTip="When the inventory overlay is visible and the player position is set, click-through is enabled automatically." />
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Marker colors -->
+            <GroupBox Header="Marker Colors" Padding="8" Margin="0,0,0,12">
+                <StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="20" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Pin (pending)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding Colors.PinPending, UpdateSourceTrigger=LostFocus}" />
+                        <Border   Grid.Row="0" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                  Background="{Binding Brushes.PinPending}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Pin (finalized)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding Colors.PinFinalized, UpdateSourceTrigger=LostFocus}" />
+                        <Border   Grid.Row="1" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                  Background="{Binding Brushes.PinFinalized}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Player marker" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding Colors.PlayerMarker, UpdateSourceTrigger=LostFocus}" />
+                        <Border   Grid.Row="2" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                  Background="{Binding Brushes.PlayerMarker}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Route line" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding Colors.RouteLine, UpdateSourceTrigger=LostFocus}" />
+                        <Border   Grid.Row="3" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                  Background="{Binding Brushes.RouteLine}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Wedge fill" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding Colors.BearingWedgeFill, UpdateSourceTrigger=LostFocus}" />
+                        <Border   Grid.Row="4" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                  Background="{Binding Brushes.BearingWedgeFill}" />
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Wedge stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding Colors.BearingWedgeStroke, UpdateSourceTrigger=LostFocus}" />
+                        <Border   Grid.Row="5" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                  Background="{Binding Brushes.BearingWedgeStroke}" />
+                    </Grid>
+                    <TextBlock Text="ARGB hex (e.g. #FFFF0000 — opaque red, or #33FFFF80 — translucent yellow). 6-digit RGB also accepted; alpha defaults to FF."
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               TextWrapping="Wrap" Margin="0,6,0,0" />
+                    <Button Content="Reset to defaults" HorizontalAlignment="Right" Margin="0,8,0,0"
+                            Padding="10,4" Command="{Binding ResetColorsToDefaultsCommand}" />
                 </StackPanel>
             </GroupBox>
 

--- a/src/Legolas.Module/Views/LegolasPanelView.xaml.cs
+++ b/src/Legolas.Module/Views/LegolasPanelView.xaml.cs
@@ -1,6 +1,4 @@
-using System.Windows;
 using System.Windows.Controls;
-using Legolas.ViewModels;
 
 namespace Legolas.Views;
 
@@ -9,17 +7,5 @@ public partial class LegolasPanelView : UserControl
     public LegolasPanelView()
     {
         InitializeComponent();
-    }
-
-    private void ShowInventory_Click(object sender, RoutedEventArgs e)
-    {
-        if (DataContext is LegolasPanelViewModel vm)
-            vm.Session.IsInventoryVisible = !vm.Session.IsInventoryVisible;
-    }
-
-    private void ShowMap_Click(object sender, RoutedEventArgs e)
-    {
-        if (DataContext is LegolasPanelViewModel vm)
-            vm.Session.IsMapVisible = !vm.Session.IsMapVisible;
     }
 }

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -56,14 +56,17 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:SurveyItemViewModel}">
-                            <Path Data="{Binding WedgeGeometry}" Fill="#33FFFF80" Stroke="#55FFFF80" StrokeThickness="1" />
+                            <Path Data="{Binding WedgeGeometry}"
+                                  Fill="{Binding DataContext.Brushes.BearingWedgeFill, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                  Stroke="{Binding DataContext.Brushes.BearingWedgeStroke, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                  StrokeThickness="1" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
                 <!-- Route polyline layer -->
                 <Polyline Points="{Binding RoutePoints}"
-                          Stroke="Gold" StrokeThickness="2"
+                          Stroke="{Binding Brushes.RouteLine}" StrokeThickness="2"
                           StrokeDashArray="4 2" IsHitTestVisible="False" />
 
                 <!-- Player marker: outer ring + inner dot -->
@@ -72,7 +75,8 @@
                           Canvas.Left="{Binding PlayerPosition.X, Converter={x:Static controls:OffsetConverter.MinusNine}}"
                           Canvas.Top="{Binding PlayerPosition.Y, Converter={x:Static controls:OffsetConverter.MinusNine}}">
                         <Ellipse Width="18" Height="18" Stroke="White" StrokeThickness="2" Fill="Transparent" />
-                        <Ellipse Width="6" Height="6" Fill="#FF4CAF50"
+                        <Ellipse Width="6" Height="6"
+                                 Fill="{Binding Brushes.PlayerMarker}"
                                  HorizontalAlignment="Center" VerticalAlignment="Center" />
                     </Grid>
                 </Canvas>
@@ -121,12 +125,15 @@
                                     <ControlTemplate TargetType="Thumb">
                                         <Grid>
                                             <!-- Outer ring: pulses while pending (uncorrected) -->
-                                            <Ellipse Stroke="{Binding IsCorrected, Converter={x:Static controls:CorrectedToBrushConverter.Instance}}"
-                                                     StrokeThickness="2" Fill="#01000000">
+                                            <Ellipse StrokeThickness="2" Fill="#01000000">
                                                 <Ellipse.Style>
                                                     <Style TargetType="Ellipse">
                                                         <Setter Property="Opacity" Value="1" />
+                                                        <Setter Property="Stroke" Value="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                                                         <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsCorrected}" Value="True">
+                                                                <Setter Property="Stroke" Value="{Binding DataContext.Brushes.PinFinalized, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                            </DataTrigger>
                                                             <DataTrigger Binding="{Binding IsCorrected}" Value="False">
                                                                 <DataTrigger.EnterActions>
                                                                     <BeginStoryboard Name="PinPulse">
@@ -146,8 +153,18 @@
                                             </Ellipse>
                                             <!-- Center dot: the projected point -->
                                             <Ellipse Width="5" Height="5"
-                                                     Fill="{Binding IsCorrected, Converter={x:Static controls:CorrectedToBrushConverter.Instance}}"
-                                                     HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                     HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
+                                                        <Setter Property="Fill" Value="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsCorrected}" Value="True">
+                                                                <Setter Property="Fill" Value="{Binding DataContext.Brushes.PinFinalized, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Ellipse.Style>
+                                            </Ellipse>
                                             <TextBlock Text="{Binding RouteOrder, Converter={x:Static controls:OneBasedConverter.Instance}}"
                                                        Foreground="White"
                                                        HorizontalAlignment="Center" VerticalAlignment="Top"

--- a/tests/Legolas.Tests/Services/AutoOverlayCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/AutoOverlayCoordinatorTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+using Mithril.Shared.Modules;
+
+namespace Legolas.Tests.Services;
+
+public class AutoOverlayCoordinatorTests
+{
+    private static (AutoOverlayCoordinator coordinator, SessionState session, LegolasSettings settings, SurveyFlowController flow) BuildSut()
+    {
+        var settings = new LegolasSettings();
+        var session = new SessionState();
+        var flow = new SurveyFlowController(session, settings);
+        var gates = new ModuleGates();
+        gates.For("legolas").Open();
+        var coordinator = new AutoOverlayCoordinator(gates, settings, session, flow);
+        return (coordinator, session, settings, flow);
+    }
+
+    private static void EnterListening(SurveyFlowController flow, SessionState session)
+    {
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+    }
+
+    [Fact]
+    public void Initialize_no_change_when_inventory_hidden_and_idle()
+    {
+        var (coordinator, _, settings, _) = BuildSut();
+        coordinator.Initialize();
+        settings.ClickThroughInventory.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Inventory_visible_during_listening_flips_click_through_on()
+    {
+        var (coordinator, session, settings, flow) = BuildSut();
+        EnterListening(flow, session);
+        session.IsInventoryVisible = true;
+        coordinator.Initialize();
+
+        settings.ClickThroughInventory.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Inventory_visible_in_AwaitingPosition_does_not_flip()
+    {
+        var (coordinator, session, settings, _) = BuildSut();
+        coordinator.Initialize();
+        session.IsInventoryVisible = true;
+
+        settings.ClickThroughInventory.Should().BeFalse(
+            "no anchored session yet — user may want to interact with inventory normally");
+    }
+
+    [Fact]
+    public void Transition_into_active_state_with_inventory_visible_flips_click_through()
+    {
+        var (coordinator, session, settings, flow) = BuildSut();
+        coordinator.Initialize();
+        session.IsInventoryVisible = true;
+        settings.ClickThroughInventory.Should().BeFalse(); // still AwaitingPosition
+
+        EnterListening(flow, session);
+
+        settings.ClickThroughInventory.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Auto_setting_disabled_skips_flip()
+    {
+        var (coordinator, session, settings, flow) = BuildSut();
+        settings.AutoClickThroughInventoryDuringSession = false;
+        coordinator.Initialize();
+        session.IsInventoryVisible = true;
+        EnterListening(flow, session);
+
+        settings.ClickThroughInventory.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Coordinator_does_not_force_off_when_user_disables_mid_session()
+    {
+        var (coordinator, session, settings, flow) = BuildSut();
+        EnterListening(flow, session);
+        session.IsInventoryVisible = true;
+        coordinator.Initialize();
+        settings.ClickThroughInventory.Should().BeTrue();
+
+        // User flips it off manually — coordinator must not immediately re-enable
+        // until a new transition or visibility change occurs.
+        settings.ClickThroughInventory = false;
+        settings.ClickThroughInventory.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Coordinator_re_enables_on_next_state_transition()
+    {
+        var (coordinator, session, settings, flow) = BuildSut();
+        EnterListening(flow, session);
+        session.IsInventoryVisible = true;
+        coordinator.Initialize();
+
+        settings.ClickThroughInventory = false; // user opt-out
+
+        // Next transition — controller goes Listening → Gathering — should re-flip.
+        flow.OptimizeRoute();
+
+        settings.ClickThroughInventory.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Teardown_unsubscribes_and_stops_reacting()
+    {
+        var (coordinator, session, settings, flow) = BuildSut();
+        coordinator.Initialize();
+        EnterListening(flow, session);
+        coordinator.Teardown();
+
+        session.IsInventoryVisible = true; // would normally trigger
+        settings.ClickThroughInventory.Should().BeFalse();
+    }
+}

--- a/tests/Legolas.Tests/Settings/LegolasBrushesTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasBrushesTests.cs
@@ -1,0 +1,43 @@
+using System.Windows.Media;
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.Settings;
+
+public class LegolasBrushesTests
+{
+    [Fact]
+    public void Default_brushes_match_default_hex_values()
+    {
+        var brushes = new LegolasBrushes(new LegolasColors());
+
+        brushes.PinPending.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0xFF));
+        brushes.PinFinalized.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00));
+        brushes.PlayerMarker.Color.Should().Be(Color.FromArgb(0xFF, 0x4C, 0xAF, 0x50));
+        brushes.RouteLine.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0xD7, 0x00));
+        brushes.BearingWedgeFill.Color.Should().Be(Color.FromArgb(0x33, 0xFF, 0xFF, 0x80));
+        brushes.BearingWedgeStroke.Color.Should().Be(Color.FromArgb(0x55, 0xFF, 0xFF, 0x80));
+    }
+
+    [Fact]
+    public void Brush_property_change_propagates_when_color_changes()
+    {
+        var colors = new LegolasColors();
+        var brushes = new LegolasBrushes(colors);
+        var changed = new List<string?>();
+        brushes.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        colors.PinFinalized = "#FF00FF00";
+
+        changed.Should().Contain(nameof(LegolasBrushes.PinFinalized));
+        brushes.PinFinalized.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00));
+    }
+
+    [Fact]
+    public void Built_brush_is_frozen()
+    {
+        var brushes = new LegolasBrushes(new LegolasColors());
+        brushes.PinPending.IsFrozen.Should().BeTrue();
+    }
+}

--- a/tests/Legolas.Tests/Settings/LegolasColorsTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasColorsTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Legolas.Domain;
+
+namespace Legolas.Tests.Settings;
+
+public class LegolasColorsTests
+{
+    [Theory]
+    [InlineData("#FFFF0000", "#FFFF0000")]
+    [InlineData("#ff00ff00", "#FF00FF00")]
+    [InlineData("FF0000", "#FFFF0000")]      // 6-digit RGB → alpha defaults to FF
+    [InlineData("#abcdef", "#FFABCDEF")]
+    [InlineData("#33FFFF80", "#33FFFF80")]   // translucent preserved
+    public void Normalize_canonicalizes_hex(string input, string expected)
+    {
+        LegolasColors.Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("not a color")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("#XYZ")]
+    [InlineData("#GG0000")]
+    [InlineData("#FFF")]              // 3-digit not supported
+    [InlineData("#FFFFFFFFF")]        // too long
+    public void Normalize_falls_back_to_magenta_on_invalid(string? input)
+    {
+        LegolasColors.Normalize(input).Should().Be("#FFFF00FF");
+    }
+
+    [Fact]
+    public void Setter_normalizes_and_raises_property_changed()
+    {
+        var colors = new LegolasColors();
+        var changed = new List<string?>();
+        colors.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        colors.PinPending = "00ff00"; // lowercase, no hash, RGB
+
+        colors.PinPending.Should().Be("#FF00FF00");
+        changed.Should().ContainSingle().Which.Should().Be(nameof(LegolasColors.PinPending));
+    }
+
+    [Fact]
+    public void Setter_no_op_when_canonical_value_unchanged()
+    {
+        var colors = new LegolasColors();
+        colors.PinPending = "#FF00FFFF"; // matches default after normalization
+        var changed = new List<string?>();
+        colors.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        colors.PinPending = "00ffff"; // canonicalizes to same value
+
+        changed.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Closes three of issue #4's bullets in one go now that the FSM (#109) is in:

- **Marker colors are user-configurable** (#4 bullet 3). Pin pending/finalized, player marker, route line, bearing wedge fill/stroke — six ARGB hex strings under settings, with a hex TextBox + swatch preview per color in the panel and a "Reset to defaults" button.
- **Auto inventory click-through during a survey session** (#4 bullet 4). New hosted service watches the FSM and `IsInventoryVisible`; flips `ClickThroughInventory` on when both align. Opt-out toggle in the Click-Through section. Defaults on.
- **Consolidated show-overlay button** (#4 bullet 2). One "Show/Hide Overlays" toggle replaces the two separate buttons. Per-overlay hotkeys preserved for power users.

## Implementation notes

- `LegolasColors` is a manual-INPC POCO mirroring `InventoryGridSettings`'s pattern (CommunityToolkit.Mvvm + System.Text.Json source generators race on partial properties — known gotcha). Stored as 8-digit ARGB hex; 6-digit RGB is accepted on input and normalized.
- `LegolasBrushes` is a thin VM exposing pre-built frozen `SolidColorBrush` instances and re-emitting `PropertyChanged` when the underlying hex changes. WPF picks up the new brush on bound elements automatically. Avoids fighting the global resource dictionary system.
- `AutoOverlayCoordinator` only flips click-through ON. The user can still manually disable it mid-session; the next state transition re-enables. Cheapest contract that matches "automatic" without fighting the user.
- `CorrectedToBrushConverter` retired. Pin colors now flow through `Brushes.PinPending` / `Brushes.PinFinalized` driven by an `IsCorrected` DataTrigger inside the existing storyboard style.

## Behavior change

Pre-PR users will see no visual diff on first launch (defaults match exactly). On first run, `LegolasSettings.AutoClickThroughInventoryDuringSession` defaults to true — if someone had `ClickThroughInventory` deliberately off mid-session, it'll flip on once they enter Listening with the inventory open. They can opt out via the new checkbox.

## Test plan

- [x] 1506/1506 tests pass solution-wide (25 new in this PR).
- [x] App launches cleanly, no DI errors, no exceptions.
- [ ] Smoke-test manually: open Legolas tab, start a session, verify pins/route/wedge render with default colors, change a color and confirm it updates without restart.
- [ ] Toggle the consolidated overlay button — both overlays should appear/disappear together.
- [ ] Open inventory before setting position → click-through stays whatever the user had it. Set position → click-through flips on automatically.
- [ ] Manually disable click-through mid-session → it stays off until the next FSM transition.
- [ ] Hit "Reset to defaults" — colors should snap back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)