### PR TITLE
Legolas: auto-hide overlays on focus loss + global pin-nudge hotkeys

### DIFF
--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -113,6 +113,60 @@ public sealed class LegolasSettings : INotifyPropertyChanged
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AutoClickThroughInventoryDuringSession)));
         }
     }
+
+    private bool _autoHideOverlaysOnGameUnfocused = true;
+    public bool AutoHideOverlaysOnGameUnfocused
+    {
+        get => _autoHideOverlaysOnGameUnfocused;
+        set
+        {
+            if (_autoHideOverlaysOnGameUnfocused == value) return;
+            _autoHideOverlaysOnGameUnfocused = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AutoHideOverlaysOnGameUnfocused)));
+        }
+    }
+
+    private double _nudgeStepDefault = 1.0;
+    public double NudgeStepDefault
+    {
+        get => _nudgeStepDefault;
+        set
+        {
+            // Clamp to a positive minimum so a misconfigured setting can't make
+            // the nudge keys silently no-op. Using DefaultValue here would leave
+            // the user unable to override, so we just guard the lower bound.
+            var clamped = value > 0 ? value : 1.0;
+            if (Math.Abs(_nudgeStepDefault - clamped) < 1e-6) return;
+            _nudgeStepDefault = clamped;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NudgeStepDefault)));
+        }
+    }
+
+    private double _nudgeStepFast = 5.0;
+    public double NudgeStepFast
+    {
+        get => _nudgeStepFast;
+        set
+        {
+            var clamped = value > 0 ? value : 5.0;
+            if (Math.Abs(_nudgeStepFast - clamped) < 1e-6) return;
+            _nudgeStepFast = clamped;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NudgeStepFast)));
+        }
+    }
+
+    private double _nudgeStepFine = 0.25;
+    public double NudgeStepFine
+    {
+        get => _nudgeStepFine;
+        set
+        {
+            var clamped = value > 0 ? value : 0.25;
+            if (Math.Abs(_nudgeStepFine - clamped) < 1e-6) return;
+            _nudgeStepFine = clamped;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NudgeStepFine)));
+        }
+    }
 }
 
 public sealed class WindowLayout

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -126,6 +126,22 @@ public sealed class LegolasSettings : INotifyPropertyChanged
         }
     }
 
+    private string _gameProcessName = "ProjectGorgon";
+    public string GameProcessName
+    {
+        get => _gameProcessName;
+        set
+        {
+            // Trim only — the predicate is a case-insensitive substring match,
+            // so internal whitespace (e.g. "Project Gorgon") is allowed for
+            // launchers that name the executable with a space.
+            var v = value?.Trim() ?? string.Empty;
+            if (string.Equals(_gameProcessName, v, StringComparison.Ordinal)) return;
+            _gameProcessName = v;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GameProcessName)));
+        }
+    }
+
     private double _nudgeStepDefault = 1.0;
     public double NudgeStepDefault
     {

--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -194,3 +194,161 @@ public sealed class ToggleBearingWedgesCommand : IHotkeyCommand
         return Task.CompletedTask;
     }
 }
+
+// ─── Pin Nudge ───────────────────────────────────────────────────────────────
+// 12 hotkey commands (4 directions × 3 step tiers) so the user can rebind any
+// combination — including just one tier and skipping the others. Step
+// magnitudes live in LegolasSettings (NudgeStepDefault / Fast / Fine), read
+// fresh on every Execute so settings changes apply immediately. Default
+// bindings are intentionally null because arrow keys collide with in-game
+// movement; users must opt-in via the Hotkeys settings UI.
+
+public abstract class NudgePinCommandBase : IHotkeyCommand
+{
+    private readonly SessionState _session;
+    private readonly MapOverlayViewModel _map;
+    private readonly LegolasSettings _settings;
+
+    protected NudgePinCommandBase(SessionState session, MapOverlayViewModel map, LegolasSettings settings)
+    {
+        _session = session;
+        _map = map;
+        _settings = settings;
+    }
+
+    public abstract string Id { get; }
+    public abstract string DisplayName { get; }
+    public string? Category => "Legolas · Pin Nudge";
+    public HotkeyBinding? DefaultBinding => null;
+
+    /// <summary>Unit vector for the direction this command moves a pin.</summary>
+    protected abstract (double Dx, double Dy) Direction { get; }
+
+    /// <summary>Step magnitude (read from settings on each call).</summary>
+    protected abstract double Step { get; }
+
+    protected double NudgeStepDefault => _settings.NudgeStepDefault;
+    protected double NudgeStepFast => _settings.NudgeStepFast;
+    protected double NudgeStepFine => _settings.NudgeStepFine;
+
+    public Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var selected = _session.SelectedSurvey;
+        if (selected is null || !selected.EffectivePixel.HasValue) return Task.CompletedTask;
+
+        var p = selected.EffectivePixel.Value;
+        var (dx, dy) = Direction;
+        var step = Step;
+        _map.CorrectSurveyCommand.Execute(
+            new CorrectionArgs(selected, new PixelPoint(p.X + dx * step, p.Y + dy * step)));
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class NudgePinUpCommand : NudgePinCommandBase
+{
+    public NudgePinUpCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.up";
+    public override string DisplayName => "Nudge Pin Up";
+    protected override (double, double) Direction => (0, -1);
+    protected override double Step => NudgeStepDefault;
+}
+
+public sealed class NudgePinUpFastCommand : NudgePinCommandBase
+{
+    public NudgePinUpFastCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.up.fast";
+    public override string DisplayName => "Nudge Pin Up (Fast)";
+    protected override (double, double) Direction => (0, -1);
+    protected override double Step => NudgeStepFast;
+}
+
+public sealed class NudgePinUpFineCommand : NudgePinCommandBase
+{
+    public NudgePinUpFineCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.up.fine";
+    public override string DisplayName => "Nudge Pin Up (Fine)";
+    protected override (double, double) Direction => (0, -1);
+    protected override double Step => NudgeStepFine;
+}
+
+public sealed class NudgePinDownCommand : NudgePinCommandBase
+{
+    public NudgePinDownCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.down";
+    public override string DisplayName => "Nudge Pin Down";
+    protected override (double, double) Direction => (0, 1);
+    protected override double Step => NudgeStepDefault;
+}
+
+public sealed class NudgePinDownFastCommand : NudgePinCommandBase
+{
+    public NudgePinDownFastCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.down.fast";
+    public override string DisplayName => "Nudge Pin Down (Fast)";
+    protected override (double, double) Direction => (0, 1);
+    protected override double Step => NudgeStepFast;
+}
+
+public sealed class NudgePinDownFineCommand : NudgePinCommandBase
+{
+    public NudgePinDownFineCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.down.fine";
+    public override string DisplayName => "Nudge Pin Down (Fine)";
+    protected override (double, double) Direction => (0, 1);
+    protected override double Step => NudgeStepFine;
+}
+
+public sealed class NudgePinLeftCommand : NudgePinCommandBase
+{
+    public NudgePinLeftCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.left";
+    public override string DisplayName => "Nudge Pin Left";
+    protected override (double, double) Direction => (-1, 0);
+    protected override double Step => NudgeStepDefault;
+}
+
+public sealed class NudgePinLeftFastCommand : NudgePinCommandBase
+{
+    public NudgePinLeftFastCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.left.fast";
+    public override string DisplayName => "Nudge Pin Left (Fast)";
+    protected override (double, double) Direction => (-1, 0);
+    protected override double Step => NudgeStepFast;
+}
+
+public sealed class NudgePinLeftFineCommand : NudgePinCommandBase
+{
+    public NudgePinLeftFineCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.left.fine";
+    public override string DisplayName => "Nudge Pin Left (Fine)";
+    protected override (double, double) Direction => (-1, 0);
+    protected override double Step => NudgeStepFine;
+}
+
+public sealed class NudgePinRightCommand : NudgePinCommandBase
+{
+    public NudgePinRightCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.right";
+    public override string DisplayName => "Nudge Pin Right";
+    protected override (double, double) Direction => (1, 0);
+    protected override double Step => NudgeStepDefault;
+}
+
+public sealed class NudgePinRightFastCommand : NudgePinCommandBase
+{
+    public NudgePinRightFastCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.right.fast";
+    public override string DisplayName => "Nudge Pin Right (Fast)";
+    protected override (double, double) Direction => (1, 0);
+    protected override double Step => NudgeStepFast;
+}
+
+public sealed class NudgePinRightFineCommand : NudgePinCommandBase
+{
+    public NudgePinRightFineCommand(SessionState s, MapOverlayViewModel m, LegolasSettings c) : base(s, m, c) { }
+    public override string Id => "legolas.pin.nudge.right.fine";
+    public override string DisplayName => "Nudge Pin Right (Fine)";
+    protected override (double, double) Direction => (1, 0);
+    protected override double Step => NudgeStepFine;
+}

--- a/src/Legolas.Module/Hotkeys/OverlayController.cs
+++ b/src/Legolas.Module/Hotkeys/OverlayController.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using System.Windows;
 using Mithril.Shared.Modules;
+using Legolas.Domain;
+using Legolas.Services;
 using Legolas.ViewModels;
 using Legolas.Views;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,23 +15,37 @@ namespace Legolas.Hotkeys;
 /// <see cref="SessionState.IsMapVisible"/> / <see cref="SessionState.IsInventoryVisible"/>.
 /// Overlays cannot live inside the shell's ContentPresenter, so they stay as
 /// top-level <see cref="Window"/>s owned by a module-scoped controller.
+///
+/// Visibility is gated by both the user's intent flag AND the in-app
+/// foreground state from <see cref="ForegroundFocusGate"/> (issue #116) so
+/// alt-tabbing to a browser doesn't leave the overlays floating over it.
+/// The user's intent flag is never mutated here — only the rendered window.
 /// </summary>
 public sealed class OverlayController : IHostedService
 {
     private readonly IServiceProvider _services;
     private readonly ModuleGates _gates;
     private readonly SessionState _session;
+    private readonly LegolasSettings _settings;
+    private readonly ForegroundFocusGate _focusGate;
     private readonly CancellationTokenSource _stopCts = new();
     private Task? _activationTask;
     private bool _subscribed;
     private MapOverlayView? _map;
     private InventoryOverlayView? _inventory;
 
-    public OverlayController(IServiceProvider services, ModuleGates gates, SessionState session)
+    public OverlayController(
+        IServiceProvider services,
+        ModuleGates gates,
+        SessionState session,
+        LegolasSettings settings,
+        ForegroundFocusGate focusGate)
     {
         _services = services;
         _gates = gates;
         _session = session;
+        _settings = settings;
+        _focusGate = focusGate;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -44,6 +60,8 @@ public sealed class OverlayController : IHostedService
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                 {
                     _session.PropertyChanged += OnSessionPropertyChanged;
+                    _focusGate.PropertyChanged += OnFocusGatePropertyChanged;
+                    _settings.PropertyChanged += OnSettingsPropertyChanged;
                     _subscribed = true;
                     SyncMap();
                     SyncInventory();
@@ -61,7 +79,12 @@ public sealed class OverlayController : IHostedService
         if (Application.Current is null) return;
         await Application.Current.Dispatcher.InvokeAsync(() =>
         {
-            if (_subscribed) _session.PropertyChanged -= OnSessionPropertyChanged;
+            if (_subscribed)
+            {
+                _session.PropertyChanged -= OnSessionPropertyChanged;
+                _focusGate.PropertyChanged -= OnFocusGatePropertyChanged;
+                _settings.PropertyChanged -= OnSettingsPropertyChanged;
+            }
             _map?.Close();
             _inventory?.Close();
             _map = null;
@@ -75,15 +98,36 @@ public sealed class OverlayController : IHostedService
         else if (e.PropertyName == nameof(SessionState.IsInventoryVisible)) SyncInventory();
     }
 
+    private void OnFocusGatePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(ForegroundFocusGate.IsInApp)) return;
+        SyncMap();
+        SyncInventory();
+    }
+
+    private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // Toggling the auto-hide setting itself should immediately reflect on
+        // current visibility — flipping it ON while a non-game window has focus
+        // should hide the overlays right away, and flipping it OFF should
+        // restore them.
+        if (e.PropertyName != nameof(LegolasSettings.AutoHideOverlaysOnGameUnfocused)) return;
+        SyncMap();
+        SyncInventory();
+    }
+
+    private bool ShouldRender(bool sessionFlag) =>
+        sessionFlag && (_focusGate.IsInApp || !_settings.AutoHideOverlaysOnGameUnfocused);
+
     private void SyncMap()
     {
-        if (_session.IsMapVisible) EnsureMap().Show();
+        if (ShouldRender(_session.IsMapVisible)) EnsureMap().Show();
         else _map?.Hide();
     }
 
     private void SyncInventory()
     {
-        if (_session.IsInventoryVisible) EnsureInventory().Show();
+        if (ShouldRender(_session.IsInventoryVisible)) EnsureInventory().Show();
         else _inventory?.Hide();
     }
 

--- a/src/Legolas.Module/Interop/User32Focus.cs
+++ b/src/Legolas.Module/Interop/User32Focus.cs
@@ -1,0 +1,45 @@
+using System.Runtime.InteropServices;
+
+namespace Legolas.Interop;
+
+/// <summary>
+/// P/Invoke surface for foreground-window tracking. Kept separate from
+/// <see cref="Controls.ClickThrough"/> because the concerns are different — this
+/// runs once at module start to install a global hook, while ClickThrough is
+/// per-window and toggled by user settings.
+/// </summary>
+internal static partial class User32Focus
+{
+    public const uint EVENT_SYSTEM_FOREGROUND = 0x0003;
+    public const uint WINEVENT_OUTOFCONTEXT = 0x0000;
+    public const uint WINEVENT_SKIPOWNPROCESS = 0x0002;
+
+    public delegate void WinEventProc(
+        IntPtr hWinEventHook,
+        uint eventType,
+        IntPtr hwnd,
+        int idObject,
+        int idChild,
+        uint idEventThread,
+        uint dwmsEventTime);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    public static partial IntPtr SetWinEventHook(
+        uint eventMin,
+        uint eventMax,
+        IntPtr hmodWinEventProc,
+        WinEventProc lpfnWinEventProc,
+        uint idProcess,
+        uint idThread,
+        uint dwFlags);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool UnhookWinEvent(IntPtr hWinEventHook);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    public static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    public static partial IntPtr GetForegroundWindow();
+}

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -113,6 +113,11 @@ public sealed class LegolasModule : IMithrilModule
             return view;
         });
 
+        // Foreground-focus tracking (issue #116). Singleton + hosted-service
+        // so OverlayController can read its IsInApp state directly.
+        services.AddSingleton<ForegroundFocusGate>();
+        services.AddHostedService(sp => sp.GetRequiredService<ForegroundFocusGate>());
+
         // Overlay lifecycle
         services.AddHostedService<OverlayController>();
         services.AddHostedService<AutoOverlayCoordinator>();
@@ -130,6 +135,19 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<IHotkeyCommand, ToggleInventoryClickThroughCommand>();
         services.AddSingleton<IHotkeyCommand, ToggleAllOverlaysCommand>();
         services.AddSingleton<IHotkeyCommand, ToggleBearingWedgesCommand>();
+        // Issue #117: 12 pin-nudge commands (4 directions × 3 step tiers)
+        services.AddSingleton<IHotkeyCommand, NudgePinUpCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinUpFastCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinUpFineCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinDownCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinDownFastCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinDownFineCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinLeftCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinLeftFastCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinLeftFineCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinRightCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinRightFastCommand>();
+        services.AddSingleton<IHotkeyCommand, NudgePinRightFineCommand>();
 
         // Chat-log ingestion
         services.AddHostedService<LogIngestionService>();

--- a/src/Legolas.Module/Services/ForegroundFocusGate.cs
+++ b/src/Legolas.Module/Services/ForegroundFocusGate.cs
@@ -1,0 +1,146 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows;
+using Legolas.Interop;
+using Microsoft.Extensions.Hosting;
+using Mithril.Shared.Modules;
+
+namespace Legolas.Services;
+
+/// <summary>
+/// Tracks whether the foreground window belongs to Mithril or the Project
+/// Gorgon game process. Exposes a single observable <see cref="IsInApp"/> bool
+/// that <see cref="Hotkeys.OverlayController"/> ANDs with the user's
+/// IsMapVisible / IsInventoryVisible flags so overlays vanish while the user
+/// is in a browser, Discord, etc., and reappear (with prior intent preserved)
+/// when they come back.
+/// </summary>
+public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
+{
+    private readonly ModuleGates _gates;
+    private readonly CancellationTokenSource _stopCts = new();
+    private readonly uint _ownPid;
+
+    // Held to prevent GC of the delegate while the native hook is live.
+    private User32Focus.WinEventProc? _hookProc;
+    private IntPtr _hookHandle = IntPtr.Zero;
+    private Task? _activationTask;
+    private bool _isInApp = true;
+
+    public ForegroundFocusGate(ModuleGates gates)
+    {
+        _gates = gates;
+        _ownPid = (uint)Environment.ProcessId;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool IsInApp
+    {
+        get => _isInApp;
+        private set
+        {
+            if (_isInApp == value) return;
+            _isInApp = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInApp)));
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Wait on the legolas module gate before installing the hook — there's
+        // no overlay to gate before the user opens the Legolas tab, and we
+        // don't want to claim a system-wide hook for an unused module.
+        _activationTask = Task.Run(async () =>
+        {
+            try
+            {
+                await _gates.For("legolas").WaitAsync(_stopCts.Token).ConfigureAwait(false);
+                if (Application.Current?.Dispatcher is { } dispatcher)
+                {
+                    await dispatcher.InvokeAsync(InstallHook);
+                }
+            }
+            catch (OperationCanceledException) { }
+        }, _stopCts.Token);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _stopCts.Cancel();
+        if (_activationTask is not null) { try { await _activationTask.ConfigureAwait(false); } catch { } }
+        if (Application.Current?.Dispatcher is { } dispatcher)
+        {
+            await dispatcher.InvokeAsync(UninstallHook);
+        }
+    }
+
+    private void InstallHook()
+    {
+        if (_hookHandle != IntPtr.Zero) return;
+        _hookProc = OnWinEvent;
+        _hookHandle = User32Focus.SetWinEventHook(
+            User32Focus.EVENT_SYSTEM_FOREGROUND,
+            User32Focus.EVENT_SYSTEM_FOREGROUND,
+            IntPtr.Zero,
+            _hookProc,
+            idProcess: 0,
+            idThread: 0,
+            User32Focus.WINEVENT_OUTOFCONTEXT);
+
+        // Hook delivery is event-driven, so seed the gate from the current
+        // foreground window — otherwise IsInApp stays at its default until the
+        // next focus change.
+        EvaluateForeground(User32Focus.GetForegroundWindow());
+    }
+
+    private void UninstallHook()
+    {
+        if (_hookHandle == IntPtr.Zero) return;
+        User32Focus.UnhookWinEvent(_hookHandle);
+        _hookHandle = IntPtr.Zero;
+        _hookProc = null;
+    }
+
+    private void OnWinEvent(
+        IntPtr hWinEventHook,
+        uint eventType,
+        IntPtr hwnd,
+        int idObject,
+        int idChild,
+        uint idEventThread,
+        uint dwmsEventTime)
+    {
+        if (eventType != User32Focus.EVENT_SYSTEM_FOREGROUND) return;
+        EvaluateForeground(hwnd);
+    }
+
+    private void EvaluateForeground(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) return;
+        IsInApp = IsForegroundInApp(hwnd);
+    }
+
+    private bool IsForegroundInApp(IntPtr hwnd)
+    {
+        User32Focus.GetWindowThreadProcessId(hwnd, out var pid);
+        if (pid == 0) return _isInApp;
+        if (pid == _ownPid) return true;
+
+        try
+        {
+            using var proc = Process.GetProcessById((int)pid);
+            // ProcessName excludes the .exe extension on Windows, matching
+            // the canonical "ProjectGorgon" name.
+            return string.Equals(proc.ProcessName, "ProjectGorgon", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Process exited between the hook firing and us looking it up,
+            // or access denied (elevated process). Treat as out-of-app so
+            // overlays hide rather than stick around incorrectly.
+            return false;
+        }
+    }
+}

--- a/src/Legolas.Module/Services/ForegroundFocusGate.cs
+++ b/src/Legolas.Module/Services/ForegroundFocusGate.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
+using Legolas.Domain;
 using Legolas.Interop;
 using Microsoft.Extensions.Hosting;
 using Mithril.Shared.Modules;
@@ -8,16 +9,23 @@ using Mithril.Shared.Modules;
 namespace Legolas.Services;
 
 /// <summary>
-/// Tracks whether the foreground window belongs to Mithril or the Project
-/// Gorgon game process. Exposes a single observable <see cref="IsInApp"/> bool
-/// that <see cref="Hotkeys.OverlayController"/> ANDs with the user's
-/// IsMapVisible / IsInventoryVisible flags so overlays vanish while the user
-/// is in a browser, Discord, etc., and reappear (with prior intent preserved)
-/// when they come back.
+/// Tracks whether the foreground window belongs to Mithril or the configured
+/// game process. Exposes a single observable <see cref="IsInApp"/> bool that
+/// <see cref="Hotkeys.OverlayController"/> ANDs with the user's IsMapVisible /
+/// IsInventoryVisible flags so overlays vanish while the user is in a browser,
+/// Discord, etc., and reappear (with prior intent preserved) when they come
+/// back.
+///
+/// The "in-app" predicate matches by self-PID OR a case-insensitive substring
+/// match against <see cref="LegolasSettings.GameProcessName"/>. Substring
+/// match is forgiving across Steam/Itch/standalone naming variations (e.g.
+/// "ProjectGorgon", "Project Gorgon", "ProjectGorgon64") and lets the user
+/// override via the settings UI without a code change.
 /// </summary>
 public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
 {
     private readonly ModuleGates _gates;
+    private readonly LegolasSettings _settings;
     private readonly CancellationTokenSource _stopCts = new();
     private readonly uint _ownPid;
 
@@ -27,9 +35,10 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
     private Task? _activationTask;
     private bool _isInApp = true;
 
-    public ForegroundFocusGate(ModuleGates gates)
+    public ForegroundFocusGate(ModuleGates gates, LegolasSettings settings)
     {
         _gates = gates;
+        _settings = settings;
         _ownPid = (uint)Environment.ProcessId;
     }
 
@@ -89,6 +98,11 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
             idThread: 0,
             User32Focus.WINEVENT_OUTOFCONTEXT);
 
+        // Re-evaluate the current foreground when the user changes the
+        // configured process name — otherwise they'd have to alt-tab to make
+        // a corrected name take effect.
+        _settings.PropertyChanged += OnSettingsPropertyChanged;
+
         // Hook delivery is event-driven, so seed the gate from the current
         // foreground window — otherwise IsInApp stays at its default until the
         // next focus change.
@@ -98,9 +112,16 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
     private void UninstallHook()
     {
         if (_hookHandle == IntPtr.Zero) return;
+        _settings.PropertyChanged -= OnSettingsPropertyChanged;
         User32Focus.UnhookWinEvent(_hookHandle);
         _hookHandle = IntPtr.Zero;
         _hookProc = null;
+    }
+
+    private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(LegolasSettings.GameProcessName)) return;
+        EvaluateForeground(User32Focus.GetForegroundWindow());
     }
 
     private void OnWinEvent(
@@ -128,12 +149,16 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
         if (pid == 0) return _isInApp;
         if (pid == _ownPid) return true;
 
+        var configured = _settings.GameProcessName;
+        if (string.IsNullOrWhiteSpace(configured)) return false;
+
         try
         {
             using var proc = Process.GetProcessById((int)pid);
-            // ProcessName excludes the .exe extension on Windows, matching
-            // the canonical "ProjectGorgon" name.
-            return string.Equals(proc.ProcessName, "ProjectGorgon", StringComparison.OrdinalIgnoreCase);
+            // Substring match (case-insensitive) so "ProjectGorgon",
+            // "ProjectGorgon64", or "Project Gorgon" all count as in-app
+            // without forcing the user to know the exact image name.
+            return proc.ProcessName.Contains(configured, StringComparison.OrdinalIgnoreCase);
         }
         catch
         {

--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -89,6 +89,47 @@ public sealed partial class ControlPanelViewModel : ObservableObject
         }
     }
 
+    public bool AutoHideOverlaysOnGameUnfocused
+    {
+        get => _settings.AutoHideOverlaysOnGameUnfocused;
+        set
+        {
+            if (_settings.AutoHideOverlaysOnGameUnfocused == value) return;
+            _settings.AutoHideOverlaysOnGameUnfocused = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double NudgeStepDefault
+    {
+        get => _settings.NudgeStepDefault;
+        set
+        {
+            _settings.NudgeStepDefault = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double NudgeStepFast
+    {
+        get => _settings.NudgeStepFast;
+        set
+        {
+            _settings.NudgeStepFast = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double NudgeStepFine
+    {
+        get => _settings.NudgeStepFine;
+        set
+        {
+            _settings.NudgeStepFine = value;
+            OnPropertyChanged();
+        }
+    }
+
     [RelayCommand]
     private void StartSession() => SurveyFlow.Reset();
 

--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
 using Legolas.Flow;
+using Legolas.Interop;
 
 namespace Legolas.ViewModels;
 
@@ -97,6 +99,67 @@ public sealed partial class ControlPanelViewModel : ObservableObject
             if (_settings.AutoHideOverlaysOnGameUnfocused == value) return;
             _settings.AutoHideOverlaysOnGameUnfocused = value;
             OnPropertyChanged();
+        }
+    }
+
+    public string GameProcessName
+    {
+        get => _settings.GameProcessName;
+        set
+        {
+            if (string.Equals(_settings.GameProcessName, value, StringComparison.Ordinal)) return;
+            _settings.GameProcessName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    [ObservableProperty]
+    private string _detectGameProcessStatus = string.Empty;
+
+    /// <summary>
+    /// Capture the foreground window's process name 3 seconds after click,
+    /// so the user has time to alt-tab to the game. Skips Mithril's own
+    /// process — the foreground at click-time is always Mithril, so without
+    /// the delay we'd just overwrite the setting with our own name.
+    /// </summary>
+    [RelayCommand]
+    private async Task DetectGameProcessAsync()
+    {
+        for (var i = 3; i > 0; i--)
+        {
+            DetectGameProcessStatus = $"Switch to the game window... capturing in {i}s";
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        var hwnd = User32Focus.GetForegroundWindow();
+        if (hwnd == IntPtr.Zero)
+        {
+            DetectGameProcessStatus = "No foreground window detected.";
+            return;
+        }
+
+        User32Focus.GetWindowThreadProcessId(hwnd, out var pid);
+        if (pid == 0)
+        {
+            DetectGameProcessStatus = "Could not resolve foreground process ID.";
+            return;
+        }
+
+        if (pid == (uint)Environment.ProcessId)
+        {
+            DetectGameProcessStatus = "Mithril was foreground — switch to the game and try again.";
+            return;
+        }
+
+        try
+        {
+            using var proc = Process.GetProcessById((int)pid);
+            GameProcessName = proc.ProcessName;
+            DetectGameProcessStatus = $"Captured: {proc.ProcessName}";
+        }
+        catch (Exception ex)
+        {
+            DetectGameProcessStatus = $"Could not read process: {ex.Message}";
         }
     }
 

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -91,6 +91,12 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             RebuildRouteGeometry();
             if (sender is SurveyItemViewModel s) RebuildWedgeFor(s);
         }
+        else if (e.PropertyName is nameof(SurveyItemViewModel.IsActiveTarget))
+        {
+            // Active-target change rotates the live segment without changing
+            // the rest of the route, so don't churn the full polyline.
+            RebuildActiveSegment();
+        }
     }
 
     public ObservableCollection<SurveyItemViewModel> Surveys => _session.Surveys;
@@ -115,6 +121,17 @@ public sealed partial class MapOverlayViewModel : ObservableObject
 
     [ObservableProperty]
     private PointCollection _routePoints = new();
+
+    /// <summary>
+    /// Two-point polyline drawn on top of the static route line: from the
+    /// most-recently-collected pin (or the player anchor if nothing's been
+    /// collected yet) to the current <see cref="SurveyItemViewModel.IsActiveTarget"/>
+    /// pin. We can't read the player's live position — we only know the anchor —
+    /// so the last-collected pin is the closest available proxy for "where the
+    /// player physically is right now". Empty when there's no active target.
+    /// </summary>
+    [ObservableProperty]
+    private PointCollection _activeSegmentPoints = new();
 
     [ObservableProperty] private double _zoom = 1.0;
     [ObservableProperty] private double _panX;
@@ -324,6 +341,7 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         if (!_session.ShowRouteLines)
         {
             RoutePoints = new PointCollection();
+            ActiveSegmentPoints = new PointCollection();
             return;
         }
 
@@ -339,6 +357,43 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             points.Add(new Point(p.X, p.Y));
         }
         RoutePoints = points;
+
+        RebuildActiveSegment();
+    }
+
+    private void RebuildActiveSegment()
+    {
+        if (!_session.ShowRouteLines)
+        {
+            ActiveSegmentPoints = new PointCollection();
+            return;
+        }
+
+        var active = Surveys.FirstOrDefault(s => s.IsActiveTarget);
+        if (active is null || !active.EffectivePixel.HasValue)
+        {
+            ActiveSegmentPoints = new PointCollection();
+            return;
+        }
+
+        // We can't read the live player position — only the anchor set via
+        // "Set Player Position". Use the most-recently-collected pin (highest
+        // RouteOrder among collected) as a proxy for where the player is now;
+        // fall back to the anchor before the first collection.
+        var lastCollected = Surveys
+            .Where(s => s.Collected && s.RouteOrder.HasValue && s.EffectivePixel.HasValue)
+            .OrderByDescending(s => s.RouteOrder!.Value)
+            .FirstOrDefault();
+
+        var startX = lastCollected?.EffectivePixel?.X ?? PlayerPosition.X;
+        var startY = lastCollected?.EffectivePixel?.Y ?? PlayerPosition.Y;
+        var endPx = active.EffectivePixel.Value;
+
+        ActiveSegmentPoints = new PointCollection
+        {
+            new Point(startX, startY),
+            new Point(endPx.X, endPx.Y),
+        };
     }
 }
 

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -50,10 +50,33 @@ public sealed partial class SessionState : ObservableObject
         foreach (var s in Surveys)
             s.IsActiveTarget = ReferenceEquals(s, next);
 
+        UpdateActiveTargetSummary(next);
+
         // Fire only on the transition: non-empty collection where nothing is
         // uncollected. After a reset (Surveys becomes empty) this doesn't re-fire.
         if (next is null && Surveys.Count > 0)
             AllCollected?.Invoke();
+    }
+
+    /// <summary>
+    /// One-line "Next: #6 of 12 — Pin Name" surfaced in the wizard panel so
+    /// players can see route progress without opening the map overlay.
+    /// Empty when there's no active target (idle, all collected, or no route
+    /// has been computed yet).
+    /// </summary>
+    [ObservableProperty]
+    private string _activeTargetSummary = string.Empty;
+
+    private void UpdateActiveTargetSummary(SurveyItemViewModel? active)
+    {
+        if (active is null || !active.RouteOrder.HasValue)
+        {
+            ActiveTargetSummary = string.Empty;
+            return;
+        }
+        var total = Surveys.Count(s => s.RouteOrder.HasValue);
+        var oneBased = active.RouteOrder!.Value + 1;
+        ActiveTargetSummary = $"Next: #{oneBased} of {total} — {active.Name}";
     }
 
     [ObservableProperty] private PixelPoint _playerPosition = new(400, 300);

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -68,9 +68,23 @@
 
             <!-- Auto-hide on game unfocus (issue #116) -->
             <GroupBox Header="Auto-Hide" Padding="8" Margin="0,0,0,12">
-                <CheckBox Content="Auto-hide overlays when neither the game nor Mithril has focus"
-                          IsChecked="{Binding ControlPanel.AutoHideOverlaysOnGameUnfocused}"
-                          ToolTip="Hides the map and inventory overlays while you alt-tab to a browser, Discord, etc., and restores whichever was visible when you return." />
+                <StackPanel>
+                    <CheckBox Content="Auto-hide overlays when neither the game nor Mithril has focus"
+                              IsChecked="{Binding ControlPanel.AutoHideOverlaysOnGameUnfocused}"
+                              ToolTip="Hides the map and inventory overlays while you alt-tab to a browser, Discord, etc., and restores whichever was visible when you return." />
+                    <TextBlock Text="Game process name (case-insensitive substring match — covers ProjectGorgon, ProjectGorgon64, Project Gorgon, etc.):"
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               TextWrapping="Wrap" Margin="0,8,0,4" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox Width="240" VerticalAlignment="Center"
+                                 Text="{Binding ControlPanel.GameProcessName, UpdateSourceTrigger=LostFocus}" />
+                        <Button Content="Detect from foreground (3s)" Margin="8,0,0,0" Padding="8,2"
+                                Command="{Binding ControlPanel.DetectGameProcessCommand}"
+                                ToolTip="Click, then alt-tab to the game window — its process name is captured after a 3-second countdown." />
+                    </StackPanel>
+                    <TextBlock Text="{Binding ControlPanel.DetectGameProcessStatus}"
+                               Foreground="{StaticResource TextTertiaryBrush}" Margin="0,4,0,0" />
+                </StackPanel>
             </GroupBox>
 
             <!-- Click-through -->

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -66,6 +66,13 @@
                 </Grid>
             </GroupBox>
 
+            <!-- Auto-hide on game unfocus (issue #116) -->
+            <GroupBox Header="Auto-Hide" Padding="8" Margin="0,0,0,12">
+                <CheckBox Content="Auto-hide overlays when neither the game nor Mithril has focus"
+                          IsChecked="{Binding ControlPanel.AutoHideOverlaysOnGameUnfocused}"
+                          ToolTip="Hides the map and inventory overlays while you alt-tab to a browser, Discord, etc., and restores whichever was visible when you return." />
+            </GroupBox>
+
             <!-- Click-through -->
             <GroupBox Header="Click-Through" Padding="8" Margin="0,0,0,12">
                 <StackPanel>
@@ -98,6 +105,41 @@
                         <TextBox Width="48" Margin="6,0,0,0" VerticalAlignment="Center"
                                  Text="{Binding ControlPanel.SurveyPinRadiusMetres, StringFormat=0.0, UpdateSourceTrigger=LostFocus}" />
                     </StackPanel>
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Pin Nudge (issue #117) -->
+            <GroupBox Header="Pin Nudge" Padding="8" Margin="0,0,0,12">
+                <StackPanel>
+                    <TextBlock Text="Step magnitudes (pixels) for the global Nudge Pin hotkeys. Bind keys under Settings → Hotkeys, category &quot;Legolas · Pin Nudge&quot;."
+                               Foreground="{StaticResource TextTertiaryBrush}" TextWrapping="Wrap" Margin="0,0,0,8" />
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="64" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Default step (px):" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding ControlPanel.NudgeStepDefault, StringFormat=0.##, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock Grid.Row="0" Grid.Column="2" Text="Default 1.0" Foreground="{StaticResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Fast step (px):" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding ControlPanel.NudgeStepFast, StringFormat=0.##, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock Grid.Row="1" Grid.Column="2" Text="Default 5.0" Foreground="{StaticResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Fine step (px):" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                                  Text="{Binding ControlPanel.NudgeStepFine, StringFormat=0.##, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock Grid.Row="2" Grid.Column="2" Text="Default 0.25" Foreground="{StaticResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
+                    </Grid>
                 </StackPanel>
             </GroupBox>
 

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -129,8 +129,14 @@
                                 <Thumb.Template>
                                     <ControlTemplate TargetType="Thumb">
                                         <Grid>
-                                            <!-- Outer ring: pulses while pending (uncorrected) -->
-                                            <Ellipse StrokeThickness="2" Fill="#01000000">
+                                            <!-- Outer ring: pulses opacity + stroke thickness + glow,
+                                                 plus marching-ants dashes, while pending (uncorrected) -->
+                                            <Ellipse StrokeThickness="2" Fill="#01000000"
+                                                     StrokeDashArray="4 2" StrokeDashOffset="0">
+                                                <Ellipse.Effect>
+                                                    <DropShadowEffect ShadowDepth="0" BlurRadius="4" Opacity="0.85"
+                                                                      Color="{Binding DataContext.Brushes.PinPending.Color, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                </Ellipse.Effect>
                                                 <Ellipse.Style>
                                                     <Style TargetType="Ellipse">
                                                         <Setter Property="Opacity" Value="1" />
@@ -145,11 +151,22 @@
                                                                         <Storyboard RepeatBehavior="Forever" AutoReverse="True">
                                                                             <DoubleAnimation Storyboard.TargetProperty="Opacity"
                                                                                 From="1.0" To="0.35" Duration="0:0:0.7" />
+                                                                            <DoubleAnimation Storyboard.TargetProperty="StrokeThickness"
+                                                                                From="2.0" To="4.0" Duration="0:0:0.7" />
+                                                                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.Effect).(DropShadowEffect.BlurRadius)"
+                                                                                From="4" To="16" Duration="0:0:0.7" />
+                                                                        </Storyboard>
+                                                                    </BeginStoryboard>
+                                                                    <BeginStoryboard Name="PinDashMarch">
+                                                                        <Storyboard RepeatBehavior="Forever">
+                                                                            <DoubleAnimation Storyboard.TargetProperty="StrokeDashOffset"
+                                                                                From="0" To="6" Duration="0:0:1.0" />
                                                                         </Storyboard>
                                                                     </BeginStoryboard>
                                                                 </DataTrigger.EnterActions>
                                                                 <DataTrigger.ExitActions>
                                                                     <StopStoryboard BeginStoryboardName="PinPulse" />
+                                                                    <StopStoryboard BeginStoryboardName="PinDashMarch" />
                                                                 </DataTrigger.ExitActions>
                                                             </DataTrigger>
                                                         </Style.Triggers>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -74,6 +74,25 @@
                           Stroke="{Binding Brushes.RouteLine}" StrokeThickness="2"
                           StrokeDashArray="4 2" IsHitTestVisible="False" />
 
+                <!-- Active segment: from the last-collected pin (or the anchor) to the
+                     current active target. Drawn on top of the static route line with a
+                     marching-ants StrokeDashOffset animation, so the player's eye is led
+                     to "where to go next" without numbering individual pins. -->
+                <Polyline Points="{Binding ActiveSegmentPoints}"
+                          Stroke="{Binding Brushes.RouteLine}" StrokeThickness="4"
+                          StrokeDashArray="6 3" IsHitTestVisible="False">
+                    <Polyline.Triggers>
+                        <EventTrigger RoutedEvent="Polyline.Loaded">
+                            <BeginStoryboard>
+                                <Storyboard RepeatBehavior="Forever">
+                                    <DoubleAnimation Storyboard.TargetProperty="StrokeDashOffset"
+                                                     From="0" To="9" Duration="0:0:0.6" />
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+                    </Polyline.Triggers>
+                </Polyline>
+
                 <!-- Player marker: outer ring + inner dot -->
                 <Canvas IsHitTestVisible="False">
                     <Grid Width="18" Height="18"
@@ -193,10 +212,6 @@
                                                     </Style>
                                                 </Ellipse.Style>
                                             </Ellipse>
-                                            <TextBlock Text="{Binding RouteOrder, Converter={x:Static controls:OneBasedConverter.Instance}}"
-                                                       Foreground="White"
-                                                       HorizontalAlignment="Center" VerticalAlignment="Top"
-                                                       Margin="0,2,0,0" FontSize="{DynamicResource AppFontSizeSmall}" FontWeight="Bold" />
                                         </Grid>
                                     </ControlTemplate>
                                 </Thumb.Template>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -130,17 +130,23 @@
                                     <ControlTemplate TargetType="Thumb">
                                         <Grid>
                                             <!-- Outer ring: pulses opacity + stroke thickness + glow,
-                                                 plus marching-ants dashes, while pending (uncorrected) -->
+                                                 plus marching-ants dashes, while pending (uncorrected).
+                                                 Effect is set via a Setter (not a property-element) so it
+                                                 exists before the IsCorrected=False trigger walks the
+                                                 (UIElement.Effect).(DropShadowEffect.BlurRadius) animation
+                                                 path — otherwise WPF throws "Effect property does not
+                                                 point to a DependencyObject" at template materialization. -->
                                             <Ellipse StrokeThickness="2" Fill="#01000000"
                                                      StrokeDashArray="4 2" StrokeDashOffset="0">
-                                                <Ellipse.Effect>
-                                                    <DropShadowEffect ShadowDepth="0" BlurRadius="4" Opacity="0.85"
-                                                                      Color="{Binding DataContext.Brushes.PinPending.Color, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                </Ellipse.Effect>
                                                 <Ellipse.Style>
                                                     <Style TargetType="Ellipse">
                                                         <Setter Property="Opacity" Value="1" />
                                                         <Setter Property="Stroke" Value="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                        <Setter Property="Effect">
+                                                            <Setter.Value>
+                                                                <DropShadowEffect ShadowDepth="0" BlurRadius="4" Opacity="0.85" Color="#FFFFFFFF" />
+                                                            </Setter.Value>
+                                                        </Setter>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding IsCorrected}" Value="True">
                                                                 <Setter Property="Stroke" Value="{Binding DataContext.Brushes.PinFinalized, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -74,26 +74,16 @@ public partial class MapOverlayView : Window
 
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
-        if (DataContext is not MapOverlayViewModel vm) { base.OnPreviewKeyDown(e); return; }
-        var selected = vm.Session.SelectedSurvey;
-        if (selected is null || !selected.EffectivePixel.HasValue) { base.OnPreviewKeyDown(e); return; }
-
-        var step = (Keyboard.Modifiers & ModifierKeys.Shift) != 0 ? 5.0
-                 : (Keyboard.Modifiers & ModifierKeys.Control) != 0 ? 0.25
-                 : 1.0;
-        double dx = 0, dy = 0;
-        switch (e.Key)
+        // Arrow-key pin nudging moved to global IHotkeyCommand registrations
+        // (Legolas · Pin Nudge category) so it works while the game window has
+        // focus. Local handler now only clears the active selection on Escape.
+        if (DataContext is MapOverlayViewModel vm && e.Key == Key.Escape)
         {
-            case Key.Left: dx = -step; break;
-            case Key.Right: dx = step; break;
-            case Key.Up: dy = -step; break;
-            case Key.Down: dy = step; break;
-            case Key.Escape: vm.Session.SelectedSurvey = null; e.Handled = true; return;
-            default: base.OnPreviewKeyDown(e); return;
+            vm.Session.SelectedSurvey = null;
+            e.Handled = true;
+            return;
         }
-        var p = selected.EffectivePixel.Value;
-        vm.CorrectSurveyCommand.Execute(new CorrectionArgs(selected, new PixelPoint(p.X + dx, p.Y + dy)));
-        e.Handled = true;
+        base.OnPreviewKeyDown(e);
     }
 
     private void SurveyDot_DragDelta(object sender, DragDeltaEventArgs e)

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -264,9 +264,30 @@
                 <!-- Gathering -->
                 <StackPanel Visibility="{Binding CurrentStep, Converter={x:Static controls:EnumMatchConverter.ToVisibility}, ConverterParameter=Gathering}">
                     <TextBlock Text="Walk to each target in order. We'll mark them collected automatically. New surveys are ignored until you reset (the projector is anchored to where you started)."
-                               TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,24"
+                               TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,16"
                                FontSize="{DynamicResource AppFontSizeBody}"
                                Foreground="{StaticResource TextSecondaryBrush}" />
+
+                    <!-- Active-target summary: shows progress + the next pin's name out
+                         here, since the map overlay no longer numbers individual pins. -->
+                    <Border Background="{StaticResource AccentSoftBrush}" CornerRadius="3" Padding="12,8" Margin="0,0,0,20"
+                            HorizontalAlignment="Center">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Session.ActiveTargetSummary}" Value="">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock Text="{Binding Session.ActiveTargetSummary}"
+                                   FontWeight="SemiBold"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource AccentSoftTextBrush}" />
+                    </Border>
+
                     <Button Content="Mark current collected" Style="{StaticResource WizardPrimaryButton}"
                             HorizontalAlignment="Center" Margin="0"
                             Command="{Binding ControlPanel.MarkCurrentCollectedCommand}" />

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -222,13 +222,24 @@
                             <TextBlock Text="1.  Use the leftmost survey"
                                        FontSize="{DynamicResource AppFontSizeBody}"
                                        Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
-                            <TextBlock Text="2.  Click its position on the map when the [Status] line appears"
+                            <TextBlock TextWrapping="Wrap"
                                        FontSize="{DynamicResource AppFontSizeBody}"
-                                       Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
+                                       Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2">
+                                <Run Text="2.  Click its position on the map. For the first couple of surveys, read the " />
+                                <Run Text="[Status]" FontWeight="SemiBold" />
+                                <Run Text=" line in chat for direction + distance. After that we have enough data to project, so upcoming pins will pre-position themselves — just click near the in-game ping." />
+                            </TextBlock>
                             <TextBlock Text="3.  Repeat left-to-right, then start the next row from the left"
                                        FontSize="{DynamicResource AppFontSizeBody}"
                                        Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
                         </StackPanel>
+                        <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0,12,0,0"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource TextTertiaryBrush}">
+                            <Run Text="Tip: fine-tune the selected pin with the Pin Nudge hotkeys — bind keys under Settings → Hotkeys, category " />
+                            <Run Text="Legolas · Pin Nudge" FontStyle="Italic" />
+                            <Run Text="." />
+                        </TextBlock>
                     </StackPanel>
                     <Border Background="{StaticResource AccentSoftBrush}" CornerRadius="3" Padding="12,8" Margin="0,0,0,20"
                             HorizontalAlignment="Center">

--- a/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
+++ b/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
@@ -1,0 +1,156 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Hotkeys;
+using Legolas.Services;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.Hotkeys;
+
+public class NudgePinCommandTests
+{
+    private static (SessionState session, MapOverlayViewModel map, LegolasSettings settings)
+        BuildSut()
+    {
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(new LegolasColors());
+        var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
+        return (session, map, settings);
+    }
+
+    private static SurveyItemViewModel SeedSelectedSurveyAt(
+        SessionState session, double x, double y)
+    {
+        var survey = Survey.Create("Test", new MetreOffset(0, 0), gridIndex: 0)
+            with { ManualOverride = new PixelPoint(x, y) };
+        var vm = new SurveyItemViewModel(survey);
+        session.Surveys.Add(vm);
+        session.SelectedSurvey = vm;
+        return vm;
+    }
+
+    [Fact]
+    public async Task Up_default_moves_pin_minus_one_y()
+    {
+        var (session, map, settings) = BuildSut();
+        var vm = SeedSelectedSurveyAt(session, 100, 200);
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        vm.Model.ManualOverride!.Value.X.Should().Be(100);
+        vm.Model.ManualOverride!.Value.Y.Should().Be(199);
+    }
+
+    [Fact]
+    public async Task Down_fast_moves_pin_plus_five_y()
+    {
+        var (session, map, settings) = BuildSut();
+        var vm = SeedSelectedSurveyAt(session, 100, 200);
+        var cmd = new NudgePinDownFastCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        vm.Model.ManualOverride!.Value.X.Should().Be(100);
+        vm.Model.ManualOverride!.Value.Y.Should().BeApproximately(205, 1e-9);
+    }
+
+    [Fact]
+    public async Task Right_fine_moves_pin_plus_quarter_x()
+    {
+        var (session, map, settings) = BuildSut();
+        var vm = SeedSelectedSurveyAt(session, 100, 200);
+        var cmd = new NudgePinRightFineCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        vm.Model.ManualOverride!.Value.X.Should().BeApproximately(100.25, 1e-9);
+        vm.Model.ManualOverride!.Value.Y.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task Left_default_moves_pin_minus_one_x()
+    {
+        var (session, map, settings) = BuildSut();
+        var vm = SeedSelectedSurveyAt(session, 100, 200);
+        var cmd = new NudgePinLeftCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        vm.Model.ManualOverride!.Value.X.Should().Be(99);
+        vm.Model.ManualOverride!.Value.Y.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task Override_default_step_changes_resulting_pixel()
+    {
+        var (session, map, settings) = BuildSut();
+        var vm = SeedSelectedSurveyAt(session, 100, 200);
+        settings.NudgeStepDefault = 3.0;
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        vm.Model.ManualOverride!.Value.Y.Should().Be(197);
+    }
+
+    [Fact]
+    public async Task Null_selected_survey_is_noop()
+    {
+        var (session, map, settings) = BuildSut();
+        session.SelectedSurvey = null;
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        var act = () => cmd.ExecuteAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Selected_survey_without_effective_pixel_is_noop()
+    {
+        var (session, map, settings) = BuildSut();
+        var survey = Survey.Create("Test", new MetreOffset(0, 0), gridIndex: 0);
+        // No ManualOverride and no PixelPos → EffectivePixel is null.
+        var vm = new SurveyItemViewModel(survey);
+        session.Surveys.Add(vm);
+        session.SelectedSurvey = vm;
+
+        var cmd = new NudgePinUpCommand(session, map, settings);
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        vm.Model.ManualOverride.Should().BeNull("nudge cannot start from no pixel");
+    }
+
+    [Fact]
+    public void Negative_step_setting_clamps_to_default()
+    {
+        var settings = new LegolasSettings();
+        settings.NudgeStepDefault = -2.0;
+        settings.NudgeStepDefault.Should().Be(1.0, "negative step would silently disable the nudge");
+    }
+
+    [Fact]
+    public void Zero_step_setting_clamps_to_default()
+    {
+        var settings = new LegolasSettings();
+        settings.NudgeStepFast = 0;
+        settings.NudgeStepFast.Should().Be(5.0);
+        settings.NudgeStepFine = 0;
+        settings.NudgeStepFine.Should().Be(0.25);
+    }
+
+    [Fact]
+    public void Hotkey_metadata_is_categorised_under_pin_nudge()
+    {
+        var (session, map, settings) = BuildSut();
+        var cmd = new NudgePinUpCommand(session, map, settings);
+        cmd.Category.Should().Be("Legolas · Pin Nudge");
+        cmd.Id.Should().Be("legolas.pin.nudge.up");
+        cmd.DefaultBinding.Should().BeNull("arrow keys collide with in-game movement; user must opt in");
+    }
+}

--- a/tests/Legolas.Tests/Settings/LegolasSettingsGameProcessTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasSettingsGameProcessTests.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Legolas.Domain;
+
+namespace Legolas.Tests.Settings;
+
+public class LegolasSettingsGameProcessTests
+{
+    [Fact]
+    public void GameProcessName_default_is_ProjectGorgon()
+    {
+        new LegolasSettings().GameProcessName.Should().Be("ProjectGorgon");
+    }
+
+    [Fact]
+    public void GameProcessName_trims_whitespace_on_set()
+    {
+        var s = new LegolasSettings();
+        s.GameProcessName = "  PG_x64  ";
+        s.GameProcessName.Should().Be("PG_x64");
+    }
+
+    [Fact]
+    public void GameProcessName_preserves_internal_whitespace()
+    {
+        // Substring match must still work for launchers that name the
+        // executable with a space, so internal spaces are preserved.
+        var s = new LegolasSettings();
+        s.GameProcessName = "Project Gorgon";
+        s.GameProcessName.Should().Be("Project Gorgon");
+    }
+
+    [Fact]
+    public void GameProcessName_null_becomes_empty()
+    {
+        var s = new LegolasSettings();
+        s.GameProcessName = null!;
+        s.GameProcessName.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void GameProcessName_raises_PropertyChanged_on_change()
+    {
+        var s = new LegolasSettings();
+        var changed = new List<string?>();
+        ((INotifyPropertyChanged)s).PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        s.GameProcessName = "Different";
+
+        changed.Should().Contain(nameof(LegolasSettings.GameProcessName));
+    }
+
+    [Fact]
+    public void GameProcessName_does_not_raise_PropertyChanged_when_unchanged()
+    {
+        var s = new LegolasSettings { GameProcessName = "ProjectGorgon" };
+        var changed = new List<string?>();
+        ((INotifyPropertyChanged)s).PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        s.GameProcessName = "ProjectGorgon";
+        s.GameProcessName = "  ProjectGorgon  "; // post-trim equal to existing
+
+        changed.Should().NotContain(nameof(LegolasSettings.GameProcessName));
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/ActiveTargetTests.cs
+++ b/tests/Legolas.Tests/ViewModels/ActiveTargetTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.ViewModels;
+
+public class ActiveTargetTests
+{
+    private static (SessionState session, MapOverlayViewModel map, LegolasSettings settings)
+        BuildSut()
+    {
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(new LegolasColors());
+        var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
+        return (session, map, settings);
+    }
+
+    private static SurveyItemViewModel SeedSurveyAt(SessionState session, string name, double x, double y, int routeOrder)
+    {
+        var survey = Survey.Create(name, new MetreOffset(x, y), gridIndex: routeOrder)
+            with { ManualOverride = new PixelPoint(x, y), RouteOrder = routeOrder };
+        var vm = new SurveyItemViewModel(survey);
+        session.Surveys.Add(vm);
+        return vm;
+    }
+
+    // ─── ActiveSegmentPoints ─────────────────────────────────────────────
+
+    [Fact]
+    public void ActiveSegment_is_empty_when_no_active_target()
+    {
+        var (_, map, _) = BuildSut();
+        map.ActiveSegmentPoints.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void ActiveSegment_runs_from_anchor_to_active_when_nothing_collected()
+    {
+        var (session, map, _) = BuildSut();
+        session.PlayerPosition = new PixelPoint(100, 100);
+        SeedSurveyAt(session, "First", 200, 200, 0);
+        SeedSurveyAt(session, "Second", 300, 300, 1);
+
+        // Active target is the first uncollected — the one at (200,200).
+        map.ActiveSegmentPoints.Count.Should().Be(2);
+        map.ActiveSegmentPoints[0].X.Should().Be(100);
+        map.ActiveSegmentPoints[0].Y.Should().Be(100);
+        map.ActiveSegmentPoints[1].X.Should().Be(200);
+        map.ActiveSegmentPoints[1].Y.Should().Be(200);
+    }
+
+    [Fact]
+    public void ActiveSegment_starts_from_last_collected_pin_after_one_collection()
+    {
+        var (session, map, _) = BuildSut();
+        session.PlayerPosition = new PixelPoint(100, 100);
+        var first = SeedSurveyAt(session, "First", 200, 200, 0);
+        SeedSurveyAt(session, "Second", 300, 300, 1);
+
+        first.UpdateModel(first.Model with { Collected = true });
+
+        // Active target rotates to "Second"; segment now starts from the
+        // most-recently-collected pin (First @ 200,200), not the anchor.
+        map.ActiveSegmentPoints.Count.Should().Be(2);
+        map.ActiveSegmentPoints[0].X.Should().Be(200);
+        map.ActiveSegmentPoints[0].Y.Should().Be(200);
+        map.ActiveSegmentPoints[1].X.Should().Be(300);
+        map.ActiveSegmentPoints[1].Y.Should().Be(300);
+    }
+
+    [Fact]
+    public void ActiveSegment_uses_highest_RouteOrder_collected_as_start()
+    {
+        var (session, map, _) = BuildSut();
+        session.PlayerPosition = new PixelPoint(0, 0);
+        var p0 = SeedSurveyAt(session, "P0", 100, 100, 0);
+        var p1 = SeedSurveyAt(session, "P1", 200, 200, 1);
+        SeedSurveyAt(session, "P2", 300, 300, 2);
+
+        p0.UpdateModel(p0.Model with { Collected = true });
+        p1.UpdateModel(p1.Model with { Collected = true });
+
+        // Highest-ordered collected is P1 @ (200,200); active target is P2.
+        map.ActiveSegmentPoints[0].X.Should().Be(200);
+        map.ActiveSegmentPoints[0].Y.Should().Be(200);
+        map.ActiveSegmentPoints[1].X.Should().Be(300);
+        map.ActiveSegmentPoints[1].Y.Should().Be(300);
+    }
+
+    [Fact]
+    public void ActiveSegment_clears_when_route_lines_disabled()
+    {
+        var (session, map, _) = BuildSut();
+        session.PlayerPosition = new PixelPoint(0, 0);
+        SeedSurveyAt(session, "P0", 100, 100, 0);
+        map.ActiveSegmentPoints.Count.Should().Be(2, "sanity check");
+
+        session.ShowRouteLines = false;
+
+        map.ActiveSegmentPoints.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void ActiveSegment_clears_when_all_collected()
+    {
+        var (session, map, _) = BuildSut();
+        session.PlayerPosition = new PixelPoint(0, 0);
+        var only = SeedSurveyAt(session, "Only", 100, 100, 0);
+
+        only.UpdateModel(only.Model with { Collected = true });
+
+        map.ActiveSegmentPoints.Count.Should().Be(0, "no remaining active target → no segment");
+    }
+
+    // ─── ActiveTargetSummary ─────────────────────────────────────────────
+
+    [Fact]
+    public void Summary_is_empty_initially()
+    {
+        var session = new SessionState();
+        session.ActiveTargetSummary.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Summary_formats_as_one_based_count_and_name()
+    {
+        var (session, _, _) = BuildSut();
+        SeedSurveyAt(session, "Hawthorn Tree", 100, 100, 0);
+        SeedSurveyAt(session, "Pine", 200, 200, 1);
+        SeedSurveyAt(session, "Oak", 300, 300, 2);
+
+        // First active target: P0 (RouteOrder=0 → "#1 of 3 — Hawthorn Tree")
+        session.ActiveTargetSummary.Should().Be("Next: #1 of 3 — Hawthorn Tree");
+    }
+
+    [Fact]
+    public void Summary_advances_as_pins_are_collected()
+    {
+        var (session, _, _) = BuildSut();
+        var p0 = SeedSurveyAt(session, "Pin0", 100, 100, 0);
+        SeedSurveyAt(session, "Pin1", 200, 200, 1);
+
+        p0.UpdateModel(p0.Model with { Collected = true });
+
+        session.ActiveTargetSummary.Should().Be("Next: #2 of 2 — Pin1");
+    }
+
+    [Fact]
+    public void Summary_clears_when_all_collected()
+    {
+        var (session, _, _) = BuildSut();
+        var only = SeedSurveyAt(session, "Only", 100, 100, 0);
+
+        only.UpdateModel(only.Model with { Collected = true });
+
+        session.ActiveTargetSummary.Should().Be(string.Empty);
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #116 — Auto-hide the map and inventory overlays when neither Mithril nor Project Gorgon has foreground focus. New `ForegroundFocusGate` (`SetWinEventHook` on `EVENT_SYSTEM_FOREGROUND`) gates the existing show/hide path in `OverlayController` without mutating `SessionState.IsMapVisible` / `IsInventoryVisible`, so when focus returns the previously-visible overlays come back and previously-hidden ones stay hidden. New `AutoHideOverlaysOnGameUnfocused` setting (default on) with a checkbox in Legolas settings to opt out.
- Closes #117 — 12 new `IHotkeyCommand` registrations (4 directions × 3 step tiers) under category **Legolas · Pin Nudge** so pin nudging works while the *game* window has focus. `DefaultBinding => null` because arrow keys collide with in-game movement; users opt in via Settings → Hotkeys. Step magnitudes are configurable (`NudgeStepDefault` / `Fast` / `Fine`), clamped > 0 to avoid silent no-op. The local `OnPreviewKeyDown` arrow handler in `MapOverlayView` was removed to eliminate double-nudge — only Escape-clears-selection remains.
- Polish — Pending-pin outer ring now layers four animations (opacity pulse + stroke-thickness pulse + marching-ants dashes + drop-shadow glow). All stop cleanly when `IsCorrected = true`.

## Architecture notes

- **No mutation of intent flags.** The gate is a render filter: `visible = sessionFlag && (gate.IsInApp || !settings.AutoHideOverlaysOnGameUnfocused)`. This is what makes "previously-hidden stays hidden" fall out for free.
- **In-app predicate** is `pid == ownPid || ProcessName equals "ProjectGorgon" (case-insensitive)`. The plan briefly considered also matching the foreground process's `MainModule.FileName` against `GameLocator.AutoDetectGameRoot()`, but `GameLocator` returns the LocalLow *data* path, not the install root — the game executable doesn't live there, so the check would never succeed. Process-name match is the robust signal.
- **12 commands cost 0 OS hooks** until the user binds them. [`HotkeyService.RegisterAll()`](https://github.com/arthur-conde/project-gorgon/blob/main/src/Mithril.Shared/Hotkeys/HotkeyService.cs#L37) only calls `RegisterHotKey` for entries in `_lastBindings`, so unbound commands appear as searchable rows in the Hotkeys settings UI without claiming any system-wide combos.
- **Hook lifetime.** The `WINEVENTPROC` delegate is held in a private field to prevent GC; `WINEVENT_OUTOFCONTEXT` delivery means the callback runs on the WPF UI thread, so no marshaling is needed when the callback flips `IsInApp`. `Process.GetProcessById` is wrapped in a `try/catch` to handle race exits and elevated-process access denials.

## Tests

- 10 new unit tests in `tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs` covering: per-direction movement, all three tiers, `null SelectedSurvey` no-op, missing `EffectivePixel` no-op, settings override changes the resulting pixel, negative/zero step values clamp to defaults, and hotkey metadata (Id/Category/DefaultBinding).
- Full **Legolas.Tests** (108) and full solution test suite green save for one pre-existing flake in `IconCachePreloadTests.PreloadAsync_downloads_missing_ids_and_reports_progress` (unrelated to this change — passes in isolation, fails sporadically under suite-level concurrency).

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors).
- [x] `dotnet test tests/Legolas.Tests` — 108/108 green including 10 new nudge tests.
- [x] App boots cleanly (`Mithril.exe` launches with main window).
- [ ] **Manual UI verification needed** — interactive checks I cannot drive from the CLI:
  - [ ] Open both overlays, alt-tab to a browser → both hide. Alt-tab back → both restore.
  - [ ] Hide inventory manually, alt-tab away, back → only map restores.
  - [ ] Uncheck *Auto-hide overlays when neither the game nor Mithril has focus* → overlays stay visible across focus loss.
  - [ ] With the actual game running, alt-tab Mithril ↔ Project Gorgon → no overlay flicker.
  - [ ] Bind nudge hotkeys (e.g. `Ctrl+Alt+Up/Down/Left/Right` for default tier) — focus the game window, press them, pin moves.
  - [ ] Plain arrow keys with map overlay focused → nothing happens (local handler removed).
  - [ ] Place a fresh pin → outer ring shows opacity pulse + stroke-thickness pulse + marching ants + glow. Nudge it once → all three animations stop and the ring switches to the finalized brush.
  - [ ] Change `NudgeStepDefault` to e.g. 3.0 → default nudge moves 3 px. Set to 0 → setter clamps back to 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)