### PR TITLE
fix(elrond): show real Level + BonusLevels in umbrella section header

### DIFF
--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -9,13 +9,15 @@ namespace Elrond.Domain;
 /// <see cref="RecipeAnalysis.CompletionsToLevel"/> reflect the total gap to that goal.
 /// <para/>
 /// <see cref="IsUmbrellaSection"/> is true when the section's host skill has no
-/// XpTable (e.g. Phrenology, Anatomy umbrella categories). The view degrades
-/// the section header to <c>—</c> placeholders for level/XP/remaining since
-/// those values are meaningless for skills that aren't directly levelable.
+/// XpTable (e.g. Phrenology, Anatomy umbrella categories). The view degrades the
+/// XP fraction, remaining-line, and progress bar to placeholders since those
+/// values are meaningless without a curve — but <see cref="CurrentLevel"/> and
+/// <see cref="CurrentBonusLevels"/> remain meaningful and come straight from the export.
 /// </summary>
 public sealed record SkillAnalysis(
     string SkillName,
     int CurrentLevel,
+    int CurrentBonusLevels,
     long CurrentXp,
     long XpNeededForNextLevel,
     long XpRemaining,

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -64,6 +64,7 @@ public sealed class SkillAdvisorEngine
             return null;
 
         var sectionLevel = sectionCharSkill.Level;
+        var sectionBonusLevels = sectionCharSkill.BonusLevels;
         var sectionCurrentXp = sectionCharSkill.XpTowardNextLevel;
         var sectionXpNeeded = sectionCharSkill.XpNeededForNextLevel;
 
@@ -203,8 +204,10 @@ public sealed class SkillAdvisorEngine
         var milestones = BuildMilestones(sectionKey, sectionLevel, sectionCurrentXp, sectionXpNeeded, maxLevels: 10);
 
         // Umbrella skills (Phrenology, Anatomy, Augmentation, …) have no XpTable,
-        // so the section header should degrade to "—" placeholders. Detection by
-        // missing/None XpTable is robust without needing IsUmbrellaSkill projected.
+        // so the section header degrades the XP fraction / progress bar / remaining
+        // line to "—". Level + BonusLevels still come from the export and render
+        // normally. Detection by missing/None XpTable is robust without needing
+        // IsUmbrellaSkill projected.
         var sectionEntry = _ref.Skills.TryGetValue(sectionKey, out var se) ? se : null;
         var isUmbrellaSection = sectionEntry is null
             || string.IsNullOrEmpty(sectionEntry.XpTable)
@@ -213,6 +216,7 @@ public sealed class SkillAdvisorEngine
         return new SkillAnalysis(
             sectionKey,
             sectionLevel,
+            sectionBonusLevels,
             sectionCurrentXp,
             sectionXpNeeded,
             sectionXpRemaining,

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -128,15 +128,23 @@ public sealed partial class SkillAdvisorViewModel
     private SkillAnalysis? _analysis;
 
     /// <summary>
-    /// Section-header strings that degrade to <c>—</c> when the section is an umbrella
-    /// skill (no XpTable). Backed by <see cref="Analysis"/> — the partial OnAnalysisChanged
-    /// raises change notifications so the bound TextBlocks refresh.
+    /// Section-header strings backed by <see cref="Analysis"/>. The partial
+    /// OnAnalysisChanged raises change notifications so the bound TextBlocks
+    /// refresh. <see cref="SectionLevelText"/> and <see cref="SectionBonusLevelsText"/>
+    /// always render the export's values (even for umbrellas — Phrenology has a
+    /// real Level even though it has no XpTable). The XP fraction / remaining-line
+    /// text degrades to <c>—</c> for umbrellas because the export uses 0/1 sentinels
+    /// there and rendering those would be misleading.
     /// </summary>
     public string SectionLevelText => Analysis switch
     {
         null => "—",
-        { IsUmbrellaSection: true } => "—",
         var a => a.CurrentLevel.ToString(),
+    };
+    public string SectionBonusLevelsText => Analysis switch
+    {
+        { CurrentBonusLevels: > 0 } a => $" ({a.CurrentBonusLevels} from bonuses)",
+        _ => string.Empty,
     };
     public string SectionCurrentXpText => Analysis switch
     {
@@ -196,6 +204,7 @@ public sealed partial class SkillAdvisorViewModel
         // Section-header text properties are computed from Analysis; nudge the bound
         // TextBlocks to re-evaluate now that the source has changed.
         OnPropertyChanged(nameof(SectionLevelText));
+        OnPropertyChanged(nameof(SectionBonusLevelsText));
         OnPropertyChanged(nameof(SectionCurrentXpText));
         OnPropertyChanged(nameof(SectionXpNeededText));
         OnPropertyChanged(nameof(SectionXpRemainingText));

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -108,11 +108,13 @@
                                 <!-- Bind to the display-name view-model property so the section
                                      header shows the human "Weapon Augmentation", not the
                                      id-shaped key "WeaponAugmentBrewing" that Analysis.SkillName
-                                     carries. SectionLevelText degrades to "—" for umbrella
-                                     sections (Phrenology, Anatomy) that aren't directly levelable. -->
+                                     carries. SectionBonusLevelsText carries its own leading
+                                     space and is empty when BonusLevels==0, so it just
+                                     vanishes for skills without bonus levels. -->
                                 <Run Text="{Binding SelectedSkillDisplayName, Mode=OneWay}"/>
                                 <Run Text=" Level "/>
                                 <Run Text="{Binding SectionLevelText, Mode=OneWay}"/>
+                                <Run Text="{Binding SectionBonusLevelsText, Mode=OneWay}"/>
                             </TextBlock>
                             <TextBlock DockPanel.Dock="Right" HorizontalAlignment="Right"
                                        Foreground="{StaticResource TextSecondaryBrush}" FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center">

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -205,8 +205,9 @@ public class SkillAdvisorEngineTests
     public void Analyze_UmbrellaSection_FlagsAnalysisAsUmbrella()
     {
         // Phrenology is the canonical umbrella: XpTable="None", recipes file under it
-        // but reward per-race sub-skills. The view degrades the section header to "—"
-        // placeholders for level/XP/remaining when this flag is set.
+        // but reward per-race sub-skills. The view degrades the section header's
+        // XP fraction / progress bar / remaining-line to "—" when this flag is set;
+        // CurrentLevel and CurrentBonusLevels still come from the export and render.
         var refData = new FakeRefData();
         refData.AddSkill("Phrenology", id: 86, combat: false, xpTable: "None", maxBonusLevels: 125);
         refData.AddSkill("Phrenology_Humans", id: 87, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
@@ -227,6 +228,63 @@ public class SkillAdvisorEngineTests
 
         analysis.IsUmbrellaSection.Should().BeTrue(
             because: "Phrenology has XpTable=None — the section can't be directly leveled");
+    }
+
+    [Fact]
+    public void Analyze_UmbrellaSection_HeaderHasRealLevelFromExport()
+    {
+        // Regression for #150: umbrella sections used to render Level "—" in the
+        // header even though the export carries a real Level (and BonusLevels).
+        // Phrenology with Level=9, BonusLevels=9 (the issue's repro fixture) — the
+        // export's 0/1 sentinel for XpTowardNextLevel/XpNeededForNextLevel still
+        // means the XP fraction is meaningless, but the level number itself isn't.
+        var refData = new FakeRefData();
+        refData.AddSkill("Phrenology", id: 86, combat: false, xpTable: "None", maxBonusLevels: 125);
+        refData.AddSkill("Phrenology_Humans", id: 87, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
+        refData.AddXpTable("TypicalNoncombatSkill", [10L, 50L, 50L, 50L, 50L]);
+        refData.AddRecipe("recipe_phren_human", "Human Phrenology Research", "HumanPhrenologyResearch",
+            "Phrenology_Humans", 1, "Phrenology_Humans", 20, 100, null, null, null, sortSkill: "Phrenology");
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill>
+            {
+                ["Phrenology"] = new(9, 9, 0, 1),
+                ["Phrenology_Humans"] = new(2, 0, 10, 50),
+            },
+            recipes: new Dictionary<string, int>());
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Phrenology", character)!;
+
+        analysis.CurrentLevel.Should().Be(9,
+            because: "umbrella sections still have a meaningful Level in the export — only the XP curve is missing");
+        analysis.CurrentBonusLevels.Should().Be(9,
+            because: "BonusLevels comes straight from the export and should flow through to the section header");
+    }
+
+    [Fact]
+    public void Analyze_PopulatesCurrentBonusLevelsFromCharacterExport()
+    {
+        // Normal (non-umbrella) section: BonusLevels must still be carried through
+        // SkillAnalysis so the header can render "Alchemy Level 26 (3 from bonuses)".
+        var refData = new FakeRefData();
+        refData.AddSkill("Alchemy", id: 2, combat: false, xpTable: "TypicalNoncombatSkill", maxBonusLevels: 25);
+        refData.AddXpTable("TypicalNoncombatSkill", new long[] { 10L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L,
+            50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L, 50L });
+        refData.AddRecipe("recipe_potion", "Potion", "Potion", "Alchemy", 1, "Alchemy", 10, 40, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Alchemy"] = new(26, 3, 100, 500) },
+            recipes: new Dictionary<string, int>());
+
+        var engine = new SkillAdvisorEngine(refData);
+        var analysis = engine.Analyze("Alchemy", character)!;
+
+        analysis.CurrentLevel.Should().Be(26);
+        analysis.CurrentBonusLevels.Should().Be(3,
+            because: "the engine must denormalise CharacterSkill.BonusLevels onto SkillAnalysis so the VM can render '(N from bonuses)'");
+        analysis.IsUmbrellaSection.Should().BeFalse(
+            because: "Alchemy has a normal XpTable — bonus-level rendering must work for non-umbrella sections too");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #150.

- **Umbrella sections** (Phrenology, Anatomy, …) used to render `Level —` in the section header. The export carries a real `Level` for umbrellas — only the XP curve is missing — so the level number now renders normally; only the XP fraction, remaining-line, and progress bar continue to degrade to `—` (those genuinely have only 0/1 sentinel data for umbrellas).
- **All sections** now show the `BonusLevels` split that the in-game UI surfaces — e.g. `Phrenology Level 9 (9 from bonuses)`, `Alchemy Level 26 (3 from bonuses)`. `CharacterSkill.BonusLevels` was already parsed but unused downstream; the engine now denormalises it onto `SkillAnalysis` so the VM can render the breakdown without re-querying the snapshot.

### Files

- `src/Elrond.Module/Domain/SkillAnalysis.cs` — new `CurrentBonusLevels` field on the record
- `src/Elrond.Module/Services/SkillAdvisorEngine.cs` — pass `sectionCharSkill.BonusLevels` through to `SkillAnalysis`
- `src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs` — drop the `IsUmbrellaSection => "—"` arm from `SectionLevelText`; add sibling `SectionBonusLevelsText` (empty when zero, `" (N from bonuses)"` otherwise) and wire it into `OnAnalysisChanged`
- `src/Elrond.Module/Views/SkillAdvisorView.xaml` — append one `<Run Text="{Binding SectionBonusLevelsText}"/>` to the header `TextBlock`
- `tests/Elrond.Tests/SkillAdvisorEngineTests.cs` — two new tests (`Analyze_UmbrellaSection_HeaderHasRealLevelFromExport`, `Analyze_PopulatesCurrentBonusLevelsFromCharacterExport`)

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (warnings-as-errors)
- [x] `dotnet test Mithril.slnx` — 1450+ tests pass, including the 2 new Elrond engine tests
- [x] Smoke: open a character export with `Phrenology { Level: 9, BonusLevels: 9 }`, navigate to Elrond → Phrenology, confirm header reads `Phrenology Level 9 (9 from bonuses)` with XP fraction + progress bar still hidden
- [x] Smoke: open a normal section with non-zero BonusLevels (e.g. `Alchemy { Level: 26, BonusLevels: 3 }`) — header reads `Alchemy Level 26 (3 from bonuses)` with the existing XP/progress UI intact
- [x] Smoke: open a normal section with `BonusLevels: 0` — header unchanged from today (`Skill Level N`, no suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)