### PR TITLE
feat(legolas): nudgeable player anchor until first survey lands (#120)

### DIFF
--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -233,14 +233,26 @@ public abstract class NudgePinCommandBase : IHotkeyCommand
 
     public Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var selected = _session.SelectedSurvey;
-        if (selected is null || !selected.EffectivePixel.HasValue) return Task.CompletedTask;
-
-        var p = selected.EffectivePixel.Value;
         var (dx, dy) = Direction;
         var step = Step;
-        _map.CorrectSurveyCommand.Execute(
-            new CorrectionArgs(selected, new PixelPoint(p.X + dx * step, p.Y + dy * step)));
+
+        var selected = _session.SelectedSurvey;
+        if (selected is not null && selected.EffectivePixel.HasValue)
+        {
+            var p = selected.EffectivePixel.Value;
+            _map.CorrectSurveyCommand.Execute(
+                new CorrectionArgs(selected, new PixelPoint(p.X + dx * step, p.Y + dy * step)));
+            return Task.CompletedTask;
+        }
+
+        // No pin selected: fall through to the anchor while it's still editable
+        // (post-Set Position, pre-first-survey). Once a survey lands the anchor
+        // becomes load-bearing for projection and IsAnchorEditable flips false.
+        if (_session.IsAnchorEditable)
+        {
+            var p = _session.PlayerPosition;
+            _map.MoveAnchor(new PixelPoint(p.X + dx * step, p.Y + dy * step));
+        }
         return Task.CompletedTask;
     }
 }

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -155,6 +155,20 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         _surveyFlow.ConfirmPlayerPosition();
     }
 
+    /// <summary>
+    /// Reposition the anchor without crossing FSM states. Only valid while
+    /// <see cref="SessionState.IsAnchorEditable"/>; intended for drag/nudge
+    /// fine-tuning between <see cref="SetPlayerPosition"/> and the first survey.
+    /// No reproject is needed (no surveys exist yet); wedges and route geometry
+    /// rebuild via the existing <c>PlayerPosition</c> change handler in the ctor.
+    /// </summary>
+    public void MoveAnchor(PixelPoint where)
+    {
+        if (!_session.IsAnchorEditable) return;
+        _session.PlayerPosition = where;
+        _projector.SetOrigin(where);
+    }
+
     [RelayCommand]
     public void HandleMapClick(PixelPoint where)
     {

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -29,6 +29,7 @@ public sealed partial class SessionState : ObservableObject
             foreach (SurveyItemViewModel s in e.OldItems)
                 s.PropertyChanged -= OnSurveyPropertyChanged;
         RecalculateActiveTarget();
+        OnPropertyChanged(nameof(IsAnchorEditable));
     }
 
     private void OnSurveyPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -81,6 +82,17 @@ public sealed partial class SessionState : ObservableObject
 
     [ObservableProperty] private PixelPoint _playerPosition = new(400, 300);
     [ObservableProperty] private bool _hasPlayerPosition;
+
+    /// <summary>
+    /// True while the anchor click was made but no survey has produced a vector
+    /// from it yet. In this window the marker can be re-dragged or nudged
+    /// without consequence; once a survey lands, the anchor becomes load-bearing
+    /// (every <see cref="MetreOffset"/> projection is relative to it) and is sealed.
+    /// </summary>
+    public bool IsAnchorEditable => HasPlayerPosition && Surveys.Count == 0;
+
+    partial void OnHasPlayerPositionChanged(bool value)
+        => OnPropertyChanged(nameof(IsAnchorEditable));
     [ObservableProperty] private string _lastLogEvent = "(waiting)";
     [ObservableProperty] private bool _showBearingWedges = true;
     [ObservableProperty] private bool _showRouteLines = true;

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -93,16 +93,33 @@
                     </Polyline.Triggers>
                 </Polyline>
 
-                <!-- Player marker: outer ring + inner dot -->
-                <Canvas IsHitTestVisible="False">
-                    <Grid Width="18" Height="18"
-                          Canvas.Left="{Binding PlayerPosition.X, Converter={x:Static controls:OffsetConverter.MinusNine}}"
-                          Canvas.Top="{Binding PlayerPosition.Y, Converter={x:Static controls:OffsetConverter.MinusNine}}">
-                        <Ellipse Width="18" Height="18" Stroke="White" StrokeThickness="2" Fill="Transparent" />
-                        <Ellipse Width="6" Height="6"
-                                 Fill="{Binding Brushes.PlayerMarker}"
-                                 HorizontalAlignment="Center" VerticalAlignment="Center" />
-                    </Grid>
+                <!-- Player marker: outer ring + inner dot.
+                     Wrapped in a Thumb so the user can fine-tune the anchor by
+                     dragging — but only while no surveys exist. Once the first
+                     survey lands, projection is anchored to this point and
+                     IsAnchorEditable flips false, restoring the legacy
+                     non-interactive behaviour. -->
+                <Canvas>
+                    <Thumb Width="18" Height="18"
+                           Canvas.Left="{Binding PlayerPosition.X, Converter={x:Static controls:OffsetConverter.MinusNine}}"
+                           Canvas.Top="{Binding PlayerPosition.Y, Converter={x:Static controls:OffsetConverter.MinusNine}}"
+                           IsHitTestVisible="{Binding Session.IsAnchorEditable}"
+                           Cursor="SizeAll"
+                           ToolTip="Drag to fine-tune anchor (locks once the first survey lands)"
+                           DragStarted="PlayerAnchor_DragStarted"
+                           DragDelta="PlayerAnchor_DragDelta"
+                           DragCompleted="PlayerAnchor_DragCompleted">
+                        <Thumb.Template>
+                            <ControlTemplate TargetType="Thumb">
+                                <Grid Width="18" Height="18" Background="Transparent">
+                                    <Ellipse Width="18" Height="18" Stroke="White" StrokeThickness="2" Fill="Transparent" />
+                                    <Ellipse Width="6" Height="6"
+                                             Fill="{Binding Brushes.PlayerMarker}"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                </Grid>
+                            </ControlTemplate>
+                        </Thumb.Template>
+                    </Thumb>
                 </Canvas>
 
                 <!-- Survey dots with drag-to-correct -->

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -19,6 +19,7 @@ public partial class MapOverlayView : Window
     private double _panStartX;
     private double _panStartY;
     private Vector _grabOffset;
+    private Vector _anchorGrabOffset;
     private SurveyItemViewModel? _placementDrag;
 
     public MapOverlayView()
@@ -101,6 +102,46 @@ public partial class MapOverlayView : Window
         // track the cursor 1:1 regardless of viewport zoom.
         t.X += e.HorizontalChange;
         t.Y += e.VerticalChange;
+    }
+
+    private void PlayerAnchor_DragStarted(object sender, DragStartedEventArgs e)
+    {
+        if (DataContext is not MapOverlayViewModel vm) return;
+        if (!vm.Session.IsAnchorEditable) return;
+        // Clear pin selection so subsequent keyboard nudges fall through to the
+        // anchor (NudgePinCommandBase routes by SelectedSurvey first).
+        vm.Session.SelectedSurvey = null;
+        var cursor = Mouse.GetPosition(Viewport);
+        _anchorGrabOffset = cursor - new Point(vm.PlayerPosition.X, vm.PlayerPosition.Y);
+    }
+
+    private void PlayerAnchor_DragDelta(object sender, DragDeltaEventArgs e)
+    {
+        // Same transient-transform trick as SurveyDot_DragDelta — the binding
+        // re-positions the Thumb on DragCompleted.
+        if (sender is not Thumb thumb) return;
+        if (thumb.RenderTransform is not TranslateTransform t || t.IsFrozen)
+        {
+            t = new TranslateTransform();
+            thumb.RenderTransform = t;
+        }
+        t.X += e.HorizontalChange;
+        t.Y += e.VerticalChange;
+    }
+
+    private void PlayerAnchor_DragCompleted(object sender, DragCompletedEventArgs e)
+    {
+        if (sender is not Thumb thumb) return;
+        thumb.RenderTransform = Transform.Identity;
+        if (e.Canceled) return;
+        if (DataContext is not MapOverlayViewModel vm) return;
+        // Re-check editability — a survey could have landed mid-drag and sealed
+        // the anchor. Silently dropping the move is safer than committing it.
+        if (!vm.Session.IsAnchorEditable) return;
+        var cursor = Mouse.GetPosition(Viewport);
+        var newCenter = new PixelPoint(cursor.X - _anchorGrabOffset.X, cursor.Y - _anchorGrabOffset.Y);
+        _anchorGrabOffset = new Vector(0, 0);
+        vm.MoveAnchor(newCenter);
     }
 
     private void SurveyDot_DragCompleted(object sender, DragCompletedEventArgs e)

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -234,6 +234,12 @@
                                        Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
                         </StackPanel>
                         <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0,12,0,0"
+                                   Visibility="{Binding Session.IsAnchorEditable, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource TextTertiaryBrush}">
+                            <Run Text="Tip: drag the white player marker on the map to fine-tune your starting point — anchor locks once the first survey lands." />
+                        </TextBlock>
+                        <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0,12,0,0"
                                    FontSize="{DynamicResource AppFontSizeBody}"
                                    Foreground="{StaticResource TextTertiaryBrush}">
                             <Run Text="Tip: fine-tune the selected pin with the Pin Nudge hotkeys — bind keys under Settings → Hotkeys, category " />

--- a/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
+++ b/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
@@ -153,4 +153,110 @@ public class NudgePinCommandTests
         cmd.Id.Should().Be("legolas.pin.nudge.up");
         cmd.DefaultBinding.Should().BeNull("arrow keys collide with in-game movement; user must opt in");
     }
+
+    // ─── Anchor fallback (issue #120) ──────────────────────────────────────
+    // When no pin is selected and the anchor is still editable (post-Set
+    // Position, pre-first-survey), nudge keys should move the anchor instead
+    // of no-op'ing.
+
+    [Fact]
+    public async Task Up_with_no_pin_and_editable_anchor_moves_anchor_minus_one_y()
+    {
+        var (session, map, settings) = BuildSut();
+        session.SelectedSurvey = null;
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(400, 300);
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        session.PlayerPosition.X.Should().Be(400);
+        session.PlayerPosition.Y.Should().Be(299);
+    }
+
+    [Fact]
+    public async Task Right_fast_with_no_pin_and_editable_anchor_moves_anchor_plus_five_x()
+    {
+        var (session, map, settings) = BuildSut();
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(400, 300);
+        var cmd = new NudgePinRightFastCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        session.PlayerPosition.X.Should().BeApproximately(405, 1e-9);
+        session.PlayerPosition.Y.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task Down_fine_with_no_pin_and_editable_anchor_moves_anchor_plus_quarter_y()
+    {
+        var (session, map, settings) = BuildSut();
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(400, 300);
+        var cmd = new NudgePinDownFineCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        session.PlayerPosition.X.Should().Be(400);
+        session.PlayerPosition.Y.Should().BeApproximately(300.25, 1e-9);
+    }
+
+    [Fact]
+    public async Task No_pin_and_anchor_unset_is_noop()
+    {
+        var (session, map, settings) = BuildSut();
+        // HasPlayerPosition stays false → IsAnchorEditable is false even though
+        // there are no surveys.
+        var initial = session.PlayerPosition;
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        session.PlayerPosition.X.Should().Be(initial.X);
+        session.PlayerPosition.Y.Should().Be(initial.Y);
+    }
+
+    [Fact]
+    public async Task No_pin_and_anchor_locked_is_noop()
+    {
+        var (session, map, settings) = BuildSut();
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(400, 300);
+        // Adding any survey seals the anchor.
+        var survey = Survey.Create("Sealer", new MetreOffset(1, 1), gridIndex: 0)
+            with { ManualOverride = new PixelPoint(420, 320) };
+        session.Surveys.Add(new SurveyItemViewModel(survey));
+        session.SelectedSurvey = null;
+
+        var cmd = new NudgePinUpCommand(session, map, settings);
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        session.PlayerPosition.X.Should().Be(400, "anchor is locked once a survey lands");
+        session.PlayerPosition.Y.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task Selected_pin_takes_precedence_over_editable_anchor()
+    {
+        // Regression guard: if both fallbacks are eligible (selected pin AND
+        // editable anchor), the selected pin wins — keeps the existing nudge
+        // semantics intact for users who have a pin selected mid-session.
+        var (session, map, settings) = BuildSut();
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(400, 300);
+        // Important: anchor is still editable (Surveys.Count == 0).
+        // Use a "shadow" pin that lives only in SelectedSurvey, not in Surveys —
+        // matches the hotkey-routing precondition without sealing the anchor.
+        var shadow = Survey.Create("Shadow", new MetreOffset(0, 0), gridIndex: 99)
+            with { ManualOverride = new PixelPoint(100, 200) };
+        var shadowVm = new SurveyItemViewModel(shadow);
+        session.SelectedSurvey = shadowVm;
+        session.IsAnchorEditable.Should().BeTrue();
+
+        var cmd = new NudgePinUpCommand(session, map, settings);
+        await cmd.ExecuteAsync(CancellationToken.None);
+
+        session.PlayerPosition.Y.Should().Be(300, "selected pin should be nudged, not the anchor");
+    }
 }

--- a/tests/Legolas.Tests/ViewModels/AnchorEditableTests.cs
+++ b/tests/Legolas.Tests/ViewModels/AnchorEditableTests.cs
@@ -1,0 +1,139 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.ViewModels;
+
+public class AnchorEditableTests
+{
+    private static (SessionState session, MapOverlayViewModel map, LegolasSettings settings)
+        BuildSut()
+    {
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(new LegolasColors());
+        var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
+        return (session, map, settings);
+    }
+
+    // ─── SessionState.IsAnchorEditable truth table ──────────────────────────
+
+    [Fact]
+    public void IsAnchorEditable_is_false_before_anchor_is_set()
+    {
+        var session = new SessionState();
+        session.IsAnchorEditable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAnchorEditable_is_true_after_anchor_is_set_with_no_surveys()
+    {
+        var session = new SessionState();
+        session.HasPlayerPosition = true;
+        session.IsAnchorEditable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAnchorEditable_flips_false_when_first_survey_is_added()
+    {
+        var session = new SessionState();
+        session.HasPlayerPosition = true;
+        session.IsAnchorEditable.Should().BeTrue();
+
+        var s = Survey.Create("First", new MetreOffset(1, 1), gridIndex: 0)
+            with { ManualOverride = new PixelPoint(50, 50) };
+        session.Surveys.Add(new SurveyItemViewModel(s));
+
+        session.IsAnchorEditable.Should().BeFalse("first survey seals the anchor");
+    }
+
+    [Fact]
+    public void IsAnchorEditable_returns_to_true_when_surveys_cleared()
+    {
+        var session = new SessionState();
+        session.HasPlayerPosition = true;
+        var s = Survey.Create("First", new MetreOffset(1, 1), gridIndex: 0);
+        session.Surveys.Add(new SurveyItemViewModel(s));
+        session.IsAnchorEditable.Should().BeFalse();
+
+        session.ClearSurveys();
+
+        session.IsAnchorEditable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAnchorEditable_fires_PropertyChanged_when_anchor_is_set()
+    {
+        var session = new SessionState();
+        var seen = new List<string?>();
+        session.PropertyChanged += (_, e) => seen.Add(e.PropertyName);
+
+        session.HasPlayerPosition = true;
+
+        seen.Should().Contain(nameof(SessionState.IsAnchorEditable));
+    }
+
+    [Fact]
+    public void IsAnchorEditable_fires_PropertyChanged_when_first_survey_lands()
+    {
+        var session = new SessionState();
+        session.HasPlayerPosition = true;
+
+        var seen = new List<string?>();
+        session.PropertyChanged += (_, e) => seen.Add(e.PropertyName);
+
+        var s = Survey.Create("First", new MetreOffset(1, 1), gridIndex: 0);
+        session.Surveys.Add(new SurveyItemViewModel(s));
+
+        seen.Should().Contain(nameof(SessionState.IsAnchorEditable));
+    }
+
+    // ─── MapOverlayViewModel.MoveAnchor ─────────────────────────────────────
+
+    [Fact]
+    public void MoveAnchor_updates_PlayerPosition_when_editable()
+    {
+        var (session, map, _) = BuildSut();
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(100, 100);
+
+        map.MoveAnchor(new PixelPoint(150, 175));
+
+        session.PlayerPosition.X.Should().Be(150);
+        session.PlayerPosition.Y.Should().Be(175);
+    }
+
+    [Fact]
+    public void MoveAnchor_is_noop_before_anchor_is_set()
+    {
+        var (session, map, _) = BuildSut();
+        var initial = session.PlayerPosition;
+
+        map.MoveAnchor(new PixelPoint(999, 999));
+
+        session.PlayerPosition.X.Should().Be(initial.X);
+        session.PlayerPosition.Y.Should().Be(initial.Y);
+    }
+
+    [Fact]
+    public void MoveAnchor_is_noop_after_first_survey_lands()
+    {
+        var (session, map, _) = BuildSut();
+        session.HasPlayerPosition = true;
+        session.PlayerPosition = new PixelPoint(100, 100);
+        var s = Survey.Create("First", new MetreOffset(1, 1), gridIndex: 0)
+            with { ManualOverride = new PixelPoint(120, 120) };
+        session.Surveys.Add(new SurveyItemViewModel(s));
+
+        map.MoveAnchor(new PixelPoint(999, 999));
+
+        session.PlayerPosition.X.Should().Be(100, "anchor is sealed once vectors exist");
+        session.PlayerPosition.Y.Should().Be(100);
+    }
+}


### PR DESCRIPTION
Closes #120.

## Summary
- The Set-Player-Position click was a one-shot — fat-fingering forced a *Reset Session*. Until the first survey produces a `MetreOffset` vector from that anchor, the anchor has no downstream consequences, so it can safely be repositioned.
- Derived `SessionState.IsAnchorEditable = HasPlayerPosition && Surveys.Count == 0`. Flips false the moment the first survey is added, never reactivates within the same session unless surveys are cleared.
- Player marker is now a `Thumb` with `IsHitTestVisible` bound to `IsAnchorEditable` — drag to fine-tune; the existing visuals (white ring + accent dot) are preserved via the Thumb's `ControlTemplate`.
- `NudgePinCommandBase.ExecuteAsync` falls through to nudge the anchor when no pin is selected *and* the anchor is editable. No new hotkey IDs, no new step settings — the existing Default/Fast/Fine tiers apply equally.
- New `MapOverlayViewModel.MoveAnchor(PixelPoint)` performs the re-anchor without re-entering `AwaitingPosition`, since we're already in `Listening`. Distinct from `SetPlayerPosition`, which triggers the FSM transition.
- Wizard *Listening* step gains a tertiary hint that auto-hides once the first pin lands.

## Test plan
- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors).
- [x] `dotnet test Mithril.slnx` — full suite green, including 16 new tests:
  - `AnchorEditableTests` — `IsAnchorEditable` truth table + `PropertyChanged` + `MoveAnchor` no-op behaviour.
  - `NudgePinCommandTests` — anchor-fallback Up/Down/Left/Right at default/fast/fine tiers, no-op when anchor unset or sealed, selected-pin precedence regression.
- [ ] Manual end-to-end (next live session): drag the marker pre-survey, confirm it follows the cursor; bind a Pin Nudge hotkey, verify it routes to the anchor with no pin selected and to the pin once one is selected; confirm the hint disappears after the first pin lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)