### PR TITLE
feat(legolas): configurable pin appearance + survey UX polish (#131)

### DIFF
--- a/src/Legolas.Module/Domain/HexColor.cs
+++ b/src/Legolas.Module/Domain/HexColor.cs
@@ -1,0 +1,39 @@
+namespace Legolas.Domain;
+
+/// <summary>
+/// Shared ARGB-hex normalisation for the colour-bearing settings classes
+/// (<see cref="LegolasColors"/>, <see cref="LegolasPinShapeStyle"/>,
+/// <see cref="LegolasActivePinStyle"/>). All callers funnel through
+/// <see cref="Normalize"/> so user-typed hex strings end up canonical
+/// regardless of which class persists them.
+/// </summary>
+public static class HexColor
+{
+    /// <summary>
+    /// Coerces input to a canonical 8-digit ARGB hex string. Accepts either
+    /// 6-digit (RGB; alpha defaults to FF) or 8-digit (ARGB) forms with or
+    /// without a leading '#'. Invalid strings fall back to opaque magenta so
+    /// the bug is visible rather than silently transparent.
+    /// </summary>
+    public static string Normalize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return "#FFFF00FF";
+        var s = input.Trim();
+        if (s.StartsWith("#")) s = s.Substring(1);
+        return s.Length switch
+        {
+            6 when IsHex(s) => "#FF" + s.ToUpperInvariant(),
+            8 when IsHex(s) => "#" + s.ToUpperInvariant(),
+            _ => "#FFFF00FF",
+        };
+    }
+
+    private static bool IsHex(string s)
+    {
+        foreach (var c in s)
+        {
+            if (!Uri.IsHexDigit(c)) return false;
+        }
+        return true;
+    }
+}

--- a/src/Legolas.Module/Domain/LegolasActivePinStyle.cs
+++ b/src/Legolas.Module/Domain/LegolasActivePinStyle.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// Highlight overlay applied to the pin currently held in
+/// <c>SessionState.SelectedSurvey</c> while the FSM is in <c>Listening</c>.
+/// Kept distinct from <see cref="LegolasPinStyle"/> so users can change
+/// "what active looks like" without touching the base pin appearance.
+/// </summary>
+public sealed class LegolasActivePinStyle : INotifyPropertyChanged
+{
+    private ActivePinTreatment _treatment = ActivePinTreatment.Halo;
+    public ActivePinTreatment Treatment
+    {
+        get => _treatment;
+        set => Set(ref _treatment, value);
+    }
+
+    private string _color = "#FFFFFFFF";
+    public string Color
+    {
+        get => _color;
+        set => SetHex(ref _color, value);
+    }
+
+    private double _haloThickness = 2.0;
+    public double HaloThickness
+    {
+        get => _haloThickness;
+        set => Set(ref _haloThickness, Math.Max(0, value));
+    }
+
+    private double _haloPaddingPx = 3.0;
+    public double HaloPaddingPx
+    {
+        get => _haloPaddingPx;
+        set => Set(ref _haloPaddingPx, Math.Max(0, value));
+    }
+
+    /// <summary>
+    /// Blur radius of the <see cref="ActivePinTreatment.Glow"/> effect, in
+    /// pixels. Larger values bleed further beyond the pin shape; 0 collapses
+    /// the glow to nothing. Distinct from the halo's static ring — the glow
+    /// is a soft <see cref="System.Windows.Media.Effects.DropShadowEffect"/>
+    /// that doesn't compete visually with the in-game survey ping animation.
+    /// </summary>
+    private double _glowBlurRadius = 12.0;
+    public double GlowBlurRadius
+    {
+        get => _glowBlurRadius;
+        set => Set(ref _glowBlurRadius, Math.Max(0, value));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetHex(ref string field, string? value, [CallerMemberName] string? name = null)
+    {
+        var normalized = HexColor.Normalize(value);
+        if (string.Equals(field, normalized, StringComparison.OrdinalIgnoreCase)) return;
+        field = normalized;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/src/Legolas.Module/Domain/LegolasColors.cs
+++ b/src/Legolas.Module/Domain/LegolasColors.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 namespace Legolas.Domain;
 
@@ -12,30 +13,6 @@ namespace Legolas.Domain;
 /// </summary>
 public sealed class LegolasColors : INotifyPropertyChanged
 {
-    /// <summary>Pin shown for an uncorrected (projector-suggested) survey target.</summary>
-    private string _pinPending = "#FF00FFFF"; // cyan
-    public string PinPending
-    {
-        get => _pinPending;
-        set => SetHex(ref _pinPending, value);
-    }
-
-    /// <summary>Pin shown for a manually-corrected (finalized) survey target.</summary>
-    private string _pinFinalized = "#FFFF0000"; // red
-    public string PinFinalized
-    {
-        get => _pinFinalized;
-        set => SetHex(ref _pinFinalized, value);
-    }
-
-    /// <summary>Centre dot of the player position marker.</summary>
-    private string _playerMarker = "#FF4CAF50"; // green
-    public string PlayerMarker
-    {
-        get => _playerMarker;
-        set => SetHex(ref _playerMarker, value);
-    }
-
     /// <summary>Optimised route polyline.</summary>
     private string _routeLine = "#FFFFD700"; // gold
     public string RouteLine
@@ -60,41 +37,46 @@ public sealed class LegolasColors : INotifyPropertyChanged
         set => SetHex(ref _bearingWedgeStroke, value);
     }
 
+    /// <summary>
+    /// v1 single-colour pin field. Removed from the public surface in v2 — this
+    /// pair stays only so <see cref="LegolasSettings.Migrate"/> can read the
+    /// stored value and carry it forward into <c>PinStyle.Outer.StrokeColor</c>
+    /// and <c>PinStyle.Center.FillColor</c>. The migrator clears it back to
+    /// <c>null</c> so it doesn't reappear in saved JSON.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("pinPending")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LegacyPinPending { get; set; }
+
+    /// <summary>
+    /// v1 corrected-pin colour. Unused on main since #130 collapsed the
+    /// click-to-confirm flow. Migrated forward into
+    /// <c>ActivePinStyle.Color</c> so users who customised it don't lose it.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("pinFinalized")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LegacyPinFinalized { get; set; }
+
+    /// <summary>
+    /// v1 player anchor centre-dot colour. Removed from the public surface in
+    /// v2; <see cref="LegolasSettings.Migrate"/> copies it into
+    /// <c>PlayerPinStyle.Center.FillColor</c> so users who customised the
+    /// player marker keep their colour. Cleared after migration.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("playerMarker")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LegacyPlayerMarker { get; set; }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private void SetHex(ref string field, string? value, [CallerMemberName] string? name = null)
     {
-        var normalized = Normalize(value);
+        var normalized = HexColor.Normalize(value);
         if (string.Equals(field, normalized, StringComparison.OrdinalIgnoreCase)) return;
         field = normalized;
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-    }
-
-    /// <summary>
-    /// Coerces input to a canonical 8-digit ARGB hex string. Accepts either
-    /// 6-digit (RGB; alpha defaults to FF) or 8-digit (ARGB) forms with or
-    /// without a leading '#'. Invalid strings fall back to opaque magenta so
-    /// the bug is visible rather than silently transparent.
-    /// </summary>
-    public static string Normalize(string? input)
-    {
-        if (string.IsNullOrWhiteSpace(input)) return "#FFFF00FF";
-        var s = input.Trim();
-        if (s.StartsWith("#")) s = s.Substring(1);
-        return s.Length switch
-        {
-            6 when IsHex(s) => "#FF" + s.ToUpperInvariant(),
-            8 when IsHex(s) => "#" + s.ToUpperInvariant(),
-            _ => "#FFFF00FF",
-        };
-    }
-
-    private static bool IsHex(string s)
-    {
-        foreach (var c in s)
-        {
-            if (!Uri.IsHexDigit(c)) return false;
-        }
-        return true;
     }
 }

--- a/src/Legolas.Module/Domain/LegolasPinShapeStyle.cs
+++ b/src/Legolas.Module/Domain/LegolasPinShapeStyle.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// Configuration for one of the two survey-pin shapes (outer ring or centre
+/// indicator). Both fill and stroke are independent so users can build
+/// hollow / filled / outlined pins in any combination. Manual
+/// <see cref="INotifyPropertyChanged"/> for the same reason as
+/// <see cref="LegolasColors"/> — the CommunityToolkit + STJ source generators
+/// race on partial properties and silently drop fields.
+/// </summary>
+public sealed class LegolasPinShapeStyle : INotifyPropertyChanged
+{
+    private PinShape _shape = PinShape.Circle;
+    public PinShape Shape
+    {
+        get => _shape;
+        set => Set(ref _shape, value);
+    }
+
+    private string _fillColor = "#01000000";
+    public string FillColor
+    {
+        get => _fillColor;
+        set => SetHex(ref _fillColor, value);
+    }
+
+    private string _strokeColor = "#FF00FFFF";
+    public string StrokeColor
+    {
+        get => _strokeColor;
+        set => SetHex(ref _strokeColor, value);
+    }
+
+    private PinStrokeStyle _strokeStyle = PinStrokeStyle.Dashed;
+    public PinStrokeStyle StrokeStyle
+    {
+        get => _strokeStyle;
+        set => Set(ref _strokeStyle, value);
+    }
+
+    private double _strokeThickness = 2.0;
+    public double StrokeThickness
+    {
+        get => _strokeThickness;
+        set => Set(ref _strokeThickness, Math.Max(0, value));
+    }
+
+    private double _size = 5.0;
+    public double Size
+    {
+        get => _size;
+        set => Set(ref _size, Math.Max(0, value));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetHex(ref string field, string? value, [CallerMemberName] string? name = null)
+    {
+        var normalized = HexColor.Normalize(value);
+        if (string.Equals(field, normalized, StringComparison.OrdinalIgnoreCase)) return;
+        field = normalized;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/src/Legolas.Module/Domain/LegolasPinStyle.cs
+++ b/src/Legolas.Module/Domain/LegolasPinStyle.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// Composite pin appearance: outer ring + centre indicator. Each
+/// <see cref="LegolasPinShapeStyle"/> child is fully independent — fill,
+/// stroke, shape, and stroke style are all separately configurable, so
+/// "what a pin looks like" stays orthogonal to "what active means" (handled
+/// by <see cref="LegolasActivePinStyle"/>).
+/// </summary>
+/// <remarks>
+/// The outer shape's diameter intentionally is not duplicated here — it
+/// remains driven by <c>LegolasSettings.SurveyPinRadiusMetres</c> so the
+/// existing "Pin radius (px)" slider continues to work without a binding
+/// rewrite. The centre shape carries its own <see cref="LegolasPinShapeStyle.Size"/>.
+/// </remarks>
+public sealed class LegolasPinStyle : INotifyPropertyChanged
+{
+    public LegolasPinStyle()
+    {
+        Outer = BuildOuterDefault();
+        Center = BuildCenterDefault();
+        Outer.PropertyChanged += OnChildChanged;
+        Center.PropertyChanged += OnChildChanged;
+    }
+
+    public LegolasPinShapeStyle Outer { get; set; }
+    public LegolasPinShapeStyle Center { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private static LegolasPinShapeStyle BuildOuterDefault() => new()
+    {
+        Shape = PinShape.Circle,
+        // Near-transparent fill keeps the outer ring hit-testable for the
+        // Thumb's drag-handle behaviour while remaining visually empty.
+        FillColor = "#01000000",
+        StrokeColor = "#FF00FFFF",
+        StrokeStyle = PinStrokeStyle.Dashed,
+        StrokeThickness = 2.0,
+        // Outer Size is unused — diameter is driven by SurveyPinRadiusMetres.
+        Size = 0.0,
+    };
+
+    private static LegolasPinShapeStyle BuildCenterDefault() => new()
+    {
+        Shape = PinShape.Circle,
+        FillColor = "#FF00FFFF",
+        StrokeColor = "#00000000",
+        StrokeStyle = PinStrokeStyle.None,
+        StrokeThickness = 0.0,
+        Size = 5.0,
+    };
+
+    /// <summary>
+    /// Factory for the player anchor pin style. Defaults reproduce the v1
+    /// hardcoded look: 18px white-stroked transparent circle outer + 2×2 green
+    /// square centre dot (matches the old <c>LegolasColors.PlayerMarker</c>
+    /// default of <c>#FF4CAF50</c>). Player pin's outer Size is meaningful
+    /// (drives the Thumb bounds), unlike the survey pin where outer size is
+    /// driven by <c>SurveyPinRadiusMetres</c>.
+    /// </summary>
+    public static LegolasPinStyle PlayerDefaults()
+    {
+        var style = new LegolasPinStyle();
+        style.Outer.Shape = PinShape.Circle;
+        style.Outer.FillColor = "#00000000";
+        style.Outer.StrokeColor = "#FFFFFFFF";
+        style.Outer.StrokeStyle = PinStrokeStyle.Solid;
+        style.Outer.StrokeThickness = 2.0;
+        style.Outer.Size = 18.0;
+
+        style.Center.Shape = PinShape.Square;
+        style.Center.FillColor = "#FF4CAF50";
+        style.Center.StrokeColor = "#00000000";
+        style.Center.StrokeStyle = PinStrokeStyle.None;
+        style.Center.StrokeThickness = 0.0;
+        style.Center.Size = 2.0;
+        return style;
+    }
+
+    private void OnChildChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // Forward child-property names so brush/converter bindings against
+        // PinStyle.Outer.* see the change. WPF's binding engine resolves
+        // dotted paths by re-subscribing to the leaf's PropertyChanged, so
+        // this is mostly belt-and-braces — but the LegolasBrushes forwarder
+        // listens at this level, and that's the load-bearing consumer.
+        var prefix = ReferenceEquals(sender, Outer) ? "Outer." : "Center.";
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prefix + e.PropertyName));
+    }
+}

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -1,9 +1,63 @@
 using System.ComponentModel;
+using Mithril.Shared.Character;
 
 namespace Legolas.Domain;
 
-public sealed class LegolasSettings : INotifyPropertyChanged
+public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<LegolasSettings>
 {
+    public const int Version = 2;
+    public static int CurrentVersion => Version;
+
+    /// <summary>
+    /// v1 had no schema field; v2 introduces <see cref="LegolasPinStyle"/> +
+    /// <see cref="LegolasActivePinStyle"/> + per-pin <see cref="PlayerPinStyle"/>
+    /// and removes the old <c>PinPending</c>/<c>PinFinalized</c>/<c>PlayerMarker</c>
+    /// fields from <see cref="LegolasColors"/>. Defaults to <c>1</c> (not
+    /// <see cref="Version"/>) so that v1 JSON, which lacks the
+    /// <c>schemaVersion</c> field, deserializes with the legacy version and
+    /// triggers <see cref="Migrate"/>. Fresh in-memory instances also start at
+    /// <c>1</c> — no-op migration since their legacy fields are null — and the
+    /// loader bumps to current after persisting.
+    /// </summary>
+    public int SchemaVersion { get; set; } = 1;
+
+    public static LegolasSettings Migrate(LegolasSettings loaded)
+    {
+        if (loaded.SchemaVersion >= Version) return loaded;
+
+        // v1 → v2: carry forward the user's customised pin colours into the
+        // new style sub-states so they don't reset to defaults.
+        //   * pinPending — single v1 colour, drove BOTH the survey pin's outer
+        //     stroke AND its centre fill; lands in both fields.
+        //   * pinFinalized — unused on main since #130; promoted to the
+        //     active-pin highlight colour for users who customised it.
+        //   * playerMarker — v1 player anchor's centre dot colour; lands in
+        //     PlayerPinStyle.Center.FillColor (the outer ring was hardcoded
+        //     white, so PlayerPinStyle.Outer.* keeps its v1-equivalent default).
+        var legacyPending = loaded.Colors.LegacyPinPending;
+        var legacyFinalized = loaded.Colors.LegacyPinFinalized;
+        var legacyPlayer = loaded.Colors.LegacyPlayerMarker;
+
+        if (!string.IsNullOrWhiteSpace(legacyPending))
+        {
+            loaded.PinStyle.Outer.StrokeColor = legacyPending;
+            loaded.PinStyle.Center.FillColor = legacyPending;
+        }
+        if (!string.IsNullOrWhiteSpace(legacyFinalized))
+        {
+            loaded.ActivePinStyle.Color = legacyFinalized;
+        }
+        if (!string.IsNullOrWhiteSpace(legacyPlayer))
+        {
+            loaded.PlayerPinStyle.Center.FillColor = legacyPlayer;
+        }
+
+        loaded.Colors.LegacyPinPending = null;
+        loaded.Colors.LegacyPinFinalized = null;
+        loaded.Colors.LegacyPlayerMarker = null;
+        return loaded;
+    }
+
     private double _surveyDedupRadiusMetres = 5.0;
     public double SurveyDedupRadiusMetres
     {
@@ -34,6 +88,9 @@ public sealed class LegolasSettings : INotifyPropertyChanged
 
     public InventoryGridSettings InventoryGrid { get; set; } = new();
     public LegolasColors Colors { get; set; } = new();
+    public LegolasPinStyle PinStyle { get; set; } = new();
+    public LegolasPinStyle PlayerPinStyle { get; set; } = LegolasPinStyle.PlayerDefaults();
+    public LegolasActivePinStyle ActivePinStyle { get; set; } = new();
     public WindowLayout MapOverlay { get; set; } = new() { Width = 800, Height = 600 };
     public WindowLayout InventoryOverlay { get; set; } = new() { Width = 540, Height = 440 };
 

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -178,6 +178,23 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
         }
     }
 
+    /// <summary>
+    /// Mirror the wizard panel's nudge pad onto the map overlay. Off by
+    /// default to keep the overlay clean; users who prefer to nudge without
+    /// alt-tabbing flip this on.
+    /// </summary>
+    private bool _showNudgePadOnOverlay;
+    public bool ShowNudgePadOnOverlay
+    {
+        get => _showNudgePadOnOverlay;
+        set
+        {
+            if (_showNudgePadOnOverlay == value) return;
+            _showNudgePadOnOverlay = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShowNudgePadOnOverlay)));
+        }
+    }
+
     private bool _autoHideOverlaysOnGameUnfocused = true;
     public bool AutoHideOverlaysOnGameUnfocused
     {

--- a/src/Legolas.Module/Domain/NudgeStepSize.cs
+++ b/src/Legolas.Module/Domain/NudgeStepSize.cs
@@ -1,0 +1,13 @@
+namespace Legolas.Domain;
+
+/// <summary>
+/// Step magnitude tier for on-screen nudge pad clicks. Mirrors the three
+/// tiers users can hot-key (NudgePinUp/Fast/Fine etc.). Each tier resolves
+/// to a magnitude via <c>LegolasSettings.NudgeStepDefault/Fast/Fine</c>.
+/// </summary>
+public enum NudgeStepSize
+{
+    Fine,
+    Default,
+    Fast,
+}

--- a/src/Legolas.Module/Domain/NudgeStepSizeRadioConverter.cs
+++ b/src/Legolas.Module/Domain/NudgeStepSizeRadioConverter.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// Two-way binding glue for "RadioButton IsChecked ↔ enum-valued property":
+/// returns true when the bound enum equals the converter parameter (so the
+/// matching RadioButton is checked); on the way back, only commits the
+/// parameter value when the radio is being checked (ignoring the redundant
+/// uncheck-side notification — RadioButton group toggling fires both).
+/// </summary>
+public sealed class NudgeStepSizeRadioConverter : IValueConverter
+{
+    public static readonly NudgeStepSizeRadioConverter Instance = new();
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not NudgeStepSize current) return false;
+        if (parameter is not NudgeStepSize target) return false;
+        return current == target;
+    }
+
+    public object? ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b && b && parameter is NudgeStepSize target) return target;
+        return Binding.DoNothing;
+    }
+}

--- a/src/Legolas.Module/Domain/PinShape.cs
+++ b/src/Legolas.Module/Domain/PinShape.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// Shape primitive used by the survey-pin DataTemplate's outer + centre Paths.
+/// <see cref="None"/> hides the corresponding shape entirely (renders as
+/// <c>Geometry.Empty</c>) — useful for users who want only the outer ring or
+/// only the centre marker.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PinShape>))]
+public enum PinShape
+{
+    Circle,
+    Square,
+    Diamond,
+    Cross,
+    None,
+}
+
+/// <summary>Stroke pattern for pin outlines.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PinStrokeStyle>))]
+public enum PinStrokeStyle
+{
+    None,
+    Solid,
+    Dashed,
+}
+
+/// <summary>
+/// Visual treatment applied to the pin currently held in
+/// <c>SessionState.SelectedSurvey</c> while the FSM is in <c>Listening</c>.
+/// Only <see cref="Halo"/> is wired in the initial pass; the others are
+/// reserved enum slots so a follow-up PR can add them without a schema bump.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ActivePinTreatment>))]
+public enum ActivePinTreatment
+{
+    Halo,
+    Glow,
+    ScaleUp,
+    FillSwap,
+}

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -38,6 +38,12 @@ public sealed partial class SurveyFlowController : ObservableObject
         _session = session;
         _settings = settings;
         _session.AllCollected += OnAllCollected;
+        // CanOptimize reads Surveys.Count, but [NotifyPropertyChangedFor] only
+        // fires from CurrentState. Without this subscription the Go! button
+        // stays disabled forever — surveys arrive, count goes 0→N, but the
+        // bound IsEnabled never refreshes. Re-emit on every collection change
+        // so the wizard's primary action lights up the moment a pin lands.
+        _session.Surveys.CollectionChanged += (_, _) => OnPropertyChanged(nameof(CanOptimize));
     }
 
     [ObservableProperty]

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -83,6 +83,7 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<MapOverlayViewModel>();
         services.AddSingleton<InventoryGridSettingsViewModel>();
         services.AddSingleton<MotherlodeViewModel>();
+        services.AddSingleton<NudgePadViewModel>();
 
         // Panel view (shell-hosted UserControl) — singleton so it keeps scroll/state across tab switches.
         // The panel directly hosts the wizard; settings live in the per-module settings tab.
@@ -100,7 +101,8 @@ public sealed class LegolasModule : IMithrilModule
         {
             var view = new MapOverlayView(
                 sp.GetRequiredService<LegolasSettings>(),
-                sp.GetRequiredService<SettingsAutoSaver<LegolasSettings>>());
+                sp.GetRequiredService<SettingsAutoSaver<LegolasSettings>>(),
+                sp.GetRequiredService<NudgePadViewModel>());
             view.DataContext = sp.GetRequiredService<MapOverlayViewModel>();
             return view;
         });

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -33,7 +33,7 @@ public sealed class LegolasModule : IMithrilModule
         var dir = Path.Combine(localApp, "Mithril", "Legolas");
         var settingsPath = Path.Combine(dir, "settings.json");
 
-        services.AddMithrilSettings<LegolasSettings>(settingsPath, LegolasSettingsJsonContext.Default.LegolasSettings);
+        services.AddMithrilVersionedSettings<LegolasSettings>(settingsPath, LegolasSettingsJsonContext.Default.LegolasSettings);
         services.AddSingleton<InventoryGridSettings>(sp =>
             sp.GetRequiredService<LegolasSettings>().InventoryGrid);
         services.AddSingleton<LegolasColors>(sp =>

--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -102,6 +102,17 @@ public sealed partial class ControlPanelViewModel : ObservableObject
         }
     }
 
+    public bool ShowNudgePadOnOverlay
+    {
+        get => _settings.ShowNudgePadOnOverlay;
+        set
+        {
+            if (_settings.ShowNudgePadOnOverlay == value) return;
+            _settings.ShowNudgePadOnOverlay = value;
+            OnPropertyChanged();
+        }
+    }
+
     public string GameProcessName
     {
         get => _settings.GameProcessName;

--- a/src/Legolas.Module/ViewModels/LegolasBrushes.cs
+++ b/src/Legolas.Module/ViewModels/LegolasBrushes.cs
@@ -6,28 +6,43 @@ using Legolas.Domain;
 namespace Legolas.ViewModels;
 
 /// <summary>
-/// View-model wrapper around <see cref="LegolasColors"/> exposing pre-built
+/// View-model wrapper around <see cref="LegolasSettings"/> exposing pre-built
 /// <see cref="SolidColorBrush"/> instances for XAML bindings. WPF resource
 /// dictionaries don't observe POCO settings cleanly, so views bind through
 /// this object instead and we re-emit a fresh brush whenever the underlying
-/// hex changes.
+/// hex changes. Takes the whole <see cref="LegolasSettings"/> so we don't have
+/// to register every sub-state class with DI individually.
 /// </summary>
 public sealed class LegolasBrushes : ObservableObject
 {
-    private readonly LegolasColors _colors;
+    private readonly LegolasSettings _settings;
 
-    public LegolasBrushes(LegolasColors colors)
+    public LegolasBrushes(LegolasSettings settings)
     {
-        _colors = colors;
-        _colors.PropertyChanged += OnColorsPropertyChanged;
+        _settings = settings;
+        _settings.Colors.PropertyChanged += OnColorsChanged;
+        _settings.PinStyle.Outer.PropertyChanged += OnSurveyOuterChanged;
+        _settings.PinStyle.Center.PropertyChanged += OnSurveyCenterChanged;
+        _settings.PlayerPinStyle.Outer.PropertyChanged += OnPlayerOuterChanged;
+        _settings.PlayerPinStyle.Center.PropertyChanged += OnPlayerCenterChanged;
+        _settings.ActivePinStyle.PropertyChanged += OnActiveChanged;
     }
 
-    public SolidColorBrush PinPending => Build(_colors.PinPending);
-    public SolidColorBrush PinFinalized => Build(_colors.PinFinalized);
-    public SolidColorBrush PlayerMarker => Build(_colors.PlayerMarker);
-    public SolidColorBrush RouteLine => Build(_colors.RouteLine);
-    public SolidColorBrush BearingWedgeFill => Build(_colors.BearingWedgeFill);
-    public SolidColorBrush BearingWedgeStroke => Build(_colors.BearingWedgeStroke);
+    public SolidColorBrush RouteLine => Build(_settings.Colors.RouteLine);
+    public SolidColorBrush BearingWedgeFill => Build(_settings.Colors.BearingWedgeFill);
+    public SolidColorBrush BearingWedgeStroke => Build(_settings.Colors.BearingWedgeStroke);
+
+    public SolidColorBrush OuterFill => Build(_settings.PinStyle.Outer.FillColor);
+    public SolidColorBrush OuterStroke => Build(_settings.PinStyle.Outer.StrokeColor);
+    public SolidColorBrush CenterFill => Build(_settings.PinStyle.Center.FillColor);
+    public SolidColorBrush CenterStroke => Build(_settings.PinStyle.Center.StrokeColor);
+
+    public SolidColorBrush PlayerOuterFill => Build(_settings.PlayerPinStyle.Outer.FillColor);
+    public SolidColorBrush PlayerOuterStroke => Build(_settings.PlayerPinStyle.Outer.StrokeColor);
+    public SolidColorBrush PlayerCenterFill => Build(_settings.PlayerPinStyle.Center.FillColor);
+    public SolidColorBrush PlayerCenterStroke => Build(_settings.PlayerPinStyle.Center.StrokeColor);
+
+    public SolidColorBrush ActivePin => Build(_settings.ActivePinStyle.Color);
 
     private static SolidColorBrush Build(string hex)
     {
@@ -37,13 +52,13 @@ public sealed class LegolasBrushes : ObservableObject
     }
 
     /// <summary>
-    /// Parse the canonical 8-digit ARGB hex written by <see cref="LegolasColors.Normalize"/>.
+    /// Parse the canonical 8-digit ARGB hex written by <see cref="HexColor.Normalize"/>.
     /// Falls back to opaque magenta on malformed input — the same fail-loud
     /// fallback as the settings layer, so a bad value is visible everywhere.
     /// </summary>
     public static Color Parse(string hex)
     {
-        var normalized = LegolasColors.Normalize(hex);
+        var normalized = HexColor.Normalize(hex);
         var s = normalized.Substring(1); // strip '#'
         var a = byte.Parse(s.Substring(0, 2), System.Globalization.NumberStyles.HexNumber);
         var r = byte.Parse(s.Substring(2, 2), System.Globalization.NumberStyles.HexNumber);
@@ -52,11 +67,51 @@ public sealed class LegolasBrushes : ObservableObject
         return Color.FromArgb(a, r, g, b);
     }
 
-    private void OnColorsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    private void OnColorsChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // Forward each color property → matching brush property notification.
-        // Names line up 1:1, so re-emit the same name and bound views re-fetch.
         if (!string.IsNullOrEmpty(e.PropertyName))
             OnPropertyChanged(e.PropertyName);
+    }
+
+    private void OnSurveyOuterChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(LegolasPinShapeStyle.FillColor): OnPropertyChanged(nameof(OuterFill)); break;
+            case nameof(LegolasPinShapeStyle.StrokeColor): OnPropertyChanged(nameof(OuterStroke)); break;
+        }
+    }
+
+    private void OnSurveyCenterChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(LegolasPinShapeStyle.FillColor): OnPropertyChanged(nameof(CenterFill)); break;
+            case nameof(LegolasPinShapeStyle.StrokeColor): OnPropertyChanged(nameof(CenterStroke)); break;
+        }
+    }
+
+    private void OnPlayerOuterChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(LegolasPinShapeStyle.FillColor): OnPropertyChanged(nameof(PlayerOuterFill)); break;
+            case nameof(LegolasPinShapeStyle.StrokeColor): OnPropertyChanged(nameof(PlayerOuterStroke)); break;
+        }
+    }
+
+    private void OnPlayerCenterChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(LegolasPinShapeStyle.FillColor): OnPropertyChanged(nameof(PlayerCenterFill)); break;
+            case nameof(LegolasPinShapeStyle.StrokeColor): OnPropertyChanged(nameof(PlayerCenterStroke)); break;
+        }
+    }
+
+    private void OnActiveChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(LegolasActivePinStyle.Color))
+            OnPropertyChanged(nameof(ActivePin));
     }
 }

--- a/src/Legolas.Module/ViewModels/LegolasSettingsViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasSettingsViewModel.cs
@@ -7,7 +7,8 @@ namespace Legolas.ViewModels;
 
 /// <summary>
 /// Composes the per-module settings groups (overlay options, click-through,
-/// marker colors, inventory grid) for the shell's per-module settings tab.
+/// map colours, survey pin appearance, player pin appearance, active-pin
+/// highlight, inventory grid) for the shell's per-module settings tab.
 /// Bindings are intentionally pass-through to the existing sub-VMs / state
 /// objects so the lift from <see cref="LegolasPanelView"/> is purely structural.
 /// </summary>
@@ -17,14 +18,17 @@ public sealed partial class LegolasSettingsViewModel : ObservableObject
         SessionState session,
         ControlPanelViewModel controlPanel,
         InventoryGridSettingsViewModel gridSettings,
-        LegolasColors colors,
+        LegolasSettings settings,
         LegolasBrushes brushes,
         SettingsAutoSaver<LegolasSettings> saver)
     {
         Session = session;
         ControlPanel = controlPanel;
         GridSettings = gridSettings;
-        Colors = colors;
+        Colors = settings.Colors;
+        PinStyle = settings.PinStyle;
+        PlayerPinStyle = settings.PlayerPinStyle;
+        ActivePinStyle = settings.ActivePinStyle;
         Brushes = brushes;
 
         // Surface autosave activity in the footer so the user knows their
@@ -41,7 +45,22 @@ public sealed partial class LegolasSettingsViewModel : ObservableObject
     public ControlPanelViewModel ControlPanel { get; }
     public InventoryGridSettingsViewModel GridSettings { get; }
     public LegolasColors Colors { get; }
+    public LegolasPinStyle PinStyle { get; }
+    public LegolasPinStyle PlayerPinStyle { get; }
+    public LegolasActivePinStyle ActivePinStyle { get; }
     public LegolasBrushes Brushes { get; }
+
+    public IReadOnlyList<PinShape> PinShapes { get; } = Enum.GetValues<PinShape>();
+    public IReadOnlyList<PinStrokeStyle> PinStrokeStyles { get; } = Enum.GetValues<PinStrokeStyle>();
+    public IReadOnlyList<ActivePinTreatment> ActivePinTreatments { get; } = Enum.GetValues<ActivePinTreatment>();
+
+    /// <summary>
+    /// Outer diameter used by the in-settings preview rectangles. Larger than
+    /// the typical map-overlay <c>SurveyPinRadiusMetres</c> so colour/stroke
+    /// changes are visible without squinting; centre size and halo padding
+    /// remain at their configured values so the user sees them in real terms.
+    /// </summary>
+    public double PreviewPinDiameter => 48.0;
 
     [ObservableProperty]
     private DateTimeOffset? _lastSavedAt;
@@ -53,11 +72,45 @@ public sealed partial class LegolasSettingsViewModel : ObservableObject
     private void ResetColorsToDefaults()
     {
         var defaults = new LegolasColors();
-        Colors.PinPending = defaults.PinPending;
-        Colors.PinFinalized = defaults.PinFinalized;
-        Colors.PlayerMarker = defaults.PlayerMarker;
         Colors.RouteLine = defaults.RouteLine;
         Colors.BearingWedgeFill = defaults.BearingWedgeFill;
         Colors.BearingWedgeStroke = defaults.BearingWedgeStroke;
+    }
+
+    [RelayCommand]
+    private void ResetPinStyleToDefaults()
+    {
+        var defaults = new LegolasPinStyle();
+        CopyShape(defaults.Outer, PinStyle.Outer);
+        CopyShape(defaults.Center, PinStyle.Center);
+    }
+
+    [RelayCommand]
+    private void ResetPlayerPinStyleToDefaults()
+    {
+        var defaults = LegolasPinStyle.PlayerDefaults();
+        CopyShape(defaults.Outer, PlayerPinStyle.Outer);
+        CopyShape(defaults.Center, PlayerPinStyle.Center);
+    }
+
+    [RelayCommand]
+    private void ResetActivePinStyleToDefaults()
+    {
+        var defaults = new LegolasActivePinStyle();
+        ActivePinStyle.Treatment = defaults.Treatment;
+        ActivePinStyle.Color = defaults.Color;
+        ActivePinStyle.HaloThickness = defaults.HaloThickness;
+        ActivePinStyle.HaloPaddingPx = defaults.HaloPaddingPx;
+        ActivePinStyle.GlowBlurRadius = defaults.GlowBlurRadius;
+    }
+
+    private static void CopyShape(LegolasPinShapeStyle from, LegolasPinShapeStyle to)
+    {
+        to.Shape = from.Shape;
+        to.FillColor = from.FillColor;
+        to.StrokeColor = from.StrokeColor;
+        to.StrokeStyle = from.StrokeStyle;
+        to.StrokeThickness = from.StrokeThickness;
+        to.Size = from.Size;
     }
 }

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -39,7 +39,8 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         MotherlodeFlowController motherlodeFlow,
         ControlPanelViewModel controlPanel,
         MotherlodeViewModel motherlode,
-        MapOverlayViewModel mapOverlay)
+        MapOverlayViewModel mapOverlay,
+        NudgePadViewModel nudgePad)
     {
         _session = session;
         _surveyFlow = surveyFlow;
@@ -47,6 +48,7 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         ControlPanel = controlPanel;
         Motherlode = motherlode;
         MapOverlay = mapOverlay;
+        NudgePad = nudgePad;
 
         _surveyFlow.PropertyChanged += OnSurveyFlowChanged;
         _motherlodeFlow.PropertyChanged += OnMotherlodeFlowChanged;
@@ -93,6 +95,7 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
     public ControlPanelViewModel ControlPanel { get; }
     public MotherlodeViewModel Motherlode { get; }
     public MapOverlayViewModel MapOverlay { get; }
+    public NudgePadViewModel NudgePad { get; }
 
     public SessionState Session => _session;
     public SurveyFlowController SurveyFlow => _surveyFlow;

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -73,6 +73,9 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         // Forward FSM state changes so the pin DataTemplate can gate the
         // active-pin halo on Listening (the only phase where SelectedSurvey
         // is meaningful — Gathering uses IsActiveTarget + marching ants).
+        // RebuildAllWedges on transition catches the post-Optimize case
+        // where surveys that arrived after the route was computed have
+        // RouteOrder=null and therefore aren't cleared by Optimize itself.
         _surveyFlow.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(SurveyFlowController.CurrentState))
@@ -80,6 +83,7 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 OnPropertyChanged(nameof(IsListening));
                 OnPropertyChanged(nameof(OverlayHint));
                 OnPropertyChanged(nameof(IsOverlayHintVisible));
+                RebuildAllWedges();
             }
         };
     }
@@ -355,10 +359,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     {
         // Wedges visualize bearing uncertainty before placement is confirmed.
         // After PR #130's auto-place flow, IsCorrected stays false even for
-        // confidently-placed pins, so we also hide wedges once the pin is
-        // routed (post-Optimize) or collected/skipped — the uncertainty has
-        // served its purpose and wedges otherwise clutter the Gathering view.
+        // confidently-placed pins, so we also hide wedges:
+        //   * once the pin is routed (post-Optimize) or collected/skipped,
+        //   * any time the FSM has left Listening — Gathering/Done shouldn't
+        //     show wedges at all, even for surveys that arrived after the
+        //     most recent Optimize and therefore have RouteOrder=null.
         if (!_session.ShowBearingWedges
+            || _surveyFlow.CurrentState != SurveyFlowState.Listening
             || s.IsCorrected
             || s.RouteOrder.HasValue
             || s.Collected

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -61,6 +61,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             {
                 RebuildAllWedges();
             }
+            else if (e.PropertyName is nameof(SessionState.IsAnchorEditable)
+                  or nameof(SessionState.HasPlayerPosition))
+            {
+                // Anchor-editable state gates the "drag to refine" hint.
+                OnPropertyChanged(nameof(OverlayHint));
+                OnPropertyChanged(nameof(IsOverlayHintVisible));
+            }
         };
 
         // Forward FSM state changes so the pin DataTemplate can gate the
@@ -69,12 +76,42 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         _surveyFlow.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(SurveyFlowController.CurrentState))
+            {
                 OnPropertyChanged(nameof(IsListening));
+                OnPropertyChanged(nameof(OverlayHint));
+                OnPropertyChanged(nameof(IsOverlayHintVisible));
+            }
         };
     }
 
     /// <summary>True iff the survey FSM is in <c>Listening</c>.</summary>
     public bool IsListening => _surveyFlow.CurrentState == SurveyFlowState.Listening;
+
+    /// <summary>
+    /// Move the currently-nudgeable target by <c>(dx, dy) * step</c>. Routes
+    /// to <see cref="SessionState.SelectedSurvey"/> when one is selected and
+    /// has a pixel position; falls back to the player anchor while it's still
+    /// editable. No-op otherwise. Shared between the keyboard hotkey commands
+    /// (NudgePinCommandBase) and the on-screen nudge pad — same semantics, same
+    /// commit path through CorrectSurveyCommand / MoveAnchor.
+    /// </summary>
+    public void Nudge(double dx, double dy, double step)
+    {
+        var selected = _session.SelectedSurvey;
+        if (selected is not null && selected.EffectivePixel.HasValue)
+        {
+            var p = selected.EffectivePixel.Value;
+            CorrectSurveyCommand.Execute(
+                new CorrectionArgs(selected, new PixelPoint(p.X + dx * step, p.Y + dy * step)));
+            return;
+        }
+
+        if (_session.IsAnchorEditable)
+        {
+            var p = _session.PlayerPosition;
+            MoveAnchor(new PixelPoint(p.X + dx * step, p.Y + dy * step));
+        }
+    }
 
     private void OnSurveysCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
@@ -136,6 +173,31 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     /// <summary>Active-pin highlight configuration. Falls back to defaults
     /// when the simpler test constructor is used (no settings).</summary>
     public LegolasActivePinStyle ActivePinStyle => _settings?.ActivePinStyle ?? _defaultActivePinStyle;
+
+    /// <summary>
+    /// Context-aware on-overlay instruction. Empty during normal use; appears
+    /// for the two states where a new user can stall:
+    ///  * AwaitingPosition: needs a click to set the anchor.
+    ///  * Listening with anchor placed but no surveys yet: the anchor's initial
+    ///    projection scale can stick the pin off-screen (#131 follow-up). The
+    ///    drag-anywhere gesture rescues it; the hint tells the user how.
+    /// Hidden in Gathering/Done where the route geometry speaks for itself.
+    /// </summary>
+    public string OverlayHint
+    {
+        get
+        {
+            return _surveyFlow.CurrentState switch
+            {
+                SurveyFlowState.AwaitingPosition => "Click anywhere on this map to mark your player position.",
+                SurveyFlowState.Listening when _session.IsAnchorEditable
+                    => "Drag the map to fine-tune your position. Use the Surveying skill in-game — pins place automatically.",
+                _ => string.Empty,
+            };
+        }
+    }
+
+    public bool IsOverlayHintVisible => !string.IsNullOrEmpty(OverlayHint);
 
     public PixelPoint PlayerPosition
     {
@@ -291,7 +353,17 @@ public sealed partial class MapOverlayViewModel : ObservableObject
 
     private void RebuildWedgeFor(SurveyItemViewModel s)
     {
-        if (!_session.ShowBearingWedges || s.IsCorrected || s.Offset.Magnitude < 1e-6)
+        // Wedges visualize bearing uncertainty before placement is confirmed.
+        // After PR #130's auto-place flow, IsCorrected stays false even for
+        // confidently-placed pins, so we also hide wedges once the pin is
+        // routed (post-Optimize) or collected/skipped — the uncertainty has
+        // served its purpose and wedges otherwise clutter the Gathering view.
+        if (!_session.ShowBearingWedges
+            || s.IsCorrected
+            || s.RouteOrder.HasValue
+            || s.Collected
+            || s.Skipped
+            || s.Offset.Magnitude < 1e-6)
         {
             s.WedgeGeometry = null;
             return;

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -62,7 +62,19 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 RebuildAllWedges();
             }
         };
+
+        // Forward FSM state changes so the pin DataTemplate can gate the
+        // active-pin halo on Listening (the only phase where SelectedSurvey
+        // is meaningful — Gathering uses IsActiveTarget + marching ants).
+        _surveyFlow.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(SurveyFlowController.CurrentState))
+                OnPropertyChanged(nameof(IsListening));
+        };
     }
+
+    /// <summary>True iff the survey FSM is in <c>Listening</c>.</summary>
+    public bool IsListening => _surveyFlow.CurrentState == SurveyFlowState.Listening;
 
     private void OnSurveysCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
@@ -106,6 +118,24 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     public SurveyFlowController SurveyFlow => _surveyFlow;
 
     public LegolasBrushes Brushes => _brushes;
+
+    private static readonly LegolasPinStyle _defaultPinStyle = new();
+    private static readonly LegolasPinStyle _defaultPlayerPinStyle = LegolasPinStyle.PlayerDefaults();
+    private static readonly LegolasActivePinStyle _defaultActivePinStyle = new();
+
+    /// <summary>Survey pin shape configuration for the DataTemplate. Falls
+    /// back to defaults when the simpler test constructor is used (no settings).</summary>
+    public LegolasPinStyle PinStyle => _settings?.PinStyle ?? _defaultPinStyle;
+
+    /// <summary>Player anchor pin shape configuration. Same shape model as
+    /// <see cref="PinStyle"/> but with player-specific defaults; the player
+    /// pin's outer Size is meaningful (drives Thumb bounds) while the survey
+    /// pin's outer size still comes from <c>SurveyPinRadiusMetres</c>.</summary>
+    public LegolasPinStyle PlayerPinStyle => _settings?.PlayerPinStyle ?? _defaultPlayerPinStyle;
+
+    /// <summary>Active-pin highlight configuration. Falls back to defaults
+    /// when the simpler test constructor is used (no settings).</summary>
+    public LegolasActivePinStyle ActivePinStyle => _settings?.ActivePinStyle ?? _defaultActivePinStyle;
 
     public PixelPoint PlayerPosition
     {

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -68,14 +68,17 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 OnPropertyChanged(nameof(OverlayHint));
                 OnPropertyChanged(nameof(IsOverlayHintVisible));
             }
+            else if (e.PropertyName is nameof(SessionState.Mode))
+            {
+                // Switching between Survey and Motherlode flips wedge
+                // visibility wholesale — Survey hides them, Motherlode shows.
+                RebuildAllWedges();
+            }
         };
 
         // Forward FSM state changes so the pin DataTemplate can gate the
         // active-pin halo on Listening (the only phase where SelectedSurvey
         // is meaningful — Gathering uses IsActiveTarget + marching ants).
-        // RebuildAllWedges on transition catches the post-Optimize case
-        // where surveys that arrived after the route was computed have
-        // RouteOrder=null and therefore aren't cleared by Optimize itself.
         _surveyFlow.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(SurveyFlowController.CurrentState))
@@ -83,7 +86,6 @@ public sealed partial class MapOverlayViewModel : ObservableObject
                 OnPropertyChanged(nameof(IsListening));
                 OnPropertyChanged(nameof(OverlayHint));
                 OnPropertyChanged(nameof(IsOverlayHintVisible));
-                RebuildAllWedges();
             }
         };
     }
@@ -357,17 +359,14 @@ public sealed partial class MapOverlayViewModel : ObservableObject
 
     private void RebuildWedgeFor(SurveyItemViewModel s)
     {
-        // Wedges visualize bearing uncertainty before placement is confirmed.
-        // After PR #130's auto-place flow, IsCorrected stays false even for
-        // confidently-placed pins, so we also hide wedges:
-        //   * once the pin is routed (post-Optimize) or collected/skipped,
-        //   * any time the FSM has left Listening — Gathering/Done shouldn't
-        //     show wedges at all, even for surveys that arrived after the
-        //     most recent Optimize and therefore have RouteOrder=null.
+        // Wedges only render in Motherlode mode. Survey mode's 4-DOF refit
+        // (PR #130) lands pins essentially pixel-perfect, so the bearing arc
+        // adds no information — the optimised route + the placed pins are
+        // sufficient and precise. Motherlode triangulation has no comparable
+        // refit, so the bearing arc still narrows the search there.
         if (!_session.ShowBearingWedges
-            || _surveyFlow.CurrentState != SurveyFlowState.Listening
+            || _session.Mode != SessionMode.Motherlode
             || s.IsCorrected
-            || s.RouteOrder.HasValue
             || s.Collected
             || s.Skipped
             || s.Offset.Magnitude < 1e-6)

--- a/src/Legolas.Module/ViewModels/NudgePadViewModel.cs
+++ b/src/Legolas.Module/ViewModels/NudgePadViewModel.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Legolas.Domain;
+
+namespace Legolas.ViewModels;
+
+/// <summary>
+/// On-screen nudge controls. Exposes four directional commands plus a
+/// step-size tier so the user can fine-tune pin or anchor placement without
+/// binding hotkeys. Shared between the wizard panel (always visible) and the
+/// map overlay (gated by <c>LegolasSettings.ShowNudgePadOnOverlay</c>) so the
+/// d-pad layout has one source of truth.
+/// </summary>
+public sealed partial class NudgePadViewModel : ObservableObject
+{
+    private readonly SessionState _session;
+    private readonly MapOverlayViewModel _map;
+    private readonly LegolasSettings _settings;
+
+    public NudgePadViewModel(SessionState session, MapOverlayViewModel map, LegolasSettings settings)
+    {
+        _session = session;
+        _map = map;
+        _settings = settings;
+
+        // The pad is "available" iff there's something to nudge: a selected
+        // survey, OR the player anchor while it's still editable. Recompute
+        // when either input changes so buttons enable/disable live.
+        _session.PropertyChanged += OnSessionChanged;
+        _session.Surveys.CollectionChanged += (_, _) => RaiseAvailability();
+    }
+
+    private void OnSessionChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(SessionState.SelectedSurvey)
+            or nameof(SessionState.IsAnchorEditable)
+            or nameof(SessionState.HasPlayerPosition))
+        {
+            RaiseAvailability();
+        }
+    }
+
+    private void RaiseAvailability()
+    {
+        OnPropertyChanged(nameof(IsAvailable));
+        OnPropertyChanged(nameof(NudgeTargetLabel));
+    }
+
+    /// <summary>True iff there is a pin or anchor available to nudge.</summary>
+    public bool IsAvailable
+        => _session.SelectedSurvey is not null
+            || _session.IsAnchorEditable;
+
+    /// <summary>
+    /// Short human label of what the buttons will move. Used by the panel-side
+    /// pad so the user can tell at a glance whether they're nudging a pin or
+    /// the anchor.
+    /// </summary>
+    public string NudgeTargetLabel
+    {
+        get
+        {
+            var sel = _session.SelectedSurvey;
+            if (sel is not null) return $"Pin: {sel.Name}";
+            if (_session.IsAnchorEditable) return "Player anchor";
+            return "(no target — select a pin)";
+        }
+    }
+
+    [ObservableProperty]
+    private NudgeStepSize _selectedStep = NudgeStepSize.Default;
+
+    private double Magnitude => SelectedStep switch
+    {
+        NudgeStepSize.Fine => _settings.NudgeStepFine,
+        NudgeStepSize.Fast => _settings.NudgeStepFast,
+        _ => _settings.NudgeStepDefault,
+    };
+
+    [RelayCommand]
+    private void NudgeUp() => _map.Nudge(0, -1, Magnitude);
+
+    [RelayCommand]
+    private void NudgeDown() => _map.Nudge(0, 1, Magnitude);
+
+    [RelayCommand]
+    private void NudgeLeft() => _map.Nudge(-1, 0, Magnitude);
+
+    [RelayCommand]
+    private void NudgeRight() => _map.Nudge(1, 0, Magnitude);
+}

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -105,6 +105,18 @@ public sealed partial class SessionState : ObservableObject
     [ObservableProperty]
     private SurveyItemViewModel? _selectedSurvey;
 
+    /// <summary>
+    /// Mirror the SelectedSurvey identity onto each pin's IsSelected flag so
+    /// the DataTemplate can drive its halo treatment without dotted-path
+    /// MultiBindings against a sibling property. Mirrors the
+    /// <see cref="RecalculateActiveTarget"/> pattern.
+    /// </summary>
+    partial void OnSelectedSurveyChanged(SurveyItemViewModel? value)
+    {
+        foreach (var s in Surveys)
+            s.IsSelected = ReferenceEquals(s, value);
+    }
+
     public void ClearSurveys()
     {
         Surveys.Clear();

--- a/src/Legolas.Module/ViewModels/SurveyItemViewModel.cs
+++ b/src/Legolas.Module/ViewModels/SurveyItemViewModel.cs
@@ -15,6 +15,16 @@ public sealed partial class SurveyItemViewModel : ObservableObject
     [ObservableProperty]
     private bool _isActiveTarget;
 
+    /// <summary>
+    /// True iff this pin is the <c>SessionState.SelectedSurvey</c> — the
+    /// pin a keyboard nudge will move. Drives the active-pin halo treatment
+    /// while the FSM is in <c>Listening</c>. Distinct from
+    /// <see cref="IsActiveTarget"/>, which marks the next pin to visit
+    /// during <c>Gathering</c>.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isSelected;
+
     public SurveyItemViewModel(Survey model)
     {
         _model = model;

--- a/src/Legolas.Module/Views/Converters/GlowEffectConverter.cs
+++ b/src/Legolas.Module/Views/Converters/GlowEffectConverter.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// Returns a soft <see cref="DropShadowEffect"/> for the active pin when the
+/// chosen treatment is <see cref="ActivePinTreatment.Glow"/>, else <c>null</c>.
+/// Inputs: <c>(IsSelected, IsListening, ActivePinTreatment, ActivePin brush,
+/// GlowBlurRadius)</c>. Distinct from <see cref="HaloVisibilityConverter"/>
+/// which gates a static halo ring on the same conditions but for the Halo
+/// treatment. The glow doesn't compete with the in-game survey ping animation
+/// (which is a hard red ring shrinking inward) the way a static halo does.
+/// </summary>
+public sealed class GlowEffectConverter : IMultiValueConverter
+{
+    public static readonly GlowEffectConverter Instance = new();
+
+    public object? Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 5) return null;
+        var isSelected = values[0] is bool b1 && b1;
+        var isListening = values[1] is bool b2 && b2;
+        var treatment = values[2] is ActivePinTreatment t ? t : ActivePinTreatment.Halo;
+        if (!(isSelected && isListening && treatment == ActivePinTreatment.Glow)) return null;
+
+        var color = values[3] is SolidColorBrush brush ? brush.Color : Colors.White;
+        var blur = values[4] switch
+        {
+            double d => d,
+            int i => i,
+            float f => f,
+            _ => 0.0,
+        };
+        if (blur <= 0) return null;
+
+        return new DropShadowEffect
+        {
+            Color = color,
+            // ShadowDepth = 0 makes the effect a symmetric glow, not a
+            // directional drop shadow. Opacity carries the brush's alpha.
+            ShadowDepth = 0,
+            BlurRadius = blur,
+            Opacity = color.A / 255.0,
+        };
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Legolas.Module/Views/Converters/HaloGeometryConverter.cs
+++ b/src/Legolas.Module/Views/Converters/HaloGeometryConverter.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// Builds the active-pin halo geometry. Takes <c>(outerShape, pinDiameter,
+/// haloPaddingPx)</c> and produces a shape sized to <c>pinDiameter + 2 *
+/// haloPaddingPx</c>, centred so the halo Path overlaps the outer pin shape
+/// concentrically inside the Thumb's Grid.
+/// </summary>
+public sealed class HaloGeometryConverter : IMultiValueConverter
+{
+    public static readonly HaloGeometryConverter Instance = new();
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 3) return Geometry.Empty;
+        if (values[0] is not PinShape shape) return Geometry.Empty;
+        var diameter = ToDouble(values[1]);
+        var padding = ToDouble(values[2]);
+        var size = diameter + 2 * padding;
+        return size <= 0 ? Geometry.Empty : PinShapeToGeometryConverter.BuildGeometry(shape, size);
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+
+    private static double ToDouble(object? v) => v switch
+    {
+        double d => d,
+        int i => i,
+        float f => f,
+        _ => 0.0,
+    };
+}

--- a/src/Legolas.Module/Views/Converters/HaloVisibilityConverter.cs
+++ b/src/Legolas.Module/Views/Converters/HaloVisibilityConverter.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// Visibility for the active-pin halo overlay. Visible iff
+/// <c>(IsSelected, IsListening, ActivePinTreatment)</c> all line up: the pin
+/// is the SelectedSurvey, the FSM is in Listening (Gathering uses the
+/// marching-ants line instead), and the user picked the Halo treatment.
+/// </summary>
+public sealed class HaloVisibilityConverter : IMultiValueConverter
+{
+    public static readonly HaloVisibilityConverter Instance = new();
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 3) return Visibility.Collapsed;
+        var isSelected = values[0] is bool b1 && b1;
+        var isListening = values[1] is bool b2 && b2;
+        var treatment = values[2] is ActivePinTreatment t ? t : ActivePinTreatment.Halo;
+        return (isSelected && isListening && treatment == ActivePinTreatment.Halo)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Legolas.Module/Views/Converters/PinShapeToGeometryConverter.cs
+++ b/src/Legolas.Module/Views/Converters/PinShapeToGeometryConverter.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// Maps <c>(PinShape, double size)</c> → <see cref="Geometry"/> for the
+/// pin DataTemplate's outer + centre Paths. The geometry is built around
+/// (0,0)–(size,size) so the Path occupies a known box; the Thumb container
+/// centres the Grid containing both shapes.
+/// </summary>
+public sealed class PinShapeToGeometryConverter : IMultiValueConverter
+{
+    public static readonly PinShapeToGeometryConverter Instance = new();
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 2 || values[0] is not PinShape shape) return Geometry.Empty;
+        var size = ToDouble(values[1]);
+        if (size <= 0) return Geometry.Empty;
+        return BuildGeometry(shape, size);
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+
+    public static Geometry BuildGeometry(PinShape shape, double size) => shape switch
+    {
+        PinShape.Circle => new EllipseGeometry(new System.Windows.Point(size / 2, size / 2), size / 2, size / 2),
+        PinShape.Square => new RectangleGeometry(new System.Windows.Rect(0, 0, size, size)),
+        PinShape.Diamond => BuildDiamond(size),
+        PinShape.Cross => BuildCross(size),
+        PinShape.None => Geometry.Empty,
+        _ => Geometry.Empty,
+    };
+
+    private static Geometry BuildDiamond(double size)
+    {
+        var half = size / 2;
+        var fig = new PathFigure
+        {
+            StartPoint = new System.Windows.Point(half, 0),
+            IsClosed = true,
+            IsFilled = true,
+        };
+        fig.Segments.Add(new LineSegment(new System.Windows.Point(size, half), true));
+        fig.Segments.Add(new LineSegment(new System.Windows.Point(half, size), true));
+        fig.Segments.Add(new LineSegment(new System.Windows.Point(0, half), true));
+        var path = new PathGeometry();
+        path.Figures.Add(fig);
+        return path;
+    }
+
+    private static Geometry BuildCross(double size)
+    {
+        // Cross = horizontal + vertical bar each ~1/3 the box thickness, centred.
+        // Thinner than this and the cross disappears at small sizes; thicker
+        // and it becomes a plus-sign block.
+        var arm = size / 3;
+        var offset = (size - arm) / 2;
+        var group = new GeometryGroup();
+        group.Children.Add(new RectangleGeometry(new System.Windows.Rect(0, offset, size, arm)));
+        group.Children.Add(new RectangleGeometry(new System.Windows.Rect(offset, 0, arm, size)));
+        return group;
+    }
+
+    private static double ToDouble(object? v) => v switch
+    {
+        double d => d,
+        int i => i,
+        float f => f,
+        _ => 0.0,
+    };
+}

--- a/src/Legolas.Module/Views/Converters/PreviewGlowEffectConverter.cs
+++ b/src/Legolas.Module/Views/Converters/PreviewGlowEffectConverter.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// Preview-only sibling to <see cref="GlowEffectConverter"/>. Skips the
+/// IsSelected / IsListening gates (those don't apply to a static preview)
+/// and just returns a <see cref="DropShadowEffect"/> when the user has
+/// <see cref="ActivePinTreatment.Glow"/> selected. Inputs:
+/// <c>(ActivePinTreatment, ActivePin brush, GlowBlurRadius)</c>.
+/// </summary>
+public sealed class PreviewGlowEffectConverter : IMultiValueConverter
+{
+    public static readonly PreviewGlowEffectConverter Instance = new();
+
+    public object? Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 3) return null;
+        if (values[0] is not ActivePinTreatment treatment || treatment != ActivePinTreatment.Glow) return null;
+
+        var color = values[1] is SolidColorBrush brush ? brush.Color : Colors.White;
+        var blur = values[2] switch
+        {
+            double d => d,
+            int i => i,
+            float f => f,
+            _ => 0.0,
+        };
+        if (blur <= 0) return null;
+
+        return new DropShadowEffect
+        {
+            Color = color,
+            ShadowDepth = 0,
+            BlurRadius = blur,
+            Opacity = color.A / 255.0,
+        };
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Legolas.Module/Views/Converters/StrokeStyleToDashArrayConverter.cs
+++ b/src/Legolas.Module/Views/Converters/StrokeStyleToDashArrayConverter.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// <see cref="PinStrokeStyle.Dashed"/> → "4 2" dash pattern; everything else →
+/// <c>null</c> (solid line, or no stroke when paired with thickness 0). The
+/// "None" case still returns <c>null</c> here — visibility is enforced via
+/// <see cref="StrokeStyleToThicknessConverter"/> which zeroes the thickness.
+/// </summary>
+public sealed class StrokeStyleToDashArrayConverter : IValueConverter
+{
+    public static readonly StrokeStyleToDashArrayConverter Instance = new();
+
+    public object? Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is PinStrokeStyle.Dashed ? new DoubleCollection { 4, 2 } : null;
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Legolas.Module/Views/Converters/StrokeStyleToThicknessConverter.cs
+++ b/src/Legolas.Module/Views/Converters/StrokeStyleToThicknessConverter.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.Windows.Data;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// Multiplexes <c>(PinStrokeStyle, configured thickness)</c> into the actual
+/// rendered <c>StrokeThickness</c>: <see cref="PinStrokeStyle.None"/> forces 0
+/// regardless of the configured thickness; Solid/Dashed pass through. Lets the
+/// user choose a thickness once and toggle the stroke on/off via the style
+/// dropdown without zeroing their value.
+/// </summary>
+public sealed class StrokeStyleToThicknessConverter : IMultiValueConverter
+{
+    public static readonly StrokeStyleToThicknessConverter Instance = new();
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 2) return 0.0;
+        if (values[0] is not PinStrokeStyle style) return 0.0;
+        if (style == PinStrokeStyle.None) return 0.0;
+        return values[1] switch
+        {
+            double d => d,
+            int i => (double)i,
+            float f => (double)f,
+            _ => 0.0,
+        };
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Legolas.Module/Views/Converters/TreatmentToHaloVisibilityConverter.cs
+++ b/src/Legolas.Module/Views/Converters/TreatmentToHaloVisibilityConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using Legolas.Domain;
+
+namespace Legolas.Views.Converters;
+
+/// <summary>
+/// <see cref="ActivePinTreatment.Halo"/> → <see cref="Visibility.Visible"/>;
+/// every other treatment → <see cref="Visibility.Collapsed"/>. Used by the
+/// settings preview to show the halo Path only when the user has Halo
+/// selected, distinct from <see cref="HaloVisibilityConverter"/> which also
+/// checks IsSelected + IsListening (those don't apply in the preview).
+/// </summary>
+public sealed class TreatmentToHaloVisibilityConverter : IValueConverter
+{
+    public static readonly TreatmentToHaloVisibilityConverter Instance = new();
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is ActivePinTreatment.Halo ? Visibility.Visible : Visibility.Collapsed;
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Legolas.Module/Views/LegolasPanelView.xaml
+++ b/src/Legolas.Module/Views/LegolasPanelView.xaml
@@ -3,8 +3,26 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:views="clr-namespace:Legolas.Views"
              Background="{DynamicResource BgPrimaryBrush}">
-    <!-- The panel hosts the wizard directly. Settings (overlay options,
-         click-through, marker colors, inventory grid) live in the shell's
-         per-module settings tab via LegolasModule.SettingsViewType. -->
-    <views:WizardView />
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <!-- The panel hosts the wizard plus a docked nudge pad. Pad lives at the
+         bottom so it doesn't push the wizard's primary action buttons off-screen
+         on shorter windows; auto-disables when there's no pin or anchor to
+         nudge. Settings (overlay options, click-through, marker colors,
+         inventory grid) live in the per-module settings tab via
+         LegolasModule.SettingsViewType. -->
+    <DockPanel>
+        <Border DockPanel.Dock="Bottom"
+                BorderBrush="{StaticResource TextTertiaryBrush}"
+                BorderThickness="0,1,0,0"
+                Padding="12,10">
+            <views:NudgePadView DataContext="{Binding NudgePad}" />
+        </Border>
+        <views:WizardView />
+    </DockPanel>
 </UserControl>

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Legolas.Views.LegolasSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:Legolas.Views.Converters"
              Background="{DynamicResource BgPrimaryBrush}">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -157,8 +158,10 @@
                 </StackPanel>
             </GroupBox>
 
-            <!-- Marker colors -->
-            <GroupBox Header="Marker Colors" Padding="8" Margin="0,0,0,12">
+            <!-- Map colours (route + wedges). Player marker moved into its own
+                 "Player Pin" group below — it's now a configurable pin like the
+                 survey pin, not just a colour. -->
+            <GroupBox Header="Map Colors" Padding="8" Margin="0,0,0,12">
                 <StackPanel>
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -170,45 +173,24 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Pin (pending)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Route line" VerticalAlignment="Center" Margin="0,4,8,4" />
                         <TextBox  Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
-                                  Text="{Binding Colors.PinPending, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="0" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                  Background="{Binding Brushes.PinPending}" />
-
-                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Pin (finalized)" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
-                                  Text="{Binding Colors.PinFinalized, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="1" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                  Background="{Binding Brushes.PinFinalized}" />
-
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Player marker" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
-                                  Text="{Binding Colors.PlayerMarker, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="2" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
-                                  Background="{Binding Brushes.PlayerMarker}" />
-
-                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Route line" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
                                   Text="{Binding Colors.RouteLine, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="3" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                        <Border   Grid.Row="0" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
                                   Background="{Binding Brushes.RouteLine}" />
 
-                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Wedge fill" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Wedge fill" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
                                   Text="{Binding Colors.BearingWedgeFill, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="4" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                        <Border   Grid.Row="1" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
                                   Background="{Binding Brushes.BearingWedgeFill}" />
 
-                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Wedge stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
-                        <TextBox  Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Wedge stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox  Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,4,4"
                                   Text="{Binding Colors.BearingWedgeStroke, UpdateSourceTrigger=LostFocus}" />
-                        <Border   Grid.Row="5" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                        <Border   Grid.Row="2" Grid.Column="2" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
                                   Background="{Binding Brushes.BearingWedgeStroke}" />
                     </Grid>
                     <TextBlock Text="ARGB hex (e.g. #FFFF0000 — opaque red, or #33FFFF80 — translucent yellow). 6-digit RGB also accepted; alpha defaults to FF."
@@ -216,6 +198,463 @@
                                TextWrapping="Wrap" Margin="0,6,0,0" />
                     <Button Content="Reset to defaults" HorizontalAlignment="Right" Margin="0,8,0,0"
                             Padding="10,4" Command="{Binding ResetColorsToDefaultsCommand}" />
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Pin Appearance (issue #131) -->
+            <GroupBox Header="Pin Appearance" Padding="8" Margin="0,0,0,12">
+                <StackPanel>
+                    <TextBlock Text="Outer ring and centre indicator are independent — fill, stroke, shape, and stroke style can each be set per shape. Outer ring diameter follows the &quot;Pin radius&quot; slider above; the centre has its own size."
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               TextWrapping="Wrap" Margin="0,0,0,8" />
+
+                    <!-- Live preview — same Path layers as the real map DataTemplate, just
+                         scaled up so colour/stroke/shape tweaks are immediately visible. -->
+                    <Border BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                            Background="#FF101010" Padding="12" Margin="0,0,0,12"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Grid Width="64" Height="64">
+                                <!-- Outer shape -->
+                                <Path Fill="{Binding Brushes.OuterFill}"
+                                      Stroke="{Binding Brushes.OuterStroke}"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      StrokeDashArray="{Binding PinStyle.Outer.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                    <Path.StrokeThickness>
+                                        <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                            <Binding Path="PinStyle.Outer.StrokeStyle" />
+                                            <Binding Path="PinStyle.Outer.StrokeThickness" />
+                                        </MultiBinding>
+                                    </Path.StrokeThickness>
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                            <Binding Path="PinStyle.Outer.Shape" />
+                                            <Binding Path="PreviewPinDiameter" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                                <!-- Centre indicator -->
+                                <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      Fill="{Binding Brushes.CenterFill}"
+                                      Stroke="{Binding Brushes.CenterStroke}"
+                                      StrokeDashArray="{Binding PinStyle.Center.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                    <Path.StrokeThickness>
+                                        <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                            <Binding Path="PinStyle.Center.StrokeStyle" />
+                                            <Binding Path="PinStyle.Center.StrokeThickness" />
+                                        </MultiBinding>
+                                    </Path.StrokeThickness>
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                            <Binding Path="PinStyle.Center.Shape" />
+                                            <Binding Path="PinStyle.Center.Size" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                            </Grid>
+                            <TextBlock Text="Preview" VerticalAlignment="Center" Margin="16,0,0,0"
+                                       Foreground="{StaticResource TextTertiaryBrush}" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Outer ring. Grid uses a 4-column layout — label | flex-control |
+                         numeric-value | swatch — so slider rows and colour rows can share
+                         the same template without the value TextBox overlapping the slider. -->
+                    <TextBlock Text="Outer" FontWeight="SemiBold" Margin="0,4,0,4" />
+                    <Grid Margin="12,0,0,0" DataContext="{Binding PinStyle.Outer}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                            <ColumnDefinition Width="24" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Shape" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinShapes, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding Shape}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.OuterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.OuterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinStrokeStyles, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding StrokeStyle}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Stroke thickness" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="0" Maximum="6" Value="{Binding StrokeThickness}" />
+                        <TextBox   Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeThickness, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+                    </Grid>
+
+                    <!-- Centre indicator -->
+                    <TextBlock Text="Centre" FontWeight="SemiBold" Margin="0,12,0,4" />
+                    <Grid Margin="12,0,0,0" DataContext="{Binding PinStyle.Center}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                            <ColumnDefinition Width="24" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Shape" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinShapes, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding Shape}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.CenterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.CenterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinStrokeStyles, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding StrokeStyle}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Stroke thickness" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="0" Maximum="6" Value="{Binding StrokeThickness}" />
+                        <TextBox   Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeThickness, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Size (px)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="1" Maximum="20" Value="{Binding Size}" />
+                        <TextBox   Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding Size, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+                    </Grid>
+
+                    <Button Content="Reset to defaults" HorizontalAlignment="Right" Margin="0,12,0,0"
+                            Padding="10,4" Command="{Binding ResetPinStyleToDefaultsCommand}" />
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Player Pin (issue #131) — same shape model as the survey pin but with
+                 player-specific defaults (white circle outer + small green centre dot).
+                 Outer.Size is meaningful here: it drives the Thumb bounds on the map. -->
+            <GroupBox Header="Player Pin" Padding="8" Margin="0,0,0,12">
+                <StackPanel>
+                    <TextBlock Text="The player anchor pin. Same shape + colour controls as the survey pin; here the outer Size is the actual on-map diameter (no separate radius slider)."
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               TextWrapping="Wrap" Margin="0,0,0,8" />
+
+                    <!-- Live preview of the player pin. -->
+                    <Border BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                            Background="#FF101010" Padding="12" Margin="0,0,0,12"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Grid Width="64" Height="64">
+                                <Path Fill="{Binding Brushes.PlayerOuterFill}"
+                                      Stroke="{Binding Brushes.PlayerOuterStroke}"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      StrokeDashArray="{Binding PlayerPinStyle.Outer.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                    <Path.StrokeThickness>
+                                        <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                            <Binding Path="PlayerPinStyle.Outer.StrokeStyle" />
+                                            <Binding Path="PlayerPinStyle.Outer.StrokeThickness" />
+                                        </MultiBinding>
+                                    </Path.StrokeThickness>
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                            <Binding Path="PlayerPinStyle.Outer.Shape" />
+                                            <Binding Path="PlayerPinStyle.Outer.Size" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                                <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      Fill="{Binding Brushes.PlayerCenterFill}"
+                                      Stroke="{Binding Brushes.PlayerCenterStroke}"
+                                      StrokeDashArray="{Binding PlayerPinStyle.Center.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                    <Path.StrokeThickness>
+                                        <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                            <Binding Path="PlayerPinStyle.Center.StrokeStyle" />
+                                            <Binding Path="PlayerPinStyle.Center.StrokeThickness" />
+                                        </MultiBinding>
+                                    </Path.StrokeThickness>
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                            <Binding Path="PlayerPinStyle.Center.Shape" />
+                                            <Binding Path="PlayerPinStyle.Center.Size" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                            </Grid>
+                            <TextBlock Text="Preview" VerticalAlignment="Center" Margin="16,0,0,0"
+                                       Foreground="{StaticResource TextTertiaryBrush}" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Outer ring -->
+                    <TextBlock Text="Outer" FontWeight="SemiBold" Margin="0,4,0,4" />
+                    <Grid Margin="12,0,0,0" DataContext="{Binding PlayerPinStyle.Outer}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                            <ColumnDefinition Width="24" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Shape" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinShapes, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding Shape}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.PlayerOuterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.PlayerOuterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinStrokeStyles, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding StrokeStyle}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Stroke thickness" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="0" Maximum="6" Value="{Binding StrokeThickness}" />
+                        <TextBox   Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeThickness, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Size (px)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="2" Maximum="40" Value="{Binding Size}" />
+                        <TextBox   Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding Size, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+                    </Grid>
+
+                    <!-- Centre indicator -->
+                    <TextBlock Text="Centre" FontWeight="SemiBold" Margin="0,12,0,4" />
+                    <Grid Margin="12,0,0,0" DataContext="{Binding PlayerPinStyle.Center}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                            <ColumnDefinition Width="24" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Shape" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinShapes, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding Shape}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Fill" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding FillColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.PlayerCenterFill, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Stroke" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeColor, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="2" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.PlayerCenterStroke, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Stroke style" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.PinStrokeStyles, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding StrokeStyle}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Stroke thickness" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="0" Maximum="6" Value="{Binding StrokeThickness}" />
+                        <TextBox   Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding StrokeThickness, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Size (px)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="1" Maximum="20" Value="{Binding Size}" />
+                        <TextBox   Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding Size, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+                    </Grid>
+
+                    <Button Content="Reset to defaults" HorizontalAlignment="Right" Margin="0,12,0,0"
+                            Padding="10,4" Command="{Binding ResetPlayerPinStyleToDefaultsCommand}" />
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Active Pin Highlight (issue #131) -->
+            <GroupBox Header="Active Pin Highlight" Padding="8" Margin="0,0,0,12">
+                <StackPanel>
+                    <TextBlock Text="Visual treatment for the pin you'd nudge with a keyboard shortcut. Only visible while the survey FSM is in Listening — Gathering uses the marching-ants line on the active target instead. Halo draws a static ring (cheap, crisp, can clash with the in-game survey ping animation); Glow draws a soft DropShadow (doesn't clash, slightly softer feel). ScaleUp / FillSwap are reserved for a future PR."
+                               Foreground="{StaticResource TextTertiaryBrush}"
+                               TextWrapping="Wrap" Margin="0,0,0,8" />
+
+                    <!-- Live preview that mirrors the chosen treatment. The halo Path's
+                         visibility is gated on Treatment==Halo; the Grid.Effect carries the
+                         Glow when Treatment==Glow. The IsSelected/IsListening checks that
+                         apply on the real map don't apply here — this is a static "what
+                         does active look like" preview. -->
+                    <Border BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                            Background="#FF101010" Padding="12" Margin="0,0,0,12"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Grid Width="80" Height="80">
+                                <Grid.Effect>
+                                    <MultiBinding Converter="{x:Static converters:PreviewGlowEffectConverter.Instance}">
+                                        <Binding Path="ActivePinStyle.Treatment" />
+                                        <Binding Path="Brushes.ActivePin" />
+                                        <Binding Path="ActivePinStyle.GlowBlurRadius" />
+                                    </MultiBinding>
+                                </Grid.Effect>
+                                <!-- Halo (outermost), shown only when Treatment == Halo. -->
+                                <Path Stroke="{Binding Brushes.ActivePin}"
+                                      Fill="Transparent"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      Visibility="{Binding ActivePinStyle.Treatment, Converter={x:Static converters:TreatmentToHaloVisibilityConverter.Instance}}"
+                                      StrokeThickness="{Binding ActivePinStyle.HaloThickness}">
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:HaloGeometryConverter.Instance}">
+                                            <Binding Path="PinStyle.Outer.Shape" />
+                                            <Binding Path="PreviewPinDiameter" />
+                                            <Binding Path="ActivePinStyle.HaloPaddingPx" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                                <!-- Outer shape -->
+                                <Path Fill="{Binding Brushes.OuterFill}"
+                                      Stroke="{Binding Brushes.OuterStroke}"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      StrokeDashArray="{Binding PinStyle.Outer.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                    <Path.StrokeThickness>
+                                        <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                            <Binding Path="PinStyle.Outer.StrokeStyle" />
+                                            <Binding Path="PinStyle.Outer.StrokeThickness" />
+                                        </MultiBinding>
+                                    </Path.StrokeThickness>
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                            <Binding Path="PinStyle.Outer.Shape" />
+                                            <Binding Path="PreviewPinDiameter" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                                <!-- Centre indicator -->
+                                <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                      Fill="{Binding Brushes.CenterFill}"
+                                      Stroke="{Binding Brushes.CenterStroke}"
+                                      StrokeDashArray="{Binding PinStyle.Center.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                    <Path.StrokeThickness>
+                                        <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                            <Binding Path="PinStyle.Center.StrokeStyle" />
+                                            <Binding Path="PinStyle.Center.StrokeThickness" />
+                                        </MultiBinding>
+                                    </Path.StrokeThickness>
+                                    <Path.Data>
+                                        <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                            <Binding Path="PinStyle.Center.Shape" />
+                                            <Binding Path="PinStyle.Center.Size" />
+                                        </MultiBinding>
+                                    </Path.Data>
+                                </Path>
+                            </Grid>
+                            <TextBlock Text="Preview (active pin)" VerticalAlignment="Center" Margin="16,0,0,0"
+                                       Foreground="{StaticResource TextTertiaryBrush}" />
+                        </StackPanel>
+                    </Border>
+
+                    <Grid DataContext="{Binding ActivePinStyle}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                            <ColumnDefinition Width="24" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Treatment" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <ComboBox  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Center" Margin="0,4,0,4"
+                                   ItemsSource="{Binding DataContext.ActivePinTreatments, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                   SelectedItem="{Binding Treatment}" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Color" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <TextBox   Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding Color, UpdateSourceTrigger=LostFocus}" />
+                        <Border    Grid.Row="1" Grid.Column="3" Width="16" Height="16" BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                                   Background="{Binding DataContext.Brushes.ActivePin, RelativeSource={RelativeSource AncestorType=GroupBox}}" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Halo thickness" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="1" Maximum="6" Value="{Binding HaloThickness}" />
+                        <TextBox   Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding HaloThickness, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Halo padding (px)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="0" Maximum="10" Value="{Binding HaloPaddingPx}" />
+                        <TextBox   Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding HaloPaddingPx, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Glow blur (px)" VerticalAlignment="Center" Margin="0,4,8,4" />
+                        <Slider    Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" Margin="0,4,8,4"
+                                   Minimum="0" Maximum="30" Value="{Binding GlowBlurRadius}" />
+                        <TextBox   Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Margin="0,4,4,4"
+                                   Text="{Binding GlowBlurRadius, StringFormat=0.#, UpdateSourceTrigger=LostFocus}" />
+                    </Grid>
+                    <Button Content="Reset to defaults" HorizontalAlignment="Right" Margin="0,12,0,0"
+                            Padding="10,4" Command="{Binding ResetActivePinStyleToDefaultsCommand}" />
                 </StackPanel>
             </GroupBox>
 

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -155,6 +155,10 @@
                                   Text="{Binding ControlPanel.NudgeStepFine, StringFormat=0.##, UpdateSourceTrigger=LostFocus}" />
                         <TextBlock Grid.Row="2" Grid.Column="2" Text="Default 0.25" Foreground="{StaticResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
                     </Grid>
+                    <CheckBox Content="Show nudge pad on the map overlay"
+                              IsChecked="{Binding ControlPanel.ShowNudgePadOnOverlay}"
+                              Margin="0,8,0,0"
+                              ToolTip="Mirror the wizard-panel nudge pad onto the map overlay's bottom-right corner. Useful if you don't want to alt-tab between the game and Mithril to fine-tune pins." />
                 </StackPanel>
             </GroupBox>
 

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -1,9 +1,11 @@
 <Window x:Class="Legolas.Views.MapOverlayView"
+        x:Name="Self"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:Legolas.ViewModels"
         xmlns:controls="clr-namespace:Legolas.Controls"
         xmlns:converters="clr-namespace:Legolas.Views.Converters"
+        xmlns:views="clr-namespace:Legolas.Views"
         Title="Map Overlay"
         WindowStyle="None"
         AllowsTransparency="True"
@@ -38,7 +40,9 @@
 
             <Grid x:Name="ViewportRoot" ClipToBounds="True" Background="Transparent">
               <Grid x:Name="Viewport" Background="Transparent"
-                    MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
+                    MouseLeftButtonDown="Viewport_MouseLeftButtonDown"
+                    MouseMove="Viewport_MouseMove"
+                    MouseLeftButtonUp="Viewport_MouseLeftButtonUp">
                 <!-- Bearing-uncertainty wedge layer (behind everything) -->
                 <ItemsControl ItemsSource="{Binding Surveys}" IsHitTestVisible="False">
                     <ItemsControl.ItemsPanel>
@@ -284,6 +288,36 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <!-- Optional on-overlay nudge pad (toggle in settings). Same VM as
+                     the wizard panel's pad, so step-size selection stays in sync. -->
+                <Border HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                        Margin="0,0,16,16" Padding="10,8"
+                        Background="#CC101010" BorderBrush="#FF505050" BorderThickness="1"
+                        CornerRadius="4">
+                    <Border.Visibility>
+                        <Binding ElementName="Self" Path="Settings.ShowNudgePadOnOverlay"
+                                 Converter="{x:Static controls:BoolToVisibilityConverter.Instance}" />
+                    </Border.Visibility>
+                    <views:NudgePadView DataContext="{Binding ElementName=Self, Path=NudgePad}" />
+                </Border>
+
+                <!-- On-overlay hint banner. Shown only during AwaitingPosition
+                     and Listening-with-no-surveys (where a freshly-projected
+                     anchor can land off-screen). IsHitTestVisible=False so the
+                     banner doesn't block the drag-to-place gesture it documents. -->
+                <Border HorizontalAlignment="Center" VerticalAlignment="Top"
+                        Margin="0,12,0,0" Padding="14,8"
+                        Background="#CC101010" BorderBrush="#FF505050" BorderThickness="1"
+                        CornerRadius="4" MaxWidth="520"
+                        IsHitTestVisible="False"
+                        Visibility="{Binding IsOverlayHintVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                    <TextBlock Text="{Binding OverlayHint}"
+                               Foreground="#FFE0E0E0"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"
+                               FontSize="13" />
+                </Border>
               </Grid>
             </Grid>
         </DockPanel>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -296,7 +296,11 @@
                         <Binding ElementName="Self" Path="Settings.ShowNudgePadOnOverlay"
                                  Converter="{x:Static controls:BoolToVisibilityConverter.Instance}" />
                     </Border.Visibility>
-                    <views:NudgePadView DataContext="{Binding ElementName=Self, Path=NudgePad}" />
+                    <!-- DataContext set explicitly in code-behind. ElementName=Self
+                         binding to a plain CLR auto-property (NudgePad) is brittle
+                         w.r.t. ctor-body timing; null-binding silently broke the
+                         pad's Command/IsChecked bindings, so we set it deterministically. -->
+                    <views:NudgePadView x:Name="OverlayNudgePad" />
                 </Border>
 
                 <!-- On-overlay hint banner. Shown only during AwaitingPosition

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:Legolas.ViewModels"
         xmlns:controls="clr-namespace:Legolas.Controls"
+        xmlns:converters="clr-namespace:Legolas.Views.Converters"
         Title="Map Overlay"
         WindowStyle="None"
         AllowsTransparency="True"
@@ -86,25 +87,71 @@
                      IsAnchorEditable flips false, restoring the legacy
                      non-interactive behaviour. -->
                 <Canvas>
-                    <Thumb Width="18" Height="18"
-                           Canvas.Left="{Binding PlayerPosition.X, Converter={x:Static controls:OffsetConverter.MinusNine}}"
-                           Canvas.Top="{Binding PlayerPosition.Y, Converter={x:Static controls:OffsetConverter.MinusNine}}"
+                    <!-- Player anchor pin. Width/Height + Canvas offset all derive from
+                         PlayerPinStyle.Outer.Size (configurable per #131); the centre
+                         indicator's size is independent (PlayerPinStyle.Center.Size). -->
+                    <Thumb Width="{Binding PlayerPinStyle.Outer.Size}"
+                           Height="{Binding PlayerPinStyle.Outer.Size}"
                            IsHitTestVisible="{Binding Session.IsAnchorEditable}"
                            Cursor="SizeAll"
                            ToolTip="Drag to fine-tune anchor (locks once the first survey lands)"
                            DragStarted="PlayerAnchor_DragStarted"
                            DragDelta="PlayerAnchor_DragDelta"
                            DragCompleted="PlayerAnchor_DragCompleted">
+                        <Canvas.Left>
+                            <MultiBinding Converter="{x:Static controls:CenterOffsetConverter.Instance}">
+                                <Binding Path="PlayerPosition.X" />
+                                <Binding Path="PlayerPinStyle.Outer.Size" />
+                            </MultiBinding>
+                        </Canvas.Left>
+                        <Canvas.Top>
+                            <MultiBinding Converter="{x:Static controls:CenterOffsetConverter.Instance}">
+                                <Binding Path="PlayerPosition.Y" />
+                                <Binding Path="PlayerPinStyle.Outer.Size" />
+                            </MultiBinding>
+                        </Canvas.Top>
                         <Thumb.Template>
                             <ControlTemplate TargetType="Thumb">
-                                <Grid Width="18" Height="18" Background="Transparent">
-                                    <Ellipse Width="18" Height="18" Stroke="White" StrokeThickness="2" Fill="Transparent" />
-                                    <Rectangle Width="2" Height="2"
-                                               Fill="{Binding Brushes.PlayerMarker}"
-                                               SnapsToDevicePixels="True"
-                                               UseLayoutRounding="True"
-                                               RenderOptions.EdgeMode="Aliased"
-                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                <Grid Background="Transparent">
+                                    <!-- Outer shape (configurable). -->
+                                    <Path Fill="{Binding Brushes.PlayerOuterFill}"
+                                          Stroke="{Binding Brushes.PlayerOuterStroke}"
+                                          StrokeDashArray="{Binding PlayerPinStyle.Outer.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                        <Path.StrokeThickness>
+                                            <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                                <Binding Path="PlayerPinStyle.Outer.StrokeStyle" />
+                                                <Binding Path="PlayerPinStyle.Outer.StrokeThickness" />
+                                            </MultiBinding>
+                                        </Path.StrokeThickness>
+                                        <Path.Data>
+                                            <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                                <Binding Path="PlayerPinStyle.Outer.Shape" />
+                                                <Binding Path="PlayerPinStyle.Outer.Size" />
+                                            </MultiBinding>
+                                        </Path.Data>
+                                    </Path>
+                                    <!-- Centre indicator (configurable). Pixel-snapping
+                                         retained for the default 2×2 case. -->
+                                    <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                          Fill="{Binding Brushes.PlayerCenterFill}"
+                                          Stroke="{Binding Brushes.PlayerCenterStroke}"
+                                          SnapsToDevicePixels="True"
+                                          UseLayoutRounding="True"
+                                          RenderOptions.EdgeMode="Aliased"
+                                          StrokeDashArray="{Binding PlayerPinStyle.Center.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                        <Path.StrokeThickness>
+                                            <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                                <Binding Path="PlayerPinStyle.Center.StrokeStyle" />
+                                                <Binding Path="PlayerPinStyle.Center.StrokeThickness" />
+                                            </MultiBinding>
+                                        </Path.StrokeThickness>
+                                        <Path.Data>
+                                            <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                                <Binding Path="PlayerPinStyle.Center.Shape" />
+                                                <Binding Path="PlayerPinStyle.Center.Size" />
+                                            </MultiBinding>
+                                        </Path.Data>
+                                    </Path>
                                 </Grid>
                             </ControlTemplate>
                         </Thumb.Template>
@@ -153,18 +200,83 @@
                                    ToolTip="{Binding Name}">
                                 <Thumb.Template>
                                     <ControlTemplate TargetType="Thumb">
+                                        <!-- Three-layer pin (issue #131): halo (active highlight), outer
+                                             shape, centre indicator. All driven by LegolasPinStyle +
+                                             LegolasActivePinStyle so the user can fully customise shape,
+                                             stroke, and fill of each. The Grid.Effect adds a soft glow
+                                             when ActivePinTreatment.Glow is selected — distinct from the
+                                             static halo so it doesn't clash with the in-game survey
+                                             ping animation. -->
                                         <Grid>
-                                            <!-- Outer ring + center dot, both PinPending colour. The earlier
-                                                 IsCorrected pulse/glow signalled "the user still owes a click";
-                                                 with auto-placement that input is no longer required, so the
-                                                 animation has been dropped. Pin styling (border, radius, active
-                                                 highlight) is being overhauled separately. -->
-                                            <Ellipse StrokeThickness="2" Fill="#01000000"
-                                                     StrokeDashArray="4 2"
-                                                     Stroke="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                            <Ellipse Width="5" Height="5"
-                                                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                     Fill="{Binding DataContext.Brushes.PinPending, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            <Grid.Effect>
+                                                <MultiBinding Converter="{x:Static converters:GlowEffectConverter.Instance}">
+                                                    <Binding Path="IsSelected" />
+                                                    <Binding Path="DataContext.IsListening" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    <Binding Path="DataContext.ActivePinStyle.Treatment" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    <Binding Path="DataContext.Brushes.ActivePin" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    <Binding Path="DataContext.ActivePinStyle.GlowBlurRadius" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                </MultiBinding>
+                                            </Grid.Effect>
+                                            <!-- Halo: visible only when this pin is the SelectedSurvey
+                                                 AND the FSM is in Listening AND the configured treatment
+                                                 is Halo. Geometry is the outer shape sized up by
+                                                 ActivePinStyle.HaloPaddingPx on each side. -->
+                                            <Path Stroke="{Binding DataContext.Brushes.ActivePin, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                  Fill="Transparent"
+                                                  HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                  StrokeThickness="{Binding DataContext.ActivePinStyle.HaloThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
+                                                <Path.Visibility>
+                                                    <MultiBinding Converter="{x:Static converters:HaloVisibilityConverter.Instance}">
+                                                        <Binding Path="IsSelected" />
+                                                        <Binding Path="DataContext.IsListening" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.ActivePinStyle.Treatment" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    </MultiBinding>
+                                                </Path.Visibility>
+                                                <Path.Data>
+                                                    <MultiBinding Converter="{x:Static converters:HaloGeometryConverter.Instance}">
+                                                        <Binding Path="DataContext.PinStyle.Outer.Shape" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.PinDiameter" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.ActivePinStyle.HaloPaddingPx" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    </MultiBinding>
+                                                </Path.Data>
+                                            </Path>
+
+                                            <!-- Outer shape — fills the Thumb. -->
+                                            <Path Fill="{Binding DataContext.Brushes.OuterFill, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                  Stroke="{Binding DataContext.Brushes.OuterStroke, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                  StrokeDashArray="{Binding DataContext.PinStyle.Outer.StrokeStyle, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                                <Path.StrokeThickness>
+                                                    <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                                        <Binding Path="DataContext.PinStyle.Outer.StrokeStyle" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.PinStyle.Outer.StrokeThickness" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    </MultiBinding>
+                                                </Path.StrokeThickness>
+                                                <Path.Data>
+                                                    <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                                        <Binding Path="DataContext.PinStyle.Outer.Shape" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.PinDiameter" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    </MultiBinding>
+                                                </Path.Data>
+                                            </Path>
+
+                                            <!-- Centre indicator — sized independently from the outer shape. -->
+                                            <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                  Fill="{Binding DataContext.Brushes.CenterFill, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                  Stroke="{Binding DataContext.Brushes.CenterStroke, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                  StrokeDashArray="{Binding DataContext.PinStyle.Center.StrokeStyle, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                                                <Path.StrokeThickness>
+                                                    <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                                        <Binding Path="DataContext.PinStyle.Center.StrokeStyle" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.PinStyle.Center.StrokeThickness" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    </MultiBinding>
+                                                </Path.StrokeThickness>
+                                                <Path.Data>
+                                                    <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                                        <Binding Path="DataContext.PinStyle.Center.Shape" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                        <Binding Path="DataContext.PinStyle.Center.Size" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                                    </MultiBinding>
+                                                </Path.Data>
+                                            </Path>
                                         </Grid>
                                     </ControlTemplate>
                                 </Thumb.Template>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -91,17 +91,13 @@
                      IsAnchorEditable flips false, restoring the legacy
                      non-interactive behaviour. -->
                 <Canvas>
-                    <!-- Player anchor pin. Width/Height + Canvas offset all derive from
-                         PlayerPinStyle.Outer.Size (configurable per #131); the centre
-                         indicator's size is independent (PlayerPinStyle.Center.Size). -->
-                    <Thumb Width="{Binding PlayerPinStyle.Outer.Size}"
-                           Height="{Binding PlayerPinStyle.Outer.Size}"
-                           IsHitTestVisible="{Binding Session.IsAnchorEditable}"
-                           Cursor="SizeAll"
-                           ToolTip="Drag to fine-tune anchor (locks once the first survey lands)"
-                           DragStarted="PlayerAnchor_DragStarted"
-                           DragDelta="PlayerAnchor_DragDelta"
-                           DragCompleted="PlayerAnchor_DragCompleted">
+                    <!-- Player anchor pin. Purely visual — viewport handles drags via
+                         Viewport_MouseLeftButton* handlers, which route by FSM state +
+                         IsAnchorEditable to either move the anchor or the SelectedSurvey.
+                         Removing the Thumb also removes its Width/Height cage that was
+                         clipping the rendered pin to the size box. -->
+                    <Grid IsHitTestVisible="False"
+                          ToolTip="Drag the map to fine-tune anchor (locks once the first survey lands)">
                         <Canvas.Left>
                             <MultiBinding Converter="{x:Static controls:CenterOffsetConverter.Instance}">
                                 <Binding Path="PlayerPosition.X" />
@@ -114,56 +110,57 @@
                                 <Binding Path="PlayerPinStyle.Outer.Size" />
                             </MultiBinding>
                         </Canvas.Top>
-                        <Thumb.Template>
-                            <ControlTemplate TargetType="Thumb">
-                                <Grid Background="Transparent">
-                                    <!-- Outer shape (configurable). -->
-                                    <Path Fill="{Binding Brushes.PlayerOuterFill}"
-                                          Stroke="{Binding Brushes.PlayerOuterStroke}"
-                                          StrokeDashArray="{Binding PlayerPinStyle.Outer.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
-                                        <Path.StrokeThickness>
-                                            <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
-                                                <Binding Path="PlayerPinStyle.Outer.StrokeStyle" />
-                                                <Binding Path="PlayerPinStyle.Outer.StrokeThickness" />
-                                            </MultiBinding>
-                                        </Path.StrokeThickness>
-                                        <Path.Data>
-                                            <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
-                                                <Binding Path="PlayerPinStyle.Outer.Shape" />
-                                                <Binding Path="PlayerPinStyle.Outer.Size" />
-                                            </MultiBinding>
-                                        </Path.Data>
-                                    </Path>
-                                    <!-- Centre indicator (configurable). Pixel-snapping
-                                         retained for the default 2×2 case. -->
-                                    <Path HorizontalAlignment="Center" VerticalAlignment="Center"
-                                          Fill="{Binding Brushes.PlayerCenterFill}"
-                                          Stroke="{Binding Brushes.PlayerCenterStroke}"
-                                          SnapsToDevicePixels="True"
-                                          UseLayoutRounding="True"
-                                          RenderOptions.EdgeMode="Aliased"
-                                          StrokeDashArray="{Binding PlayerPinStyle.Center.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
-                                        <Path.StrokeThickness>
-                                            <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
-                                                <Binding Path="PlayerPinStyle.Center.StrokeStyle" />
-                                                <Binding Path="PlayerPinStyle.Center.StrokeThickness" />
-                                            </MultiBinding>
-                                        </Path.StrokeThickness>
-                                        <Path.Data>
-                                            <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
-                                                <Binding Path="PlayerPinStyle.Center.Shape" />
-                                                <Binding Path="PlayerPinStyle.Center.Size" />
-                                            </MultiBinding>
-                                        </Path.Data>
-                                    </Path>
-                                </Grid>
-                            </ControlTemplate>
-                        </Thumb.Template>
-                    </Thumb>
+                        <!-- Outer shape (configurable). Stretch="Uniform" + Centre
+                             alignment: stroke fits within the Path's layout slot
+                             without overflow, geometry stays concentric with the
+                             centre indicator regardless of how the Grid auto-sizes. -->
+                        <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                              Stretch="Uniform"
+                              Fill="{Binding Brushes.PlayerOuterFill}"
+                              Stroke="{Binding Brushes.PlayerOuterStroke}"
+                              StrokeDashArray="{Binding PlayerPinStyle.Outer.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                            <Path.StrokeThickness>
+                                <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                    <Binding Path="PlayerPinStyle.Outer.StrokeStyle" />
+                                    <Binding Path="PlayerPinStyle.Outer.StrokeThickness" />
+                                </MultiBinding>
+                            </Path.StrokeThickness>
+                            <Path.Data>
+                                <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                    <Binding Path="PlayerPinStyle.Outer.Shape" />
+                                    <Binding Path="PlayerPinStyle.Outer.Size" />
+                                </MultiBinding>
+                            </Path.Data>
+                        </Path>
+                        <!-- Centre indicator (configurable). Pixel-snapping retained
+                             for the default 2×2 case. -->
+                        <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                              Stretch="Uniform"
+                              Fill="{Binding Brushes.PlayerCenterFill}"
+                              Stroke="{Binding Brushes.PlayerCenterStroke}"
+                              SnapsToDevicePixels="True"
+                              UseLayoutRounding="True"
+                              RenderOptions.EdgeMode="Aliased"
+                              StrokeDashArray="{Binding PlayerPinStyle.Center.StrokeStyle, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
+                            <Path.StrokeThickness>
+                                <MultiBinding Converter="{x:Static converters:StrokeStyleToThicknessConverter.Instance}">
+                                    <Binding Path="PlayerPinStyle.Center.StrokeStyle" />
+                                    <Binding Path="PlayerPinStyle.Center.StrokeThickness" />
+                                </MultiBinding>
+                            </Path.StrokeThickness>
+                            <Path.Data>
+                                <MultiBinding Converter="{x:Static converters:PinShapeToGeometryConverter.Instance}">
+                                    <Binding Path="PlayerPinStyle.Center.Shape" />
+                                    <Binding Path="PlayerPinStyle.Center.Size" />
+                                </MultiBinding>
+                            </Path.Data>
+                        </Path>
+                    </Grid>
                 </Canvas>
 
-                <!-- Survey dots with drag-to-correct -->
-                <ItemsControl ItemsSource="{Binding Surveys}">
+                <!-- Survey dots. Purely visual — selection happens in the wizard panel
+                     (ListBox), drag happens via the viewport-wide click handler. -->
+                <ItemsControl ItemsSource="{Binding Surveys}" IsHitTestVisible="False">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <Canvas />
@@ -196,31 +193,25 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type vm:SurveyItemViewModel}">
-                            <Thumb Width="{Binding DataContext.PinDiameter, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                   Height="{Binding DataContext.PinDiameter, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                   DragStarted="SurveyDot_DragStarted"
-                                   DragDelta="SurveyDot_DragDelta"
-                                   DragCompleted="SurveyDot_DragCompleted"
-                                   ToolTip="{Binding Name}">
-                                <Thumb.Template>
-                                    <ControlTemplate TargetType="Thumb">
-                                        <!-- Three-layer pin (issue #131): halo (active highlight), outer
-                                             shape, centre indicator. All driven by LegolasPinStyle +
-                                             LegolasActivePinStyle so the user can fully customise shape,
-                                             stroke, and fill of each. The Grid.Effect adds a soft glow
-                                             when ActivePinTreatment.Glow is selected — distinct from the
-                                             static halo so it doesn't clash with the in-game survey
-                                             ping animation. -->
-                                        <Grid>
-                                            <Grid.Effect>
-                                                <MultiBinding Converter="{x:Static converters:GlowEffectConverter.Instance}">
-                                                    <Binding Path="IsSelected" />
-                                                    <Binding Path="DataContext.IsListening" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
-                                                    <Binding Path="DataContext.ActivePinStyle.Treatment" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
-                                                    <Binding Path="DataContext.Brushes.ActivePin" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
-                                                    <Binding Path="DataContext.ActivePinStyle.GlowBlurRadius" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
-                                                </MultiBinding>
-                                            </Grid.Effect>
+                            <!-- Three-layer pin (issue #131): halo (active highlight),
+                                 outer shape, centre indicator. All driven by
+                                 LegolasPinStyle + LegolasActivePinStyle so the user can
+                                 fully customise shape, stroke, and fill of each.
+                                 Grid.Effect adds a soft glow when ActivePinTreatment.Glow
+                                 is selected. Grid auto-sizes to its largest child;
+                                 each Path uses Stretch="Uniform" + Center alignment so
+                                 strokes fit within their layout slot and stay concentric
+                                 even when the Halo grows the Grid. -->
+                            <Grid ToolTip="{Binding Name}">
+                                <Grid.Effect>
+                                    <MultiBinding Converter="{x:Static converters:GlowEffectConverter.Instance}">
+                                        <Binding Path="IsSelected" />
+                                        <Binding Path="DataContext.IsListening" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                        <Binding Path="DataContext.ActivePinStyle.Treatment" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                        <Binding Path="DataContext.Brushes.ActivePin" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                        <Binding Path="DataContext.ActivePinStyle.GlowBlurRadius" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
+                                    </MultiBinding>
+                                </Grid.Effect>
                                             <!-- Halo: visible only when this pin is the SelectedSurvey
                                                  AND the FSM is in Listening AND the configured treatment
                                                  is Halo. Geometry is the outer shape sized up by
@@ -228,6 +219,7 @@
                                             <Path Stroke="{Binding DataContext.Brushes.ActivePin, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                   Fill="Transparent"
                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                  Stretch="Uniform"
                                                   StrokeThickness="{Binding DataContext.ActivePinStyle.HaloThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
                                                 <Path.Visibility>
                                                     <MultiBinding Converter="{x:Static converters:HaloVisibilityConverter.Instance}">
@@ -245,8 +237,15 @@
                                                 </Path.Data>
                                             </Path>
 
-                                            <!-- Outer shape — fills the Thumb. -->
-                                            <Path Fill="{Binding DataContext.Brushes.OuterFill, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                            <!-- Outer shape. Stretch="Uniform" scales geometry+stroke to
+                                                 fit the Grid's PinDiameter bounds — strokes don't
+                                                 overflow (no clipping) and "Pin radius" represents the
+                                                 outer-bound radius rather than the geometry-only radius.
+                                                 Centre alignment so the shape stays concentric if the
+                                                 Halo grows the parent Grid. -->
+                                            <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                  Stretch="Uniform"
+                                                  Fill="{Binding DataContext.Brushes.OuterFill, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                   Stroke="{Binding DataContext.Brushes.OuterStroke, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                   StrokeDashArray="{Binding DataContext.PinStyle.Outer.StrokeStyle, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
                                                 <Path.StrokeThickness>
@@ -265,6 +264,7 @@
 
                                             <!-- Centre indicator — sized independently from the outer shape. -->
                                             <Path HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                  Stretch="Uniform"
                                                   Fill="{Binding DataContext.Brushes.CenterFill, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                   Stroke="{Binding DataContext.Brushes.CenterStroke, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                   StrokeDashArray="{Binding DataContext.PinStyle.Center.StrokeStyle, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={x:Static converters:StrokeStyleToDashArrayConverter.Instance}}">
@@ -280,11 +280,8 @@
                                                         <Binding Path="DataContext.PinStyle.Center.Size" RelativeSource="{RelativeSource AncestorType=ItemsControl}" />
                                                     </MultiBinding>
                                                 </Path.Data>
-                                            </Path>
-                                        </Grid>
-                                    </ControlTemplate>
-                                </Thumb.Template>
-                            </Thumb>
+                                </Path>
+                            </Grid>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -22,17 +22,14 @@ public partial class MapOverlayView : Window
     /// pad's host border). Same instance as the one MapOverlayViewModel sees.</summary>
     public LegolasSettings? Settings { get; }
 
-    private Vector _grabOffset;
-    private Vector _anchorGrabOffset;
-
     // State for the "drag anywhere on the viewport to move the active pin"
-    // gesture (issue #131 follow-up). Routes by FSM state + IsAnchorEditable:
+    // gesture. Routes by FSM state + IsAnchorEditable:
     //  * AwaitingPosition: first MouseDown sets anchor (existing HandleMapClick);
     //    drag continues to refine the anchor.
     //  * Listening + IsAnchorEditable (anchor set, no surveys yet): drag moves
-    //    the player anchor — important when the anchor lands off-screen and
-    //    can't be grabbed via its Thumb.
-    //  * Listening with surveys: drag moves SessionState.SelectedSurvey.
+    //    the player anchor.
+    //  * Listening with surveys: drag moves SessionState.SelectedSurvey, which
+    //    is set from the wizard panel's survey list (no per-pin Thumb grab).
     private bool _draggingAnchorFromViewport;
     private SurveyItemViewModel? _draggingPinFromViewport;
 
@@ -67,28 +64,6 @@ public partial class MapOverlayView : Window
         }
     }
 
-    private void SurveyDot_DragStarted(object sender, DragStartedEventArgs e)
-    {
-        if (sender is not Thumb thumb) return;
-        // Grabbing a pin also selects it for arrow-key nudging.
-        if (thumb.DataContext is SurveyItemViewModel s
-            && DataContext is MapOverlayViewModel vm)
-        {
-            vm.Session.SelectedSurvey = s;
-        }
-        // Capture offset from the dot's center to the cursor at grab time, so
-        // the released dot ends up where the user expected (no snap to cursor).
-        var cursor = Mouse.GetPosition(Viewport);
-        if (thumb.DataContext is SurveyItemViewModel sel && sel.EffectivePixel.HasValue)
-        {
-            _grabOffset = cursor - new Point(sel.EffectivePixel.Value.X, sel.EffectivePixel.Value.Y);
-        }
-        else
-        {
-            _grabOffset = new Vector(0, 0);
-        }
-    }
-
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
         // Arrow-key pin nudging moved to global IHotkeyCommand registrations
@@ -103,77 +78,9 @@ public partial class MapOverlayView : Window
         base.OnPreviewKeyDown(e);
     }
 
-    private void SurveyDot_DragDelta(object sender, DragDeltaEventArgs e)
-    {
-        if (sender is not Thumb thumb) return;
-        // Always create/replace with a mutable transform (XAML-declared ones
-        // can be auto-frozen in template contexts).
-        if (thumb.RenderTransform is not TranslateTransform t || t.IsFrozen)
-        {
-            t = new TranslateTransform();
-            thumb.RenderTransform = t;
-        }
-        t.X += e.HorizontalChange;
-        t.Y += e.VerticalChange;
-    }
-
-    private void PlayerAnchor_DragStarted(object sender, DragStartedEventArgs e)
-    {
-        if (DataContext is not MapOverlayViewModel vm) return;
-        if (!vm.Session.IsAnchorEditable) return;
-        // Clear pin selection so subsequent keyboard nudges fall through to the
-        // anchor (NudgePinCommandBase routes by SelectedSurvey first).
-        vm.Session.SelectedSurvey = null;
-        var cursor = Mouse.GetPosition(Viewport);
-        _anchorGrabOffset = cursor - new Point(vm.PlayerPosition.X, vm.PlayerPosition.Y);
-    }
-
-    private void PlayerAnchor_DragDelta(object sender, DragDeltaEventArgs e)
-    {
-        // Same transient-transform trick as SurveyDot_DragDelta — the binding
-        // re-positions the Thumb on DragCompleted.
-        if (sender is not Thumb thumb) return;
-        if (thumb.RenderTransform is not TranslateTransform t || t.IsFrozen)
-        {
-            t = new TranslateTransform();
-            thumb.RenderTransform = t;
-        }
-        t.X += e.HorizontalChange;
-        t.Y += e.VerticalChange;
-    }
-
-    private void PlayerAnchor_DragCompleted(object sender, DragCompletedEventArgs e)
-    {
-        if (sender is not Thumb thumb) return;
-        thumb.RenderTransform = Transform.Identity;
-        if (e.Canceled) return;
-        if (DataContext is not MapOverlayViewModel vm) return;
-        // Re-check editability — a survey could have landed mid-drag and sealed
-        // the anchor. Silently dropping the move is safer than committing it.
-        if (!vm.Session.IsAnchorEditable) return;
-        var cursor = Mouse.GetPosition(Viewport);
-        var newCenter = new PixelPoint(cursor.X - _anchorGrabOffset.X, cursor.Y - _anchorGrabOffset.Y);
-        _anchorGrabOffset = new Vector(0, 0);
-        vm.MoveAnchor(newCenter);
-    }
-
-    private void SurveyDot_DragCompleted(object sender, DragCompletedEventArgs e)
-    {
-        if (sender is not Thumb thumb) return;
-
-        // Drop the transient drag transform; binding to ManualOverride/EffectivePixel
-        // re-positions the dot.
-        thumb.RenderTransform = Transform.Identity;
-
-        if (e.Canceled) return;
-        if (thumb.DataContext is not SurveyItemViewModel survey) return;
-        if (DataContext is not MapOverlayViewModel vm) return;
-
-        var cursor = Mouse.GetPosition(Viewport);
-        var newCenter = new PixelPoint(cursor.X - _grabOffset.X, cursor.Y - _grabOffset.Y);
-        _grabOffset = new Vector(0, 0);
-        vm.CorrectSurveyCommand.Execute(new CorrectionArgs(survey, newCenter));
-    }
+    // Per-pin Thumb drag handlers were removed when pins became visual-only.
+    // All click + drag interaction now flows through the viewport handlers
+    // below; selection moved to the wizard panel's survey list.
 
     private void Viewport_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -42,6 +42,11 @@ public partial class MapOverlayView : Window
     {
         Settings = settings;
         NudgePad = nudgePad;
+        // Set the overlay pad's DataContext directly. An ElementName=Self binding
+        // on a non-notifying CLR property would resolve at indeterminate timing;
+        // assigning here guarantees the pad has its VM before any user input
+        // arrives, so Command/IsChecked bindings inside the pad always work.
+        OverlayNudgePad.DataContext = nudgePad;
         WindowLayoutBinder.Bind(this, settings.MapOverlay, saver.Touch);
         Loaded += (_, _) =>
         {

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -12,16 +12,39 @@ namespace Legolas.Views;
 
 public partial class MapOverlayView : Window
 {
+    /// <summary>VM for the optional on-overlay nudge pad. Surfaced as a property
+    /// (rather than going through MapOverlayViewModel) to avoid a fake cycle:
+    /// NudgePadViewModel depends on MapOverlayViewModel, so MapOverlayViewModel
+    /// can't take NudgePadViewModel as a ctor param.</summary>
+    public NudgePadViewModel? NudgePad { get; }
+
+    /// <summary>Surfaced for the overlay-local toggle binding (Visibility on the
+    /// pad's host border). Same instance as the one MapOverlayViewModel sees.</summary>
+    public LegolasSettings? Settings { get; }
+
     private Vector _grabOffset;
     private Vector _anchorGrabOffset;
+
+    // State for the "drag anywhere on the viewport to move the active pin"
+    // gesture (issue #131 follow-up). Routes by FSM state + IsAnchorEditable:
+    //  * AwaitingPosition: first MouseDown sets anchor (existing HandleMapClick);
+    //    drag continues to refine the anchor.
+    //  * Listening + IsAnchorEditable (anchor set, no surveys yet): drag moves
+    //    the player anchor — important when the anchor lands off-screen and
+    //    can't be grabbed via its Thumb.
+    //  * Listening with surveys: drag moves SessionState.SelectedSurvey.
+    private bool _draggingAnchorFromViewport;
+    private SurveyItemViewModel? _draggingPinFromViewport;
 
     public MapOverlayView()
     {
         InitializeComponent();
     }
 
-    public MapOverlayView(LegolasSettings settings, SettingsAutoSaver<LegolasSettings> saver) : this()
+    public MapOverlayView(LegolasSettings settings, SettingsAutoSaver<LegolasSettings> saver, NudgePadViewModel nudgePad) : this()
     {
+        Settings = settings;
+        NudgePad = nudgePad;
         WindowLayoutBinder.Bind(this, settings.MapOverlay, saver.Touch);
         Loaded += (_, _) =>
         {
@@ -163,10 +186,81 @@ public partial class MapOverlayView : Window
         var canvasPos = Mouse.GetPosition(Viewport);
         var clickPoint = new PixelPoint(canvasPos.X, canvasPos.Y);
 
-        // The VM only acts on clicks while the FSM is in AwaitingPosition (anchor
-        // setup). Survey placement is automatic; corrections are drag-only. This
-        // handler is still here so AwaitingPosition continues to work.
-        vm.HandleMapClickCommand.Execute(clickPoint);
+        // AwaitingPosition: first click sets the anchor and transitions FSM to
+        // Listening. Fall through into the IsAnchorEditable path below so the
+        // user can keep dragging to refine the anchor without releasing.
+        if (vm.SurveyFlow.CurrentState == SurveyFlowState.AwaitingPosition)
+        {
+            vm.HandleMapClickCommand.Execute(clickPoint);
+        }
+
+        if (vm.Session.IsAnchorEditable)
+        {
+            _draggingAnchorFromViewport = true;
+            vm.MoveAnchor(clickPoint);
+            Viewport.CaptureMouse();
+            e.Handled = true;
+            return;
+        }
+
+        var selected = vm.Session.SelectedSurvey;
+        if (selected != null && !selected.Collected && !selected.Skipped)
+        {
+            _draggingPinFromViewport = selected;
+            ApplyDraggedPinPosition(canvasPos);
+            Viewport.CaptureMouse();
+            e.Handled = true;
+            return;
+        }
+
         e.Handled = true;
+    }
+
+    private void Viewport_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (!Viewport.IsMouseCaptured) return;
+        if (DataContext is not MapOverlayViewModel vm) return;
+        var canvasPos = Mouse.GetPosition(Viewport);
+
+        if (_draggingAnchorFromViewport)
+        {
+            vm.MoveAnchor(new PixelPoint(canvasPos.X, canvasPos.Y));
+            return;
+        }
+        if (_draggingPinFromViewport is not null)
+        {
+            ApplyDraggedPinPosition(canvasPos);
+        }
+    }
+
+    private void Viewport_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!Viewport.IsMouseCaptured) return;
+        Viewport.ReleaseMouseCapture();
+
+        if (_draggingAnchorFromViewport)
+        {
+            _draggingAnchorFromViewport = false;
+            return;
+        }
+
+        if (_draggingPinFromViewport is not null && DataContext is MapOverlayViewModel vm)
+        {
+            // Final commit through CorrectSurveyCommand — this triggers the
+            // projector refit and route rebuild that intermediate Move events
+            // intentionally skip.
+            var canvasPos = Mouse.GetPosition(Viewport);
+            var finalPixel = new PixelPoint(canvasPos.X, canvasPos.Y);
+            vm.CorrectSurveyCommand.Execute(new CorrectionArgs(_draggingPinFromViewport, finalPixel));
+            _draggingPinFromViewport = null;
+        }
+    }
+
+    private void ApplyDraggedPinPosition(Point cursor)
+    {
+        if (_draggingPinFromViewport is null) return;
+        var newPixel = new PixelPoint(cursor.X, cursor.Y);
+        var updated = _draggingPinFromViewport.Model with { ManualOverride = newPixel };
+        _draggingPinFromViewport.UpdateModel(updated);
     }
 }

--- a/src/Legolas.Module/Views/NudgePadView.xaml
+++ b/src/Legolas.Module/Views/NudgePadView.xaml
@@ -1,0 +1,119 @@
+<UserControl x:Class="Legolas.Views.NudgePadView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:domain="clr-namespace:Legolas.Domain">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Compact direction button. BasedOn the implicit Button style so
+                 it picks up Mithril's chrome, then tightened for a 32x32 d-pad cell. -->
+            <Style x:Key="NudgeButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                <Setter Property="Width" Value="32" />
+                <Setter Property="Height" Value="32" />
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="Margin" Value="2" />
+                <Setter Property="FontSize" Value="14" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+            </Style>
+
+            <!-- Step-tier toggle. RadioButton in a "tab" style so the three
+                 tiers are visually grouped and only one can be active. -->
+            <Style x:Key="StepRadio" TargetType="RadioButton">
+                <Setter Property="Margin" Value="2,0" />
+                <Setter Property="Padding" Value="8,3" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{StaticResource TextTertiaryBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RadioButton">
+                            <Border x:Name="Bd"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="3"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Bd" Property="Background" Value="{StaticResource AccentBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- ObjectDataProvider for binding RadioButton IsChecked to an enum
+                 property is verbose; a tiny converter is cleaner. Using
+                 IsChecked="{Binding SelectedStep, Converter=..., ConverterParameter=Fine}"
+                 here would also work — instead we route via separate command
+                 invocations + GroupName so the radio behavior is XAML-only. -->
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <StackPanel Orientation="Vertical" HorizontalAlignment="Center"
+                IsEnabled="{Binding IsAvailable}">
+        <!-- Target context line — only meaningful in the panel; overlay is
+             tighter and skips this. Both consumers bind through the same
+             VM so the label stays in sync. -->
+        <TextBlock Text="{Binding NudgeTargetLabel}"
+                   Foreground="{StaticResource TextTertiaryBrush}"
+                   FontSize="11"
+                   TextAlignment="Center"
+                   Margin="0,0,0,4" />
+
+        <!-- D-pad. Empty centre cell keeps the cross shape readable. -->
+        <Grid HorizontalAlignment="Center">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button Grid.Row="0" Grid.Column="1" Style="{StaticResource NudgeButton}"
+                    Content="↑" ToolTip="Nudge up"
+                    Command="{Binding NudgeUpCommand}" />
+            <Button Grid.Row="1" Grid.Column="0" Style="{StaticResource NudgeButton}"
+                    Content="←" ToolTip="Nudge left"
+                    Command="{Binding NudgeLeftCommand}" />
+            <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource NudgeButton}"
+                    Content="→" ToolTip="Nudge right"
+                    Command="{Binding NudgeRightCommand}" />
+            <Button Grid.Row="2" Grid.Column="1" Style="{StaticResource NudgeButton}"
+                    Content="↓" ToolTip="Nudge down"
+                    Command="{Binding NudgeDownCommand}" />
+        </Grid>
+
+        <!-- Step-tier picker. Three RadioButtons sharing a GroupName so they're
+             mutually exclusive; each binds via a DataTrigger-style converter on
+             the enum. Using string converter parameter via a static enum-binding
+             trick keeps the XAML self-contained. -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,8,0,0">
+            <RadioButton Style="{StaticResource StepRadio}" GroupName="NudgeStep"
+                         Content="Fine"
+                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fine}}" />
+            <RadioButton Style="{StaticResource StepRadio}" GroupName="NudgeStep"
+                         Content="Default"
+                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Default}}" />
+            <RadioButton Style="{StaticResource StepRadio}" GroupName="NudgeStep"
+                         Content="Fast"
+                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fast}}" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/Legolas.Module/Views/NudgePadView.xaml
+++ b/src/Legolas.Module/Views/NudgePadView.xaml
@@ -19,13 +19,14 @@
                 <Setter Property="FontWeight" Value="SemiBold" />
             </Style>
 
-            <!-- Step-tier toggle. ToggleButton (not RadioButton) so exclusivity
-                 is driven purely by the SelectedStep binding — RadioButton's
-                 NameScope-based group exclusivity desyncs across the two
-                 NudgePadView instances (wizard + overlay), since each
-                 UserControl introduces its own scope. With ToggleButton the
-                 only source of truth is the bound enum on the shared VM. -->
-            <Style x:Key="StepToggle" TargetType="ToggleButton">
+            <!-- Step-tier picker. RadioButton is the right primitive (mutually
+                 exclusive selection); re-templated to render as a chip rather
+                 than the default circle bullet. Cross-instance sync (wizard ↔
+                 overlay) comes from the shared SelectedStep on the singleton
+                 VM via TwoWay binding — not from RadioButton's NameScope-bound
+                 GroupName, which would only group siblings within one
+                 UserControl. -->
+            <Style x:Key="StepToggle" TargetType="RadioButton">
                 <Setter Property="Margin" Value="2,0" />
                 <Setter Property="Padding" Value="8,3" />
                 <Setter Property="Background" Value="Transparent" />
@@ -36,7 +37,7 @@
                 <Setter Property="HorizontalContentAlignment" Value="Center" />
                 <Setter Property="Template">
                     <Setter.Value>
-                        <ControlTemplate TargetType="ToggleButton">
+                        <ControlTemplate TargetType="RadioButton">
                             <Border x:Name="Bd"
                                     Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -98,26 +99,21 @@
                     Command="{Binding NudgeDownCommand}" />
         </Grid>
 
-        <!-- Step-tier picker. ToggleButtons keyed off SelectedStep via a
-             converter — the bound enum is the single source of truth for
-             exclusivity, so toggles in different NudgePadView instances stay
-             in sync (wizard ↔ overlay). -->
+        <!-- Step-tier picker. RadioButtons bound TwoWay to SelectedStep via
+             NudgeStepSizeRadioConverter; the converter's ConvertBack returns
+             Binding.DoNothing on the uncheck side, so the source-of-truth is
+             only ever set by an explicit user check. The shared singleton VM
+             keeps both NudgePadView instances (wizard + overlay) in sync. -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,8,0,0">
-            <ToggleButton Style="{StaticResource StepToggle}"
-                          Content="Fine"
-                          Tag="{x:Static domain:NudgeStepSize.Fine}"
-                          Click="StepToggle_Click"
-                          IsChecked="{Binding SelectedStep, Mode=OneWay, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fine}}" />
-            <ToggleButton Style="{StaticResource StepToggle}"
-                          Content="Default"
-                          Tag="{x:Static domain:NudgeStepSize.Default}"
-                          Click="StepToggle_Click"
-                          IsChecked="{Binding SelectedStep, Mode=OneWay, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Default}}" />
-            <ToggleButton Style="{StaticResource StepToggle}"
-                          Content="Fast"
-                          Tag="{x:Static domain:NudgeStepSize.Fast}"
-                          Click="StepToggle_Click"
-                          IsChecked="{Binding SelectedStep, Mode=OneWay, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fast}}" />
+            <RadioButton Style="{StaticResource StepToggle}"
+                         Content="Fine"
+                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fine}}" />
+            <RadioButton Style="{StaticResource StepToggle}"
+                         Content="Default"
+                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Default}}" />
+            <RadioButton Style="{StaticResource StepToggle}"
+                         Content="Fast"
+                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fast}}" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/Legolas.Module/Views/NudgePadView.xaml
+++ b/src/Legolas.Module/Views/NudgePadView.xaml
@@ -19,9 +19,13 @@
                 <Setter Property="FontWeight" Value="SemiBold" />
             </Style>
 
-            <!-- Step-tier toggle. RadioButton in a "tab" style so the three
-                 tiers are visually grouped and only one can be active. -->
-            <Style x:Key="StepRadio" TargetType="RadioButton">
+            <!-- Step-tier toggle. ToggleButton (not RadioButton) so exclusivity
+                 is driven purely by the SelectedStep binding — RadioButton's
+                 NameScope-based group exclusivity desyncs across the two
+                 NudgePadView instances (wizard + overlay), since each
+                 UserControl introduces its own scope. With ToggleButton the
+                 only source of truth is the bound enum on the shared VM. -->
+            <Style x:Key="StepToggle" TargetType="ToggleButton">
                 <Setter Property="Margin" Value="2,0" />
                 <Setter Property="Padding" Value="8,3" />
                 <Setter Property="Background" Value="Transparent" />
@@ -32,7 +36,7 @@
                 <Setter Property="HorizontalContentAlignment" Value="Center" />
                 <Setter Property="Template">
                     <Setter.Value>
-                        <ControlTemplate TargetType="RadioButton">
+                        <ControlTemplate TargetType="ToggleButton">
                             <Border x:Name="Bd"
                                     Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -53,12 +57,6 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-
-            <!-- ObjectDataProvider for binding RadioButton IsChecked to an enum
-                 property is verbose; a tiny converter is cleaner. Using
-                 IsChecked="{Binding SelectedStep, Converter=..., ConverterParameter=Fine}"
-                 here would also work — instead we route via separate command
-                 invocations + GroupName so the radio behavior is XAML-only. -->
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -100,20 +98,26 @@
                     Command="{Binding NudgeDownCommand}" />
         </Grid>
 
-        <!-- Step-tier picker. Three RadioButtons sharing a GroupName so they're
-             mutually exclusive; each binds via a DataTrigger-style converter on
-             the enum. Using string converter parameter via a static enum-binding
-             trick keeps the XAML self-contained. -->
+        <!-- Step-tier picker. ToggleButtons keyed off SelectedStep via a
+             converter — the bound enum is the single source of truth for
+             exclusivity, so toggles in different NudgePadView instances stay
+             in sync (wizard ↔ overlay). -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,8,0,0">
-            <RadioButton Style="{StaticResource StepRadio}" GroupName="NudgeStep"
-                         Content="Fine"
-                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fine}}" />
-            <RadioButton Style="{StaticResource StepRadio}" GroupName="NudgeStep"
-                         Content="Default"
-                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Default}}" />
-            <RadioButton Style="{StaticResource StepRadio}" GroupName="NudgeStep"
-                         Content="Fast"
-                         IsChecked="{Binding SelectedStep, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fast}}" />
+            <ToggleButton Style="{StaticResource StepToggle}"
+                          Content="Fine"
+                          Tag="{x:Static domain:NudgeStepSize.Fine}"
+                          Click="StepToggle_Click"
+                          IsChecked="{Binding SelectedStep, Mode=OneWay, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fine}}" />
+            <ToggleButton Style="{StaticResource StepToggle}"
+                          Content="Default"
+                          Tag="{x:Static domain:NudgeStepSize.Default}"
+                          Click="StepToggle_Click"
+                          IsChecked="{Binding SelectedStep, Mode=OneWay, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Default}}" />
+            <ToggleButton Style="{StaticResource StepToggle}"
+                          Content="Fast"
+                          Tag="{x:Static domain:NudgeStepSize.Fast}"
+                          Click="StepToggle_Click"
+                          IsChecked="{Binding SelectedStep, Mode=OneWay, Converter={x:Static domain:NudgeStepSizeRadioConverter.Instance}, ConverterParameter={x:Static domain:NudgeStepSize.Fast}}" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/Legolas.Module/Views/NudgePadView.xaml.cs
+++ b/src/Legolas.Module/Views/NudgePadView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Legolas.Views;
+
+public partial class NudgePadView : UserControl
+{
+    public NudgePadView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Legolas.Module/Views/NudgePadView.xaml.cs
+++ b/src/Legolas.Module/Views/NudgePadView.xaml.cs
@@ -1,4 +1,8 @@
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Legolas.Domain;
+using Legolas.ViewModels;
 
 namespace Legolas.Views;
 
@@ -7,5 +11,23 @@ public partial class NudgePadView : UserControl
     public NudgePadView()
     {
         InitializeComponent();
+    }
+
+    /// <summary>
+    /// Step-toggle click handler. Sets <see cref="NudgePadViewModel.SelectedStep"/>
+    /// to this toggle's tagged tier and re-asserts <c>IsChecked = true</c>.
+    /// Re-asserting matters for the "click the already-active toggle" case:
+    /// ToggleButton's default click flips IsChecked, but we want it to stay
+    /// pinned to the bound enum (no "all toggles off" state). Mode=OneWay on
+    /// the IsChecked binding keeps the bound enum the single source of truth.
+    /// </summary>
+    private void StepToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not ToggleButton btn) return;
+        if (btn.Tag is not NudgeStepSize tier) return;
+        if (DataContext is not NudgePadViewModel vm) return;
+
+        vm.SelectedStep = tier;
+        btn.IsChecked = true;
     }
 }

--- a/src/Legolas.Module/Views/NudgePadView.xaml.cs
+++ b/src/Legolas.Module/Views/NudgePadView.xaml.cs
@@ -1,8 +1,4 @@
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using Legolas.Domain;
-using Legolas.ViewModels;
 
 namespace Legolas.Views;
 
@@ -11,23 +7,5 @@ public partial class NudgePadView : UserControl
     public NudgePadView()
     {
         InitializeComponent();
-    }
-
-    /// <summary>
-    /// Step-toggle click handler. Sets <see cref="NudgePadViewModel.SelectedStep"/>
-    /// to this toggle's tagged tier and re-asserts <c>IsChecked = true</c>.
-    /// Re-asserting matters for the "click the already-active toggle" case:
-    /// ToggleButton's default click flips IsChecked, but we want it to stay
-    /// pinned to the bound enum (no "all toggles off" state). Mode=OneWay on
-    /// the IsChecked binding keeps the bound enum the single source of truth.
-    /// </summary>
-    private void StepToggle_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is not ToggleButton btn) return;
-        if (btn.Tag is not NudgeStepSize tier) return;
-        if (DataContext is not NudgePadViewModel vm) return;
-
-        vm.SelectedStep = tier;
-        btn.IsChecked = true;
     }
 }

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -234,15 +234,57 @@
                             <Run Text="." />
                         </TextBlock>
                     </StackPanel>
-                    <Border Background="{StaticResource AccentSoftBrush}" CornerRadius="3" Padding="12,8" Margin="0,0,0,20"
-                            HorizontalAlignment="Center">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Pins placed: " Foreground="{StaticResource AccentSoftTextBrush}"
-                                       FontSize="{DynamicResource AppFontSizeBody}" />
-                            <TextBlock Text="{Binding Session.Surveys.Count}" FontWeight="SemiBold"
-                                       FontSize="{DynamicResource AppFontSizeBody}"
-                                       Foreground="{StaticResource AccentSoftTextBrush}" />
-                        </StackPanel>
+                    <!-- Survey list. Selecting an item sets Session.SelectedSurvey, which
+                         the overlay drag-pad uses as its target and the nudge pad routes
+                         to. ListBox uses VirtualizingStackPanel by default — important for
+                         survey runs of 100+ pins. -->
+                    <Border Background="{StaticResource BgSurfaceBrush}"
+                            BorderBrush="{StaticResource TextTertiaryBrush}" BorderThickness="1"
+                            CornerRadius="3" Margin="0,0,0,12">
+                        <DockPanel>
+                            <Border DockPanel.Dock="Top"
+                                    Background="{StaticResource AccentSoftBrush}"
+                                    Padding="10,4">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Pins placed: " Foreground="{StaticResource AccentSoftTextBrush}"
+                                               FontSize="{DynamicResource AppFontSizeBody}" />
+                                    <TextBlock Text="{Binding Session.Surveys.Count}" FontWeight="SemiBold"
+                                               FontSize="{DynamicResource AppFontSizeBody}"
+                                               Foreground="{StaticResource AccentSoftTextBrush}" />
+                                    <TextBlock Text=" — click to select" Foreground="{StaticResource AccentSoftTextBrush}"
+                                               FontSize="{DynamicResource AppFontSize}"
+                                               VerticalAlignment="Center" Margin="6,0,0,0" />
+                                </StackPanel>
+                            </Border>
+                            <ListBox x:Name="SurveyList"
+                                     ItemsSource="{Binding Session.Surveys}"
+                                     SelectedItem="{Binding Session.SelectedSurvey, Mode=TwoWay}"
+                                     SelectionChanged="SurveyList_SelectionChanged"
+                                     BorderThickness="0"
+                                     MaxHeight="240"
+                                     Background="Transparent"
+                                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                     VirtualizingPanel.IsVirtualizing="True"
+                                     VirtualizingPanel.VirtualizationMode="Recycling">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel />
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:SurveyItemViewModel}">
+                                        <StackPanel Orientation="Horizontal" Margin="0,2">
+                                            <TextBlock Width="24" TextAlignment="Right" Margin="0,0,8,0"
+                                                       Text="{Binding RouteOrder, TargetNullValue=•, FallbackValue=•}"
+                                                       Foreground="{StaticResource TextTertiaryBrush}"
+                                                       FontSize="{DynamicResource AppFontSize}" />
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontSize="{DynamicResource AppFontSize}" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </DockPanel>
                     </Border>
                     <Button Content="Go!" Style="{StaticResource WizardPrimaryButton}"
                             HorizontalAlignment="Center" Margin="0"

--- a/src/Legolas.Module/Views/WizardView.xaml.cs
+++ b/src/Legolas.Module/Views/WizardView.xaml.cs
@@ -5,4 +5,20 @@ namespace Legolas.Views;
 public partial class WizardView : UserControl
 {
     public WizardView() => InitializeComponent();
+
+    /// <summary>
+    /// Auto-scroll the survey ListBox so the freshly-selected pin is visible.
+    /// Selection changes on three paths: log-ingestion auto-selects the latest
+    /// arriving survey, the user clicks a row directly (already in view), and
+    /// the nudge hotkeys / pad change pin focus. The first and third can leave
+    /// the selected pin off-screen for long survey runs (100+ pins), so a
+    /// simple ScrollIntoView is the QoL win.
+    /// </summary>
+    private void SurveyList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (sender is ListBox listBox && listBox.SelectedItem is not null)
+        {
+            listBox.ScrollIntoView(listBox.SelectedItem);
+        }
+    }
 }

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -133,6 +133,40 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Variant of <see cref="AddMithrilSettings{T}"/> for settings types that
+    /// implement <see cref="IVersionedState{T}"/>. After loading, dispatches
+    /// through <c>T.Migrate</c> when the persisted <c>SchemaVersion</c> doesn't
+    /// match <c>T.CurrentVersion</c>, then writes the migrated form back so the
+    /// legacy fields don't linger on disk. Mirrors <see cref="PerCharacterStore{T}"/>'s
+    /// dispatch — kept as a separate overload so the constraint failure surfaces
+    /// at the call site instead of at runtime.
+    /// </summary>
+    public static IServiceCollection AddMithrilVersionedSettings<T>(
+        this IServiceCollection services,
+        string settingsPath,
+        JsonTypeInfo<T> typeInfo)
+        where T : class, INotifyPropertyChanged, IVersionedState<T>, new()
+    {
+        services.AddSingleton<ISettingsStore<T>>(_ =>
+            new JsonSettingsStore<T>(settingsPath, typeInfo));
+        services.AddSingleton<T>(sp =>
+        {
+            var store = sp.GetRequiredService<ISettingsStore<T>>();
+            var loaded = store.Load();
+            if (loaded.SchemaVersion != T.CurrentVersion)
+            {
+                loaded = T.Migrate(loaded);
+                loaded.SchemaVersion = T.CurrentVersion;
+                store.Save(loaded);
+            }
+            return loaded;
+        });
+        services.AddSingleton<SettingsAutoSaver<T>>();
+        services.AddHostedService(sp => sp.GetRequiredService<SettingsAutoSaver<T>>());
+        return services;
+    }
+
     public static IServiceCollection AddMithrilIcons(this IServiceCollection services, string cacheDirectory)
     {
         var settingsPath = System.IO.Path.Combine(cacheDirectory, "settings.json");

--- a/src/Mithril.Shared/Hotkeys/Controls/HotkeyChipControl.cs
+++ b/src/Mithril.Shared/Hotkeys/Controls/HotkeyChipControl.cs
@@ -60,6 +60,7 @@ public sealed class HotkeyChipControl : Control
 
     private IDisposable? _captureScope;
     private HotkeyBinding? _previousBinding;
+    private Button? _clearButton;
 
     private static void OnBindingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -69,7 +70,16 @@ public sealed class HotkeyChipControl : Control
     public override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
+        if (_clearButton is not null) _clearButton.Click -= OnClearButtonClick;
+        _clearButton = GetTemplateChild("PART_ClearButton") as Button;
+        if (_clearButton is not null) _clearButton.Click += OnClearButtonClick;
         RefreshDisplay();
+    }
+
+    private void OnClearButtonClick(object sender, RoutedEventArgs e)
+    {
+        Commit(null);
+        e.Handled = true;
     }
 
     private void RefreshDisplay()
@@ -93,9 +103,25 @@ public sealed class HotkeyChipControl : Control
     protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
     {
         base.OnMouseLeftButtonDown(e);
-        if (State != HotkeyChipState.Capturing) StartCapture();
+        if (_clearButton is not null && e.OriginalSource is DependencyObject src && IsDescendantOf(src, _clearButton))
+            return;
+        if (State == HotkeyChipState.Capturing) CancelCapture();
+        else StartCapture();
         Focus();
         e.Handled = true;
+    }
+
+    private static bool IsDescendantOf(DependencyObject node, DependencyObject ancestor)
+    {
+        DependencyObject? current = node;
+        while (current is not null)
+        {
+            if (ReferenceEquals(current, ancestor)) return true;
+            current = current is Visual
+                ? VisualTreeHelper.GetParent(current)
+                : LogicalTreeHelper.GetParent(current);
+        }
+        return false;
     }
 
     protected override void OnLostKeyboardFocus(KeyboardFocusChangedEventArgs e)
@@ -139,14 +165,7 @@ public sealed class HotkeyChipControl : Control
 
         var key = e.Key == Key.System ? e.SystemKey : e.Key;
 
-        if (key == Key.Escape) { CancelCapture(); e.Handled = true; return; }
         if (IsModifierOnly(key)) { RefreshDisplay(); e.Handled = true; return; }
-        if (key is Key.Back or Key.Delete && Keyboard.Modifiers == ModifierKeys.None)
-        {
-            Commit(null);
-            e.Handled = true;
-            return;
-        }
         if (IsLockKey(key)) { e.Handled = true; return; } // ignore
 
         var mods = HotkeyModifiers.None;

--- a/src/Mithril.Shared/Themes/Generic.xaml
+++ b/src/Mithril.Shared/Themes/Generic.xaml
@@ -15,25 +15,61 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type hk:HotkeyChipControl}">
-                    <Border x:Name="Bd"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="3"
-                            Padding="{TemplateBinding Padding}"
-                            SnapsToDevicePixels="True">
-                        <TextBlock x:Name="Txt"
-                                   Text="{TemplateBinding DisplayText}"
-                                   Foreground="{TemplateBinding Foreground}"
-                                   FontFamily="{TemplateBinding FontFamily}"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"/>
-                    </Border>
+                    <DockPanel LastChildFill="True">
+                        <Button x:Name="PART_ClearButton"
+                                DockPanel.Dock="Right"
+                                VerticalAlignment="Center"
+                                Width="16" Height="16"
+                                Padding="0"
+                                Margin="6,0,0,0"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                Foreground="#88FFFFFF"
+                                Cursor="Hand"
+                                Focusable="False"
+                                ToolTip="Clear binding">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="ClearBd"
+                                            Background="{TemplateBinding Background}"
+                                            CornerRadius="2">
+                                        <TextBlock Text="&#x2715;"
+                                                   Foreground="{TemplateBinding Foreground}"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   FontSize="11"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="ClearBd" Property="Background" Value="#33FFFFFF"/>
+                                            <Setter Property="Foreground" Value="#FFD04040"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
+                        <Border x:Name="Bd"
+                                MinWidth="{TemplateBinding MinWidth}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <TextBlock x:Name="Txt"
+                                       Text="{TemplateBinding DisplayText}"
+                                       Foreground="{TemplateBinding Foreground}"
+                                       FontFamily="{TemplateBinding FontFamily}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"/>
+                        </Border>
+                    </DockPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="State" Value="Capturing">
                             <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
                             <Setter TargetName="Bd" Property="Background"  Value="#33D4A847"/>
                             <Setter TargetName="Txt" Property="Foreground" Value="#FFD4A847"/>
+                            <Setter TargetName="PART_ClearButton" Property="Visibility" Value="Collapsed"/>
                         </Trigger>
                         <Trigger Property="State" Value="Conflict">
                             <Setter TargetName="Bd" Property="BorderBrush" Value="#FFE0A030"/>
@@ -49,6 +85,7 @@
                         </Trigger>
                         <Trigger Property="Binding" Value="{x:Null}">
                             <Setter TargetName="Txt" Property="Foreground" Value="#88FFFFFF"/>
+                            <Setter TargetName="PART_ClearButton" Property="Visibility" Value="Hidden"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
+++ b/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
@@ -17,7 +17,7 @@ public class NudgePinCommandTests
         var surveyFlow = new SurveyFlowController(session, settings);
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
         var projector = new CoordinateProjector();
-        var brushes = new LegolasBrushes(new LegolasColors());
+        var brushes = new LegolasBrushes(settings);
         var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
         return (session, map, settings);
     }

--- a/tests/Legolas.Tests/Settings/LegolasBrushesTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasBrushesTests.cs
@@ -7,37 +7,70 @@ namespace Legolas.Tests.Settings;
 
 public class LegolasBrushesTests
 {
-    [Fact]
-    public void Default_brushes_match_default_hex_values()
+    private static LegolasBrushes Create(out LegolasSettings settings)
     {
-        var brushes = new LegolasBrushes(new LegolasColors());
-
-        brushes.PinPending.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0xFF));
-        brushes.PinFinalized.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00));
-        brushes.PlayerMarker.Color.Should().Be(Color.FromArgb(0xFF, 0x4C, 0xAF, 0x50));
-        brushes.RouteLine.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0xD7, 0x00));
-        brushes.BearingWedgeFill.Color.Should().Be(Color.FromArgb(0x33, 0xFF, 0xFF, 0x80));
-        brushes.BearingWedgeStroke.Color.Should().Be(Color.FromArgb(0x55, 0xFF, 0xFF, 0x80));
+        settings = new LegolasSettings();
+        return new LegolasBrushes(settings);
     }
 
     [Fact]
-    public void Brush_property_change_propagates_when_color_changes()
+    public void Default_brushes_match_default_hex_values()
     {
-        var colors = new LegolasColors();
-        var brushes = new LegolasBrushes(colors);
+        var brushes = Create(out _);
+
+        brushes.RouteLine.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0xD7, 0x00));
+        brushes.BearingWedgeFill.Color.Should().Be(Color.FromArgb(0x33, 0xFF, 0xFF, 0x80));
+        brushes.BearingWedgeStroke.Color.Should().Be(Color.FromArgb(0x55, 0xFF, 0xFF, 0x80));
+        brushes.OuterStroke.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0xFF));
+        brushes.CenterFill.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0xFF));
+        brushes.PlayerOuterStroke.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF));
+        brushes.PlayerCenterFill.Color.Should().Be(Color.FromArgb(0xFF, 0x4C, 0xAF, 0x50));
+        brushes.ActivePin.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF));
+    }
+
+    [Fact]
+    public void Pin_outer_stroke_change_propagates_to_brush()
+    {
+        var brushes = Create(out var settings);
         var changed = new List<string?>();
         brushes.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
 
-        colors.PinFinalized = "#FF00FF00";
+        settings.PinStyle.Outer.StrokeColor = "#FF00FF00";
 
-        changed.Should().Contain(nameof(LegolasBrushes.PinFinalized));
-        brushes.PinFinalized.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00));
+        changed.Should().Contain(nameof(LegolasBrushes.OuterStroke));
+        brushes.OuterStroke.Color.Should().Be(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00));
+    }
+
+    [Fact]
+    public void Player_center_fill_change_propagates_to_brush()
+    {
+        var brushes = Create(out var settings);
+        var changed = new List<string?>();
+        brushes.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        settings.PlayerPinStyle.Center.FillColor = "#FF8800AA";
+
+        changed.Should().Contain(nameof(LegolasBrushes.PlayerCenterFill));
+        brushes.PlayerCenterFill.Color.Should().Be(Color.FromArgb(0xFF, 0x88, 0x00, 0xAA));
+    }
+
+    [Fact]
+    public void Active_pin_color_change_propagates_to_brush()
+    {
+        var brushes = Create(out var settings);
+        var changed = new List<string?>();
+        brushes.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        settings.ActivePinStyle.Color = "#FFFF8800";
+
+        changed.Should().Contain(nameof(LegolasBrushes.ActivePin));
+        brushes.ActivePin.Color.Should().Be(Color.FromArgb(0xFF, 0xFF, 0x88, 0x00));
     }
 
     [Fact]
     public void Built_brush_is_frozen()
     {
-        var brushes = new LegolasBrushes(new LegolasColors());
-        brushes.PinPending.IsFrozen.Should().BeTrue();
+        var brushes = Create(out _);
+        brushes.OuterStroke.IsFrozen.Should().BeTrue();
     }
 }

--- a/tests/Legolas.Tests/Settings/LegolasColorsTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasColorsTests.cs
@@ -13,7 +13,7 @@ public class LegolasColorsTests
     [InlineData("#33FFFF80", "#33FFFF80")]   // translucent preserved
     public void Normalize_canonicalizes_hex(string input, string expected)
     {
-        LegolasColors.Normalize(input).Should().Be(expected);
+        HexColor.Normalize(input).Should().Be(expected);
     }
 
     [Theory]
@@ -26,7 +26,7 @@ public class LegolasColorsTests
     [InlineData("#FFFFFFFFF")]        // too long
     public void Normalize_falls_back_to_magenta_on_invalid(string? input)
     {
-        LegolasColors.Normalize(input).Should().Be("#FFFF00FF");
+        HexColor.Normalize(input).Should().Be("#FFFF00FF");
     }
 
     [Fact]
@@ -36,21 +36,21 @@ public class LegolasColorsTests
         var changed = new List<string?>();
         colors.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
 
-        colors.PinPending = "00ff00"; // lowercase, no hash, RGB
+        colors.RouteLine = "00ff00"; // lowercase, no hash, RGB
 
-        colors.PinPending.Should().Be("#FF00FF00");
-        changed.Should().ContainSingle().Which.Should().Be(nameof(LegolasColors.PinPending));
+        colors.RouteLine.Should().Be("#FF00FF00");
+        changed.Should().ContainSingle().Which.Should().Be(nameof(LegolasColors.RouteLine));
     }
 
     [Fact]
     public void Setter_no_op_when_canonical_value_unchanged()
     {
         var colors = new LegolasColors();
-        colors.PinPending = "#FF00FFFF"; // matches default after normalization
+        colors.RouteLine = "#FFFFD700"; // matches default after normalization
         var changed = new List<string?>();
         colors.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
 
-        colors.PinPending = "00ffff"; // canonicalizes to same value
+        colors.RouteLine = "ffd700"; // canonicalizes to same value
 
         changed.Should().BeEmpty();
     }

--- a/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using FluentAssertions;
+using Legolas.Domain;
+
+namespace Legolas.Tests.Settings;
+
+public class LegolasSettingsMigrationTests
+{
+    [Fact]
+    public void Migrates_v1_pinPending_into_outer_stroke_and_center_fill()
+    {
+        var json = """
+            {
+              "colors": {
+                "pinPending": "#FF00FF00",
+                "pinFinalized": "#FFFF8800",
+                "playerMarker": "#FFAA00AA",
+                "routeLine": "#FFFFD700",
+                "bearingWedgeFill": "#33FFFF80",
+                "bearingWedgeStroke": "#55FFFF80"
+              }
+            }
+            """;
+        var loaded = JsonSerializer.Deserialize(json, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+
+        // SchemaVersion missing in v1 JSON → C# default of 1; Migrate should
+        // detect the gap and run the upgrade.
+        loaded.SchemaVersion.Should().Be(1);
+        loaded.Colors.LegacyPinPending.Should().Be("#FF00FF00");
+        loaded.Colors.LegacyPinFinalized.Should().Be("#FFFF8800");
+        loaded.Colors.LegacyPlayerMarker.Should().Be("#FFAA00AA");
+
+        var migrated = LegolasSettings.Migrate(loaded);
+
+        migrated.PinStyle.Outer.StrokeColor.Should().Be("#FF00FF00");
+        migrated.PinStyle.Center.FillColor.Should().Be("#FF00FF00");
+        migrated.ActivePinStyle.Color.Should().Be("#FFFF8800");
+        migrated.PlayerPinStyle.Center.FillColor.Should().Be("#FFAA00AA");
+        migrated.Colors.LegacyPinPending.Should().BeNull();
+        migrated.Colors.LegacyPinFinalized.Should().BeNull();
+        migrated.Colors.LegacyPlayerMarker.Should().BeNull();
+    }
+
+    [Fact]
+    public void Migrating_a_v2_instance_is_a_no_op()
+    {
+        var fresh = new LegolasSettings();
+        fresh.PinStyle.Outer.StrokeColor = "#FFAA0000"; // user customisation
+        fresh.PinStyle.Center.FillColor = "#FF00AA00";
+        fresh.ActivePinStyle.Color = "#FF0000AA";
+
+        var migrated = LegolasSettings.Migrate(fresh);
+
+        // SchemaVersion was already current → no copy / no overwrite of customisations.
+        migrated.PinStyle.Outer.StrokeColor.Should().Be("#FFAA0000");
+        migrated.PinStyle.Center.FillColor.Should().Be("#FF00AA00");
+        migrated.ActivePinStyle.Color.Should().Be("#FF0000AA");
+    }
+
+    [Fact]
+    public void V1_blob_with_only_pinPending_leaves_active_pin_color_at_default()
+    {
+        var json = """
+            {
+              "colors": {
+                "pinPending": "#FF00FF00"
+              }
+            }
+            """;
+        var loaded = JsonSerializer.Deserialize(json, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+        var defaultActiveColor = new LegolasActivePinStyle().Color;
+        var defaultPlayerCenterFill = LegolasPinStyle.PlayerDefaults().Center.FillColor;
+
+        var migrated = LegolasSettings.Migrate(loaded);
+
+        migrated.PinStyle.Outer.StrokeColor.Should().Be("#FF00FF00");
+        migrated.PinStyle.Center.FillColor.Should().Be("#FF00FF00");
+        migrated.ActivePinStyle.Color.Should().Be(defaultActiveColor);
+        migrated.PlayerPinStyle.Center.FillColor.Should().Be(defaultPlayerCenterFill);
+    }
+
+    [Fact]
+    public void V1_blob_with_only_playerMarker_migrates_into_player_pin_center_fill()
+    {
+        var json = """
+            {
+              "colors": {
+                "playerMarker": "#FF4488FF"
+              }
+            }
+            """;
+        var loaded = JsonSerializer.Deserialize(json, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+
+        var migrated = LegolasSettings.Migrate(loaded);
+
+        migrated.PlayerPinStyle.Center.FillColor.Should().Be("#FF4488FF");
+        // Outer player defaults preserved (white stroke from PlayerDefaults factory).
+        migrated.PlayerPinStyle.Outer.StrokeColor.Should().Be("#FFFFFFFF");
+    }
+
+    [Fact]
+    public void Migrated_settings_round_trip_through_json_drop_legacy_fields()
+    {
+        var v1 = """
+            {
+              "colors": {
+                "pinPending": "#FF00FF00",
+                "pinFinalized": "#FFFF8800",
+                "playerMarker": "#FFAA00AA"
+              }
+            }
+            """;
+        var loaded = JsonSerializer.Deserialize(v1, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+        var migrated = LegolasSettings.Migrate(loaded);
+        migrated.SchemaVersion = LegolasSettings.CurrentVersion;
+
+        var written = JsonSerializer.Serialize(migrated, LegolasSettingsJsonContext.Default.LegolasSettings);
+
+        // Legacy field keys should not reappear in saved JSON now that they
+        // were cleared.
+        written.Should().NotContain("pinPending");
+        written.Should().NotContain("pinFinalized");
+        written.Should().NotContain("playerMarker");
+        written.Should().Contain("\"schemaVersion\": 2");
+    }
+}

--- a/tests/Legolas.Tests/Settings/PinShapeGeometryTests.cs
+++ b/tests/Legolas.Tests/Settings/PinShapeGeometryTests.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using System.Windows.Media;
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Views.Converters;
+
+namespace Legolas.Tests.Settings;
+
+public class PinShapeGeometryTests
+{
+    private const double Size = 10.0;
+
+    [Theory]
+    [InlineData(PinShape.Circle)]
+    [InlineData(PinShape.Square)]
+    [InlineData(PinShape.Diamond)]
+    [InlineData(PinShape.Cross)]
+    public void Each_shape_fills_its_size_box_within_tolerance(PinShape shape)
+    {
+        var geometry = PinShapeToGeometryConverter.BuildGeometry(shape, Size);
+        var bounds = geometry.Bounds;
+
+        // Allow a half-pixel of slack — RectangleGeometry's Bounds match
+        // exactly, but PathGeometry/EllipseGeometry can compute slightly
+        // different extents depending on tessellation.
+        bounds.Left.Should().BeApproximately(0.0, 0.5);
+        bounds.Top.Should().BeApproximately(0.0, 0.5);
+        bounds.Right.Should().BeApproximately(Size, 0.5);
+        bounds.Bottom.Should().BeApproximately(Size, 0.5);
+    }
+
+    [Fact]
+    public void None_returns_empty_geometry()
+    {
+        var geometry = PinShapeToGeometryConverter.BuildGeometry(PinShape.None, Size);
+        geometry.Should().BeSameAs(Geometry.Empty);
+    }
+
+    [Fact]
+    public void Zero_or_negative_size_returns_empty_geometry()
+    {
+        var converter = PinShapeToGeometryConverter.Instance;
+        var result = converter.Convert(new object[] { PinShape.Circle, 0.0 }, typeof(Geometry), null!, CultureInfo.InvariantCulture);
+        result.Should().BeSameAs(Geometry.Empty);
+    }
+
+    [Fact]
+    public void Multi_value_converter_wires_through_to_BuildGeometry()
+    {
+        var converter = PinShapeToGeometryConverter.Instance;
+        var result = converter.Convert(new object[] { PinShape.Square, Size }, typeof(Geometry), null!, CultureInfo.InvariantCulture);
+        result.Should().BeOfType<RectangleGeometry>();
+        ((RectangleGeometry)result).Rect.Width.Should().Be(Size);
+        ((RectangleGeometry)result).Rect.Height.Should().Be(Size);
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/ActiveTargetTests.cs
+++ b/tests/Legolas.Tests/ViewModels/ActiveTargetTests.cs
@@ -16,7 +16,7 @@ public class ActiveTargetTests
         var surveyFlow = new SurveyFlowController(session, settings);
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
         var projector = new CoordinateProjector();
-        var brushes = new LegolasBrushes(new LegolasColors());
+        var brushes = new LegolasBrushes(settings);
         var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
         return (session, map, settings);
     }

--- a/tests/Legolas.Tests/ViewModels/AnchorEditableTests.cs
+++ b/tests/Legolas.Tests/ViewModels/AnchorEditableTests.cs
@@ -17,7 +17,7 @@ public class AnchorEditableTests
         var surveyFlow = new SurveyFlowController(session, settings);
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
         var projector = new CoordinateProjector();
-        var brushes = new LegolasBrushes(new LegolasColors());
+        var brushes = new LegolasBrushes(settings);
         var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
         return (session, map, settings);
     }

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -21,7 +21,7 @@ public class LegolasWizardViewModelTests
         var trilat = new TrilaterationSolver();
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
         var projector = new CoordinateProjector();
-        var brushes = new LegolasBrushes(new LegolasColors());
+        var brushes = new LegolasBrushes(settings);
         var motherlode = new MotherlodeViewModel(trilat, optimizer, session, motherlodeFlow);
         var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
         var wizard = new LegolasWizardViewModel(session, surveyFlow, motherlodeFlow,

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -24,8 +24,9 @@ public class LegolasWizardViewModelTests
         var brushes = new LegolasBrushes(settings);
         var motherlode = new MotherlodeViewModel(trilat, optimizer, session, motherlodeFlow);
         var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
+        var nudgePad = new NudgePadViewModel(session, mapOverlay, settings);
         var wizard = new LegolasWizardViewModel(session, surveyFlow, motherlodeFlow,
-            controlPanel, motherlode, mapOverlay);
+            controlPanel, motherlode, mapOverlay, nudgePad);
         return (wizard, session, surveyFlow, motherlodeFlow, settings);
     }
 


### PR DESCRIPTION
## Summary

Closes #131. Built out as #131 first, then iterated through testing into a broader survey-UX pass.

**Configurable pin appearance** (the #131 ask):
- Three new sub-states — `LegolasPinStyle` (outer + centre shapes), `LegolasActivePinStyle` (Halo / Glow highlight), and a player-pin variant — each persisted in settings, fully customisable from the Pin Appearance / Active Pin Highlight / Player Pin groups.
- New `IVersionedState<LegolasSettings>` migration: legacy `colors.pinPending` and `colors.pinFinalized` map forward into the new pin/highlight colours. Backed by a new `AddMithrilVersionedSettings<T>` overload in Mithril.Shared.
- Renders via a `PinShape` enum + geometry/stroke converters; outer + centre Paths use `Stretch=\"Uniform\"` so strokes fit within the layout slot — no clipping.
- Tests: `LegolasSettingsMigrationTests`, `PinShapeGeometryTests`, plus brush tests updated for the new ctor.

**Survey UX polish** (emerged from testing):
- Removed Thumb cages from pins after they were found to clip rendering — viewport-wide drag-pad now handles selection-aware drag (anchor while \`IsAnchorEditable\`, selected pin in Listening).
- Wizard panel grew a virtualized survey ListBox (handles 200+ pins) with auto-scroll on selection; pad-arrow nudges pick up the selected pin.
- Bearing wedges scoped to Motherlode mode — Survey 4-DOF refit is precise enough that wedges were just visual noise.
- Go! button now reactively enables on first pin arrival (subscribed to `Surveys.CollectionChanged`).
- Hotkey chip: inline clear button, allow binding any key.
- Nudge pad component (panel + optional overlay), shared singleton VM, RadioButton-based step picker (Fine/Default/Fast). Cross-instance sync via TwoWay binding.

## Test plan
- [x] `dotnet build Mithril.slnx` — clean
- [x] Migration: v1 settings.json with `pinPending` + `pinFinalized` migrates to new pin/highlight colours; legacy fields drop on save
- [x] Default-fresh: pins render as the original cyan dashed circle + cyan dot
- [x] Settings: shape/colour/stroke changes update on the map immediately (no restart)
- [x] Halo + Glow active treatments render only while `Listening + IsSelected`
- [x] Drag-pad: viewport drag moves anchor (pre-Listening / IsAnchorEditable) or selected survey
- [x] Wizard list: virtualization, selection auto-scrolls, nudges follow selection
- [x] Wedges: gone in Survey, present only in Motherlode
- [x] Nudge pad: clicking Fine/Default/Fast in either pad updates both; arrows fire from both pads

🤖 Generated with [Claude Code](https://claude.com/claude-code)