### PR TITLE
feat(hotkeys): per-binding 'Always on' override (#138)

### DIFF
--- a/src/Mithril.Shared/Hotkeys/HotkeyBinding.cs
+++ b/src/Mithril.Shared/Hotkeys/HotkeyBinding.cs
@@ -10,4 +10,4 @@ public enum HotkeyModifiers : uint
     Win = 0x0008,
 }
 
-public sealed record HotkeyBinding(string CommandId, uint VirtualKey, HotkeyModifiers Modifiers);
+public sealed record HotkeyBinding(string CommandId, uint VirtualKey, HotkeyModifiers Modifiers, bool AlwaysOn = false);

--- a/src/Mithril.Shared/Hotkeys/HotkeyService.cs
+++ b/src/Mithril.Shared/Hotkeys/HotkeyService.cs
@@ -27,12 +27,18 @@ public sealed partial class HotkeyService : IHotkeyService
     }
 
     /// <summary>
-    /// True when <paramref name="command"/> should hold a Win32 registration
-    /// given the current gate state. Extracted from <see cref="RegisterAll"/>
-    /// so unit tests can exercise the rule without a real hwnd.
+    /// True when a binding should hold a Win32 registration given the current
+    /// gate state. <paramref name="effectiveRespectsFocusGate"/> is the AND of
+    /// the command's <see cref="IHotkeyCommand.RespectsFocusGate"/> default and
+    /// any per-binding override (<see cref="HotkeyBinding.AlwaysOn"/> forces it
+    /// off). Extracted from <see cref="RegisterAll"/> so unit tests can
+    /// exercise the rule without a real hwnd.
     /// </summary>
-    public static bool ShouldRegister(IHotkeyCommand command, bool gateCanFire)
-        => gateCanFire || !command.RespectsFocusGate;
+    public static bool ShouldRegister(bool effectiveRespectsFocusGate, bool gateCanFire)
+        => gateCanFire || !effectiveRespectsFocusGate;
+
+    public static bool EffectiveRespectsFocusGate(IHotkeyCommand command, HotkeyBinding binding)
+        => command.RespectsFocusGate && !binding.AlwaysOn;
 
     public void Attach(IntPtr hwnd)
     {
@@ -62,9 +68,9 @@ public sealed partial class HotkeyService : IHotkeyService
                 report[binding.CommandId] = "Command no longer exists in this build.";
                 continue;
             }
-            if (!ShouldRegister(command, canFire))
+            if (!ShouldRegister(EffectiveRespectsFocusGate(command, binding), canFire))
             {
-                // Gate is closed and this command respects it; defer until the
+                // Gate is closed and this binding respects it; defer until the
                 // gate reopens. Not a failure — leave the report entry null.
                 report[binding.CommandId] = null;
                 continue;

--- a/src/Mithril.Shell/ViewModels/HotkeyBindingsViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/HotkeyBindingsViewModel.cs
@@ -33,8 +33,44 @@ public sealed partial class HotkeyRowViewModel : HotkeyRowViewModelBase, INotify
     public HotkeyBinding? Binding
     {
         get => _binding;
-        set { _binding = value; OnPropertyChanged(nameof(Binding)); }
+        set
+        {
+            _binding = value;
+            OnPropertyChanged(nameof(Binding));
+            OnPropertyChanged(nameof(AlwaysOn));
+            OnPropertyChanged(nameof(CanToggleAlwaysOn));
+            OnPropertyChanged(nameof(IsEffectivelyGlobal));
+        }
     }
+
+    /// <summary>
+    /// Per-binding override: when true, forces the hotkey to stay registered
+    /// even while Mithril/the game is unfocused, regardless of the command's
+    /// <see cref="IHotkeyCommand.RespectsFocusGate"/> default. No-op when no
+    /// binding is set.
+    /// </summary>
+    public bool AlwaysOn
+    {
+        get => _binding?.AlwaysOn ?? false;
+        set
+        {
+            if (_binding is null || _binding.AlwaysOn == value) return;
+            // Re-using the Binding setter pipes us through the existing
+            // OnRowPropertyChanged handler, which persists + re-registers.
+            Binding = _binding with { AlwaysOn = value };
+        }
+    }
+
+    public bool CanToggleAlwaysOn => _binding is not null;
+
+    /// <summary>
+    /// True when this binding ignores the foreground focus gate today —
+    /// either because the command opted out at the dev level, or because
+    /// the user toggled <see cref="AlwaysOn"/>. Drives the Globe badge.
+    /// </summary>
+    public bool IsEffectivelyGlobal
+        => _binding is not null
+           && !HotkeyService.EffectiveRespectsFocusGate(Command, _binding);
 
     public string? ConflictWith
     {
@@ -54,9 +90,12 @@ public sealed partial class HotkeyRowViewModel : HotkeyRowViewModelBase, INotify
 
     public void Commit(HotkeyBinding? newBinding)
     {
+        // The chip control produces a fresh binding from key+modifiers, so it
+        // doesn't carry forward AlwaysOn — preserve whatever the user had.
+        var preservedAlwaysOn = _binding?.AlwaysOn ?? false;
         if (newBinding is null) _settings.HotkeyBindings.Remove(Command.Id);
-        else _settings.HotkeyBindings[Command.Id] = newBinding with { CommandId = Command.Id };
-        Binding = newBinding is null ? null : newBinding with { CommandId = Command.Id };
+        else _settings.HotkeyBindings[Command.Id] = newBinding with { CommandId = Command.Id, AlwaysOn = preservedAlwaysOn };
+        Binding = newBinding is null ? null : newBinding with { CommandId = Command.Id, AlwaysOn = preservedAlwaysOn };
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/Mithril.Shell/Views/HotkeyBindingsView.xaml
+++ b/src/Mithril.Shell/Views/HotkeyBindingsView.xaml
@@ -88,8 +88,21 @@
                             <hk:HotkeyChipControl DockPanel.Dock="Right"
                                                   Binding="{Binding Binding, Mode=TwoWay}"
                                                   HotkeyService="{Binding DataContext.HotkeyService, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                            <CheckBox DockPanel.Dock="Right" Margin="0,0,8,0" VerticalAlignment="Center"
+                                      Content="Always on"
+                                      Foreground="#FFB8B8B8"
+                                      FontSize="{DynamicResource AppFontSizeHint}"
+                                      IsChecked="{Binding AlwaysOn, Mode=TwoWay}"
+                                      IsEnabled="{Binding CanToggleAlwaysOn}"
+                                      ToolTip="Keep this hotkey registered even when Mithril and the game are both unfocused (e.g. while you're in a browser)."/>
                             <StackPanel>
-                                <TextBlock Text="{Binding DisplayName}" Foreground="#FFE8E8E8"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <icon:PackIconLucide Kind="Globe" Width="11" Height="11"
+                                                         Foreground="#FF7AB8E0" VerticalAlignment="Center" Margin="0,0,5,0"
+                                                         Visibility="{Binding IsEffectivelyGlobal, Converter={StaticResource BoolToVis}}"
+                                                         ToolTip="Global: fires regardless of which app has focus."/>
+                                    <TextBlock Text="{Binding DisplayName}" Foreground="#FFE8E8E8"/>
+                                </StackPanel>
                                 <StackPanel Orientation="Horizontal"
                                            Visibility="{Binding HasConflict, Converter={StaticResource BoolToVis}}">
                                     <icon:PackIconLucide Kind="TriangleAlert" Width="11" Height="11" Foreground="#FFE0A030" VerticalAlignment="Center" Margin="0,0,3,0"/>

--- a/tests/Mithril.Shared.Tests/HotkeyServiceShouldRegisterTests.cs
+++ b/tests/Mithril.Shared.Tests/HotkeyServiceShouldRegisterTests.cs
@@ -7,14 +7,32 @@ namespace Mithril.Shared.Tests;
 public class HotkeyServiceShouldRegisterTests
 {
     [Theory]
-    [InlineData(true, true, true)]    // gate open, command respects gate -> register
-    [InlineData(false, true, false)]  // gate closed, command respects gate -> skip
-    [InlineData(false, false, true)]  // gate closed, command opts out -> register
-    [InlineData(true, false, true)]   // gate open, command opts out -> register
-    public void ShouldRegister_TruthTable(bool gateCanFire, bool respectsGate, bool expected)
+    [InlineData(true, true, true)]    // gate open, binding respects gate -> register
+    [InlineData(false, true, false)]  // gate closed, binding respects gate -> skip
+    [InlineData(false, false, true)]  // gate closed, binding doesn't respect gate -> register
+    [InlineData(true, false, true)]   // gate open, binding doesn't respect gate -> register
+    public void ShouldRegister_TruthTable(bool gateCanFire, bool effectiveRespectsGate, bool expected)
     {
-        var command = new FakeCommand(respectsGate);
-        HotkeyService.ShouldRegister(command, gateCanFire).Should().Be(expected);
+        HotkeyService.ShouldRegister(effectiveRespectsGate, gateCanFire).Should().Be(expected);
+    }
+
+    public static TheoryData<bool, bool, bool> EffectiveData() => new()
+    {
+        // commandRespectsGate, bindingAlwaysOn, expectedEffectiveRespects
+        { true,  false, true  }, // dev gates, user did not override -> gates
+        { true,  true,  false }, // dev gates, user forced always-on -> stays registered
+        { false, false, false }, // dev opted out -> stays registered, AlwaysOn redundant
+        { false, true,  false }, // dev opted out, user also forced -> stays registered
+    };
+
+    [Theory]
+    [MemberData(nameof(EffectiveData))]
+    public void EffectiveRespectsFocusGate_FoldsCommandDefaultAndBindingOverride(
+        bool commandRespects, bool bindingAlwaysOn, bool expected)
+    {
+        var command = new FakeCommand(commandRespects);
+        var binding = new HotkeyBinding("fake", 65, HotkeyModifiers.Ctrl, AlwaysOn: bindingAlwaysOn);
+        HotkeyService.EffectiveRespectsFocusGate(command, binding).Should().Be(expected);
     }
 
     private sealed class FakeCommand : IHotkeyCommand


### PR DESCRIPTION
Closes #138. Builds on #137.

## Summary

- \`HotkeyBinding\` gains \`bool AlwaysOn = false\` — a per-binding override that forces a hotkey to stay registered even when Mithril and the game are both unfocused, regardless of the command's \`RespectsFocusGate\` default.
- \`HotkeyService\` folds dev default + user override via a new \`EffectiveRespectsFocusGate(command, binding)\` helper. \`ShouldRegister\` now takes the effective bool, keeping the gate logic single-source-of-truth.
- Settings JSON migrates silently: missing field deserializes to \`false\` (use dev default).
- \`HotkeyRowViewModel\` exposes \`AlwaysOn\` / \`CanToggleAlwaysOn\` / \`IsEffectivelyGlobal\`. Setting \`AlwaysOn\` rebuilds the \`Binding\` record, piping through the existing re-register handler. \`Commit()\` preserves \`AlwaysOn\` across key-rebinds (chip control produces a fresh binding with default \`AlwaysOn=false\`, which would otherwise lose the user's choice).
- Settings UI gets two new affordances per row:
  - **\"Always on\" checkbox** — flips the per-binding override. Disabled until a binding is set.
  - **Globe badge** next to the display name — visible whenever the effective gate is off (either the dev opted out *or* the user toggled Always-on).

## Why two-state, not tri-state

The issue raised the option of a tri-state \`bool?\` (default / global / gated). I shipped two-state because the asymmetric case (user wanting to *gate* a default-global command like Toggle Map Overlay) hasn't been requested and adding tri-state UI complexity speculatively muddles the affordance. \`HotkeyBinding\` is a record — easy to extend later if anyone asks.

## Test plan

- [x] \`dotnet build Mithril.slnx\` — clean
- [x] \`dotnet test Mithril.slnx\` — 635/636 pass; the one failure (\`LogPatternCatalogParityTests.Every_Catalog_Entry_Resolves_To_A_Real_GeneratedRegex_Method\`) is pre-existing on \`main\` from #136's catalog drift, unrelated to this PR.
- [x] New \`EffectiveRespectsFocusGate\` truth-table covers all 4 dev/user combos (registers both the asymmetric \"dev gates, user forces global\" and the redundant \"dev opts out, user also flips\" cases).
- [ ] Manual: open Settings → Hotkeys; verify Globe badge shows on the two Toggle Overlay rows by default. Pick a Pin Nudge row, check \"Always on\" — Globe badge appears, hotkey now fires from a browser. Un-check — Globe disappears, browser sees the keystroke again.
- [ ] Manual: with \"Always on\" checked on a Pin Nudge row, rebind the key combo via the chip — confirm the override is preserved (badge still shows after rebind).
- [ ] Manual: restart Mithril — overrides persist (settings JSON round-trips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)