### PR TITLE
feat(legolas): gate Pin Nudge hotkeys on session state (#139)

### DIFF
--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Mithril.Shared.Hotkeys;
 using Legolas.Domain;
 using Legolas.Flow;
@@ -207,7 +208,7 @@ public sealed class ToggleBearingWedgesCommand : IHotkeyCommand
 // bindings are intentionally null because arrow keys collide with in-game
 // movement; users must opt-in via the Hotkeys settings UI.
 
-public abstract class NudgePinCommandBase : IHotkeyCommand
+public abstract class NudgePinCommandBase : IGatedHotkeyCommand
 {
     private readonly SessionState _session;
     private readonly MapOverlayViewModel _map;
@@ -218,12 +219,40 @@ public abstract class NudgePinCommandBase : IHotkeyCommand
         _session = session;
         _map = map;
         _settings = settings;
+        // Forward the two SessionState signals that change whether a pin is
+        // available to nudge. IsAnchorEditable is itself derived from
+        // HasPlayerPosition + Surveys.Count (both already raise PropertyChanged
+        // for IsAnchorEditable in SessionState), so subscribing to it covers
+        // anchor placement, anchor sealing on first survey, and session reset.
+        _session.PropertyChanged += OnSessionPropertyChanged;
     }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public abstract string Id { get; }
     public abstract string DisplayName { get; }
     public string? Category => "Legolas · Pin Nudge";
     public HotkeyBinding? DefaultBinding => null;
+
+    /// <summary>
+    /// Pin Nudge only matters when there's actually a target to nudge:
+    /// the anchor while it's still editable, or a selected survey pin.
+    /// Outside both windows, arrow keys are dead weight that would otherwise
+    /// be eaten system-wide (#139). The Execute body re-checks the same
+    /// conditions, so a registration that briefly outraces a state change
+    /// is harmless.
+    /// </summary>
+    public bool IsRegistrable
+        => _session.IsAnchorEditable || _session.SelectedSurvey is not null;
+
+    private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(SessionState.IsAnchorEditable)
+            or nameof(SessionState.SelectedSurvey))
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsRegistrable)));
+        }
+    }
 
     /// <summary>Unit vector for the direction this command moves a pin.</summary>
     protected abstract (double Dx, double Dy) Direction { get; }

--- a/src/Mithril.Shared/Hotkeys/HotkeyService.cs
+++ b/src/Mithril.Shared/Hotkeys/HotkeyService.cs
@@ -24,6 +24,10 @@ public sealed partial class HotkeyService : IHotkeyService
         _registry = registry;
         _gate = gate;
         _gate.PropertyChanged += OnGatePropertyChanged;
+        foreach (var gated in _registry.Commands.OfType<IGatedHotkeyCommand>())
+        {
+            gated.PropertyChanged += OnGatedCommandPropertyChanged;
+        }
     }
 
     /// <summary>
@@ -39,6 +43,14 @@ public sealed partial class HotkeyService : IHotkeyService
 
     public static bool EffectiveRespectsFocusGate(IHotkeyCommand command, HotkeyBinding binding)
         => command.RespectsFocusGate && !binding.AlwaysOn;
+
+    /// <summary>
+    /// True when a command's per-command predicate (if any) currently allows
+    /// registration. Commands without an <see cref="IGatedHotkeyCommand"/>
+    /// implementation are always registrable.
+    /// </summary>
+    public static bool IsCommandRegistrable(IHotkeyCommand command)
+        => command is not IGatedHotkeyCommand g || g.IsRegistrable;
 
     public void Attach(IntPtr hwnd)
     {
@@ -68,10 +80,12 @@ public sealed partial class HotkeyService : IHotkeyService
                 report[binding.CommandId] = "Command no longer exists in this build.";
                 continue;
             }
-            if (!ShouldRegister(EffectiveRespectsFocusGate(command, binding), canFire))
+            if (!ShouldRegister(EffectiveRespectsFocusGate(command, binding), canFire) ||
+                !IsCommandRegistrable(command))
             {
-                // Gate is closed and this binding respects it; defer until the
-                // gate reopens. Not a failure — leave the report entry null.
+                // Gate closed (or per-command predicate says skip); defer until
+                // the relevant signal flips. Not a failure — report entry stays
+                // null.
                 report[binding.CommandId] = null;
                 continue;
             }
@@ -118,6 +132,13 @@ public sealed partial class HotkeyService : IHotkeyService
         RegisterAll();
     }
 
+    private void OnGatedCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IGatedHotkeyCommand.IsRegistrable) && !string.IsNullOrEmpty(e.PropertyName)) return;
+        if (_captureDepth > 0) return;
+        RegisterAll();
+    }
+
     private sealed class CaptureScope : IDisposable
     {
         private readonly HotkeyService _svc;
@@ -142,6 +163,10 @@ public sealed partial class HotkeyService : IHotkeyService
     public void Dispose()
     {
         _gate.PropertyChanged -= OnGatePropertyChanged;
+        foreach (var gated in _registry.Commands.OfType<IGatedHotkeyCommand>())
+        {
+            gated.PropertyChanged -= OnGatedCommandPropertyChanged;
+        }
         UnregisterAll();
         _source?.RemoveHook(WndProc);
     }

--- a/src/Mithril.Shared/Hotkeys/IGatedHotkeyCommand.cs
+++ b/src/Mithril.Shared/Hotkeys/IGatedHotkeyCommand.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+
+namespace Mithril.Shared.Hotkeys;
+
+/// <summary>
+/// Optional secondary interface for commands whose registration depends on
+/// runtime state beyond foreground focus (e.g. Legolas Pin Nudge only being
+/// useful while a pin is positionally uncertain). Composes with
+/// <see cref="IHotkeyGate"/>: a binding registers iff the focus gate allows
+/// it AND <see cref="IsRegistrable"/> is true.
+///
+/// Commands signal state changes via <see cref="INotifyPropertyChanged"/>;
+/// <see cref="HotkeyService"/> subscribes during construction and re-applies
+/// registration on each change.
+/// </summary>
+public interface IGatedHotkeyCommand : IHotkeyCommand, INotifyPropertyChanged
+{
+    bool IsRegistrable { get; }
+}

--- a/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
+++ b/tests/Legolas.Tests/Hotkeys/NudgePinCommandTests.cs
@@ -4,6 +4,7 @@ using Legolas.Flow;
 using Legolas.Hotkeys;
 using Legolas.Services;
 using Legolas.ViewModels;
+using Mithril.Shared.Hotkeys;
 
 namespace Legolas.Tests.Hotkeys;
 
@@ -258,5 +259,79 @@ public class NudgePinCommandTests
         await cmd.ExecuteAsync(CancellationToken.None);
 
         session.PlayerPosition.Y.Should().Be(300, "selected pin should be nudged, not the anchor");
+    }
+
+    // ─── #139: registration gate ─────────────────────────────────────────────
+
+    [Fact]
+    public void IsRegistrable_false_at_idle()
+    {
+        var (session, map, settings) = BuildSut();
+        var cmd = new NudgePinUpCommand(session, map, settings);
+        cmd.IsRegistrable.Should().BeFalse("idle session has no pin to nudge");
+    }
+
+    [Fact]
+    public void IsRegistrable_true_when_anchor_editable()
+    {
+        var (session, map, settings) = BuildSut();
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        session.HasPlayerPosition = true;
+
+        session.IsAnchorEditable.Should().BeTrue();
+        cmd.IsRegistrable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRegistrable_true_when_survey_selected()
+    {
+        var (session, map, settings) = BuildSut();
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        SeedSelectedSurveyAt(session, 100, 200);
+
+        cmd.IsRegistrable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRegistrable_false_after_anchor_seals_with_no_selection()
+    {
+        // Reproduce the in-game pain point: anchor placed, first survey lands,
+        // anchor becomes load-bearing (IsAnchorEditable=false), nothing
+        // selected — arrow keys should pass through to the game.
+        var (session, map, settings) = BuildSut();
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        session.HasPlayerPosition = true;
+        cmd.IsRegistrable.Should().BeTrue();
+
+        var survey = Survey.Create("First", new MetreOffset(0, 0), gridIndex: 0);
+        session.Surveys.Add(new SurveyItemViewModel(survey));
+        // Surveys.Count > 0 → IsAnchorEditable flips false; selection is null.
+
+        session.IsAnchorEditable.Should().BeFalse();
+        session.SelectedSurvey.Should().BeNull();
+        cmd.IsRegistrable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRegistrable_raises_PropertyChanged_on_session_state_changes()
+    {
+        var (session, map, settings) = BuildSut();
+        var cmd = new NudgePinUpCommand(session, map, settings);
+
+        var fires = 0;
+        ((IGatedHotkeyCommand)cmd).PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(IGatedHotkeyCommand.IsRegistrable)) fires++;
+        };
+
+        session.HasPlayerPosition = true;       // → IsAnchorEditable change
+        session.SelectedSurvey =
+            new SurveyItemViewModel(Survey.Create("S", new MetreOffset(0, 0), gridIndex: 0)); // → SelectedSurvey change
+
+        fires.Should().BeGreaterThanOrEqualTo(2,
+            "HotkeyService relies on these signals to flip Win32 registration");
     }
 }

--- a/tests/Mithril.Shared.Tests/HotkeyServiceShouldRegisterTests.cs
+++ b/tests/Mithril.Shared.Tests/HotkeyServiceShouldRegisterTests.cs
@@ -35,6 +35,21 @@ public class HotkeyServiceShouldRegisterTests
         HotkeyService.EffectiveRespectsFocusGate(command, binding).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsCommandRegistrable_PlainCommand_AlwaysTrue()
+    {
+        HotkeyService.IsCommandRegistrable(new FakeCommand(respectsGate: true)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsCommandRegistrable_GatedCommand_FollowsPredicate(bool registrable)
+    {
+        var gated = new FakeGatedCommand { IsRegistrable = registrable };
+        HotkeyService.IsCommandRegistrable(gated).Should().Be(registrable);
+    }
+
     private sealed class FakeCommand : IHotkeyCommand
     {
         public FakeCommand(bool respectsGate) { RespectsFocusGate = respectsGate; }
@@ -44,5 +59,16 @@ public class HotkeyServiceShouldRegisterTests
         public HotkeyBinding? DefaultBinding => null;
         public bool RespectsFocusGate { get; }
         public Task ExecuteAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class FakeGatedCommand : IGatedHotkeyCommand
+    {
+        public string Id => "fake-gated";
+        public string DisplayName => "Fake (Gated)";
+        public string? Category => null;
+        public HotkeyBinding? DefaultBinding => null;
+        public bool IsRegistrable { get; set; }
+        public Task ExecuteAsync(CancellationToken ct) => Task.CompletedTask;
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
     }
 }


### PR DESCRIPTION
Closes #139. Builds on #137 (focus gate) and #138 (per-binding override).

## Summary

- **New \`IGatedHotkeyCommand\`** in \`Mithril.Shared.Hotkeys\` — optional secondary interface for commands whose registration depends on runtime state beyond focus. Composes with \`IHotkeyGate\`: a binding registers iff the focus gate allows AND the command's \`IsRegistrable\` is true.
- **\`HotkeyService\`** subscribes to each registered \`IGatedHotkeyCommand\` at construction. \`RegisterAll\` AND-merges \`IsCommandRegistrable(command)\` into the per-binding check; \`PropertyChanged\` for \`IsRegistrable\` triggers re-registration through the same \`_captureDepth\`-aware path the focus gate uses. \`Dispose\` unsubscribes.
- **\`NudgePinCommandBase\`** implements \`IGatedHotkeyCommand\`. \`IsRegistrable = session.IsAnchorEditable || session.SelectedSurvey != null\`. The base forwards \`SessionState.PropertyChanged\` for the two contributing properties; all 12 NudgePin* subclasses inherit the wiring with zero per-class duplication.

The user-visible result: arrow keys bound to Pin Nudge no longer get captured Win32-globally during combat / walking / idle session / post-route. They only hold the registration during the two windows where nudging is actually meaningful — anchor placement and per-pin refinement.

## Why this is the right shape

Earlier consideration was \"FSM gate on \`AwaitingPosition\`/\`Listening\`\". The session-state predicate (\`IsAnchorEditable || SelectedSurvey != null\`) is tighter — it gates on the actual *target* of the nudge rather than the FSM's broader state, naturally covering the \"early Listening, anchor still editable\" window and the \"any state, survey pin selected\" case without hard-coding the FSM transition diagram. \`SessionState\` already raises \`PropertyChanged\` for \`IsAnchorEditable\` from both \`HasPlayerPosition\` setter and the \`Surveys\` collection-changed handler, so the two-property subscription is sufficient.

## Test plan

- [x] \`dotnet build Mithril.slnx\` — clean
- [x] \`dotnet test Mithril.slnx\` — 638/639 pass; the one failure (\`LogPatternCatalogParityTests\`) is pre-existing on \`main\` from #136 catalog drift, unrelated.
- [x] New \`HotkeyServiceShouldRegisterTests\` — \`IsCommandRegistrable\` truth-table for plain and gated commands.
- [x] New \`NudgePinCommandTests\` (5 cases): idle (false), anchor editable (true), survey selected (true), anchor sealed with no selection (false — the in-game pain point), \`PropertyChanged\` plumbing fires on both \`IsAnchorEditable\` and \`SelectedSurvey\` transitions.
- [ ] Manual: in-game, run a full survey session — confirm arrow keys are dead during combat (no anchor / sealed anchor / no selection), live during anchor placement, and live again after clicking a survey pin to refine.
- [ ] Manual: leave Pin Nudge bound but stay in idle session (no Set Position) — alt-tab to a browser, press arrow — keystroke goes to browser even when focus gate would otherwise allow it (gated command always honors its predicate, regardless of \`AlwaysOn\`).

## Layering recap

| Gate | Source | When evaluated |
|---|---|---|
| Focus | \`IHotkeyGate.CanFire\` (Legolas's \`ForegroundFocusGate\`) | per registration cycle |
| Per-binding override | \`HotkeyBinding.AlwaysOn\` (#138) | folds into \`EffectiveRespectsFocusGate\` |
| Per-command predicate | \`IGatedHotkeyCommand.IsRegistrable\` (this PR) | AND-merged into \`RegisterAll\` |

A binding registers iff: \`ShouldRegister(EffectiveRespectsFocusGate(cmd, binding), gate.CanFire) && IsCommandRegistrable(cmd)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)