### PR TITLE
feat(legolas): gate hotkey registration on Mithril/game foreground focus (#133)

### DIFF
--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -92,6 +92,8 @@ public sealed class ToggleMapOverlayCommand : IHotkeyCommand
     public string DisplayName => "Toggle Map Overlay";
     public string? Category => "Legolas · Overlay";
     public HotkeyBinding? DefaultBinding => null;
+    // Stays registered while alt-tabbed so the user can peek at the map from a browser.
+    public bool RespectsFocusGate => false;
     public Task ExecuteAsync(CancellationToken cancellationToken)
     {
         _session.IsMapVisible = !_session.IsMapVisible;
@@ -107,6 +109,8 @@ public sealed class ToggleInventoryOverlayCommand : IHotkeyCommand
     public string DisplayName => "Toggle Inventory Overlay";
     public string? Category => "Legolas · Overlay";
     public HotkeyBinding? DefaultBinding => null;
+    // Stays registered while alt-tabbed so the user can peek at inventory from a browser.
+    public bool RespectsFocusGate => false;
     public Task ExecuteAsync(CancellationToken cancellationToken)
     {
         _session.IsInventoryVisible = !_session.IsInventoryVisible;

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -18,6 +18,7 @@ using Legolas.Sharing;
 using Legolas.ViewModels;
 using Legolas.Views;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Legolas;
@@ -151,6 +152,9 @@ public sealed class LegolasModule : IMithrilModule
         // so OverlayController can read its IsInApp state directly.
         services.AddSingleton<ForegroundFocusGate>();
         services.AddHostedService(sp => sp.GetRequiredService<ForegroundFocusGate>());
+        // Issue #133: swap HotkeyService's gate so registrations track in-app focus.
+        services.Replace(ServiceDescriptor.Singleton<IHotkeyGate>(
+            sp => sp.GetRequiredService<ForegroundFocusGate>()));
 
         // Overlay lifecycle
         services.AddHostedService<OverlayController>();

--- a/src/Legolas.Module/Services/ForegroundFocusGate.cs
+++ b/src/Legolas.Module/Services/ForegroundFocusGate.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using Legolas.Domain;
 using Legolas.Interop;
 using Microsoft.Extensions.Hosting;
+using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Modules;
 
 namespace Legolas.Services;
@@ -22,7 +23,7 @@ namespace Legolas.Services;
 /// "ProjectGorgon", "Project Gorgon", "ProjectGorgon64") and lets the user
 /// override via the settings UI without a code change.
 /// </summary>
-public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
+public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged, IHotkeyGate
 {
     private readonly ModuleGates _gates;
     private readonly LegolasSettings _settings;
@@ -52,8 +53,13 @@ public sealed class ForegroundFocusGate : IHostedService, INotifyPropertyChanged
             if (_isInApp == value) return;
             _isInApp = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInApp)));
+            // Mirror onto IHotkeyGate.CanFire so HotkeyService re-registers
+            // bindings when focus crosses the in-app boundary.
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanFire)));
         }
     }
+
+    public bool CanFire => IsInApp;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf.Dialogs;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Mithril.Shared.DependencyInjection;
@@ -180,10 +181,13 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddMithrilHotkeys(this IServiceCollection services) =>
-        services
+    public static IServiceCollection AddMithrilHotkeys(this IServiceCollection services)
+    {
+        services.TryAddSingleton<IHotkeyGate, AlwaysOpenHotkeyGate>();
+        return services
             .AddSingleton<HotkeyRegistry>()
             .AddSingleton<IHotkeyService, HotkeyService>();
+    }
 
     public static IServiceCollection AddMithrilModuleGates(this IServiceCollection services) =>
         services.AddSingleton<ModuleGates>();

--- a/src/Mithril.Shared/Hotkeys/AlwaysOpenHotkeyGate.cs
+++ b/src/Mithril.Shared/Hotkeys/AlwaysOpenHotkeyGate.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel;
+
+namespace Mithril.Shared.Hotkeys;
+
+public sealed class AlwaysOpenHotkeyGate : IHotkeyGate
+{
+    public bool CanFire => true;
+    public event PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
+}

--- a/src/Mithril.Shared/Hotkeys/HotkeyService.cs
+++ b/src/Mithril.Shared/Hotkeys/HotkeyService.cs
@@ -10,6 +10,7 @@ public sealed partial class HotkeyService : IHotkeyService
     private const int WM_HOTKEY = 0x0312;
 
     private readonly HotkeyRegistry _registry;
+    private readonly IHotkeyGate _gate;
     private readonly Dictionary<int, IHotkeyCommand> _byRegistrationId = new();
     private readonly Dictionary<string, int> _byCommandId = new(StringComparer.Ordinal);
     private IReadOnlyList<HotkeyBinding> _lastBindings = Array.Empty<HotkeyBinding>();
@@ -18,7 +19,20 @@ public sealed partial class HotkeyService : IHotkeyService
     private int _nextId = 0xB000;
     private int _captureDepth;
 
-    public HotkeyService(HotkeyRegistry registry) { _registry = registry; }
+    public HotkeyService(HotkeyRegistry registry, IHotkeyGate gate)
+    {
+        _registry = registry;
+        _gate = gate;
+        _gate.PropertyChanged += OnGatePropertyChanged;
+    }
+
+    /// <summary>
+    /// True when <paramref name="command"/> should hold a Win32 registration
+    /// given the current gate state. Extracted from <see cref="RegisterAll"/>
+    /// so unit tests can exercise the rule without a real hwnd.
+    /// </summary>
+    public static bool ShouldRegister(IHotkeyCommand command, bool gateCanFire)
+        => gateCanFire || !command.RespectsFocusGate;
 
     public void Attach(IntPtr hwnd)
     {
@@ -40,11 +54,19 @@ public sealed partial class HotkeyService : IHotkeyService
         UnregisterAll();
         if (_hwnd == IntPtr.Zero || _captureDepth > 0) return report;
 
+        var canFire = _gate.CanFire;
         foreach (var binding in _lastBindings)
         {
             if (!_registry.TryGet(binding.CommandId, out var command))
             {
                 report[binding.CommandId] = "Command no longer exists in this build.";
+                continue;
+            }
+            if (!ShouldRegister(command, canFire))
+            {
+                // Gate is closed and this command respects it; defer until the
+                // gate reopens. Not a failure — leave the report entry null.
+                report[binding.CommandId] = null;
                 continue;
             }
             var id = _nextId++;
@@ -83,6 +105,13 @@ public sealed partial class HotkeyService : IHotkeyService
         if (_captureDepth == 0) RegisterAll();
     }
 
+    private void OnGatePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IHotkeyGate.CanFire) && !string.IsNullOrEmpty(e.PropertyName)) return;
+        if (_captureDepth > 0) return; // capture session will re-evaluate on end
+        RegisterAll();
+    }
+
     private sealed class CaptureScope : IDisposable
     {
         private readonly HotkeyService _svc;
@@ -106,6 +135,7 @@ public sealed partial class HotkeyService : IHotkeyService
 
     public void Dispose()
     {
+        _gate.PropertyChanged -= OnGatePropertyChanged;
         UnregisterAll();
         _source?.RemoveHook(WndProc);
     }

--- a/src/Mithril.Shared/Hotkeys/IHotkeyCommand.cs
+++ b/src/Mithril.Shared/Hotkeys/IHotkeyCommand.cs
@@ -7,4 +7,9 @@ public interface IHotkeyCommand
     string? Category { get; }
     HotkeyBinding? DefaultBinding { get; }
     Task ExecuteAsync(CancellationToken ct);
+
+    // Default true: most commands act on game state and shouldn't fire when the
+    // user has alt-tabbed to a browser. Overlay-toggle commands opt out so the
+    // user can still peek at the map/inventory from out-of-app.
+    bool RespectsFocusGate => true;
 }

--- a/src/Mithril.Shared/Hotkeys/IHotkeyGate.cs
+++ b/src/Mithril.Shared/Hotkeys/IHotkeyGate.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+
+namespace Mithril.Shared.Hotkeys;
+
+/// <summary>
+/// Controls whether <see cref="HotkeyService"/> currently holds its system-wide
+/// Win32 hotkey registrations. When <see cref="CanFire"/> flips, the service
+/// unregisters or re-registers so other apps can receive the keystrokes the
+/// rest of the time. Default registration (<see cref="AlwaysOpenHotkeyGate"/>)
+/// keeps everything always-on; Legolas swaps in a foreground-aware gate.
+/// </summary>
+public interface IHotkeyGate : INotifyPropertyChanged
+{
+    bool CanFire { get; }
+}

--- a/tests/Mithril.Shared.Tests/HotkeyServiceShouldRegisterTests.cs
+++ b/tests/Mithril.Shared.Tests/HotkeyServiceShouldRegisterTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Mithril.Shared.Hotkeys;
+using Xunit;
+
+namespace Mithril.Shared.Tests;
+
+public class HotkeyServiceShouldRegisterTests
+{
+    [Theory]
+    [InlineData(true, true, true)]    // gate open, command respects gate -> register
+    [InlineData(false, true, false)]  // gate closed, command respects gate -> skip
+    [InlineData(false, false, true)]  // gate closed, command opts out -> register
+    [InlineData(true, false, true)]   // gate open, command opts out -> register
+    public void ShouldRegister_TruthTable(bool gateCanFire, bool respectsGate, bool expected)
+    {
+        var command = new FakeCommand(respectsGate);
+        HotkeyService.ShouldRegister(command, gateCanFire).Should().Be(expected);
+    }
+
+    private sealed class FakeCommand : IHotkeyCommand
+    {
+        public FakeCommand(bool respectsGate) { RespectsFocusGate = respectsGate; }
+        public string Id => "fake";
+        public string DisplayName => "Fake";
+        public string? Category => null;
+        public HotkeyBinding? DefaultBinding => null;
+        public bool RespectsFocusGate { get; }
+        public Task ExecuteAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #133.

## Summary

- New `IHotkeyGate` in `Mithril.Shared.Hotkeys` with default `AlwaysOpenHotkeyGate` (a Mithril without Legolas behaves exactly as today).
- `HotkeyService` takes the gate, gates `RegisterAll` on `gate.CanFire`, and re-registers on `PropertyChanged`. Existing `_captureDepth` suppression path (used by the rebind UI) is untouched. Per-command opt-out via new `IHotkeyCommand.RespectsFocusGate` (default `true` via default-interface-member).
- `ForegroundFocusGate` (already tracking Mithril/game foreground via `SetWinEventHook`) implements `IHotkeyGate` directly — `CanFire => IsInApp`, double-fires `PropertyChanged` for both names so existing `OverlayController` wiring is unaffected. `LegolasModule` swaps the default gate via `services.Replace`.
- `ToggleMapOverlayCommand` / `ToggleInventoryOverlayCommand` opt out so the user can peek at the map/inventory from a browser. All other commands (notably the 12 Pin Nudge variants) keep the default — they're the motivating case for the gate.
- Unit tests cover the four-cell truth table of the new `HotkeyService.ShouldRegister(command, gateCanFire)` helper.

## Test plan

- [ ] `dotnet build src/Mithril.Shared/Mithril.Shared.csproj` — clean (verified locally)
- [ ] `dotnet build src/Legolas.Module/Legolas.Module.csproj` — clean (verified locally)
- [ ] `dotnet test tests/Mithril.Shared.Tests --filter \"FullyQualifiedName~HotkeyServiceShouldRegisterTests\"` — 4/4 pass (verified locally)
- [ ] `dotnet test tests/Legolas.Tests` — 179/179 pass (verified locally)
- [ ] Manual: with Legolas tab opened, alt-tab to a browser; press a Pin Nudge arrow-key binding — keystroke lands in the browser instead of being consumed.
- [ ] Manual: while alt-tabbed, press the Toggle Map Overlay binding — still toggles (opt-out works).
- [ ] Manual: open Settings → rebind a hotkey while alt-tabbed; capture UI still works and bindings re-register correctly when the dialog closes.
- [ ] Manual: with the game foregrounded, all bindings fire normally (gate `CanFire=true` via game-process match).

> Note: pre-existing `LogPatternCatalogParityTests.Every_Catalog_Entry_Resolves_To_A_Real_GeneratedRegex_Method` failure on `main` is unrelated to this PR (catalog drift from #136's `CollectRegex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)