### PR TITLE
fix(legolas): floor overlay opacity at 1% so faded overlays stay clickable

### DIFF
--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -37,14 +37,20 @@ public sealed class LegolasSettings : INotifyPropertyChanged
     public WindowLayout MapOverlay { get; set; } = new() { Width = 800, Height = 600 };
     public WindowLayout InventoryOverlay { get; set; } = new() { Width = 540, Height = 440 };
 
+    // WPF stops hit-testing fully-transparent elements regardless of IsHitTestVisible,
+    // so a 0-opacity overlay silently becomes unclickable. Floor at 1% — visually
+    // indistinguishable from invisible, but the surface stays interactive.
+    public const double MinInteractiveOpacity = 0.01;
+
     private double _mapOpacity = 1.0;
     public double MapOpacity
     {
         get => _mapOpacity;
         set
         {
-            if (Math.Abs(_mapOpacity - value) < 1e-6) return;
-            _mapOpacity = value;
+            var clamped = Math.Max(value, MinInteractiveOpacity);
+            if (Math.Abs(_mapOpacity - clamped) < 1e-6) return;
+            _mapOpacity = clamped;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MapOpacity)));
         }
     }
@@ -55,8 +61,9 @@ public sealed class LegolasSettings : INotifyPropertyChanged
         get => _inventoryOpacity;
         set
         {
-            if (Math.Abs(_inventoryOpacity - value) < 1e-6) return;
-            _inventoryOpacity = value;
+            var clamped = Math.Max(value, MinInteractiveOpacity);
+            if (Math.Abs(_inventoryOpacity - clamped) < 1e-6) return;
+            _inventoryOpacity = clamped;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(InventoryOpacity)));
         }
     }

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -46,13 +46,13 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Map opacity" VerticalAlignment="Center" Margin="0,4,8,4" />
-                    <Slider   Grid.Row="0" Grid.Column="1" Minimum="0.0" Maximum="1.0"
+                    <Slider   Grid.Row="0" Grid.Column="1" Minimum="0.01" Maximum="1.0"
                               Value="{Binding Session.MapOpacity}" VerticalAlignment="Center" />
                     <TextBox  Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" Margin="4,0,0,0"
                               Text="{Binding Session.MapOpacity, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Inv opacity" VerticalAlignment="Center" Margin="0,4,8,4" />
-                    <Slider   Grid.Row="1" Grid.Column="1" Minimum="0.0" Maximum="1.0"
+                    <Slider   Grid.Row="1" Grid.Column="1" Minimum="0.01" Maximum="1.0"
                               Value="{Binding Session.InventoryOpacity}" VerticalAlignment="Center" />
                     <TextBox  Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Margin="4,0,0,0"
                               Text="{Binding Session.InventoryOpacity, StringFormat=0.00, UpdateSourceTrigger=LostFocus}" />


### PR DESCRIPTION
## Summary

WPF stops hit-testing fully-transparent elements regardless of `IsHitTestVisible`, so a 0-opacity overlay silently becomes unclickable. Discovered while exercising the auto-hide / opacity-slider behavior.

- Slider `Minimum` bumps from `0.0` → `0.01` on both Map and Inventory opacity sliders. 1% is visually indistinguishable from invisible but keeps the surface live.
- `MapOpacity` / `InventoryOpacity` setters now clamp via `Math.Max(value, MinInteractiveOpacity)` so typing `0` in the companion TextBox, or loading old persisted state with `0`, self-heals on next read.
- New `LegolasSettings.MinInteractiveOpacity` constant carries the value with a comment explaining the WPF behavior so a future reader doesn't "fix" the floor.

If a Legolas overlay genuinely needs to be inert, `Visibility=Collapsed` is the correct signal — not `Opacity=0`.

## Test plan

- [ ] `dotnet build Mithril.slnx` clean (verified — 0 warnings, 0 errors on Legolas.Module)
- [ ] Open Legolas settings → drag Map opacity slider all the way left; confirm it stops at 1% and the map overlay still receives clicks
- [ ] Type `0` into the Map opacity TextBox; confirm it snaps to `0.01`
- [ ] Repeat for Inventory opacity
- [ ] Existing user with persisted `0` opacity: confirm setting auto-corrects on first launch

— drafted by Claude (Opus 4.7), posted by @arthur-conde