### PR TITLE
feat(legolas): 4-DOF Refit + auto-place every survey (no click-to-confirm)

### DIFF
--- a/docs/legolas-overview.md
+++ b/docs/legolas-overview.md
@@ -12,9 +12,9 @@ Project Gorgon's **Surveying** skill produces survey items that go in the player
 
 Legolas tails the chat log, parses these offsets, and:
 
-1. Asks the user to mark their current position on a map overlay (sets the projector anchor).
-2. Plots each survey at the projected pixel position.
-3. Lets the user drag/nudge mis-projected pins; ≥2 corrections trigger a least-squares refit of scale + rotation.
+1. Asks the user to mark their current position on a map overlay (sets the initial projector anchor).
+2. Plots every detected survey at the projected pixel position. The user never has to click to confirm placement.
+3. Lets the user drag/nudge mis-projected pins; ≥2 corrections trigger a least-squares refit of all four similarity-transform parameters (origin, scale, rotation). The visible anchor follows the refitted origin.
 4. Optimises a route through the unvisited pins.
 5. Watches for `… collected!` lines to mark pins done; auto-resets when the last one drops (configurable).
 
@@ -29,24 +29,24 @@ ChatLog tail              [src/Mithril.Shared/Logging — IChatLogStream]
 ChatLogParser            [Services/ChatLogParser.cs]   regex → SurveyDetected | ItemCollected | MotherlodeDistance | UnknownLine
    │
    ▼
-LogIngestionService      [Services/LogIngestionService.cs]   dedup; auto-place if ≥2 corrections; otherwise hand to FSM
+LogIngestionService      [Services/LogIngestionService.cs]   dedup, auto-place every survey, surface inventory overlay
    │
    ▼
-SurveyFlowController     [Flow/SurveyFlowController.cs]    state mutations + transition events
+SurveyFlowController     [Flow/SurveyFlowController.cs]    state machine; logs/diagnoses out-of-state arrivals
    │
    ▼
-SessionState             [ViewModels/SessionState.cs]   observable shared state (Surveys, PendingSurvey, PlayerPosition…)
+SessionState             [ViewModels/SessionState.cs]   observable shared state (Surveys, SelectedSurvey, PlayerPosition…)
    │                        ▲
-   │                        │ user input
+   │                        │ user input (drag/nudge to correct)
    │                        │
    ▼                     MapOverlayViewModel             [ViewModels/MapOverlayViewModel.cs]
-CoordinateProjector      [Services/CoordinateProjector.cs]   metres → pixels; refits scale + rotation
+CoordinateProjector      [Services/CoordinateProjector.cs]   metres → pixels; 4-DOF refit of origin/scale/rotation
    │
    ▼
 MapOverlayView (XAML)    [Views/MapOverlayView.xaml]   pin layer, route polyline, bearing wedges, anchor thumb
 ```
 
-The user's only inputs to the loop are: clicking the map (sets anchor or places the pending pin), dragging/nudging an existing pin, and pressing **Optimize Route**.
+The user's only inputs to the loop are: clicking the map *once* in `AwaitingPosition` (sets the initial anchor), dragging/nudging existing pins to correct them, and pressing **Optimize Route**. Survey placement is automatic — there is no per-survey click-to-confirm gesture.
 
 ## Coordinate model
 
@@ -68,7 +68,7 @@ Output is a [`MetreOffset(East, North)`](../src/Legolas.Module/Domain/MetreOffse
 
 | Field | Meaning |
 |---|---|
-| `_origin : PixelPoint` | Screen pixel that represents "the player's anchor". Set by `SetOrigin` (map click) or `CalibrateFromClick`. **Never moved by `Refit`**. |
+| `_origin : PixelPoint` | Screen pixel that represents "the player's anchor". Set by `SetOrigin` (map click), seeded by `CalibrateFromClick` for tests, or refitted from corrections by `Refit`. |
 | `_scale : double` | Pixels per metre. |
 | `_rotation : double` | Radians. Map-north relative to overlay-up, measured clockwise. |
 
@@ -80,12 +80,19 @@ Three operations:
   rotN = -E·sin(θ) + N·cos(θ)
   pixel = (origin.X + scale·rotE,  origin.Y - scale·rotN)
   ```
-- **`SetOrigin(PixelPoint)`** — moves the anchor without touching scale/rotation. Called by the "Set Player Position" map-click flow.
-- **`Refit(IReadOnlyList<(MetreOffset, PixelPoint)>)`** — least-squares scale + circular-mean rotation fit:
-  - Scale: `Σ(rPixel · rOffset) / Σ(rOffset²)` — weighted by metre-magnitude.
-  - Rotation: `atan2(Σ sin Δφ, Σ cos Δφ)` — circular mean of bearing deltas, immune to angle-wrap.
-  - **Threshold:** silently no-ops unless ≥2 *non-degenerate* corrections survive (`rOffset > 1e-9` and `rPixel > 1e-9`). Zero-magnitude offsets or pixel coincidences are skipped.
-  - **Origin invariant:** `Refit` does not touch `_origin`. The anchor stays where the user clicked.
+- **`SetOrigin(PixelPoint)`** — moves the anchor without touching scale/rotation. Called by the "Set Player Position" map-click flow as the initial anchor.
+- **`Refit(IReadOnlyList<(MetreOffset, PixelPoint)>)`** — closed-form 2D similarity LSQ. Solves for **all four parameters** (origin X, origin Y, scale, rotation) simultaneously, expressed via 2D-complex arithmetic for compactness:
+  ```
+  z_i = east_i − j·north_i           (− to flip world-N to screen-up)
+  w_i = px_i + j·py_i
+  c   = Σ (w_i − w̄)·conj(z_i − z̄) / Σ |z_i − z̄|²
+  scale    = |c|
+  rotation = arg(c)
+  origin   = w̄ − c·z̄
+  ```
+  Equivalent to the Umeyama 1991 algorithm specialised to 2D with uniform scale.
+  - **Threshold:** silently no-ops unless ≥2 *non-degenerate* corrections (centred metre vectors with non-zero magnitude). Coincident-points case no-ops cleanly instead of dividing by ~0.
+  - **Why 4-DOF instead of 2-DOF:** the user's "Set Player Position" click is rarely pixel-perfect, so any residual anchor bias used to be absorbed into scale/rotation as a permanent residual error — worst near the anchor, basically invisible far away. Solving for the origin as well removes this bias. After Refit, `MapOverlayViewModel` propagates `_projector.Origin` back to `Session.PlayerPosition` so the visible anchor follows the projector's belief.
 
 ### Bearing convention
 
@@ -93,13 +100,12 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 
 ## SurveyFlowController FSM
 
-[`SurveyFlowController`](../src/Legolas.Module/Flow/SurveyFlowController.cs). Five states:
+[`SurveyFlowController`](../src/Legolas.Module/Flow/SurveyFlowController.cs). Four states:
 
 | State | Meaning |
 |---|---|
 | `AwaitingPosition` | No anchor set yet. Map clicks become the anchor. |
-| `Listening` | Anchor set; idle. Incoming `SurveyDetected` events are accepted. |
-| `AwaitingPin` | A `SurveyDetected` has arrived; `PendingSurvey` is set; map clicks place the pin. |
+| `Listening` | Anchor set; surveys auto-place as they arrive. The default working state. |
 | `Gathering` | Route optimised; user is walking it. **New `SurveyDetected` events are dropped** (position-anchor constraint). |
 | `Done` | All surveys collected. If `AutoResetWhenAllCollected`, `Reset()` immediately follows. |
 
@@ -108,19 +114,16 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 | From | Trigger | To | Notes |
 |---|---|---|---|
 | `AwaitingPosition` | `ConfirmPlayerPosition()` | `Listening` | After caller has updated `PlayerPosition` and the projector origin. |
-| `Listening` | `OnSurveyDetected(sd)` | `AwaitingPin` | Sets `PendingSurvey`, makes inventory overlay visible. |
-| `AwaitingPin` | `OnSurveyDetected(sd)` | `AwaitingPin` | Overwrites pending pin (pre-FSM behaviour preserved). |
-| `AwaitingPin` | `ConfirmPin()` | `Listening` | Caller has added the pin to `Surveys`. |
-| `Listening` | `NoteAutoPlacedSurvey(sd)` | `Listening` | Used when `LogIngestionService` auto-placed a pin (≥2 corrections existed). No transition. |
+| `Listening` | `NoteSurveyDetected(sd)` | `Listening` | No transition. Surfaces inventory overlay; `LogIngestionService` has already auto-placed the pin. |
 | `Listening` | `OptimizeRoute()` | `Gathering` | Caller has assigned `RouteOrder`s. Surveys must be non-empty. |
 | `Listening` \| `Gathering` | `AllCollected` event (auto) | `Done` | Fires when last uncollected survey is marked. |
 | `Done` | `Reset()` (auto, if setting on) | `Listening` \| `AwaitingPosition` | Routes through `Reset` — see below. |
-| any | `RequestSetPlayerPosition()` | `AwaitingPosition` | Re-anchor. Clears `PendingSurvey`. **Preserves `Surveys`** — their offsets are still valid; only the projector origin will move. |
-| any | `Reset()` | `Listening` if `HasPlayerPosition`, else `AwaitingPosition` | Clears `Surveys` and `PendingSurvey`. **Does not reset the projector** — caller is responsible. |
+| any | `RequestSetPlayerPosition()` | `AwaitingPosition` | Re-anchor. **Preserves `Surveys`** — their offsets are still valid; only the projector origin will move. |
+| any | `Reset()` | `Listening` if `HasPlayerPosition`, else `AwaitingPosition` | Clears `Surveys`. **Does not reset the projector** — caller is responsible. |
 
 ### Dropped-survey diagnostics
 
-`OnSurveyDetected` and `NoteAutoPlacedSurvey` both check `CanAcceptSurvey` (`Listening` or `AwaitingPin`). When dropping, `SessionState.LastLogEvent` is set to a human-readable reason — surfaced in the panel's status strip. The reason map is at [`DescribeWhyDropped`](../src/Legolas.Module/Flow/SurveyFlowController.cs#L217-L223).
+`NoteSurveyDetected` checks `CanAcceptSurvey` (true only in `Listening`). When dropping (called from `AwaitingPosition`, `Gathering`, or `Done`), `SessionState.LastLogEvent` is set to a human-readable reason — surfaced in the panel's status strip. Reason map: see `DescribeWhyDropped` in the controller.
 
 ## SessionState
 
@@ -129,12 +132,11 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 | Field | Lifetime | Notes |
 |---|---|---|
 | `Surveys : ObservableCollection<SurveyItemViewModel>` | Session | Cleared by `Reset()`. Fires `AllCollected` event when last uncollected is marked. |
-| `PendingSurvey : SurveyDetected?` | Transition | Set during `AwaitingPin`. Cleared by `ConfirmPin` / `RequestSetPlayerPosition`. |
-| `PlayerPosition : PixelPoint` | Session | The anchor click. Mutating this re-fires `RebuildRouteGeometry` + wedges. |
+| `PlayerPosition : PixelPoint` | Session | The projector anchor in pixel space. Initially set by the user's click; updated to follow `_projector.Origin` after every Refit. Mutating this re-fires `RebuildRouteGeometry` + wedges. |
 | `HasPlayerPosition : bool` | Session | True once `SetPlayerPosition` runs. |
 | `IsAnchorEditable : bool` | Derived | `HasPlayerPosition && Surveys.Count == 0`. See below. |
-| `SelectedSurvey : SurveyItemViewModel?` | UI | Drives nudge-command targeting. |
-| `IsMapVisible`, `IsInventoryVisible : bool` | UI | Overlay visibility intent — `OverlayController` reacts. |
+| `SelectedSurvey : SurveyItemViewModel?` | UI | Drives nudge-command targeting. Auto-set to the most-recently-placed survey by `LogIngestionService` so arrow-key adjustments target the new pin. |
+| `IsMapVisible`, `IsInventoryVisible : bool` | UI | Overlay visibility intent — `OverlayController` reacts. `IsInventoryVisible` is set true by `NoteSurveyDetected` so the user sees which slot to pick next. |
 | `MapOpacity`, `InventoryOpacity : double` | **Persisted** | Bidirectionally synced with `LegolasSettings` in [`LegolasModule.Register`](../src/Legolas.Module/LegolasModule.cs). |
 | `Mode : SessionMode` | Session | `Survey \| Motherlode`. |
 
@@ -234,21 +236,21 @@ The FSM's `Gathering` state is the explicit mitigation: once the route is optimi
 
 This is not a heuristic; it's a hard constraint. Don't relax it without solving the position-tracking problem.
 
-### Anchor is load-bearing after first survey
+### Anchor is "manually editable" only before the first survey
 
-`IsAnchorEditable` flips to false the instant `Surveys.Count` goes 0→1. From that point on, the anchor pixel is the projection origin for every pin. Moving it would invalidate every pin's projection (the offsets stay the same, but their pixel positions would shift wholesale).
+`IsAnchorEditable` flips to false the instant `Surveys.Count` goes 0→1. From that point on, manual drag/nudge of the player marker is disabled — but **the projector's origin still moves** automatically as Refit runs. The visible anchor follows `_projector.Origin` after every refit.
 
-If you need to re-anchor mid-session, the user has to `Reset()` (loses all pins) or trigger `RequestSetPlayerPosition` (keeps pins; the next `ConfirmPlayerPosition` updates the projector origin, which *will* visibly move every uncorrected pin to a new pixel position).
+If you need to re-anchor *manually* mid-session, the user has to `Reset()` (loses all pins) or trigger `RequestSetPlayerPosition` (keeps pins; the next `ConfirmPlayerPosition` overrides the projector origin to wherever the user clicked).
 
 ### Refit threshold is ≥2 *non-degenerate* corrections
 
-`Refit` skips corrections where either the metre offset or the pixel distance is below `1e-9`. So a pin at the player's exact location, or one the user dragged onto the anchor, doesn't count. The effective minimum for a refit to actually run is two pins that are both away from the origin and away from each other.
+`Refit` skips corrections whose centred metre vector has near-zero magnitude (Σ |z'|² < 1e-9). So two coincident pins, or all pins at exactly the same offset, won't refit. The effective minimum for a refit to actually run is two corrections at meaningfully different metre offsets.
 
-`LogIngestionService` checks `corrections.Count >= 2` to decide whether to auto-place rather than enter `AwaitingPin`. That check uses raw count — a degenerate correction will trick it into auto-placing even though `Refit` will silently no-op. Probably benign in practice, but worth knowing.
+### Placement is automatic; correction requires a drag
 
-### `Refit` doesn't move the origin
+After the auto-place rework, surveys are placed at the projected pixel position the moment they arrive — the user never has to click to confirm. The only correction gesture is **dragging** (or arrow-key nudging) an existing pin. A drag sets `ManualOverride`; that's the sole signal that a pin's pixel position is user-vouched-for.
 
-Scale and rotation refit; the origin stays where `SetOrigin` last put it. If a user's anchor click was off but their pin corrections are good, the pins will project at the right scale + bearing but with a parallel-translated offset. The fix is to re-anchor (which preserves pins per `RequestSetPlayerPosition`).
+This is a deliberate split: in the old flow, every forced click became a "correction" the projector trusted, even when the user had no idea where the in-game ping really was and was just clicking to satisfy the FSM. The wrong-click-becomes-bad-calibration data flowed into Refit and made everything worse. With the split, only deliberate user input drives Refit.
 
 ### Coordinate-system inversion
 

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Legolas.Domain;
 using Legolas.ViewModels;
@@ -6,15 +5,14 @@ using Legolas.ViewModels;
 namespace Legolas.Flow;
 
 /// <summary>
-/// Phase a Survey-mode session can be in. See docs/agent-plans/legolas-state-machine.md
-/// for the full diagram and rationale (notably the post-Optimize "no new surveys" rule
-/// driven by the position-anchor constraint).
+/// Phase a Survey-mode session can be in. See docs/legolas-overview.md for the
+/// full flow + invariants (post-Optimize "no new surveys" rule, anchor-becomes-
+/// load-bearing-after-first-survey, etc.).
 /// </summary>
 public enum SurveyFlowState
 {
     AwaitingPosition,
     Listening,
-    AwaitingPin,
     Gathering,
     Done,
 }
@@ -26,9 +24,9 @@ public sealed record SurveyTransition(
 
 /// <summary>
 /// State machine for Survey mode. Methods are the public transition API; direct
-/// mutation of <see cref="SessionState.Surveys"/> / <see cref="SessionState.PendingSurvey"/>
-/// outside this class is no longer supported (still possible at the language level,
-/// but considered a bug — call a controller method instead).
+/// mutation of <see cref="SessionState.Surveys"/> outside this class is no longer
+/// supported (still possible at the language level, but considered a bug — call a
+/// controller method instead).
 /// </summary>
 public sealed partial class SurveyFlowController : ObservableObject
 {
@@ -40,7 +38,6 @@ public sealed partial class SurveyFlowController : ObservableObject
         _session = session;
         _settings = settings;
         _session.AllCollected += OnAllCollected;
-        _session.PropertyChanged += OnSessionPropertyChanged;
     }
 
     [ObservableProperty]
@@ -61,16 +58,13 @@ public sealed partial class SurveyFlowController : ObservableObject
     {
         SurveyFlowState.AwaitingPosition => "Click the map to set player position",
         SurveyFlowState.Listening => "Listening for surveys",
-        SurveyFlowState.AwaitingPin when _session.PendingSurvey is { } p =>
-            $"Click the ping for: {p.Name}  ({p.Offset.East:0}E, {p.Offset.North:0}N)",
-        SurveyFlowState.AwaitingPin => "Click the ping on the map",
         SurveyFlowState.Gathering => "Walk to each target — new surveys will be ignored until reset",
         SurveyFlowState.Done => "All surveys collected",
         _ => "",
     };
 
-    /// <summary>True when <see cref="OnSurveyDetected"/> would be accepted.</summary>
-    public bool CanAcceptSurvey => CurrentState is SurveyFlowState.Listening or SurveyFlowState.AwaitingPin;
+    /// <summary>True when <see cref="NoteSurveyDetected"/> would be accepted.</summary>
+    public bool CanAcceptSurvey => CurrentState is SurveyFlowState.Listening;
 
     /// <summary>True when <see cref="OptimizeRoute"/> would be accepted.</summary>
     public bool CanOptimize => CurrentState == SurveyFlowState.Listening && _session.Surveys.Count > 0;
@@ -94,71 +88,31 @@ public sealed partial class SurveyFlowController : ObservableObject
     /// Re-anchor request (e.g. user pressed "Set Player Position"). Goes back to
     /// <c>AwaitingPosition</c> from any state. Preserves <see cref="SessionState.Surveys"/>
     /// (their offsets remain valid; only the projector origin will change on the next
-    /// <see cref="ConfirmPlayerPosition"/>). Clears any pending pin.
+    /// <see cref="ConfirmPlayerPosition"/>).
     /// </summary>
     public void RequestSetPlayerPosition()
     {
-        _session.PendingSurvey = null;
         if (CurrentState == SurveyFlowState.AwaitingPosition) return;
         TransitionTo(SurveyFlowState.AwaitingPosition, nameof(RequestSetPlayerPosition));
     }
 
     /// <summary>
-    /// A new <see cref="SurveyDetected"/> arrived. Sets <see cref="SessionState.PendingSurvey"/>
-    /// and transitions to <c>AwaitingPin</c> from <c>Listening</c> or <c>AwaitingPin</c>
-    /// (overwriting any prior pending — preserves pre-FSM behaviour). Dropped from
-    /// <c>Gathering</c>/<c>Done</c>/<c>AwaitingPosition</c> per the position-anchor
-    /// constraint (see plan doc).
+    /// A new <see cref="SurveyDetected"/> arrived. Caller (LogIngestionService) has
+    /// already auto-placed the pin at the projected position. The controller's job
+    /// is purely to surface the inventory overlay and to log/diagnose drops when
+    /// the survey arrived in a state that doesn't accept new surveys (Gathering /
+    /// Done / AwaitingPosition — the position-anchor constraint).
     /// </summary>
-    public void OnSurveyDetected(SurveyDetected sd)
+    public void NoteSurveyDetected(SurveyDetected sd)
     {
         if (!CanAcceptSurvey)
         {
             _session.LastLogEvent = $"Survey: {sd.Name} → ignored ({DescribeWhyDropped()})";
             return;
         }
-        // Surface the inventory grid the moment a survey vector lands so the
-        // user can see which slot to pick next. AutoOverlayCoordinator picks
-        // up the visibility change and enables click-through if opted in.
+        // Surface the inventory grid so the user can see which slot to pick next.
+        // AutoOverlayCoordinator reacts to visibility changes for click-through.
         _session.IsInventoryVisible = true;
-        _session.PendingSurvey = sd;
-        if (CurrentState != SurveyFlowState.AwaitingPin)
-            TransitionTo(SurveyFlowState.AwaitingPin, nameof(OnSurveyDetected));
-    }
-
-    /// <summary>
-    /// Caller has placed the pending pin (added it to <see cref="SessionState.Surveys"/>).
-    /// Clears <see cref="SessionState.PendingSurvey"/> and returns to <c>Listening</c>.
-    /// </summary>
-    public void ConfirmPin()
-    {
-        if (CurrentState != SurveyFlowState.AwaitingPin)
-        {
-            _session.LastLogEvent = $"ConfirmPin ignored — state is {CurrentState}";
-            return;
-        }
-        _session.PendingSurvey = null;
-        TransitionTo(SurveyFlowState.Listening, nameof(ConfirmPin));
-    }
-
-    /// <summary>
-    /// Survey came in with ≥2 corrections already on file → caller auto-placed the pin
-    /// without entering <c>AwaitingPin</c>. Stays in <c>Listening</c>; no transition.
-    /// Exists to keep symmetry with <see cref="OnSurveyDetected"/>: callers should
-    /// invoke exactly one of the two for every detected survey, so the controller has
-    /// a chance to log/diagnose.
-    /// </summary>
-    public void NoteAutoPlacedSurvey(SurveyDetected sd)
-    {
-        if (!CanAcceptSurvey)
-        {
-            _session.LastLogEvent = $"Survey: {sd.Name} → ignored ({DescribeWhyDropped()})";
-            return;
-        }
-        // Surface the inventory grid as for OnSurveyDetected — even when the
-        // pin auto-placed, the user still wants to see which slot to pick next.
-        _session.IsInventoryVisible = true;
-        // No transition; the auto-placement happened directly in Listening.
     }
 
     /// <summary>Listening → Gathering. Caller is responsible for actually computing the route.</summary>
@@ -173,15 +127,14 @@ public sealed partial class SurveyFlowController : ObservableObject
     }
 
     /// <summary>
-    /// Reset the session: clears surveys + pending pin, returns to either
-    /// <c>Listening</c> (if a player position is still set) or <c>AwaitingPosition</c>.
-    /// Preserves the projector anchor; caller is responsible for clearing the projector
-    /// if they want a hard reset.
+    /// Reset the session: clears surveys, returns to either <c>Listening</c> (if a
+    /// player position is still set) or <c>AwaitingPosition</c>. Preserves the
+    /// projector anchor; caller is responsible for clearing the projector if they
+    /// want a hard reset.
     /// </summary>
     public void Reset()
     {
         _session.ClearSurveys();
-        _session.PendingSurvey = null;
         var target = _session.HasPlayerPosition
             ? SurveyFlowState.Listening
             : SurveyFlowState.AwaitingPosition;
@@ -204,14 +157,6 @@ public sealed partial class SurveyFlowController : ObservableObject
         if (prev == next) return;
         CurrentState = next; // generated setter fires PropertyChanged for state + dependents
         Transitioned?.Invoke(new SurveyTransition(prev, next, trigger));
-    }
-
-    private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        // PhaseDescription's AwaitingPin branch reads PendingSurvey. Forward the
-        // change so bound UI reflects updated pin prompts without an extra subscriber.
-        if (e.PropertyName == nameof(SessionState.PendingSurvey))
-            OnPropertyChanged(nameof(PhaseDescription));
     }
 
     private string DescribeWhyDropped() => CurrentState switch

--- a/src/Legolas.Module/Services/CoordinateProjector.cs
+++ b/src/Legolas.Module/Services/CoordinateProjector.cs
@@ -50,6 +50,27 @@ public sealed class CoordinateProjector : ICoordinateProjector
         _rotation = NormaliseAngle(phiPixel - phiOffset);
     }
 
+    /// <summary>
+    /// Closed-form 2D similarity fit (origin + scale + rotation) from corrected
+    /// (offset, pixel) pairs. Equivalent to the Umeyama algorithm specialised to 2D
+    /// with uniform scale; expressed via complex-number arithmetic for compactness.
+    ///
+    /// Model: <c>pixel = origin + s\u00b7R(\u03b8)\u00b7offset</c>, where the projection screens
+    /// north as -Y. Encoding <c>z = east \u2212 j\u00b7north</c> and <c>w = px + j\u00b7py</c>
+    /// turns the model into the linear <c>w = O + c\u00b7z</c> with <c>c = s\u00b7e^(j\u03b8)</c>,
+    /// whose least-squares solution is closed-form.
+    ///
+    /// Earlier 2-DOF implementation kept origin fixed at the user's "Set Player
+    /// Position" click. That click is rarely pixel-perfect, so the residual bias
+    /// was absorbed into scale and rotation \u2014 leaving a constant pixel error that
+    /// dominates near-anchor projections. Solving for all four parameters at once
+    /// removes the bias.
+    ///
+    /// Requires <c>corrections.Count &gt;= 2</c> AND at least 2 contributing
+    /// (non-degenerate) corrections \u2014 i.e. centred metre vectors with non-zero
+    /// magnitude. Two coincident points carry no rotation/scale information.
+    /// Silently no-ops otherwise.
+    /// </summary>
     public void Refit(IReadOnlyList<(MetreOffset Offset, PixelPoint Pixel)> corrections)
     {
         if (corrections.Count < 2)
@@ -57,53 +78,62 @@ public sealed class CoordinateProjector : ICoordinateProjector
             return;
         }
 
-        double scaleNumerator = 0;
-        double scaleDenominator = 0;
-        double bearingSin = 0;
-        double bearingCos = 0;
-        var contributingCount = 0;
-
+        double zSumRe = 0, zSumIm = 0, wSumRe = 0, wSumIm = 0;
         foreach (var (offset, pixel) in corrections)
         {
-            var rOffset = offset.Magnitude;
-            if (rOffset < 1e-9)
+            zSumRe += offset.East;
+            zSumIm += -offset.North;
+            wSumRe += pixel.X;
+            wSumIm += pixel.Y;
+        }
+        var n = corrections.Count;
+        var zMeanRe = zSumRe / n;
+        var zMeanIm = zSumIm / n;
+        var wMeanRe = wSumRe / n;
+        var wMeanIm = wSumIm / n;
+
+        // c = \u03a3 (w' \u00b7 conj(z')) / \u03a3 |z'|\u00b2
+        double numRe = 0, numIm = 0, denom = 0;
+        var contributing = 0;
+        foreach (var (offset, pixel) in corrections)
+        {
+            var zRe = offset.East - zMeanRe;
+            var zIm = -offset.North - zMeanIm;
+            var wRe = pixel.X - wMeanRe;
+            var wIm = pixel.Y - wMeanIm;
+            var mag2 = zRe * zRe + zIm * zIm;
+            if (mag2 < 1e-9)
             {
                 continue;
             }
-
-            var dx = pixel.X - _origin.X;
-            var dy = pixel.Y - _origin.Y;
-            var rPixel = Math.Sqrt(dx * dx + dy * dy);
-            if (rPixel < 1e-9)
-            {
-                continue;
-            }
-
-            // Weighted least-squares scale: s = \u03a3(r_p * r_o) / \u03a3(r_o^2).
-            scaleNumerator += rPixel * rOffset;
-            scaleDenominator += rOffset * rOffset;
-
-            // Circular mean of (\u03c6_p - \u03c6_o) gives rotation without angle-wrap bugs.
-            var phiOffset = Math.Atan2(offset.East, offset.North);
-            var phiPixel = Math.Atan2(dx, -dy);
-            var dPhi = phiPixel - phiOffset;
-            bearingSin += Math.Sin(dPhi);
-            bearingCos += Math.Cos(dPhi);
-
-            contributingCount++;
+            // (wRe + j\u00b7wIm) \u00b7 (zRe \u2212 j\u00b7zIm) = (wRe\u00b7zRe + wIm\u00b7zIm) + j\u00b7(wIm\u00b7zRe \u2212 wRe\u00b7zIm)
+            numRe += wRe * zRe + wIm * zIm;
+            numIm += wIm * zRe - wRe * zIm;
+            denom += mag2;
+            contributing++;
         }
 
-        if (contributingCount < 2)
+        if (contributing < 2 || denom < 1e-9)
         {
             return;
         }
 
-        if (scaleDenominator > 1e-9)
+        var cRe = numRe / denom;
+        var cIm = numIm / denom;
+
+        var newScale = Math.Sqrt(cRe * cRe + cIm * cIm);
+        if (newScale < 1e-9)
         {
-            _scale = scaleNumerator / scaleDenominator;
+            return;
         }
 
-        _rotation = NormaliseAngle(Math.Atan2(bearingSin, bearingCos));
+        // O = w\u0304 \u2212 c\u00b7z\u0304
+        var cZmeanRe = cRe * zMeanRe - cIm * zMeanIm;
+        var cZmeanIm = cRe * zMeanIm + cIm * zMeanRe;
+
+        _scale = newScale;
+        _rotation = NormaliseAngle(Math.Atan2(cIm, cRe));
+        _origin = new PixelPoint(wMeanRe - cZmeanRe, wMeanIm - cZmeanIm);
     }
 
     private static double NormaliseAngle(double radians)

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -102,7 +102,7 @@ public sealed class LogIngestionService : BackgroundService
         if (!_surveyFlow.CanAcceptSurvey)
         {
             // Controller writes its own diagnostic to LastLogEvent.
-            _surveyFlow.OnSurveyDetected(sd);
+            _surveyFlow.NoteSurveyDetected(sd);
             return;
         }
 
@@ -112,30 +112,23 @@ public sealed class LogIngestionService : BackgroundService
             duplicate.UpdateModel(duplicate.Model with { Offset = sd.Offset });
             return;
         }
+
+        // Auto-place every survey at the projected position. The user only ever
+        // interacts to *correct* a pin (drag/nudge), which sets ManualOverride and
+        // drives Refit. A click during AwaitingPin used to set ManualOverride from
+        // the click, but that conflated "place" with "correct" — every forced click
+        // (often a guess) became calibration data. After the rework, placement
+        // never sets ManualOverride; only explicit drags do.
+        var index = _session.Surveys.Count;
         var newPixel = _projector.Project(sd.Offset);
-
-        var correctionCount = 0;
-        foreach (var s in _session.Surveys)
-        {
-            if (s.Model.ManualOverride.HasValue) correctionCount++;
-        }
-        if (correctionCount >= 2)
-        {
-            var index = _session.Surveys.Count;
-            var survey = Survey.Create(sd.Name, sd.Offset, gridIndex: index)
-                with { PixelPos = newPixel };
-            var newPinVm = new SurveyItemViewModel(survey);
-            _session.Surveys.Add(newPinVm);
-            // Make the new pin the arrow-key nudge target. Without this, arrows
-            // continue to move the previously-selected pin and a refit ripples
-            // the new pin's position too — looks like "two pins moved on one
-            // keypress". Mirrors what the manual-place path already does.
-            _session.SelectedSurvey = newPinVm;
-            _surveyFlow.NoteAutoPlacedSurvey(sd);
-            return;
-        }
-
-        _surveyFlow.OnSurveyDetected(sd);
+        var survey = Survey.Create(sd.Name, sd.Offset, gridIndex: index)
+            with { PixelPos = newPixel };
+        var newPinVm = new SurveyItemViewModel(survey);
+        _session.Surveys.Add(newPinVm);
+        // Make the new pin the keyboard-nudge target so arrow-key adjustments
+        // act on the just-arrived pin rather than the previously-selected one.
+        _session.SelectedSurvey = newPinVm;
+        _surveyFlow.NoteSurveyDetected(sd);
     }
 
     private SurveyItemViewModel? FindDuplicate(string name, MetreOffset newOffset, double radiusMetres)

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -17,7 +17,6 @@ public enum WizardStep
     PickMode,
     AwaitingPosition,
     Listening,
-    AwaitingPin,
     Gathering,
     Done,
     MotherlodeMeasuring,
@@ -74,8 +73,7 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         // Entering Listening / Gathering auto-opens the inventory overlay.
         // Listening: user is picking the leftmost survey to use — they need the
         // bag visible to see which one. Gathering: the queue serves as a
-        // walk-the-route checklist. AwaitingPin (Place) inherits visibility
-        // from Listening since we never auto-hide between transitions.
+        // walk-the-route checklist.
         if (value is WizardStep.Listening or WizardStep.Gathering)
             _session.IsInventoryVisible = true;
     }
@@ -86,7 +84,6 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         WizardStep.PickMode => "What are you doing?",
         WizardStep.AwaitingPosition => "Show me where you are",
         WizardStep.Listening => "Use a survey",
-        WizardStep.AwaitingPin => "Place this pin",
         WizardStep.Gathering => "Walk your route",
         WizardStep.Done => "All collected",
         WizardStep.MotherlodeMeasuring => "Motherlode",
@@ -144,12 +141,6 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
                 // and clear surveys (they were anchored to the old position).
                 _session.HasPlayerPosition = false;
                 _surveyFlow.Reset();
-                break;
-            case WizardStep.AwaitingPin:
-                // Cancel the pending pin. ConfirmPin clears PendingSurvey + transitions
-                // back to Listening — same effect as a "cancel", just named after the
-                // happy-path call site.
-                _surveyFlow.ConfirmPin();
                 break;
             case WizardStep.Gathering:
             case WizardStep.Done:
@@ -228,7 +219,6 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
             {
                 SurveyFlowState.AwaitingPosition => WizardStep.AwaitingPosition,
                 SurveyFlowState.Listening => WizardStep.Listening,
-                SurveyFlowState.AwaitingPin => WizardStep.AwaitingPin,
                 SurveyFlowState.Gathering => WizardStep.Gathering,
                 SurveyFlowState.Done => WizardStep.Done,
                 _ => WizardStep.AwaitingPosition,

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -160,57 +160,37 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     [RelayCommand]
     public void HandleMapClick(PixelPoint where)
     {
-        switch (_surveyFlow.CurrentState)
-        {
-            case SurveyFlowState.AwaitingPosition:
-                SetPlayerPosition(where);
-                break;
-            case SurveyFlowState.AwaitingPin when _session.PendingSurvey is not null:
-                PlacePendingPinAt(where);
-                break;
-            // Listening / Gathering / Done: ignore map clicks (prevents accidental
-            // re-anchor mid-session). User must press Set Player Position to re-anchor.
-        }
+        // The only state where a map click means "do something" is AwaitingPosition,
+        // where the click sets the projector anchor. Surveys auto-place; user
+        // corrections are exclusively drag/nudge gestures on existing pins.
+        if (_surveyFlow.CurrentState == SurveyFlowState.AwaitingPosition)
+            SetPlayerPosition(where);
     }
 
     /// <summary>
-    /// Place the pending survey's pin at <paramref name="where"/> and return
-    /// the new VM so the caller can keep dragging it. Returns null if there
-    /// is nothing pending.
+    /// Recomputes the projector from any pins with <see cref="Survey.ManualOverride"/>
+    /// set, propagates the refitted origin back to <see cref="SessionState.PlayerPosition"/>
+    /// so the on-screen anchor follows the projector's belief, and reprojects every
+    /// uncorrected pin. No-op below the 2-correction threshold.
     /// </summary>
-    public SurveyItemViewModel? PlacePendingPinAt(PixelPoint where)
+    private void TryRefitFromCorrections()
     {
-        if (_surveyFlow.CurrentState != SurveyFlowState.AwaitingPin) return null;
-        if (_session.PendingSurvey is not { } pending) return null;
-        var placed = PlacePin(pending, where);
-        _surveyFlow.ConfirmPin();
-        return placed;
-    }
-
-    private SurveyItemViewModel PlacePin(SurveyDetected sd, PixelPoint click)
-    {
-        var index = _session.Surveys.Count;
-        var pixel = _projector.Project(sd.Offset);
-        var survey = Survey.Create(sd.Name, sd.Offset, gridIndex: index)
-            with { PixelPos = pixel, ManualOverride = click };
-        var vm = new SurveyItemViewModel(survey);
-        _session.Surveys.Add(vm);
-
         var corrections = Surveys
             .Where(s => s.Model.ManualOverride.HasValue)
             .Select(s => (s.Offset, s.Model.ManualOverride!.Value))
             .ToArray();
-        if (corrections.Length >= 2)
-        {
-            _projector.Refit(corrections);
-            ReprojectUncorrected();
-            OnPropertyChanged(nameof(Scale));
-            OnPropertyChanged(nameof(RotationDegrees));
-            OnPropertyChanged(nameof(PinRadius));
-            OnPropertyChanged(nameof(PinDiameter));
-        }
-        RebuildRouteGeometry();
-        return vm;
+        if (corrections.Length < 2) return;
+
+        _projector.Refit(corrections);
+        // Projector origin may have moved during the 4-DOF refit. Sync the visible
+        // anchor so the player marker keeps representing "where the projector
+        // thinks the player is", not the user's stale initial click.
+        _session.PlayerPosition = _projector.Origin;
+        ReprojectUncorrected();
+        OnPropertyChanged(nameof(Scale));
+        OnPropertyChanged(nameof(RotationDegrees));
+        OnPropertyChanged(nameof(PinRadius));
+        OnPropertyChanged(nameof(PinDiameter));
     }
 
     public double Scale => _projector.Scale;
@@ -229,21 +209,7 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         var updated = vm.Model with { ManualOverride = args.NewPixel };
         vm.UpdateModel(updated);
 
-        var corrections = Surveys
-            .Where(s => s.IsCorrected && s.Model.ManualOverride.HasValue)
-            .Select(s => (s.Offset, s.Model.ManualOverride!.Value))
-            .ToArray();
-
-        if (corrections.Length >= 2)
-        {
-            _projector.Refit(corrections);
-            ReprojectUncorrected();
-            OnPropertyChanged(nameof(Scale));
-            OnPropertyChanged(nameof(RotationDegrees));
-            OnPropertyChanged(nameof(PinRadius));
-            OnPropertyChanged(nameof(PinDiameter));
-        }
-
+        TryRefitFromCorrections();
         RebuildRouteGeometry();
     }
 

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -103,9 +103,6 @@ public sealed partial class SessionState : ObservableObject
     [ObservableProperty] private bool _isInventoryVisible;
 
     [ObservableProperty]
-    private SurveyDetected? _pendingSurvey;
-
-    [ObservableProperty]
     private SurveyItemViewModel? _selectedSurvey;
 
     public void ClearSurveys()

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -35,9 +35,7 @@
                 </StackPanel>
             </Border>
 
-            <Grid x:Name="ViewportRoot" ClipToBounds="True" Background="Transparent"
-                  MouseLeftButtonUp="Viewport_MouseLeftButtonUp"
-                  MouseMove="Viewport_MouseMove">
+            <Grid x:Name="ViewportRoot" ClipToBounds="True" Background="Transparent">
               <Grid x:Name="Viewport" Background="Transparent"
                     MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
                 <!-- Bearing-uncertainty wedge layer (behind everything) -->
@@ -156,70 +154,17 @@
                                 <Thumb.Template>
                                     <ControlTemplate TargetType="Thumb">
                                         <Grid>
-                                            <!-- Outer ring: pulses opacity + stroke thickness + glow,
-                                                 plus marching-ants dashes, while pending (uncorrected).
-                                                 Effect is set via a Setter (not a property-element) so it
-                                                 exists before the IsCorrected=False trigger walks the
-                                                 (UIElement.Effect).(DropShadowEffect.BlurRadius) animation
-                                                 path — otherwise WPF throws "Effect property does not
-                                                 point to a DependencyObject" at template materialization. -->
+                                            <!-- Outer ring + center dot, both PinPending colour. The earlier
+                                                 IsCorrected pulse/glow signalled "the user still owes a click";
+                                                 with auto-placement that input is no longer required, so the
+                                                 animation has been dropped. Pin styling (border, radius, active
+                                                 highlight) is being overhauled separately. -->
                                             <Ellipse StrokeThickness="2" Fill="#01000000"
-                                                     StrokeDashArray="4 2" StrokeDashOffset="0">
-                                                <Ellipse.Style>
-                                                    <Style TargetType="Ellipse">
-                                                        <Setter Property="Opacity" Value="1" />
-                                                        <Setter Property="Stroke" Value="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                        <Setter Property="Effect">
-                                                            <Setter.Value>
-                                                                <DropShadowEffect ShadowDepth="0" BlurRadius="4" Opacity="0.85" Color="#FFFFFFFF" />
-                                                            </Setter.Value>
-                                                        </Setter>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsCorrected}" Value="True">
-                                                                <Setter Property="Stroke" Value="{Binding DataContext.Brushes.PinFinalized, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding IsCorrected}" Value="False">
-                                                                <DataTrigger.EnterActions>
-                                                                    <BeginStoryboard Name="PinPulse">
-                                                                        <Storyboard RepeatBehavior="Forever" AutoReverse="True">
-                                                                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
-                                                                                From="1.0" To="0.35" Duration="0:0:0.7" />
-                                                                            <DoubleAnimation Storyboard.TargetProperty="StrokeThickness"
-                                                                                From="2.0" To="4.0" Duration="0:0:0.7" />
-                                                                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.Effect).(DropShadowEffect.BlurRadius)"
-                                                                                From="4" To="16" Duration="0:0:0.7" />
-                                                                        </Storyboard>
-                                                                    </BeginStoryboard>
-                                                                    <BeginStoryboard Name="PinDashMarch">
-                                                                        <Storyboard RepeatBehavior="Forever">
-                                                                            <DoubleAnimation Storyboard.TargetProperty="StrokeDashOffset"
-                                                                                From="0" To="6" Duration="0:0:1.0" />
-                                                                        </Storyboard>
-                                                                    </BeginStoryboard>
-                                                                </DataTrigger.EnterActions>
-                                                                <DataTrigger.ExitActions>
-                                                                    <StopStoryboard BeginStoryboardName="PinPulse" />
-                                                                    <StopStoryboard BeginStoryboardName="PinDashMarch" />
-                                                                </DataTrigger.ExitActions>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Ellipse.Style>
-                                            </Ellipse>
-                                            <!-- Center dot: the projected point -->
+                                                     StrokeDashArray="4 2"
+                                                     Stroke="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                                             <Ellipse Width="5" Height="5"
-                                                     HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                <Ellipse.Style>
-                                                    <Style TargetType="Ellipse">
-                                                        <Setter Property="Fill" Value="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsCorrected}" Value="True">
-                                                                <Setter Property="Fill" Value="{Binding DataContext.Brushes.PinFinalized, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Ellipse.Style>
-                                            </Ellipse>
+                                                     HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                     Fill="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                                         </Grid>
                                     </ControlTemplate>
                                 </Thumb.Template>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -14,7 +14,6 @@ public partial class MapOverlayView : Window
 {
     private Vector _grabOffset;
     private Vector _anchorGrabOffset;
-    private SurveyItemViewModel? _placementDrag;
 
     public MapOverlayView()
     {
@@ -164,48 +163,10 @@ public partial class MapOverlayView : Window
         var canvasPos = Mouse.GetPosition(Viewport);
         var clickPoint = new PixelPoint(canvasPos.X, canvasPos.Y);
 
-        // AwaitingPin: place the pin and let the user keep dragging without
-        // releasing the mouse — same gesture for placement and fine-tuning.
-        if (vm.SurveyFlow.CurrentState == SurveyFlowState.AwaitingPin
-            && vm.Session.PendingSurvey is not null)
-        {
-            var placed = vm.PlacePendingPinAt(clickPoint);
-            if (placed is not null)
-            {
-                _placementDrag = placed;
-                vm.Session.SelectedSurvey = placed;
-                ViewportRoot.CaptureMouse();
-                e.Handled = true;
-                return;
-            }
-        }
-
+        // The VM only acts on clicks while the FSM is in AwaitingPosition (anchor
+        // setup). Survey placement is automatic; corrections are drag-only. This
+        // handler is still here so AwaitingPosition continues to work.
         vm.HandleMapClickCommand.Execute(clickPoint);
         e.Handled = true;
-    }
-
-    private void Viewport_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
-    {
-        if (_placementDrag is null) return;
-        if (DataContext is not MapOverlayViewModel vm) return;
-
-        var canvasPos = Mouse.GetPosition(Viewport);
-        // Final position via CorrectSurvey so the projector refit fires once
-        // with the user's final intended location.
-        vm.CorrectSurveyCommand.Execute(new CorrectionArgs(_placementDrag,
-            new PixelPoint(canvasPos.X, canvasPos.Y)));
-        _placementDrag = null;
-        ViewportRoot.ReleaseMouseCapture();
-        e.Handled = true;
-    }
-
-    private void Viewport_MouseMove(object sender, MouseEventArgs e)
-    {
-        // Live-update the just-placed pin as the user continues to hold the
-        // mouse button — feels like one continuous place-and-position gesture.
-        if (_placementDrag is null) return;
-        var pos = e.GetPosition(Viewport);
-        _placementDrag.UpdateModel(_placementDrag.Model
-            with { ManualOverride = new PixelPoint(pos.X, pos.Y) });
     }
 }

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -89,19 +89,6 @@
                         </TextBlock.Style>
                     </TextBlock>
                     <TextBlock Style="{StaticResource WizardBreadcrumbSeparator}" />
-                    <TextBlock Text="Place">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock" BasedOn="{StaticResource WizardBreadcrumbStep}">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding CurrentStep}" Value="AwaitingPin">
-                                        <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
-                                        <Setter Property="FontWeight" Value="SemiBold" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                    <TextBlock Style="{StaticResource WizardBreadcrumbSeparator}" />
                     <TextBlock Text="Walk">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource WizardBreadcrumbStep}">
@@ -262,20 +249,6 @@
                             Command="{Binding MapOverlay.OptimizeRouteCommand}"
                             IsEnabled="{Binding SurveyFlow.CanOptimize}"
                             ToolTip="Compute the shortest path through all placed pins and start walking" />
-                </StackPanel>
-
-                <!-- AwaitingPin -->
-                <StackPanel Visibility="{Binding CurrentStep, Converter={x:Static controls:EnumMatchConverter.ToVisibility}, ConverterParameter=AwaitingPin}">
-                    <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,12"
-                               FontSize="{DynamicResource AppFontSizeBody}"
-                               Foreground="{StaticResource TextSecondaryBrush}">
-                        <Run Text="Survey detected: " />
-                        <Run Text="{Binding Session.PendingSurvey.Name, FallbackValue=''}" FontWeight="SemiBold" />
-                    </TextBlock>
-                    <TextBlock Text="Click on the map where the ping is showing in-game."
-                               TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center"
-                               FontSize="{DynamicResource AppFontSizeBody}"
-                               Foreground="{StaticResource TextSecondaryBrush}" />
                 </StackPanel>
 
                 <!-- Gathering -->

--- a/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
+++ b/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
@@ -50,52 +50,31 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
-    public void OnSurveyDetected_Listening_to_AwaitingPin_with_pending_set()
+    public void NoteSurveyDetected_Listening_no_transition_surfaces_inventory()
     {
-        var (flow, session, _, _) = BuildSut();
-        Anchor(flow, session);
-        var sd = NewSurvey();
-        flow.OnSurveyDetected(sd);
-        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPin);
-        session.PendingSurvey.Should().Be(sd);
-    }
-
-    [Fact]
-    public void ConfirmPin_AwaitingPin_to_Listening_clears_pending()
-    {
-        var (flow, session, _, _) = BuildSut();
-        Anchor(flow, session);
-        flow.OnSurveyDetected(NewSurvey());
-        flow.ConfirmPin();
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
-        session.PendingSurvey.Should().BeNull();
-    }
-
-    [Fact]
-    public void OnSurveyDetected_AwaitingPin_overwrites_pending_no_double_transition()
-    {
+        // After the rework: surveys auto-place, so the controller only logs/diagnoses.
+        // Listening is the only state that accepts a survey notification; entering it
+        // surfaces the inventory overlay (AutoOverlayCoordinator reacts to visibility).
         var (flow, session, _, transitions) = BuildSut();
         Anchor(flow, session);
-        flow.OnSurveyDetected(NewSurvey("Diamond"));
         transitions.Clear();
+        session.IsInventoryVisible.Should().BeFalse();
 
-        var second = NewSurvey("Coal");
-        flow.OnSurveyDetected(second);
+        flow.NoteSurveyDetected(NewSurvey());
 
-        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPin);
-        session.PendingSurvey.Should().Be(second);
-        transitions.Should().BeEmpty(); // no AwaitingPin → AwaitingPin self-transition
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        session.IsInventoryVisible.Should().BeTrue();
+        transitions.Should().BeEmpty();
     }
 
     [Fact]
-    public void OnSurveyDetected_AwaitingPosition_dropped_with_diagnostic()
+    public void NoteSurveyDetected_AwaitingPosition_dropped_with_diagnostic()
     {
         var (flow, session, _, transitions) = BuildSut();
-        var sd = NewSurvey();
-        flow.OnSurveyDetected(sd);
+        flow.NoteSurveyDetected(NewSurvey());
         flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
-        session.PendingSurvey.Should().BeNull();
         session.LastLogEvent.Should().Contain("ignored").And.Contain("set player position first");
+        session.IsInventoryVisible.Should().BeFalse();
         transitions.Should().BeEmpty();
     }
 
@@ -123,33 +102,30 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
-    public void OnSurveyDetected_Gathering_dropped_per_position_anchor_constraint()
+    public void NoteSurveyDetected_Gathering_dropped_per_position_anchor_constraint()
     {
         var (flow, session, _, transitions) = BuildSut();
         Anchor(flow, session);
         flow.OptimizeRoute();
         transitions.Clear();
 
-        flow.OnSurveyDetected(NewSurvey());
+        flow.NoteSurveyDetected(NewSurvey());
 
         flow.CurrentState.Should().Be(SurveyFlowState.Gathering);
-        session.PendingSurvey.Should().BeNull();
         session.LastLogEvent.Should().Contain("route in progress");
         transitions.Should().BeEmpty();
     }
 
     [Fact]
-    public void RequestSetPlayerPosition_from_Listening_clears_pending_preserves_surveys()
+    public void RequestSetPlayerPosition_from_Listening_preserves_surveys()
     {
         var (flow, session, _, _) = BuildSut();
         Anchor(flow, session);
-        flow.OnSurveyDetected(NewSurvey()); // sets PendingSurvey, goes to AwaitingPin
         session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 0)));
 
         flow.RequestSetPlayerPosition();
 
         flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
-        session.PendingSurvey.Should().BeNull();
         session.Surveys.Should().HaveCount(1, "RequestSetPlayerPosition is a re-anchor, not a Reset");
     }
 
@@ -243,34 +219,6 @@ public class SurveyFlowControllerTests
         Anchor(flow, session);
         transitions.Clear();
         flow.ConfirmPlayerPosition();
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
-        transitions.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void ConfirmPin_from_Listening_is_noop_with_diagnostic()
-    {
-        var (flow, session, _, transitions) = BuildSut();
-        Anchor(flow, session);
-        transitions.Clear();
-        flow.ConfirmPin();
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
-        session.LastLogEvent.Should().Contain("ConfirmPin ignored");
-        transitions.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void NoteAutoPlacedSurvey_Listening_no_transition()
-    {
-        // ≥2-corrections shortcut: caller placed the pin directly without going through
-        // AwaitingPin. Controller stays in Listening; method exists for symmetry +
-        // potential future diagnostics.
-        var (flow, session, _, transitions) = BuildSut();
-        Anchor(flow, session);
-        transitions.Clear();
-
-        flow.NoteAutoPlacedSurvey(NewSurvey());
-
         flow.CurrentState.Should().Be(SurveyFlowState.Listening);
         transitions.Should().BeEmpty();
     }

--- a/tests/Legolas.Tests/Projection/CoordinateProjectorTests.cs
+++ b/tests/Legolas.Tests/Projection/CoordinateProjectorTests.cs
@@ -69,6 +69,70 @@ public class CoordinateProjectorTests
 
         fitted.Scale.Should().BeApproximately(expectedScale, 1e-6);
         fitted.RotationRadians.Should().BeApproximately(expectedRotation, 1e-6);
+        fitted.Origin.X.Should().BeApproximately(origin.X, 1e-6);
+        fitted.Origin.Y.Should().BeApproximately(origin.Y, 1e-6);
+    }
+
+    [Fact]
+    public void Refit_recovers_true_origin_even_when_setorigin_was_biased()
+    {
+        // The fix: the original 2-DOF Refit kept origin pinned to wherever SetOrigin
+        // last put it, absorbing any anchor bias into scale/rotation as a permanent
+        // residual — worst near the anchor, vanishingly small far away. The new
+        // 4-DOF Refit recovers the true origin alongside scale/rotation.
+
+        const double expectedScale = 3.0;
+        var expectedRotation = Math.PI / 6;
+        var trueOrigin = new PixelPoint(500, 400);
+        var biasedOrigin = new PixelPoint(508, 397); // user clicked 8px east, 3px north of where they actually are
+
+        var offsets = new[]
+        {
+            new MetreOffset(10, 0),
+            new MetreOffset(0, 15),
+            new MetreOffset(-8, 12),
+            new MetreOffset(5, -7),
+            new MetreOffset(20, 25),
+        };
+
+        var corrections = new List<(MetreOffset, PixelPoint)>();
+        foreach (var offset in offsets)
+        {
+            var cos = Math.Cos(expectedRotation);
+            var sin = Math.Sin(expectedRotation);
+            var rotE = offset.East * cos + offset.North * sin;
+            var rotN = -offset.East * sin + offset.North * cos;
+            var pixel = new PixelPoint(trueOrigin.X + expectedScale * rotE,
+                                        trueOrigin.Y - expectedScale * rotN);
+            corrections.Add((offset, pixel));
+        }
+
+        var fitted = new CoordinateProjector();
+        fitted.SetOrigin(biasedOrigin);
+        fitted.Refit(corrections);
+
+        fitted.Scale.Should().BeApproximately(expectedScale, 1e-6);
+        fitted.RotationRadians.Should().BeApproximately(expectedRotation, 1e-6);
+        fitted.Origin.X.Should().BeApproximately(trueOrigin.X, 1e-6);
+        fitted.Origin.Y.Should().BeApproximately(trueOrigin.Y, 1e-6);
+    }
+
+    [Fact]
+    public void Refit_is_noop_when_all_corrections_are_coincident()
+    {
+        // Two corrections at the same offset/pixel carry no rotation/scale info —
+        // their centred metre vectors are zero, so Σ |z'|² = 0. Should silently
+        // no-op rather than divide by zero.
+        var projector = new CoordinateProjector();
+        projector.SetOrigin(new PixelPoint(100, 100));
+        var originalScale = projector.Scale;
+        var originalRotation = projector.RotationRadians;
+
+        var pt = (new MetreOffset(5, 5), new PixelPoint(120, 80));
+        projector.Refit(new[] { pt, pt });
+
+        projector.Scale.Should().Be(originalScale);
+        projector.RotationRadians.Should().Be(originalRotation);
     }
 
     [Fact]

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -70,11 +70,10 @@ public class LegolasWizardViewModelTests
         surveyFlow.ConfirmPlayerPosition();
         wizard.CurrentStep.Should().Be(WizardStep.Listening);
 
+        // Surveys auto-place after the rework — NoteSurveyDetected stays in Listening
+        // and surfaces the inventory overlay; no AwaitingPin step in between.
         var sd = new SurveyDetected(FixedTime, "Diamond", new MetreOffset(50, 30));
-        surveyFlow.OnSurveyDetected(sd);
-        wizard.CurrentStep.Should().Be(WizardStep.AwaitingPin);
-
-        surveyFlow.ConfirmPin();
+        surveyFlow.NoteSurveyDetected(sd);
         wizard.CurrentStep.Should().Be(WizardStep.Listening);
 
         // Add at least one pin so OptimizeRoute is meaningful (state machine permits the transition regardless).
@@ -229,20 +228,4 @@ public class LegolasWizardViewModelTests
         session.HasPlayerPosition.Should().BeFalse();
     }
 
-    [Fact]
-    public void Back_from_AwaitingPin_cancels_pending_and_returns_to_Listening()
-    {
-        var (wizard, session, surveyFlow, _, _) = BuildSut();
-        wizard.PickSurveyModeCommand.Execute(null);
-        session.HasPlayerPosition = true;
-        surveyFlow.ConfirmPlayerPosition();
-        surveyFlow.OnSurveyDetected(new SurveyDetected(FixedTime, "Diamond", new MetreOffset(50, 30)));
-        wizard.CurrentStep.Should().Be(WizardStep.AwaitingPin);
-        session.PendingSurvey.Should().NotBeNull();
-
-        wizard.BackCommand.Execute(null);
-
-        wizard.CurrentStep.Should().Be(WizardStep.Listening);
-        session.PendingSurvey.Should().BeNull();
-    }
 }


### PR DESCRIPTION
Stack: based on \`feat/legolas-remove-overlay-zoom-pan-126\` (#127). After #127 merges, GitHub will auto-retarget this PR to \`main\`.

## Why

Survey-session feedback flagged two interlocking problems:

1. **Projection accuracy degrades near the anchor.** Pins close to the player marker landed visibly off the in-game landmarks, while distant pins looked fine. Diagnosis: \`CoordinateProjector.Refit\` was a 2-DOF fit (scale + rotation only) that left the origin pinned to wherever the user clicked \"Set Player Position\". Any pixel-level imprecision in that click became a constant residual error — invisible far away but dominant nearby. Worse, the LSQ fit for scale/rotation was *also* biased because it treated the wrong origin as truth.

2. **\"I have to click but I don't know where\" pollutes calibration.** Every click in \`AwaitingPin\` set \`ManualOverride = clickPos\`, treating placement and correction as the same gesture. Forced clicks (made just to satisfy the FSM, often without knowing the in-game ping's exact location) became calibration data the projector trusted. Combined with the new 4-DOF refit, those guesses could now bias the anchor too.

## Fix

### 4-DOF Refit (closed-form 2D similarity LSQ)

Solves for **origin, scale, rotation** simultaneously. Math via 2D-complex arithmetic (Umeyama 1991 specialised to 2D + uniform scale):

\`\`\`
z_i = east_i − j·north_i          (− to flip world-N to screen-up)
w_i = px_i + j·py_i
c   = Σ (w_i − w̄)·conj(z_i − z̄) / Σ |z_i − z̄|²
scale    = |c|
rotation = arg(c)
origin   = w̄ − c·z̄
\`\`\`

After Refit, \`MapOverlayViewModel\` propagates \`_projector.Origin\` back to \`Session.PlayerPosition\` so the visible anchor follows the projector's belief. If the user's initial click was off, they'll see the marker snap to the optimal position on the 2nd correction.

### Auto-place every survey; drag = correct

- \`LogIngestionService.HandleSurveyDetected\` always auto-places at the projected position. \`ManualOverride\` is exclusively set by drag/nudge — never by clicks.
- \`SurveyFlowController\`: \`AwaitingPin\` removed from the enum. \`OnSurveyDetected\` / \`ConfirmPin\` / \`NoteAutoPlacedSurvey\` collapsed into a single \`NoteSurveyDetected\` that just toggles inventory visibility and logs out-of-state drops.
- \`SessionState.PendingSurvey\` removed. \`MapOverlayView\` placement-click branch and \`_placementDrag\` field gone.
- Wizard: \`WizardStep.AwaitingPin\` and the \"Place\" breadcrumb removed.

### Visuals (minimal)

Drop the \`IsCorrected=false\` pulse animation. With auto-place, every uncorrected pin would have pulsed forever — the symptom that made auto-placed pins look \"incomplete\" and prompted the user feedback. Pin styling (border, radius, active highlight, color schema) is being overhauled in a separate session, so this PR stops at \"remove the misleading animation\". No \`LegolasColors\` schema changes; no migration needed.

## Test plan

- [x] Build clean (\`dotnet build Mithril.slnx\`): 0 warnings, 0 errors.
- [x] Tests: 136/136 in \`tests/Legolas.Tests\`. Full solution test run: 180 + 136 + 29 + 5 + 622 = all pass.
- [x] Headline test: \`Refit_recovers_true_origin_even_when_setorigin_was_biased\` proves the bias case (initial \`SetOrigin\` off by 8/3 px, fitted origin matches truth to 1e-6).
- [ ] Live smoke test (I can't drive WPF from here):
  - Anchor click → first survey lands automatically (no click-to-confirm).
  - Drag two pins to ground truth → marker visibly snaps to refitted origin; uncorrected pins reproject to better positions.
  - Near-anchor pins now align with landmarks.
  - Pin pulse is gone; pins look settled at rest.

## Followups (separate sessions)

- Pin-config overhaul: configurable border style, radius, color, and an \"active pin\" highlight distinct from \"active target\". Will use the \`IVersionedState<T>\` schema-bump pattern when introducing new \`LegolasColors\` slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)