### PR TITLE
fix(logging): sync collect-regex catalog entry with C# parser

### DIFF
--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -263,7 +263,7 @@
       ]
     },
     "legolas.ChatLogParser.CollectRegex": {
-      "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+(?:x(?<count>\\d+)\\s+)?collected!",
+      "pattern": "\\[Status\\]\\s+(?<name>.+?)(?:\\s+x(?<count>\\d+))?\\s+collected!(?:\\s+Also found\\s+(?<bonus>.+?)\\s+\\(speed bonus!\\))?",
       "source": "chat",
       "module": "legolas",
       "csharp": {
@@ -274,7 +274,8 @@
       "eventType": "legolas.ItemCollected",
       "fields": [
         { "name": "name", "group": "name", "type": "string" },
-        { "name": "count", "group": "count", "type": "int" }
+        { "name": "count", "group": "count", "type": "int" },
+        { "name": "bonus", "group": "bonus", "type": "string" }
       ]
     },
     "legolas.ChatLogParser.MotherlodeRegex": {


### PR DESCRIPTION
## Summary

\`LogPatternCatalogParityTests.Every_Catalog_Entry_Resolves_To_A_Real_GeneratedRegex_Method\` has been failing on \`main\` since #136 (~12 days). The test enforces character-for-character parity between the C# \`[GeneratedRegex]\` attributes and \`src/Mithril.Shared/Reference/log-patterns.json\` (the catalog the TypeScript MCP at \`tools/MithrilLogMcp\` reads). #136 added the speed-bonus capture group to \`Legolas.Services.ChatLogParser.CollectRegex\` but didn't update the catalog, leaving the two out of sync.

## Why this matters

The MCP queries collect events through the JSON catalog. With the stale entry, MCP-side parsing has been:
- failing to match any \"Item collected! Also found Bonus (speed bonus!)\" line, and
- using a slightly differently-shaped count group than the C# version (the optional wrapper bracketed \`x...\s+\` instead of \`\s+x...\`)

So anyone querying historical log data through the MCP has been missing speed-bonus item drops.

## The fix

One file. Pattern updated to match the current C# regex verbatim, and a new \`bonus\` field added to the entry's \`fields\` list.

**C# (live):**
\`\[Status\]\s+(?<name>.+?)(?:\s+x(?<count>\d+))?\s+collected!(?:\s+Also found\s+(?<bonus>.+?)\s+\(speed bonus!\))?\`

The TS catalog loader is generic — \`fields: raw.fields ?? []\` plumbs the new field through automatically, so no MCP code change is needed.

## Test plan

- [x] \`dotnet test tests/Mithril.Shared.Tests\` — \`LogPatternCatalogParityTests\` now passes (639/639 vs 638/639 before)
- [x] \`dotnet test Mithril.slnx\` — all suites green, no regressions
- [ ] If anyone uses the MCP downstream, manual smoke that an MCP query for collect events now returns the \`bonus\` field

## Note on framing

The test isn't outdated — it's working exactly as designed. Its job is to catch drift between the two sources of truth, and it caught a real one. The catalog was what fell out of sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)