### PR TITLE
feat(legolas): auto-hide overlays between sessions + wizard toggle button

### DIFF
--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -167,6 +167,24 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     }
 
     /// <summary>
+    /// Hide both overlays on Done→Ready (session ends) and re-show them on
+    /// Ready→Listening (next survey lands). Lets the user keep the game
+    /// window uncluttered between cycles without manual toggling. Default on
+    /// — opt out for users who want overlays to stay visible across runs.
+    /// </summary>
+    private bool _hideOverlaysBetweenSessions = true;
+    public bool HideOverlaysBetweenSessions
+    {
+        get => _hideOverlaysBetweenSessions;
+        set
+        {
+            if (_hideOverlaysBetweenSessions == value) return;
+            _hideOverlaysBetweenSessions = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HideOverlaysBetweenSessions)));
+        }
+    }
+
+    /// <summary>
     /// When true, the end-of-run report dialog auto-pops as soon as the FSM hits Done.
     /// Snapshot is taken regardless — this only gates whether the dialog opens
     /// automatically. The wizard always offers a manual "View last report" button.

--- a/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
+++ b/src/Legolas.Module/ViewModels/ControlPanelViewModel.cs
@@ -102,6 +102,17 @@ public sealed partial class ControlPanelViewModel : ObservableObject
         }
     }
 
+    public bool HideOverlaysBetweenSessions
+    {
+        get => _settings.HideOverlaysBetweenSessions;
+        set
+        {
+            if (_settings.HideOverlaysBetweenSessions == value) return;
+            _settings.HideOverlaysBetweenSessions = value;
+            OnPropertyChanged();
+        }
+    }
+
     public bool ShowNudgePadOnOverlay
     {
         get => _settings.ShowNudgePadOnOverlay;

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -73,11 +73,62 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         NudgePad = nudgePad;
 
         _surveyFlow.PropertyChanged += OnSurveyFlowChanged;
+        _surveyFlow.Transitioned += OnSurveyFlowTransitioned;
         _motherlodeFlow.PropertyChanged += OnMotherlodeFlowChanged;
         _session.PropertyChanged += OnSessionChanged;
         if (_reportService is not null)
             _reportService.ReportGenerated += OnReportGenerated;
         RecomputeStep();
+    }
+
+    /// <summary>
+    /// FSM-edge-driven overlay management. Two cases:
+    ///   * Done → Ready (session just ended via auto-reset or a manual reset
+    ///     from Done): hide both overlays so the game window is uncluttered
+    ///     between cycles.
+    ///   * Ready → Listening (next cycle starts — a fresh survey landed):
+    ///     re-show both. The user is engaged again; they're either going to
+    ///     keep popping or hit Go.
+    /// Both edges are gated on <see cref="LegolasSettings.HideOverlaysBetweenSessions"/>
+    /// so users who prefer always-visible overlays opt out wholesale.
+    /// Listening↔Ready edges from a manual mid-session reset don't qualify
+    /// — the test "Reset preserves overlay visibility" pins that behaviour.
+    /// </summary>
+    private void OnSurveyFlowTransitioned(SurveyTransition t)
+    {
+        if (!_settings.HideOverlaysBetweenSessions) return;
+
+        if (t.From == SurveyFlowState.Done && t.To == SurveyFlowState.Ready)
+        {
+            _session.IsMapVisible = false;
+            _session.IsInventoryVisible = false;
+        }
+        else if (t.From == SurveyFlowState.Ready && t.To == SurveyFlowState.Listening)
+        {
+            _session.IsMapVisible = true;
+            _session.IsInventoryVisible = true;
+        }
+    }
+
+    /// <summary>
+    /// True when at least one overlay is currently visible. Drives the wizard
+    /// hero row's overlay-toggle button: a click flips both to the opposite
+    /// state, mirroring the <c>ToggleAllOverlaysCommand</c> hotkey shape.
+    /// </summary>
+    public bool AreOverlaysVisible => _session.IsMapVisible || _session.IsInventoryVisible;
+
+    /// <summary>
+    /// Wizard-hero overlay toggle. Sets both <see cref="SessionState.IsMapVisible"/>
+    /// and <see cref="SessionState.IsInventoryVisible"/> to the same target value
+    /// (the opposite of <see cref="AreOverlaysVisible"/>) so the two overlays move
+    /// in lockstep, matching the hotkey-driven <c>ToggleAllOverlaysCommand</c>.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleOverlays()
+    {
+        var target = !AreOverlaysVisible;
+        _session.IsMapVisible = target;
+        _session.IsInventoryVisible = target;
     }
 
     /// <summary>True once the user has clicked Survey or Motherlode in step 0.</summary>
@@ -230,6 +281,13 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         // Hotkey-driven mode flip should re-project the wizard's step.
         if (e.PropertyName == nameof(SessionState.Mode))
             RecomputeStep();
+        // Bubble overlay-visibility changes up to AreOverlaysVisible so the
+        // hero-row toggle button's icon/tooltip stay in sync with the actual
+        // session state (toggled by the button itself, the hotkey, or the
+        // FSM-edge auto-hide/show in OnSurveyFlowTransitioned).
+        else if (e.PropertyName is nameof(SessionState.IsMapVisible)
+                              or nameof(SessionState.IsInventoryVisible))
+            OnPropertyChanged(nameof(AreOverlaysVisible));
     }
 
     /// <summary>

--- a/src/Legolas.Module/Views/LegolasSettingsView.xaml
+++ b/src/Legolas.Module/Views/LegolasSettingsView.xaml
@@ -73,6 +73,10 @@
                     <CheckBox Content="Auto-hide overlays when neither the game nor Mithril has focus"
                               IsChecked="{Binding ControlPanel.AutoHideOverlaysOnGameUnfocused}"
                               ToolTip="Hides the map and inventory overlays while you alt-tab to a browser, Discord, etc., and restores whichever was visible when you return." />
+                    <CheckBox Content="Hide overlays between survey runs"
+                              Margin="0,4,0,0"
+                              IsChecked="{Binding ControlPanel.HideOverlaysBetweenSessions}"
+                              ToolTip="Hide both overlays when a session ends (Done) and re-show them when the next survey lands. Off keeps them visible across runs." />
                     <TextBlock Text="Game process name (case-insensitive substring match — covers ProjectGorgon, ProjectGorgon64, Project Gorgon, etc.):"
                                Foreground="{StaticResource TextTertiaryBrush}"
                                TextWrapping="Wrap" Margin="0,8,0,4" />

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -148,7 +148,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="40" />
                         <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="40" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Button Grid.Column="0" Style="{StaticResource MithrilToolbarButtonStyle}"
                             Command="{Binding BackCommand}" ToolTip="Back one step"
@@ -160,12 +160,19 @@
                                FontSize="32" FontWeight="SemiBold"
                                HorizontalAlignment="Center" TextAlignment="Center"
                                Foreground="{StaticResource TextPrimaryBrush}" />
-                    <Button Grid.Column="2" Style="{StaticResource MithrilToolbarButtonStyle}"
-                            Command="{Binding WizardResetCommand}" ToolTip="Reset this flow (overlays stay open)"
-                            VerticalAlignment="Center" HorizontalAlignment="Right"
-                            Visibility="{Binding HasPickedMode, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                        <icon:PackIconLucide Kind="RotateCcw" Width="14" Height="14" />
-                    </Button>
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
+                                Visibility="{Binding HasPickedMode, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <Button Style="{StaticResource MithrilToolbarButtonStyle}"
+                                Command="{Binding ToggleOverlaysCommand}"
+                                ToolTip="Show or hide both overlays (map and inventory)"
+                                Margin="0,0,4,0">
+                            <icon:PackIconLucide Kind="Eye" Width="14" Height="14" />
+                        </Button>
+                        <Button Style="{StaticResource MithrilToolbarButtonStyle}"
+                                Command="{Binding WizardResetCommand}" ToolTip="Reset this flow (overlays stay open)">
+                            <icon:PackIconLucide Kind="RotateCcw" Width="14" Height="14" />
+                        </Button>
+                    </StackPanel>
                 </Grid>
 
                 <!-- Step bodies — one visible at a time, keyed off CurrentStep. -->

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -229,4 +229,136 @@ public class LegolasWizardViewModelTests
         session.HasPlayerPosition.Should().BeFalse();
     }
 
+    /// <summary>
+    /// End-to-end happy path covering the auto-hide / auto-show round trip.
+    /// Run #1: anchor → first pin → collect → auto-reset (hide). Run #2:
+    /// next pin → re-show. Pins both edges in one fixture so the contract
+    /// is described as a single observable cycle, not two disconnected facts.
+    /// </summary>
+    [Fact]
+    public void Overlays_auto_hide_on_DoneToReady_and_re_show_on_next_survey()
+    {
+        var (_, session, surveyFlow, _, settings) = BuildSut();
+        settings.AutoResetWhenAllCollected = true;
+        settings.HideOverlaysBetweenSessions = true;
+
+        // Cycle 1: anchor + first survey + collect → auto-reset fires Done→Ready.
+        session.HasPlayerPosition = true;
+        surveyFlow.ConfirmPlayerPosition();
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);  // Ready→Listening — overlays already true here
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Ready,
+            "auto-reset returned to Ready after Done");
+        session.IsMapVisible.Should().BeFalse("Done→Ready hides the map");
+        session.IsInventoryVisible.Should().BeFalse("Done→Ready hides the inventory");
+
+        // Cycle 2: next survey arrives in Ready → both overlays re-show.
+        var s2 = new SurveyItemViewModel(Survey.Create("Coal", new MetreOffset(10, 0), 0));
+        session.Surveys.Add(s2);
+
+        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Listening,
+            "first pin in cycle 2 takes Ready→Listening");
+        session.IsMapVisible.Should().BeTrue("Ready→Listening re-shows the map");
+        session.IsInventoryVisible.Should().BeTrue("Ready→Listening re-shows the inventory");
+    }
+
+    [Fact]
+    public void Overlay_auto_hide_does_nothing_when_setting_off()
+    {
+        var (wizard, session, surveyFlow, _, settings) = BuildSut();
+        settings.AutoResetWhenAllCollected = true;
+        settings.HideOverlaysBetweenSessions = false;
+
+        // Drive through the full happy path so OnCurrentStepChanged opens
+        // both overlays — the auto-hide-disabled assertion is only meaningful
+        // when there's something to (not) hide.
+        wizard.PickSurveyModeCommand.Execute(null);  // map opens (AwaitingPosition)
+        session.HasPlayerPosition = true;
+        surveyFlow.ConfirmPlayerPosition();          // inventory opens (WizardStep.Listening)
+        session.IsMapVisible.Should().BeTrue();
+        session.IsInventoryVisible.Should().BeTrue();
+
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        s1.UpdateModel(s1.Model with { Collected = true });
+
+        surveyFlow.CurrentState.Should().Be(SurveyFlowState.Ready);
+        // With the setting off, the FSM-edge handler doesn't touch overlay
+        // visibility — they stay where the OnCurrentStepChanged path left them.
+        session.IsMapVisible.Should().BeTrue();
+        session.IsInventoryVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Overlay_auto_hide_does_not_fire_on_manual_reset_mid_session()
+    {
+        // Listening→Ready (manual Reset call from a live mid-session state)
+        // is NOT the Done→Ready edge — the user intent is "do this flow
+        // again", not "session ended". Overlays must stay where they are.
+        // Belt-and-braces alongside Reset_preserves_overlay_visibility.
+        var (_, session, surveyFlow, _, settings) = BuildSut();
+        settings.HideOverlaysBetweenSessions = true;
+        session.HasPlayerPosition = true;
+        surveyFlow.ConfirmPlayerPosition();
+        var s1 = new SurveyItemViewModel(Survey.Create("Diamond", new MetreOffset(50, 30), 0));
+        session.Surveys.Add(s1);
+        session.IsMapVisible = true;
+        session.IsInventoryVisible = true;
+
+        surveyFlow.Reset();  // Listening → Ready (not Done→Ready)
+
+        session.IsMapVisible.Should().BeTrue();
+        session.IsInventoryVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToggleOverlays_when_either_visible_hides_both()
+    {
+        var (wizard, session, _, _, _) = BuildSut();
+        session.IsMapVisible = true;
+        session.IsInventoryVisible = false;
+        wizard.AreOverlaysVisible.Should().BeTrue();
+
+        wizard.ToggleOverlaysCommand.Execute(null);
+
+        session.IsMapVisible.Should().BeFalse();
+        session.IsInventoryVisible.Should().BeFalse();
+        wizard.AreOverlaysVisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToggleOverlays_when_both_hidden_shows_both()
+    {
+        var (wizard, session, _, _, _) = BuildSut();
+        session.IsMapVisible = false;
+        session.IsInventoryVisible = false;
+        wizard.AreOverlaysVisible.Should().BeFalse();
+
+        wizard.ToggleOverlaysCommand.Execute(null);
+
+        session.IsMapVisible.Should().BeTrue();
+        session.IsInventoryVisible.Should().BeTrue();
+        wizard.AreOverlaysVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreOverlaysVisible_change_notifies_when_session_visibility_flips()
+    {
+        var (wizard, session, _, _, _) = BuildSut();
+        session.IsMapVisible = false;
+        session.IsInventoryVisible = false;
+        var notifications = 0;
+        wizard.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(LegolasWizardViewModel.AreOverlaysVisible))
+                notifications++;
+        };
+
+        session.IsMapVisible = true;  // false → true should notify
+        session.IsInventoryVisible = true;  // false → true should notify
+
+        notifications.Should().BeGreaterOrEqualTo(2);
+    }
 }


### PR DESCRIPTION
## Summary

- **Auto-hide overlays between sessions.** On Done→Ready (auto-reset, or manual reset from Done) both overlays hide so the game window is uncluttered between cycles. On Ready→Listening (next survey lands) both re-show in lockstep. Gated on a new \`HideOverlaysBetweenSessions\` setting (default \`true\`). Listening↔Ready from a manual mid-session reset doesn't qualify and preserves overlay visibility.
- **One setting, not two.** Auto-hide and auto-show are two halves of the same preference — splitting them invites foot-gun configurations (\"hide but don't re-show\" strands the user reopening overlays every cycle).
- **Wizard hero-row toggle button.** Eye icon next to Reset, gated on \`HasPickedMode\`. Reuses the \`ToggleAllOverlaysCommand\` hotkey shape (\`!AreOverlaysVisible\` flips both in lockstep). Provides a discoverable in-flow control and a manual override when the auto-hide picks the wrong moment.

## Test plan

- [x] \`dotnet test tests/Legolas.Tests\` — 195/195 (was 189; 6 new tests added)
- [x] \`dotnet test Mithril.slnx\` — only the pre-existing \`LogPatternCatalogParityTests\` failure remains (unrelated, identical on \`main\`)
- [ ] Manual smoke: complete a survey run, verify both overlays auto-hide on Done→Ready
- [ ] Manual smoke: use a survey item, verify both overlays re-show on Ready→Listening
- [ ] Manual smoke: open Settings → Legolas → Auto-Hide, uncheck \"Hide overlays between survey runs\", verify the auto-hide stops firing
- [ ] Manual smoke: click the Eye icon in the wizard hero row, verify both overlays toggle together
- [ ] Manual smoke: verify the existing \`Reset_preserves_overlay_visibility\` behaviour still holds — manual mid-session reset keeps overlays open

## New tests

- \`Overlays_auto_hide_on_DoneToReady_and_re_show_on_next_survey\` — round trip happy path
- \`Overlay_auto_hide_does_nothing_when_setting_off\` — opt-out verified
- \`Overlay_auto_hide_does_not_fire_on_manual_reset_mid_session\` — Listening→Ready isn't Done→Ready
- \`ToggleOverlays_when_either_visible_hides_both\` + \`ToggleOverlays_when_both_hidden_shows_both\` — toggle command in both directions
- \`AreOverlaysVisible_change_notifies_when_session_visibility_flips\` — bound button stays in sync regardless of which path mutated visibility

## Notes for reviewers

- New setting follows the existing auto-* pattern (private backing field, INotifyPropertyChanged, ControlPanelViewModel passthrough). No JSON-schema bump required — missing field on old user JSON deserializes to the C# default \`true\`, which is also the desired default behaviour.
- The hero-row layout column-3 width changed from \`40\` to \`Auto\` to fit a 2-button \`StackPanel\` (toggle + reset). The title shifts marginally to accommodate; intentional.
- \`OnSurveyFlowTransitioned\` is purely additive — no existing wizard logic was rewritten or removed. The first session through still gets its overlay-open from the existing \`OnCurrentStepChanged\` path; the new handler only kicks in for cycle 2+ and the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)