### PR TITLE
fix(legolas): Ready state owns session start, closes second-run StartedAt=null bug

### DIFF
--- a/docs/legolas-overview.md
+++ b/docs/legolas-overview.md
@@ -104,30 +104,34 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 
 ## SurveyFlowController FSM
 
-[`SurveyFlowController`](../src/Legolas.Module/Flow/SurveyFlowController.cs). Four states:
+[`SurveyFlowController`](../src/Legolas.Module/Flow/SurveyFlowController.cs). Five states:
 
 | State | Meaning |
 |---|---|
 | `AwaitingPosition` | No anchor set yet. Map clicks become the anchor. |
-| `Listening` | Anchor set; surveys auto-place as they arrive. The default working state. |
+| `Ready` | Anchor set, no surveys placed yet. Accepts the first survey but doesn't expose the route-optimise control. The state where `IsAnchorEditable` is true. |
+| `Listening` | Anchor set; surveys auto-place as they arrive. The default mid-run working state. |
 | `Gathering` | Route optimised; user is walking it. **New `SurveyDetected` events are dropped** (position-anchor constraint). |
 | `Done` | All surveys collected. If `AutoResetWhenAllCollected`, `Reset()` immediately follows. |
+
+`Ready` exists so every Listening session has a fresh `StartedAt` stamp — the timestamp is bound to the Ready→Listening edge (first-survey arrival), which fires on every cycle, instead of the once-per-app-session AwaitingPosition→Listening edge that the previous design used. See "Second-run StartedAt regression" in pitfalls below.
 
 ### Transitions
 
 | From | Trigger | To | Notes |
 |---|---|---|---|
-| `AwaitingPosition` | `ConfirmPlayerPosition()` | `Listening` | After caller has updated `PlayerPosition` and the projector origin. |
-| `Listening` | `NoteSurveyDetected(sd)` | `Listening` | No transition. Surfaces inventory overlay; `LogIngestionService` has already auto-placed the pin. |
-| `Listening` | `OptimizeRoute()` | `Gathering` | Caller has assigned `RouteOrder`s. Surveys must be non-empty. |
+| `AwaitingPosition` | `ConfirmPlayerPosition()` | `Ready` | After caller has updated `PlayerPosition` and the projector origin. |
+| `Ready` | `Surveys.Add` (first pin lands) | `Listening` | Driven by `OnSurveysChanged` in the controller. **Stamps `SessionState.StartedAt`** at this moment — that's the canonical "session started" time. |
+| `Ready` \| `Listening` | `NoteSurveyDetected(sd)` | (same) | No transition. Surfaces inventory overlay; `LogIngestionService` has already auto-placed the pin (and the Ready→Listening edge above is what closes the loop). |
+| `Listening` | `OptimizeRoute()` | `Gathering` | Caller has assigned `RouteOrder`s. The "non-empty surveys" precondition is structural: Listening state implies `Surveys.Count > 0`. |
 | `Listening` \| `Gathering` | `AllCollected` event (auto) | `Done` | Fires when last uncollected survey is marked. |
-| `Done` | `Reset()` (auto, if setting on) | `Listening` \| `AwaitingPosition` | Routes through `Reset` — see below. |
+| `Done` | `Reset()` (auto, if setting on) | `Ready` \| `AwaitingPosition` | Routes through `Reset` — see below. |
 | any | `RequestSetPlayerPosition()` | `AwaitingPosition` | Re-anchor. **Preserves `Surveys`** — their offsets are still valid; only the projector origin will move. |
-| any | `Reset()` | `Listening` if `HasPlayerPosition`, else `AwaitingPosition` | Clears `Surveys`. **Does not reset the projector** — caller is responsible. |
+| any | `Reset()` | `Ready` if `HasPlayerPosition`, else `AwaitingPosition` | Clears `Surveys` (and `StartedAt`). **Does not reset the projector** — caller is responsible. |
 
 ### Dropped-survey diagnostics
 
-`NoteSurveyDetected` checks `CanAcceptSurvey` (true only in `Listening`). When dropping (called from `AwaitingPosition`, `Gathering`, or `Done`), `SessionState.LastLogEvent` is set to a human-readable reason — surfaced in the panel's status strip. Reason map: see `DescribeWhyDropped` in the controller.
+`NoteSurveyDetected` checks `CanAcceptSurvey` (true in `Ready` and `Listening`). When dropping (called from `AwaitingPosition`, `Gathering`, or `Done`), `SessionState.LastLogEvent` is set to a human-readable reason — surfaced in the panel's status strip. Reason map: see `DescribeWhyDropped` in the controller.
 
 ## SessionState
 
@@ -308,6 +312,10 @@ WPF screen Y grows downward; map north grows upward. `Project` negates the rotat
 ### Overlay is strictly 1:1 with the game map
 
 No internal zoom/pan ([#126](https://github.com/arthur-conde/project-gorgon/pull/127)). The window size and position are user-controlled (header drag + edge resize via `WindowLayoutBinder`); the D2D canvas inside renders at exactly 1 DIP per CSS pixel, and the D3D11 back buffer is sized in device pixels for per-monitor DPI correctness. If you find yourself adding a `RenderTransform` or scaling factor to anything inside `Viewport`, stop and reconsider — the entire model assumes canvas pixel == screen pixel == game-map pixel.
+
+### Second-run `StartedAt` regression — keep the stamp on the Ready→Listening edge
+
+`SessionState.StartedAt` is stamped inside `SurveyFlowController.OnSurveysChanged` at the moment the first pin lands while in `Ready`. Don't move it to `ConfirmPlayerPosition` (or any AwaitingPosition→x edge) — the original design did that, and `AutoResetWhenAllCollected = true` (the default) returns the FSM to a non-AwaitingPosition state, so the second run's first-survey edge had nothing to re-trigger the stamp. Symptom: the share-card render shows `0s elapsed` despite a real multi-minute run, with `StartedAt` and `CompletedAt` differing only by the gap between two consecutive `_clock.GetUtcNow()` calls in `LegolasReportService.BuildPayload`. The regression test pinning this is `SecondCycle_after_AutoReset_re_stamps_StartedAt` in `SurveyFlowControllerTests`.
 
 ### Renderer is Direct2D in a D3DImage, not WPF retained-mode
 

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Legolas.Domain;
 using Legolas.ViewModels;
@@ -12,6 +13,7 @@ namespace Legolas.Flow;
 public enum SurveyFlowState
 {
     AwaitingPosition,
+    Ready,
     Listening,
     Gathering,
     Done,
@@ -40,12 +42,28 @@ public sealed partial class SurveyFlowController : ObservableObject
         _settings = settings;
         _clock = clock ?? TimeProvider.System;
         _session.AllCollected += OnAllCollected;
-        // CanOptimize reads Surveys.Count, but [NotifyPropertyChangedFor] only
-        // fires from CurrentState. Without this subscription the Go! button
-        // stays disabled forever — surveys arrive, count goes 0→N, but the
-        // bound IsEnabled never refreshes. Re-emit on every collection change
-        // so the wizard's primary action lights up the moment a pin lands.
-        _session.Surveys.CollectionChanged += (_, _) => OnPropertyChanged(nameof(CanOptimize));
+        _session.Surveys.CollectionChanged += OnSurveysChanged;
+    }
+
+    /// <summary>
+    /// Bridges <see cref="SessionState.Surveys"/> mutations back to FSM concerns:
+    ///   * Ready → Listening on the first pin landing (which also stamps
+    ///     <see cref="SessionState.StartedAt"/> — every run gets a fresh start
+    ///     timestamp without depending on whether <c>ConfirmPlayerPosition</c> ran).
+    ///   * <see cref="CanOptimize"/> change-notify after every add/remove/reset
+    ///     (the dependency on <c>Surveys.Count</c> isn't visible to the
+    ///     <c>[NotifyPropertyChangedFor]</c> source generator).
+    /// </summary>
+    private void OnSurveysChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Add
+            && _session.Surveys.Count == 1
+            && CurrentState == SurveyFlowState.Ready)
+        {
+            _session.StartedAt = _clock.GetUtcNow();
+            TransitionTo(SurveyFlowState.Listening, "FirstSurvey");
+        }
+        OnPropertyChanged(nameof(CanOptimize));
     }
 
     [ObservableProperty]
@@ -65,6 +83,7 @@ public sealed partial class SurveyFlowController : ObservableObject
     public string PhaseDescription => CurrentState switch
     {
         SurveyFlowState.AwaitingPosition => "Click the map to set player position",
+        SurveyFlowState.Ready => "Ready — waiting for your first survey",
         SurveyFlowState.Listening => "Listening for surveys",
         SurveyFlowState.Gathering => "Walk to each target — new surveys will be ignored until reset",
         SurveyFlowState.Done => "All surveys collected",
@@ -72,15 +91,20 @@ public sealed partial class SurveyFlowController : ObservableObject
     };
 
     /// <summary>True when <see cref="NoteSurveyDetected"/> would be accepted.</summary>
-    public bool CanAcceptSurvey => CurrentState is SurveyFlowState.Listening;
+    public bool CanAcceptSurvey => CurrentState is SurveyFlowState.Ready or SurveyFlowState.Listening;
 
-    /// <summary>True when <see cref="OptimizeRoute"/> would be accepted.</summary>
-    public bool CanOptimize => CurrentState == SurveyFlowState.Listening && _session.Surveys.Count > 0;
+    /// <summary>
+    /// True when <see cref="OptimizeRoute"/> would be accepted. Only Listening
+    /// qualifies — Ready means the surveys list is empty by construction (the
+    /// Ready→Listening transition fires the moment the first pin lands), so the
+    /// "non-empty surveys" precondition is encoded structurally in the state.
+    /// </summary>
+    public bool CanOptimize => CurrentState == SurveyFlowState.Listening;
 
     /// <summary>
     /// Confirms a player position has been set (caller has already updated the projector
     /// and <see cref="SessionState.PlayerPosition"/>). Transitions <c>AwaitingPosition →
-    /// Listening</c>. No-op from other states.
+    /// Ready</c>. No-op from other states.
     /// </summary>
     public void ConfirmPlayerPosition()
     {
@@ -89,10 +113,7 @@ public sealed partial class SurveyFlowController : ObservableObject
             _session.LastLogEvent = $"ConfirmPlayerPosition ignored — state is {CurrentState}";
             return;
         }
-        // Stamp the session start when the user actually commits to a run. ClearSurveys
-        // (called from Reset) wipes this so the next session gets a fresh stamp.
-        _session.StartedAt ??= _clock.GetUtcNow();
-        TransitionTo(SurveyFlowState.Listening, nameof(ConfirmPlayerPosition));
+        TransitionTo(SurveyFlowState.Ready, nameof(ConfirmPlayerPosition));
     }
 
     /// <summary>
@@ -112,7 +133,9 @@ public sealed partial class SurveyFlowController : ObservableObject
     /// already auto-placed the pin at the projected position. The controller's job
     /// is purely to surface the inventory overlay and to log/diagnose drops when
     /// the survey arrived in a state that doesn't accept new surveys (Gathering /
-    /// Done / AwaitingPosition — the position-anchor constraint).
+    /// Done / AwaitingPosition — the position-anchor constraint). The Ready→Listening
+    /// transition + StartedAt stamp on first survey lives in
+    /// <see cref="OnSurveysChanged"/>, so this stays a pure diagnostic + UI hook.
     /// </summary>
     public void NoteSurveyDetected(SurveyDetected sd)
     {
@@ -138,16 +161,18 @@ public sealed partial class SurveyFlowController : ObservableObject
     }
 
     /// <summary>
-    /// Reset the session: clears surveys, returns to either <c>Listening</c> (if a
+    /// Reset the session: clears surveys, returns to either <c>Ready</c> (if a
     /// player position is still set) or <c>AwaitingPosition</c>. Preserves the
     /// projector anchor; caller is responsible for clearing the projector if they
-    /// want a hard reset.
+    /// want a hard reset. Landing on Ready (not Listening) is what closes the
+    /// previous "second-run StartedAt = null" trap — the next first-survey arrival
+    /// re-stamps a fresh start time via <see cref="OnSurveysChanged"/>.
     /// </summary>
     public void Reset()
     {
         _session.ClearSurveys();
         var target = _session.HasPlayerPosition
-            ? SurveyFlowState.Listening
+            ? SurveyFlowState.Ready
             : SurveyFlowState.AwaitingPosition;
         if (CurrentState != target)
             TransitionTo(target, nameof(Reset));
@@ -175,6 +200,8 @@ public sealed partial class SurveyFlowController : ObservableObject
         SurveyFlowState.AwaitingPosition => "set player position first",
         SurveyFlowState.Gathering => "route in progress; reset to start a new session",
         SurveyFlowState.Done => "session done; reset to start a new session",
+        // Ready and Listening accept surveys, so this branch is only reached
+        // for unanticipated future states; keep a generic fallback.
         _ => $"state is {CurrentState}",
     };
 }

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -302,6 +302,15 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
             : _surveyFlow.CurrentState switch
             {
                 SurveyFlowState.AwaitingPosition => WizardStep.AwaitingPosition,
+                // Ready and Listening project to the same wizard step. The
+                // existing Listening UI block already adapts cleanly to an
+                // empty Surveys list (instructions stay forward-looking, the
+                // pin list shows "0 placed", the Go! button gates on
+                // CanOptimize, and the IsAnchorEditable tip surfaces only
+                // while no pins have landed) — so promoting Ready to its own
+                // wizard step would just add noise without changing what the
+                // user sees.
+                SurveyFlowState.Ready => WizardStep.Listening,
                 SurveyFlowState.Listening => WizardStep.Listening,
                 SurveyFlowState.Gathering => WizardStep.Gathering,
                 SurveyFlowState.Done => WizardStep.Done,

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -194,7 +194,7 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             return _surveyFlow.CurrentState switch
             {
                 SurveyFlowState.AwaitingPosition => "Click anywhere on this map to mark your player position.",
-                SurveyFlowState.Listening when _session.IsAnchorEditable
+                SurveyFlowState.Ready
                     => "Drag the map to fine-tune your position. Use the Surveying skill in-game — pins place automatically.",
                 _ => string.Empty,
             };

--- a/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
+++ b/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
@@ -9,14 +9,27 @@ public class SurveyFlowControllerTests
 {
     private static readonly DateTime FixedTime = new(2026, 5, 6, 12, 0, 0, DateTimeKind.Utc);
 
-    private static (SurveyFlowController flow, SessionState session, LegolasSettings settings, List<SurveyTransition> transitions) BuildSut()
+    /// <summary>
+    /// Frozen-clock TimeProvider so StartedAt assertions can pin specific instants.
+    /// Mirrors the FakeClock used in <c>LegolasReportServiceTests</c>.
+    /// </summary>
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeClock(DateTimeOffset start) { _now = start; }
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Set(DateTimeOffset when) => _now = when;
+    }
+
+    private static (SurveyFlowController flow, SessionState session, LegolasSettings settings, List<SurveyTransition> transitions, FakeClock clock) BuildSut()
     {
         var session = new SessionState();
         var settings = new LegolasSettings();
-        var flow = new SurveyFlowController(session, settings);
+        var clock = new FakeClock(new DateTimeOffset(FixedTime, TimeSpan.Zero));
+        var flow = new SurveyFlowController(session, settings, clock);
         var transitions = new List<SurveyTransition>();
         flow.Transitioned += transitions.Add;
-        return (flow, session, settings, transitions);
+        return (flow, session, settings, transitions, clock);
     }
 
     private static SurveyDetected NewSurvey(string name = "Diamond", int east = 50, int north = 30) =>
@@ -25,7 +38,8 @@ public class SurveyFlowControllerTests
     private static void Anchor(SurveyFlowController flow, SessionState session)
     {
         // Pretend the caller has set the projector + player position; controller only
-        // needs to know the player position is now valid.
+        // needs to know the player position is now valid. After this call the FSM is
+        // in Ready (waiting for the first survey to land).
         session.HasPlayerPosition = true;
         flow.ConfirmPlayerPosition();
     }
@@ -33,36 +47,114 @@ public class SurveyFlowControllerTests
     [Fact]
     public void InitialState_is_AwaitingPosition()
     {
-        var (flow, _, _, _) = BuildSut();
+        var (flow, _, _, _, _) = BuildSut();
         flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
     }
 
     [Fact]
-    public void ConfirmPlayerPosition_AwaitingPosition_to_Listening()
+    public void ConfirmPlayerPosition_AwaitingPosition_to_Ready()
     {
-        var (flow, session, _, transitions) = BuildSut();
+        var (flow, session, _, transitions, _) = BuildSut();
         session.HasPlayerPosition = true;
         flow.ConfirmPlayerPosition();
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready);
         transitions.Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new SurveyTransition(
-                SurveyFlowState.AwaitingPosition, SurveyFlowState.Listening, "ConfirmPlayerPosition"));
+                SurveyFlowState.AwaitingPosition, SurveyFlowState.Ready, "ConfirmPlayerPosition"));
     }
 
     [Fact]
-    public void NoteSurveyDetected_Listening_no_transition_surfaces_inventory()
+    public void ConfirmPlayerPosition_does_not_stamp_StartedAt()
+    {
+        // The stamp lives on the Ready→Listening edge (first survey arriving) so it
+        // re-fires every cycle. ConfirmPlayerPosition is now purely a state move.
+        var (flow, session, _, _, _) = BuildSut();
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+        session.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void FirstSurvey_in_Ready_transitions_to_Listening_and_stamps_StartedAt()
+    {
+        var (flow, session, _, transitions, clock) = BuildSut();
+        Anchor(flow, session);
+        transitions.Clear();
+        var stampMoment = new DateTimeOffset(FixedTime.AddMinutes(2), TimeSpan.Zero);
+        clock.Set(stampMoment);
+
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        session.StartedAt.Should().Be(stampMoment);
+        transitions.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new SurveyTransition(
+                SurveyFlowState.Ready, SurveyFlowState.Listening, "FirstSurvey"));
+    }
+
+    [Fact]
+    public void SubsequentSurveys_do_not_re_stamp_StartedAt()
+    {
+        // StartedAt is set once per Listening session. Adding more pins shouldn't
+        // overwrite it — ElapsedText would otherwise march backward toward zero.
+        var (flow, session, _, _, clock) = BuildSut();
+        Anchor(flow, session);
+        var first = new DateTimeOffset(FixedTime.AddMinutes(1), TimeSpan.Zero);
+        clock.Set(first);
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
+
+        clock.Set(new DateTimeOffset(FixedTime.AddMinutes(5), TimeSpan.Zero));
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 1)));
+
+        session.StartedAt.Should().Be(first);
+    }
+
+    [Fact]
+    public void SecondCycle_after_AutoReset_re_stamps_StartedAt()
+    {
+        // Regression: previously StartedAt was tied to AwaitingPosition→Listening
+        // and never re-fired after auto-reset, so run #2 had StartedAt == CompletedAt
+        // (≈ 0s elapsed). The Ready-state redesign means every first-survey arrival
+        // stamps fresh, regardless of how many cycles came before.
+        var (flow, session, settings, _, clock) = BuildSut();
+        settings.AutoResetWhenAllCollected = true;
+        Anchor(flow, session);
+
+        // Cycle 1: surveys arrive, all collected, auto-reset returns to Ready.
+        var t1Start = new DateTimeOffset(FixedTime.AddMinutes(1), TimeSpan.Zero);
+        clock.Set(t1Start);
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready, "auto-reset lands on Ready");
+        session.StartedAt.Should().BeNull("ClearSurveys wiped the cycle-1 stamp");
+
+        // Cycle 2: a fresh survey arrives.
+        var t2Start = new DateTimeOffset(FixedTime.AddMinutes(10), TimeSpan.Zero);
+        clock.Set(t2Start);
+        var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 0));
+        session.Surveys.Add(s2);
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        session.StartedAt.Should().Be(t2Start, "second cycle re-stamped on first survey");
+    }
+
+    [Fact]
+    public void NoteSurveyDetected_Ready_surfaces_inventory_without_transition()
     {
         // After the rework: surveys auto-place, so the controller only logs/diagnoses.
-        // Listening is the only state that accepts a survey notification; entering it
-        // surfaces the inventory overlay (AutoOverlayCoordinator reacts to visibility).
-        var (flow, session, _, transitions) = BuildSut();
+        // Ready accepts notifications (the actual Ready→Listening edge is driven by
+        // Surveys.CollectionChanged) and surfaces the inventory overlay.
+        var (flow, session, _, transitions, _) = BuildSut();
         Anchor(flow, session);
         transitions.Clear();
         session.IsInventoryVisible.Should().BeFalse();
 
         flow.NoteSurveyDetected(NewSurvey());
 
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready,
+            "NoteSurveyDetected itself doesn't transition — that's CollectionChanged's job");
         session.IsInventoryVisible.Should().BeTrue();
         transitions.Should().BeEmpty();
     }
@@ -70,7 +162,7 @@ public class SurveyFlowControllerTests
     [Fact]
     public void NoteSurveyDetected_AwaitingPosition_dropped_with_diagnostic()
     {
-        var (flow, session, _, transitions) = BuildSut();
+        var (flow, session, _, transitions, _) = BuildSut();
         flow.NoteSurveyDetected(NewSurvey());
         flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
         session.LastLogEvent.Should().Contain("ignored").And.Contain("set player position first");
@@ -81,7 +173,7 @@ public class SurveyFlowControllerTests
     [Fact]
     public void OptimizeRoute_Listening_to_Gathering_when_surveys_present()
     {
-        var (flow, session, _, _) = BuildSut();
+        var (flow, session, _, _, _) = BuildSut();
         Anchor(flow, session);
         session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
         flow.OptimizeRoute();
@@ -89,23 +181,30 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
-    public void OptimizeRoute_Listening_with_no_surveys_still_transitions()
+    public void OptimizeRoute_in_Ready_is_noop()
     {
-        // The "are there surveys" check is exposed via CanOptimize; the transition
-        // method itself doesn't enforce — callers gate via CanOptimize. Documented
-        // shape so tests pin it.
-        var (flow, session, _, _) = BuildSut();
+        // The "non-empty surveys" precondition that used to live in CanOptimize is
+        // now structural: Ready means surveys is empty, and OptimizeRoute requires
+        // Listening. So calling OptimizeRoute from Ready (anchored, no pins) is a
+        // no-op + diagnostic, the same shape as calling it from any other non-Listening
+        // state.
+        var (flow, session, _, _, _) = BuildSut();
         Anchor(flow, session);
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready);
         flow.CanOptimize.Should().BeFalse();
+
         flow.OptimizeRoute();
-        flow.CurrentState.Should().Be(SurveyFlowState.Gathering);
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready);
+        session.LastLogEvent.Should().Contain("OptimizeRoute ignored");
     }
 
     [Fact]
     public void NoteSurveyDetected_Gathering_dropped_per_position_anchor_constraint()
     {
-        var (flow, session, _, transitions) = BuildSut();
+        var (flow, session, _, transitions, _) = BuildSut();
         Anchor(flow, session);
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
         flow.OptimizeRoute();
         transitions.Clear();
 
@@ -119,7 +218,7 @@ public class SurveyFlowControllerTests
     [Fact]
     public void RequestSetPlayerPosition_from_Listening_preserves_surveys()
     {
-        var (flow, session, _, _) = BuildSut();
+        var (flow, session, _, _, _) = BuildSut();
         Anchor(flow, session);
         session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 0)));
 
@@ -130,23 +229,24 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
-    public void Reset_clears_surveys_and_returns_to_Listening_when_position_known()
+    public void Reset_clears_surveys_and_returns_to_Ready_when_position_known()
     {
-        var (flow, session, _, _) = BuildSut();
+        var (flow, session, _, _, _) = BuildSut();
         Anchor(flow, session);
         session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0)));
         flow.OptimizeRoute();
 
         flow.Reset();
 
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening, "HasPlayerPosition is true");
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready, "HasPlayerPosition is true");
         session.Surveys.Should().BeEmpty();
+        session.StartedAt.Should().BeNull("Reset wipes the stamp; next first-survey re-stamps");
     }
 
     [Fact]
     public void Reset_returns_to_AwaitingPosition_when_no_position()
     {
-        var (flow, session, _, _) = BuildSut();
+        var (flow, session, _, _, _) = BuildSut();
         Anchor(flow, session);
         session.HasPlayerPosition = false;
 
@@ -156,9 +256,9 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
-    public void AllCollected_Gathering_to_Done_then_AutoReset_back_to_Listening()
+    public void AllCollected_Gathering_to_Done_then_AutoReset_back_to_Ready()
     {
-        var (flow, session, settings, transitions) = BuildSut();
+        var (flow, session, settings, transitions, _) = BuildSut();
         Anchor(flow, session);
         var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
         var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 1));
@@ -172,16 +272,16 @@ public class SurveyFlowControllerTests
         s1.UpdateModel(s1.Model with { Collected = true });
         s2.UpdateModel(s2.Model with { Collected = true });
 
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening, "auto-reset returned us to Listening");
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready, "auto-reset returned us to Ready");
         session.Surveys.Should().BeEmpty();
         transitions.Select(t => t.To).Should().ContainInOrder(
-            SurveyFlowState.Done, SurveyFlowState.Listening);
+            SurveyFlowState.Done, SurveyFlowState.Ready);
     }
 
     [Fact]
     public void AllCollected_Gathering_to_Done_no_AutoReset_stays_Done()
     {
-        var (flow, session, settings, _) = BuildSut();
+        var (flow, session, settings, _, _) = BuildSut();
         Anchor(flow, session);
         settings.AutoResetWhenAllCollected = false;
         var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
@@ -200,7 +300,7 @@ public class SurveyFlowControllerTests
         // Mark-collected works in Listening too (via hotkey, before optimizing).
         // Preserves pre-FSM behaviour: AllCollected fires a session reset regardless
         // of whether the user optimized first.
-        var (flow, session, settings, transitions) = BuildSut();
+        var (flow, session, settings, transitions, _) = BuildSut();
         Anchor(flow, session);
         settings.AutoResetWhenAllCollected = false;
         var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
@@ -213,13 +313,13 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
-    public void ConfirmPlayerPosition_from_Listening_is_noop()
+    public void ConfirmPlayerPosition_from_Ready_is_noop()
     {
-        var (flow, session, _, transitions) = BuildSut();
+        var (flow, session, _, transitions, _) = BuildSut();
         Anchor(flow, session);
         transitions.Clear();
         flow.ConfirmPlayerPosition();
-        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        flow.CurrentState.Should().Be(SurveyFlowState.Ready);
         transitions.Should().BeEmpty();
     }
 }

--- a/tests/Legolas.Tests/Services/AutoOverlayCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/AutoOverlayCoordinatorTests.cs
@@ -101,6 +101,8 @@ public class AutoOverlayCoordinatorTests
     {
         var (coordinator, session, settings, flow) = BuildSut();
         EnterListening(flow, session);
+        // Add a pin to advance Ready → Listening (OptimizeRoute requires Listening).
+        session.Surveys.Add(new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), gridIndex: 0)));
         session.IsInventoryVisible = true;
         coordinator.Initialize();
 

--- a/tests/Legolas.Tests/Sharing/LegolasReportServiceTests.cs
+++ b/tests/Legolas.Tests/Sharing/LegolasReportServiceTests.cs
@@ -42,19 +42,22 @@ public class LegolasReportServiceTests
         var (report, flow, session, settings, clock) = BuildSut();
         settings.AutoResetWhenAllCollected = false;
 
-        // Start the session: anchor + transition to Listening (clock stamps StartedAt).
+        // Start the session: anchor → Ready. Clock is at SessionStart for the
+        // first survey landing — that's the Ready→Listening edge that stamps
+        // StartedAt now (the previous design stamped on AwaitingPosition→Listening,
+        // but the Ready-state redesign moved it so every cycle re-stamps).
         session.HasPlayerPosition = true;
         flow.ConfirmPlayerPosition();
-
-        // Advance clock + collect items + add the final survey-collected mark.
-        clock.Set(SessionEnd);
-        session.CollectedItems["Diamond"] = 3;
-        session.CollectedItems["Coal"] = 5;
         var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
         var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 1));
         session.Surveys.Add(s1);
         session.Surveys.Add(s2);
         flow.OptimizeRoute();
+
+        // Advance clock + record items + collect.
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 3;
+        session.CollectedItems["Coal"] = 5;
 
         // Marking the last one fires AllCollected → Transitioned(Done) → snapshot built.
         s1.UpdateModel(s1.Model with { Collected = true });
@@ -88,12 +91,12 @@ public class LegolasReportServiceTests
 
         session.HasPlayerPosition = true;
         flow.ConfirmPlayerPosition();
-        clock.Set(SessionEnd);
-        session.CollectedItems["Diamond"] = 3;
-        session.CollectedItems["NotInCatalog"] = 1;
         var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
         session.Surveys.Add(s1);
         flow.OptimizeRoute();
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 3;
+        session.CollectedItems["NotInCatalog"] = 1;
         s1.UpdateModel(s1.Model with { Collected = true });
 
         var p = report.LatestReport!;
@@ -115,11 +118,11 @@ public class LegolasReportServiceTests
 
         session.HasPlayerPosition = true;
         flow.ConfirmPlayerPosition();
-        clock.Set(SessionEnd);
-        session.CollectedItems["Diamond"] = 3;
         var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
         session.Surveys.Add(s1);
         flow.OptimizeRoute();
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 3;
         s1.UpdateModel(s1.Model with { Collected = true });
 
         // Auto-reset has cleared the live session…
@@ -131,6 +134,47 @@ public class LegolasReportServiceTests
         report.LatestReport.Should().NotBeNull();
         report.LatestReport!.SurveyCount.Should().Be(1);
         report.LatestReport.UnknownByName!["Diamond"].Should().Be(3);
+    }
+
+    [Fact]
+    public void Second_cycle_after_AutoReset_reports_real_elapsed_time()
+    {
+        // Regression: the original bug (Emraell's "0s elapsed" payload) was that
+        // StartedAt was stamped only on AwaitingPosition→Listening, so after
+        // auto-reset returned the FSM to Listening with StartedAt wiped, the next
+        // run never re-stamped. The Ready-state redesign moves the stamp onto the
+        // Ready→Listening edge (first-survey-arrival), which fires on every cycle.
+        var (report, flow, session, settings, clock) = BuildSut();
+        settings.AutoResetWhenAllCollected = true;
+
+        session.HasPlayerPosition = true;
+        flow.ConfirmPlayerPosition();
+
+        // Cycle 1: surveys arrive at SessionStart, all collected at SessionEnd,
+        // auto-reset fires.
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        clock.Set(SessionEnd);
+        session.CollectedItems["Diamond"] = 1;
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        // Cycle 2: clock advances another 10 minutes before any survey arrives.
+        var cycle2Start = SessionEnd.AddMinutes(10);
+        var cycle2End = cycle2Start.AddMinutes(7);
+        clock.Set(cycle2Start);
+        session.CollectedItems.Clear();
+        session.CollectedItems["Coal"] = 2;
+        var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 0));
+        session.Surveys.Add(s2);
+        clock.Set(cycle2End);
+        s2.UpdateModel(s2.Model with { Collected = true });
+
+        // The latest report is from cycle 2. Its elapsed must reflect the cycle-2
+        // clock advance, not collapse to ~0 (the pre-fix symptom).
+        var p = report.LatestReport!;
+        p.StartedAt.Should().Be(cycle2Start);
+        p.CompletedAt.Should().Be(cycle2End);
+        (p.CompletedAt - p.StartedAt).Should().Be(TimeSpan.FromMinutes(7));
     }
 
     [Fact]

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -98,7 +98,7 @@ public class LegolasWizardViewModelTests
         session.IsInventoryVisible = true;
         session.HasPlayerPosition = true;
         surveyFlow.ConfirmPlayerPosition();
-        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Ready);
 
         wizard.ChangeModeCommand.Execute(null);
 
@@ -106,9 +106,9 @@ public class LegolasWizardViewModelTests
         wizard.CurrentStep.Should().Be(WizardStep.PickMode);
         session.IsMapVisible.Should().BeFalse();
         session.IsInventoryVisible.Should().BeFalse();
-        // FSM Reset preserves player position, so SurveyFlow returns to Listening
+        // FSM Reset preserves player position, so SurveyFlow returns to Ready
         // (per controller semantics — Reset doesn't clear the anchor).
-        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Ready);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- End-of-run share cards rendered \`0s elapsed\` for any second-or-later survey run in the same app session — \`StartedAt\` and \`CompletedAt\` differed by only ~37 µs (two consecutive \`_clock.GetUtcNow()\` calls). Root cause: the stamp lived on the once-per-app-session AwaitingPosition→Listening edge; \`AutoResetWhenAllCollected\` (default \`true\`) returned the FSM to Listening with \`StartedAt\` wiped, and there was no edge to re-stamp.
- Fix: insert a \`Ready\` state between AwaitingPosition and Listening. \`ConfirmPlayerPosition\` lands on Ready; the Ready→Listening edge (driven by \`Surveys.CollectionChanged\` on first pin) is what stamps \`StartedAt\`. Reset returns to Ready, so every cycle re-stamps fresh.
- Side cleanups: \`CanOptimize\` simplifies to \`CurrentState == Listening\` (the "non-empty surveys" precondition is now structural), \`CanAcceptSurvey\` broadens to Ready ∪ Listening, the wizard projects Ready → \`WizardStep.Listening\` so no new XAML panel is needed.

## Regression coverage

- \`SecondCycle_after_AutoReset_re_stamps_StartedAt\` (FSM level) — asserts cycle 2's StartedAt picks up the cycle-2 clock advance, not the ~0s collapse
- \`Second_cycle_after_AutoReset_reports_real_elapsed_time\` (report-service level) — pins the exact Emraell-payload pattern with \`(CompletedAt - StartedAt) == 7 minutes\`

## Test plan

- [x] \`dotnet test tests/Legolas.Tests\` — 189/189 pass
- [x] \`dotnet test Mithril.slnx\` — only pre-existing failure (\`LogPatternCatalogParityTests.Every_Catalog_Entry_Resolves_To_A_Real_GeneratedRegex_Method\`) remains, confirmed identical on \`main\`
- [ ] Manual smoke: run a survey session, complete it, run a second session in the same app session, verify share-card elapsed text reflects real wall-clock duration
- [ ] Manual smoke: verify the wizard breadcrumb / inventory auto-show / Go! button gating still feel right across the AwaitingPosition → Ready → Listening → Gathering → Done cycle

## Notes for reviewers

- \`docs/legolas-overview.md\` updated with the new state, the new transition table, and a "Second-run StartedAt regression" entry under pitfalls so future contributors don't move the stamp back to \`ConfirmPlayerPosition\`.
- \`Ready → WizardStep.Listening\` projection is deliberate: the existing Listening UI block already handles both empty (Ready) and non-empty (Listening) cases via \`Session.IsAnchorEditable\` and \`CanOptimize\` bindings — promoting Ready to its own wizard step would just add noise without changing what the user sees.
- The pre-existing test failure surfaced during the run is unrelated to this PR (it fails identically on \`main\` — verified by stashing and re-running); not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)