### PR TITLE
Elrond #129: cookbook picker + deep linking + umbrella sections

### DIFF
--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -19,7 +19,11 @@ public sealed record SkillAnalysis(
     int? GoalLevel = null);
 
 /// <summary>
-/// One recipe's analysis for a given skill and character.
+/// One recipe's analysis for a given cookbook section + character. <see cref="RewardSkill"/>
+/// names the skill that actually earns XP when this recipe is crafted; it may differ from
+/// the section the recipe is filed under (a Fish Stew filed in <c>Cooking</c> rewards
+/// <c>Fishing</c> XP), and the row's <see cref="EffectiveXp"/>/<see cref="CompletionsToLevel"/>
+/// reflect that reward skill, not the section.
 /// </summary>
 public sealed record RecipeAnalysis(
     string RecipeKey,
@@ -38,7 +42,8 @@ public sealed record RecipeAnalysis(
     double Complexity,
     double? Efficiency,
     IReadOnlyList<RecipeIngredientDisplay> Ingredients,
-    IReadOnlyList<CraftedGearPreview> CraftedOutputs);
+    IReadOnlyList<CraftedGearPreview> CraftedOutputs,
+    string RewardSkill = "");
 
 /// <summary>Display-ready ingredient for a recipe tooltip.</summary>
 public sealed record RecipeIngredientDisplay(string Name, int IconId, int StackSize, float? ChanceToConsume);

--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -7,6 +7,11 @@ namespace Elrond.Domain;
 /// available recipes with their effective XP, and future level milestones.
 /// When <see cref="GoalLevel"/> is set, <see cref="XpRemaining"/> and
 /// <see cref="RecipeAnalysis.CompletionsToLevel"/> reflect the total gap to that goal.
+/// <para/>
+/// <see cref="IsUmbrellaSection"/> is true when the section's host skill has no
+/// XpTable (e.g. Phrenology, Anatomy umbrella categories). The view degrades
+/// the section header to <c>—</c> placeholders for level/XP/remaining since
+/// those values are meaningless for skills that aren't directly levelable.
 /// </summary>
 public sealed record SkillAnalysis(
     string SkillName,
@@ -16,7 +21,8 @@ public sealed record SkillAnalysis(
     long XpRemaining,
     IReadOnlyList<RecipeAnalysis> Recipes,
     IReadOnlyList<XpMilestone> Milestones,
-    int? GoalLevel = null);
+    int? GoalLevel = null,
+    bool IsUmbrellaSection = false);
 
 /// <summary>
 /// One recipe's analysis for a given cookbook section + character. <see cref="RewardSkill"/>
@@ -24,6 +30,13 @@ public sealed record SkillAnalysis(
 /// the section the recipe is filed under (a Fish Stew filed in <c>Cooking</c> rewards
 /// <c>Fishing</c> XP), and the row's <see cref="EffectiveXp"/>/<see cref="CompletionsToLevel"/>
 /// reflect that reward skill, not the section.
+/// <para/>
+/// <see cref="RewardSkillCurrentLevel"/>/<see cref="RewardSkillCurrentXp"/>/<see cref="RewardSkillXpNeededForNextLevel"/>
+/// denormalise the active character's progress in this recipe's reward skill so
+/// the detail pane can show "where you stand on the skill this craft moves" without
+/// re-querying the character. <see cref="RewardSkillDiffersFromSection"/> drives the
+/// visibility of that target-skill panel — when it's false, the section header above
+/// already covers it.
 /// </summary>
 public sealed record RecipeAnalysis(
     string RecipeKey,
@@ -44,7 +57,11 @@ public sealed record RecipeAnalysis(
     IReadOnlyList<RecipeIngredientDisplay> Ingredients,
     IReadOnlyList<CraftedGearPreview> CraftedOutputs,
     string RewardSkill = "",
-    string RewardSkillDisplayName = "");
+    string RewardSkillDisplayName = "",
+    int RewardSkillCurrentLevel = 0,
+    long RewardSkillCurrentXp = 0,
+    long RewardSkillXpNeededForNextLevel = 0,
+    bool RewardSkillDiffersFromSection = false);
 
 /// <summary>Display-ready ingredient for a recipe tooltip.</summary>
 public sealed record RecipeIngredientDisplay(string Name, int IconId, int StackSize, float? ChanceToConsume);

--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -43,7 +43,8 @@ public sealed record RecipeAnalysis(
     double? Efficiency,
     IReadOnlyList<RecipeIngredientDisplay> Ingredients,
     IReadOnlyList<CraftedGearPreview> CraftedOutputs,
-    string RewardSkill = "");
+    string RewardSkill = "",
+    string RewardSkillDisplayName = "");
 
 /// <summary>Display-ready ingredient for a recipe tooltip.</summary>
 public sealed record RecipeIngredientDisplay(string Name, int IconId, int StackSize, float? ChanceToConsume);

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -39,6 +39,10 @@ public sealed class ElrondModule : IMithrilModule
             sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
             sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
             sp.GetRequiredService<ElrondSettings>()));
+        services.AddSingleton<IElrondSkillImportTarget>(sp => new Services.ElrondSkillImportTarget(
+            sp.GetRequiredService<SkillAdvisorViewModel>(),
+            sp.GetService<IModuleActivator>(),
+            sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
         services.AddSingleton<SkillAdvisorView>(sp => new SkillAdvisorView
         {
             DataContext = sp.GetRequiredService<SkillAdvisorViewModel>(),

--- a/src/Elrond.Module/Services/ElrondSkillImportTarget.cs
+++ b/src/Elrond.Module/Services/ElrondSkillImportTarget.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using Elrond.ViewModels;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Elrond.Services;
+
+/// <summary>
+/// Elrond's implementation of <see cref="IElrondSkillImportTarget"/>. Brings the
+/// Elrond tab to the foreground via <see cref="IModuleActivator"/>, then forwards
+/// the skill key into <see cref="SkillAdvisorViewModel.SelectSkillFromDeepLink"/>
+/// — that method handles the not-yet-ready cases (no active character, reference
+/// data still loading) via its internal pending-deep-link stash, so this target
+/// stays a thin adapter.
+/// </summary>
+public sealed class ElrondSkillImportTarget : IElrondSkillImportTarget
+{
+    private readonly SkillAdvisorViewModel _vm;
+    private readonly IModuleActivator? _activator;
+    private readonly IDiagnosticsSink? _diag;
+
+    public ElrondSkillImportTarget(
+        SkillAdvisorViewModel viewModel,
+        IModuleActivator? activator = null,
+        IDiagnosticsSink? diag = null)
+    {
+        _vm = viewModel;
+        _activator = activator;
+        _diag = diag;
+    }
+
+    public void ImportFromLinkPayload(string skillKey)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            Apply(skillKey);
+        else
+            dispatcher.InvokeAsync(() => Apply(skillKey));
+    }
+
+    private void Apply(string skillKey)
+    {
+        if (_activator is not null && !_activator.Activate("elrond"))
+            _diag?.Info("Elrond", "Deep-link import: module activator could not find 'elrond'.");
+        _vm.SelectSkillFromDeepLink(skillKey);
+    }
+}

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -154,6 +154,7 @@ public sealed class SkillAdvisorEngine
             var rewardSkillDisplayName = _ref.Skills.TryGetValue(recipe.RewardSkill, out var rewardSkillEntry)
                 ? rewardSkillEntry.DisplayName
                 : recipe.RewardSkill;
+            var rewardDiffersFromSection = !recipe.RewardSkill.Equals(sectionKey, StringComparison.Ordinal);
 
             recipeAnalyses.Add(new RecipeAnalysis(
                 recipe.Key,
@@ -174,7 +175,11 @@ public sealed class SkillAdvisorEngine
                 ingredients,
                 craftedOutputs,
                 RewardSkill: recipe.RewardSkill,
-                RewardSkillDisplayName: rewardSkillDisplayName));
+                RewardSkillDisplayName: rewardSkillDisplayName,
+                RewardSkillCurrentLevel: rewardCharSkill?.Level ?? 0,
+                RewardSkillCurrentXp: rewardCharSkill?.XpTowardNextLevel ?? 0,
+                RewardSkillXpNeededForNextLevel: rewardCharSkill?.XpNeededForNextLevel ?? 0,
+                RewardSkillDiffersFromSection: rewardDiffersFromSection));
         }
 
         recipeAnalyses.Sort((a, b) =>
@@ -186,6 +191,14 @@ public sealed class SkillAdvisorEngine
 
         var milestones = BuildMilestones(sectionKey, sectionLevel, sectionCurrentXp, sectionXpNeeded, maxLevels: 10);
 
+        // Umbrella skills (Phrenology, Anatomy, Augmentation, …) have no XpTable,
+        // so the section header should degrade to "—" placeholders. Detection by
+        // missing/None XpTable is robust without needing IsUmbrellaSkill projected.
+        var sectionEntry = _ref.Skills.TryGetValue(sectionKey, out var se) ? se : null;
+        var isUmbrellaSection = sectionEntry is null
+            || string.IsNullOrEmpty(sectionEntry.XpTable)
+            || sectionEntry.XpTable.Equals("None", StringComparison.Ordinal);
+
         return new SkillAnalysis(
             sectionKey,
             sectionLevel,
@@ -194,7 +207,8 @@ public sealed class SkillAdvisorEngine
             sectionXpRemaining,
             recipeAnalyses,
             milestones,
-            goalLevel is { } g && g > sectionLevel ? goalLevel : null);
+            goalLevel is { } g && g > sectionLevel ? goalLevel : null,
+            IsUmbrellaSection: isUmbrellaSection);
     }
 
     internal int ComputeEffectiveXp(RecipeEntry recipe, int playerLevel)

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -151,6 +151,10 @@ public sealed class SkillAdvisorEngine
                 ? nextCraftXp / complexity
                 : null;
 
+            var rewardSkillDisplayName = _ref.Skills.TryGetValue(recipe.RewardSkill, out var rewardSkillEntry)
+                ? rewardSkillEntry.DisplayName
+                : recipe.RewardSkill;
+
             recipeAnalyses.Add(new RecipeAnalysis(
                 recipe.Key,
                 recipe.Name,
@@ -169,7 +173,8 @@ public sealed class SkillAdvisorEngine
                 efficiency,
                 ingredients,
                 craftedOutputs,
-                RewardSkill: recipe.RewardSkill));
+                RewardSkill: recipe.RewardSkill,
+                RewardSkillDisplayName: rewardSkillDisplayName));
         }
 
         recipeAnalyses.Sort((a, b) =>

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -18,65 +18,104 @@ public sealed class SkillAdvisorEngine
     }
 
     /// <summary>
-    /// Returns all skill names that have at least one recipe awarding XP,
-    /// sorted alphabetically.
+    /// Returns all cookbook section names — distinct values of
+    /// <c>SortSkill ?? RewardSkill</c> across recipes that award XP, sorted
+    /// alphabetically. A "section" is the in-game cookbook category a recipe
+    /// is filed under: typically the same as <c>RewardSkill</c>, but for some
+    /// recipes (fish-based foods → <c>Cooking</c>) the filing differs from the
+    /// XP-earning skill.
     /// </summary>
-    public IReadOnlyList<string> GetSkillsWithRecipes()
+    public IReadOnlyList<string> GetCookbookSections()
     {
-        var skills = new HashSet<string>(StringComparer.Ordinal);
+        var sections = new HashSet<string>(StringComparer.Ordinal);
         foreach (var recipe in _ref.Recipes.Values)
         {
-            if (!string.IsNullOrEmpty(recipe.RewardSkill) && recipe.RewardSkillXp > 0)
-                skills.Add(recipe.RewardSkill);
+            if (recipe.RewardSkillXp <= 0 && recipe.RewardSkillXpFirstTime <= 0) continue;
+            var section = FilingSkillOf(recipe);
+            if (!string.IsNullOrEmpty(section))
+                sections.Add(section);
         }
-        var list = skills.ToList();
+        var list = sections.ToList();
         list.Sort(StringComparer.Ordinal);
         return list;
     }
 
+    /// <summary>The cookbook section a recipe is filed under: <c>SortSkill</c> if set, else <c>RewardSkill</c>.</summary>
+    internal static string FilingSkillOf(RecipeEntry recipe) =>
+        string.IsNullOrEmpty(recipe.SortSkill) ? recipe.RewardSkill : recipe.SortSkill;
+
     /// <summary>
-    /// Analyze a skill for a given character: available recipes, XP rewards,
-    /// first-time bonuses, and leveling milestones.
-    /// When <paramref name="goalLevel"/> is set, XP remaining and completions-to-level
-    /// reflect the total gap from current progress to that goal.
+    /// Analyze a cookbook section for a given character: every recipe filed under
+    /// <paramref name="sectionKey"/>, with each recipe's metrics (effective XP,
+    /// completions-to-level, first-time bonus) computed against its own
+    /// <c>RewardSkill</c> — which may differ from the section. The section's
+    /// header level/XP read from the character's progress in the section's skill
+    /// (when present); recipes whose RewardSkill differs from the section show
+    /// completions toward their own next level (no goal-aware projection).
     /// </summary>
-    public SkillAnalysis? Analyze(string skillName, CharacterSnapshot character, bool includeZeroXp = false, int? goalLevel = null)
+    public SkillAnalysis? Analyze(string sectionKey, CharacterSnapshot character, bool includeZeroXp = false, int? goalLevel = null)
     {
-        if (!character.Skills.TryGetValue(skillName, out var charSkill))
+        // The section must correspond to a known character skill — exotic filings
+        // (e.g. Race_Fae) that aren't real character skills can't be advised on
+        // because the header progress bar has no data to show. The picker filters
+        // sections by character.Skills.ContainsKey upstream, so this is a guard
+        // for direct callers (deep links to unfamiliar sections, tests).
+        if (!character.Skills.TryGetValue(sectionKey, out var sectionCharSkill))
             return null;
 
-        var currentLevel = charSkill.Level;
-        var currentXp = charSkill.XpTowardNextLevel;
-        var xpNeeded = charSkill.XpNeededForNextLevel;
+        var sectionLevel = sectionCharSkill.Level;
+        var sectionCurrentXp = sectionCharSkill.XpTowardNextLevel;
+        var sectionXpNeeded = sectionCharSkill.XpNeededForNextLevel;
 
-        long xpRemaining;
-        if (goalLevel is { } goal && goal > currentLevel)
-            xpRemaining = ComputeXpToGoal(skillName, currentLevel, currentXp, xpNeeded, goal);
+        long sectionXpRemaining;
+        if (goalLevel is { } goal && goal > sectionLevel)
+            sectionXpRemaining = ComputeXpToGoal(sectionKey, sectionLevel, sectionCurrentXp, sectionXpNeeded, goal);
         else
-            xpRemaining = xpNeeded - currentXp;
+            sectionXpRemaining = sectionXpNeeded - sectionCurrentXp;
+        if (sectionXpRemaining < 0) sectionXpRemaining = 0;
 
-        if (xpRemaining < 0) xpRemaining = 0;
-
-        // Find all recipes that reward this skill
         var recipeAnalyses = new List<RecipeAnalysis>();
         foreach (var recipe in _ref.Recipes.Values)
         {
-            if (!recipe.RewardSkill.Equals(skillName, StringComparison.Ordinal)) continue;
+            if (!FilingSkillOf(recipe).Equals(sectionKey, StringComparison.Ordinal)) continue;
             if (recipe.RewardSkillXp <= 0 && recipe.RewardSkillXpFirstTime <= 0) continue;
             if (!includeZeroXp && recipe.RewardSkillXp <= 0) continue;
+
+            // Per-recipe character context: we need the character's level in this recipe's
+            // RewardSkill to compute drop-off and completions-to-its-own-level. May be null
+            // if the character hasn't learned the reward skill yet.
+            character.Skills.TryGetValue(recipe.RewardSkill, out var rewardCharSkill);
+            var rewardLevel = rewardCharSkill?.Level ?? 0;
 
             var isKnown = character.RecipeCompletions.TryGetValue(recipe.InternalName, out var timesCompleted);
             var firstTimeBonusAvailable = isKnown && timesCompleted == 0 && recipe.RewardSkillXpFirstTime > 0;
 
-            var effectiveXp = ComputeEffectiveXp(recipe, currentLevel);
+            var effectiveXp = ComputeEffectiveXp(recipe, rewardLevel);
+
+            // Goal-awareness: if the recipe rewards the section's skill, share the
+            // section-level goal. Otherwise (mixed-reward recipes filed here) just
+            // show completions to that recipe's own next level.
+            long xpRemainingForThisRecipe;
+            if (rewardCharSkill is null)
+            {
+                xpRemainingForThisRecipe = 0;
+            }
+            else if (recipe.RewardSkill.Equals(sectionKey, StringComparison.Ordinal))
+            {
+                xpRemainingForThisRecipe = sectionXpRemaining;
+            }
+            else
+            {
+                xpRemainingForThisRecipe = rewardCharSkill.XpNeededForNextLevel - rewardCharSkill.XpTowardNextLevel;
+                if (xpRemainingForThisRecipe < 0) xpRemainingForThisRecipe = 0;
+            }
 
             int? completionsToLevel = null;
-            if (effectiveXp > 0 && xpRemaining > 0)
+            if (effectiveXp > 0 && xpRemainingForThisRecipe > 0)
             {
                 if (firstTimeBonusAvailable && recipe.RewardSkillXpFirstTime > 0)
                 {
-                    // First completion uses first-time bonus XP
-                    var afterFirst = xpRemaining - recipe.RewardSkillXpFirstTime;
+                    var afterFirst = xpRemainingForThisRecipe - recipe.RewardSkillXpFirstTime;
                     if (afterFirst <= 0)
                         completionsToLevel = 1;
                     else
@@ -84,7 +123,7 @@ public sealed class SkillAdvisorEngine
                 }
                 else
                 {
-                    completionsToLevel = (int)Math.Ceiling((double)xpRemaining / effectiveXp);
+                    completionsToLevel = (int)Math.Ceiling((double)xpRemainingForThisRecipe / effectiveXp);
                 }
             }
 
@@ -103,17 +142,11 @@ public sealed class SkillAdvisorEngine
 
             var craftedOutputs = ResultEffectsParser.ParseCraftedGear(recipe.ResultEffects, _ref);
 
-            // ChanceToConsume weights catalysts (e.g. Butter's 20%-chance bottle)
-            // fractionally — without it, complexity overcounts.
             var complexity = recipe.Ingredients
                 .Sum(i => i.StackSize * (double)(i.ChanceToConsume ?? 1.0f));
-            // What the player actually pockets next craft. First-time bonus is
-            // not subject to the dropoff curve (matches CompletionsToLevel above).
             var nextCraftXp = firstTimeBonusAvailable && recipe.RewardSkillXpFirstTime > 0
                 ? recipe.RewardSkillXpFirstTime
                 : effectiveXp;
-            // 0-XP recipes aren't a math hazard, just noise — null suppresses them
-            // alongside the actual divide-by-zero case (zero-ingredient trainers).
             double? efficiency = nextCraftXp > 0 && complexity > 0
                 ? nextCraftXp / complexity
                 : null;
@@ -135,10 +168,10 @@ public sealed class SkillAdvisorEngine
                 complexity,
                 efficiency,
                 ingredients,
-                craftedOutputs));
+                craftedOutputs,
+                RewardSkill: recipe.RewardSkill));
         }
 
-        // Sort: level required ascending, then effective XP descending
         recipeAnalyses.Sort((a, b) =>
         {
             var cmp = a.LevelRequired.CompareTo(b.LevelRequired);
@@ -146,18 +179,17 @@ public sealed class SkillAdvisorEngine
             return b.EffectiveXp.CompareTo(a.EffectiveXp);
         });
 
-        // Build XP milestones for next ~10 levels
-        var milestones = BuildMilestones(skillName, currentLevel, currentXp, xpNeeded, maxLevels: 10);
+        var milestones = BuildMilestones(sectionKey, sectionLevel, sectionCurrentXp, sectionXpNeeded, maxLevels: 10);
 
         return new SkillAnalysis(
-            skillName,
-            currentLevel,
-            currentXp,
-            xpNeeded,
-            xpRemaining,
+            sectionKey,
+            sectionLevel,
+            sectionCurrentXp,
+            sectionXpNeeded,
+            sectionXpRemaining,
             recipeAnalyses,
             milestones,
-            goalLevel is { } g && g > currentLevel ? goalLevel : null);
+            goalLevel is { } g && g > sectionLevel ? goalLevel : null);
     }
 
     internal int ComputeEffectiveXp(RecipeEntry recipe, int playerLevel)

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -90,16 +90,30 @@ public sealed partial class SkillAdvisorViewModel
         _activeChar.CharacterExportsChanged += OnActiveCharacterChanged;
         _referenceData.FileUpdated += OnReferenceUpdated;
 
-        ReloadSkills();
+        BuildSkillTree();
     }
 
     // ── Observable properties ────────────────────────────────────────────
 
     [ObservableProperty]
-    private ObservableCollection<string> _availableSkills = [];
+    private ObservableCollection<SkillNode> _skillTreeRoots = [];
 
     [ObservableProperty]
     private string? _selectedSkill;
+
+    [ObservableProperty]
+    private string? _selectedSkillDisplayName;
+
+    [ObservableProperty]
+    private int? _selectedSkillLevel;
+
+    /// <summary>
+    /// Skill key requested via <see cref="SelectSkillFromDeepLink"/> that couldn't
+    /// be applied at request time (reference data not yet loaded, no active
+    /// character, or the skill not in the active character's known set). Consumed
+    /// by <see cref="BuildSkillTree"/> after each rebuild.
+    /// </summary>
+    private string? _pendingDeepLinkSkill;
 
     [ObservableProperty]
     private SkillAnalysis? _analysis;
@@ -125,6 +139,7 @@ public sealed partial class SkillAdvisorViewModel
     {
         if (value is not null)
             _settings.LastSkill = value;
+        UpdateSelectedSkillSummary(value);
         Reanalyze();
     }
 
@@ -283,18 +298,171 @@ public sealed partial class SkillAdvisorViewModel
 
     // ── Private helpers ──────────────────────────────────────────────────
 
-    private void ReloadSkills()
+    /// <summary>
+    /// Public deep-link entry point for <c>mithril://elrond/{skillKey}</c>. Selects
+    /// the named skill if it's already in the active character's known set. If the
+    /// view-model isn't ready (no character, no reference data, or character doesn't
+    /// know the skill yet) the request is stashed and applied after the next tree
+    /// rebuild — covers character-switch and CDN-refresh races.
+    /// </summary>
+    public void SelectSkillFromDeepLink(string skillKey)
     {
-        var skills = _engine.GetSkillsWithRecipes();
+        if (string.IsNullOrEmpty(skillKey)) return;
 
         var active = _activeChar.ActiveCharacter;
-        if (active is not null)
+        var leafKeys = CollectLeafKeys(SkillTreeRoots);
+        if (active is not null && leafKeys.Contains(skillKey))
         {
-            skills = skills.Where(s => active.Skills.ContainsKey(s)).ToList();
+            _pendingDeepLinkSkill = null;
+            SelectedSkill = skillKey;
+            return;
         }
 
-        AvailableSkills = new ObservableCollection<string>(skills);
-        SelectedSkill = skills.Contains(_settings.LastSkill) ? _settings.LastSkill : skills.FirstOrDefault();
+        // Stash and apply after the next tree rebuild. Surface a status hint so
+        // the user knows we received the request even when we can't act on it yet.
+        _pendingDeepLinkSkill = skillKey;
+        if (active is null)
+        {
+            StatusMessage = $"Deep link for '{skillKey}' will apply once a character is active.";
+        }
+        else
+        {
+            var displayName = _referenceData.Skills.TryGetValue(skillKey, out var entry)
+                ? entry.DisplayName
+                : skillKey;
+            StatusMessage = $"Elrond cannot advise on '{displayName}' for {active.Name} — the character has no recipes for it.";
+        }
+    }
+
+    private void BuildSkillTree()
+    {
+        var active = _activeChar.ActiveCharacter;
+        if (active is null)
+        {
+            SkillTreeRoots = [];
+            SelectedSkill = null;
+            return;
+        }
+
+        // Leaf set: skills the engine knows recipes for AND the character has learned.
+        var leafKeys = _engine.GetSkillsWithRecipes()
+            .Where(k => active.Skills.ContainsKey(k))
+            .ToList();
+
+        // Build leaf nodes carrying the character's current level/XP.
+        var leaves = new List<SkillNode>(leafKeys.Count);
+        foreach (var key in leafKeys)
+        {
+            var displayName = _referenceData.Skills.TryGetValue(key, out var entry) ? entry.DisplayName : key;
+            var charSkill = active.Skills[key];
+            leaves.Add(new SkillNode(
+                Key: key,
+                DisplayName: displayName,
+                CurrentLevel: charSkill.Level,
+                CurrentXp: charSkill.XpTowardNextLevel,
+                XpNeededForNextLevel: charSkill.XpNeededForNextLevel,
+                IsHeaderOnly: false,
+                Children: []));
+        }
+
+        // Group by immediate parent (skills.json Parents[0]). Parents that show up
+        // here are header-only — they group children but are themselves never
+        // selectable, even if the parent skill itself happens to have recipes.
+        var rootsList = new List<SkillNode>();
+        var parentBuckets = new Dictionary<string, List<SkillNode>>(StringComparer.Ordinal);
+        foreach (var leaf in leaves)
+        {
+            var parentKey = _referenceData.Skills.TryGetValue(leaf.Key, out var entry)
+                ? entry.Parents.FirstOrDefault()
+                : null;
+            if (string.IsNullOrEmpty(parentKey))
+            {
+                rootsList.Add(leaf);
+            }
+            else
+            {
+                if (!parentBuckets.TryGetValue(parentKey, out var bucket))
+                {
+                    bucket = [];
+                    parentBuckets[parentKey] = bucket;
+                }
+                bucket.Add(leaf);
+            }
+        }
+
+        foreach (var (parentKey, children) in parentBuckets)
+        {
+            var parentDisplay = _referenceData.Skills.TryGetValue(parentKey, out var pe) ? pe.DisplayName : parentKey;
+            var sortedChildren = children
+                .OrderBy(c => c.DisplayName, StringComparer.Ordinal)
+                .ToList();
+            rootsList.Add(new SkillNode(
+                Key: parentKey,
+                DisplayName: parentDisplay,
+                CurrentLevel: null,
+                CurrentXp: null,
+                XpNeededForNextLevel: null,
+                IsHeaderOnly: true,
+                Children: sortedChildren));
+        }
+
+        rootsList = rootsList
+            .OrderBy(n => n.DisplayName, StringComparer.Ordinal)
+            .ToList();
+
+        SkillTreeRoots = new ObservableCollection<SkillNode>(rootsList);
+
+        // Select: pending deep-link wins, then last-persisted skill, then first leaf.
+        var allLeafKeys = new HashSet<string>(leafKeys, StringComparer.Ordinal);
+        if (_pendingDeepLinkSkill is { } pending && allLeafKeys.Contains(pending))
+        {
+            _pendingDeepLinkSkill = null;
+            SelectedSkill = pending;
+        }
+        else if (allLeafKeys.Contains(_settings.LastSkill ?? string.Empty))
+        {
+            SelectedSkill = _settings.LastSkill;
+        }
+        else
+        {
+            SelectedSkill = leafKeys.FirstOrDefault();
+        }
+    }
+
+    private static HashSet<string> CollectLeafKeys(IEnumerable<SkillNode> nodes)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var node in nodes)
+        {
+            if (node.IsHeaderOnly)
+            {
+                foreach (var child in CollectLeafKeys(node.Children)) set.Add(child);
+            }
+            else
+            {
+                set.Add(node.Key);
+            }
+        }
+        return set;
+    }
+
+    private void UpdateSelectedSkillSummary(string? skillKey)
+    {
+        if (skillKey is null)
+        {
+            SelectedSkillDisplayName = null;
+            SelectedSkillLevel = null;
+            return;
+        }
+
+        SelectedSkillDisplayName = _referenceData.Skills.TryGetValue(skillKey, out var entry)
+            ? entry.DisplayName
+            : skillKey;
+
+        var active = _activeChar.ActiveCharacter;
+        SelectedSkillLevel = active is not null && active.Skills.TryGetValue(skillKey, out var charSkill)
+            ? charSkill.Level
+            : null;
     }
 
     private void Reanalyze()
@@ -342,7 +510,7 @@ public sealed partial class SkillAdvisorViewModel
     {
         OnUiThread(() =>
         {
-            ReloadSkills();
+            BuildSkillTree();
             Reanalyze();
         });
     }
@@ -352,7 +520,7 @@ public sealed partial class SkillAdvisorViewModel
         if (key is not ("recipes" or "skills" or "xptables")) return;
         OnUiThread(() =>
         {
-            ReloadSkills();
+            BuildSkillTree();
             Reanalyze();
         });
     }

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -124,6 +124,36 @@ public sealed partial class SkillAdvisorViewModel
     [ObservableProperty]
     private SkillAnalysis? _analysis;
 
+    /// <summary>
+    /// Section-header strings that degrade to <c>—</c> when the section is an umbrella
+    /// skill (no XpTable). Backed by <see cref="Analysis"/> — the partial OnAnalysisChanged
+    /// raises change notifications so the bound TextBlocks refresh.
+    /// </summary>
+    public string SectionLevelText => Analysis switch
+    {
+        null => "—",
+        { IsUmbrellaSection: true } => "—",
+        var a => a.CurrentLevel.ToString(),
+    };
+    public string SectionCurrentXpText => Analysis switch
+    {
+        null => "—",
+        { IsUmbrellaSection: true } => "—",
+        var a => a.CurrentXp.ToString("N0"),
+    };
+    public string SectionXpNeededText => Analysis switch
+    {
+        null => "—",
+        { IsUmbrellaSection: true } => "—",
+        var a => a.XpNeededForNextLevel.ToString("N0"),
+    };
+    public string SectionXpRemainingText => Analysis switch
+    {
+        null => "—",
+        { IsUmbrellaSection: true } => "—",
+        var a => a.XpRemaining.ToString("N0"),
+    };
+
     [ObservableProperty]
     private RecipeAnalysis? _selectedRecipe;
 
@@ -160,6 +190,12 @@ public sealed partial class SkillAdvisorViewModel
     {
         // CraftableOnly closes over Analysis.CurrentLevel — re-run the filter when it shifts.
         RecipesView.Refresh();
+        // Section-header text properties are computed from Analysis; nudge the bound
+        // TextBlocks to re-evaluate now that the source has changed.
+        OnPropertyChanged(nameof(SectionLevelText));
+        OnPropertyChanged(nameof(SectionCurrentXpText));
+        OnPropertyChanged(nameof(SectionXpNeededText));
+        OnPropertyChanged(nameof(SectionXpRemainingText));
     }
 
     partial void OnViewModeChanged(string value)

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -71,6 +71,12 @@ public sealed partial class SkillAdvisorViewModel
             new("FirstTimeBonusOnly", "First Time Bonus Only", r => r.FirstTimeBonusAvailable, inverted: false, isActive: false),
             new("CraftableOnly",      "Craftable only",        r => Analysis is { } a && r.LevelRequired <= a.CurrentLevel, inverted: false, isActive: true),
             new("HideZeroXp",         "Hide 0 XP",             r => r.EffectiveXp > 0,         inverted: false, isActive: true),
+            // Cookbook view shows recipes filed under a section regardless of which skill they level
+            // (a fish dish in Cooking levels Fishing). Toggling this filter on hides the mixed-reward
+            // recipes — useful when the user wants the classic "what levels skill X" view.
+            new("RewardingSectionOnly", "Only recipes that level this skill",
+                r => Analysis is { } a && r.RewardSkill.Equals(a.SkillName, StringComparison.Ordinal),
+                inverted: false, isActive: false),
         ];
 
         var view = (ListCollectionView)CollectionViewSource.GetDefaultView(_recipes);
@@ -367,33 +373,56 @@ public sealed partial class SkillAdvisorViewModel
                 Children: []));
         }
 
-        // Group by immediate parent (skills.json Parents[0]). Parents that show up
-        // here are header-only — they group children but are themselves never
-        // selectable, even if the parent skill itself happens to have recipes.
-        var rootsList = new List<SkillNode>();
+        // Group leaves by their immediate parent (skills.json Parents[0]).
+        // A leaf with no parent → potential root. A leaf with a parent → goes into
+        // its parent's bucket; the parent will be materialized as a tree node below.
+        var leafByKey = leaves.ToDictionary(l => l.Key, StringComparer.Ordinal);
         var parentBuckets = new Dictionary<string, List<SkillNode>>(StringComparer.Ordinal);
         foreach (var leaf in leaves)
         {
             var parentKey = _referenceData.Skills.TryGetValue(leaf.Key, out var entry)
                 ? entry.Parents.FirstOrDefault()
                 : null;
-            if (string.IsNullOrEmpty(parentKey))
+            if (string.IsNullOrEmpty(parentKey)) continue;
+            if (!parentBuckets.TryGetValue(parentKey, out var bucket))
             {
-                rootsList.Add(leaf);
+                bucket = [];
+                parentBuckets[parentKey] = bucket;
+            }
+            bucket.Add(leaf);
+        }
+
+        // Build roots: every leaf with no parent. A leaf with a parent is nested
+        // either under a sibling-leaf (if its parent is in our set) or under a
+        // pure header node materialized below. If a root leaf has children of
+        // its own, attach them — produces ONE selectable node with nested
+        // children rather than duplicating the leaf alongside a separate header.
+        var rootsList = new List<SkillNode>();
+        foreach (var leaf in leaves)
+        {
+            var parentKey = _referenceData.Skills.TryGetValue(leaf.Key, out var entry)
+                ? entry.Parents.FirstOrDefault()
+                : null;
+            if (!string.IsNullOrEmpty(parentKey)) continue;
+            if (parentBuckets.TryGetValue(leaf.Key, out var ownChildren))
+            {
+                var sortedChildren = ownChildren
+                    .OrderBy(c => c.DisplayName, StringComparer.Ordinal)
+                    .ToList();
+                rootsList.Add(leaf with { Children = sortedChildren });
             }
             else
             {
-                if (!parentBuckets.TryGetValue(parentKey, out var bucket))
-                {
-                    bucket = [];
-                    parentBuckets[parentKey] = bucket;
-                }
-                bucket.Add(leaf);
+                rootsList.Add(leaf);
             }
         }
 
+        // Pure header parents — referenced by children but not themselves a leaf
+        // (e.g. "Augmentation" when none of its child Augment* skills file recipes
+        // directly under Augmentation itself). Materialize as header-only nodes.
         foreach (var (parentKey, children) in parentBuckets)
         {
+            if (leafByKey.ContainsKey(parentKey)) continue;
             var parentDisplay = _referenceData.Skills.TryGetValue(parentKey, out var pe) ? pe.DisplayName : parentKey;
             var sortedChildren = children
                 .OrderBy(c => c.DisplayName, StringComparer.Ordinal)

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -96,13 +96,13 @@ public sealed partial class SkillAdvisorViewModel
         _activeChar.CharacterExportsChanged += OnActiveCharacterChanged;
         _referenceData.FileUpdated += OnReferenceUpdated;
 
-        BuildSkillTree();
+        BuildSkillNodes();
     }
 
     // ── Observable properties ────────────────────────────────────────────
 
     [ObservableProperty]
-    private ObservableCollection<SkillNode> _skillTreeRoots = [];
+    private ObservableCollection<SkillNode> _skillNodes = [];
 
     [ObservableProperty]
     private string? _selectedSkill;
@@ -117,7 +117,7 @@ public sealed partial class SkillAdvisorViewModel
     /// Skill key requested via <see cref="SelectSkillFromDeepLink"/> that couldn't
     /// be applied at request time (reference data not yet loaded, no active
     /// character, or the skill not in the active character's known set). Consumed
-    /// by <see cref="BuildSkillTree"/> after each rebuild.
+    /// by <see cref="BuildSkillNodes"/> after each rebuild.
     /// </summary>
     private string? _pendingDeepLinkSkill;
 
@@ -316,7 +316,7 @@ public sealed partial class SkillAdvisorViewModel
         if (string.IsNullOrEmpty(skillKey)) return;
 
         var active = _activeChar.ActiveCharacter;
-        var leafKeys = CollectLeafKeys(SkillTreeRoots);
+        var leafKeys = SkillNodes.Select(n => n.Key).ToHashSet(StringComparer.Ordinal);
         if (active is not null && leafKeys.Contains(skillKey))
         {
             _pendingDeepLinkSkill = null;
@@ -324,7 +324,7 @@ public sealed partial class SkillAdvisorViewModel
             return;
         }
 
-        // Stash and apply after the next tree rebuild. Surface a status hint so
+        // Stash and apply after the next list rebuild. Surface a status hint so
         // the user knows we received the request even when we can't act on it yet.
         _pendingDeepLinkSkill = skillKey;
         if (active is null)
@@ -340,141 +340,54 @@ public sealed partial class SkillAdvisorViewModel
         }
     }
 
-    private void BuildSkillTree()
+    private void BuildSkillNodes()
     {
         var active = _activeChar.ActiveCharacter;
         if (active is null)
         {
-            SkillTreeRoots = [];
+            SkillNodes = [];
             SelectedSkill = null;
             return;
         }
 
-        // Leaf set: cookbook sections (SortSkill ?? RewardSkill) the character has the
-        // section's own skill for. Sections that aren't real character skills
-        // (e.g. Race_Fae) drop out — the engine can't advise on them.
-        var leafKeys = _engine.GetCookbookSections()
+        // Cookbook sections (SortSkill ?? RewardSkill) the character has the section's
+        // own skill for. Sections that aren't real character skills (e.g. Race_Fae)
+        // drop out — the engine can't advise on them. Sorted alphabetically by display
+        // name; flat list, no hierarchy (the picker organises by recipe filing, which
+        // is flat in the in-game cookbook).
+        var nodes = _engine.GetCookbookSections()
             .Where(k => active.Skills.ContainsKey(k))
-            .ToList();
-
-        // Build leaf nodes carrying the character's current level/XP.
-        var leaves = new List<SkillNode>(leafKeys.Count);
-        foreach (var key in leafKeys)
-        {
-            var displayName = _referenceData.Skills.TryGetValue(key, out var entry) ? entry.DisplayName : key;
-            var charSkill = active.Skills[key];
-            leaves.Add(new SkillNode(
-                Key: key,
-                DisplayName: displayName,
-                CurrentLevel: charSkill.Level,
-                CurrentXp: charSkill.XpTowardNextLevel,
-                XpNeededForNextLevel: charSkill.XpNeededForNextLevel,
-                IsHeaderOnly: false,
-                Children: []));
-        }
-
-        // Group leaves by their immediate parent (skills.json Parents[0]).
-        // A leaf with no parent → potential root. A leaf with a parent → goes into
-        // its parent's bucket; the parent will be materialized as a tree node below.
-        var leafByKey = leaves.ToDictionary(l => l.Key, StringComparer.Ordinal);
-        var parentBuckets = new Dictionary<string, List<SkillNode>>(StringComparer.Ordinal);
-        foreach (var leaf in leaves)
-        {
-            var parentKey = _referenceData.Skills.TryGetValue(leaf.Key, out var entry)
-                ? entry.Parents.FirstOrDefault()
-                : null;
-            if (string.IsNullOrEmpty(parentKey)) continue;
-            if (!parentBuckets.TryGetValue(parentKey, out var bucket))
+            .Select(k =>
             {
-                bucket = [];
-                parentBuckets[parentKey] = bucket;
-            }
-            bucket.Add(leaf);
-        }
-
-        // Build roots: every leaf with no parent. A leaf with a parent is nested
-        // either under a sibling-leaf (if its parent is in our set) or under a
-        // pure header node materialized below. If a root leaf has children of
-        // its own, attach them — produces ONE selectable node with nested
-        // children rather than duplicating the leaf alongside a separate header.
-        var rootsList = new List<SkillNode>();
-        foreach (var leaf in leaves)
-        {
-            var parentKey = _referenceData.Skills.TryGetValue(leaf.Key, out var entry)
-                ? entry.Parents.FirstOrDefault()
-                : null;
-            if (!string.IsNullOrEmpty(parentKey)) continue;
-            if (parentBuckets.TryGetValue(leaf.Key, out var ownChildren))
-            {
-                var sortedChildren = ownChildren
-                    .OrderBy(c => c.DisplayName, StringComparer.Ordinal)
-                    .ToList();
-                rootsList.Add(leaf with { Children = sortedChildren });
-            }
-            else
-            {
-                rootsList.Add(leaf);
-            }
-        }
-
-        // Pure header parents — referenced by children but not themselves a leaf
-        // (e.g. "Augmentation" when none of its child Augment* skills file recipes
-        // directly under Augmentation itself). Materialize as header-only nodes.
-        foreach (var (parentKey, children) in parentBuckets)
-        {
-            if (leafByKey.ContainsKey(parentKey)) continue;
-            var parentDisplay = _referenceData.Skills.TryGetValue(parentKey, out var pe) ? pe.DisplayName : parentKey;
-            var sortedChildren = children
-                .OrderBy(c => c.DisplayName, StringComparer.Ordinal)
-                .ToList();
-            rootsList.Add(new SkillNode(
-                Key: parentKey,
-                DisplayName: parentDisplay,
-                CurrentLevel: null,
-                CurrentXp: null,
-                XpNeededForNextLevel: null,
-                IsHeaderOnly: true,
-                Children: sortedChildren));
-        }
-
-        rootsList = rootsList
+                var displayName = _referenceData.Skills.TryGetValue(k, out var entry) ? entry.DisplayName : k;
+                var charSkill = active.Skills[k];
+                return new SkillNode(
+                    Key: k,
+                    DisplayName: displayName,
+                    CurrentLevel: charSkill.Level,
+                    CurrentXp: charSkill.XpTowardNextLevel,
+                    XpNeededForNextLevel: charSkill.XpNeededForNextLevel);
+            })
             .OrderBy(n => n.DisplayName, StringComparer.Ordinal)
             .ToList();
 
-        SkillTreeRoots = new ObservableCollection<SkillNode>(rootsList);
+        SkillNodes = new ObservableCollection<SkillNode>(nodes);
 
-        // Select: pending deep-link wins, then last-persisted skill, then first leaf.
-        var allLeafKeys = new HashSet<string>(leafKeys, StringComparer.Ordinal);
-        if (_pendingDeepLinkSkill is { } pending && allLeafKeys.Contains(pending))
+        // Select: pending deep-link wins, then last-persisted skill, then first node.
+        var allKeys = new HashSet<string>(nodes.Select(n => n.Key), StringComparer.Ordinal);
+        if (_pendingDeepLinkSkill is { } pending && allKeys.Contains(pending))
         {
             _pendingDeepLinkSkill = null;
             SelectedSkill = pending;
         }
-        else if (allLeafKeys.Contains(_settings.LastSkill ?? string.Empty))
+        else if (allKeys.Contains(_settings.LastSkill ?? string.Empty))
         {
             SelectedSkill = _settings.LastSkill;
         }
         else
         {
-            SelectedSkill = leafKeys.FirstOrDefault();
+            SelectedSkill = nodes.Select(n => n.Key).FirstOrDefault();
         }
-    }
-
-    private static HashSet<string> CollectLeafKeys(IEnumerable<SkillNode> nodes)
-    {
-        var set = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var node in nodes)
-        {
-            if (node.IsHeaderOnly)
-            {
-                foreach (var child in CollectLeafKeys(node.Children)) set.Add(child);
-            }
-            else
-            {
-                set.Add(node.Key);
-            }
-        }
-        return set;
     }
 
     private void UpdateSelectedSkillSummary(string? skillKey)
@@ -541,7 +454,7 @@ public sealed partial class SkillAdvisorViewModel
     {
         OnUiThread(() =>
         {
-            BuildSkillTree();
+            BuildSkillNodes();
             Reanalyze();
         });
     }
@@ -551,7 +464,7 @@ public sealed partial class SkillAdvisorViewModel
         if (key is not ("recipes" or "skills" or "xptables")) return;
         OnUiThread(() =>
         {
-            BuildSkillTree();
+            BuildSkillNodes();
             Reanalyze();
         });
     }

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -344,8 +344,10 @@ public sealed partial class SkillAdvisorViewModel
             return;
         }
 
-        // Leaf set: skills the engine knows recipes for AND the character has learned.
-        var leafKeys = _engine.GetSkillsWithRecipes()
+        // Leaf set: cookbook sections (SortSkill ?? RewardSkill) the character has the
+        // section's own skill for. Sections that aren't real character skills
+        // (e.g. Race_Fae) drop out — the engine can't advise on them.
+        var leafKeys = _engine.GetCookbookSections()
             .Where(k => active.Skills.ContainsKey(k))
             .ToList();
 

--- a/src/Elrond.Module/ViewModels/SkillNode.cs
+++ b/src/Elrond.Module/ViewModels/SkillNode.cs
@@ -1,19 +1,15 @@
 namespace Elrond.ViewModels;
 
 /// <summary>
-/// One node in the Elrond skill picker tree. Leaves carry the active character's
-/// level/XP for the skill; headers are non-selectable parents that exist purely
-/// to group their children (e.g. <c>Augmentation</c> grouping its four
-/// <c>*AugmentBrewing</c> children).
+/// One row in the Elrond skill picker — a craftable cookbook section the active
+/// character has the host skill for, with their current level/XP for that skill.
+/// The picker is flat: hierarchy from <c>skills.json</c> Parents isn't surfaced
+/// because the picker organises by recipe filing (<c>SortSkill</c>), which is
+/// flat in the in-game cookbook.
 /// </summary>
 public sealed record SkillNode(
     string Key,
     string DisplayName,
-    int? CurrentLevel,
-    long? CurrentXp,
-    long? XpNeededForNextLevel,
-    bool IsHeaderOnly,
-    IReadOnlyList<SkillNode> Children)
-{
-    public bool IsSelectable => !IsHeaderOnly;
-}
+    int CurrentLevel,
+    long CurrentXp,
+    long XpNeededForNextLevel);

--- a/src/Elrond.Module/ViewModels/SkillNode.cs
+++ b/src/Elrond.Module/ViewModels/SkillNode.cs
@@ -1,0 +1,19 @@
+namespace Elrond.ViewModels;
+
+/// <summary>
+/// One node in the Elrond skill picker tree. Leaves carry the active character's
+/// level/XP for the skill; headers are non-selectable parents that exist purely
+/// to group their children (e.g. <c>Augmentation</c> grouping its four
+/// <c>*AugmentBrewing</c> children).
+/// </summary>
+public sealed record SkillNode(
+    string Key,
+    string DisplayName,
+    int? CurrentLevel,
+    long? CurrentXp,
+    long? XpNeededForNextLevel,
+    bool IsHeaderOnly,
+    IReadOnlyList<SkillNode> Children)
+{
+    public bool IsSelectable => !IsHeaderOnly;
+}

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -39,7 +39,7 @@
                 <ColumnDefinition Width="{StaticResource RecipeColToLevel}"/>
             </Grid.ColumnDefinitions>
             <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="1" Text="{Binding RewardSkill}" HorizontalAlignment="Left" VerticalAlignment="Center"
+            <TextBlock Grid.Column="1" Text="{Binding RewardSkillDisplayName}" HorizontalAlignment="Left" VerticalAlignment="Center"
                        Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" TextTrimming="CharacterEllipsis"/>
             <TextBlock Grid.Column="2" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             <TextBlock Grid.Column="3" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
@@ -62,7 +62,7 @@
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{Binding RecipeName}" Foreground="{StaticResource TextPrimaryBrush}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
                     <Border Background="#33D4A847" CornerRadius="3" Padding="6,1" Margin="8,0,0,0" VerticalAlignment="Center">
-                        <TextBlock Text="{Binding RewardSkill}" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding RewardSkillDisplayName}" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                     </Border>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,3,0,0">

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -17,6 +17,7 @@
          in SkillAdvisorView. Keep these in sync; both Grids reference the same keys
          so the header always lines up with the rows below it. -->
     <GridLength x:Key="RecipeColRecipe">*</GridLength>
+    <GridLength x:Key="RecipeColReward">90</GridLength>
     <GridLength x:Key="RecipeColLvl">50</GridLength>
     <GridLength x:Key="RecipeColFirst">40</GridLength>
     <GridLength x:Key="RecipeColEffXp">80</GridLength>
@@ -29,6 +30,7 @@
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="{StaticResource RecipeColRecipe}"/>
+                <ColumnDefinition Width="{StaticResource RecipeColReward}"/>
                 <ColumnDefinition Width="{StaticResource RecipeColLvl}"/>
                 <ColumnDefinition Width="{StaticResource RecipeColFirst}"/>
                 <ColumnDefinition Width="{StaticResource RecipeColEffXp}"/>
@@ -37,12 +39,14 @@
                 <ColumnDefinition Width="{StaticResource RecipeColToLevel}"/>
             </Grid.ColumnDefinitions>
             <wpf:IconNameCell Grid.Column="0" IconId="{Binding IconId}" DisplayName="{Binding RecipeName}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="1" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="2" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="3" Text="{Binding EffectiveXp, StringFormat=N0}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="4" Text="{Binding Complexity, StringFormat=F1}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="5" Text="{Binding Efficiency, StringFormat=F1, TargetNullValue=—}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="6" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1" Text="{Binding RewardSkill}" HorizontalAlignment="Left" VerticalAlignment="Center"
+                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" TextTrimming="CharacterEllipsis"/>
+            <TextBlock Grid.Column="2" Text="{Binding LevelRequired}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="3" Text="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToCheck}}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" Text="{Binding EffectiveXp, StringFormat=N0}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="5" Text="{Binding Complexity, StringFormat=F1}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="6" Text="{Binding Efficiency, StringFormat=F1, TargetNullValue=—}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="7" Text="{Binding CompletionsToLevel, Converter={StaticResource NullableInt}}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
         </Grid>
     </DataTemplate>
 
@@ -55,7 +59,12 @@
                 <TextBlock Text="1st time" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeSmall}"/>
             </Border>
             <StackPanel VerticalAlignment="Center">
-                <TextBlock Text="{Binding RecipeName}" Foreground="{StaticResource TextPrimaryBrush}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{Binding RecipeName}" Foreground="{StaticResource TextPrimaryBrush}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                    <Border Background="#33D4A847" CornerRadius="3" Padding="6,1" Margin="8,0,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="{Binding RewardSkill}" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+                    </Border>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
                     <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
                         <Run Text="Lvl "/><Run Text="{Binding LevelRequired, Mode=OneWay}"/>

--- a/src/Elrond.Module/Views/Resources.xaml
+++ b/src/Elrond.Module/Views/Resources.xaml
@@ -50,7 +50,9 @@
         </Grid>
     </DataTemplate>
 
-    <!-- Recipe card template — bigger icon, stacked metadata pills, more breathing room. -->
+    <!-- Recipe card template — bigger icon, stacked metadata pills, more breathing room.
+         Right-side badges (1st-time, Rewards) dock on the right so they line up vertically
+         across cards regardless of recipe name length. -->
     <DataTemplate x:Key="RecipeCardTemplate">
         <DockPanel>
             <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}" Width="36" Height="36" Margin="0,0,12,0" VerticalAlignment="Center"/>
@@ -58,13 +60,11 @@
                     Visibility="{Binding FirstTimeBonusAvailable, Converter={StaticResource BoolToVisibility}}">
                 <TextBlock Text="1st time" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeSmall}"/>
             </Border>
+            <Border DockPanel.Dock="Right" Background="#33D4A847" CornerRadius="3" Padding="6,1" Margin="8,0,0,0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding RewardSkillDisplayName}" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
+            </Border>
             <StackPanel VerticalAlignment="Center">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding RecipeName}" Foreground="{StaticResource TextPrimaryBrush}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                    <Border Background="#33D4A847" CornerRadius="3" Padding="6,1" Margin="8,0,0,0" VerticalAlignment="Center">
-                        <TextBlock Text="{Binding RewardSkillDisplayName}" Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
-                    </Border>
-                </StackPanel>
+                <TextBlock Text="{Binding RecipeName}" Foreground="{StaticResource TextPrimaryBrush}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
                 <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
                     <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}">
                         <Run Text="Lvl "/><Run Text="{Binding LevelRequired, Mode=OneWay}"/>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -105,7 +105,11 @@
                             <icon:PackIconLucide DockPanel.Dock="Right" Kind="ChevronDown" VerticalAlignment="Center"
                                                  Width="14" Height="14" Foreground="{StaticResource TextSecondaryBrush}" Margin="8,0,0,0"/>
                             <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeXLarge}" Foreground="{StaticResource TextPrimaryBrush}">
-                                <Run Text="{Binding Analysis.SkillName, Mode=OneWay}"/>
+                                <!-- Bind to the display-name view-model property so the section
+                                     header shows the human "Weapon Augmentation", not the
+                                     id-shaped key "WeaponAugmentBrewing" that Analysis.SkillName
+                                     carries. -->
+                                <Run Text="{Binding SelectedSkillDisplayName, Mode=OneWay}"/>
                                 <Run Text=" Level "/>
                                 <Run Text="{Binding Analysis.CurrentLevel, Mode=OneWay}"/>
                             </TextBlock>
@@ -141,50 +145,63 @@
                                   SelectedItemChanged="OnSkillTreeSelectionChanged">
                             <TreeView.Resources>
                                 <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
-                                    <Border Padding="4,4">
-                                        <DockPanel LastChildFill="True">
-                                            <!-- Right side: compact level + XP for leaves; blank for headers. -->
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0"
-                                                        VerticalAlignment="Center"
-                                                        Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
-                                                <TextBlock Foreground="{StaticResource TextPrimaryBrush}"
-                                                           FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center"
-                                                           Width="46" TextAlignment="Right">
-                                                    <Run Text="Lv."/><Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
-                                                </TextBlock>
-                                                <Border Width="84" Height="8" Margin="8,0,8,0" VerticalAlignment="Center"
-                                                        Background="#FF333333" BorderBrush="{StaticResource BorderSubtleBrush}"
-                                                        BorderThickness="1" CornerRadius="2">
-                                                    <ProgressBar Foreground="{StaticResource AccentBrush}" Background="Transparent" BorderThickness="0"
-                                                                 Minimum="0"
-                                                                 Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
-                                                                 Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
-                                                </Border>
-                                                <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
-                                                           FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center"
-                                                           Width="98" TextAlignment="Right">
-                                                    <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/><Run Text=" / "/><Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
-                                                </TextBlock>
-                                            </StackPanel>
-                                            <!-- Left side: skill name. Headers get a muted, smaller treatment so they read as group labels. -->
-                                            <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
-                                                        <Setter Property="FontWeight" Value="Normal"/>
-                                                        <Setter Property="FontSize" Value="{DynamicResource AppFontSize}"/>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsHeaderOnly}" Value="True">
-                                                                <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
-                                                                <Setter Property="FontWeight" Value="SemiBold"/>
-                                                                <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </DockPanel>
-                                    </Border>
+                                    <!-- Column-aligned layout: skill name takes the variable-width slot,
+                                         level / bar / XP sit in fixed columns so the eye can scan
+                                         vertically across rows. Headers collapse the right-side columns. -->
+                                    <Grid Margin="0,1">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="46"/>
+                                            <ColumnDefinition Width="100"/>
+                                            <ColumnDefinition Width="110"/>
+                                        </Grid.ColumnDefinitions>
+                                        <!-- Skill name. Header rows render with smaller, all-caps treatment
+                                             plus a top margin to read as group labels. -->
+                                        <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
+                                                   VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
+                                                   Margin="0,2">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                                                    <Setter Property="FontWeight" Value="Normal"/>
+                                                    <Setter Property="FontSize" Value="{DynamicResource AppFontSize}"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsHeaderOnly}" Value="True">
+                                                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                                                            <Setter Property="FontWeight" Value="SemiBold"/>
+                                                            <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
+                                                            <Setter Property="Margin" Value="0,8,0,2"/>
+                                                            <Setter Property="Opacity" Value="0.85"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <TextBlock Grid.Column="1"
+                                                   Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
+                                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSize}"
+                                                   VerticalAlignment="Center" TextAlignment="Right" Margin="8,0,0,0">
+                                            <Run Text="Lv."/><Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
+                                        </TextBlock>
+                                        <Border Grid.Column="2" Width="84" Height="8" Margin="8,0,8,0"
+                                                VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                                                Background="#FF333333" BorderBrush="{StaticResource BorderSubtleBrush}"
+                                                BorderThickness="1" CornerRadius="2"
+                                                Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
+                                            <ProgressBar Foreground="{StaticResource AccentBrush}" Background="Transparent" BorderThickness="0"
+                                                         Minimum="0"
+                                                         Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                         Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                        </Border>
+                                        <TextBlock Grid.Column="3"
+                                                   Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
+                                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   VerticalAlignment="Center" TextAlignment="Right">
+                                            <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/><Run Text=" / "/><Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                        </TextBlock>
+                                    </Grid>
                                 </HierarchicalDataTemplate>
                             </TreeView.Resources>
                             <TreeView.ItemContainerStyle>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -108,26 +108,39 @@
                                 <!-- Bind to the display-name view-model property so the section
                                      header shows the human "Weapon Augmentation", not the
                                      id-shaped key "WeaponAugmentBrewing" that Analysis.SkillName
-                                     carries. -->
+                                     carries. SectionLevelText degrades to "—" for umbrella
+                                     sections (Phrenology, Anatomy) that aren't directly levelable. -->
                                 <Run Text="{Binding SelectedSkillDisplayName, Mode=OneWay}"/>
                                 <Run Text=" Level "/>
-                                <Run Text="{Binding Analysis.CurrentLevel, Mode=OneWay}"/>
+                                <Run Text="{Binding SectionLevelText, Mode=OneWay}"/>
                             </TextBlock>
                             <TextBlock DockPanel.Dock="Right" HorizontalAlignment="Right"
                                        Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">
-                                <Run Text="{Binding Analysis.CurrentXp, Mode=OneWay, StringFormat=N0}"/>
+                                <Run Text="{Binding SectionCurrentXpText, Mode=OneWay}"/>
                                 <Run Text=" / "/>
-                                <Run Text="{Binding Analysis.XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                <Run Text="{Binding SectionXpNeededText, Mode=OneWay}"/>
                                 <Run Text=" XP"/>
                             </TextBlock>
                         </DockPanel>
+                        <!-- Hide the progress bar for umbrella sections — there's nothing to show. -->
                         <ProgressBar Height="8"
                                      Minimum="0"
-                                     Maximum="{Binding Analysis.XpNeededForNextLevel, Mode=OneWay}"
-                                     Value="{Binding Analysis.CurrentXp, Mode=OneWay}"
-                                     Foreground="{StaticResource AccentBrush}" Background="#FF333333"/>
+                                     Maximum="{Binding Analysis.XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                     Value="{Binding Analysis.CurrentXp, Mode=OneWay, FallbackValue=0}"
+                                     Foreground="{StaticResource AccentBrush}" Background="#FF333333">
+                            <ProgressBar.Style>
+                                <Style TargetType="ProgressBar">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Analysis.IsUmbrellaSection}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ProgressBar.Style>
+                        </ProgressBar>
                         <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,4,0,0">
-                            <Run Text="{Binding Analysis.XpRemaining, Mode=OneWay, StringFormat=N0}"/>
+                            <Run Text="{Binding SectionXpRemainingText, Mode=OneWay}"/>
                             <Run Text=" XP remaining to "/>
                             <Run Text="{Binding Analysis.GoalLevel, Mode=OneWay, TargetNullValue='next level', StringFormat='level {0}'}"/>
                         </TextBlock>
@@ -349,8 +362,61 @@
                                               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                                               ShowsPreview="True"/>
 
-                                <!-- Detail pane -->
-                                <Border Grid.Column="2" Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
+                                <!-- Detail pane: a separate target-skill panel (Block A) sits above
+                                     the recipe detail (Block B). Block A only renders when the
+                                     selected recipe's RewardSkill differs from the section — for
+                                     fish-in-Cooking or any Phrenology recipe — surfacing "where
+                                     you stand on the skill this craft actually moves". -->
+                                <Grid Grid.Column="2">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <Border Grid.Row="0" Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
+                                            BorderThickness="1" CornerRadius="3" Padding="12" Margin="0,0,0,8"
+                                            DataContext="{Binding SelectedRecipe}">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding RewardSkillDiffersFromSection}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <StackPanel>
+                                            <TextBlock Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
+                                                       FontWeight="SemiBold" Margin="0,0,0,4">
+                                                <Run Text="Levels:"/>
+                                                <Run Text="{Binding RewardSkillDisplayName, Mode=OneWay}"
+                                                     Foreground="{StaticResource AccentBrush}"/>
+                                            </TextBlock>
+                                            <DockPanel Margin="0,0,0,6">
+                                                <TextBlock DockPanel.Dock="Right"
+                                                           Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSize}"
+                                                           VerticalAlignment="Center">
+                                                    <Run Text="{Binding RewardSkillCurrentXp, Mode=OneWay, StringFormat=N0}"/>
+                                                    <Run Text=" / "/>
+                                                    <Run Text="{Binding RewardSkillXpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                                    <Run Text=" XP"/>
+                                                </TextBlock>
+                                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}"
+                                                           FontSize="{DynamicResource AppFontSizeLarge}"
+                                                           Foreground="{StaticResource TextPrimaryBrush}">
+                                                    <Run Text="Lv. "/><Run Text="{Binding RewardSkillCurrentLevel, Mode=OneWay}"/>
+                                                </TextBlock>
+                                            </DockPanel>
+                                            <ProgressBar Height="6"
+                                                         Foreground="{StaticResource AccentBrush}" Background="#FF333333"
+                                                         BorderThickness="0"
+                                                         Minimum="0"
+                                                         Maximum="{Binding RewardSkillXpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                         Value="{Binding RewardSkillCurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                        </StackPanel>
+                                    </Border>
+                                <Border Grid.Row="1" Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
                                         BorderThickness="1" CornerRadius="3" Padding="12">
                                     <Grid>
                                         <!-- Empty inner state -->
@@ -474,6 +540,7 @@
                                         </ScrollViewer>
                                     </Grid>
                                 </Border>
+                                </Grid>
                             </Grid>
                         </DockPanel>
                     </TabItem>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -143,76 +143,65 @@
                             BorderBrush="{StaticResource AccentBrush}" BorderThickness="1"
                             CornerRadius="3" Padding="4"
                             Width="{Binding ActualWidth, ElementName=SkillPickerToggle}">
-                        <TreeView x:Name="SkillTreeView" MaxHeight="520"
-                                  Background="Transparent" BorderThickness="0"
-                                  ItemsSource="{Binding SkillTreeRoots}"
-                                  SelectedItemChanged="OnSkillTreeSelectionChanged">
-                            <TreeView.Resources>
-                                <!-- Override WPF default selection colours so the selected
-                                     TreeViewItem doesn't paint a white background that makes
-                                     our text unreadable. Scoped to this TreeView only. -->
+                        <ListBox x:Name="SkillListBox" MaxHeight="520"
+                                 Background="Transparent" BorderThickness="0"
+                                 ItemsSource="{Binding SkillNodes}"
+                                 SelectionChanged="OnSkillListSelectionChanged"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                            <ListBox.Resources>
+                                <!-- Override WPF default selection colours so the selected row
+                                     doesn't paint a white background that makes our text unreadable.
+                                     Scoped to this ListBox only. -->
                                 <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#33D4A847"/>
                                 <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="#FFFFFFFF"/>
                                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#22D4A847"/>
                                 <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="#FFFFFFFF"/>
                                 <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#22D4A847"/>
-
-                                <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
-                                    <!-- Mirrors the skill-summary panel's visual language 1:1: same
-                                         header font + size for the name+level line, same right-aligned
-                                         XP fraction, same 8 px progress bar, same "remaining" hint
-                                         beneath. Header-only rows collapse the leaf parts and render
-                                         as a smaller accent group label. -->
-                                    <StackPanel Margin="0,4">
-                                        <!-- Header (group label) — visible only when IsHeaderOnly. -->
-                                        <TextBlock Text="{Binding DisplayName}"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   Foreground="{StaticResource AccentBrush}"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   Visibility="{Binding IsHeaderOnly, Converter={StaticResource BoolToVisibility}}"/>
-                                        <!-- Leaf — visible when IsSelectable. Three rows mirroring the panel:
-                                             title + XP, progress bar, remaining hint. -->
-                                        <StackPanel Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
-                                            <DockPanel Margin="0,0,0,6">
-                                                <TextBlock DockPanel.Dock="Right"
-                                                           Foreground="{StaticResource TextSecondaryBrush}"
-                                                           FontSize="{DynamicResource AppFontSize}"
-                                                           VerticalAlignment="Center">
-                                                    <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/>
-                                                    <Run Text=" / "/>
-                                                    <Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
-                                                    <Run Text=" XP"/>
-                                                </TextBlock>
-                                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}"
-                                                           FontSize="{DynamicResource AppFontSizeXLarge}"
-                                                           Foreground="{StaticResource TextPrimaryBrush}"
-                                                           TextTrimming="CharacterEllipsis">
-                                                    <Run Text="{Binding DisplayName, Mode=OneWay}"/>
-                                                    <Run Text=" Level "/>
-                                                    <Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
-                                                </TextBlock>
-                                            </DockPanel>
-                                            <ProgressBar Height="8"
-                                                         Foreground="{StaticResource AccentBrush}" Background="#FF333333"
-                                                         BorderThickness="0"
-                                                         Minimum="0"
-                                                         Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
-                                                         Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
-                                        </StackPanel>
-                                    </StackPanel>
-                                </HierarchicalDataTemplate>
-                            </TreeView.Resources>
-                            <TreeView.ItemContainerStyle>
-                                <Style TargetType="TreeViewItem">
-                                    <Setter Property="IsExpanded" Value="True"/>
-                                    <!-- Stretch the row content to the full popup width so progress
-                                         bars span the row and the right-side XP text actually sits
-                                         on the right edge instead of butting against the level number. -->
+                            </ListBox.Resources>
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <!-- Stretch the row content to full popup width so progress
+                                         bars span the row and the right-side XP text actually
+                                         sits on the right edge. -->
                                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    <Setter Property="Padding" Value="6,4"/>
                                 </Style>
-                            </TreeView.ItemContainerStyle>
-                        </TreeView>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type vm:SkillNode}">
+                                    <!-- Each row mirrors the skill-summary panel's visual language 1:1:
+                                         same header font + size for the name+level line, same right-aligned
+                                         XP fraction, same 8 px progress bar. -->
+                                    <StackPanel>
+                                        <DockPanel Margin="0,0,0,6">
+                                            <TextBlock DockPanel.Dock="Right"
+                                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                                       FontSize="{DynamicResource AppFontSize}"
+                                                       VerticalAlignment="Center">
+                                                <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/>
+                                                <Run Text=" / "/>
+                                                <Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                                <Run Text=" XP"/>
+                                            </TextBlock>
+                                            <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}"
+                                                       FontSize="{DynamicResource AppFontSizeXLarge}"
+                                                       Foreground="{StaticResource TextPrimaryBrush}"
+                                                       TextTrimming="CharacterEllipsis">
+                                                <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                                <Run Text=" Level "/>
+                                                <Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
+                                            </TextBlock>
+                                        </DockPanel>
+                                        <ProgressBar Height="8"
+                                                     Foreground="{StaticResource AccentBrush}" Background="#FF333333"
+                                                     BorderThickness="0"
+                                                     Minimum="0"
+                                                     Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                     Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </Border>
                 </Popup>
 

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -136,72 +136,66 @@
                 <Popup x:Name="SkillPickerPopup" DockPanel.Dock="Top"
                        PlacementTarget="{Binding ElementName=SkillPickerToggle}"
                        Placement="Bottom" StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade">
+                    <!-- Border width binds to the toggle's actual width so the popup spans the
+                         same horizontal extent as the panel above it; rows then get the same
+                         room as the summary header to read in the same visual language. -->
                     <Border Background="{StaticResource BgSurfaceBrush}"
                             BorderBrush="{StaticResource AccentBrush}" BorderThickness="1"
-                            CornerRadius="3" Padding="4">
-                        <TreeView x:Name="SkillTreeView" Width="460" MaxHeight="520"
+                            CornerRadius="3" Padding="4"
+                            Width="{Binding ActualWidth, ElementName=SkillPickerToggle}">
+                        <TreeView x:Name="SkillTreeView" MaxHeight="520"
                                   Background="Transparent" BorderThickness="0"
                                   ItemsSource="{Binding SkillTreeRoots}"
                                   SelectedItemChanged="OnSkillTreeSelectionChanged">
                             <TreeView.Resources>
+                                <!-- Override WPF default selection colours so the selected
+                                     TreeViewItem doesn't paint a white background that makes
+                                     our text unreadable. Scoped to this TreeView only. -->
+                                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#33D4A847"/>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="#FFFFFFFF"/>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#22D4A847"/>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="#FFFFFFFF"/>
+                                <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#22D4A847"/>
+
                                 <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
-                                    <!-- Column-aligned layout: skill name takes the variable-width slot,
-                                         level / bar / XP sit in fixed columns so the eye can scan
-                                         vertically across rows. Headers collapse the right-side columns. -->
-                                    <Grid Margin="0,1">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="46"/>
-                                            <ColumnDefinition Width="100"/>
-                                            <ColumnDefinition Width="110"/>
-                                        </Grid.ColumnDefinitions>
-                                        <!-- Skill name. Header rows render with smaller, all-caps treatment
-                                             plus a top margin to read as group labels. -->
-                                        <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
-                                                   VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
-                                                   Margin="0,2">
-                                            <TextBlock.Style>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
-                                                    <Setter Property="FontWeight" Value="Normal"/>
-                                                    <Setter Property="FontSize" Value="{DynamicResource AppFontSize}"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsHeaderOnly}" Value="True">
-                                                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
-                                                            <Setter Property="FontWeight" Value="SemiBold"/>
-                                                            <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
-                                                            <Setter Property="Margin" Value="0,8,0,2"/>
-                                                            <Setter Property="Opacity" Value="0.85"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBlock.Style>
-                                        </TextBlock>
-                                        <TextBlock Grid.Column="1"
-                                                   Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
-                                                   Foreground="{StaticResource TextPrimaryBrush}"
-                                                   FontSize="{DynamicResource AppFontSize}"
-                                                   VerticalAlignment="Center" TextAlignment="Right" Margin="8,0,0,0">
-                                            <Run Text="Lv."/><Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
-                                        </TextBlock>
-                                        <Border Grid.Column="2" Width="84" Height="8" Margin="8,0,8,0"
-                                                VerticalAlignment="Center" HorizontalAlignment="Stretch"
-                                                Background="#FF333333" BorderBrush="{StaticResource BorderSubtleBrush}"
-                                                BorderThickness="1" CornerRadius="2"
-                                                Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
-                                            <ProgressBar Foreground="{StaticResource AccentBrush}" Background="Transparent" BorderThickness="0"
-                                                         Minimum="0"
-                                                         Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
-                                                         Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
-                                        </Border>
-                                        <TextBlock Grid.Column="3"
-                                                   Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
-                                                   Foreground="{StaticResource TextSecondaryBrush}"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   VerticalAlignment="Center" TextAlignment="Right">
-                                            <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/><Run Text=" / "/><Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
-                                        </TextBlock>
-                                    </Grid>
+                                    <!-- Each row mirrors the skill-summary panel's visual language:
+                                         display name + level (header font) on the left, XP fraction on
+                                         the right, full-width progress bar beneath. Header-only rows
+                                         collapse the level/XP/bar and render as accent group labels. -->
+                                    <StackPanel Margin="2,3">
+                                        <DockPanel Margin="0,0,0,4">
+                                            <TextBlock DockPanel.Dock="Right"
+                                                       Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
+                                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                                       VerticalAlignment="Center">
+                                                <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/><Run Text=" / "/><Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                                <Run Text=" XP"/>
+                                            </TextBlock>
+                                            <!-- Leaf row: bold display name + "Level N" suffix in muted secondary -->
+                                            <TextBlock TextTrimming="CharacterEllipsis"
+                                                       Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
+                                                       FontFamily="{DynamicResource AppHeaderFontFamily}"
+                                                       FontSize="{DynamicResource AppFontSizeMedium}">
+                                                <Run Text="{Binding DisplayName, Mode=OneWay}" Foreground="{StaticResource TextPrimaryBrush}"/><Run Text=" Level " Foreground="{StaticResource TextSecondaryBrush}"/><Run Text="{Binding CurrentLevel, Mode=OneWay}" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                            </TextBlock>
+                                            <!-- Header row: section name only, smaller + accent -->
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       Foreground="{StaticResource AccentBrush}"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                                       Margin="0,4,0,0"
+                                                       Visibility="{Binding IsHeaderOnly, Converter={StaticResource BoolToVisibility}}"/>
+                                        </DockPanel>
+                                        <ProgressBar Height="6"
+                                                     Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
+                                                     Foreground="{StaticResource AccentBrush}" Background="#FF333333"
+                                                     BorderThickness="0"
+                                                     Minimum="0"
+                                                     Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                     Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                    </StackPanel>
                                 </HierarchicalDataTemplate>
                             </TreeView.Resources>
                             <TreeView.ItemContainerStyle>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -158,49 +158,58 @@
                                 <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#22D4A847"/>
 
                                 <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
-                                    <!-- Each row mirrors the skill-summary panel's visual language:
-                                         display name + level (header font) on the left, XP fraction on
-                                         the right, full-width progress bar beneath. Header-only rows
-                                         collapse the level/XP/bar and render as accent group labels. -->
-                                    <StackPanel Margin="2,3">
-                                        <DockPanel Margin="0,0,0,4">
-                                            <TextBlock DockPanel.Dock="Right"
-                                                       Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
-                                                       Foreground="{StaticResource TextSecondaryBrush}"
-                                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                                       VerticalAlignment="Center">
-                                                <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/><Run Text=" / "/><Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
-                                                <Run Text=" XP"/>
-                                            </TextBlock>
-                                            <!-- Leaf row: bold display name + "Level N" suffix in muted secondary -->
-                                            <TextBlock TextTrimming="CharacterEllipsis"
-                                                       Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
-                                                       FontFamily="{DynamicResource AppHeaderFontFamily}"
-                                                       FontSize="{DynamicResource AppFontSizeMedium}">
-                                                <Run Text="{Binding DisplayName, Mode=OneWay}" Foreground="{StaticResource TextPrimaryBrush}"/><Run Text=" Level " Foreground="{StaticResource TextSecondaryBrush}"/><Run Text="{Binding CurrentLevel, Mode=OneWay}" Foreground="{StaticResource TextSecondaryBrush}"/>
-                                            </TextBlock>
-                                            <!-- Header row: section name only, smaller + accent -->
-                                            <TextBlock Text="{Binding DisplayName}"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       Foreground="{StaticResource AccentBrush}"
-                                                       FontWeight="SemiBold"
-                                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                                       Margin="0,4,0,0"
-                                                       Visibility="{Binding IsHeaderOnly, Converter={StaticResource BoolToVisibility}}"/>
-                                        </DockPanel>
-                                        <ProgressBar Height="6"
-                                                     Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}"
-                                                     Foreground="{StaticResource AccentBrush}" Background="#FF333333"
-                                                     BorderThickness="0"
-                                                     Minimum="0"
-                                                     Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
-                                                     Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                    <!-- Mirrors the skill-summary panel's visual language 1:1: same
+                                         header font + size for the name+level line, same right-aligned
+                                         XP fraction, same 8 px progress bar, same "remaining" hint
+                                         beneath. Header-only rows collapse the leaf parts and render
+                                         as a smaller accent group label. -->
+                                    <StackPanel Margin="0,4">
+                                        <!-- Header (group label) — visible only when IsHeaderOnly. -->
+                                        <TextBlock Text="{Binding DisplayName}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Foreground="{StaticResource AccentBrush}"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   Visibility="{Binding IsHeaderOnly, Converter={StaticResource BoolToVisibility}}"/>
+                                        <!-- Leaf — visible when IsSelectable. Three rows mirroring the panel:
+                                             title + XP, progress bar, remaining hint. -->
+                                        <StackPanel Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
+                                            <DockPanel Margin="0,0,0,6">
+                                                <TextBlock DockPanel.Dock="Right"
+                                                           Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSize}"
+                                                           VerticalAlignment="Center">
+                                                    <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/>
+                                                    <Run Text=" / "/>
+                                                    <Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                                    <Run Text=" XP"/>
+                                                </TextBlock>
+                                                <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}"
+                                                           FontSize="{DynamicResource AppFontSizeXLarge}"
+                                                           Foreground="{StaticResource TextPrimaryBrush}"
+                                                           TextTrimming="CharacterEllipsis">
+                                                    <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                                    <Run Text=" Level "/>
+                                                    <Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
+                                                </TextBlock>
+                                            </DockPanel>
+                                            <ProgressBar Height="8"
+                                                         Foreground="{StaticResource AccentBrush}" Background="#FF333333"
+                                                         BorderThickness="0"
+                                                         Minimum="0"
+                                                         Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                         Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                        </StackPanel>
                                     </StackPanel>
                                 </HierarchicalDataTemplate>
                             </TreeView.Resources>
                             <TreeView.ItemContainerStyle>
                                 <Style TargetType="TreeViewItem">
                                     <Setter Property="IsExpanded" Value="True"/>
+                                    <!-- Stretch the row content to the full popup width so progress
+                                         bars span the row and the right-side XP text actually sits
+                                         on the right edge instead of butting against the level number. -->
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                                 </Style>
                             </TreeView.ItemContainerStyle>
                         </TreeView>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -44,9 +44,79 @@
 
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Skill:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <ComboBox Width="180"
-                          ItemsSource="{Binding AvailableSkills}"
-                          SelectedItem="{Binding SelectedSkill}"/>
+                <ToggleButton x:Name="SkillPickerToggle"
+                              Width="280" Padding="10,4" HorizontalContentAlignment="Stretch"
+                              IsChecked="{Binding ElementName=SkillPickerPopup, Path=IsOpen, Mode=TwoWay}">
+                    <DockPanel LastChildFill="True">
+                        <icon:PackIconLucide DockPanel.Dock="Right" Kind="ChevronDown"
+                                             Width="12" Height="12" VerticalAlignment="Center" Margin="6,0,0,0"
+                                             Foreground="{StaticResource TextSecondaryBrush}"/>
+                        <TextBlock VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
+                            <Run Text="{Binding SelectedSkillDisplayName, Mode=OneWay, FallbackValue='Select skill...', TargetNullValue='Select skill...'}"
+                                 Foreground="{StaticResource TextPrimaryBrush}"/><Run Text=" "/><Run
+                                 Text="{Binding SelectedSkillLevel, Mode=OneWay, StringFormat='Lv. {0}', TargetNullValue=''}"
+                                 Foreground="{StaticResource TextSecondaryBrush}"/>
+                        </TextBlock>
+                    </DockPanel>
+                </ToggleButton>
+                <Popup x:Name="SkillPickerPopup"
+                       PlacementTarget="{Binding ElementName=SkillPickerToggle}"
+                       Placement="Bottom" StaysOpen="False" AllowsTransparency="True"
+                       PopupAnimation="Fade">
+                    <Border Background="{StaticResource BgSurfaceBrush}"
+                            BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
+                            CornerRadius="3" Padding="4">
+                        <TreeView x:Name="SkillTreeView" Width="360" MaxHeight="500"
+                                  Background="Transparent" BorderThickness="0"
+                                  ItemsSource="{Binding SkillTreeRoots}"
+                                  SelectedItemChanged="OnSkillTreeSelectionChanged">
+                            <TreeView.Resources>
+                                <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
+                                    <Border Padding="6,3">
+                                        <DockPanel LastChildFill="True">
+                                            <!-- Right side: compact level + XP for leaves; blank for headers -->
+                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0"
+                                                        VerticalAlignment="Center"
+                                                        Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
+                                                <TextBlock Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
+                                                           VerticalAlignment="Center">
+                                                    <Run Text="Lv."/><Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
+                                                </TextBlock>
+                                                <Border Width="60" Height="6" Margin="6,0,0,0" VerticalAlignment="Center"
+                                                        Background="#FF333333" CornerRadius="2">
+                                                    <ProgressBar Foreground="{StaticResource AccentBrush}" Background="Transparent" BorderThickness="0"
+                                                                 Minimum="0"
+                                                                 Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                                 Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                                </Border>
+                                            </StackPanel>
+                                            <!-- Left side: skill name. Headers get a muted treatment to read as group labels. -->
+                                            <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                                                        <Setter Property="FontWeight" Value="Normal"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsHeaderOnly}" Value="True">
+                                                                <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+                                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </DockPanel>
+                                    </Border>
+                                </HierarchicalDataTemplate>
+                            </TreeView.Resources>
+                            <TreeView.ItemContainerStyle>
+                                <Style TargetType="TreeViewItem">
+                                    <Setter Property="IsExpanded" Value="True"/>
+                                </Style>
+                            </TreeView.ItemContainerStyle>
+                        </TreeView>
+                    </Border>
+                </Popup>
             </StackPanel>
         </DockPanel>
 

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -31,9 +31,11 @@
             </StackPanel>
         </DockPanel>
 
-        <!-- Top control strip: refresh + skill picker (shared by both tabs) -->
+        <!-- Top control strip: just the Refresh button now. The skill picker
+             lives on the skill-summary panel below — clicking the panel opens
+             the tree popup. -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10">
-            <Button DockPanel.Dock="Right" Padding="10,4" Margin="8,0,0,0"
+            <Button DockPanel.Dock="Right" Padding="10,4"
                     Command="{Binding RefreshCharacterDataCommand}"
                     ToolTip="Re-scan the Reports folder for new character exports">
                 <StackPanel Orientation="Horizontal">
@@ -41,83 +43,7 @@
                     <TextBlock Text="Refresh" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
-
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Skill:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <ToggleButton x:Name="SkillPickerToggle"
-                              Width="280" Padding="10,4" HorizontalContentAlignment="Stretch"
-                              IsChecked="{Binding ElementName=SkillPickerPopup, Path=IsOpen, Mode=TwoWay}">
-                    <DockPanel LastChildFill="True">
-                        <icon:PackIconLucide DockPanel.Dock="Right" Kind="ChevronDown"
-                                             Width="12" Height="12" VerticalAlignment="Center" Margin="6,0,0,0"
-                                             Foreground="{StaticResource TextSecondaryBrush}"/>
-                        <TextBlock VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
-                            <Run Text="{Binding SelectedSkillDisplayName, Mode=OneWay, FallbackValue='Select skill...', TargetNullValue='Select skill...'}"
-                                 Foreground="{StaticResource TextPrimaryBrush}"/><Run Text=" "/><Run
-                                 Text="{Binding SelectedSkillLevel, Mode=OneWay, StringFormat='Lv. {0}', TargetNullValue=''}"
-                                 Foreground="{StaticResource TextSecondaryBrush}"/>
-                        </TextBlock>
-                    </DockPanel>
-                </ToggleButton>
-                <Popup x:Name="SkillPickerPopup"
-                       PlacementTarget="{Binding ElementName=SkillPickerToggle}"
-                       Placement="Bottom" StaysOpen="False" AllowsTransparency="True"
-                       PopupAnimation="Fade">
-                    <Border Background="{StaticResource BgSurfaceBrush}"
-                            BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
-                            CornerRadius="3" Padding="4">
-                        <TreeView x:Name="SkillTreeView" Width="360" MaxHeight="500"
-                                  Background="Transparent" BorderThickness="0"
-                                  ItemsSource="{Binding SkillTreeRoots}"
-                                  SelectedItemChanged="OnSkillTreeSelectionChanged">
-                            <TreeView.Resources>
-                                <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
-                                    <Border Padding="6,3">
-                                        <DockPanel LastChildFill="True">
-                                            <!-- Right side: compact level + XP for leaves; blank for headers -->
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0"
-                                                        VerticalAlignment="Center"
-                                                        Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
-                                                <TextBlock Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSizeHint}"
-                                                           VerticalAlignment="Center">
-                                                    <Run Text="Lv."/><Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
-                                                </TextBlock>
-                                                <Border Width="60" Height="6" Margin="6,0,0,0" VerticalAlignment="Center"
-                                                        Background="#FF333333" CornerRadius="2">
-                                                    <ProgressBar Foreground="{StaticResource AccentBrush}" Background="Transparent" BorderThickness="0"
-                                                                 Minimum="0"
-                                                                 Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
-                                                                 Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
-                                                </Border>
-                                            </StackPanel>
-                                            <!-- Left side: skill name. Headers get a muted treatment to read as group labels. -->
-                                            <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
-                                                        <Setter Property="FontWeight" Value="Normal"/>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsHeaderOnly}" Value="True">
-                                                                <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
-                                                                <Setter Property="FontWeight" Value="SemiBold"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </DockPanel>
-                                    </Border>
-                                </HierarchicalDataTemplate>
-                            </TreeView.Resources>
-                            <TreeView.ItemContainerStyle>
-                                <Style TargetType="TreeViewItem">
-                                    <Setter Property="IsExpanded" Value="True"/>
-                                </Style>
-                            </TreeView.ItemContainerStyle>
-                        </TreeView>
-                    </Border>
-                </Popup>
-            </StackPanel>
+            <Grid/>
         </DockPanel>
 
         <!-- Status bar -->
@@ -150,11 +76,34 @@
 
             <!-- Analysis content -->
             <DockPanel Visibility="{Binding Analysis, Converter={x:Static vm:NullToVisConverter.Instance}}">
-                <!-- Skill summary panel (shared by both tabs) -->
-                <Border DockPanel.Dock="Top" Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
-                        BorderThickness="1" Padding="12" CornerRadius="3" Margin="0,0,0,10">
+                <!-- Skill summary panel doubles as the picker trigger: clicking it
+                     opens the tree popup. The chevron + hover affordance hint at
+                     the click target. -->
+                <ToggleButton x:Name="SkillPickerToggle" DockPanel.Dock="Top" Margin="0,0,0,10"
+                              Cursor="Hand" Padding="0" HorizontalContentAlignment="Stretch"
+                              IsChecked="{Binding ElementName=SkillPickerPopup, Path=IsOpen, Mode=TwoWay}">
+                    <ToggleButton.Template>
+                        <ControlTemplate TargetType="ToggleButton">
+                            <Border x:Name="OuterBorder"
+                                    Background="{StaticResource BgSurfaceBrush}"
+                                    BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
+                                    Padding="12" CornerRadius="3">
+                                <ContentPresenter HorizontalAlignment="Stretch"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                </Trigger>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="OuterBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </ToggleButton.Template>
                     <StackPanel>
                         <DockPanel Margin="0,0,0,6">
+                            <icon:PackIconLucide DockPanel.Dock="Right" Kind="ChevronDown" VerticalAlignment="Center"
+                                                 Width="14" Height="14" Foreground="{StaticResource TextSecondaryBrush}" Margin="8,0,0,0"/>
                             <TextBlock FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeXLarge}" Foreground="{StaticResource TextPrimaryBrush}">
                                 <Run Text="{Binding Analysis.SkillName, Mode=OneWay}"/>
                                 <Run Text=" Level "/>
@@ -179,7 +128,73 @@
                             <Run Text="{Binding Analysis.GoalLevel, Mode=OneWay, TargetNullValue='next level', StringFormat='level {0}'}"/>
                         </TextBlock>
                     </StackPanel>
-                </Border>
+                </ToggleButton>
+                <Popup x:Name="SkillPickerPopup" DockPanel.Dock="Top"
+                       PlacementTarget="{Binding ElementName=SkillPickerToggle}"
+                       Placement="Bottom" StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade">
+                    <Border Background="{StaticResource BgSurfaceBrush}"
+                            BorderBrush="{StaticResource AccentBrush}" BorderThickness="1"
+                            CornerRadius="3" Padding="4">
+                        <TreeView x:Name="SkillTreeView" Width="460" MaxHeight="520"
+                                  Background="Transparent" BorderThickness="0"
+                                  ItemsSource="{Binding SkillTreeRoots}"
+                                  SelectedItemChanged="OnSkillTreeSelectionChanged">
+                            <TreeView.Resources>
+                                <HierarchicalDataTemplate DataType="{x:Type vm:SkillNode}" ItemsSource="{Binding Children}">
+                                    <Border Padding="4,4">
+                                        <DockPanel LastChildFill="True">
+                                            <!-- Right side: compact level + XP for leaves; blank for headers. -->
+                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="12,0,0,0"
+                                                        VerticalAlignment="Center"
+                                                        Visibility="{Binding IsSelectable, Converter={StaticResource BoolToVisibility}}">
+                                                <TextBlock Foreground="{StaticResource TextPrimaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center"
+                                                           Width="46" TextAlignment="Right">
+                                                    <Run Text="Lv."/><Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
+                                                </TextBlock>
+                                                <Border Width="84" Height="8" Margin="8,0,8,0" VerticalAlignment="Center"
+                                                        Background="#FF333333" BorderBrush="{StaticResource BorderSubtleBrush}"
+                                                        BorderThickness="1" CornerRadius="2">
+                                                    <ProgressBar Foreground="{StaticResource AccentBrush}" Background="Transparent" BorderThickness="0"
+                                                                 Minimum="0"
+                                                                 Maximum="{Binding XpNeededForNextLevel, Mode=OneWay, FallbackValue=1}"
+                                                                 Value="{Binding CurrentXp, Mode=OneWay, FallbackValue=0}"/>
+                                                </Border>
+                                                <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center"
+                                                           Width="98" TextAlignment="Right">
+                                                    <Run Text="{Binding CurrentXp, Mode=OneWay, StringFormat=N0}"/><Run Text=" / "/><Run Text="{Binding XpNeededForNextLevel, Mode=OneWay, StringFormat=N0}"/>
+                                                </TextBlock>
+                                            </StackPanel>
+                                            <!-- Left side: skill name. Headers get a muted, smaller treatment so they read as group labels. -->
+                                            <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                                                        <Setter Property="FontWeight" Value="Normal"/>
+                                                        <Setter Property="FontSize" Value="{DynamicResource AppFontSize}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsHeaderOnly}" Value="True">
+                                                                <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
+                                                                <Setter Property="FontWeight" Value="SemiBold"/>
+                                                                <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </DockPanel>
+                                    </Border>
+                                </HierarchicalDataTemplate>
+                            </TreeView.Resources>
+                            <TreeView.ItemContainerStyle>
+                                <Style TargetType="TreeViewItem">
+                                    <Setter Property="IsExpanded" Value="True"/>
+                                </Style>
+                            </TreeView.ItemContainerStyle>
+                        </TreeView>
+                    </Border>
+                </Popup>
 
                 <TabControl Background="Transparent" BorderThickness="0" Padding="0"
                             ItemContainerStyle="{StaticResource MithrilTabItemStyle}">
@@ -246,6 +261,7 @@
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="{StaticResource RecipeColRecipe}"/>
+                                                <ColumnDefinition Width="{StaticResource RecipeColReward}"/>
                                                 <ColumnDefinition Width="{StaticResource RecipeColLvl}"/>
                                                 <ColumnDefinition Width="{StaticResource RecipeColFirst}"/>
                                                 <ColumnDefinition Width="{StaticResource RecipeColEffXp}"/>
@@ -255,19 +271,22 @@
                                             </Grid.ColumnDefinitions>
                                             <TextBlock Grid.Column="0" Text="Recipe"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
-                                            <TextBlock Grid.Column="1" Text="Lvl" HorizontalAlignment="Center"
+                                            <TextBlock Grid.Column="1" Text="Rewards"
+                                                       Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"
+                                                       ToolTip="The skill that earns XP when this recipe is crafted (may differ from the cookbook section)"/>
+                                            <TextBlock Grid.Column="2" Text="Lvl" HorizontalAlignment="Center"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
-                                            <TextBlock Grid.Column="2" Text="1st?" HorizontalAlignment="Center"
+                                            <TextBlock Grid.Column="3" Text="1st?" HorizontalAlignment="Center"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
-                                            <TextBlock Grid.Column="3" Text="Eff. XP" HorizontalAlignment="Right"
+                                            <TextBlock Grid.Column="4" Text="Eff. XP" HorizontalAlignment="Right"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
-                                            <TextBlock Grid.Column="4" Text="Cmplx" HorizontalAlignment="Right"
+                                            <TextBlock Grid.Column="5" Text="Cmplx" HorizontalAlignment="Right"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"
                                                        ToolTip="Expected items consumed per craft (chance-weighted)"/>
-                                            <TextBlock Grid.Column="5" Text="XP/Item" HorizontalAlignment="Right"
+                                            <TextBlock Grid.Column="6" Text="XP/Item" HorizontalAlignment="Right"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"
                                                        ToolTip="Effective XP ÷ Complexity — higher is better"/>
-                                            <TextBlock Grid.Column="6" Text="To Level" HorizontalAlignment="Right"
+                                            <TextBlock Grid.Column="7" Text="To Level" HorizontalAlignment="Right"
                                                        Foreground="{StaticResource TextTertiaryBrush}" FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"/>
                                         </Grid>
                                     </Border>

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using Elrond.ViewModels;
 
 namespace Elrond.Views;
 
@@ -18,5 +19,21 @@ public partial class SkillAdvisorView : UserControl
     private void OnOpenFilterPopup(object sender, RoutedEventArgs e)
     {
         FilterPopup.IsOpen = !FilterPopup.IsOpen;
+    }
+
+    /// <summary>
+    /// TreeView.SelectedItem is read-only so we can't two-way bind it to the
+    /// view-model. Forward leaf selections into <see cref="SkillAdvisorViewModel.SelectedSkill"/>
+    /// and dismiss the popup; header-only picks are ignored (the user is still
+    /// expected to expand and pick a leaf).
+    /// </summary>
+    private void OnSkillTreeSelectionChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+    {
+        if (DataContext is not SkillAdvisorViewModel vm) return;
+        if (e.NewValue is not SkillNode node) return;
+        if (node.IsHeaderOnly) return;
+
+        vm.SelectedSkill = node.Key;
+        SkillPickerPopup.IsOpen = false;
     }
 }

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml.cs
@@ -22,16 +22,15 @@ public partial class SkillAdvisorView : UserControl
     }
 
     /// <summary>
-    /// TreeView.SelectedItem is read-only so we can't two-way bind it to the
-    /// view-model. Forward leaf selections into <see cref="SkillAdvisorViewModel.SelectedSkill"/>
-    /// and dismiss the popup; header-only picks are ignored (the user is still
-    /// expected to expand and pick a leaf).
+    /// Forward ListBox selection into the view-model's SelectedSkill (which is the
+    /// id-shaped key, not the SkillNode), then dismiss the popup. Forwarding via
+    /// code-behind avoids the ListBox-vs-string two-way-binding mismatch.
     /// </summary>
-    private void OnSkillTreeSelectionChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+    private void OnSkillListSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (DataContext is not SkillAdvisorViewModel vm) return;
-        if (e.NewValue is not SkillNode node) return;
-        if (node.IsHeaderOnly) return;
+        if (e.AddedItems.Count == 0) return;
+        if (e.AddedItems[0] is not SkillNode node) return;
 
         vm.SelectedSkill = node.Key;
         SkillPickerPopup.IsOpen = false;

--- a/src/Mithril.Shared/Modules/DeepLinkRouter.cs
+++ b/src/Mithril.Shared/Modules/DeepLinkRouter.cs
@@ -14,6 +14,8 @@ namespace Mithril.Shared.Modules;
 ///         <see cref="IPippinShareImportTarget"/> (Pippin shared progress).</item>
 ///   <item><c>mithril://legolas/&lt;base64url&gt;</c> — hands the payload to
 ///         <see cref="ILegolasShareImportTarget"/> (Legolas survey report).</item>
+///   <item><c>mithril://elrond/&lt;skillKey&gt;</c> — hands the payload to
+///         <see cref="IElrondSkillImportTarget"/> (Elrond skill advisor).</item>
 /// </list>
 /// Each action defines its own payload grammar so item names stay strict while the craft-list
 /// payload can hold a much longer base64url blob. Unknown actions are logged and dropped.
@@ -39,6 +41,7 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
     private readonly ICraftListImportTarget? _listImport;
     private readonly IPippinShareImportTarget? _pippinImport;
     private readonly ILegolasShareImportTarget? _legolasImport;
+    private readonly IElrondSkillImportTarget? _elrondImport;
     private readonly IDiagnosticsSink? _diag;
 
     public DeepLinkRouter(
@@ -46,12 +49,14 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
         ICraftListImportTarget? listImport = null,
         IPippinShareImportTarget? pippinImport = null,
         ILegolasShareImportTarget? legolasImport = null,
+        IElrondSkillImportTarget? elrondImport = null,
         IDiagnosticsSink? diag = null)
     {
         _itemDetail = itemDetail;
         _listImport = listImport;
         _pippinImport = pippinImport;
         _legolasImport = legolasImport;
+        _elrondImport = elrondImport;
         _diag = diag;
     }
 
@@ -124,6 +129,23 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
                     return false;
                 }
                 _legolasImport.ImportFromLinkPayload(payload);
+                return true;
+
+            case "elrond":
+                // Skill keys are id-shaped (matches SkillEntry.Key, recipes' RewardSkill);
+                // reuse the strict item pattern. Hyphens/spaces are NOT permitted — the
+                // human-readable display name is never on the wire.
+                if (!ItemPayloadPattern.IsMatch(payload))
+                {
+                    _diag?.Info("DeepLink", $"Rejected: elrond payload '{payload}' failed validation.");
+                    return false;
+                }
+                if (_elrondImport is null)
+                {
+                    _diag?.Info("DeepLink", "Rejected: no elrond import target registered.");
+                    return false;
+                }
+                _elrondImport.ImportFromLinkPayload(payload);
                 return true;
 
             default:

--- a/src/Mithril.Shared/Modules/IElrondSkillImportTarget.cs
+++ b/src/Mithril.Shared/Modules/IElrondSkillImportTarget.cs
@@ -1,0 +1,19 @@
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Optional target that handles <c>mithril://elrond/&lt;skillKey&gt;</c> deep links.
+/// Implemented by Elrond to bring its tab to the foreground and pre-select the
+/// named skill in the advisor. The router treats it as optional — if no module
+/// has registered a handler, elrond links are logged and dropped.
+/// </summary>
+public interface IElrondSkillImportTarget
+{
+    /// <summary>
+    /// Activates Elrond and selects the named skill. <paramref name="skillKey"/>
+    /// is the skill internal id (e.g. <c>"Cheesemaking"</c>, <c>"ArmorAugmentBrewing"</c>),
+    /// matching <c>SkillEntry.Key</c> and recipes' <c>RewardSkill</c> field. All
+    /// errors are logged and swallowed — callers are OS activation handlers that
+    /// mustn't throw.
+    /// </summary>
+    void ImportFromLinkPayload(string skillKey);
+}

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -28,7 +28,9 @@ public interface IReferenceDataService
     /// <summary>InternalName → RecipeEntry lookup. Matches RecipeCompletions keys from character exports.</summary>
     IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; }
 
-    /// <summary>Skill name (e.g. "Meditation") → SkillEntry.</summary>
+    /// <summary>Skill key (e.g. "Meditation", "AncillaryArmorAugmentBrewing") → SkillEntry.
+    /// Keys are id-shaped (ASCII identifier-safe) and match recipes' RewardSkill field.
+    /// For the human-readable in-game name use <see cref="SkillEntry.DisplayName"/>.</summary>
     IReadOnlyDictionary<string, SkillEntry> Skills { get; }
 
     /// <summary>XP table InternalName (e.g. "TypicalNoncombatSkill") → XpTableEntry.</summary>

--- a/src/Mithril.Shared/Reference/RecipeEntry.cs
+++ b/src/Mithril.Shared/Reference/RecipeEntry.cs
@@ -3,6 +3,15 @@ namespace Mithril.Shared.Reference;
 /// <summary>
 /// Slim projection of one entry in recipes.json. Covers skill-leveling analysis:
 /// which skill earns XP, how much, and whether first-time bonuses apply.
+/// <para/>
+/// Three skill fields, distinct concerns:
+/// <list type="bullet">
+///   <item><see cref="Skill"/> — the skill required to use the recipe (paired with <see cref="SkillLevelReq"/>).</item>
+///   <item><see cref="RewardSkill"/> — the skill that earns XP when the recipe is crafted.</item>
+///   <item><see cref="SortSkill"/> — where the recipe is filed in the in-game cookbook UI; may differ
+///         from <see cref="RewardSkill"/> (e.g. fish-based food rewards Fishing XP but files under Cooking).
+///         Null when the recipe files under <see cref="RewardSkill"/>.</item>
+/// </list>
 /// </summary>
 public sealed record RecipeEntry(
     string Key,
@@ -21,4 +30,5 @@ public sealed record RecipeEntry(
     IReadOnlyList<RecipeItemRef> ResultItems,
     string? PrereqRecipe = null,
     IReadOnlyList<RecipeItemRef>? ProtoResultItems = null,
-    IReadOnlyList<string>? ResultEffects = null);
+    IReadOnlyList<string>? ResultEffects = null,
+    string? SortSkill = null);

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -534,11 +534,36 @@ public sealed class ReferenceDataService : IReferenceDataService
         var byName = new Dictionary<string, SkillEntry>(raw.Count, StringComparer.Ordinal);
         foreach (var (key, v) in raw)
         {
-            var entry = new SkillEntry(key, v.Id, v.Combat, v.XpTable ?? "", v.MaxBonusLevels);
+            var entry = new SkillEntry(
+                Key: key,
+                DisplayName: v.Name ?? key,
+                Id: v.Id,
+                Combat: v.Combat,
+                XpTable: v.XpTable ?? "",
+                MaxBonusLevels: v.MaxBonusLevels,
+                Parents: v.Parents?.ToArray() ?? [],
+                Rewards: ProjectSkillRewards(v.Rewards));
             byName[key] = entry;
         }
         _skills = byName;
         _skillsSnapshot = new ReferenceFileSnapshot("skills", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byName.Count);
+    }
+
+    private static IReadOnlyDictionary<string, SkillRewardEntry> ProjectSkillRewards(
+        IReadOnlyDictionary<string, Mithril.Reference.Models.Misc.SkillReward>? raw)
+    {
+        if (raw is null || raw.Count == 0)
+            return new Dictionary<string, SkillRewardEntry>(StringComparer.Ordinal);
+        var projected = new Dictionary<string, SkillRewardEntry>(raw.Count, StringComparer.Ordinal);
+        foreach (var (level, reward) in raw)
+        {
+            projected[level] = new SkillRewardEntry(
+                BonusToSkill: reward.BonusToSkill,
+                Ability: reward.Ability?.ToArray() ?? [],
+                Notes: reward.Notes,
+                Recipe: reward.Recipe);
+        }
+        return projected;
     }
 
     private void ParseAndSwapXpTables(IReadOnlyDictionary<string, PocoXpTable> raw, ReferenceFileMetadata meta)

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -511,7 +511,8 @@ public sealed class ReferenceDataService : IReferenceDataService
                 results,
                 v.PrereqRecipe,
                 protoResults,
-                resultEffects);
+                resultEffects,
+                SortSkill: v.SortSkill);
             byKey[key] = entry;
             if (!string.IsNullOrEmpty(entry.InternalName)) byName[entry.InternalName] = entry;
         }

--- a/src/Mithril.Shared/Reference/SkillEntry.cs
+++ b/src/Mithril.Shared/Reference/SkillEntry.cs
@@ -1,12 +1,21 @@
 namespace Mithril.Shared.Reference;
 
 /// <summary>
-/// Slim projection of one entry in skills.json. Links skill name to its XP table
-/// and combat/noncombat classification.
+/// Slim projection of one entry in skills.json. <see cref="Key"/> is the
+/// id-shaped dictionary key (e.g. <c>"AncillaryArmorAugmentBrewing"</c>) and
+/// matches recipes' <c>RewardSkill</c> field; it is guaranteed to be ASCII
+/// identifier-safe (matches <c>[A-Za-z0-9_]+</c>) and is the canonical id used
+/// for settings persistence and <c>mithril://elrond/{key}</c> deep links.
+/// <see cref="DisplayName"/> is the human-readable in-game name (e.g.
+/// <c>"Ancillary-Armor Augmentation"</c>) sourced from the JSON <c>Name</c>
+/// field; it may contain spaces and hyphens.
 /// </summary>
 public sealed record SkillEntry(
-    string Name,
+    string Key,
+    string DisplayName,
     int Id,
     bool Combat,
     string XpTable,
-    int MaxBonusLevels);
+    int MaxBonusLevels,
+    IReadOnlyList<string> Parents,
+    IReadOnlyDictionary<string, SkillRewardEntry> Rewards);

--- a/src/Mithril.Shared/Reference/SkillRewardEntry.cs
+++ b/src/Mithril.Shared/Reference/SkillRewardEntry.cs
@@ -1,0 +1,14 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// Slim projection of one entry inside a skill's per-level rewards map. Mirrors
+/// <c>Mithril.Reference.Models.Misc.SkillReward</c> at the Mithril.Shared boundary
+/// so consumers don't need a transitive reference to Mithril.Reference's POCOs.
+/// At least one of the fields is set per row; consumers should null-check the
+/// fields they care about.
+/// </summary>
+public sealed record SkillRewardEntry(
+    string? BonusToSkill,
+    IReadOnlyList<string> Ability,
+    string? Notes,
+    string? Recipe);

--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ public static class ShellServiceCollectionExtensions
                 sp.GetService<ICraftListImportTarget>(),
                 sp.GetService<IPippinShareImportTarget>(),
                 sp.GetService<ILegolasShareImportTarget>(),
+                sp.GetService<IElrondSkillImportTarget>(),
                 sp.GetService<IDiagnosticsSink>()));
 
     public static IServiceCollection AddMithrilIngredientSources(this IServiceCollection services) =>

--- a/tests/Elrond.Tests/LevelingSimulatorTests.cs
+++ b/tests/Elrond.Tests/LevelingSimulatorTests.cs
@@ -293,7 +293,10 @@ public class LevelingSimulatorTests
         }
 
         public void AddSkill(string name, int id, bool combat, string xpTable, int maxBonusLevels)
-            => _skills[name] = new SkillEntry(name, id, combat, xpTable, maxBonusLevels);
+            => _skills[name] = new SkillEntry(
+                Key: name, DisplayName: name, Id: id, Combat: combat, XpTable: xpTable,
+                MaxBonusLevels: maxBonusLevels, Parents: [],
+                Rewards: new Dictionary<string, SkillRewardEntry>());
 
         public void AddXpTable(string internalName, long[] xpAmounts)
             => _xpTables[internalName] = new XpTableEntry(internalName, xpAmounts);

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -172,7 +172,7 @@ public class SkillAdvisorEngineTests
     }
 
     [Fact]
-    public void GetSkillsWithRecipes_ReturnsOnlySkillsWithXpRecipes()
+    public void GetCookbookSections_ReturnsOnlySectionsWithXpRecipes()
     {
         var refData = new FakeRefData();
         refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 10, 40, null, null, null);
@@ -180,9 +180,62 @@ public class SkillAdvisorEngineTests
         refData.AddRecipe("recipe_3", "NoXp", "NoXp", "Alchemy", 1, "Alchemy", 0, 0, null, null, null);
 
         var engine = new SkillAdvisorEngine(refData);
-        var skills = engine.GetSkillsWithRecipes();
+        var sections = engine.GetCookbookSections();
 
-        skills.Should().BeEquivalentTo(["Cooking", "Meditation"]);
+        sections.Should().BeEquivalentTo(["Cooking", "Meditation"]);
+    }
+
+    [Fact]
+    public void GetCookbookSections_PrefersSortSkillOverRewardSkill()
+    {
+        // Fish-based food: rewards Fishing XP but files under Cooking in the in-game cookbook.
+        // GetCookbookSections should surface "Cooking" (the filing), not "Fishing" (the reward).
+        var refData = new FakeRefData();
+        refData.AddRecipe("recipe_stew", "Fish Stew", "FishStew", "Fishing", 30, "Fishing", 60, 240,
+            null, null, null, sortSkill: "Cooking");
+        refData.AddRecipe("recipe_bread", "Bread", "Bread", "Cooking", 1, "Cooking", 20, 80,
+            null, null, null);
+
+        var engine = new SkillAdvisorEngine(refData);
+        engine.GetCookbookSections().Should().BeEquivalentTo(["Cooking"],
+            because: "all recipes file under Cooking — the standalone Fishing recipe is filed there too via SortSkill");
+    }
+
+    [Fact]
+    public void Analyze_FishRecipeFiledUnderCooking_ReportsFishingXpAndCompletions()
+    {
+        // Cookbook view: Fish Stew is filed under Cooking, but its metrics use Fishing.
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", id: 1, combat: false, xpTable: "TestTable", maxBonusLevels: 0);
+        refData.AddSkill("Fishing", id: 2, combat: false, xpTable: "TestTable", maxBonusLevels: 0);
+        refData.AddXpTable("TestTable", [100L, 200L, 300L, 400L, 500L]);
+        refData.AddRecipe("recipe_stew", "Fish Stew", "FishStew", "Fishing", 1, "Fishing", 60, 240,
+            null, null, null, sortSkill: "Cooking");
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill>
+            {
+                ["Cooking"] = new(2, 0, 0, 200),
+                ["Fishing"] = new(3, 0, 50, 300),
+            },
+            recipes: new Dictionary<string, int>
+            {
+                ["FishStew"] = 0, // known but not yet crafted → first-time bonus available
+            });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Cooking", character)!;
+
+        analysis.SkillName.Should().Be("Cooking");
+        analysis.Recipes.Should().ContainSingle();
+        var stew = analysis.Recipes[0];
+        stew.RewardSkill.Should().Be("Fishing", because: "recipe row carries its own RewardSkill for the pill/column");
+        stew.EffectiveXp.Should().Be(60);
+        // Completions-to-level uses Fishing's xpRemaining (300 - 50 = 250), NOT Cooking's
+        // (200 - 0 = 200). One first-time craft delivers 240, a second craft at 60 XP
+        // closes the remaining 10 → 2 completions.
+        stew.CompletionsToLevel.Should().Be(2,
+            because: "completions-to-level uses the recipe's own RewardSkill (Fishing), not the section (Cooking)");
     }
 
     [Fact]
@@ -320,10 +373,12 @@ public class SkillAdvisorEngineTests
 
         public void AddRecipe(string key, string name, string internalName, string skill, int skillLevelReq,
             string rewardSkill, int rewardXp, int rewardXpFirstTime,
-            int? dropOffLevel, float? dropOffPct, int? dropOffRate, string? prereqRecipe = null)
+            int? dropOffLevel, float? dropOffPct, int? dropOffRate, string? prereqRecipe = null,
+            string? sortSkill = null)
         {
             var entry = new RecipeEntry(key, name, internalName, 0, skill, skillLevelReq,
-                rewardSkill, rewardXp, rewardXpFirstTime, dropOffLevel, dropOffPct, dropOffRate, [], [], prereqRecipe);
+                rewardSkill, rewardXp, rewardXpFirstTime, dropOffLevel, dropOffPct, dropOffRate, [], [],
+                prereqRecipe, ProtoResultItems: null, ResultEffects: null, SortSkill: sortSkill);
             _recipes[key] = entry;
             _recipesByName[internalName] = entry;
         }

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -202,6 +202,71 @@ public class SkillAdvisorEngineTests
     }
 
     [Fact]
+    public void Analyze_UmbrellaSection_FlagsAnalysisAsUmbrella()
+    {
+        // Phrenology is the canonical umbrella: XpTable="None", recipes file under it
+        // but reward per-race sub-skills. The view degrades the section header to "—"
+        // placeholders for level/XP/remaining when this flag is set.
+        var refData = new FakeRefData();
+        refData.AddSkill("Phrenology", id: 86, combat: false, xpTable: "None", maxBonusLevels: 125);
+        refData.AddSkill("Phrenology_Humans", id: 87, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
+        refData.AddXpTable("TypicalNoncombatSkill", [10L, 50L, 50L, 50L, 50L]);
+        refData.AddRecipe("recipe_phren_human", "Human Phrenology Research", "HumanPhrenologyResearch",
+            "Phrenology_Humans", 1, "Phrenology_Humans", 20, 100, null, null, null, sortSkill: "Phrenology");
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill>
+            {
+                ["Phrenology"] = new(0, 0, 0, 0),
+                ["Phrenology_Humans"] = new(2, 0, 10, 50),
+            },
+            recipes: new Dictionary<string, int>());
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Phrenology", character)!;
+
+        analysis.IsUmbrellaSection.Should().BeTrue(
+            because: "Phrenology has XpTable=None — the section can't be directly leveled");
+    }
+
+    [Fact]
+    public void Analyze_NormalSection_IsNotUmbrella()
+    {
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", id: 1, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
+        refData.AddXpTable("TypicalNoncombatSkill", [10L, 50L, 50L]);
+        refData.AddRecipe("recipe_bread", "Bread", "Bread", "Cooking", 1, "Cooking", 10, 40, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(2, 0, 0, 50) },
+            recipes: new Dictionary<string, int>());
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Cooking", character)!;
+
+        analysis.IsUmbrellaSection.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Analyze_RecipeRewardsSection_DiffersFromSectionFlagIsFalse()
+    {
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", id: 1, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
+        refData.AddXpTable("TypicalNoncombatSkill", [10L, 50L, 50L]);
+        refData.AddRecipe("recipe_bread", "Bread", "Bread", "Cooking", 1, "Cooking", 10, 40, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(2, 0, 0, 50) },
+            recipes: new Dictionary<string, int>());
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Cooking", character)!;
+
+        analysis.Recipes[0].RewardSkillDiffersFromSection.Should().BeFalse(
+            because: "Bread rewards Cooking and is filed in Cooking — no need for the target-skill panel");
+    }
+
+    [Fact]
     public void Analyze_FishRecipeFiledUnderCooking_ReportsFishingXpAndCompletions()
     {
         // Cookbook view: Fish Stew is filed under Cooking, but its metrics use Fishing.
@@ -230,6 +295,11 @@ public class SkillAdvisorEngineTests
         analysis.Recipes.Should().ContainSingle();
         var stew = analysis.Recipes[0];
         stew.RewardSkill.Should().Be("Fishing", because: "recipe row carries its own RewardSkill for the pill/column");
+        stew.RewardSkillDiffersFromSection.Should().BeTrue(
+            because: "Fish Stew rewards Fishing but files under Cooking — the target-skill panel should appear");
+        stew.RewardSkillCurrentLevel.Should().Be(3, because: "denormalised from the active character's Fishing level");
+        stew.RewardSkillCurrentXp.Should().Be(50);
+        stew.RewardSkillXpNeededForNextLevel.Should().Be(300);
         stew.EffectiveXp.Should().Be(60);
         // Completions-to-level uses Fishing's xpRemaining (300 - 50 = 250), NOT Cooking's
         // (200 - 0 = 200). One first-time craft delivers 240, a second craft at 60 XP

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -329,7 +329,10 @@ public class SkillAdvisorEngineTests
         }
 
         public void AddSkill(string name, int id, bool combat, string xpTable, int maxBonusLevels)
-            => _skills[name] = new SkillEntry(name, id, combat, xpTable, maxBonusLevels);
+            => _skills[name] = new SkillEntry(
+                Key: name, DisplayName: name, Id: id, Combat: combat, XpTable: xpTable,
+                MaxBonusLevels: maxBonusLevels, Parents: [],
+                Rewards: new Dictionary<string, SkillRewardEntry>());
 
         public void AddXpTable(string internalName, long[] xpAmounts)
             => _xpTables[internalName] = new XpTableEntry(internalName, xpAmounts);

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -11,83 +11,17 @@ using Xunit;
 namespace Elrond.Tests;
 
 /// <summary>
-/// Coverage for the hierarchy-aware skill picker tree (#129).
+/// Coverage for the flat skill picker (#129).
 ///
-/// These tests exercise <see cref="SkillAdvisorViewModel.BuildSkillTree"/> and
+/// These tests exercise <see cref="SkillAdvisorViewModel.BuildSkillNodes"/> and
 /// <see cref="SkillAdvisorViewModel.SelectSkillFromDeepLink"/> through the
 /// public observable surface — wrapping the engine + reference data in fakes
-/// so we can stage parent/child relationships and active-character state
-/// without spinning up the file-IO layer.
+/// so we can stage active-character state without spinning up the file-IO layer.
 /// </summary>
 public class SkillAdvisorViewModelTests
 {
     [Fact]
-    public void BuildSkillTree_ParentWithOwnRecipes_GetsChildrenNestedNotDuplicated()
-    {
-        // Regression: when a parent skill (Alchemy) has its own recipes AND a
-        // child (Transmutation) also has recipes, we used to emit two nodes —
-        // one selectable Alchemy leaf at root + a separate header-only Alchemy
-        // grouping Transmutation. Now: a single selectable Alchemy node with
-        // Transmutation nested under it.
-        var (vm, _, _, _) = MakeFixture(
-            characterSkills: new Dictionary<string, CharacterSkill>
-            {
-                ["Alchemy"] = new(26, 0, 100, 200),
-                ["Transmutation"] = new(48, 0, 0, 200),
-            },
-            register: r =>
-            {
-                r.AddSkill("Alchemy", parents: []);
-                r.AddSkill("Transmutation", parents: ["Alchemy"]);
-                r.AddRecipe(rewardSkill: "Alchemy");
-                r.AddRecipe(rewardSkill: "Transmutation");
-            });
-
-        vm.SkillTreeRoots.Should().ContainSingle(
-            because: "Alchemy is the root; Transmutation nests under it");
-        var alchemy = vm.SkillTreeRoots[0];
-        alchemy.Key.Should().Be("Alchemy");
-        alchemy.IsHeaderOnly.Should().BeFalse(because: "Alchemy itself has recipes — it's selectable");
-        alchemy.IsSelectable.Should().BeTrue();
-        alchemy.CurrentLevel.Should().Be(26);
-        alchemy.Children.Should().ContainSingle();
-        alchemy.Children[0].Key.Should().Be("Transmutation");
-    }
-
-    [Fact]
-    public void BuildSkillTree_GroupsAugmentationChildren_UnderHeaderOnlyParent()
-    {
-        // The two AugmentBrewing leaves both list "Augmentation" as their parent —
-        // they should collapse into a single header-only Augmentation node.
-        var (vm, _, _, _) = MakeFixture(
-            characterSkills: new Dictionary<string, CharacterSkill>
-            {
-                ["ArmorAugmentBrewing"] = new(20, 0, 100, 200),
-                ["WeaponAugmentBrewing"] = new(15, 0, 50, 150),
-            },
-            register: r =>
-            {
-                r.AddSkill("Augmentation", parents: []);
-                r.AddSkill("ArmorAugmentBrewing", parents: ["Augmentation"]);
-                r.AddSkill("WeaponAugmentBrewing", parents: ["Augmentation"]);
-                r.AddRecipe(rewardSkill: "ArmorAugmentBrewing");
-                r.AddRecipe(rewardSkill: "WeaponAugmentBrewing");
-            });
-
-        vm.SkillTreeRoots.Should().ContainSingle(
-            because: "both leaves share Augmentation as their parent — only the parent is a root");
-        var augmentation = vm.SkillTreeRoots[0];
-        augmentation.Key.Should().Be("Augmentation");
-        augmentation.IsHeaderOnly.Should().BeTrue();
-        augmentation.IsSelectable.Should().BeFalse();
-        augmentation.Children.Should().HaveCount(2);
-        augmentation.Children.Select(c => c.Key).Should().Equal(
-            ["ArmorAugmentBrewing", "WeaponAugmentBrewing"],
-            because: "children sort alphabetically by display name");
-    }
-
-    [Fact]
-    public void BuildSkillTree_OmitsSkillsCharacterDoesNotKnow()
+    public void BuildSkillNodes_OmitsSkillsCharacterDoesNotKnow()
     {
         var (vm, _, _, _) = MakeFixture(
             characterSkills: new Dictionary<string, CharacterSkill>
@@ -103,12 +37,12 @@ public class SkillAdvisorViewModelTests
                 r.AddRecipe(rewardSkill: "Mycology");
             });
 
-        vm.SkillTreeRoots.Should().ContainSingle();
-        vm.SkillTreeRoots[0].Key.Should().Be("Cooking");
+        vm.SkillNodes.Should().ContainSingle();
+        vm.SkillNodes[0].Key.Should().Be("Cooking");
     }
 
     [Fact]
-    public void BuildSkillTree_SortsChildrenAlphabeticallyByDisplayName()
+    public void BuildSkillNodes_SortsAlphabeticallyByDisplayName()
     {
         // Display name (not Key) drives ordering. Keys are id-shaped; display names
         // can have a different alphabetical order.
@@ -129,7 +63,7 @@ public class SkillAdvisorViewModelTests
                 r.AddRecipe(rewardSkill: "MidSkill");
             });
 
-        vm.SkillTreeRoots.Select(n => n.DisplayName).Should().Equal(["Apple", "Banana", "Cherry"]);
+        vm.SkillNodes.Select(n => n.DisplayName).Should().Equal(["Apple", "Banana", "Cherry"]);
     }
 
     [Fact]

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -1,0 +1,273 @@
+using System.Linq;
+using Elrond.Domain;
+using Elrond.Services;
+using Elrond.ViewModels;
+using FluentAssertions;
+using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
+using Xunit;
+
+namespace Elrond.Tests;
+
+/// <summary>
+/// Coverage for the hierarchy-aware skill picker tree (#129).
+///
+/// These tests exercise <see cref="SkillAdvisorViewModel.BuildSkillTree"/> and
+/// <see cref="SkillAdvisorViewModel.SelectSkillFromDeepLink"/> through the
+/// public observable surface — wrapping the engine + reference data in fakes
+/// so we can stage parent/child relationships and active-character state
+/// without spinning up the file-IO layer.
+/// </summary>
+public class SkillAdvisorViewModelTests
+{
+    [Fact]
+    public void BuildSkillTree_GroupsAugmentationChildren_UnderHeaderOnlyParent()
+    {
+        // The two AugmentBrewing leaves both list "Augmentation" as their parent —
+        // they should collapse into a single header-only Augmentation node.
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill>
+            {
+                ["ArmorAugmentBrewing"] = new(20, 0, 100, 200),
+                ["WeaponAugmentBrewing"] = new(15, 0, 50, 150),
+            },
+            register: r =>
+            {
+                r.AddSkill("Augmentation", parents: []);
+                r.AddSkill("ArmorAugmentBrewing", parents: ["Augmentation"]);
+                r.AddSkill("WeaponAugmentBrewing", parents: ["Augmentation"]);
+                r.AddRecipe(rewardSkill: "ArmorAugmentBrewing");
+                r.AddRecipe(rewardSkill: "WeaponAugmentBrewing");
+            });
+
+        vm.SkillTreeRoots.Should().ContainSingle(
+            because: "both leaves share Augmentation as their parent — only the parent is a root");
+        var augmentation = vm.SkillTreeRoots[0];
+        augmentation.Key.Should().Be("Augmentation");
+        augmentation.IsHeaderOnly.Should().BeTrue();
+        augmentation.IsSelectable.Should().BeFalse();
+        augmentation.Children.Should().HaveCount(2);
+        augmentation.Children.Select(c => c.Key).Should().Equal(
+            ["ArmorAugmentBrewing", "WeaponAugmentBrewing"],
+            because: "children sort alphabetically by display name");
+    }
+
+    [Fact]
+    public void BuildSkillTree_OmitsSkillsCharacterDoesNotKnow()
+    {
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill>
+            {
+                ["Cooking"] = new(10, 0, 0, 100),
+                // Mycology missing — character has not learned it.
+            },
+            register: r =>
+            {
+                r.AddSkill("Cooking", parents: []);
+                r.AddSkill("Mycology", parents: []);
+                r.AddRecipe(rewardSkill: "Cooking");
+                r.AddRecipe(rewardSkill: "Mycology");
+            });
+
+        vm.SkillTreeRoots.Should().ContainSingle();
+        vm.SkillTreeRoots[0].Key.Should().Be("Cooking");
+    }
+
+    [Fact]
+    public void BuildSkillTree_SortsChildrenAlphabeticallyByDisplayName()
+    {
+        // Display name (not Key) drives ordering. Keys are id-shaped; display names
+        // can have a different alphabetical order.
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill>
+            {
+                ["ZebraSkill"] = new(1, 0, 0, 1),
+                ["AlphaSkill"] = new(1, 0, 0, 1),
+                ["MidSkill"] = new(1, 0, 0, 1),
+            },
+            register: r =>
+            {
+                r.AddSkill("ZebraSkill", parents: [], displayName: "Apple");
+                r.AddSkill("AlphaSkill", parents: [], displayName: "Banana");
+                r.AddSkill("MidSkill", parents: [], displayName: "Cherry");
+                r.AddRecipe(rewardSkill: "ZebraSkill");
+                r.AddRecipe(rewardSkill: "AlphaSkill");
+                r.AddRecipe(rewardSkill: "MidSkill");
+            });
+
+        vm.SkillTreeRoots.Select(n => n.DisplayName).Should().Equal(["Apple", "Banana", "Cherry"]);
+    }
+
+    [Fact]
+    public void SelectSkillFromDeepLink_KnownSkill_SetsSelectedSkill()
+    {
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill>
+            {
+                ["Cooking"] = new(10, 0, 0, 100),
+                ["Mycology"] = new(5, 0, 0, 50),
+            },
+            register: r =>
+            {
+                r.AddSkill("Cooking", parents: []);
+                r.AddSkill("Mycology", parents: []);
+                r.AddRecipe(rewardSkill: "Cooking");
+                r.AddRecipe(rewardSkill: "Mycology");
+            });
+
+        vm.SelectSkillFromDeepLink("Mycology");
+
+        vm.SelectedSkill.Should().Be("Mycology");
+    }
+
+    [Fact]
+    public void SelectSkillFromDeepLink_BeforeCharacterLoaded_AppliesAfterCharacterArrives()
+    {
+        // Stage: no active character at deep-link time.
+        var (vm, refData, characterSvc, _) = MakeFixture(
+            characterSkills: null,
+            register: r =>
+            {
+                r.AddSkill("Cooking", parents: []);
+                r.AddRecipe(rewardSkill: "Cooking");
+            });
+
+        vm.SelectSkillFromDeepLink("Cooking");
+        vm.SelectedSkill.Should().BeNull(because: "no character yet — the request should be stashed, not applied");
+
+        // Character arrives.
+        characterSvc.SetCharacter(new CharacterSnapshot(
+            "TestChar", "TestServer", DateTimeOffset.UtcNow,
+            new Dictionary<string, CharacterSkill> { ["Cooking"] = new(5, 0, 0, 100) },
+            new Dictionary<string, int>(), new Dictionary<string, string>()));
+
+        vm.SelectedSkill.Should().Be("Cooking",
+            because: "the stashed request should apply after the character export landed");
+    }
+
+    [Fact]
+    public void SelectSkillFromDeepLink_UnknownSkill_LeavesSelectionUnchanged()
+    {
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill>
+            {
+                ["Cooking"] = new(10, 0, 0, 100),
+            },
+            register: r =>
+            {
+                r.AddSkill("Cooking", parents: []);
+                r.AddRecipe(rewardSkill: "Cooking");
+            });
+
+        var initialSelection = vm.SelectedSkill;
+        vm.SelectSkillFromDeepLink("DoesNotExist");
+
+        vm.SelectedSkill.Should().Be(initialSelection,
+            because: "an unknown skill key should not steal a valid selection");
+    }
+
+    // ── Fixture ──────────────────────────────────────────────────────────
+
+    private static (SkillAdvisorViewModel vm, FakeRefData refData, FakeActiveCharacterService characterSvc, ElrondSettings settings)
+        MakeFixture(
+            IReadOnlyDictionary<string, CharacterSkill>? characterSkills,
+            Action<FakeRefData> register)
+    {
+        var refData = new FakeRefData();
+        register(refData);
+
+        var characterSvc = new FakeActiveCharacterService();
+        if (characterSkills is not null)
+        {
+            characterSvc.SetCharacter(new CharacterSnapshot(
+                "TestChar", "TestServer", DateTimeOffset.UtcNow,
+                characterSkills, new Dictionary<string, int>(), new Dictionary<string, string>()));
+        }
+
+        var settings = new ElrondSettings();
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+        var vm = new SkillAdvisorViewModel(engine, simulator, characterSvc, refData, settings);
+        return (vm, refData, characterSvc, settings);
+    }
+
+    private sealed class FakeActiveCharacterService : IActiveCharacterService
+    {
+        public IReadOnlyList<CharacterSnapshot> Characters { get; private set; } = [];
+        public IReadOnlyList<ReportFileInfo> StorageReports { get; } = [];
+        public string? ActiveCharacterName => ActiveCharacter?.Name;
+        public string? ActiveServer => ActiveCharacter?.Server;
+        public CharacterSnapshot? ActiveCharacter { get; private set; }
+        public ReportFileInfo? ActiveStorageReport => null;
+        public StorageReport? ActiveStorageContents => null;
+
+        public void SetCharacter(CharacterSnapshot snapshot)
+        {
+            ActiveCharacter = snapshot;
+            Characters = [snapshot];
+            ActiveCharacterChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void SetActiveCharacter(string name, string server) { }
+        public void Refresh() { }
+
+        public event EventHandler? ActiveCharacterChanged;
+        public event EventHandler? CharacterExportsChanged { add { } remove { } }
+        public event EventHandler? StorageReportsChanged { add { } remove { } }
+
+        public void Dispose() { }
+    }
+
+    private sealed class FakeRefData : IReferenceDataService
+    {
+        private readonly Dictionary<string, RecipeEntry> _recipes = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, RecipeEntry> _recipesByName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, XpTableEntry> _xpTables = new(StringComparer.Ordinal);
+
+        public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables"];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+        public ItemKeywordIndex KeywordIndex { get; } = ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes => _recipes;
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName => _recipesByName;
+        public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xpTables;
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+
+        public void AddSkill(string key, string[] parents, string? displayName = null)
+            => _skills[key] = new SkillEntry(
+                Key: key, DisplayName: displayName ?? key, Id: 0, Combat: false,
+                XpTable: "TypicalNoncombatSkill", MaxBonusLevels: 0, Parents: parents,
+                Rewards: new Dictionary<string, SkillRewardEntry>());
+
+        private int _recipeSerial;
+        public void AddRecipe(string rewardSkill)
+        {
+            var id = ++_recipeSerial;
+            var key = $"recipe_{id}";
+            var name = $"Test Recipe {id}";
+            var entry = new RecipeEntry(
+                Key: key, Name: name, InternalName: name, IconId: 0,
+                Skill: rewardSkill, SkillLevelReq: 1,
+                RewardSkill: rewardSkill, RewardSkillXp: 10, RewardSkillXpFirstTime: 20,
+                RewardSkillXpDropOffLevel: null, RewardSkillXpDropOffPct: null, RewardSkillXpDropOffRate: null,
+                Ingredients: [], ResultItems: []);
+            _recipes[key] = entry;
+            _recipesByName[name] = entry;
+        }
+    }
+}

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -22,6 +22,39 @@ namespace Elrond.Tests;
 public class SkillAdvisorViewModelTests
 {
     [Fact]
+    public void BuildSkillTree_ParentWithOwnRecipes_GetsChildrenNestedNotDuplicated()
+    {
+        // Regression: when a parent skill (Alchemy) has its own recipes AND a
+        // child (Transmutation) also has recipes, we used to emit two nodes —
+        // one selectable Alchemy leaf at root + a separate header-only Alchemy
+        // grouping Transmutation. Now: a single selectable Alchemy node with
+        // Transmutation nested under it.
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill>
+            {
+                ["Alchemy"] = new(26, 0, 100, 200),
+                ["Transmutation"] = new(48, 0, 0, 200),
+            },
+            register: r =>
+            {
+                r.AddSkill("Alchemy", parents: []);
+                r.AddSkill("Transmutation", parents: ["Alchemy"]);
+                r.AddRecipe(rewardSkill: "Alchemy");
+                r.AddRecipe(rewardSkill: "Transmutation");
+            });
+
+        vm.SkillTreeRoots.Should().ContainSingle(
+            because: "Alchemy is the root; Transmutation nests under it");
+        var alchemy = vm.SkillTreeRoots[0];
+        alchemy.Key.Should().Be("Alchemy");
+        alchemy.IsHeaderOnly.Should().BeFalse(because: "Alchemy itself has recipes — it's selectable");
+        alchemy.IsSelectable.Should().BeTrue();
+        alchemy.CurrentLevel.Should().Be(26);
+        alchemy.Children.Should().ContainSingle();
+        alchemy.Children[0].Key.Should().Be("Transmutation");
+    }
+
+    [Fact]
     public void BuildSkillTree_GroupsAugmentationChildren_UnderHeaderOnlyParent()
     {
         // The two AugmentBrewing leaves both list "Augmentation" as their parent —

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
@@ -247,4 +247,65 @@ public class DeepLinkRouterTests
         public string? LastPayload { get; private set; }
         public void ImportFromLinkPayload(string base64UrlPayload) => LastPayload = base64UrlPayload;
     }
+
+    // ---- mithril://elrond/… branch ------------------------------------------
+
+    [Fact]
+    public void ElrondUri_Dispatched_WithSkillKey()
+    {
+        var presenter = new RecordingPresenter();
+        var elrondTarget = new RecordingElrondTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null,
+            legolasImport: null, elrondImport: elrondTarget);
+
+        var handled = router.Handle("mithril://elrond/ArmorAugmentBrewing");
+
+        handled.Should().BeTrue();
+        elrondTarget.LastPayload.Should().Be("ArmorAugmentBrewing");
+    }
+
+    [Fact]
+    public void ElrondUri_WithoutRegisteredTarget_IsDropped()
+    {
+        var presenter = new RecordingPresenter();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null,
+            legolasImport: null, elrondImport: null);
+
+        router.Handle("mithril://elrond/Cooking").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("mithril://elrond/has-hyphen")]   // hyphen — display names allowed but not on the wire
+    [InlineData("mithril://elrond/has space")]
+    [InlineData("mithril://elrond/")]
+    [InlineData("mithril://elrond/has.dot")]
+    public void ElrondUri_MalformedPayload_IsRejected(string uri)
+    {
+        var presenter = new RecordingPresenter();
+        var elrondTarget = new RecordingElrondTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null,
+            legolasImport: null, elrondImport: elrondTarget);
+
+        router.Handle(uri).Should().BeFalse();
+        elrondTarget.LastPayload.Should().BeNull();
+    }
+
+    [Fact]
+    public void ElrondUri_PayloadOverLengthCap_IsRejected()
+    {
+        var presenter = new RecordingPresenter();
+        var elrondTarget = new RecordingElrondTarget();
+        var router = new DeepLinkRouter(presenter, listImport: null, pippinImport: null,
+            legolasImport: null, elrondImport: elrondTarget);
+
+        var tooLong = new string('A', 129);
+        router.Handle($"mithril://elrond/{tooLong}").Should().BeFalse();
+        elrondTarget.LastPayload.Should().BeNull();
+    }
+
+    private sealed class RecordingElrondTarget : IElrondSkillImportTarget
+    {
+        public string? LastPayload { get; private set; }
+        public void ImportFromLinkPayload(string skillKey) => LastPayload = skillKey;
+    }
 }

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -376,6 +376,48 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void Recipe_ProjectsSortSkill_WhenPresent()
+    {
+        // SortSkill says where the recipe is filed in the in-game cookbook UI.
+        // Differs from RewardSkill for fish-based foods (Fishing XP, filed under Cooking).
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.json"), """
+            {
+              "recipe_fish_stew": {
+                "Name": "Fish Stew",
+                "InternalName": "FishStew",
+                "Skill": "Fishing",
+                "SkillLevelReq": 30,
+                "RewardSkill": "Fishing",
+                "RewardSkillXp": 60,
+                "RewardSkillXpFirstTime": 240,
+                "SortSkill": "Cooking"
+              },
+              "recipe_bread": {
+                "Name": "Bread",
+                "InternalName": "Bread",
+                "Skill": "Cooking",
+                "SkillLevelReq": 5,
+                "RewardSkill": "Cooking",
+                "RewardSkillXp": 20,
+                "RewardSkillXpFirstTime": 80
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.Recipes["recipe_fish_stew"].SortSkill.Should().Be("Cooking",
+            because: "SortSkill is filed under Cooking even though XP goes to Fishing");
+        svc.Recipes["recipe_fish_stew"].RewardSkill.Should().Be("Fishing");
+        svc.Recipes["recipe_bread"].SortSkill.Should().BeNull(
+            because: "recipes that file under their RewardSkill leave SortSkill absent");
+        svc.Recipes["recipe_bread"].RewardSkill.Should().Be("Cooking");
+    }
+
+    [Fact]
     public void Skill_RealBundledFile_ProjectsAugmentationHierarchy()
     {
         // Cross-check the projection against the real bundled skills.json: the four

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -310,6 +310,98 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void Skill_ProjectsKeyAndDisplayNameSeparately()
+    {
+        // SkillEntry.Key carries the id-shaped dictionary key (matches recipes' RewardSkill);
+        // DisplayName carries the human-readable JSON "Name" field (may contain spaces/hyphens).
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "skills.json"), """
+            {
+              "AncillaryArmorAugmentBrewing": {
+                "Id": 700,
+                "Combat": false,
+                "Name": "Ancillary-Armor Augmentation",
+                "XpTable": "TypicalNoncombatSkill",
+                "MaxBonusLevels": 25
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "skills.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.Skills.Should().ContainKey("AncillaryArmorAugmentBrewing");
+        var entry = svc.Skills["AncillaryArmorAugmentBrewing"];
+        entry.Key.Should().Be("AncillaryArmorAugmentBrewing");
+        entry.DisplayName.Should().Be("Ancillary-Armor Augmentation");
+        entry.XpTable.Should().Be("TypicalNoncombatSkill");
+        entry.MaxBonusLevels.Should().Be(25);
+    }
+
+    [Fact]
+    public void Skill_ProjectsParentsAndRewards()
+    {
+        // Verifies Parents (hierarchy) and Rewards (cross-skill XP graph) project
+        // through the SkillEntry projection. AncillaryArmorAugmentBrewing rolls up
+        // under Augmentation and feeds Augmentation XP at lvl 1.
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "skills.json"), """
+            {
+              "AncillaryArmorAugmentBrewing": {
+                "Id": 700,
+                "Combat": false,
+                "Name": "Ancillary-Armor Augmentation",
+                "XpTable": "TypicalNoncombatSkill",
+                "MaxBonusLevels": 25,
+                "Parents": ["Augmentation"],
+                "Rewards": {
+                  "1":  { "BonusToSkill": "Augmentation" },
+                  "35": { "BonusToSkill": "Alchemy", "Notes": "See basic info" }
+                }
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "skills.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        var entry = svc.Skills["AncillaryArmorAugmentBrewing"];
+        entry.Parents.Should().Equal(["Augmentation"]);
+        entry.Rewards.Should().ContainKey("1");
+        entry.Rewards["1"].BonusToSkill.Should().Be("Augmentation");
+        entry.Rewards["35"].BonusToSkill.Should().Be("Alchemy");
+        entry.Rewards["35"].Notes.Should().Be("See basic info");
+    }
+
+    [Fact]
+    public void Skill_RealBundledFile_ProjectsAugmentationHierarchy()
+    {
+        // Cross-check the projection against the real bundled skills.json: the four
+        // Augmentation children must roll up under "Augmentation" with the parent
+        // itself present as its own entry.
+        var realBundled = Path.Combine(AppContext.BaseDirectory, "Reference", "BundledData");
+        if (!File.Exists(Path.Combine(realBundled, "skills.json")))
+            return;
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: realBundled);
+
+        svc.Skills.Should().ContainKey("Augmentation");
+        var children = new[]
+        {
+            "ArmorAugmentBrewing", "WeaponAugmentBrewing",
+            "JewelryAugmentBrewing", "AncillaryArmorAugmentBrewing",
+        };
+        foreach (var key in children)
+        {
+            svc.Skills.Should().ContainKey(key);
+            svc.Skills[key].Parents.Should().Contain("Augmentation",
+                because: $"{key} should roll up under Augmentation");
+        }
+    }
+
+    [Fact]
     public void Quest_item_source_resolves_questId_to_quest_InternalName()
     {
         // sources_items.json carries questId numerically; the parser should look up


### PR DESCRIPTION
## Summary

- Replace Elrond's bare ComboBox with a panel-as-picker over a flat alphabetical list of cookbook sections (`SortSkill ?? RewardSkill`), driven by skills the active character can level via crafting
- Pivot the engine from "recipes-for-this-skill" to "recipes-filed-under-this-section" with per-recipe metrics computed against each recipe's own RewardSkill — so a Fish Stew in Cooking reports Fishing XP and Fishing-completions-to-level, not Cooking
- Wire `mithril://elrond/{skillKey}` deep links via the existing `IDeepLinkRouter`, mirroring the Pippin / Celebrimbor / Legolas pattern
- Surface umbrella sections (Phrenology, Anatomy) gracefully: section header degrades to `—` placeholders and a target-skill panel appears in the detail column showing the user's progress in the recipe's actual reward skill

## What changed

### Reference layer (Mithril.Shared)

- `SkillEntry`: rename `Name` → `Key` (id-shaped, was always misleadingly named); add `DisplayName`, `Parents`, `Rewards`. New `SkillRewardEntry` mirrors the upstream POCO so Mithril.Shared's public surface doesn't leak `Mithril.Reference.Models.Misc.SkillReward`.
- `RecipeEntry`: add `SortSkill` (the in-game cookbook filing key, distinct from `RewardSkill`).
- `IDeepLinkRouter` / `DeepLinkRouter`: new `IElrondSkillImportTarget` slot; `mithril://elrond/{key}` reuses the strict ASCII identifier regex (skill keys are id-shaped per the rename above).

### Engine (Elrond)

- `GetSkillsWithRecipes` → `GetCookbookSections`: distinct `SortSkill ?? RewardSkill` values from XP-bearing recipes.
- `Analyze(sectionKey, …)`: filters by `FilingSkillOf(recipe)` instead of `RewardSkill`. Per-recipe metrics (`EffectiveXp`, `CompletionsToLevel`) now compute against each recipe's own RewardSkill — goal-aware completions only apply when reward matches the section.
- `SkillAnalysis` gains `IsUmbrellaSection` (true when section's `XpTable` is missing or `"None"`).
- `RecipeAnalysis` gains `RewardSkill` / `RewardSkillDisplayName` plus denormalised character progress in the reward skill (`RewardSkillCurrentLevel` / `CurrentXp` / `XpNeededForNextLevel`) and a `RewardSkillDiffersFromSection` bool driving the new panel's visibility.
- `LevelingSimulator` unchanged — it's still skill-leveling-focused and correctly filters by `RewardSkill`.

### View (Elrond)

- Top-row chrome simplified: just the Refresh button. The skill-summary panel itself is the picker trigger — clicking it opens the popup beneath. Hover and open both paint an accent border on the panel.
- Picker is a `ListBox` (was a `TreeView` mid-PR but the hierarchy added complexity that wasn't earning its keep — the in-game cookbook is flat). Each row mirrors the section panel's visual language 1:1: same XLarge header font, same XP fraction format, same 8px progress bar. Popup width binds to the panel's `ActualWidth` so the dropdown lines up under it.
- WPF default selection brushes overridden locally on the ListBox so the selected row doesn't paint white-on-white.
- Recipe rows get a new "Rewards" column (rows view) and an accent pill (cards view) showing each recipe's RewardSkill display name. New "Only recipes that level this skill" filter (default off) for users who want the classic single-skill leveling view.
- Detail column splits into two stacked Borders inside column 2: a conditional target-skill panel (Block A, only when `RewardSkillDiffersFromSection`) sits above the existing recipe-detail Border (Block B). Block A shows the active character's progress in the recipe's actual reward skill — essential for umbrella sections (Phrenology research → `Phrenology_Humans` etc.) and mixed-reward sections (fish recipes in Cooking → Fishing).
- Section header degrades to `—` placeholders for level / XP / remaining when `Analysis.IsUmbrellaSection`; the progress bar collapses.

## Tests

New / updated coverage:

- `ReferenceDataServiceTests`: `Skill_ProjectsKeyAndDisplayNameSeparately`, `Skill_ProjectsParentsAndRewards`, `Skill_RealBundledFile_ProjectsAugmentationHierarchy`, `Recipe_ProjectsSortSkill_WhenPresent`
- `DeepLinkRouterTests`: four new `mithril://elrond/...` cases (dispatched, dropped-without-target, malformed-rejected theory, over-length-rejected) following the existing item/list/pippin/legolas pattern
- `SkillAdvisorEngineTests`: `GetCookbookSections_PrefersSortSkillOverRewardSkill`, `Analyze_FishRecipeFiledUnderCooking_ReportsFishingXpAndCompletions` (cookbook view per-recipe metrics + reward-skill denormalisation), `Analyze_UmbrellaSection_FlagsAnalysisAsUmbrella`, `Analyze_NormalSection_IsNotUmbrella`, `Analyze_RecipeRewardsSection_DiffersFromSectionFlagIsFalse`
- `SkillAdvisorViewModelTests` (new): `BuildSkillNodes_OmitsSkillsCharacterDoesNotKnow`, `BuildSkillNodes_SortsAlphabeticallyByDisplayName`, deep-link tests (`SelectSkillFromDeepLink_KnownSkill_SetsSelectedSkill`, `_BeforeCharacterLoaded_AppliesAfterCharacterArrives`, `_UnknownSkill_LeavesSelectionUnchanged`)

All 1,435 tests pass across 14 projects (one occasionally flaky FileIO test in Mithril.Shared.Tests, passes on rerun — not from this PR).

## Test plan

- [ ] `dotnet build Mithril.slnx` — clean (warnings-as-errors enforced)
- [ ] `dotnet test Mithril.slnx` — all green
- [ ] Open Elrond tab; the skill-summary panel itself is the picker trigger (chevron in the corner; hover + open paint an accent border)
- [x] Click the panel; popup spans the panel's width; rows show display name + level + XP + progress bar in the same visual language as the panel header
- [ ] Pick Cooking; recipes filed there appear, including fish recipes whose Rewards column shows "Fishing"
- [x] Click a fish recipe; the new target-skill panel appears in the detail column showing your Fishing progress
- [x] Pick Phrenology; section header shows `Level —` / `— / — XP` / `— XP remaining` with no progress bar
- [x] Click any Phrenology research recipe; target-skill panel appears showing the per-race Phrenology progress
- [ ] Toggle "Only recipes that level this skill" filter; mixed-reward recipes hide
- [x] From a terminal: `start mithril://elrond/Cooking` — Mithril activates, Elrond tab opens, Cooking selected
- [x] `start mithril://elrond/Mycology` — same; settings persist last selection across restarts

— drafted by Claude (Opus 4.7), posted by @arthur-conde