### PR TITLE
feat(legolas): end-of-run survey report (text + PNG + share link)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
+    <PackageVersion Include="MahApps.Metro" Version="2.4.11" />
     <PackageVersion Include="MahApps.Metro.IconPacks.Lucide" Version="6.0.0" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="Serilog" Version="4.2.0" />

--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -12,6 +12,20 @@ public sealed record SurveyDetected(
 public sealed record ItemCollected(
     DateTime Timestamp,
     string Name,
+    int Count,
+    string? SpeedBonusItem = null) : GameEvent(Timestamp);
+
+/// <summary>
+/// "[Status] X xN added to inventory." — the only chat line that carries the real
+/// item count. The matching <see cref="ItemCollected"/> line that follows has no
+/// count for survey collections (PG moved counts onto "added to inventory" lines).
+/// LogIngestionService buffers these and drains the buffer on the next
+/// <see cref="ItemCollected"/>, so non-survey adds (skinning, crafting, vendor
+/// purchases) don't leak into the survey report.
+/// </summary>
+public sealed record ItemAddedToInventory(
+    DateTime Timestamp,
+    string Name,
     int Count) : GameEvent(Timestamp);
 
 public sealed record MotherlodeDistance(

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -166,6 +166,29 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
         }
     }
 
+    /// <summary>
+    /// When true, the end-of-run report dialog auto-pops as soon as the FSM hits Done.
+    /// Snapshot is taken regardless — this only gates whether the dialog opens
+    /// automatically. The wizard always offers a manual "View last report" button.
+    /// </summary>
+    private bool _showReportOnDone = true;
+    public bool ShowReportOnDone
+    {
+        get => _showReportOnDone;
+        set
+        {
+            if (_showReportOnDone == value) return;
+            _showReportOnDone = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShowReportOnDone)));
+        }
+    }
+
+    /// <summary>
+    /// Last directory the user saved a report image / JSON to. Pre-fills the SaveFileDialog
+    /// so successive saves land in the same folder. Null = use the OS default.
+    /// </summary>
+    public string? ReportSaveDirectory { get; set; }
+
     private bool _autoClickThroughInventoryDuringSession = true;
     public bool AutoClickThroughInventoryDuringSession
     {

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -32,11 +32,13 @@ public sealed partial class SurveyFlowController : ObservableObject
 {
     private readonly SessionState _session;
     private readonly LegolasSettings _settings;
+    private readonly TimeProvider _clock;
 
-    public SurveyFlowController(SessionState session, LegolasSettings settings)
+    public SurveyFlowController(SessionState session, LegolasSettings settings, TimeProvider? clock = null)
     {
         _session = session;
         _settings = settings;
+        _clock = clock ?? TimeProvider.System;
         _session.AllCollected += OnAllCollected;
         // CanOptimize reads Surveys.Count, but [NotifyPropertyChangedFor] only
         // fires from CurrentState. Without this subscription the Go! button
@@ -87,6 +89,9 @@ public sealed partial class SurveyFlowController : ObservableObject
             _session.LastLogEvent = $"ConfirmPlayerPosition ignored — state is {CurrentState}";
             return;
         }
+        // Stamp the session start when the user actually commits to a run. ClearSurveys
+        // (called from Reset) wipes this so the next session gets a fresh stamp.
+        _session.StartedAt ??= _clock.GetUtcNow();
         TransitionTo(SurveyFlowState.Listening, nameof(ConfirmPlayerPosition));
     }
 

--- a/src/Legolas.Module/Legolas.Module.csproj
+++ b/src/Legolas.Module/Legolas.Module.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="MahApps.Metro" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -1,14 +1,20 @@
 using System.IO;
+using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Hotkeys;
+using Mithril.Shared.Icons;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Dialogs;
 using MahApps.Metro.IconPacks;
 using Mithril.Shared.Settings;
 using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.Hotkeys;
 using Legolas.Services;
+using Legolas.Sharing;
 using Legolas.ViewModels;
 using Legolas.Views;
 using Microsoft.Extensions.DependencyInjection;
@@ -76,6 +82,32 @@ public sealed class LegolasModule : IMithrilModule
         });
         services.AddSingleton<SurveyFlowController>();
         services.AddSingleton<MotherlodeFlowController>();
+
+        // End-of-run report (text + PNG + JSON + share link). Singleton so the
+        // latest snapshot survives FSM resets and is available for the wizard's
+        // "View last report" button. IActiveCharacterService is optional —
+        // anonymous reports are valid and the report service tolerates a null.
+        services.AddSingleton<LegolasReportService>(sp => new LegolasReportService(
+            sp.GetRequiredService<SurveyFlowController>(),
+            sp.GetRequiredService<SessionState>(),
+            clock: TimeProvider.System,
+            activeChar: sp.GetService<IActiveCharacterService>(),
+            refData: sp.GetService<IReferenceDataService>()));
+        services.AddSingleton<LegolasShareCardRenderer>(sp => new LegolasShareCardRenderer(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IIconCacheService>()));
+
+        // Sharing — mithril://legolas/<payload> import target. Opens the same
+        // share dialog the sender used so the receiver gets text + JSON + card
+        // preview + copy/save buttons rather than a stripped-down view.
+        services.AddSingleton<ILegolasShareImportTarget>(sp => new LegolasShareImportTarget(
+            sp.GetService<LegolasShareCardRenderer>(),
+            sp.GetService<LegolasSettings>(),
+            sp.GetService<IDialogService>(),
+            sp.GetService<IReferenceDataService>(),
+            sp.GetService<IModuleActivator>(),
+            sp.GetService<IDiagnosticsSink>()));
+
         services.AddSingleton<LegolasWizardViewModel>();
         services.AddSingleton<LegolasSettingsViewModel>();
         services.AddSingleton<ControlPanelViewModel>();

--- a/src/Legolas.Module/Services/ChatLogParser.cs
+++ b/src/Legolas.Module/Services/ChatLogParser.cs
@@ -10,9 +10,20 @@ public sealed partial class ChatLogParser : IChatLogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
     private static partial Regex SurveyRegex();
 
-    [GeneratedRegex(@"\[Status\]\s+(?<name>.+?)\s+(?:x(?<count>\d+)\s+)?collected!",
+    // Survey collection. PG moved counts onto the "added to inventory" line, so the
+    // (?:x...)? group is rarely present in real chat — keep it matched so legacy /
+    // edge cases still parse. The optional "Also found Y (speed bonus!)" suffix
+    // captures the second item produced by a survey speed bonus.
+    [GeneratedRegex(@"\[Status\]\s+(?<name>.+?)(?:\s+x(?<count>\d+))?\s+collected!(?:\s+Also found\s+(?<bonus>.+?)\s+\(speed bonus!\))?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
     private static partial Regex CollectRegex();
+
+    // "[Status] X added to inventory." or "[Status] X xN added to inventory."
+    // Trailing period is matched loosely; we don't anchor end-of-line so any later
+    // chat formatter quirks (e.g. trailing whitespace) still resolve.
+    [GeneratedRegex(@"\[Status\]\s+(?<name>.+?)(?:\s+x(?<count>\d+))?\s+added to inventory\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex InventoryAddRegex();
 
     [GeneratedRegex(@"The treasure is (?<dist>\d+) metres from here",
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
@@ -39,6 +50,23 @@ public sealed partial class ChatLogParser : IChatLogParser
                 new MetreOffset(east, north));
         }
 
+        // Try "added to inventory" before "collected!" — the regexes don't overlap
+        // (different anchor phrases), but ordering keeps intent obvious.
+        var addMatch = InventoryAddRegex().Match(line);
+        if (addMatch.Success)
+        {
+            var count = 1;
+            if (addMatch.Groups["count"].Success
+                && int.TryParse(addMatch.Groups["count"].ValueSpan, out var addN))
+            {
+                count = addN;
+            }
+            return new ItemAddedToInventory(
+                timestamp,
+                addMatch.Groups["name"].Value.Trim(),
+                count);
+        }
+
         var collectMatch = CollectRegex().Match(line);
         if (collectMatch.Success)
         {
@@ -48,10 +76,16 @@ public sealed partial class ChatLogParser : IChatLogParser
             {
                 count = n;
             }
+            string? bonus = null;
+            if (collectMatch.Groups["bonus"].Success)
+            {
+                bonus = collectMatch.Groups["bonus"].Value.Trim();
+            }
             return new ItemCollected(
                 timestamp,
                 collectMatch.Groups["name"].Value.Trim(),
-                count);
+                count,
+                bonus);
         }
 
         var motherlodeMatch = MotherlodeRegex().Match(line);

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -56,6 +56,18 @@ public sealed class LogIngestionService : BackgroundService
         }
     }
 
+    /// <summary>
+    /// Buffer of recent "[Status] X xN added to inventory." adds. PG fires these
+    /// before the matching "[Status] X collected!" line and they're the only
+    /// place real item counts appear. We drain matching entries on each
+    /// <see cref="ItemCollected"/> (primary + speed-bonus item if present) so
+    /// unrelated adds (skinning, crafting, vendor purchases) get discarded
+    /// instead of leaking into the survey report. Capped to bound memory if
+    /// "collected!" never arrives for some buffered entry.
+    /// </summary>
+    private const int PendingAddBufferCap = 32;
+    private readonly List<(string Name, int Count)> _pendingAdds = new();
+
     private void Dispatch(GameEvent evt)
     {
         PostToUi(() =>
@@ -65,6 +77,9 @@ public sealed class LogIngestionService : BackgroundService
             {
                 case SurveyDetected sd:
                     HandleSurveyDetected(sd);
+                    break;
+                case ItemAddedToInventory ia:
+                    HandleItemAddedToInventory(ia);
                     break;
                 case ItemCollected ic:
                     HandleItemCollected(ic);
@@ -79,7 +94,9 @@ public sealed class LogIngestionService : BackgroundService
     private static string Describe(GameEvent evt) => evt switch
     {
         SurveyDetected sd => $"Survey: {sd.Name} ({sd.Offset.East:0}E, {sd.Offset.North:0}N)",
-        ItemCollected ic => $"Collected: {ic.Name} x{ic.Count}",
+        ItemAddedToInventory ia => $"Added: {ia.Name} x{ia.Count}",
+        ItemCollected ic when ic.SpeedBonusItem is not null => $"Collected: {ic.Name} (+ {ic.SpeedBonusItem} speed bonus)",
+        ItemCollected ic => $"Collected: {ic.Name}",
         MotherlodeDistance md => $"Motherlode: {md.DistanceMetres}m",
         UnknownLine ul => $"Unknown: {ul.RawLine}",
         _ => evt.GetType().Name,
@@ -145,8 +162,28 @@ public sealed class LogIngestionService : BackgroundService
         return null;
     }
 
+    private void HandleItemAddedToInventory(ItemAddedToInventory ia)
+    {
+        _pendingAdds.Add((ia.Name, ia.Count));
+        if (_pendingAdds.Count > PendingAddBufferCap)
+            _pendingAdds.RemoveRange(0, _pendingAdds.Count - PendingAddBufferCap);
+    }
+
     private void HandleItemCollected(ItemCollected ic)
     {
+        // Drain pending "added to inventory" entries that match this collection.
+        // Primary item + (optional) speed-bonus item are the only ones that count
+        // toward this survey; everything else in the buffer is unrelated noise
+        // (skinning drops, vendor purchases, etc.) and gets discarded after.
+        var primaryCount = DrainPendingForName(ic.Name);
+        AccumulateCollected(ic.Name, primaryCount);
+        if (!string.IsNullOrEmpty(ic.SpeedBonusItem))
+        {
+            var bonusCount = DrainPendingForName(ic.SpeedBonusItem!);
+            AccumulateCollected(ic.SpeedBonusItem!, bonusCount);
+        }
+        _pendingAdds.Clear();
+
         SurveyItemViewModel? best = null;
         var bestOrder = int.MaxValue;
         foreach (var s in _session.Surveys)
@@ -164,12 +201,37 @@ public sealed class LogIngestionService : BackgroundService
         if (best is not null)
         {
             best.UpdateModel(best.Model with { Collected = true });
-            _session.LastLogEvent = $"Collected: {ic.Name} x{ic.Count} → marked";
+            _session.LastLogEvent = $"Collected: {ic.Name} → marked";
             return;
         }
 
         _session.LastLogEvent = _session.Surveys.Count == 0
-            ? $"Collected: {ic.Name} x{ic.Count} → no surveys tracked"
-            : $"Collected: {ic.Name} x{ic.Count} → no name match (have {string.Join(", ", _session.Surveys.Where(s => !s.Collected).Select(s => s.Name).Take(3))})";
+            ? $"Collected: {ic.Name} → no surveys tracked"
+            : $"Collected: {ic.Name} → no name match (have {string.Join(", ", _session.Surveys.Where(s => !s.Collected).Select(s => s.Name).Take(3))})";
+    }
+
+    private int DrainPendingForName(string name)
+    {
+        // Walk back-to-front so we consume the most recent matching adds first
+        // (and so RemoveAt indices stay valid as we shrink the list).
+        var total = 0;
+        for (var i = _pendingAdds.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(_pendingAdds[i].Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                total += _pendingAdds[i].Count;
+                _pendingAdds.RemoveAt(i);
+            }
+        }
+        // Defensive default: if the chat-log "added to inventory" line never arrived
+        // (unusual, but timing skew can happen), credit at least one item so the
+        // report doesn't drop the collection entirely.
+        return total > 0 ? total : 1;
+    }
+
+    private void AccumulateCollected(string name, int count)
+    {
+        _session.CollectedItems.TryGetValue(name, out var existing);
+        _session.CollectedItems[name] = existing + count;
     }
 }

--- a/src/Legolas.Module/Sharing/LegolasReportService.cs
+++ b/src/Legolas.Module/Sharing/LegolasReportService.cs
@@ -1,0 +1,196 @@
+using System.Globalization;
+using System.Text;
+using Legolas.Flow;
+using Legolas.ViewModels;
+using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
+
+namespace Legolas.Sharing;
+
+/// <summary>
+/// Snapshots the active <see cref="SessionState"/> when the survey FSM reaches
+/// <see cref="SurveyFlowState.Done"/> and exposes the result for the share dialog.
+///
+/// The snapshot has to happen at the transition itself: <see cref="LegolasSettings.AutoResetWhenAllCollected"/>
+/// is true by default, and that immediately calls
+/// <see cref="SurveyFlowController.Reset"/> after the Done transition fires —
+/// which empties <c>SessionState.Surveys</c> and <c>SessionState.CollectedItems</c>.
+/// We hook <c>Transitioned</c>, which fires synchronously inside <c>TransitionTo</c>
+/// before the auto-reset branch runs, so the data is still intact.
+///
+/// The session collects items by display name (the chat parser only sees prose);
+/// we resolve to <see cref="ItemEntry.InternalName"/> at snapshot time via
+/// <see cref="IReferenceDataService"/> so the wire payload is CDN-version- and
+/// locale-stable. Items that don't resolve fall through to
+/// <see cref="LegolasSharePayload.UnknownByName"/> rather than being dropped.
+/// </summary>
+public sealed class LegolasReportService
+{
+    private readonly SessionState _session;
+    private readonly IActiveCharacterService? _activeChar;
+    private readonly IReferenceDataService? _refData;
+    private readonly TimeProvider _clock;
+    private Dictionary<string, ItemEntry>? _byDisplayName;
+
+    public LegolasReportService(
+        SurveyFlowController flow,
+        SessionState session,
+        TimeProvider? clock = null,
+        IActiveCharacterService? activeChar = null,
+        IReferenceDataService? refData = null)
+    {
+        _session = session;
+        _activeChar = activeChar;
+        _refData = refData;
+        _clock = clock ?? TimeProvider.System;
+        flow.Transitioned += OnTransitioned;
+    }
+
+    /// <summary>
+    /// Most recent end-of-run snapshot. Survives subsequent FSM resets, so the
+    /// "View last report" button can re-open the dialog after Auto-reset has
+    /// already cleared <c>SessionState</c>.
+    /// </summary>
+    public LegolasSharePayload? LatestReport { get; private set; }
+
+    /// <summary>Fires (UI thread) when a new report is built.</summary>
+    public event Action<LegolasSharePayload>? ReportGenerated;
+
+    public LegolasSharePayload BuildPayload(bool includeCharacterName)
+    {
+        var resolved = new Dictionary<string, int>(StringComparer.Ordinal);
+        Dictionary<string, int>? unknown = null;
+
+        foreach (var (displayName, count) in _session.CollectedItems)
+        {
+            if (TryResolveByDisplayName(displayName, out var entry))
+            {
+                resolved.TryGetValue(entry.InternalName, out var existing);
+                resolved[entry.InternalName] = existing + count;
+            }
+            else
+            {
+                unknown ??= new Dictionary<string, int>(StringComparer.Ordinal);
+                unknown.TryGetValue(displayName, out var existing);
+                unknown[displayName] = existing + count;
+            }
+        }
+
+        return new LegolasSharePayload
+        {
+            CharacterName = includeCharacterName ? _activeChar?.ActiveCharacterName : null,
+            StartedAt = _session.StartedAt ?? _clock.GetUtcNow(),
+            CompletedAt = _clock.GetUtcNow(),
+            Mode = _session.Mode,
+            SurveyCount = _session.Surveys.Count,
+            CollectedItemsByInternalName = resolved,
+            UnknownByName = unknown,
+        };
+    }
+
+    private bool TryResolveByDisplayName(string displayName, out ItemEntry entry)
+    {
+        entry = null!;
+        if (_refData is null) return false;
+        // Lazy-build a display-name index on first need. The reference data set is
+        // bounded (~thousand items); a full scan would also work but the index
+        // keeps repeated lookups O(1) within a single payload build.
+        if (_byDisplayName is null)
+        {
+            var index = new Dictionary<string, ItemEntry>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in _refData.Items.Values)
+            {
+                // First-match-wins: ambiguous display names (rare for survey items)
+                // resolve to whichever one we see first, which is a presentational
+                // best-effort. Recipients re-resolve from their own catalog anyway.
+                index.TryAdd(item.Name, item);
+            }
+            _byDisplayName = index;
+        }
+        if (_byDisplayName.TryGetValue(displayName, out var found))
+        {
+            entry = found;
+            return true;
+        }
+        return false;
+    }
+
+    private void OnTransitioned(SurveyTransition t)
+    {
+        if (t.To != SurveyFlowState.Done) return;
+        // v1 scope: Survey mode only. Motherlode runs aren't meaningfully summarisable
+        // (they end with a single dig) — defer to a future enhancement if desired.
+        if (_session.Mode != SessionMode.Survey) return;
+
+        var payload = BuildPayload(includeCharacterName: true);
+        LatestReport = payload;
+        ReportGenerated?.Invoke(payload);
+    }
+
+    /// <summary>
+    /// Discord/forum-friendly text summary. The optional <paramref name="refData"/>
+    /// is used to resolve <c>InternalName</c> keys into display names; fall back to
+    /// the InternalName itself when no resolver is supplied or the item isn't in
+    /// the local catalog.
+    /// </summary>
+    public static string BuildSummary(LegolasSharePayload payload, IReferenceDataService? refData = null)
+    {
+        var sb = new StringBuilder();
+        var who = string.IsNullOrWhiteSpace(payload.CharacterName)
+            ? "Anonymous"
+            : payload.CharacterName!;
+        sb.AppendLine($"{who} — Survey run complete");
+
+        var elapsed = payload.CompletedAt - payload.StartedAt;
+        sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+            "Started {0} · finished {1} · elapsed {2}",
+            payload.StartedAt.LocalDateTime.ToString("g", CultureInfo.CurrentCulture),
+            payload.CompletedAt.LocalDateTime.ToString("g", CultureInfo.CurrentCulture),
+            FormatElapsed(elapsed)));
+
+        sb.AppendLine($"Surveys collected: {payload.SurveyCount}");
+
+        var lines = new List<(string Display, int Count)>();
+        foreach (var (internalName, count) in payload.CollectedItemsByInternalName)
+        {
+            var display = (refData is not null && refData.ItemsByInternalName.TryGetValue(internalName, out var entry))
+                ? entry.Name
+                : internalName;
+            lines.Add((display, count));
+        }
+        if (payload.UnknownByName is { Count: > 0 } unk)
+        {
+            foreach (var (name, count) in unk)
+                lines.Add((name, count));
+        }
+
+        if (lines.Count > 0)
+        {
+            sb.AppendLine("Items earned:");
+            foreach (var (display, count) in lines
+                         .OrderByDescending(l => l.Count)
+                         .ThenBy(l => l.Display, StringComparer.OrdinalIgnoreCase))
+            {
+                sb.AppendLine($"  • {display} ×{count}");
+            }
+        }
+        else
+        {
+            sb.AppendLine("Items earned: (none recorded)");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string FormatElapsed(TimeSpan elapsed)
+    {
+        if (elapsed.TotalSeconds < 0) elapsed = TimeSpan.Zero;
+        if (elapsed.TotalHours >= 1)
+            return string.Format(CultureInfo.InvariantCulture, "{0:0}h {1:0}m {2:0}s",
+                Math.Floor(elapsed.TotalHours), elapsed.Minutes, elapsed.Seconds);
+        if (elapsed.TotalMinutes >= 1)
+            return string.Format(CultureInfo.InvariantCulture, "{0:0}m {1:0}s",
+                Math.Floor(elapsed.TotalMinutes), elapsed.Seconds);
+        return string.Format(CultureInfo.InvariantCulture, "{0:0}s", elapsed.TotalSeconds);
+    }
+}

--- a/src/Legolas.Module/Sharing/LegolasShareCardRenderer.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareCardRenderer.cs
@@ -26,14 +26,16 @@ public sealed class LegolasShareCardRenderer
         _iconCache = iconCache;
     }
 
-    /// <summary>1000×400 social card. Async — renders on a background STA worker thread
-    /// so the UI stays responsive while WPF lays out the visual tree.</summary>
+    /// <summary>1000-wide social card, auto-height. The card view sets a MinHeight
+    /// floor so sparse runs don't look dinky; many items grow the card downward via
+    /// the WrapPanel. Async — renders on a background STA worker so the UI stays
+    /// responsive during layout.</summary>
     public Task<BitmapSource> RenderCardAsync(LegolasSharePayload payload)
         => RenderOnStaWorker(() =>
         {
             var vm = new LegolasShareCardViewModel(payload, _refData, _iconCache);
             var view = new LegolasShareCardView { DataContext = vm };
-            return RenderControl(view, LegolasShareCardViewModel.CardWidth, LegolasShareCardViewModel.CardHeight);
+            return RenderControl(view, LegolasShareCardViewModel.CardWidth, height: null);
         });
 
     private static Task<BitmapSource> RenderOnStaWorker(Func<BitmapSource> render)
@@ -53,20 +55,40 @@ public sealed class LegolasShareCardRenderer
         return tcs.Task;
     }
 
-    private static BitmapSource RenderControl(FrameworkElement control, double width, double height)
+    private static BitmapSource RenderControl(FrameworkElement control, double width, double? height)
     {
         // Force a layout pass so every binding resolves before the render. Without the
         // explicit Measure/Arrange/UpdateLayout dance, a never-parented FrameworkElement
         // has zero size and RenderTargetBitmap captures nothing.
         control.Width = width;
-        control.Height = height;
-        control.Measure(new Size(width, height));
-        control.Arrange(new Rect(0, 0, width, height));
-        control.UpdateLayout();
+        double finalHeight;
+        if (height is { } fixedHeight)
+        {
+            control.Height = fixedHeight;
+            control.Measure(new Size(width, fixedHeight));
+            control.Arrange(new Rect(0, 0, width, fixedHeight));
+            control.UpdateLayout();
+            finalHeight = fixedHeight;
+        }
+        else
+        {
+            // Two-pass measure: WrapPanel + ItemsControl don't fully materialise their
+            // children on a single Measure pass when handed infinite height. We need
+            // Measure → Arrange → UpdateLayout → Measure so the second Measure sees
+            // realised item containers and reports the true DesiredSize.
+            control.Measure(new Size(width, double.PositiveInfinity));
+            control.Arrange(new Rect(0, 0, width, control.DesiredSize.Height));
+            control.UpdateLayout();
+            control.Measure(new Size(width, double.PositiveInfinity));
+            var natural = control.DesiredSize.Height;
+            control.Arrange(new Rect(0, 0, width, natural));
+            control.UpdateLayout();
+            finalHeight = natural;
+        }
 
         var bitmap = new RenderTargetBitmap(
             (int)Math.Ceiling(width),
-            (int)Math.Ceiling(height),
+            (int)Math.Ceiling(finalHeight),
             96, 96, PixelFormats.Pbgra32);
         bitmap.Render(control);
         bitmap.Freeze();

--- a/src/Legolas.Module/Sharing/LegolasShareCardRenderer.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareCardRenderer.cs
@@ -1,0 +1,75 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Reference;
+
+namespace Legolas.Sharing;
+
+/// <summary>
+/// Renders a <see cref="LegolasSharePayload"/> to a <see cref="BitmapSource"/>
+/// off-screen via <see cref="RenderTargetBitmap"/>. Mirrors Pippin's
+/// <c>PippinShareCardRenderer</c> — same STA-worker-thread + Measure/Arrange/UpdateLayout
+/// choreography, same <c>BitmapSource.Freeze()</c> so the bitmap crosses threads
+/// safely back to the UI thread for clipboard / save dialogs.
+/// </summary>
+public sealed class LegolasShareCardRenderer
+{
+    private readonly IReferenceDataService _refData;
+    private readonly IIconCacheService _iconCache;
+
+    public LegolasShareCardRenderer(IReferenceDataService refData, IIconCacheService iconCache)
+    {
+        _refData = refData;
+        _iconCache = iconCache;
+    }
+
+    /// <summary>1000×400 social card. Async — renders on a background STA worker thread
+    /// so the UI stays responsive while WPF lays out the visual tree.</summary>
+    public Task<BitmapSource> RenderCardAsync(LegolasSharePayload payload)
+        => RenderOnStaWorker(() =>
+        {
+            var vm = new LegolasShareCardViewModel(payload, _refData, _iconCache);
+            var view = new LegolasShareCardView { DataContext = vm };
+            return RenderControl(view, LegolasShareCardViewModel.CardWidth, LegolasShareCardViewModel.CardHeight);
+        });
+
+    private static Task<BitmapSource> RenderOnStaWorker(Func<BitmapSource> render)
+    {
+        var tcs = new TaskCompletionSource<BitmapSource>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try { tcs.SetResult(render()); }
+            catch (Exception ex) { tcs.SetException(ex); }
+        })
+        {
+            IsBackground = true,
+            Name = "LegolasShareRender",
+        };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return tcs.Task;
+    }
+
+    private static BitmapSource RenderControl(FrameworkElement control, double width, double height)
+    {
+        // Force a layout pass so every binding resolves before the render. Without the
+        // explicit Measure/Arrange/UpdateLayout dance, a never-parented FrameworkElement
+        // has zero size and RenderTargetBitmap captures nothing.
+        control.Width = width;
+        control.Height = height;
+        control.Measure(new Size(width, height));
+        control.Arrange(new Rect(0, 0, width, height));
+        control.UpdateLayout();
+
+        var bitmap = new RenderTargetBitmap(
+            (int)Math.Ceiling(width),
+            (int)Math.Ceiling(height),
+            96, 96, PixelFormats.Pbgra32);
+        bitmap.Render(control);
+        bitmap.Freeze();
+        return bitmap;
+    }
+}

--- a/src/Legolas.Module/Sharing/LegolasShareCardView.xaml
+++ b/src/Legolas.Module/Sharing/LegolasShareCardView.xaml
@@ -1,0 +1,85 @@
+<UserControl x:Class="Legolas.Sharing.LegolasShareCardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Legolas.Sharing"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:LegolasShareCardViewModel}"
+             Width="1000" Height="400"
+             Background="#FF1A1A1A"
+             FontFamily="Segoe UI"
+             UseLayoutRounding="True"
+             SnapsToDevicePixels="True">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Border BorderBrush="#3387B380" BorderThickness="1" CornerRadius="8" Padding="32">
+        <DockPanel>
+            <!-- Header -->
+            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,16">
+                <StackPanel Orientation="Horizontal">
+                    <Image Source="pack://application:,,,/Legolas.Module;component/Resources/legolas.ico"
+                           Width="40" Height="40" VerticalAlignment="Center" Margin="0,0,14,0"/>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding CharacterTitle}" FontSize="32" FontWeight="SemiBold"
+                                   Foreground="#FF87B380"/>
+                        <TextBlock Text="{Binding SubtitleText}" FontSize="14" Foreground="#88FFFFFF"/>
+                    </StackPanel>
+                    <Border Margin="20,0,0,0" Padding="10,4" VerticalAlignment="Center"
+                            Background="#3387B380" CornerRadius="4">
+                        <TextBlock Text="{Binding SurveyCountText}" Foreground="#FF87B380"
+                                   FontSize="14" FontWeight="SemiBold"/>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Footer (timestamps) -->
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                        HorizontalAlignment="Right" Margin="0,12,0,0">
+                <TextBlock Text="{Binding StartedText}" Foreground="#66FFFFFF" FontSize="12" Margin="0,0,16,0"/>
+                <TextBlock Text="{Binding CompletedText}" Foreground="#66FFFFFF" FontSize="12"/>
+            </StackPanel>
+
+            <!-- Items earned -->
+            <StackPanel DockPanel.Dock="Bottom" Margin="0,16,0,0">
+                <TextBlock Text="Items earned" Foreground="#66FFFFFF" FontSize="12" Margin="0,0,0,6"/>
+                <ItemsControl ItemsSource="{Binding Items}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel Orientation="Horizontal"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="#FF222222" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                    CornerRadius="4" Padding="8,4" Margin="0,0,8,8">
+                                <StackPanel Orientation="Horizontal">
+                                    <Image Source="{Binding Icon}" Width="20" Height="20" VerticalAlignment="Center"
+                                           Margin="0,0,6,0"
+                                           Visibility="{Binding HasIcon, Converter={StaticResource BoolToVis}}"/>
+                                    <TextBlock Text="{Binding Name}" Foreground="#FFE8E8E8" FontSize="13"
+                                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <TextBlock Text="{Binding CountText}" Foreground="#FF87B380"
+                                               FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- Hero: elapsed time -->
+            <StackPanel VerticalAlignment="Center">
+                <TextBlock Text="{Binding ElapsedText}" FontSize="64" FontWeight="SemiBold"
+                           Foreground="#FFE8E8E8" HorizontalAlignment="Center"/>
+                <TextBlock Text="elapsed" FontSize="14" Foreground="#88FFFFFF"
+                           HorizontalAlignment="Center" Margin="0,4,0,0"/>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/Legolas.Module/Sharing/LegolasShareCardView.xaml
+++ b/src/Legolas.Module/Sharing/LegolasShareCardView.xaml
@@ -6,7 +6,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance vm:LegolasShareCardViewModel}"
-             Width="1000" Height="400"
+             Width="1000" MinHeight="320"
              Background="#FF1A1A1A"
              FontFamily="Segoe UI"
              UseLayoutRounding="True"
@@ -20,34 +20,54 @@
     </UserControl.Resources>
     <Border BorderBrush="#3387B380" BorderThickness="1" CornerRadius="8" Padding="32">
         <DockPanel>
-            <!-- Header -->
-            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,16">
-                <StackPanel Orientation="Horizontal">
-                    <Image Source="pack://application:,,,/Legolas.Module;component/Resources/legolas.ico"
-                           Width="40" Height="40" VerticalAlignment="Center" Margin="0,0,14,0"/>
-                    <StackPanel VerticalAlignment="Center">
-                        <TextBlock Text="{Binding CharacterTitle}" FontSize="32" FontWeight="SemiBold"
-                                   Foreground="#FF87B380"/>
-                        <TextBlock Text="{Binding SubtitleText}" FontSize="14" Foreground="#88FFFFFF"/>
-                    </StackPanel>
-                    <Border Margin="20,0,0,0" Padding="10,4" VerticalAlignment="Center"
-                            Background="#3387B380" CornerRadius="4">
-                        <TextBlock Text="{Binding SurveyCountText}" Foreground="#FF87B380"
-                                   FontSize="14" FontWeight="SemiBold"/>
-                    </Border>
-                </StackPanel>
-            </StackPanel>
+            <!-- Header: character info on the left, elapsed pushed to the upper-right
+                 corner. Smaller than the previous centered hero — items are now the
+                 visual focus, with elapsed acting as a stat alongside the survey badge. -->
+            <Grid DockPanel.Dock="Top" Margin="0,0,0,22">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
 
-            <!-- Footer (timestamps) -->
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Top">
+                    <Image Source="pack://application:,,,/Legolas.Module;component/Resources/legolas.ico"
+                           Width="40" Height="40" VerticalAlignment="Top" Margin="0,0,14,0"/>
+                    <StackPanel VerticalAlignment="Top">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding CharacterTitle}" FontSize="32" FontWeight="SemiBold"
+                                       Foreground="#FF87B380" VerticalAlignment="Center"/>
+                            <Border Margin="14,0,0,0" Padding="10,4" VerticalAlignment="Center"
+                                    Background="#3387B380" CornerRadius="4">
+                                <TextBlock Text="{Binding SurveyCountText}" Foreground="#FF87B380"
+                                           FontSize="14" FontWeight="SemiBold"/>
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Text="{Binding SubtitleText}" FontSize="14" Foreground="#88FFFFFF"
+                                   Margin="0,2,0,0"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="20,0,0,0">
+                    <TextBlock Text="{Binding ElapsedText}" FontSize="36" FontWeight="SemiBold"
+                               Foreground="#FFE8E8E8" HorizontalAlignment="Right"/>
+                    <TextBlock Text="elapsed" FontSize="12" Foreground="#88FFFFFF"
+                               HorizontalAlignment="Right" Margin="0,2,2,0"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Footer (timestamps) — anchored to the bottom of the auto-grown card. -->
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
-                        HorizontalAlignment="Right" Margin="0,12,0,0">
+                        HorizontalAlignment="Right" Margin="0,18,0,0">
                 <TextBlock Text="{Binding StartedText}" Foreground="#66FFFFFF" FontSize="12" Margin="0,0,16,0"/>
                 <TextBlock Text="{Binding CompletedText}" Foreground="#66FFFFFF" FontSize="12"/>
             </StackPanel>
 
-            <!-- Items earned -->
-            <StackPanel DockPanel.Dock="Bottom" Margin="0,16,0,0">
-                <TextBlock Text="Items earned" Foreground="#66FFFFFF" FontSize="12" Margin="0,0,0,6"/>
+            <!-- Items earned — the visual hero. Larger tiles (40×40 icons + name + ×N).
+                 WrapPanel grows the card vertically when more items are present; the
+                 renderer's two-pass measure picks up the natural DesiredSize. -->
+            <StackPanel>
+                <TextBlock Text="Items earned" Foreground="#88FFFFFF" FontSize="12"
+                           Margin="0,0,0,10" FontWeight="SemiBold"/>
                 <ItemsControl ItemsSource="{Binding Items}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
@@ -57,28 +77,22 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Background="#FF222222" BorderBrush="#33FFFFFF" BorderThickness="1"
-                                    CornerRadius="4" Padding="8,4" Margin="0,0,8,8">
+                                    CornerRadius="6" Padding="10,8" Margin="0,0,10,10" MinWidth="170">
                                 <StackPanel Orientation="Horizontal">
-                                    <Image Source="{Binding Icon}" Width="20" Height="20" VerticalAlignment="Center"
-                                           Margin="0,0,6,0"
+                                    <Image Source="{Binding Icon}" Width="40" Height="40" VerticalAlignment="Center"
+                                           Margin="0,0,10,0"
                                            Visibility="{Binding HasIcon, Converter={StaticResource BoolToVis}}"/>
-                                    <TextBlock Text="{Binding Name}" Foreground="#FFE8E8E8" FontSize="13"
-                                               VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                    <TextBlock Text="{Binding CountText}" Foreground="#FF87B380"
-                                               FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <StackPanel VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding Name}" Foreground="#FFE8E8E8"
+                                                   FontSize="14" FontWeight="SemiBold"/>
+                                        <TextBlock Text="{Binding CountText}" Foreground="#FF87B380"
+                                                   FontSize="13" Margin="0,2,0,0"/>
+                                    </StackPanel>
                                 </StackPanel>
                             </Border>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-            </StackPanel>
-
-            <!-- Hero: elapsed time -->
-            <StackPanel VerticalAlignment="Center">
-                <TextBlock Text="{Binding ElapsedText}" FontSize="64" FontWeight="SemiBold"
-                           Foreground="#FFE8E8E8" HorizontalAlignment="Center"/>
-                <TextBlock Text="elapsed" FontSize="14" Foreground="#88FFFFFF"
-                           HorizontalAlignment="Center" Margin="0,4,0,0"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/src/Legolas.Module/Sharing/LegolasShareCardView.xaml.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareCardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Legolas.Sharing;
+
+public partial class LegolasShareCardView : UserControl
+{
+    public LegolasShareCardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Legolas.Module/Sharing/LegolasShareCardViewModel.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareCardViewModel.cs
@@ -15,7 +15,10 @@ namespace Legolas.Sharing;
 public sealed class LegolasShareCardViewModel
 {
     public const double CardWidth = 1000;
-    public const double CardHeight = 400;
+    // The card auto-grows vertically with the items WrapPanel; CardMinHeight keeps
+    // sparse runs (1–2 items) from looking dinky. Fixed-height layout is gone — see
+    // the renderer's two-pass measure for the auto-height pipeline.
+    public const double CardMinHeight = 320;
 
     public LegolasShareCardViewModel(
         LegolasSharePayload payload,

--- a/src/Legolas.Module/Sharing/LegolasShareCardViewModel.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareCardViewModel.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using System.Windows.Media.Imaging;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Reference;
+
+namespace Legolas.Sharing;
+
+/// <summary>
+/// View model for the Legolas social-card share image. Built from a
+/// <see cref="LegolasSharePayload"/>; bitmap icons resolve through
+/// <see cref="IIconCacheService"/> at construction time so the off-screen
+/// render in <see cref="LegolasShareCardRenderer"/> doesn't depend on the
+/// IconImage Loaded lifecycle (which doesn't fire for unparented visuals).
+/// </summary>
+public sealed class LegolasShareCardViewModel
+{
+    public const double CardWidth = 1000;
+    public const double CardHeight = 400;
+
+    public LegolasShareCardViewModel(
+        LegolasSharePayload payload,
+        IReferenceDataService? refData,
+        IIconCacheService? iconCache)
+    {
+        var hasName = !string.IsNullOrWhiteSpace(payload.CharacterName);
+        CharacterTitle = hasName ? payload.CharacterName! : "Legolas · Survey";
+        HasIdentity = hasName;
+        SubtitleText = "Survey run complete";
+
+        var elapsed = payload.CompletedAt - payload.StartedAt;
+        ElapsedText = LegolasReportService.FormatElapsed(elapsed);
+        SurveyCountText = payload.SurveyCount == 1
+            ? "1 survey"
+            : string.Format(CultureInfo.InvariantCulture, "{0} surveys", payload.SurveyCount);
+
+        StartedText = string.Format(CultureInfo.InvariantCulture,
+            "Started {0:g}", payload.StartedAt.LocalDateTime);
+        CompletedText = string.Format(CultureInfo.InvariantCulture,
+            "Finished {0:g}", payload.CompletedAt.LocalDateTime);
+
+        // Build all rows up-front — resolved (InternalName-keyed) and unknown (display-name-keyed)
+        // — then take the top N by count for display. Resolved entries get an icon; unknowns
+        // render name-only.
+        var all = new List<LegolasShareItem>();
+        foreach (var (internalName, count) in payload.CollectedItemsByInternalName)
+        {
+            string display = internalName;
+            BitmapImage? icon = null;
+            if (refData is not null && refData.ItemsByInternalName.TryGetValue(internalName, out var entry))
+            {
+                display = entry.Name;
+                if (iconCache is not null && entry.IconId > 0)
+                    icon = iconCache.GetOrLoadIcon(entry.IconId);
+            }
+            all.Add(new LegolasShareItem(display, count, icon));
+        }
+        if (payload.UnknownByName is { Count: > 0 } unknown)
+        {
+            foreach (var (name, count) in unknown)
+                all.Add(new LegolasShareItem(name, count, null));
+        }
+
+        Items = all
+            .OrderByDescending(i => i.Count)
+            .ThenBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(MaxItemsOnCard)
+            .ToList();
+    }
+
+    private const int MaxItemsOnCard = 12;
+
+    public string CharacterTitle { get; }
+    public bool HasIdentity { get; }
+    public string SubtitleText { get; }
+    public string ElapsedText { get; }
+    public string SurveyCountText { get; }
+    public string StartedText { get; }
+    public string CompletedText { get; }
+    public IReadOnlyList<LegolasShareItem> Items { get; }
+}
+
+public sealed record LegolasShareItem(string Name, int Count, BitmapImage? Icon)
+{
+    public string CountText => $"×{Count}";
+    public bool HasIcon => Icon is not null;
+}

--- a/src/Legolas.Module/Sharing/LegolasShareDialog.xaml
+++ b/src/Legolas.Module/Sharing/LegolasShareDialog.xaml
@@ -1,0 +1,97 @@
+<UserControl x:Class="Legolas.Sharing.LegolasShareDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:vm="clr-namespace:Legolas.Sharing"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:LegolasShareDialogViewModel}"
+             MinWidth="720" MaxWidth="1040">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <!-- App resources first so our brushes / fonts win in case of key collisions
+                 with MahApps theme keys. The MahApps dictionaries below give DropDownButton
+                 / DropDownMenu their polish (custom popup chrome, item hover, etc.) without
+                 us having to hand-roll a Popup + Border + Buttons combo. Scoped to this
+                 dialog so the rest of the app's visuals aren't touched. -->
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Steel.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <StackPanel>
+        <CheckBox Content="Include character name" IsChecked="{Binding IncludeCharacterName}"
+                  Visibility="{Binding ShowCharacterNameToggle, Converter={StaticResource BoolToVis}}"
+                  Foreground="#CCFFFFFF" Margin="0,0,0,12"/>
+
+        <!-- Hero: card preview. Re-renders on every payload change (toggle).
+             The image itself is 1000×400; we let it scale uniformly to fit the
+             dialog's content width, which at MaxWidth=1040 puts the preview at
+             near-native size so the small footer / item-strip text stays readable.
+             A thin status overlay shows while a render is in flight so the user
+             knows the bitmap below is briefly stale. -->
+        <Border Background="#FF101010" BorderBrush="#FF333333" BorderThickness="1"
+                CornerRadius="4" Padding="8" Margin="0,0,0,10">
+            <Grid>
+                <Image Source="{Binding CardPreview}" Stretch="Uniform" StretchDirection="DownOnly"
+                       HorizontalAlignment="Center"/>
+                <TextBlock Text="Rendering preview…" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Visibility="{Binding IsRenderingPreview, Converter={StaticResource BoolToVis}}"/>
+            </Grid>
+        </Border>
+
+        <!-- Bootstrap-style split: a regular Button for the primary (stable) action
+             paired with a mah:DropDownButton for alternates. We deliberately don't use
+             mah:SplitButton — it derives from ComboBox and treats picking an item as
+             "this is now the default", which isn't the affordance we want here.
+             Each MenuItem in the DropDownButton carries its own Command, and
+             MahApps owns the popup chrome / dark theming so we don't fight it.
+
+             ContentCharacterCasing=Normal opts out of MahApps's default uppercase
+             button face so the primary face matches the menu items below it.
+             CornerRadius is split — primary keeps its left corners, dropdown keeps
+             its right corners, inner corners square — so the pair reads as one
+             control. The seam between them stays (full borders preserved); the
+             cosmetic "merge the borders" tweaks regressed the focus / hover chrome
+             so they're intentionally not in here. -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+
+            <Button Content="Copy image" Command="{Binding CopyImageCommand}"
+                    Padding="12,6"
+                    mah:ControlsHelper.ContentCharacterCasing="Normal"
+                    mah:ControlsHelper.CornerRadius="3,0,0,3"/>
+            <mah:DropDownButton ToolTip="More copy options" Margin="0,0,8,0"
+                                mah:ControlsHelper.ContentCharacterCasing="Normal"
+                                mah:ControlsHelper.CornerRadius="0,3,3,0">
+                <mah:DropDownButton.Items>
+                    <MenuItem Header="Copy link"  Command="{Binding CopyLinkCommand}"/>
+                    <MenuItem Header="Copy text"  Command="{Binding CopySummaryCommand}"/>
+                    <MenuItem Header="Copy JSON"  Command="{Binding CopyJsonCommand}"/>
+                </mah:DropDownButton.Items>
+            </mah:DropDownButton>
+
+            <Button Content="Save image…" Command="{Binding SaveImageCommand}"
+                    Padding="10,6"
+                    mah:ControlsHelper.ContentCharacterCasing="Normal"
+                    mah:ControlsHelper.CornerRadius="3,0,0,3"/>
+            <mah:DropDownButton ToolTip="More save options"
+                                mah:ControlsHelper.ContentCharacterCasing="Normal"
+                                mah:ControlsHelper.CornerRadius="0,3,3,0">
+                <mah:DropDownButton.Items>
+                    <MenuItem Header="Save JSON…" Command="{Binding SaveJsonCommand}"/>
+                </mah:DropDownButton.Items>
+            </mah:DropDownButton>
+
+        </StackPanel>
+
+        <TextBlock Text="{Binding StatusMessage}" Foreground="#FF7AB880"
+                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,10,0,0"
+                   Visibility="{Binding StatusMessage, Converter={StaticResource NullOrEmptyToVis}}"/>
+    </StackPanel>
+</UserControl>

--- a/src/Legolas.Module/Sharing/LegolasShareDialog.xaml.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareDialog.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Legolas.Sharing;
+
+public partial class LegolasShareDialog : UserControl
+{
+    public LegolasShareDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Legolas.Module/Sharing/LegolasShareDialogViewModel.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareDialogViewModel.cs
@@ -1,0 +1,213 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Legolas.Domain;
+using Microsoft.Win32;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Sharing;
+using Mithril.Shared.Wpf.Dialogs;
+
+namespace Legolas.Sharing;
+
+/// <summary>
+/// Dialog for the end-of-run survey report. Image-as-hero layout: the rendered
+/// 1000×400 card is the headline; copy/save buttons act on the image, the text
+/// summary, the JSON payload, or the <c>mithril://legolas/&lt;base64url&gt;</c>
+/// share link. The same dialog serves both ends of the share flow — the wizard
+/// uses it after Done, and <see cref="LegolasShareImportTarget"/> uses it when a
+/// deep link is opened, so receiver and sender see identical artifacts.
+///
+/// The card preview re-renders whenever the payload changes (i.e. when the
+/// "Include character name" toggle flips). Render runs on a background STA worker
+/// thread; the bitmap is frozen before it returns, so the UI thread can swap it
+/// in safely.
+/// </summary>
+public sealed partial class LegolasShareDialogViewModel : DialogViewModelBase
+{
+    private readonly LegolasShareCardRenderer? _renderer;
+    private readonly LegolasSettings _settings;
+    private readonly Func<bool, LegolasSharePayload> _buildPayload;
+    private readonly IReferenceDataService? _refData;
+
+    public LegolasShareDialogViewModel(
+        Func<bool, LegolasSharePayload> buildPayload,
+        LegolasShareCardRenderer? renderer,
+        LegolasSettings settings,
+        bool hasCharacterName,
+        bool showCharacterNameToggle = true,
+        IReferenceDataService? refData = null)
+    {
+        _buildPayload = buildPayload;
+        _renderer = renderer;
+        _settings = settings;
+        _refData = refData;
+        HasCharacterName = hasCharacterName;
+        // Anonymizing someone else's identity isn't a meaningful affordance for
+        // a receiver — they didn't pick the name. The import target passes
+        // showCharacterNameToggle=false so the checkbox stays hidden.
+        ShowCharacterNameToggle = showCharacterNameToggle && hasCharacterName;
+        _includeCharacterName = hasCharacterName;
+        Refresh();
+    }
+
+    public override string Title => "Survey complete";
+    public override string PrimaryButtonText => "Close";
+    public override string? SecondaryButtonText => null;
+
+    // Card preview is 1000×400; outer host needs room for the image plus dialog
+    // chrome (title bar, button row, content padding). 1100 leaves the card at
+    // near-1:1 with breathing room on either side.
+    public override double MaxContentWidth => 1100;
+
+    public bool HasCharacterName { get; }
+    public bool ShowCharacterNameToggle { get; }
+    public bool HasRenderer => _renderer is not null;
+
+    [ObservableProperty] private bool _includeCharacterName;
+    [ObservableProperty] private string _shareLink = "";
+    [ObservableProperty] private string _jsonPayload = "";
+    [ObservableProperty] private string _summary = "";
+    [ObservableProperty] private string _statusMessage = "";
+    [ObservableProperty] private BitmapSource? _cardPreview;
+    [ObservableProperty] private bool _isRenderingPreview;
+
+    /// <summary>
+    /// Cached payload for the current toggle state. Populated by <see cref="Refresh"/>
+    /// so copy/save commands operate on a stable snapshot rather than re-invoking
+    /// <see cref="_buildPayload"/> mid-action (which would be racy with a fresh
+    /// FSM state on the sender side).
+    /// </summary>
+    private LegolasSharePayload _currentPayload = new();
+
+    partial void OnIncludeCharacterNameChanged(bool value) => Refresh();
+
+    private void Refresh()
+    {
+        _currentPayload = _buildPayload(IncludeCharacterName && HasCharacterName);
+        JsonPayload = JsonSerializer.Serialize(_currentPayload, LegolasShareJsonContext.Default.LegolasSharePayload);
+        ShareLink = "mithril://legolas/" + ShareCodec.EncodePayload(JsonPayload);
+        Summary = LegolasReportService.BuildSummary(_currentPayload, _refData);
+        // Kick off a fresh card render. Don't await — the render is fire-and-forget;
+        // the UI binds to CardPreview which is updated on completion.
+        _ = RenderPreviewAsync();
+    }
+
+    private async Task RenderPreviewAsync()
+    {
+        if (_renderer is null) return;
+        IsRenderingPreview = true;
+        try
+        {
+            var image = await _renderer.RenderCardAsync(_currentPayload).ConfigureAwait(true);
+            CardPreview = image;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Preview render failed: {ex.Message}";
+        }
+        finally
+        {
+            IsRenderingPreview = false;
+        }
+    }
+
+    [RelayCommand] private void CopyLink() => CopyText(ShareLink, "Share link copied to clipboard.");
+    [RelayCommand] private void CopyJson() => CopyText(JsonPayload, "JSON copied to clipboard.");
+    [RelayCommand] private void CopySummary() => CopyText(Summary, "Summary copied to clipboard.");
+
+    [RelayCommand]
+    private void CopyImage()
+    {
+        if (CardPreview is null)
+        {
+            StatusMessage = "Preview not ready yet.";
+            return;
+        }
+        try
+        {
+            // copy: true persists the bitmap on the clipboard past Mithril's
+            // lifetime — paste in Discord still works after closing.
+            Clipboard.SetDataObject(new DataObject(DataFormats.Bitmap, CardPreview), copy: true);
+            StatusMessage = "Card image copied to clipboard.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Could not copy image: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private void SaveImage()
+    {
+        if (CardPreview is null)
+        {
+            StatusMessage = "Preview not ready yet.";
+            return;
+        }
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save Legolas Report Image",
+            Filter = "PNG image (*.png)|*.png|All files (*.*)|*.*",
+            DefaultExt = "png",
+            FileName = $"legolas-report-{DateTimeOffset.UtcNow:yyyyMMdd-HHmm}.png",
+            InitialDirectory = _settings.ReportSaveDirectory ?? "",
+        };
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            using var fs = File.Create(dialog.FileName);
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(CardPreview));
+            encoder.Save(fs);
+            _settings.ReportSaveDirectory = Path.GetDirectoryName(dialog.FileName);
+            StatusMessage = $"Saved to {dialog.FileName}";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Save failed: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private void SaveJson()
+    {
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save Legolas Report",
+            Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+            DefaultExt = "json",
+            FileName = $"legolas-report-{DateTimeOffset.UtcNow:yyyyMMdd-HHmm}.json",
+            InitialDirectory = _settings.ReportSaveDirectory ?? "",
+        };
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, JsonPayload, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            _settings.ReportSaveDirectory = Path.GetDirectoryName(dialog.FileName);
+            StatusMessage = $"Saved to {dialog.FileName}";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Save failed: {ex.Message}";
+        }
+    }
+
+    private void CopyText(string text, string okMessage)
+    {
+        try
+        {
+            Clipboard.SetDataObject(new DataObject(DataFormats.UnicodeText, text), copy: true);
+            StatusMessage = okMessage;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Could not copy to clipboard: {ex.Message}";
+        }
+    }
+}

--- a/src/Legolas.Module/Sharing/LegolasShareImportTarget.cs
+++ b/src/Legolas.Module/Sharing/LegolasShareImportTarget.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using System.Windows;
+using Legolas.Domain;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Sharing;
+using Mithril.Shared.Wpf.Dialogs;
+
+namespace Legolas.Sharing;
+
+/// <summary>
+/// Legolas's implementation of <see cref="ILegolasShareImportTarget"/>. Decodes the
+/// deep link's base64url payload, deserializes a <see cref="LegolasSharePayload"/>,
+/// and opens the same <see cref="LegolasShareDialog"/> the sender used — giving the
+/// receiver the full toolkit (text summary, JSON, card preview, copy/save buttons,
+/// re-share link) instead of a stripped-down read-only view.
+/// </summary>
+public sealed class LegolasShareImportTarget : ILegolasShareImportTarget
+{
+    private readonly LegolasShareCardRenderer? _renderer;
+    private readonly LegolasSettings? _settings;
+    private readonly IDialogService? _dialogs;
+    private readonly IReferenceDataService? _refData;
+    private readonly IModuleActivator? _activator;
+    private readonly IDiagnosticsSink? _diag;
+
+    public LegolasShareImportTarget(
+        LegolasShareCardRenderer? renderer = null,
+        LegolasSettings? settings = null,
+        IDialogService? dialogs = null,
+        IReferenceDataService? refData = null,
+        IModuleActivator? activator = null,
+        IDiagnosticsSink? diag = null)
+    {
+        _renderer = renderer;
+        _settings = settings;
+        _dialogs = dialogs;
+        _refData = refData;
+        _activator = activator;
+        _diag = diag;
+    }
+
+    public void ImportFromLinkPayload(string base64UrlPayload)
+    {
+        if (!ShareCodec.TryDecodePayload(base64UrlPayload, out var json, out var error))
+        {
+            _diag?.Info("Legolas", $"Share link decode failed: {error}");
+            return;
+        }
+
+        LegolasSharePayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize(json, LegolasShareJsonContext.Default.LegolasSharePayload);
+        }
+        catch (JsonException ex)
+        {
+            _diag?.Info("Legolas", $"Share link payload is not valid LegolasSharePayload JSON: {ex.Message}");
+            return;
+        }
+        if (payload is null)
+        {
+            _diag?.Info("Legolas", "Share link payload deserialized to null.");
+            return;
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            Show(payload);
+        else
+            dispatcher.InvokeAsync(() => Show(payload));
+    }
+
+    private void Show(LegolasSharePayload payload)
+    {
+        if (_activator is not null && !_activator.Activate("legolas"))
+            _diag?.Info("Legolas", "Deep-link import: module activator could not find 'legolas'.");
+
+        if (_dialogs is null || _settings is null)
+        {
+            _diag?.Info("Legolas", "Share import: no dialog service or settings registered; cannot open dialog.");
+            return;
+        }
+
+        // The receiver doesn't get to anonymize someone else's identity — the
+        // toggle is hidden via showCharacterNameToggle=false, and the buildPayload
+        // ignores the bool and always returns what the sender encoded.
+        var hadName = !string.IsNullOrWhiteSpace(payload.CharacterName);
+        var vm = new LegolasShareDialogViewModel(
+            buildPayload: _ => payload,
+            renderer: _renderer,
+            settings: _settings,
+            hasCharacterName: hadName,
+            showCharacterNameToggle: false,
+            refData: _refData);
+        _dialogs.ShowDialog(vm, new LegolasShareDialog());
+    }
+}

--- a/src/Legolas.Module/Sharing/LegolasSharePayload.cs
+++ b/src/Legolas.Module/Sharing/LegolasSharePayload.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Serialization;
+using Legolas.ViewModels;
+
+namespace Legolas.Sharing;
+
+/// <summary>
+/// Wire format for sharing the result of a Legolas survey run. Carried inside a
+/// <c>mithril://legolas/&lt;base64url&gt;</c> deep link or pasted as JSON. The payload
+/// stores item display names (parser-canonical) as keys — the recipient resolves
+/// icons against their own <see cref="Mithril.Shared.Reference.IReferenceDataService"/>
+/// snapshot at render time, the same shape Pippin uses for its share payload.
+/// </summary>
+public sealed class LegolasSharePayload
+{
+    public const int CurrentVersion = 1;
+
+    public int SchemaVersion { get; set; } = CurrentVersion;
+
+    /// <summary>
+    /// Sender's character name. Null when the sender opted out of sharing identity in
+    /// the share dialog. The shared-report view labels itself "Shared report" in
+    /// that case.
+    /// </summary>
+    public string? CharacterName { get; set; }
+
+    /// <summary>UTC instant the session started — when the player anchor was confirmed.</summary>
+    public DateTimeOffset StartedAt { get; set; }
+
+    /// <summary>UTC instant the FSM hit Done.</summary>
+    public DateTimeOffset CompletedAt { get; set; }
+
+    /// <summary>Survey vs Motherlode. v1 only emits payloads in Survey mode.</summary>
+    public SessionMode Mode { get; set; } = SessionMode.Survey;
+
+    /// <summary>Number of survey nodes the player walked through this run.</summary>
+    public int SurveyCount { get; set; }
+
+    /// <summary>
+    /// Items earned, keyed by item <c>InternalName</c> → total quantity. The recipient
+    /// resolves display names + icons against their own
+    /// <see cref="Mithril.Shared.Reference.IReferenceDataService"/> snapshot at render
+    /// time, so the payload survives CDN-version drift and locale differences.
+    /// Mirrors Pippin's <c>EatenFoodsByInternalName</c>.
+    /// </summary>
+    public Dictionary<string, int> CollectedItemsByInternalName { get; set; } =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Items the sender's local catalog couldn't resolve, kept by display name as a
+    /// best-effort orphan group. Recipient renders them name-only with no icon.
+    /// Optional — omitted when empty.
+    /// </summary>
+    public Dictionary<string, int>? UnknownByName { get; set; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(LegolasSharePayload))]
+public partial class LegolasShareJsonContext : JsonSerializerContext { }

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -3,6 +3,10 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
 using Legolas.Flow;
+using Legolas.Sharing;
+using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Dialogs;
 
 namespace Legolas.ViewModels;
 
@@ -32,6 +36,12 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
     private readonly SessionState _session;
     private readonly SurveyFlowController _surveyFlow;
     private readonly MotherlodeFlowController _motherlodeFlow;
+    private readonly LegolasSettings _settings;
+    private readonly LegolasReportService? _reportService;
+    private readonly LegolasShareCardRenderer? _renderer;
+    private readonly IActiveCharacterService? _activeChar;
+    private readonly IReferenceDataService? _refData;
+    private readonly IDialogService? _dialogs;
 
     public LegolasWizardViewModel(
         SessionState session,
@@ -40,11 +50,23 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         ControlPanelViewModel controlPanel,
         MotherlodeViewModel motherlode,
         MapOverlayViewModel mapOverlay,
-        NudgePadViewModel nudgePad)
+        NudgePadViewModel nudgePad,
+        LegolasSettings settings,
+        LegolasReportService? reportService = null,
+        LegolasShareCardRenderer? renderer = null,
+        IActiveCharacterService? activeChar = null,
+        IReferenceDataService? refData = null,
+        IDialogService? dialogs = null)
     {
         _session = session;
         _surveyFlow = surveyFlow;
         _motherlodeFlow = motherlodeFlow;
+        _settings = settings;
+        _reportService = reportService;
+        _renderer = renderer;
+        _activeChar = activeChar;
+        _refData = refData;
+        _dialogs = dialogs;
         ControlPanel = controlPanel;
         Motherlode = motherlode;
         MapOverlay = mapOverlay;
@@ -53,6 +75,8 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _surveyFlow.PropertyChanged += OnSurveyFlowChanged;
         _motherlodeFlow.PropertyChanged += OnMotherlodeFlowChanged;
         _session.PropertyChanged += OnSessionChanged;
+        if (_reportService is not null)
+            _reportService.ReportGenerated += OnReportGenerated;
         RecomputeStep();
     }
 
@@ -206,6 +230,63 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         // Hotkey-driven mode flip should re-project the wizard's step.
         if (e.PropertyName == nameof(SessionState.Mode))
             RecomputeStep();
+    }
+
+    /// <summary>
+    /// True once a survey run has completed at least once this app session, so the
+    /// wizard can show a "View last report" button. The snapshot lives on the
+    /// report service across FSM resets, so this stays true even after AutoReset
+    /// has cleared <see cref="SessionState"/>.
+    /// </summary>
+    public bool HasLatestReport => _reportService?.LatestReport is not null;
+
+    private void OnReportGenerated(LegolasSharePayload payload)
+    {
+        OnPropertyChanged(nameof(HasLatestReport));
+        if (_settings.ShowReportOnDone)
+            ShowReportDialog(payload);
+    }
+
+    [RelayCommand]
+    private void ViewLastReport()
+    {
+        var payload = _reportService?.LatestReport;
+        if (payload is null) return;
+        ShowReportDialog(payload);
+    }
+
+    private void ShowReportDialog(LegolasSharePayload payload)
+    {
+        if (_dialogs is null || _reportService is null) return;
+        // Capture the just-built payload so the dialog can rebuild on character-name
+        // toggle without the FSM having to be in Done at click time.
+        var captured = payload;
+        var hasName = !string.IsNullOrWhiteSpace(_activeChar?.ActiveCharacterName);
+        var vm = new LegolasShareDialogViewModel(
+            buildPayload: includeName =>
+            {
+                if (includeName == (captured.CharacterName != null)) return captured;
+                // Toggle the character name on the captured snapshot rather than
+                // re-snapshotting from a now-reset SessionState.
+                return new LegolasSharePayload
+                {
+                    SchemaVersion = captured.SchemaVersion,
+                    CharacterName = includeName ? _activeChar?.ActiveCharacterName : null,
+                    StartedAt = captured.StartedAt,
+                    CompletedAt = captured.CompletedAt,
+                    Mode = captured.Mode,
+                    SurveyCount = captured.SurveyCount,
+                    CollectedItemsByInternalName = new Dictionary<string, int>(captured.CollectedItemsByInternalName, StringComparer.Ordinal),
+                    UnknownByName = captured.UnknownByName is null
+                        ? null
+                        : new Dictionary<string, int>(captured.UnknownByName, StringComparer.Ordinal),
+                };
+            },
+            renderer: _renderer,
+            settings: _settings,
+            hasCharacterName: hasName,
+            refData: _refData);
+        _dialogs.ShowDialog(vm, new LegolasShareDialog());
     }
 
     private void RecomputeStep()

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -14,6 +15,23 @@ namespace Legolas.ViewModels;
 public sealed partial class SessionState : ObservableObject
 {
     public ObservableCollection<SurveyItemViewModel> Surveys { get; } = new();
+
+    /// <summary>
+    /// Items the player has actually collected during this session, keyed by item
+    /// display name (parser-canonical, case-insensitive). Surveys map 1:1 to a
+    /// surveyed node, but a node can yield multiple items — the chat parser is the
+    /// only place we see real quantities, so the ingestion service accumulates
+    /// here. Cleared by <see cref="ClearSurveys"/> alongside the survey list.
+    /// </summary>
+    public Dictionary<string, int> CollectedItems { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Wall-clock instant the current session started — set when the FSM transitions
+    /// AwaitingPosition → Listening (i.e. the user confirmed a player anchor and is
+    /// ready to listen for surveys). Null when no session has been started.
+    /// Cleared by <see cref="ClearSurveys"/>.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; set; }
 
     public SessionState()
     {
@@ -120,6 +138,8 @@ public sealed partial class SessionState : ObservableObject
     public void ClearSurveys()
     {
         Surveys.Clear();
+        CollectedItems.Clear();
+        StartedAt = null;
     }
 }
 

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -331,6 +331,10 @@
                                TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center"
                                FontSize="{DynamicResource AppFontSizeBody}"
                                Foreground="{StaticResource TextSecondaryBrush}" />
+                    <Button Content="View report" Padding="14,6" Margin="0,16,0,0" HorizontalAlignment="Center"
+                            Command="{Binding ViewLastReportCommand}"
+                            Visibility="{Binding HasLatestReport, Converter={StaticResource BoolToVis}}"
+                            ToolTip="Re-open the end-of-run summary (text + PNG card)" />
                 </StackPanel>
 
                 <!-- MotherlodeMeasuring -->

--- a/src/Mithril.Shared/Mithril.Shared.csproj
+++ b/src/Mithril.Shared/Mithril.Shared.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Formatting.Compact" />
+    <PackageReference Include="MahApps.Metro" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
     <PackageReference Include="NAudio" />
   </ItemGroup>

--- a/src/Mithril.Shared/Modules/DeepLinkRouter.cs
+++ b/src/Mithril.Shared/Modules/DeepLinkRouter.cs
@@ -12,6 +12,8 @@ namespace Mithril.Shared.Modules;
 ///         <see cref="ICraftListImportTarget"/> (Celebrimbor).</item>
 ///   <item><c>mithril://pippin/&lt;base64url&gt;</c> — hands the payload to
 ///         <see cref="IPippinShareImportTarget"/> (Pippin shared progress).</item>
+///   <item><c>mithril://legolas/&lt;base64url&gt;</c> — hands the payload to
+///         <see cref="ILegolasShareImportTarget"/> (Legolas survey report).</item>
 /// </list>
 /// Each action defines its own payload grammar so item names stay strict while the craft-list
 /// payload can hold a much longer base64url blob. Unknown actions are logged and dropped.
@@ -24,26 +26,32 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
     // we refuse anything that could confuse downstream lookups or smuggle separators.
     private static readonly Regex ItemPayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
 
-    // mithril://list and mithril://pippin both carry a base64url-encoded gzip payload.
+    // mithril://list, pippin, and legolas all carry a base64url-encoded gzip payload.
     // Base64url uses [A-Za-z0-9_-]; cap length well above any plausible compressed payload
     // so we fail fast on anything pathological rather than handing it to the decoder.
     private static readonly Regex ListPayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
     private static readonly Regex PippinPayloadPattern = new("^[A-Za-z0-9_-]{1,16384}$", RegexOptions.Compiled);
+    // Legolas payloads are smaller than Pippin's full-catalog progress dumps — a survey
+    // run is at most a couple dozen items + timestamps. 8192 is plenty.
+    private static readonly Regex LegolasPayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
 
     private readonly IItemDetailPresenter _itemDetail;
     private readonly ICraftListImportTarget? _listImport;
     private readonly IPippinShareImportTarget? _pippinImport;
+    private readonly ILegolasShareImportTarget? _legolasImport;
     private readonly IDiagnosticsSink? _diag;
 
     public DeepLinkRouter(
         IItemDetailPresenter itemDetail,
         ICraftListImportTarget? listImport = null,
         IPippinShareImportTarget? pippinImport = null,
+        ILegolasShareImportTarget? legolasImport = null,
         IDiagnosticsSink? diag = null)
     {
         _itemDetail = itemDetail;
         _listImport = listImport;
         _pippinImport = pippinImport;
+        _legolasImport = legolasImport;
         _diag = diag;
     }
 
@@ -102,6 +110,20 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
                     return false;
                 }
                 _pippinImport.ImportFromLinkPayload(payload);
+                return true;
+
+            case "legolas":
+                if (!LegolasPayloadPattern.IsMatch(payload))
+                {
+                    _diag?.Info("DeepLink", $"Rejected: legolas payload (len={payload.Length}) failed validation.");
+                    return false;
+                }
+                if (_legolasImport is null)
+                {
+                    _diag?.Info("DeepLink", "Rejected: no legolas import target registered.");
+                    return false;
+                }
+                _legolasImport.ImportFromLinkPayload(payload);
                 return true;
 
             default:

--- a/src/Mithril.Shared/Modules/ILegolasShareImportTarget.cs
+++ b/src/Mithril.Shared/Modules/ILegolasShareImportTarget.cs
@@ -1,0 +1,18 @@
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Optional target that handles <c>mithril://legolas/&lt;payload&gt;</c> deep links.
+/// Implemented by Legolas to decode the share payload, activate its tab, and present
+/// a read-only view of another player's survey-run report. The router treats it as
+/// optional — if no module has registered a handler, legolas links are logged and
+/// dropped.
+/// </summary>
+public interface ILegolasShareImportTarget
+{
+    /// <summary>
+    /// Decodes <paramref name="base64UrlPayload"/> (the path segment from the deep link)
+    /// and shows the read-only report view. All errors are logged and swallowed —
+    /// callers are OS activation handlers that mustn't throw.
+    /// </summary>
+    void ImportFromLinkPayload(string base64UrlPayload);
+}

--- a/src/Mithril.Shared/Wpf/Dialogs/DialogViewModelBase.cs
+++ b/src/Mithril.Shared/Wpf/Dialogs/DialogViewModelBase.cs
@@ -11,6 +11,15 @@ public abstract class DialogViewModelBase : ObservableObject
     public virtual string? SecondaryButtonText => "Cancel";
 
     /// <summary>
+    /// Caps the dialog host's outer width. The default suits prose-shaped dialogs
+    /// (settings, confirms, share links). Dialogs that embed wide content — image
+    /// previews, full-grid renders — override this so the host doesn't squeeze the
+    /// inner content down to ~560 px regardless of what the inner control's own
+    /// MaxWidth allows.
+    /// </summary>
+    public virtual double MaxContentWidth => 560;
+
+    /// <summary>
     /// Called when the primary button is clicked. Return <c>true</c> to close the dialog,
     /// <c>false</c> to keep it open (e.g. validation failed).
     /// </summary>

--- a/src/Mithril.Shared/Wpf/Dialogs/DialogWindow.xaml
+++ b/src/Mithril.Shared/Wpf/Dialogs/DialogWindow.xaml
@@ -17,7 +17,8 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border x:Name="DialogContainer"
+            Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
             MinWidth="360" MaxWidth="560">
         <DockPanel>
             <!-- Title bar -->

--- a/src/Mithril.Shared/Wpf/Dialogs/DialogWindow.xaml.cs
+++ b/src/Mithril.Shared/Wpf/Dialogs/DialogWindow.xaml.cs
@@ -15,6 +15,10 @@ public partial class DialogWindow : Window
 
         TitleText.Text = viewModel.Title;
         PrimaryButton.Content = viewModel.PrimaryButtonText;
+        // The XAML default (MaxWidth=560) suits prose-shaped dialogs; let each VM
+        // override for image-preview / wide-content cases without bumping the
+        // global cap and accidentally letting other dialogs grow.
+        DialogContainer.MaxWidth = viewModel.MaxContentWidth;
 
         if (viewModel.SecondaryButtonText is { } secondaryText)
         {

--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ public static class ShellServiceCollectionExtensions
                 sp.GetRequiredService<IItemDetailPresenter>(),
                 sp.GetService<ICraftListImportTarget>(),
                 sp.GetService<IPippinShareImportTarget>(),
+                sp.GetService<ILegolasShareImportTarget>(),
                 sp.GetService<IDiagnosticsSink>()));
 
     public static IServiceCollection AddMithrilIngredientSources(this IServiceCollection services) =>

--- a/tests/Legolas.Tests/LogTail/LogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/LogParserTests.cs
@@ -27,12 +27,42 @@ public class LogParserTests
     [Theory]
     [InlineData("[Status] Diamond x1 collected!", "Diamond", 1)]
     [InlineData("[Status] Gold Ingot x5 collected!", "Gold Ingot", 5)]
+    [InlineData("[Status] Citrine collected!", "Citrine", 1)]
+    [InlineData("[Status] Expert-Quality Metal Slab collected!", "Expert-Quality Metal Slab", 1)]
     public void Parses_item_collected(string line, string expectedName, int expectedCount)
     {
         var evt = _parser.TryParse(line, FixedTime);
 
-        evt.Should().BeOfType<ItemCollected>()
-            .Which.Should().BeEquivalentTo(new ItemCollected(FixedTime, expectedName, expectedCount));
+        var ic = evt.Should().BeOfType<ItemCollected>().Subject;
+        ic.Name.Should().Be(expectedName);
+        ic.Count.Should().Be(expectedCount);
+        ic.SpeedBonusItem.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("[Status] Garnet collected! Also found Fluorite (speed bonus!)", "Garnet", "Fluorite")]
+    [InlineData("[Status] Simple Metal Slab collected! Also found Simple Metal Slab (speed bonus!)", "Simple Metal Slab", "Simple Metal Slab")]
+    [InlineData("[Status] Carnelian collected! Also found Lapis Lazuli (speed bonus!)", "Carnelian", "Lapis Lazuli")]
+    public void Parses_item_collected_with_speed_bonus(string line, string expectedName, string expectedBonus)
+    {
+        var evt = _parser.TryParse(line, FixedTime);
+
+        var ic = evt.Should().BeOfType<ItemCollected>().Subject;
+        ic.Name.Should().Be(expectedName);
+        ic.SpeedBonusItem.Should().Be(expectedBonus);
+    }
+
+    [Theory]
+    [InlineData("[Status] Citrine x3 added to inventory.", "Citrine", 3)]
+    [InlineData("[Status] Expert-Quality Metal Slab x3 added to inventory.", "Expert-Quality Metal Slab", 3)]
+    [InlineData("[Status] Fluorite added to inventory.", "Fluorite", 1)]
+    [InlineData("[Status] Lump of Coal x10 added to inventory.", "Lump of Coal", 10)]
+    public void Parses_item_added_to_inventory(string line, string expectedName, int expectedCount)
+    {
+        var evt = _parser.TryParse(line, FixedTime);
+
+        evt.Should().BeOfType<ItemAddedToInventory>()
+            .Which.Should().BeEquivalentTo(new ItemAddedToInventory(FixedTime, expectedName, expectedCount));
     }
 
     [Fact]

--- a/tests/Legolas.Tests/Sharing/LegolasReportServiceTests.cs
+++ b/tests/Legolas.Tests/Sharing/LegolasReportServiceTests.cs
@@ -1,0 +1,288 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Sharing;
+using Legolas.ViewModels;
+using Mithril.Shared.Reference;
+
+namespace Legolas.Tests.Sharing;
+
+public class LegolasReportServiceTests
+{
+    private static readonly DateTimeOffset SessionStart = new(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset SessionEnd   = new(2026, 5, 6, 12, 8, 30, TimeSpan.Zero);
+
+    /// <summary>
+    /// Minimal in-process clock for tests. Microsoft has a richer
+    /// <c>Microsoft.Extensions.TimeProvider.Testing</c> package, but the report
+    /// service only calls <see cref="TimeProvider.GetUtcNow"/>; this fake covers it
+    /// without taking the dep.
+    /// </summary>
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeClock(DateTimeOffset start) { _now = start; }
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Set(DateTimeOffset when) => _now = when;
+    }
+
+    private static (LegolasReportService report, SurveyFlowController flow, SessionState session, LegolasSettings settings, FakeClock clock) BuildSut()
+    {
+        var clock = new FakeClock(SessionStart);
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var flow = new SurveyFlowController(session, settings, clock);
+        var report = new LegolasReportService(flow, session, clock, activeChar: null);
+        return (report, flow, session, settings, clock);
+    }
+
+    [Fact]
+    public void Snapshot_taken_at_Done_captures_surveys_and_items()
+    {
+        var (report, flow, session, settings, clock) = BuildSut();
+        settings.AutoResetWhenAllCollected = false;
+
+        // Start the session: anchor + transition to Listening (clock stamps StartedAt).
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+
+        // Advance clock + collect items + add the final survey-collected mark.
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 3;
+        session.CollectedItems["Coal"] = 5;
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 1));
+        session.Surveys.Add(s1);
+        session.Surveys.Add(s2);
+        flow.OptimizeRoute();
+
+        // Marking the last one fires AllCollected → Transitioned(Done) → snapshot built.
+        s1.UpdateModel(s1.Model with { Collected = true });
+        s2.UpdateModel(s2.Model with { Collected = true });
+
+        report.LatestReport.Should().NotBeNull();
+        var p = report.LatestReport!;
+        p.StartedAt.Should().Be(SessionStart);
+        p.CompletedAt.Should().Be(SessionEnd);
+        p.SurveyCount.Should().Be(2);
+        // Without IReferenceDataService injected, all items end up under UnknownByName
+        // (display-name keys preserved). Resolution is exercised in the next test.
+        p.CollectedItemsByInternalName.Should().BeEmpty();
+        p.UnknownByName.Should().NotBeNull();
+        p.UnknownByName!.Should().ContainKey("Diamond").WhoseValue.Should().Be(3);
+        p.UnknownByName!.Should().ContainKey("Coal").WhoseValue.Should().Be(5);
+    }
+
+    [Fact]
+    public void Snapshot_resolves_display_names_to_InternalName_when_refdata_available()
+    {
+        var clock = new FakeClock(SessionStart);
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var flow = new SurveyFlowController(session, settings, clock);
+        var refData = new StubRefData(
+            new ItemEntry(1, Name: "Diamond",   InternalName: "RawGem_Diamond", MaxStackSize: 100, IconId: 42, Keywords: Array.Empty<ItemKeyword>()),
+            new ItemEntry(2, Name: "Mystery",   InternalName: "Item_Unknown",   MaxStackSize: 100, IconId: 0,  Keywords: Array.Empty<ItemKeyword>()));
+        var report = new LegolasReportService(flow, session, clock, activeChar: null, refData: refData);
+        settings.AutoResetWhenAllCollected = false;
+
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 3;
+        session.CollectedItems["NotInCatalog"] = 1;
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        flow.OptimizeRoute();
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        var p = report.LatestReport!;
+        p.CollectedItemsByInternalName.Should().ContainKey("RawGem_Diamond")
+            .WhoseValue.Should().Be(3);
+        p.UnknownByName.Should().NotBeNull();
+        p.UnknownByName!.Should().ContainKey("NotInCatalog").WhoseValue.Should().Be(1);
+    }
+
+    [Fact]
+    public void Snapshot_survives_AutoReset_clearing_session()
+    {
+        // The whole point of the at-transition snapshot: AutoResetWhenAllCollected
+        // calls Reset() *immediately* after Done fires, which empties Surveys and
+        // CollectedItems on the SessionState. The snapshot, taken inside the
+        // Transitioned event handler, captures the unmodified state before Reset.
+        var (report, flow, session, settings, clock) = BuildSut();
+        settings.AutoResetWhenAllCollected = true;
+
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 3;
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        flow.OptimizeRoute();
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        // Auto-reset has cleared the live session…
+        session.Surveys.Should().BeEmpty();
+        session.CollectedItems.Should().BeEmpty();
+        // …but the snapshot kept the data. Without IReferenceDataService it lands
+        // in UnknownByName keyed by display name; that's exercised separately in
+        // the resolution test.
+        report.LatestReport.Should().NotBeNull();
+        report.LatestReport!.SurveyCount.Should().Be(1);
+        report.LatestReport.UnknownByName!["Diamond"].Should().Be(3);
+    }
+
+    [Fact]
+    public void Motherlode_mode_does_not_snapshot()
+    {
+        var (report, flow, session, settings, _) = BuildSut();
+        settings.AutoResetWhenAllCollected = false;
+        session.Mode = SessionMode.Motherlode;
+
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        flow.OptimizeRoute();
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        // FSM still hits Done, but the report service skips Motherlode runs in v1.
+        flow.CurrentState.Should().Be(SurveyFlowState.Done);
+        report.LatestReport.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReportGenerated_event_fires_on_Done()
+    {
+        var (report, flow, session, settings, _) = BuildSut();
+        settings.AutoResetWhenAllCollected = false;
+        LegolasSharePayload? captured = null;
+        report.ReportGenerated += p => captured = p;
+
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        flow.OptimizeRoute();
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        captured.Should().NotBeNull();
+        captured!.SurveyCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(15, "15s")]
+    [InlineData(75, "1m 15s")]
+    [InlineData(3725, "1h 2m 5s")]
+    [InlineData(0, "0s")]
+    public void FormatElapsed_renders_human_readable(int totalSeconds, string expected)
+    {
+        var s = LegolasReportService.FormatElapsed(TimeSpan.FromSeconds(totalSeconds));
+        s.Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildSummary_resolves_display_names_when_refdata_provided()
+    {
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = "Argothian",
+            StartedAt = SessionStart,
+            CompletedAt = SessionEnd,
+            SurveyCount = 4,
+            CollectedItemsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                { "RawGem_Diamond", 3 },
+                { "Coal",           7 },
+            },
+        };
+        var refData = new StubRefData(
+            new ItemEntry(1, Name: "Diamond", InternalName: "RawGem_Diamond", MaxStackSize: 100, IconId: 1, Keywords: Array.Empty<ItemKeyword>()));
+
+        var summary = LegolasReportService.BuildSummary(payload, refData);
+        summary.Should().Contain("Argothian");
+        summary.Should().Contain("Surveys collected: 4");
+        summary.Should().Contain("Diamond ×3");      // resolved display name
+        summary.Should().Contain("Coal ×7");          // unresolved → falls back to InternalName
+        summary.Should().Contain("8m 30s");
+    }
+
+    [Fact]
+    public void BuildSummary_falls_back_to_InternalName_without_refdata()
+    {
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = "Argothian",
+            StartedAt = SessionStart,
+            CompletedAt = SessionEnd,
+            SurveyCount = 2,
+            CollectedItemsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                { "RawGem_Diamond", 3 },
+            },
+        };
+
+        var summary = LegolasReportService.BuildSummary(payload);
+        summary.Should().Contain("RawGem_Diamond ×3");
+    }
+
+    [Fact]
+    public void BuildSummary_anonymous_payload_uses_anonymous_label()
+    {
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = null,
+            StartedAt = SessionStart,
+            CompletedAt = SessionEnd,
+            SurveyCount = 1,
+        };
+        LegolasReportService.BuildSummary(payload).Should().Contain("Anonymous");
+    }
+
+    /// <summary>
+    /// Minimal IReferenceDataService stub. Only <see cref="Items"/> and
+    /// <see cref="ItemsByInternalName"/> are populated — the report service uses
+    /// the former to build a display-name index and the latter for InternalName
+    /// → display-name resolution in <c>BuildSummary</c>. Other interface members
+    /// return empty/no-op since the report path doesn't touch them.
+    /// </summary>
+    private sealed class StubRefData : IReferenceDataService
+    {
+        public StubRefData(params ItemEntry[] items)
+        {
+            var byId = new Dictionary<long, ItemEntry>();
+            var byInternalName = new Dictionary<string, ItemEntry>(StringComparer.Ordinal);
+            foreach (var i in items)
+            {
+                byId[i.Id] = i;
+                byInternalName[i.InternalName] = i;
+            }
+            Items = byId;
+            ItemsByInternalName = byInternalName;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; }
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; }
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public event EventHandler<string>? FileUpdated;
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        private void Suppress() => FileUpdated?.Invoke(this, "");
+    }
+}

--- a/tests/Legolas.Tests/Sharing/LegolasShareCardViewModelTests.cs
+++ b/tests/Legolas.Tests/Sharing/LegolasShareCardViewModelTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Legolas.Sharing;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.Sharing;
+
+public class LegolasShareCardViewModelTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset End   = new(2026, 5, 6, 12, 8, 30, TimeSpan.Zero);
+
+    [Fact]
+    public void Named_payload_renders_character_as_title()
+    {
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = "Argothian",
+            StartedAt = Start,
+            CompletedAt = End,
+            SurveyCount = 4,
+        };
+
+        var vm = new LegolasShareCardViewModel(payload, refData: null, iconCache: null);
+
+        vm.CharacterTitle.Should().Be("Argothian");
+        vm.HasIdentity.Should().BeTrue();
+        vm.SurveyCountText.Should().Be("4 surveys");
+        vm.ElapsedText.Should().Be("8m 30s");
+    }
+
+    [Fact]
+    public void Anonymous_payload_falls_back_to_module_title()
+    {
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = null,
+            StartedAt = Start,
+            CompletedAt = End,
+            SurveyCount = 1,
+        };
+
+        var vm = new LegolasShareCardViewModel(payload, refData: null, iconCache: null);
+
+        vm.CharacterTitle.Should().Be("Legolas · Survey");
+        vm.HasIdentity.Should().BeFalse();
+        vm.SurveyCountText.Should().Be("1 survey");
+    }
+
+    [Fact]
+    public void Items_sorted_by_count_descending_then_name()
+    {
+        var payload = new LegolasSharePayload
+        {
+            StartedAt = Start,
+            CompletedAt = End,
+            CollectedItemsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                { "Coal",     2 },
+                { "Diamond", 12 },
+                { "Apple",    5 },
+                { "Banana",   5 },
+            },
+        };
+
+        var vm = new LegolasShareCardViewModel(payload, refData: null, iconCache: null);
+
+        vm.Items.Should().HaveCount(4);
+        vm.Items[0].Name.Should().Be("Diamond");
+        vm.Items[0].Count.Should().Be(12);
+        vm.Items[0].CountText.Should().Be("×12");
+        // Apple/Banana tie at 5; alphabetic order breaks the tie.
+        vm.Items[1].Name.Should().Be("Apple");
+        vm.Items[2].Name.Should().Be("Banana");
+        vm.Items[3].Name.Should().Be("Coal");
+    }
+
+    [Fact]
+    public void Items_capped_at_card_max()
+    {
+        var items = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < 30; i++)
+            items[$"Item{i:D2}"] = i + 1;
+        var payload = new LegolasSharePayload
+        {
+            StartedAt = Start,
+            CompletedAt = End,
+            CollectedItemsByInternalName = items,
+        };
+
+        var vm = new LegolasShareCardViewModel(payload, refData: null, iconCache: null);
+        vm.Items.Count.Should().BeLessThanOrEqualTo(12,
+            "the card has finite vertical room — overflow goes to the JSON / summary surfaces");
+    }
+
+    [Fact]
+    public void Without_refdata_or_icon_cache_items_have_no_icon()
+    {
+        var payload = new LegolasSharePayload
+        {
+            StartedAt = Start,
+            CompletedAt = End,
+            CollectedItemsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                { "Diamond", 1 },
+            },
+        };
+        var vm = new LegolasShareCardViewModel(payload, refData: null, iconCache: null);
+        vm.Items.Single().HasIcon.Should().BeFalse();
+        vm.Items.Single().Icon.Should().BeNull();
+    }
+}

--- a/tests/Legolas.Tests/Sharing/LegolasShareRoundTripTests.cs
+++ b/tests/Legolas.Tests/Sharing/LegolasShareRoundTripTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using FluentAssertions;
+using Legolas.Sharing;
+using Legolas.ViewModels;
+using Mithril.Shared.Sharing;
+
+namespace Legolas.Tests.Sharing;
+
+public class LegolasShareRoundTripTests
+{
+    [Fact]
+    public void Payload_round_trips_through_codec()
+    {
+        var original = new LegolasSharePayload
+        {
+            CharacterName = "Argothian",
+            StartedAt = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero),
+            CompletedAt = new DateTimeOffset(2026, 5, 6, 12, 8, 30, TimeSpan.Zero),
+            Mode = SessionMode.Survey,
+            SurveyCount = 3,
+            CollectedItemsByInternalName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                { "RawGem_Diamond", 3 },
+                { "Coal",            7 },
+                { "RawOre_Iron",     2 },
+            },
+            UnknownByName = new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                { "Mystery Lump", 1 },
+            },
+        };
+
+        var json = JsonSerializer.Serialize(original, LegolasShareJsonContext.Default.LegolasSharePayload);
+        var encoded = ShareCodec.EncodePayload(json);
+        ShareCodec.TryDecodePayload(encoded, out var decoded, out var err).Should().BeTrue(err);
+
+        var roundtripped = JsonSerializer.Deserialize(decoded, LegolasShareJsonContext.Default.LegolasSharePayload);
+        roundtripped.Should().NotBeNull();
+        roundtripped!.CharacterName.Should().Be("Argothian");
+        roundtripped.StartedAt.Should().Be(original.StartedAt);
+        roundtripped.CompletedAt.Should().Be(original.CompletedAt);
+        roundtripped.SurveyCount.Should().Be(3);
+        roundtripped.CollectedItemsByInternalName.Should().BeEquivalentTo(original.CollectedItemsByInternalName);
+        roundtripped.UnknownByName.Should().BeEquivalentTo(original.UnknownByName);
+    }
+
+    [Fact]
+    public void Payload_without_character_name_omits_field_from_json()
+    {
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = null,
+            StartedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            SurveyCount = 0,
+        };
+        var json = JsonSerializer.Serialize(payload, LegolasShareJsonContext.Default.LegolasSharePayload);
+        json.Should().NotContain("characterName");
+    }
+
+    [Fact]
+    public void Realistic_run_payload_fits_router_length_cap()
+    {
+        // Worst-case shape: many distinct items + a long character name.
+        var items = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < 30; i++)
+            items[$"SurveyItemNumber{i,2:D2}"] = i + 1;
+
+        var payload = new LegolasSharePayload
+        {
+            CharacterName = "AReasonablyLongCharacterName",
+            StartedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow.AddMinutes(45),
+            Mode = SessionMode.Survey,
+            SurveyCount = 30,
+            CollectedItemsByInternalName = items,
+        };
+
+        var json = JsonSerializer.Serialize(payload, LegolasShareJsonContext.Default.LegolasSharePayload);
+        var encoded = ShareCodec.EncodePayload(json);
+        // DeepLinkRouter caps legolas payloads at 8192 base64url chars.
+        encoded.Length.Should().BeLessThan(8192);
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -26,7 +26,7 @@ public class LegolasWizardViewModelTests
         var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
         var nudgePad = new NudgePadViewModel(session, mapOverlay, settings);
         var wizard = new LegolasWizardViewModel(session, surveyFlow, motherlodeFlow,
-            controlPanel, motherlode, mapOverlay, nudgePad);
+            controlPanel, motherlode, mapOverlay, nudgePad, settings);
         return (wizard, session, surveyFlow, motherlodeFlow, settings);
     }
 

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
@@ -191,4 +191,60 @@ public class DeepLinkRouterTests
         public string? LastPayload { get; private set; }
         public void ImportFromLinkPayload(string base64UrlPayload) => LastPayload = base64UrlPayload;
     }
+
+    // ---- mithril://legolas/… branch -----------------------------------------
+
+    [Fact]
+    public void LegolasUri_Dispatched_WithBase64UrlPayload()
+    {
+        var presenter = new RecordingPresenter();
+        var legolasTarget = new RecordingLegolasTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null, legolasImport: legolasTarget);
+
+        var handled = router.Handle("mithril://legolas/AB-_abcXYZ123");
+
+        handled.Should().BeTrue();
+        legolasTarget.LastPayload.Should().Be("AB-_abcXYZ123");
+    }
+
+    [Fact]
+    public void LegolasUri_WithoutRegisteredTarget_IsDropped()
+    {
+        var presenter = new RecordingPresenter();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null, legolasImport: null);
+
+        router.Handle("mithril://legolas/AB-_abcXYZ123").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("mithril://legolas/has.dot")]
+    [InlineData("mithril://legolas/has space")]
+    [InlineData("mithril://legolas/")]
+    public void LegolasUri_MalformedPayload_IsRejected(string uri)
+    {
+        var presenter = new RecordingPresenter();
+        var legolasTarget = new RecordingLegolasTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null, legolasImport: legolasTarget);
+
+        router.Handle(uri).Should().BeFalse();
+        legolasTarget.LastPayload.Should().BeNull();
+    }
+
+    [Fact]
+    public void LegolasUri_PayloadOverLengthCap_IsRejected()
+    {
+        var presenter = new RecordingPresenter();
+        var legolasTarget = new RecordingLegolasTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null, legolasImport: legolasTarget);
+
+        var tooLong = new string('A', 8193);
+        router.Handle($"mithril://legolas/{tooLong}").Should().BeFalse();
+        legolasTarget.LastPayload.Should().BeNull();
+    }
+
+    private sealed class RecordingLegolasTarget : ILegolasShareImportTarget
+    {
+        public string? LastPayload { get; private set; }
+        public void ImportFromLinkPayload(string base64UrlPayload) => LastPayload = base64UrlPayload;
+    }
 }


### PR DESCRIPTION
## Summary
- Auto-popup a share dialog when the Survey FSM reaches `Done` — text summary + 1000-wide PNG card + JSON + `mithril://legolas/<base64url>` deep-link, all driven by a versioned `LegolasSharePayload`. Snapshot is taken inside `Transitioned` (before AutoReset's `Reset()` runs), so the report survives the auto-reset path. Persistent "View report" button on the wizard re-opens the dialog after dismissal; gated by a new `ShowReportOnDone` setting.
- Item counts now reflect reality. Parser handles PG's two-line chat pattern (`[Status] X xN added to inventory.` then `[Status] X collected!`) plus the speed-bonus tail (`Also found Y (speed bonus!)`); ingestion buffers `added to inventory` events and drains them on `collected!` for primary + bonus drops. Payload is keyed by `InternalName` (CDN-version + locale stable) with an `UnknownByName` fallback for items not in the catalog. Follow-up issue #135 tracks switching the count source to `IInventoryService`.
- Receiver of a share link opens the same dialog as the sender, with the character-name toggle hidden via a `showCharacterNameToggle` ctor flag (no separate read-only viewer). Adopted MahApps.Metro for the split-button copy/save controls (scoped to the dialog so the rest of the app's chrome is untouched). Added a `MaxContentWidth` virtual on `DialogViewModelBase` so wider dialogs aren't capped to the default 560px.
- Card visuals: items are the visual hero — 40×40 icons + name + ×N tiles in a wrap-grid; elapsed time moves to a 36pt stat in the upper-right corner alongside the survey-count badge. Card auto-grows vertically (two-pass measure, mirroring Pippin) so longer runs stay readable; `SizeToContent="WidthAndHeight"` on the dialog grows the window to match.

## Test plan
- [ ] `dotnet test tests/Legolas.Tests` — `LegolasReportServiceTests`, `LegolasShareCardViewModelTests`, `LegolasShareRoundTripTests` all green
- [ ] `dotnet test tests/Mithril.Shared.Tests` — `DeepLinkRouterTests` covers 4 new `legolas` cases (valid, oversized, invalid chars, unknown action)
- [ ] Manual: drive a survey session through `Done` with `AutoResetWhenAllCollected = true`; confirm dialog auto-pops with character name, real elapsed time, real item quantities + icons
- [ ] Manual: same with `AutoReset = false`; confirm dialog still pops, "View report" button reopens it after dismissal
- [ ] Manual: speed-bonus drop (e.g. `[Status] X collected! Also found Y (speed bonus!)`) — confirm both items appear with correct counts
- [ ] Manual: copy `mithril://legolas/...` link, paste into a second instance, confirm dialog opens with imported payload + name toggle hidden
- [ ] Manual: toggle "Include character name" on the sender side; confirm card re-renders without the name and the share link round-trips that choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)