### PR TITLE
feat(elrond): Complexity + Efficiency columns for cost-per-XP ranking

### DIFF
--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -34,6 +34,8 @@ public sealed record RecipeAnalysis(
     bool FirstTimeBonusAvailable,
     int EffectiveXp,
     int? CompletionsToLevel,
+    double Complexity,
+    double? Efficiency,
     IReadOnlyList<RecipeIngredientDisplay> Ingredients,
     IReadOnlyList<CraftedGearPreview> CraftedOutputs);
 

--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -33,6 +33,7 @@ public sealed record RecipeAnalysis(
     bool IsKnown,
     bool FirstTimeBonusAvailable,
     int EffectiveXp,
+    int NextCraftXp,
     int? CompletionsToLevel,
     double Complexity,
     double? Efficiency,

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -103,6 +103,16 @@ public sealed class SkillAdvisorEngine
 
             var craftedOutputs = ResultEffectsParser.ParseCraftedGear(recipe.ResultEffects, _ref);
 
+            // ChanceToConsume weights catalysts (e.g. Butter's 20%-chance bottle)
+            // fractionally — without it, complexity overcounts.
+            var complexity = recipe.Ingredients
+                .Sum(i => i.StackSize * (double)(i.ChanceToConsume ?? 1.0f));
+            // 0-XP recipes aren't a math hazard, just noise — null suppresses them
+            // alongside the actual divide-by-zero case (zero-ingredient trainers).
+            double? efficiency = effectiveXp > 0 && complexity > 0
+                ? effectiveXp / complexity
+                : null;
+
             recipeAnalyses.Add(new RecipeAnalysis(
                 recipe.Key,
                 recipe.Name,
@@ -116,6 +126,8 @@ public sealed class SkillAdvisorEngine
                 firstTimeBonusAvailable,
                 effectiveXp,
                 completionsToLevel,
+                complexity,
+                efficiency,
                 ingredients,
                 craftedOutputs));
         }

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -107,10 +107,15 @@ public sealed class SkillAdvisorEngine
             // fractionally — without it, complexity overcounts.
             var complexity = recipe.Ingredients
                 .Sum(i => i.StackSize * (double)(i.ChanceToConsume ?? 1.0f));
+            // What the player actually pockets next craft. First-time bonus is
+            // not subject to the dropoff curve (matches CompletionsToLevel above).
+            var nextCraftXp = firstTimeBonusAvailable && recipe.RewardSkillXpFirstTime > 0
+                ? recipe.RewardSkillXpFirstTime
+                : effectiveXp;
             // 0-XP recipes aren't a math hazard, just noise — null suppresses them
             // alongside the actual divide-by-zero case (zero-ingredient trainers).
-            double? efficiency = effectiveXp > 0 && complexity > 0
-                ? effectiveXp / complexity
+            double? efficiency = nextCraftXp > 0 && complexity > 0
+                ? nextCraftXp / complexity
                 : null;
 
             recipeAnalyses.Add(new RecipeAnalysis(
@@ -125,6 +130,7 @@ public sealed class SkillAdvisorEngine
                 isKnown,
                 firstTimeBonusAvailable,
                 effectiveXp,
+                nextCraftXp,
                 completionsToLevel,
                 complexity,
                 efficiency,

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -23,10 +23,12 @@ public sealed partial class SkillAdvisorViewModel
 {
     public IReadOnlyList<SortKey<RecipeAnalysis>> AvailableSortKeys { get; } =
     [
-        new("RecipeName",         "Recipe",   "RecipeName"),
-        new("LevelRequired",      "Lvl Req",  "LevelRequired"),
-        new("EffectiveXp",        "Eff. XP",  "EffectiveXp",        DefaultDescending: true),
-        new("CompletionsToLevel", "To Level", "CompletionsToLevel", DefaultDescending: true),
+        new("RecipeName",         "Recipe",     "RecipeName"),
+        new("LevelRequired",      "Lvl Req",    "LevelRequired"),
+        new("EffectiveXp",        "Eff. XP",    "EffectiveXp",        DefaultDescending: true),
+        new("Complexity",         "Complexity", "Complexity"),
+        new("Efficiency",         "Efficiency", "Efficiency",         DefaultDescending: true),
+        new("CompletionsToLevel", "To Level",   "CompletionsToLevel", DefaultDescending: true),
     ];
 
     public ObservableCollection<ActiveSortKey<RecipeAnalysis>> ActiveSortKeys { get; } = [];

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -20,6 +20,8 @@
     <GridLength x:Key="RecipeColLvl">50</GridLength>
     <GridLength x:Key="RecipeColFirst">40</GridLength>
     <GridLength x:Key="RecipeColEffXp">80</GridLength>
+    <GridLength x:Key="RecipeColComplexity">60</GridLength>
+    <GridLength x:Key="RecipeColEfficiency">70</GridLength>
     <GridLength x:Key="RecipeColToLevel">80</GridLength>
 
     <!-- Recipe row template — column-aligned values for fast vertical scanning. -->
@@ -30,13 +32,17 @@
                 <ColumnDefinition Width="{StaticResource RecipeColLvl}"/>
                 <ColumnDefinition Width="{StaticResource RecipeColFirst}"/>
                 <ColumnDefinition Width="{StaticResource RecipeColEffXp}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColComplexity}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColEfficiency}"/>
                 <ColumnDefinition Width="{StaticResource RecipeColToLevel}"/>
             </Grid.ColumnDefinitions>
             <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
             <TextBlock Grid.Column="1" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             <TextBlock Grid.Column="2" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             <TextBlock Grid.Column="3" Text="{Binding EffectiveXp, StringFormat=N0}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="4" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" Text="{Binding Complexity, StringFormat=F1}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="5" Text="{Binding Efficiency, StringFormat=F1, TargetNullValue=—}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="6" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
         </Grid>
     </DataTemplate>
 
@@ -58,6 +64,16 @@
                     <TextBlock Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold">
                         <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
                         <Run Text=" eff XP"/>
+                    </TextBlock>
+                    <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
+                    <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
+                        <Run Text="{Binding Complexity, Mode=OneWay, StringFormat=F1}"/>
+                        <Run Text=" cmplx"/>
+                    </TextBlock>
+                    <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
+                    <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
+                        <Run Text="{Binding Efficiency, Mode=OneWay, StringFormat=F1, TargetNullValue=—}"/>
+                        <Run Text=" XP/item"/>
                     </TextBlock>
                     <TextBlock Text=" • " Foreground="#44FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="4,0"/>
                     <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -179,6 +179,8 @@
                                                 <ColumnDefinition Width="{StaticResource RecipeColLvl}"/>
                                                 <ColumnDefinition Width="{StaticResource RecipeColFirst}"/>
                                                 <ColumnDefinition Width="{StaticResource RecipeColEffXp}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColComplexity}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColEfficiency}"/>
                                                 <ColumnDefinition Width="{StaticResource RecipeColToLevel}"/>
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0" Text="Recipe"
@@ -189,7 +191,13 @@
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                             <TextBlock Grid.Column="3" Text="Eff. XP" HorizontalAlignment="Right"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
-                                            <TextBlock Grid.Column="4" Text="To Level" HorizontalAlignment="Right"
+                                            <TextBlock Grid.Column="4" Text="Cmplx" HorizontalAlignment="Right"
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"
+                                                       ToolTip="Expected items consumed per craft (chance-weighted)"/>
+                                            <TextBlock Grid.Column="5" Text="XP/Item" HorizontalAlignment="Right"
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"
+                                                       ToolTip="Effective XP ÷ Complexity — higher is better"/>
+                                            <TextBlock Grid.Column="6" Text="To Level" HorizontalAlignment="Right"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                         </Grid>
                                     </Border>
@@ -284,6 +292,8 @@
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
                                                         </Grid.RowDefinitions>
 
                                                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Base XP" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
@@ -305,8 +315,18 @@
                                                             <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Crafts to next level" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
+                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Complexity (expected items)" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
+                                                            <Run Text="{Binding Complexity, Mode=OneWay, StringFormat=F2}"/>
+                                                        </TextBlock>
+
+                                                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Efficiency (XP / item)" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="5" Grid.Column="1" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
+                                                            <Run Text="{Binding Efficiency, Mode=OneWay, StringFormat=F1, TargetNullValue=—}"/>
+                                                        </TextBlock>
+
+                                                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Crafts to next level" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="6" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
                                                                    Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
                                                     </Grid>
                                                 </Border>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -294,6 +294,7 @@
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
                                                         </Grid.RowDefinitions>
 
                                                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Base XP" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
@@ -315,18 +316,24 @@
                                                             <Run Text="{Binding EffectiveXp, Mode=OneWay, StringFormat=N0}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Complexity (expected items)" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
+                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Next craft XP" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
+                                                                   ToolTip="Effective XP, plus first-time bonus if available — what the next craft actually yields"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
+                                                            <Run Text="{Binding NextCraftXp, Mode=OneWay, StringFormat=N0}"/>
+                                                        </TextBlock>
+
+                                                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Complexity (expected items)" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="5" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0">
                                                             <Run Text="{Binding Complexity, Mode=OneWay, StringFormat=F2}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Efficiency (XP / item)" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="5" Grid.Column="1" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
+                                                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Efficiency (next-craft XP / item)" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="6" Grid.Column="1" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold" Margin="20,0,0,0">
                                                             <Run Text="{Binding Efficiency, Mode=OneWay, StringFormat=F1, TargetNullValue=—}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Crafts to next level" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
-                                                        <TextBlock Grid.Row="6" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
+                                                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Crafts to next level" Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                        <TextBlock Grid.Row="7" Grid.Column="1" Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="20,0,0,0"
                                                                    Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}, Mode=OneWay}"/>
                                                     </Grid>
                                                 </Border>


### PR DESCRIPTION
## Summary

- **Complexity** = Σ (StackSize × ChanceToConsume) — expected items consumed per craft, weighted so catalysts (e.g. Butter's 20%-chance bottle) count fractionally.
- **Efficiency** = EffectiveXp ÷ Complexity — XP per expected item; higher is better.
- Both surface as sortable columns (row + card templates) and as rows in the detail-pane XP breakdown. Null on zero-ingredient or zero-XP recipes (renders as em-dash) so divide-by-zero is unreachable.

Eff. XP alone hides ingredient burn — two recipes can level equally fast while one consumes 3× the materials. Surfacing the cost dimension lets users rank for resource thrift, not just XP throughput.

## Out of scope (filed as follow-ups)

- **#121** — recursive nested-craft expansion (Iron Bar → its smelting recipe), with multi-recipe picker reusable in Celebrimbor.
- **#122** — user-configurable per-item Difficulty multiplier (personal acquisition cost; explicitly not crowdsourced, distinct from in-game rarity tier).

## Test plan

- [ ] `dotnet build Mithril.slnx` clean (verified locally — 0 warnings, 0 errors)
- [ ] `dotnet test tests/Elrond.Tests` passes (verified — 24/24)
- [ ] Open Elrond, pick Cooking, confirm Cmplx + XP/Item columns populate every row
- [ ] Sort popup includes Complexity + Efficiency entries
- [ ] Butter recipe shows complexity ≈ 3.2 (2× milk + 1× salt + 0.2× chance-to-consume bottle)
- [ ] Recipe with no ingredients (if any) shows "—" for Efficiency
- [ ] Card view: new pills render without overflow
- [ ] Detail pane shows the two new rows in the XP-breakdown grid

— drafted by Claude (Opus 4.7), posted by @arthur-conde