### PR TITLE
Elrond: Craftable filter compares wrong skill in umbrella sections

### DIFF
--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -37,6 +37,13 @@ public sealed record SkillAnalysis(
 /// re-querying the character. <see cref="RewardSkillDiffersFromSection"/> drives the
 /// visibility of that target-skill panel — when it's false, the section header above
 /// already covers it.
+/// <para/>
+/// <see cref="GatingSkill"/>/<see cref="GatingSkillCurrentLevel"/> name the skill the recipe
+/// actually checks to decide if it's craftable (the recipe's <c>Skill</c> field paired
+/// with <see cref="LevelRequired"/>). For most recipes this matches the section and the
+/// reward skill, but in umbrella sections (Phrenology files Phrenology_Goblins recipes,
+/// Cooking files Fishing-rewarding fish stew) the gate is on a different skill — so the
+/// "Craftable only" filter must compare against this level, not the section level.
 /// </summary>
 public sealed record RecipeAnalysis(
     string RecipeKey,
@@ -61,7 +68,9 @@ public sealed record RecipeAnalysis(
     int RewardSkillCurrentLevel = 0,
     long RewardSkillCurrentXp = 0,
     long RewardSkillXpNeededForNextLevel = 0,
-    bool RewardSkillDiffersFromSection = false);
+    bool RewardSkillDiffersFromSection = false,
+    string GatingSkill = "",
+    int GatingSkillCurrentLevel = 0);
 
 /// <summary>Display-ready ingredient for a recipe tooltip.</summary>
 public sealed record RecipeIngredientDisplay(string Name, int IconId, int StackSize, float? ChanceToConsume);

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -87,6 +87,15 @@ public sealed class SkillAdvisorEngine
             character.Skills.TryGetValue(recipe.RewardSkill, out var rewardCharSkill);
             var rewardLevel = rewardCharSkill?.Level ?? 0;
 
+            // Gating skill = recipe.Skill (paired with SkillLevelReq). For most recipes this
+            // matches the section, but in umbrella sections (Phrenology files Phrenology_Goblins,
+            // Cooking files Fishing-rewarding fish stew) the gate sits on a different skill.
+            // Read the player's level there so the "Craftable only" filter compares apples to apples.
+            var gatingSkillLevel = !string.IsNullOrEmpty(recipe.Skill)
+                && character.Skills.TryGetValue(recipe.Skill, out var gatingCharSkill)
+                    ? gatingCharSkill.Level
+                    : 0;
+
             var isKnown = character.RecipeCompletions.TryGetValue(recipe.InternalName, out var timesCompleted);
             var firstTimeBonusAvailable = isKnown && timesCompleted == 0 && recipe.RewardSkillXpFirstTime > 0;
 
@@ -179,7 +188,9 @@ public sealed class SkillAdvisorEngine
                 RewardSkillCurrentLevel: rewardCharSkill?.Level ?? 0,
                 RewardSkillCurrentXp: rewardCharSkill?.XpTowardNextLevel ?? 0,
                 RewardSkillXpNeededForNextLevel: rewardCharSkill?.XpNeededForNextLevel ?? 0,
-                RewardSkillDiffersFromSection: rewardDiffersFromSection));
+                RewardSkillDiffersFromSection: rewardDiffersFromSection,
+                GatingSkill: recipe.Skill ?? string.Empty,
+                GatingSkillCurrentLevel: gatingSkillLevel));
         }
 
         recipeAnalyses.Sort((a, b) =>

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -69,7 +69,10 @@ public sealed partial class SkillAdvisorViewModel
             // Inverted: predicate r => r.IsKnown applies when IsActive=false; toggling ON reveals unknowns.
             new("ShowUnknown",        "Show unknown",          r => r.IsKnown,                inverted: true,  isActive: false),
             new("FirstTimeBonusOnly", "First Time Bonus Only", r => r.FirstTimeBonusAvailable, inverted: false, isActive: false),
-            new("CraftableOnly",      "Craftable only",        r => Analysis is { } a && r.LevelRequired <= a.CurrentLevel, inverted: false, isActive: true),
+            // CraftableOnly compares against the recipe's *gating* skill, not the section's level.
+            // In umbrella sections (Phrenology files Phrenology_Goblins recipes) those differ —
+            // see SkillAdvisorEngine.Analyze for how GatingSkillCurrentLevel is populated.
+            new("CraftableOnly",      "Craftable only",        r => r.LevelRequired <= r.GatingSkillCurrentLevel, inverted: false, isActive: true),
             new("HideZeroXp",         "Hide 0 XP",             r => r.EffectiveXp > 0,         inverted: false, isActive: true),
             // Cookbook view shows recipes filed under a section regardless of which skill they level
             // (a fish dish in Cooking levels Fishing). Toggling this filter on hides the mixed-reward
@@ -188,7 +191,7 @@ public sealed partial class SkillAdvisorViewModel
 
     partial void OnAnalysisChanged(SkillAnalysis? value)
     {
-        // CraftableOnly closes over Analysis.CurrentLevel — re-run the filter when it shifts.
+        // Filter predicates (RewardingSectionOnly) close over Analysis — re-run them when it shifts.
         RecipesView.Refresh();
         // Section-header text properties are computed from Analysis; nudge the bound
         // TextBlocks to re-evaluate now that the source has changed.

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -309,6 +309,41 @@ public class SkillAdvisorEngineTests
     }
 
     [Fact]
+    public void Analyze_UmbrellaSection_RecipeCarriesGatingSkillFromCharacter()
+    {
+        // Regression for #148: under an umbrella section like Phrenology, the recipe's gating
+        // skill (recipe.Skill, paired with SkillLevelReq) is a sub-skill — not the umbrella.
+        // The "Craftable only" filter must compare LevelRequired against the player's level
+        // in that gating skill, not the umbrella's level (which may be lower or zero).
+        var refData = new FakeRefData();
+        refData.AddSkill("Phrenology", id: 86, combat: false, xpTable: "None", maxBonusLevels: 125);
+        refData.AddSkill("Phrenology_Goblins", id: 88, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
+        refData.AddXpTable("TypicalNoncombatSkill", [10L, 50L, 50L, 50L, 50L, 210L, 210L, 210L, 210L, 210L, 420L, 420L]);
+        refData.AddRecipe("recipe_23052", "Goblin Phrenology Research 2", "GoblinPhrenologyResearch2",
+            "Phrenology_Goblins", 12, "Phrenology_Goblins", 50, 250, null, null, null, sortSkill: "Phrenology");
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill>
+            {
+                ["Phrenology"] = new(9, 0, 0, 0),               // umbrella — section header
+                ["Phrenology_Goblins"] = new(12, 0, 0, 420),    // gating skill — at the level the recipe requires
+            },
+            recipes: new Dictionary<string, int>());
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Phrenology", character)!;
+
+        var recipe = analysis.Recipes.Single();
+        recipe.LevelRequired.Should().Be(12);
+        recipe.GatingSkill.Should().Be("Phrenology_Goblins",
+            because: "the recipe's Skill field is the gating skill — not the umbrella section");
+        recipe.GatingSkillCurrentLevel.Should().Be(12,
+            because: "denormalised from the character's Phrenology_Goblins level so the Craftable filter can compare against it");
+        // Sanity: the umbrella section level is 9, which would have failed a section-level comparison.
+        analysis.CurrentLevel.Should().Be(9);
+    }
+
+    [Fact]
     public void Analyze_BuildsMilestones()
     {
         var refData = new FakeRefData();


### PR DESCRIPTION
@
Closes #148.

## Summary
- The "Craftable only" filter compared a recipes `SkillLevelReq` against the *section* skills level. In umbrella sections (Phrenology, Anatomy, Augmentation) the recipe is gated by a sub-skill, not the umbrella, so craftable recipes were being hidden.
- Add `GatingSkill` + `GatingSkillCurrentLevel` to `RecipeAnalysis`, populated from `recipe.Skill` and the matching character skill in `SkillAdvisorEngine.Analyze`.
- Switch the CraftableOnly predicate to compare against `GatingSkillCurrentLevel`.
- For normal sections (Cooking, Blacksmithing) `Skill == RewardSkill == Section`, so behaviour is unchanged.

## Test plan
- [x] New engine test reproduces the Phrenology / Phrenology_Goblins case (umbrella lv 9, gating skill lv 12, recipe req 12) and asserts `GatingSkillCurrentLevel == 12`.
- [x] `dotnet test tests/Elrond.Tests/Elrond.Tests.csproj` — 35 passing.
- [x] `dotnet test Mithril.slnx` — full suite green.
- [ ] Manual smoke: open Elrond → Phrenology with a character that has sub-skill levels and confirm previously-hidden craftable rows appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@