### PR TITLE
Gandalf timer model redesign — eliminate 1 Hz refresh storm + coarse change events (#154)

### DIFF
--- a/docs/gandalf-timer-model-redesign.md
+++ b/docs/gandalf-timer-model-redesign.md
@@ -1,0 +1,182 @@
+# Gandalf timer model redesign — eliminate 1 Hz refresh storm + coarse change events
+
+**Tracked in:** [#154](https://github.com/arthur-conde/project-gorgon/issues/154)
+**Sibling issue:** [#153](https://github.com/arthur-conde/project-gorgon/issues/153) (chest-cache write-only — separate localized fix)
+
+## Context
+
+A user opened the Gandalf → Loot tab while otherwise idle and reported lag. Tracing through the source/VM stack surfaced two structural model flaws:
+
+1. **Time isn't first-class in the model.** [`TimerRow`](../src/Gandalf.Module/Domain/TimerRow.cs)'s `Remaining` / `Fraction` / `State` project `(StartedAt, Duration, now)`, but the model has no notion of *"this row's display next changes at T."* So every consumer ticks every row every second whether anything visible would change or not. With ~50 rows × 11 properties × 1 Hz, the WPF binding pipeline + `ICollectionView.Refresh()` (with grouping + 3-key sort) burns measurable UI-thread time on rows that haven't moved.
+
+2. **Source change events are coarse and snapshot-shaped.** [`ITimerSource`](../src/Gandalf.Module/Domain/ITimerSource.cs)'s `CatalogChanged` and `ProgressChanged` are bare `EventHandler` (no payload), and `Catalog`/`Progress` are exposed as wholesale snapshots. Consumers either clear-and-rebuild their `ObservableCollection` ([`LootTimersViewModel.Sync`](../src/Gandalf.Module/ViewModels/LootTimersViewModel.cs), [`TimerListViewModel.SyncFromState`](../src/Gandalf.Module/ViewModels/TimerListViewModel.cs)) or poll on a `DispatcherTimer`. The CollectionView with grouping/sorting then thrashes. [`DashboardAggregator`](../src/Gandalf.Module/Services/DashboardAggregator.cs) is the worst offender — full cross-source rebuild on any event *plus* a 1 Hz `Recompute()` to surface state flips the coarse model can't.
+
+**Intended outcome:**
+- Idle catalog rows generate zero per-tick work.
+- A row whose visible display next changes at 14:32:00 isn't touched until 14:32:00.
+- Source mutations propagate as per-key deltas; consumers update only the affected `TimerItemViewModel` and only call `TimersView.Refresh()` when filter/sort/group keys actually changed.
+- One bundled PR; ~7 internal commits per the implementation order below; bisectable.
+- All four Gandalf timer surfaces (Loot, Quest, User-defined, Dashboard) use the same model.
+
+## Design
+
+### 1. Domain: per-row "next visible change at"
+
+Add to [`TimerRow`](../src/Gandalf.Module/Domain/TimerRow.cs):
+
+```csharp
+public DateTimeOffset? NextDisplayChangeAt { get; }
+```
+
+Pure projection from `Clock`, `Progress.StartedAt`, `Catalog.Duration`. Semantics:
+
+| Row state | NextDisplayChangeAt |
+|---|---|
+| `Idle` (no progress, or `DismissedAt` set) | `null` — never changes by time alone |
+| `Running` | `min(StartedAt + Duration, NextMinuteBoundaryAfter(Clock.GetUtcNow()))` — soonest of the state-flip moment or the "Xh Ym remaining" minute roll |
+| `Done` and `(now - CompletedAt) < 60s` | `CompletedAt + 60s` — when "done!" flips to "done 1m ago" |
+| `Done` and `(now - CompletedAt) >= 60s` | `NextMinuteBoundaryAfter(Clock.GetUtcNow())` — when "done Xm ago" rolls |
+
+The `Fraction` progress bar is **not** driven by `NextDisplayChangeAt`. The display scheduler keeps a separate fast-tick (1 Hz) gated on "any visible row is `Running` AND has its progress bar visible," which goes idle when the gate predicate is false.
+
+### 2. Pre-existing bug surfaced by the redesign — fix in this PR
+
+[`TimerItemViewModel.TimeDisplay`](../src/Gandalf.Module/ViewModels/TimerItemViewModel.cs) reads `DateTimeOffset.UtcNow` directly instead of `_row.Clock.GetUtcNow()`. Under tests using `ManualTime : TimeProvider`, the "done X ago" string drifts from the rest of the row. The new scheduler computes its wakeups from the injected clock; if the consumer reads wall-clock, the scheduler fires too early/late under fakes. **Route every time-derived read in `TimerItemViewModel` through `_row.Clock`.**
+
+### 3. Source contract: per-key batched deltas
+
+Replace [`ITimerSource`](../src/Gandalf.Module/Domain/ITimerSource.cs)'s coarse events:
+
+```csharp
+public interface ITimerSource
+{
+    string SourceId { get; }
+    IReadOnlyList<TimerCatalogEntry> Catalog { get; }
+    IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; }
+    bool TryGetProgress(string key, out TimerProgressEntry progress);   // NEW
+
+    event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;          // NEW
+    event EventHandler<TimerReadyEventArgs>? TimerReady;                 // unchanged
+    // CatalogChanged / ProgressChanged — REMOVED
+}
+
+public sealed record TimerRowDelta(
+    string Key,
+    TimerRowChangeKind Kind,
+    TimerCatalogEntry? Catalog,    // null on Removed
+    TimerProgressEntry? Progress); // null when row is idle / never started
+
+public enum TimerRowChangeKind { Added, CatalogChanged, ProgressChanged, Removed }
+
+public sealed class TimerRowsChangedEventArgs : EventArgs
+{
+    public required IReadOnlyList<TimerRowDelta> Deltas { get; init; }
+}
+```
+
+**Batched.** A calibration-overlay refresh in [`LootSource.OverlayDefeatCalibration`](../src/Gandalf.Module/Services/LootSource.cs) re-projects ~hundreds of rows; that must fire **one** `RowsChanged` with N deltas, not N events.
+
+**No compat shims.** Sources are all in-tree; the four VM consumers + `DashboardAggregator` migrate in the same PR. The old events go away in the final commit. `TimerReady` stays — already per-key, already consumed correctly by [`TimerAlarmService`](../src/Gandalf.Module/Services/TimerAlarmService.cs).
+
+**Per-key event in the underlying services.** [`DerivedTimerProgressService`](../src/Gandalf.Module/Services/DerivedTimerProgressService.cs) and [`TimerProgressService`](../src/Gandalf.Module/Services/TimerProgressService.cs) get a per-key change event so sources project deltas without re-snapshotting.
+
+### 4. New shared infrastructure (two small classes, ~150 lines each)
+
+**`TimerSourceBinder`** — new file `src/Gandalf.Module/Services/TimerSourceBinder.cs`:
+- Constructor: `(ITimerSource source, ObservableCollection<TimerItemViewModel> target, Dictionary<string, TimerItemViewModel> byKey, TimeProvider clock, Func<TimerCatalogEntry, TimerProgressEntry?, bool> isRelevant)`
+- On construction: enumerates `source.Catalog` once, populates `target` for relevant rows.
+- Subscribes to `source.RowsChanged`. For each delta:
+  - `Added` → if relevant, materialize VM, add to collection, register with scheduler.
+  - `ProgressChanged` → call `vm.UpdateRow(...)`. If relevance flipped (Quest's "no longer in journal" case), remove. **Track GroupKey before/after; if changed, signal `OnGroupKeyChanged`** so the VM can call `TimersView.Refresh()`.
+  - `CatalogChanged` → call `vm.UpdateRow(...)`. Same GroupKey-change handling — calibration overlay can flip a defeat's `Region` from `"Defeats"` to `"Tagamogi"`.
+  - `Removed` → remove from collection, unregister from scheduler.
+- Exposes `event EventHandler? GroupKeyChanged` for the host VM to bind a single `TimersView.Refresh()` call to.
+- Generalizes the existing diff-in-place pattern in [`QuestTimersViewModel.Sync`](../src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs) so all three tab VMs share it.
+
+**`TimerDisplayScheduler`** — new file `src/Gandalf.Module/Services/TimerDisplayScheduler.cs`:
+- Owns **one** `DispatcherTimer`.
+- Per registered VM, tracks `vm.Row.NextDisplayChangeAt`.
+- Reschedules `_timer.Interval` to `min(NextDisplayChangeAt) - now` whenever the heap top changes.
+- On tick: refreshes only the rows whose `NextDisplayChangeAt <= now`, recomputes their next-change, rebalances heap.
+- **Fast tick (separate `DispatcherTimer` at 1 Hz)** runs only while the predicate `_anyRunningWithVisibleProgressBar` is true. Drives `Fraction` updates for visible progress bars. Stops when no Running rows are visible.
+- When the heap is empty AND fast-tick gate is false, both timers are stopped — zero per-second work on an all-Idle tab.
+
+### 5. Per-property diff in `TimerItemViewModel.UpdateRow`
+
+Replace the unconditional 11-fire `Refresh()` with per-property comparison against last-known values. Many properties co-vary on `State` change (`IsIdle`, `IsRunning`, `IsDone`, `ShowStartButton`, `ShowRestartButton`, `ShowProgressBar`, `StatusColor`, `StatusLabel`); cache `_lastState` and fire the cluster only when state changed. `TimeDisplay` and `Fraction` get their own fields. Keep `Refresh()` as a "force-fire-all" escape hatch but stop calling it from `UpdateRow`.
+
+### 6. CheckExpirations relocation — preserves user-timer alarms
+
+[`TimerListViewModel.Tick`](../src/Gandalf.Module/ViewModels/TimerListViewModel.cs) calls `_progress.CheckExpirations()` — that's the path that stamps `CompletedAt` and fires `TimerExpired` → `UserTimerSource.TimerReady` → [`TimerAlarmService`](../src/Gandalf.Module/Services/TimerAlarmService.cs). Removing the 1 Hz tick without re-routing kills user-tab alarms.
+
+Move the responsibility into [`TimerProgressService`](../src/Gandalf.Module/Services/TimerProgressService.cs) itself: schedule a one-shot timer for the soonest known expiration; on fire, run `CheckExpirations` and reschedule. Mirrors `NextDisplayChangeAt` at the data layer — same idea, separate concern (it's about firing `TimerReady`, not about visible display).
+
+### 7. DashboardAggregator migration
+
+[`DashboardAggregator`](../src/Gandalf.Module/Services/DashboardAggregator.cs):
+- Subscribe to `RowsChanged` from each source instead of two coarse events.
+- Maintain summaries incrementally on each delta — no full-list rebuild.
+- Add `NextDisplayChangeAt` to `TimerSummary` (which has its own ad-hoc time formatter — same minute-boundary logic, share helper with `TimerRow`).
+- Expose `NextDisplayChangeAt { get; }` as the min across summaries, drives [`DashboardViewModel`](../src/Gandalf.Module/ViewModels/DashboardViewModel.cs)'s scheduler subscription.
+- **Remove the manual 1 Hz `Recompute()` tick** — `NextDisplayChangeAt`-driven scheduling replaces it.
+
+## Implementation order (one bundled PR, ~7 commits)
+
+| # | Commit | Files |
+|---|---|---|
+| 1 | Add `NextDisplayChangeAt` to `TimerRow` + `TimerRowDelta` / `TimerRowChangeKind` / `TimerRowsChangedEventArgs` records. Pure unit tests. | `Domain/TimerRow.cs`, `Domain/ITimerSource.cs` (types only) |
+| 2 | Add `RowsChanged` + `TryGetProgress` to `ITimerSource`. Implement in `LootSource`, `QuestSource`, `UserTimerSource` by subscribing to underlying services. Keep old `CatalogChanged`/`ProgressChanged` firing for now. | `Services/LootSource.cs`, `Services/QuestSource.cs`, `Services/UserTimerSource.cs`, `Services/DerivedTimerProgressService.cs`, `Services/TimerProgressService.cs` |
+| 3 | `TimerSourceBinder` + tests. | New `Services/TimerSourceBinder.cs`, new test file |
+| 4 | `TimerDisplayScheduler` + tests. | New `Services/TimerDisplayScheduler.cs`, new test file |
+| 5 | Migrate `LootTimersViewModel` → `TimerListViewModel` → `QuestTimersViewModel`. Each removes its `DispatcherTimer`, replaces `Sync` with binder, opts into scheduler. Move `CheckExpirations` into `TimerProgressService`. | All three VMs, `Services/TimerProgressService.cs` |
+| 6 | `TimerItemViewModel` per-property diff + clock-routing fix (`TimeDisplay` reads `_row.Clock`). | `ViewModels/TimerItemViewModel.cs` |
+| 7 | Migrate `DashboardAggregator` + `DashboardViewModel`. Remove `CatalogChanged`/`ProgressChanged` from `ITimerSource` and all sources. Final cleanup. | `Services/DashboardAggregator.cs`, `ViewModels/DashboardViewModel.cs`, `Domain/ITimerSource.cs`, all three sources |
+
+## Reuse / patterns to lean on
+
+- [`QuestTimersViewModel.Sync`](../src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs) already does diff-in-place on a `_byKey` dictionary against an `ObservableCollection`. `TimerSourceBinder` is this generalized.
+- [`QuestTimersViewModel.Tick`](../src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs) already gates `TimersView.Refresh()` on state changes. Generalize via the binder's `GroupKeyChanged` event.
+- The existing `QuestTimersViewModelTests.Tick_does_not_refresh_view_when_no_state_changed` test pattern (uses `ManualTime : TimeProvider`) generalizes cleanly to the new scheduler tests.
+- Project-wide `TimeProvider` injection is already universal; no new abstraction.
+
+## Tests
+
+**New unit tests:**
+- `TimerRowTests`: `NextDisplayChangeAt` correctness for Idle / Running / just-Done (<60s) / old-Done — under `ManualTime`. Include the boundary case where Running's "minute-roll" time is *before* the state-flip time.
+- `LootSourceTests` / `QuestSourceTests` / `UserTimerSourceTests`: assert `RowsChanged` fires exactly once per logical mutation, with correct `Kind`. Calibration-overlay test asserts **one** event with N deltas, not N events.
+- `TimerSourceBinderTests`: relevance predicate, GroupKey-change-mid-stream (defeat row's Region flips from `"Defeats"` to `"Tagamogi"` — must signal `GroupKeyChanged`), Add/Remove correctness, character-switch full-diff.
+- `TimerDisplaySchedulerTests`: heap ordering, re-prioritization when a row's `NextDisplayChangeAt` becomes earlier (e.g., post-Restart), no leaks when a row is removed mid-flight, fast-tick gate predicate flips correctly when last Running row finishes.
+- `TimerItemViewModelTests`: per-property diff — assert PropertyChanged fires for the right subset given a row state transition.
+
+**Generalized existing tests:**
+- Replicate `Tick_does_not_refresh_view_when_no_state_changed` from `QuestTimersViewModelTests` into `LootTimersViewModelTests` and `TimerListViewModelTests`.
+- `DashboardAggregatorTests`: assert delta-driven incremental updates produce the same `Summaries` as the old full-rebuild path on a fixed sequence of mutations.
+- `TimerAlarmService` tests: confirm user-timer alarms still fire after `CheckExpirations` moves into `TimerProgressService`.
+
+## End-to-end verification
+
+```bash
+dotnet build Mithril.slnx
+dotnet test Mithril.slnx
+dotnet run --project src/Mithril.Shell
+```
+
+Manual UI checks (from a clean run, with a character logged in):
+
+1. **Idle Loot tab.** Open Loot tab. Open Task Manager / VS Profiler. CPU should be ~0% on the Mithril process when no rows are Running. Compared with current behavior (steady ~few-percent burn for all-Idle tab from 1 Hz `Tick`), this is the load-bearing perf assertion.
+2. **Running rows present.** Loot a chest (or simulate via tail). Progress bars animate smoothly. No visible jank when other tabs / unrelated sources mutate.
+3. **State flip moment.** A chest cooldown crosses ready while the Loot tab is open — the row flips Running → Done at the exact moment, not on the next 1 Hz boundary.
+4. **Calibration overlay.** Trigger a calibration refresh. Hundreds of defeat rows mutate; the UI updates without visible jank or duplicate refresh.
+5. **Character switch.** Switch active character. All rows from prior character are removed; new character's rows appear. No leaked VMs or scheduler entries.
+6. **User-timer alarm.** Create a 5-second user timer; lock the screen. Alarm fires when timer expires (proves `CheckExpirations` relocation works).
+7. **Quest tab.** "In-journal" filter still works; quest dismiss-all still works.
+8. **Dashboard tab.** Ready-Now and Coming-Up sections update at the correct moments without 1 Hz polling.
+
+## Out of scope (explicit, with rationale)
+
+- **`ListBox` + `WrapPanel` virtualization.** Once the binder + scheduler stop the 1 Hz catalog rebuild, virtualization is a no-op for current row counts. Revisit only if Loot still lags at >200 calibrated bosses post-PR.
+- **Migrating `DashboardAggregator` to use `TimerRow` directly** instead of its own `TimerSummary`. Tempting, but grows the PR. Keep `TimerSummary`; just give it `NextDisplayChangeAt`.
+- **Replacing `EventHandler<T>` with `IObservable<T>` / channels.** The delta-+-binder pattern *is* lightweight Rx; the dependency cost isn't justified.
+- **`Storyboard`-driven `Fraction` animation.** Hours-scale progress bars don't need 60 Hz interpolation; the gated 1 Hz fast-tick is enough.
+- **Per-character debouncing in `DerivedTimerProgressService`** (the 500 ms `_debounce`) — unrelated to this redesign; do not touch.
+- **Issue [#153](https://github.com/arthur-conde/project-gorgon/issues/153)** (chest-cache write-only) — separate localized cache-schema migration, not a model redesign.

--- a/src/Gandalf.Module/Domain/ITimerSource.cs
+++ b/src/Gandalf.Module/Domain/ITimerSource.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Gandalf.Domain;
 
 /// <summary>
@@ -34,9 +36,30 @@ public interface ITimerSource
     /// </summary>
     IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; }
 
+    /// <summary>
+    /// Per-row progress lookup. Returns <c>true</c> and yields the entry when a row
+    /// has been started (even if dismissed); returns <c>false</c> for rows in
+    /// catalog-but-never-started state. Avoids the
+    /// <see cref="Progress"/> snapshot-dictionary allocation for callers that only
+    /// care about a single key (e.g. binders applying a per-key delta).
+    /// </summary>
+    bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress);
+
     event EventHandler? CatalogChanged;
     event EventHandler? ProgressChanged;
     event EventHandler<TimerReadyEventArgs>? TimerReady;
+
+    /// <summary>
+    /// Per-key batched change feed. Sources coalesce many simultaneous mutations
+    /// (calibration overlay refresh, journal load, character switch) into a single
+    /// event invocation with N deltas — one event per logical mutation, not N —
+    /// so consumers can apply all changes and call
+    /// <c>ICollectionView.Refresh</c> at most once per batch.
+    /// Fires alongside the legacy <see cref="CatalogChanged"/> /
+    /// <see cref="ProgressChanged"/> events during the rollout; those will be
+    /// removed once every consumer has migrated.
+    /// </summary>
+    event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 }
 
 public sealed record TimerCatalogEntry(

--- a/src/Gandalf.Module/Domain/ITimerSource.cs
+++ b/src/Gandalf.Module/Domain/ITimerSource.cs
@@ -59,3 +59,35 @@ public sealed class TimerReadyEventArgs : EventArgs
     public required DateTimeOffset ReadyAt { get; init; }
     public object? SourceMetadata { get; init; }
 }
+
+/// <summary>
+/// One row's worth of change inside a <see cref="TimerRowsChangedEventArgs"/>
+/// batch. <see cref="Catalog"/> is null only for <see cref="TimerRowChangeKind.Removed"/>;
+/// <see cref="Progress"/> is null when the row exists but has never been started
+/// (or was reset to idle).
+/// </summary>
+public sealed record TimerRowDelta(
+    string Key,
+    TimerRowChangeKind Kind,
+    TimerCatalogEntry? Catalog,
+    TimerProgressEntry? Progress);
+
+public enum TimerRowChangeKind
+{
+    Added,
+    CatalogChanged,
+    ProgressChanged,
+    Removed,
+}
+
+/// <summary>
+/// Batched per-key change feed for <see cref="ITimerSource"/>. Sources coalesce
+/// many simultaneous mutations (calibration overlay, character switch, journal
+/// load) into a single event with N deltas — one event invocation, not N — so
+/// consumers can apply all changes and call <c>ICollectionView.Refresh</c> at
+/// most once per batch.
+/// </summary>
+public sealed class TimerRowsChangedEventArgs : EventArgs
+{
+    public required IReadOnlyList<TimerRowDelta> Deltas { get; init; }
+}

--- a/src/Gandalf.Module/Domain/ITimerSource.cs
+++ b/src/Gandalf.Module/Domain/ITimerSource.cs
@@ -45,8 +45,6 @@ public interface ITimerSource
     /// </summary>
     bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress);
 
-    event EventHandler? CatalogChanged;
-    event EventHandler? ProgressChanged;
     event EventHandler<TimerReadyEventArgs>? TimerReady;
 
     /// <summary>
@@ -55,9 +53,6 @@ public interface ITimerSource
     /// event invocation with N deltas — one event per logical mutation, not N —
     /// so consumers can apply all changes and call
     /// <c>ICollectionView.Refresh</c> at most once per batch.
-    /// Fires alongside the legacy <see cref="CatalogChanged"/> /
-    /// <see cref="ProgressChanged"/> events during the rollout; those will be
-    /// removed once every consumer has migrated.
     /// </summary>
     event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 }

--- a/src/Gandalf.Module/Domain/TimerRow.cs
+++ b/src/Gandalf.Module/Domain/TimerRow.cs
@@ -63,4 +63,54 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
             return Math.Clamp((Clock.GetUtcNow() - Progress.StartedAt) / Catalog.Duration, 0.0, 1.0);
         }
     }
+
+    /// <summary>
+    /// Wall-clock instant at which any visible property of this row would next
+    /// flip. <c>null</c> for rows that don't change by time alone (Idle, or a
+    /// dismissed row with no upcoming resurrection). The display scheduler
+    /// orders rows by this value and only refreshes those whose moment has
+    /// arrived, replacing the per-tab 1 Hz tick that previously refreshed every
+    /// row regardless of whether anything changed.
+    /// <list type="bullet">
+    /// <item><b>Running:</b> the soonest of the state-flip moment
+    /// (<c>StartedAt + Duration</c>) and the next minute boundary — <c>"Xh Ym
+    /// remaining"</c> only changes when minutes roll.</item>
+    /// <item><b>Just-Done</b> (&lt; 60 s since completion): when <c>"done!"</c>
+    /// flips to <c>"done 1m ago"</c> at <c>CompletedAt + 60 s</c>.</item>
+    /// <item><b>Old Done:</b> the next minute boundary, when <c>"done Xm ago"</c>
+    /// rolls.</item>
+    /// </list>
+    /// <see cref="Fraction"/> is intentionally <em>not</em> driven by this
+    /// property — sub-minute progress-bar smoothness uses a separate gated
+    /// 1 Hz fast-tick that runs only while at least one Running row is
+    /// visible.
+    /// </summary>
+    public DateTimeOffset? NextDisplayChangeAt
+    {
+        get
+        {
+            if (Progress is null) return null;
+            if (Progress.DismissedAt is not null) return null;
+
+            var now = Clock.GetUtcNow();
+            var stateFlipAt = Progress.StartedAt + Catalog.Duration;
+
+            if (now < stateFlipAt)
+            {
+                var nextMinute = NextMinuteBoundaryAfter(now);
+                return stateFlipAt < nextMinute ? stateFlipAt : nextMinute;
+            }
+
+            var elapsedSinceDone = now - stateFlipAt;
+            return elapsedSinceDone < TimeSpan.FromSeconds(60)
+                ? stateFlipAt + TimeSpan.FromSeconds(60)
+                : NextMinuteBoundaryAfter(now);
+        }
+    }
+
+    private static DateTimeOffset NextMinuteBoundaryAfter(DateTimeOffset t)
+    {
+        var floor = new DateTimeOffset(t.Year, t.Month, t.Day, t.Hour, t.Minute, 0, t.Offset);
+        return floor + TimeSpan.FromMinutes(1);
+    }
 }

--- a/src/Gandalf.Module/Domain/TimerRowDeltaDiffer.cs
+++ b/src/Gandalf.Module/Domain/TimerRowDeltaDiffer.cs
@@ -1,0 +1,59 @@
+namespace Gandalf.Domain;
+
+/// <summary>
+/// Computes <see cref="TimerRowDelta"/> batches by diffing two snapshots of
+/// <c>(catalog, progress)</c>. Sources hold the previous snapshot, take a fresh
+/// one whenever they would have raised the legacy
+/// <see cref="ITimerSource.CatalogChanged"/> / <see cref="ITimerSource.ProgressChanged"/>
+/// events, and emit the diff via <see cref="ITimerSource.RowsChanged"/>.
+/// </summary>
+internal static class TimerRowDeltaDiffer
+{
+    public static IReadOnlyList<TimerRowDelta> Diff(
+        IReadOnlyDictionary<string, TimerCatalogEntry> oldCatalog,
+        IReadOnlyDictionary<string, TimerCatalogEntry> newCatalog,
+        IReadOnlyDictionary<string, TimerProgressEntry> oldProgress,
+        IReadOnlyDictionary<string, TimerProgressEntry> newProgress)
+    {
+        var deltas = new List<TimerRowDelta>();
+
+        foreach (var (key, entry) in newCatalog)
+        {
+            newProgress.TryGetValue(key, out var p);
+            if (!oldCatalog.TryGetValue(key, out var oldEntry))
+            {
+                deltas.Add(new TimerRowDelta(key, TimerRowChangeKind.Added, entry, p));
+                continue;
+            }
+
+            var catalogDiffers = !oldEntry.Equals(entry);
+            oldProgress.TryGetValue(key, out var oldP);
+            var progressDiffers = !ProgressEquals(oldP, p);
+
+            // CatalogChanged subsumes ProgressChanged — the delta carries both
+            // new catalog and new progress, so receivers see the latest state
+            // regardless of which kind they branch on. Avoiding two deltas for
+            // one row keeps batches small and ordering deterministic.
+            if (catalogDiffers)
+                deltas.Add(new TimerRowDelta(key, TimerRowChangeKind.CatalogChanged, entry, p));
+            else if (progressDiffers)
+                deltas.Add(new TimerRowDelta(key, TimerRowChangeKind.ProgressChanged, entry, p));
+        }
+
+        foreach (var key in oldCatalog.Keys)
+        {
+            if (!newCatalog.ContainsKey(key))
+                deltas.Add(new TimerRowDelta(key, TimerRowChangeKind.Removed, null, null));
+        }
+
+        return deltas;
+    }
+
+    private static bool ProgressEquals(TimerProgressEntry? a, TimerProgressEntry? b) =>
+        (a, b) switch
+        {
+            (null, null) => true,
+            (null, _) or (_, null) => false,
+            _ => a.Equals(b),
+        };
+}

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -113,6 +113,13 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<ITimerSource>(sp => sp.GetRequiredService<LootSource>());
         services.AddSingleton<TimerAlarmService>();
 
+        // Drives TimerProgressService.CheckExpirations on a one-shot timer
+        // scheduled at the soonest known user-timer expiration. Replaces
+        // the 1 Hz tick that used to live in TimerListViewModel.Tick. Owns
+        // a DispatcherTimer — kept out of TimerProgressService itself to
+        // keep WPF dependencies away from the per-character data layer.
+        services.AddSingleton<TimerExpirationScheduler>();
+
         // Dashboard aggregator + VM — fans in every registered ITimerSource.
         services.AddSingleton<DashboardAggregator>();
         services.AddSingleton<DashboardViewModel>();
@@ -127,9 +134,19 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<ICharacterPresenceService>()));
 
         services.AddSingleton<GandalfShellViewModel>();
-        services.AddSingleton<GandalfShellView>(sp => new GandalfShellView
+        services.AddSingleton<GandalfShellView>(sp =>
         {
-            DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
+            // Eagerly construct the expiration scheduler when the shell view
+            // is built. The scheduler subscribes to TimerProgressService /
+            // TimerDefinitionsService events in its ctor and owns a
+            // DispatcherTimer for the user-timer alarm path; nothing else
+            // resolves it. This is the same eager-singleton idiom that pulls
+            // TimerAlarmService in via TimerListViewModel's factory above.
+            _ = sp.GetRequiredService<TimerExpirationScheduler>();
+            return new GandalfShellView
+            {
+                DataContext = sp.GetRequiredService<GandalfShellViewModel>(),
+            };
         });
 
         services.AddSingleton<GandalfSettingsViewModel>();

--- a/src/Gandalf.Module/Services/DashboardAggregator.cs
+++ b/src/Gandalf.Module/Services/DashboardAggregator.cs
@@ -4,19 +4,24 @@ namespace Gandalf.Services;
 
 /// <summary>
 /// Cross-source aggregator. Subscribes to every registered <see cref="ITimerSource"/>'s
-/// <c>CatalogChanged</c> / <c>ProgressChanged</c> events and recomputes a flat
-/// list of <see cref="TimerSummary"/> rows. The Dashboard tab consumes the
-/// aggregator's <see cref="Updated"/> event to refresh its three sections.
+/// <see cref="ITimerSource.RowsChanged"/> per-key feed and applies deltas
+/// incrementally to a flat <see cref="TimerSummary"/> map. The Dashboard
+/// view consumes <see cref="Updated"/> to refresh its three sections.
 ///
-/// No caching beyond the projection itself — recomputation is cheap relative
-/// to the dashboard's 1Hz refresh budget. Driven by <c>TimeProvider</c> so
-/// tests can advance time deterministically.
+/// <para>State on a summary is computed against <see cref="TimeProvider"/>
+/// at projection time — pure time progression doesn't fire any source
+/// event, so the Dashboard view's 1 Hz tick still calls
+/// <see cref="Recompute"/> to surface <c>Cooling → Ready</c> transitions.
+/// Driving that tick from a <see cref="Domain.TimerRow.NextDisplayChangeAt"/>-style
+/// schedule on the aggregator is a clean follow-up; out of scope for the
+/// timer-model PR.</para>
 /// </summary>
 public sealed class DashboardAggregator : IDisposable
 {
     private readonly IReadOnlyList<ITimerSource> _sources;
     private readonly TimeProvider _time;
     private readonly object _lock = new();
+    private readonly Dictionary<(string SourceId, string Key), TimerSummary> _byKey = [];
     private IReadOnlyList<TimerSummary> _summaries = [];
 
     public DashboardAggregator(IEnumerable<ITimerSource> sources, TimeProvider? time = null)
@@ -24,16 +29,22 @@ public sealed class DashboardAggregator : IDisposable
         _sources = sources.ToArray();
         _time = time ?? TimeProvider.System;
 
+        var now = _time.GetUtcNow();
         foreach (var source in _sources)
         {
-            source.CatalogChanged += OnSourceChanged;
-            source.ProgressChanged += OnSourceChanged;
+            foreach (var entry in source.Catalog)
+            {
+                source.TryGetProgress(entry.Key, out var progress);
+                _byKey[(source.SourceId, entry.Key)] =
+                    BuildSummary(source.SourceId, entry, progress, now);
+            }
+            source.RowsChanged += OnSourceRowsChanged;
         }
 
-        Recompute();
+        SnapshotSummaries();
     }
 
-    /// <summary>Fires whenever any source's catalog or progress changes.</summary>
+    /// <summary>Fires whenever any source's deltas land or <see cref="Recompute"/> runs.</summary>
     public event EventHandler? Updated;
 
     public IReadOnlyList<TimerSummary> Summaries
@@ -42,27 +53,58 @@ public sealed class DashboardAggregator : IDisposable
     }
 
     /// <summary>
-    /// Recomputes <see cref="Summaries"/> using the current TimeProvider clock.
-    /// Called automatically on source events; call manually from the dashboard's
-    /// 1Hz tick so Cooling → Ready transitions show up without a source event.
+    /// Re-evaluates state for every summary using the current
+    /// <see cref="TimeProvider"/> clock. Source events handle catalog +
+    /// progress mutations incrementally; this method exists for the
+    /// dashboard's 1 Hz tick to catch <c>Cooling → Ready</c> transitions
+    /// that fire on time alone (no source event).
     /// </summary>
     public void Recompute()
     {
         var now = _time.GetUtcNow();
-        var list = new List<TimerSummary>();
-        foreach (var source in _sources)
+        lock (_lock)
         {
-            var progress = source.Progress;
-            foreach (var entry in source.Catalog)
+            foreach (var source in _sources)
             {
-                progress.TryGetValue(entry.Key, out var p);
-                list.Add(BuildSummary(source.SourceId, entry, p, now));
+                foreach (var entry in source.Catalog)
+                {
+                    source.TryGetProgress(entry.Key, out var progress);
+                    _byKey[(source.SourceId, entry.Key)] =
+                        BuildSummary(source.SourceId, entry, progress, now);
+                }
             }
+            SnapshotSummaries();
         }
-
-        lock (_lock) _summaries = list;
         Updated?.Invoke(this, EventArgs.Empty);
     }
+
+    private void OnSourceRowsChanged(object? sender, TimerRowsChangedEventArgs e)
+    {
+        if (sender is not ITimerSource source) return;
+
+        var any = false;
+        var now = _time.GetUtcNow();
+        lock (_lock)
+        {
+            foreach (var delta in e.Deltas)
+            {
+                var compositeKey = (source.SourceId, delta.Key);
+                if (delta.Kind == TimerRowChangeKind.Removed)
+                {
+                    if (_byKey.Remove(compositeKey)) any = true;
+                    continue;
+                }
+                if (delta.Catalog is null) continue;
+
+                _byKey[compositeKey] = BuildSummary(source.SourceId, delta.Catalog, delta.Progress, now);
+                any = true;
+            }
+            if (any) SnapshotSummaries();
+        }
+        if (any) Updated?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void SnapshotSummaries() => _summaries = _byKey.Values.ToArray();
 
     private static TimerSummary BuildSummary(
         string sourceId,
@@ -82,14 +124,9 @@ public sealed class DashboardAggregator : IDisposable
             ExpiresAt: expiresAt, State: state);
     }
 
-    private void OnSourceChanged(object? sender, EventArgs e) => Recompute();
-
     public void Dispose()
     {
         foreach (var source in _sources)
-        {
-            source.CatalogChanged -= OnSourceChanged;
-            source.ProgressChanged -= OnSourceChanged;
-        }
+            source.RowsChanged -= OnSourceRowsChanged;
     }
 }

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Settings;
@@ -51,6 +52,8 @@ public sealed class LootSource : ITimerSource, IDisposable
     private IReadOnlyDictionary<string, DefeatCatalogEntry> _calibrationByDisplayName =
         new Dictionary<string, DefeatCatalogEntry>(StringComparer.OrdinalIgnoreCase);
     private IReadOnlyList<TimerCatalogEntry> _catalog;
+    private IReadOnlyDictionary<string, TimerCatalogEntry> _lastCatalogByKey;
+    private IReadOnlyDictionary<string, TimerProgressEntry> _lastProgressByKey;
 
     public LootSource(
         DerivedTimerProgressService derived,
@@ -65,6 +68,8 @@ public sealed class LootSource : ITimerSource, IDisposable
         _time = time ?? TimeProvider.System;
         _diag = diag;
         _catalog = BuildCatalog();
+        _lastCatalogByKey = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
+        _lastProgressByKey = SnapshotProgress();
 
         _derived.ProgressChanged += OnDerivedProgressChanged;
     }
@@ -73,9 +78,18 @@ public sealed class LootSource : ITimerSource, IDisposable
     public IReadOnlyList<TimerCatalogEntry> Catalog => _catalog;
     public IReadOnlyDictionary<string, TimerProgressEntry> Progress => SnapshotProgress();
 
+    public bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress)
+    {
+        var p = _derived.GetProgress(Id, key);
+        if (p is null) { progress = null; return false; }
+        progress = new TimerProgressEntry(key, p.StartedAt, p.DismissedAt);
+        return true;
+    }
+
     public event EventHandler? CatalogChanged;
     public event EventHandler? ProgressChanged;
     public event EventHandler<TimerReadyEventArgs>? TimerReady;
+    public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
     /// <summary>
     /// Apply a chest interaction observation: stamp a cooldown row anchored on
@@ -262,6 +276,7 @@ public sealed class LootSource : ITimerSource, IDisposable
             _calibrationByDisplayName = byName;
             _catalog = BuildCatalog();
         }
+        EmitDeltas();
         CatalogChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -279,8 +294,30 @@ public sealed class LootSource : ITimerSource, IDisposable
         return (PlaceholderChestDuration, false);
     }
 
-    private void OnDerivedProgressChanged(object? sender, EventArgs e) =>
+    private void OnDerivedProgressChanged(object? sender, EventArgs e)
+    {
+        EmitDeltas();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Diff the current <c>(catalog, progress)</c> against the last snapshot,
+    /// fire <see cref="RowsChanged"/> if there are deltas, and update the
+    /// snapshot. Called from every event-firing site so the new per-key feed
+    /// stays consistent with the legacy coarse events during the rollout.
+    /// </summary>
+    private void EmitDeltas()
+    {
+        var newCatalog = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
+        var newProgress = SnapshotProgress();
+        var deltas = TimerRowDeltaDiffer.Diff(
+            _lastCatalogByKey, newCatalog,
+            _lastProgressByKey, newProgress);
+        _lastCatalogByKey = newCatalog;
+        _lastProgressByKey = newProgress;
+        if (deltas.Count > 0)
+            RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });
+    }
 
     private IReadOnlyDictionary<string, TimerProgressEntry> SnapshotProgress()
     {
@@ -343,7 +380,11 @@ public sealed class LootSource : ITimerSource, IDisposable
             _catalog = BuildCatalog();
             raised = true;
         }
-        if (raised) CatalogChanged?.Invoke(this, EventArgs.Empty);
+        if (raised)
+        {
+            EmitDeltas();
+            CatalogChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     private void FireReady(string key, string displayName, TimeSpan durationOverride, DateTimeOffset atUtc)

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -86,8 +86,6 @@ public sealed class LootSource : ITimerSource, IDisposable
         return true;
     }
 
-    public event EventHandler? CatalogChanged;
-    public event EventHandler? ProgressChanged;
     public event EventHandler<TimerReadyEventArgs>? TimerReady;
     public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
@@ -277,7 +275,6 @@ public sealed class LootSource : ITimerSource, IDisposable
             _catalog = BuildCatalog();
         }
         EmitDeltas();
-        CatalogChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private (TimeSpan duration, bool verified) ResolveDefeatDuration(string displayName)
@@ -294,17 +291,13 @@ public sealed class LootSource : ITimerSource, IDisposable
         return (PlaceholderChestDuration, false);
     }
 
-    private void OnDerivedProgressChanged(object? sender, EventArgs e)
-    {
-        EmitDeltas();
-        ProgressChanged?.Invoke(this, EventArgs.Empty);
-    }
+    private void OnDerivedProgressChanged(object? sender, EventArgs e) => EmitDeltas();
 
     /// <summary>
-    /// Diff the current <c>(catalog, progress)</c> against the last snapshot,
-    /// fire <see cref="RowsChanged"/> if there are deltas, and update the
-    /// snapshot. Called from every event-firing site so the new per-key feed
-    /// stays consistent with the legacy coarse events during the rollout.
+    /// Diff the current <c>(catalog, progress)</c> against the last snapshot
+    /// and fire <see cref="RowsChanged"/> if there are deltas. Called from
+    /// every mutation path so consumers see per-key changes without
+    /// re-snapshotting the whole catalog.
     /// </summary>
     private void EmitDeltas()
     {
@@ -374,17 +367,8 @@ public sealed class LootSource : ITimerSource, IDisposable
 
     private void EnsureCatalogReprojected()
     {
-        bool raised;
-        lock (_catalogLock)
-        {
-            _catalog = BuildCatalog();
-            raised = true;
-        }
-        if (raised)
-        {
-            EmitDeltas();
-            CatalogChanged?.Invoke(this, EventArgs.Empty);
-        }
+        lock (_catalogLock) _catalog = BuildCatalog();
+        EmitDeltas();
     }
 
     private void FireReady(string key, string displayName, TimeSpan durationOverride, DateTimeOffset atUtc)

--- a/src/Gandalf.Module/Services/QuestSource.cs
+++ b/src/Gandalf.Module/Services/QuestSource.cs
@@ -63,10 +63,24 @@ public sealed class QuestSource : ITimerSource, IDisposable
         return true;
     }
 
-    public event EventHandler? CatalogChanged;
-    public event EventHandler? ProgressChanged;
     public event EventHandler<TimerReadyEventArgs>? TimerReady;
     public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
+
+    /// <summary>
+    /// Fires when the journal-pending set mutates. Distinct from
+    /// <see cref="RowsChanged"/> because pending changes don't mutate
+    /// catalog or progress — they only shift the relevance predicate's
+    /// inputs for <see cref="QuestTimersViewModel"/>'s journal-active
+    /// filter. Subscribers respond by re-evaluating which rows they
+    /// materialise.
+    ///
+    /// <para>Will be retired by <see href="https://github.com/arthur-conde/project-gorgon/issues/155">#155</see>:
+    /// once <c>IQuestService</c> owns the active-quest list and
+    /// <see cref="QuestSource"/>'s catalog is the active set, journal
+    /// changes flow through <see cref="RowsChanged"/> as
+    /// <c>Added</c>/<c>Removed</c> deltas naturally.</para>
+    /// </summary>
+    public event EventHandler? PendingChanged;
 
     /// <summary>Snapshot of quests currently loaded in the player's journal (for the Pending filter).</summary>
     public IReadOnlySet<string> PendingInternalNames
@@ -99,15 +113,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
                 foreach (var n in resolved) _pending.Add(n);
             }
         }
-        if (changed)
-        {
-            // Pending-set changes don't mutate catalog or progress, so the
-            // RowsChanged delta will be empty — but the VM still needs to
-            // re-evaluate the journal-membership filter via the legacy
-            // ProgressChanged event until the binder gains a relevance hook.
-            EmitDeltas();
-            ProgressChanged?.Invoke(this, EventArgs.Empty);
-        }
+        if (changed) PendingChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -119,11 +125,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
         if (string.IsNullOrEmpty(questInternalName)) return;
         bool changed;
         lock (_lock) changed = _pending.Add(questInternalName);
-        if (changed)
-        {
-            EmitDeltas();
-            ProgressChanged?.Invoke(this, EventArgs.Empty);
-        }
+        if (changed) PendingChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -167,11 +169,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
         }
     }
 
-    private void OnDerivedProgressChanged(object? sender, EventArgs e)
-    {
-        EmitDeltas();
-        ProgressChanged?.Invoke(this, EventArgs.Empty);
-    }
+    private void OnDerivedProgressChanged(object? sender, EventArgs e) => EmitDeltas();
 
     private void OnReferenceFileUpdated(object? sender, string fileKey)
     {
@@ -185,7 +183,6 @@ public sealed class QuestSource : ITimerSource, IDisposable
         _derived.GarbageCollect(Id, validKeys);
 
         EmitDeltas();
-        CatalogChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>

--- a/src/Gandalf.Module/Services/QuestSource.cs
+++ b/src/Gandalf.Module/Services/QuestSource.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
 using Mithril.Shared.Reference;
 
@@ -31,6 +32,8 @@ public sealed class QuestSource : ITimerSource, IDisposable
     private readonly object _lock = new();
     private IReadOnlyList<TimerCatalogEntry> _catalog;
     private readonly HashSet<string> _pending = new(StringComparer.OrdinalIgnoreCase);
+    private IReadOnlyDictionary<string, TimerCatalogEntry> _lastCatalogByKey;
+    private IReadOnlyDictionary<string, TimerProgressEntry> _lastProgressByKey;
 
     public QuestSource(
         DerivedTimerProgressService derived,
@@ -41,6 +44,8 @@ public sealed class QuestSource : ITimerSource, IDisposable
         _refData = refData;
         _time = time ?? TimeProvider.System;
         _catalog = BuildCatalog();
+        _lastCatalogByKey = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
+        _lastProgressByKey = SnapshotProgress();
 
         _derived.ProgressChanged += OnDerivedProgressChanged;
         _refData.FileUpdated += OnReferenceFileUpdated;
@@ -50,9 +55,18 @@ public sealed class QuestSource : ITimerSource, IDisposable
     public IReadOnlyList<TimerCatalogEntry> Catalog => _catalog;
     public IReadOnlyDictionary<string, TimerProgressEntry> Progress => SnapshotProgress();
 
+    public bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress)
+    {
+        var p = _derived.GetProgress(Id, key);
+        if (p is null) { progress = null; return false; }
+        progress = new TimerProgressEntry(key, p.StartedAt, p.DismissedAt);
+        return true;
+    }
+
     public event EventHandler? CatalogChanged;
     public event EventHandler? ProgressChanged;
     public event EventHandler<TimerReadyEventArgs>? TimerReady;
+    public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
     /// <summary>Snapshot of quests currently loaded in the player's journal (for the Pending filter).</summary>
     public IReadOnlySet<string> PendingInternalNames
@@ -85,7 +99,15 @@ public sealed class QuestSource : ITimerSource, IDisposable
                 foreach (var n in resolved) _pending.Add(n);
             }
         }
-        if (changed) ProgressChanged?.Invoke(this, EventArgs.Empty);
+        if (changed)
+        {
+            // Pending-set changes don't mutate catalog or progress, so the
+            // RowsChanged delta will be empty — but the VM still needs to
+            // re-evaluate the journal-membership filter via the legacy
+            // ProgressChanged event until the binder gains a relevance hook.
+            EmitDeltas();
+            ProgressChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     /// <summary>
@@ -97,7 +119,11 @@ public sealed class QuestSource : ITimerSource, IDisposable
         if (string.IsNullOrEmpty(questInternalName)) return;
         bool changed;
         lock (_lock) changed = _pending.Add(questInternalName);
-        if (changed) ProgressChanged?.Invoke(this, EventArgs.Empty);
+        if (changed)
+        {
+            EmitDeltas();
+            ProgressChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     /// <summary>
@@ -141,8 +167,11 @@ public sealed class QuestSource : ITimerSource, IDisposable
         }
     }
 
-    private void OnDerivedProgressChanged(object? sender, EventArgs e) =>
+    private void OnDerivedProgressChanged(object? sender, EventArgs e)
+    {
+        EmitDeltas();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
 
     private void OnReferenceFileUpdated(object? sender, string fileKey)
     {
@@ -155,7 +184,27 @@ public sealed class QuestSource : ITimerSource, IDisposable
         var validKeys = newCatalog.Select(c => c.Key).ToArray();
         _derived.GarbageCollect(Id, validKeys);
 
+        EmitDeltas();
         CatalogChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Diff the current <c>(catalog, progress)</c> against the last snapshot,
+    /// fire <see cref="RowsChanged"/> if there are deltas, and update the
+    /// snapshot. Called from every event-firing site so the new per-key feed
+    /// stays consistent with the legacy coarse events during the rollout.
+    /// </summary>
+    private void EmitDeltas()
+    {
+        var newCatalog = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
+        var newProgress = SnapshotProgress();
+        var deltas = TimerRowDeltaDiffer.Diff(
+            _lastCatalogByKey, newCatalog,
+            _lastProgressByKey, newProgress);
+        _lastCatalogByKey = newCatalog;
+        _lastProgressByKey = newProgress;
+        if (deltas.Count > 0)
+            RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });
     }
 
     private IReadOnlyDictionary<string, TimerProgressEntry> SnapshotProgress()

--- a/src/Gandalf.Module/Services/TimerDisplayScheduler.cs
+++ b/src/Gandalf.Module/Services/TimerDisplayScheduler.cs
@@ -1,0 +1,272 @@
+using System.Windows;
+using System.Windows.Threading;
+using Gandalf.Domain;
+using Gandalf.ViewModels;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Wakes registered <see cref="TimerItemViewModel"/>s only when their visible
+/// display would actually change — replacing the per-tab 1 Hz
+/// <see cref="DispatcherTimer"/> that previously refreshed every row every
+/// second whether anything had moved or not.
+///
+/// <para>Two tiers:</para>
+/// <list type="bullet">
+/// <item><b>Slow tick</b> — wakes at <c>min(TimerRow.NextDisplayChangeAt)</c>
+/// across registered rows. Used when the only thing changing is the
+/// <c>"Xh Ym remaining"</c> text bucket on a Running row, or
+/// <c>"done X ago"</c> on a Done row, which only flip on minute boundaries.
+/// Idle rows return <c>null</c> for <c>NextDisplayChangeAt</c> and don't
+/// hold the timer awake at all.</item>
+/// <item><b>Fast tick</b> — 1 Hz, runs only while at least one registered
+/// row is <c>Running</c> with <c>ShowProgressBar = true</c>. Drives sub-minute
+/// <c>Fraction</c> animation on visible progress bars. Stops when the last
+/// such row finishes.</item>
+/// </list>
+///
+/// <para>When neither condition holds — all rows Idle, or all Done with
+/// <c>NextDisplayChangeAt</c> in the past for "done Xm ago" stability —
+/// both timers are stopped. Zero per-second work on an all-Idle tab.</para>
+///
+/// <para>Threading: same dispatcher contract as <see cref="TimerSourceBinder"/>.
+/// Production callers run on the UI thread; tests fall back to
+/// <see cref="Dispatcher.CurrentDispatcher"/> and drive ticks directly via
+/// <see cref="TickSlowForTests"/> / <see cref="TickFastForTests"/>.</para>
+/// </summary>
+public sealed class TimerDisplayScheduler : IDisposable
+{
+    private readonly TimeProvider _clock;
+    private readonly Dispatcher _dispatcher;
+    // Per-row scheduled wake + last-known state. Both are captured at
+    // Register / Refresh / tick time because the corresponding TimerRow
+    // properties (NextDisplayChangeAt, State) re-read the clock on every
+    // access — once the wake instant has passed, NextDisplayChangeAt
+    // already points at the next future moment and State already reads as
+    // the post-flip value, so we'd miss the transition without bookkeeping.
+    private readonly Dictionary<TimerItemViewModel, ScheduledRow> _scheduledFor = [];
+
+    private sealed class ScheduledRow
+    {
+        public DateTimeOffset? NextChangeAt;
+        public TimerState LastKnownState;
+    }
+    private readonly DispatcherTimer _slowTimer;
+    private readonly DispatcherTimer _fastTimer;
+    private bool _disposed;
+
+    public TimerDisplayScheduler(TimeProvider clock, Dispatcher? dispatcher = null)
+    {
+        _clock = clock;
+        _dispatcher = dispatcher ?? Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        _slowTimer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher);
+        _slowTimer.Tick += (_, _) => OnSlowTick();
+
+        _fastTimer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher)
+        {
+            Interval = TimeSpan.FromSeconds(1),
+        };
+        _fastTimer.Tick += (_, _) => OnFastTick();
+    }
+
+    /// <summary>
+    /// Fires when a tick caused at least one row's <see cref="TimerItemViewModel.State"/>
+    /// to transition (e.g. <c>Running → Done</c>) — the host VM should call
+    /// <c>ICollectionView.Refresh</c> because <c>IsDone</c> is in the sort
+    /// descriptors and the State filter chip needs re-evaluating.
+    /// </summary>
+    public event EventHandler? RefreshRequired;
+
+    /// <summary>
+    /// Soonest <c>NextDisplayChangeAt</c> across registered rows, or
+    /// <c>null</c> when no row needs a future wake. Exposed for tests and
+    /// diagnostics; not load-bearing for normal operation (the slow timer's
+    /// interval reflects this internally).
+    /// </summary>
+    public DateTimeOffset? NextSlowTickAt
+    {
+        get
+        {
+            DateTimeOffset? earliest = null;
+            foreach (var row in _scheduledFor.Values)
+            {
+                if (row.NextChangeAt is not { } when) continue;
+                if (earliest is null || when < earliest) earliest = when;
+            }
+            return earliest;
+        }
+    }
+
+    /// <summary>
+    /// True iff at least one registered row is <c>Running</c> with
+    /// <c>ShowProgressBar = true</c>. The fast-tick gate predicate.
+    /// </summary>
+    public bool AnyRunningWithProgressBar
+    {
+        get
+        {
+            foreach (var vm in _scheduledFor.Keys)
+                if (vm.IsRunning && vm.ShowProgressBar) return true;
+            return false;
+        }
+    }
+
+    public void Register(TimerItemViewModel vm)
+    {
+        if (_disposed) return;
+        if (_scheduledFor.ContainsKey(vm)) return;
+        _scheduledFor[vm] = Snapshot(vm);
+        ReevaluateTimers();
+    }
+
+    public void Unregister(TimerItemViewModel vm)
+    {
+        if (_disposed) return;
+        if (_scheduledFor.Remove(vm)) ReevaluateTimers();
+    }
+
+    /// <summary>
+    /// Recompute timer scheduling for a single registered row whose
+    /// <c>NextDisplayChangeAt</c> may have shifted (e.g. after the host
+    /// applied <c>UpdateRow</c> via the binder, or the user dismissed a row).
+    /// No-op if the row isn't registered.
+    /// </summary>
+    public void Refresh(TimerItemViewModel vm)
+    {
+        if (_disposed) return;
+        if (!_scheduledFor.TryGetValue(vm, out var row)) return;
+        row.NextChangeAt = vm.Row.NextDisplayChangeAt;
+        row.LastKnownState = vm.State;
+        ReevaluateTimers();
+    }
+
+    /// <summary>
+    /// Re-read <c>NextDisplayChangeAt</c> and current state for every
+    /// registered row. Call after a batch of host-side updates (e.g. when
+    /// the binder finishes applying a deltas batch and the host VM wants
+    /// the scheduler to converge against the new state).
+    /// </summary>
+    public void RefreshAll()
+    {
+        if (_disposed) return;
+        foreach (var vm in _scheduledFor.Keys.ToArray())
+        {
+            var row = _scheduledFor[vm];
+            row.NextChangeAt = vm.Row.NextDisplayChangeAt;
+            row.LastKnownState = vm.State;
+        }
+        ReevaluateTimers();
+    }
+
+    private static ScheduledRow Snapshot(TimerItemViewModel vm) =>
+        new()
+        {
+            NextChangeAt = vm.Row.NextDisplayChangeAt,
+            LastKnownState = vm.State,
+        };
+
+    /// <summary>Test hook: drive one slow-tick cycle without waiting on the dispatcher pump.</summary>
+    internal void TickSlowForTests() => OnSlowTick();
+
+    /// <summary>Test hook: drive one fast-tick cycle without waiting on the dispatcher pump.</summary>
+    internal void TickFastForTests() => OnFastTick();
+
+    private void ReevaluateTimers()
+    {
+        // Fast tick gate.
+        if (AnyRunningWithProgressBar)
+        {
+            if (!_fastTimer.IsEnabled) _fastTimer.Start();
+        }
+        else
+        {
+            if (_fastTimer.IsEnabled) _fastTimer.Stop();
+        }
+
+        // Slow tick scheduling. When fast tick is running it already wakes
+        // every second, so the slow-tick wake is redundant — let it stay
+        // stopped while fast is active.
+        if (_fastTimer.IsEnabled)
+        {
+            if (_slowTimer.IsEnabled) _slowTimer.Stop();
+            return;
+        }
+
+        var earliest = NextSlowTickAt;
+        if (earliest is null)
+        {
+            if (_slowTimer.IsEnabled) _slowTimer.Stop();
+            return;
+        }
+
+        var delay = earliest.Value - _clock.GetUtcNow();
+        // Floor: avoid sub-tick scheduling that just spins. 50 ms is below
+        // human perception for a state-flip moment but above the dispatcher's
+        // resolution noise floor.
+        if (delay < TimeSpan.FromMilliseconds(50)) delay = TimeSpan.FromMilliseconds(50);
+        _slowTimer.Interval = delay;
+        if (!_slowTimer.IsEnabled) _slowTimer.Start();
+    }
+
+    private void OnSlowTick()
+    {
+        if (_disposed) return;
+        var now = _clock.GetUtcNow();
+        Tick(refreshPredicate: scheduled =>
+            scheduled.NextChangeAt is { } when && when <= now);
+    }
+
+    private void OnFastTick()
+    {
+        if (_disposed) return;
+        // Fast-tick refresh condition is the gate predicate evaluated per VM
+        // — Running rows with visible progress bars need their Fraction
+        // refreshed every second. State-change detection happens uniformly
+        // in Tick() regardless.
+        Tick(refreshPredicate: _ => false, fastRefresh: true);
+    }
+
+    /// <summary>
+    /// Shared body for slow + fast ticks. Iterates registered rows, refreshes
+    /// those whose tier-specific condition is met, and uniformly fires
+    /// <see cref="RefreshRequired"/> when any row's state transitioned since
+    /// the last observation. State transitions are detected even on rows we
+    /// don't refresh — a Running row that just crossed to Done won't satisfy
+    /// the fast-tick gate any more, but its state-change must still propagate.
+    /// </summary>
+    private void Tick(Func<ScheduledRow, bool> refreshPredicate, bool fastRefresh = false)
+    {
+        var stateChanged = false;
+
+        foreach (var vm in _scheduledFor.Keys.ToArray())
+        {
+            var scheduled = _scheduledFor[vm];
+            var oldState = scheduled.LastKnownState;
+
+            var shouldSlowRefresh = refreshPredicate(scheduled);
+            var shouldFastRefresh = fastRefresh && vm.IsRunning && vm.ShowProgressBar;
+
+            if (shouldSlowRefresh || shouldFastRefresh)
+            {
+                vm.Refresh();
+                scheduled.NextChangeAt = vm.Row.NextDisplayChangeAt;
+            }
+
+            var newState = vm.State;
+            if (newState != oldState) stateChanged = true;
+            scheduled.LastKnownState = newState;
+        }
+
+        if (stateChanged) RefreshRequired?.Invoke(this, EventArgs.Empty);
+        ReevaluateTimers();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _slowTimer.Stop();
+        _fastTimer.Stop();
+    }
+}

--- a/src/Gandalf.Module/Services/TimerExpirationScheduler.cs
+++ b/src/Gandalf.Module/Services/TimerExpirationScheduler.cs
@@ -1,0 +1,137 @@
+using System.Windows;
+using System.Windows.Threading;
+using Gandalf.Domain;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Drives <see cref="TimerProgressService.CheckExpirations"/> on its own
+/// schedule, replacing the 1 Hz <c>TimerListViewModel.Tick</c> that
+/// previously held that responsibility. Owns a <see cref="DispatcherTimer"/>
+/// scheduled at the soonest known expiration moment across all user-timer
+/// definitions; on fire, runs <c>CheckExpirations</c> (which stamps
+/// <c>CompletedAt</c> and fires <c>TimerExpired</c> → <c>UserTimerSource.TimerReady</c>
+/// → <c>TimerAlarmService</c>) and reschedules.
+///
+/// <para>Lives in <c>Gandalf.Module</c> rather than alongside
+/// <see cref="TimerProgressService"/> in the data layer because it owns a
+/// WPF <see cref="DispatcherTimer"/> and Arthur explicitly didn't want WPF
+/// dependencies leaking into the per-character data services.</para>
+///
+/// <para>Reschedule triggers:
+/// <list type="bullet">
+/// <item><see cref="TimerProgressService.ProgressChanged"/> — covers Start /
+/// Restart / Reset / Dismiss / character-switch / clear-all-done.</item>
+/// <item><see cref="TimerDefinitionsService.DefinitionsChanged"/> — a
+/// definition added or removed shifts the compute set.</item>
+/// <item>The own tick — recompute after firing, in case
+/// <c>CheckExpirations</c> stamped a <c>CompletedAt</c> that removes one
+/// pending entry.</item>
+/// </list></para>
+///
+/// <para>When no timer is currently Running, the dispatcher timer is
+/// stopped — zero per-second work for a character with no active user
+/// timers. The "wake up at the right moment" model means a timer set 8 h
+/// from now sits silent for 8 h, then fires alarms, then sleeps again.</para>
+/// </summary>
+public sealed class TimerExpirationScheduler : IDisposable
+{
+    private readonly TimerProgressService _progress;
+    private readonly TimerDefinitionsService _defs;
+    private readonly TimeProvider _clock;
+    private readonly Dispatcher _dispatcher;
+    private readonly DispatcherTimer _timer;
+    private bool _disposed;
+
+    public TimerExpirationScheduler(
+        TimerProgressService progress,
+        TimerDefinitionsService defs,
+        TimeProvider? clock = null,
+        Dispatcher? dispatcher = null)
+    {
+        _progress = progress;
+        _defs = defs;
+        _clock = clock ?? TimeProvider.System;
+        _dispatcher = dispatcher ?? Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        _timer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher);
+        _timer.Tick += (_, _) => OnTick();
+
+        _progress.ProgressChanged += OnSourceChanged;
+        _defs.DefinitionsChanged += OnSourceChanged;
+
+        // Initial scheduling — in case timers were Running from a prior
+        // session, we want to wake at the next expiration immediately.
+        Reschedule();
+    }
+
+    /// <summary>Test hook — drive one expiration cycle without waiting on the dispatcher pump.</summary>
+    internal void TickForTests() => OnTick();
+
+    /// <summary>The next scheduled expiration moment, or <c>null</c> when no timer is Running.</summary>
+    public DateTimeOffset? NextExpirationAt => ComputeSoonest();
+
+    private void OnSourceChanged(object? sender, EventArgs e) => Dispatch(Reschedule);
+
+    private void OnTick()
+    {
+        if (_disposed) return;
+        _progress.CheckExpirations();
+        // CheckExpirations may have fired ProgressChanged via the stamping
+        // path → recursive Reschedule. Guarded internally; explicit call
+        // here covers the case where the stamp didn't actually mutate any
+        // observable state (already-stamped row).
+        Reschedule();
+    }
+
+    private void Reschedule()
+    {
+        if (_disposed) return;
+
+        var soonest = ComputeSoonest();
+        if (soonest is null)
+        {
+            if (_timer.IsEnabled) _timer.Stop();
+            return;
+        }
+
+        var now = _clock.GetUtcNow();
+        var delay = soonest.Value - now;
+        // Floor at 50 ms — same rationale as TimerDisplayScheduler. Below
+        // human perception for the alarm-fire moment but above the
+        // dispatcher's resolution noise floor.
+        if (delay < TimeSpan.FromMilliseconds(50)) delay = TimeSpan.FromMilliseconds(50);
+
+        _timer.Interval = delay;
+        if (!_timer.IsEnabled) _timer.Start();
+    }
+
+    private DateTimeOffset? ComputeSoonest()
+    {
+        DateTimeOffset? soonest = null;
+        foreach (var def in _defs.Definitions)
+        {
+            var p = _progress.GetProgress(def.Id);
+            if (p?.StartedAt is null) continue;
+            if (p.CompletedAt is not null) continue;  // already stamped — no further expiration to fire
+            var expiresAt = p.StartedAt.Value + def.Duration;
+            if (soonest is null || expiresAt < soonest) soonest = expiresAt;
+        }
+        return soonest;
+    }
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatcher.CheckAccess()) action();
+        else _dispatcher.BeginInvoke(action);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _timer.Stop();
+        _progress.ProgressChanged -= OnSourceChanged;
+        _defs.DefinitionsChanged -= OnSourceChanged;
+    }
+}

--- a/src/Gandalf.Module/Services/TimerSourceBinder.cs
+++ b/src/Gandalf.Module/Services/TimerSourceBinder.cs
@@ -45,6 +45,7 @@ public sealed class TimerSourceBinder : IDisposable
     private readonly TimeProvider _clock;
     private readonly Func<TimerCatalogEntry, TimerProgressEntry?, bool> _isRelevant;
     private readonly Dispatcher _dispatcher;
+    private readonly TimerDisplayScheduler? _scheduler;
     private readonly Dictionary<string, TimerItemViewModel> _byKey =
         new(StringComparer.Ordinal);
     private bool _disposed;
@@ -54,13 +55,15 @@ public sealed class TimerSourceBinder : IDisposable
         ObservableCollection<TimerItemViewModel> target,
         TimeProvider clock,
         Func<TimerCatalogEntry, TimerProgressEntry?, bool>? isRelevant = null,
-        Dispatcher? dispatcher = null)
+        Dispatcher? dispatcher = null,
+        TimerDisplayScheduler? scheduler = null)
     {
         _source = source;
         _target = target;
         _clock = clock;
         _isRelevant = isRelevant ?? ((_, _) => true);
         _dispatcher = dispatcher ?? Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+        _scheduler = scheduler;
 
         // Initial sync runs on whichever thread constructed the binder —
         // typically the UI thread (host VM ctor). Subsequent deltas marshal
@@ -192,6 +195,7 @@ public sealed class TimerSourceBinder : IDisposable
             var fresh = new TimerItemViewModel(new TimerRow(entry, progress) { Clock = _clock });
             _byKey[key] = fresh;
             _target.Add(fresh);
+            _scheduler?.Register(fresh);
             return true;
         }
 
@@ -200,6 +204,9 @@ public sealed class TimerSourceBinder : IDisposable
         var oldGroupKey = vm!.GroupKey;
         var oldState = vm.State;
         vm.UpdateRow(new TimerRow(entry, progress) { Clock = _clock });
+        // Tell the scheduler the row's NextDisplayChangeAt may have shifted
+        // (e.g. progress just started → state-flip moment now relevant).
+        _scheduler?.Refresh(vm);
         return vm.GroupKey != oldGroupKey || vm.State != oldState;
     }
 
@@ -207,6 +214,7 @@ public sealed class TimerSourceBinder : IDisposable
     {
         if (!_byKey.Remove(key, out var vm)) return;
         _target.Remove(vm);
+        _scheduler?.Unregister(vm);
     }
 
     private void RaiseRefreshRequired() =>

--- a/src/Gandalf.Module/Services/TimerSourceBinder.cs
+++ b/src/Gandalf.Module/Services/TimerSourceBinder.cs
@@ -1,0 +1,227 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Threading;
+using Gandalf.Domain;
+using Gandalf.ViewModels;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Generalisation of the diff-in-place pattern from
+/// <c>QuestTimersViewModel.Sync</c>. Binds an <see cref="ITimerSource"/> to a
+/// host VM's <see cref="ObservableCollection{TimerItemViewModel}"/> by
+/// translating <see cref="ITimerSource.RowsChanged"/> deltas into add /
+/// update / remove operations on the target collection — so consumers stop
+/// clearing-and-rebuilding on every event.
+///
+/// <para>Threading: source events fire from the log-ingestion background
+/// thread, but the target collection is bound to a WPF
+/// <see cref="System.Windows.Data.CollectionView"/> that requires UI-thread
+/// mutations (see <c>memory/wpf_crossthread_collection_mutations.md</c> —
+/// Pippin's GourmandViewModel was the prior incident). The binder captures
+/// the active dispatcher in its ctor and routes every collection mutation
+/// through <c>CheckAccess</c> + <c>BeginInvoke</c>; tests construct without
+/// an <see cref="Application"/> so the fallback <see cref="Dispatcher.CurrentDispatcher"/>
+/// stays on the test thread and applies inline.</para>
+///
+/// <para>Relevance filter: optional predicate (used by QuestTimersViewModel
+/// to skip the ~2,000 repeatable quests the player has never touched).
+/// LootSource and UserTimerSource pass null — every catalog row materialises.
+/// When the predicate's external inputs change (the QuestSource pending set
+/// today; <see cref="Mithril.Shared.Quests.IQuestService"/> in the planned
+/// follow-up), the host VM calls <see cref="RecheckRelevance"/>.</para>
+///
+/// <para>Refresh signal: fires <see cref="RefreshRequired"/> at the end of
+/// each delta batch when an existing row's GroupKey or State changed (the
+/// properties used by the tab VMs' sort / group / filter descriptors).
+/// CollectionView automatically picks up Add / Remove via
+/// <c>CollectionChanged</c>, so those don't need an explicit signal —
+/// only in-place property mutations do.</para>
+/// </summary>
+public sealed class TimerSourceBinder : IDisposable
+{
+    private readonly ITimerSource _source;
+    private readonly ObservableCollection<TimerItemViewModel> _target;
+    private readonly TimeProvider _clock;
+    private readonly Func<TimerCatalogEntry, TimerProgressEntry?, bool> _isRelevant;
+    private readonly Dispatcher _dispatcher;
+    private readonly Dictionary<string, TimerItemViewModel> _byKey =
+        new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    public TimerSourceBinder(
+        ITimerSource source,
+        ObservableCollection<TimerItemViewModel> target,
+        TimeProvider clock,
+        Func<TimerCatalogEntry, TimerProgressEntry?, bool>? isRelevant = null,
+        Dispatcher? dispatcher = null)
+    {
+        _source = source;
+        _target = target;
+        _clock = clock;
+        _isRelevant = isRelevant ?? ((_, _) => true);
+        _dispatcher = dispatcher ?? Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        // Initial sync runs on whichever thread constructed the binder —
+        // typically the UI thread (host VM ctor). Subsequent deltas marshal
+        // through OnRowsChanged.
+        ApplyRecheckRelevance(initial: true);
+        _source.RowsChanged += OnRowsChanged;
+    }
+
+    /// <summary>
+    /// Snapshot of the rows currently materialised, keyed by <see cref="TimerCatalogEntry.Key"/>.
+    /// Exposed so the host VM can iterate (e.g. for bulk dismiss commands)
+    /// without re-walking the source.
+    /// </summary>
+    public IReadOnlyDictionary<string, TimerItemViewModel> ByKey => _byKey;
+
+    /// <summary>
+    /// Fires after a delta batch (or <see cref="RecheckRelevance"/>) when at
+    /// least one in-place property change requires the host's
+    /// <c>ICollectionView</c> to re-run filter / sort / group.
+    /// Add / Remove are handled by <c>CollectionChanged</c> automatically and
+    /// do not raise this event.
+    /// </summary>
+    public event EventHandler? RefreshRequired;
+
+    /// <summary>
+    /// Re-evaluate the relevance predicate against every catalog row. Call
+    /// when an external input to the predicate has changed (e.g. the
+    /// QuestSource pending set, after #155 lands the <c>IQuestService</c>
+    /// active-set reshape removes the need for this entirely).
+    /// </summary>
+    public void RecheckRelevance()
+    {
+        Dispatch(() => ApplyRecheckRelevance(initial: false));
+    }
+
+    private void ApplyRecheckRelevance(bool initial)
+    {
+        if (_disposed) return;
+
+        var anyRefreshNeeded = false;
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var entry in _source.Catalog)
+        {
+            seen.Add(entry.Key);
+            _source.TryGetProgress(entry.Key, out var progress);
+            anyRefreshNeeded |= ApplyKey(entry.Key, entry, progress, isCatalogChange: true);
+        }
+
+        // Drop any materialised row whose key is no longer in the catalog.
+        foreach (var staleKey in _byKey.Keys.Where(k => !seen.Contains(k)).ToArray())
+        {
+            RemoveExistingRow(staleKey);
+            anyRefreshNeeded = true;
+        }
+
+        // The initial sync runs from the ctor — host VM hasn't subscribed
+        // to RefreshRequired yet, so suppress the signal there. The host
+        // calls TimersView.Refresh once after construction anyway.
+        if (anyRefreshNeeded && !initial) RaiseRefreshRequired();
+    }
+
+    private void OnRowsChanged(object? sender, TimerRowsChangedEventArgs e)
+    {
+        // Snapshot deltas before dispatching — the source may mutate further
+        // before the dispatcher pump gets to the work item.
+        var deltas = e.Deltas;
+        Dispatch(() => ApplyDeltas(deltas));
+    }
+
+    private void ApplyDeltas(IReadOnlyList<TimerRowDelta> deltas)
+    {
+        if (_disposed) return;
+
+        var anyRefreshNeeded = false;
+        foreach (var delta in deltas)
+        {
+            switch (delta.Kind)
+            {
+                case TimerRowChangeKind.Added:
+                case TimerRowChangeKind.CatalogChanged:
+                case TimerRowChangeKind.ProgressChanged:
+                    if (delta.Catalog is null) break;  // defensive — Added/*Changed always carry catalog
+                    anyRefreshNeeded |= ApplyKey(delta.Key, delta.Catalog, delta.Progress, isCatalogChange: delta.Kind != TimerRowChangeKind.ProgressChanged);
+                    break;
+
+                case TimerRowChangeKind.Removed:
+                    if (_byKey.ContainsKey(delta.Key))
+                    {
+                        RemoveExistingRow(delta.Key);
+                        anyRefreshNeeded = true;
+                    }
+                    break;
+            }
+        }
+
+        if (anyRefreshNeeded) RaiseRefreshRequired();
+    }
+
+    /// <summary>
+    /// Apply one row delta. Returns true iff an in-place property change
+    /// happened that warrants <see cref="RefreshRequired"/> (a state or
+    /// group-key transition on an existing row). Add / Remove are reported
+    /// as needing a refresh too because at minimum the host's filter-chip
+    /// counters may want to refresh, and the cost of one extra
+    /// <c>ICollectionView.Refresh</c> per batch is negligible.
+    /// </summary>
+    private bool ApplyKey(
+        string key,
+        TimerCatalogEntry entry,
+        TimerProgressEntry? progress,
+        bool isCatalogChange)
+    {
+        var relevant = _isRelevant(entry, progress);
+        var hadRow = _byKey.TryGetValue(key, out var vm);
+
+        if (!relevant)
+        {
+            if (hadRow)
+            {
+                RemoveExistingRow(key);
+                return true;
+            }
+            return false;
+        }
+
+        if (!hadRow)
+        {
+            var fresh = new TimerItemViewModel(new TimerRow(entry, progress) { Clock = _clock });
+            _byKey[key] = fresh;
+            _target.Add(fresh);
+            return true;
+        }
+
+        // Existing row: capture sort/group inputs before update, decide
+        // whether the host needs to Refresh after.
+        var oldGroupKey = vm!.GroupKey;
+        var oldState = vm.State;
+        vm.UpdateRow(new TimerRow(entry, progress) { Clock = _clock });
+        return vm.GroupKey != oldGroupKey || vm.State != oldState;
+    }
+
+    private void RemoveExistingRow(string key)
+    {
+        if (!_byKey.Remove(key, out var vm)) return;
+        _target.Remove(vm);
+    }
+
+    private void RaiseRefreshRequired() =>
+        RefreshRequired?.Invoke(this, EventArgs.Empty);
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatcher.CheckAccess()) action();
+        else _dispatcher.BeginInvoke(action);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _source.RowsChanged -= OnRowsChanged;
+    }
+}

--- a/src/Gandalf.Module/Services/UserTimerSource.cs
+++ b/src/Gandalf.Module/Services/UserTimerSource.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
 
 namespace Gandalf.Services;
@@ -17,6 +18,8 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
     private readonly TimerProgressService _progress;
     private IReadOnlyList<TimerCatalogEntry> _catalog;
     private IReadOnlyDictionary<string, TimerProgressEntry> _progressMap;
+    private IReadOnlyDictionary<string, TimerCatalogEntry> _lastCatalogByKey;
+    private IReadOnlyDictionary<string, TimerProgressEntry> _lastProgressByKey;
 
     public UserTimerSource(TimerDefinitionsService defs, TimerProgressService progress)
     {
@@ -24,6 +27,8 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
         _progress = progress;
         _catalog = ProjectCatalog(defs);
         _progressMap = ProjectProgress(defs, progress);
+        _lastCatalogByKey = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
+        _lastProgressByKey = _progressMap;
 
         _defs.DefinitionsChanged += OnDefinitionsChanged;
         _progress.ProgressChanged += OnProgressChanged;
@@ -34,9 +39,17 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
     public IReadOnlyList<TimerCatalogEntry> Catalog => _catalog;
     public IReadOnlyDictionary<string, TimerProgressEntry> Progress => _progressMap;
 
+    public bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress)
+    {
+        if (_progressMap.TryGetValue(key, out var p)) { progress = p; return true; }
+        progress = null;
+        return false;
+    }
+
     public event EventHandler? CatalogChanged;
     public event EventHandler? ProgressChanged;
     public event EventHandler<TimerReadyEventArgs>? TimerReady;
+    public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
     private void OnDefinitionsChanged(object? sender, EventArgs e)
     {
@@ -44,13 +57,34 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
         // A definition swap can orphan progress entries; reproject so consumers see a
         // consistent (catalog, progress) snapshot.
         _progressMap = ProjectProgress(_defs, _progress);
+        EmitDeltas();
         CatalogChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void OnProgressChanged(object? sender, EventArgs e)
     {
         _progressMap = ProjectProgress(_defs, _progress);
+        EmitDeltas();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Diff the current <c>(catalog, progress)</c> against the last snapshot,
+    /// fire <see cref="RowsChanged"/> if there are deltas, and update the
+    /// snapshot. Called from every event-firing site so the new per-key feed
+    /// stays consistent with the legacy coarse events during the rollout.
+    /// </summary>
+    private void EmitDeltas()
+    {
+        var newCatalog = _catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
+        var newProgress = _progressMap;
+        var deltas = TimerRowDeltaDiffer.Diff(
+            _lastCatalogByKey, newCatalog,
+            _lastProgressByKey, newProgress);
+        _lastCatalogByKey = newCatalog;
+        _lastProgressByKey = newProgress;
+        if (deltas.Count > 0)
+            RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });
     }
 
     private void OnTimerExpired(object? sender, TimerExpiredEventArgs e)

--- a/src/Gandalf.Module/Services/UserTimerSource.cs
+++ b/src/Gandalf.Module/Services/UserTimerSource.cs
@@ -46,8 +46,6 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
         return false;
     }
 
-    public event EventHandler? CatalogChanged;
-    public event EventHandler? ProgressChanged;
     public event EventHandler<TimerReadyEventArgs>? TimerReady;
     public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
@@ -58,14 +56,12 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
         // consistent (catalog, progress) snapshot.
         _progressMap = ProjectProgress(_defs, _progress);
         EmitDeltas();
-        CatalogChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void OnProgressChanged(object? sender, EventArgs e)
     {
         _progressMap = ProjectProgress(_defs, _progress);
         EmitDeltas();
-        ProgressChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>

--- a/src/Gandalf.Module/ViewModels/LootTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/LootTimersViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Data;
-using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Gandalf.Domain;
@@ -14,12 +13,14 @@ namespace Gandalf.ViewModels;
 /// shared <see cref="LootSource"/> and exposes Kind / State filter chips and
 /// bulk dismiss commands.
 /// </summary>
-public sealed partial class LootTimersViewModel : ObservableObject
+public sealed partial class LootTimersViewModel : ObservableObject, IDisposable
 {
     private readonly LootSource _source;
     private readonly DerivedTimerProgressService _derived;
     private readonly TimeProvider _time;
-    private readonly DispatcherTimer _refreshTimer;
+    private readonly TimerDisplayScheduler _scheduler;
+    private readonly TimerSourceBinder _binder;
+    private bool _disposed;
 
     [ObservableProperty] private LootKindFilter _kindFilter = LootKindFilter.All;
     [ObservableProperty] private LootStateFilter _stateFilter = LootStateFilter.All;
@@ -30,9 +31,6 @@ public sealed partial class LootTimersViewModel : ObservableObject
         _derived = derived;
         _time = time ?? TimeProvider.System;
 
-        _source.CatalogChanged += (_, _) => Sync();
-        _source.ProgressChanged += (_, _) => Sync();
-
         TimersView = CollectionViewSource.GetDefaultView(Timers);
         TimersView.Filter = ApplyFilter;
         TimersView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(TimerItemViewModel.GroupKey)));
@@ -40,11 +38,13 @@ public sealed partial class LootTimersViewModel : ObservableObject
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.IsDone), ListSortDirection.Descending));
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.Name), ListSortDirection.Ascending));
 
-        _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-        _refreshTimer.Tick += (_, _) => Tick();
-        _refreshTimer.Start();
+        _scheduler = new TimerDisplayScheduler(_time);
+        _binder = new TimerSourceBinder(_source, Timers, _time, scheduler: _scheduler);
 
-        Sync();
+        // Both signals trigger a single CollectionView refresh — debounced
+        // implicitly by the dispatcher (consecutive Refresh calls collapse).
+        _binder.RefreshRequired += (_, _) => TimersView.Refresh();
+        _scheduler.RefreshRequired += (_, _) => TimersView.Refresh();
     }
 
     public ObservableCollection<TimerItemViewModel> Timers { get; } = [];
@@ -91,29 +91,12 @@ public sealed partial class LootTimersViewModel : ObservableObject
         return true;
     }
 
-    private void Sync()
+    public void Dispose()
     {
-        Timers.Clear();
-        var progress = _source.Progress;
-        foreach (var entry in _source.Catalog)
-        {
-            progress.TryGetValue(entry.Key, out var p);
-            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p) { Clock = _time }));
-        }
-        TimersView.Refresh();
-    }
-
-    private void Tick()
-    {
-        var progress = _source.Progress;
-        var catalog = _source.Catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
-        foreach (var vm in Timers)
-        {
-            if (!catalog.TryGetValue(vm.Key, out var entry)) continue;
-            progress.TryGetValue(vm.Key, out var p);
-            vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
-        }
-        TimersView.Refresh();
+        if (_disposed) return;
+        _disposed = true;
+        _binder.Dispose();
+        _scheduler.Dispose();
     }
 }
 

--- a/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Data;
-using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Gandalf.Domain;
@@ -16,16 +15,19 @@ namespace Gandalf.ViewModels;
 ///
 /// Materializes only the rows the player cares about: pending in journal, or
 /// cooling/done. The full catalog is ~2,000 entries — projecting it all into
-/// a non-virtualizing WrapPanel froze the UI thread.
+/// a non-virtualizing WrapPanel froze the UI thread. Issue #155 retires this
+/// relevance predicate by reshaping QuestSource.Catalog to be the active set
+/// directly; until then, the predicate filters at materialization time and
+/// the source's coarse ProgressChanged event drives RecheckRelevance.
 /// </summary>
-public sealed partial class QuestTimersViewModel : ObservableObject
+public sealed partial class QuestTimersViewModel : ObservableObject, IDisposable
 {
     private readonly QuestSource _source;
     private readonly DerivedTimerProgressService _derived;
     private readonly TimeProvider _time;
-    private readonly DispatcherTimer _refreshTimer;
-    private readonly Dictionary<string, TimerItemViewModel> _byKey = new(StringComparer.Ordinal);
-    private Dictionary<string, TimerCatalogEntry> _catalogByKey = new(StringComparer.Ordinal);
+    private readonly TimerDisplayScheduler _scheduler;
+    private readonly TimerSourceBinder _binder;
+    private bool _disposed;
 
     [ObservableProperty] private QuestStateFilter _stateFilter = QuestStateFilter.All;
 
@@ -35,9 +37,6 @@ public sealed partial class QuestTimersViewModel : ObservableObject
         _derived = derived;
         _time = time ?? TimeProvider.System;
 
-        _source.CatalogChanged += (_, _) => Sync();
-        _source.ProgressChanged += (_, _) => Sync();
-
         TimersView = CollectionViewSource.GetDefaultView(Timers);
         TimersView.Filter = ApplyFilter;
         TimersView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(TimerItemViewModel.GroupKey)));
@@ -45,11 +44,22 @@ public sealed partial class QuestTimersViewModel : ObservableObject
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.IsDone), ListSortDirection.Descending));
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.Name), ListSortDirection.Ascending));
 
-        _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-        _refreshTimer.Tick += (_, _) => Tick();
-        _refreshTimer.Start();
+        _scheduler = new TimerDisplayScheduler(_time);
+        _binder = new TimerSourceBinder(
+            _source, Timers, _time,
+            isRelevant: IsRelevant,
+            scheduler: _scheduler);
 
-        Sync();
+        _binder.RefreshRequired += (_, _) => TimersView.Refresh();
+        _scheduler.RefreshRequired += (_, _) => TimersView.Refresh();
+
+        // Pending-set changes don't mutate catalog or progress (so they
+        // don't fire RowsChanged with non-empty deltas), but they shift
+        // relevance for every catalog row. Wire the source's coarse
+        // ProgressChanged to a relevance recheck — the small over-fire on
+        // actual progress changes is acceptable until #155 retires this
+        // entire relevance machinery.
+        _source.ProgressChanged += OnSourceProgressChanged;
     }
 
     public ObservableCollection<TimerItemViewModel> Timers { get; } = [];
@@ -99,76 +109,26 @@ public sealed partial class QuestTimersViewModel : ObservableObject
         return _source.PendingInternalNames.Contains(payload.Quest.InternalName);
     }
 
-    private static bool IsRelevant(TimerCatalogEntry entry, TimerProgressEntry? progress, IReadOnlySet<string> pending)
+    private bool IsRelevant(TimerCatalogEntry entry, TimerProgressEntry? progress)
     {
+        // Cooling or Done (any progress not dismissed) is always relevant.
         if (progress is { DismissedAt: null }) return true;
+        // Otherwise must be in journal.
         if (entry.SourceMetadata is QuestCatalogPayload payload &&
-            pending.Contains(payload.Quest.InternalName)) return true;
+            _source.PendingInternalNames.Contains(payload.Quest.InternalName)) return true;
         return false;
     }
 
-    /// <summary>
-    /// Reconcile <see cref="Timers"/> against the source's relevant set. Diffs
-    /// in place — adds new rows, updates existing rows, removes gone rows —
-    /// instead of clearing the collection, which would thrash WPF's grouping.
-    /// </summary>
-    private void Sync()
+    private void OnSourceProgressChanged(object? sender, EventArgs e) =>
+        _binder.RecheckRelevance();
+
+    public void Dispose()
     {
-        _catalogByKey = _source.Catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
-        var progress = _source.Progress;
-        var pending = _source.PendingInternalNames;
-
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var entry in _source.Catalog)
-        {
-            progress.TryGetValue(entry.Key, out var p);
-            if (!IsRelevant(entry, p, pending)) continue;
-
-            seen.Add(entry.Key);
-            if (_byKey.TryGetValue(entry.Key, out var vm))
-            {
-                vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
-            }
-            else
-            {
-                vm = new TimerItemViewModel(new TimerRow(entry, p) { Clock = _time });
-                _byKey[entry.Key] = vm;
-                Timers.Add(vm);
-            }
-        }
-
-        for (var i = Timers.Count - 1; i >= 0; i--)
-        {
-            var vm = Timers[i];
-            if (seen.Contains(vm.Key)) continue;
-            Timers.RemoveAt(i);
-            _byKey.Remove(vm.Key);
-        }
-
-        TimersView.Refresh();
-    }
-
-    /// <summary>
-    /// Per-second update of progress fractions and time labels. Per-item
-    /// <c>OnPropertyChanged</c> handles the bindings; only call
-    /// <see cref="ICollectionView.Refresh"/> when an item's <c>State</c>
-    /// transitioned (Running &harr; Done) — that changes filter / sort keys.
-    /// </summary>
-    internal void Tick()
-    {
-        var progress = _source.Progress;
-        var stateChanged = false;
-
-        foreach (var vm in _byKey.Values)
-        {
-            if (!_catalogByKey.TryGetValue(vm.Key, out var entry)) continue;
-            progress.TryGetValue(vm.Key, out var p);
-            var prior = vm.State;
-            vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
-            if (vm.State != prior) stateChanged = true;
-        }
-
-        if (stateChanged) TimersView.Refresh();
+        if (_disposed) return;
+        _disposed = true;
+        _source.ProgressChanged -= OnSourceProgressChanged;
+        _binder.Dispose();
+        _scheduler.Dispose();
     }
 }
 

--- a/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
@@ -53,13 +53,12 @@ public sealed partial class QuestTimersViewModel : ObservableObject, IDisposable
         _binder.RefreshRequired += (_, _) => TimersView.Refresh();
         _scheduler.RefreshRequired += (_, _) => TimersView.Refresh();
 
-        // Pending-set changes don't mutate catalog or progress (so they
-        // don't fire RowsChanged with non-empty deltas), but they shift
-        // relevance for every catalog row. Wire the source's coarse
-        // ProgressChanged to a relevance recheck — the small over-fire on
-        // actual progress changes is acceptable until #155 retires this
-        // entire relevance machinery.
-        _source.ProgressChanged += OnSourceProgressChanged;
+        // Pending-set changes don't mutate catalog or progress (no
+        // RowsChanged delta), but they shift relevance for every catalog
+        // row. PendingChanged is the dedicated signal — fires only when
+        // _pending actually changed. Goes away once #155 reshapes
+        // QuestSource's catalog to the active set directly.
+        _source.PendingChanged += OnPendingChanged;
     }
 
     public ObservableCollection<TimerItemViewModel> Timers { get; } = [];
@@ -119,14 +118,14 @@ public sealed partial class QuestTimersViewModel : ObservableObject, IDisposable
         return false;
     }
 
-    private void OnSourceProgressChanged(object? sender, EventArgs e) =>
+    private void OnPendingChanged(object? sender, EventArgs e) =>
         _binder.RecheckRelevance();
 
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        _source.ProgressChanged -= OnSourceProgressChanged;
+        _source.PendingChanged -= OnPendingChanged;
         _binder.Dispose();
         _scheduler.Dispose();
     }

--- a/src/Gandalf.Module/ViewModels/TimerItemViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerItemViewModel.cs
@@ -7,9 +7,26 @@ public sealed partial class TimerItemViewModel : ObservableObject
 {
     private TimerRow _row;
 
+    // Last-fired snapshot. The binder + scheduler call Refresh repeatedly
+    // (every state-flip moment, every fast-tick second on Running rows);
+    // unconditionally re-firing every PropertyChanged event is the
+    // bottleneck the redesign was aimed at. Diff against these to fire
+    // only the properties whose value actually moved.
+    private TimerCatalogEntry _lastCatalog;
+    private TimerState _lastState;
+    private double _lastFraction;
+    private string _lastTimeDisplay;
+
     [ObservableProperty] private bool _elapsedWhileAway;
 
-    public TimerItemViewModel(TimerRow row) => _row = row;
+    public TimerItemViewModel(TimerRow row)
+    {
+        _row = row;
+        _lastCatalog = row.Catalog;
+        _lastState = row.State;
+        _lastFraction = row.Fraction;
+        _lastTimeDisplay = ComputeTimeDisplay();
+    }
 
     public TimerRow Row => _row;
     public TimerCatalogEntry Catalog => _row.Catalog;
@@ -25,16 +42,7 @@ public sealed partial class TimerItemViewModel : ObservableObject
 
     public double Fraction => _row.Fraction;
 
-    public string TimeDisplay => State switch
-    {
-        TimerState.Idle => FormatDuration(_row.Duration),
-        TimerState.Done when _row.CompletedAt is { } completed =>
-            (DateTimeOffset.UtcNow - completed).TotalMinutes < 1
-                ? "done!"
-                : $"done {FormatDuration(DateTimeOffset.UtcNow - completed)} ago",
-        TimerState.Done => "done!",
-        _ => FormatDuration(_row.Remaining) + " remaining",
-    };
+    public string TimeDisplay => ComputeTimeDisplay();
 
     public string StatusColor => State switch
     {
@@ -73,23 +81,101 @@ public sealed partial class TimerItemViewModel : ObservableObject
         Refresh();
     }
 
+    /// <summary>
+    /// Per-property diff against the last-known snapshot. Fires
+    /// <see cref="ObservableObject.OnPropertyChanged(string?)"/> only for
+    /// properties whose value materially changed. Replaces the previous
+    /// "fire all 14 events on every tick" approach that drove the freeze
+    /// bug on the Loot tab.
+    ///
+    /// <para>Called by:</para>
+    /// <list type="bullet">
+    /// <item><see cref="UpdateRow"/> — after a delta-driven row swap.</item>
+    /// <item><see cref="Services.TimerDisplayScheduler"/> slow tick — when a
+    /// row's <see cref="TimerRow.NextDisplayChangeAt"/> moment elapses.</item>
+    /// <item><see cref="Services.TimerDisplayScheduler"/> fast tick — at 1 Hz
+    /// while the row is Running with a visible progress bar (drives
+    /// <see cref="Fraction"/>).</item>
+    /// </list>
+    /// </summary>
     public void Refresh()
     {
-        OnPropertyChanged(nameof(Name));
-        OnPropertyChanged(nameof(GroupKey));
-        OnPropertyChanged(nameof(State));
-        OnPropertyChanged(nameof(IsIdle));
-        OnPropertyChanged(nameof(IsRunning));
-        OnPropertyChanged(nameof(IsDone));
-        OnPropertyChanged(nameof(Fraction));
-        OnPropertyChanged(nameof(TimeDisplay));
-        OnPropertyChanged(nameof(StatusColor));
-        OnPropertyChanged(nameof(StatusLabel));
-        OnPropertyChanged(nameof(DurationLabel));
-        OnPropertyChanged(nameof(ShowStartButton));
-        OnPropertyChanged(nameof(ShowRestartButton));
-        OnPropertyChanged(nameof(ShowProgressBar));
+        // Catalog cluster — Name / GroupKey / DurationLabel are the only
+        // catalog-derived properties that flow through to bindings. Each
+        // is fired only when the corresponding catalog field changed.
+        if (!ReferenceEquals(_lastCatalog, _row.Catalog))
+        {
+            if (_lastCatalog.DisplayName != _row.Catalog.DisplayName)
+                OnPropertyChanged(nameof(Name));
+            if (!StringEquals(_lastCatalog.Region, _row.Catalog.Region))
+                OnPropertyChanged(nameof(GroupKey));
+            if (_lastCatalog.Duration != _row.Catalog.Duration)
+                OnPropertyChanged(nameof(DurationLabel));
+            _lastCatalog = _row.Catalog;
+        }
+
+        // State cluster — nine properties co-vary on a single State
+        // transition. Cache the last-known State and fire the cluster
+        // only when it flips.
+        var newState = _row.State;
+        if (newState != _lastState)
+        {
+            OnPropertyChanged(nameof(State));
+            OnPropertyChanged(nameof(IsIdle));
+            OnPropertyChanged(nameof(IsRunning));
+            OnPropertyChanged(nameof(IsDone));
+            OnPropertyChanged(nameof(StatusColor));
+            OnPropertyChanged(nameof(StatusLabel));
+            OnPropertyChanged(nameof(ShowStartButton));
+            OnPropertyChanged(nameof(ShowRestartButton));
+            OnPropertyChanged(nameof(ShowProgressBar));
+            _lastState = newState;
+        }
+
+        // Fraction (continuous while Running). Use a small tolerance so we
+        // don't fire on imperceptible double-precision drift, but the value
+        // moves visibly under any real-time advance.
+        var newFraction = _row.Fraction;
+        if (Math.Abs(newFraction - _lastFraction) > 0.0001)
+        {
+            OnPropertyChanged(nameof(Fraction));
+            _lastFraction = newFraction;
+        }
+
+        // TimeDisplay (text bucket) — changes once per minute on Running /
+        // old-Done rows, on the 60 s "done!" → "done 1m ago" flip on
+        // just-Done rows. Compute once and string-compare.
+        var newTimeDisplay = ComputeTimeDisplay();
+        if (newTimeDisplay != _lastTimeDisplay)
+        {
+            OnPropertyChanged(nameof(TimeDisplay));
+            _lastTimeDisplay = newTimeDisplay;
+        }
     }
+
+    private string ComputeTimeDisplay()
+    {
+        // Route every time-derived read through _row.Clock instead of
+        // DateTimeOffset.UtcNow — the prior wall-clock read silently broke
+        // ManualTime / FakeTimeProvider in tests (the row's State could
+        // read as Done at frozen-time T while TimeDisplay's "X ago"
+        // computed against real wall-clock would drift continuously) and
+        // would also make TimerDisplayScheduler fire "early" or "late"
+        // when wakeups are computed from the injected clock.
+        return State switch
+        {
+            TimerState.Idle => FormatDuration(_row.Duration),
+            TimerState.Done when _row.CompletedAt is { } completed =>
+                (_row.Clock.GetUtcNow() - completed).TotalMinutes < 1
+                    ? "done!"
+                    : $"done {FormatDuration(_row.Clock.GetUtcNow() - completed)} ago",
+            TimerState.Done => "done!",
+            _ => FormatDuration(_row.Remaining) + " remaining",
+        };
+    }
+
+    private static bool StringEquals(string? a, string? b) =>
+        ReferenceEquals(a, b) || (a is not null && a.Equals(b, StringComparison.Ordinal));
 
     private static string FormatDuration(TimeSpan ts)
     {

--- a/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
@@ -2,7 +2,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Data;
-using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Gandalf.Domain;
@@ -13,7 +12,7 @@ using Mithril.Shared.Wpf.Dialogs;
 
 namespace Gandalf.ViewModels;
 
-public sealed partial class TimerListViewModel : ObservableObject
+public sealed partial class TimerListViewModel : ObservableObject, IDisposable
 {
     private readonly ITimerSource _source;
     private readonly TimerDefinitionsService? _defs;
@@ -23,7 +22,9 @@ public sealed partial class TimerListViewModel : ObservableObject
     private readonly IActiveCharacterService? _active;
     private readonly ICharacterPresenceService? _presence;
     private readonly TimeProvider _time;
-    private readonly DispatcherTimer _refreshTimer;
+    private readonly TimerDisplayScheduler _scheduler;
+    private readonly TimerSourceBinder _binder;
+    private bool _disposed;
 
     public TimerListViewModel(
         ITimerSource source,
@@ -44,20 +45,27 @@ public sealed partial class TimerListViewModel : ObservableObject
         _presence = presence;
         _time = time ?? TimeProvider.System;
 
-        _source.CatalogChanged += (_, _) => { SyncFromState(); RefreshAutocomplete(); };
-        _source.ProgressChanged += (_, _) => SyncFromState();
-
         TimersView = CollectionViewSource.GetDefaultView(Timers);
         TimersView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(TimerItemViewModel.GroupKey)));
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.GroupKey), ListSortDirection.Ascending));
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.IsIdle), ListSortDirection.Descending));
         TimersView.SortDescriptions.Add(new SortDescription(nameof(TimerItemViewModel.IsDone), ListSortDirection.Ascending));
 
-        _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-        _refreshTimer.Tick += (_, _) => Tick();
-        _refreshTimer.Start();
+        _scheduler = new TimerDisplayScheduler(_time);
+        _binder = new TimerSourceBinder(_source, Timers, _time, scheduler: _scheduler);
 
-        SyncFromState();
+        _binder.RefreshRequired += OnBinderRefreshRequired;
+        _scheduler.RefreshRequired += (_, _) => TimersView.Refresh();
+
+        // ElapsedWhileAway depends on (Active character × LastActiveAt × row
+        // progress). Recompute on character switch — character export
+        // refresh isn't relevant, only "we're now looking at a different
+        // character." The binder will replay rows for the new character via
+        // the PerCharacterView swap fired from TimerProgressService, so
+        // re-applying after the active-character change naturally aligns.
+        if (_active is not null) _active.ActiveCharacterChanged += OnActiveCharacterChanged;
+
+        ApplyElapsedWhileAwayBadges();
         RefreshAutocomplete();
     }
 
@@ -173,19 +181,16 @@ public sealed partial class TimerListViewModel : ObservableObject
     [RelayCommand]
     private void DismissAll() => _alarmService?.DismissAll();
 
-    private void SyncFromState()
+    private void OnBinderRefreshRequired(object? sender, EventArgs e)
     {
-        Timers.Clear();
-        var progress = _source.Progress;
-        foreach (var entry in _source.Catalog)
-        {
-            progress.TryGetValue(entry.Key, out var p);
-            Timers.Add(new TimerItemViewModel(new TimerRow(entry, p) { Clock = _time }));
-        }
-
-        ApplyElapsedWhileAwayBadges();
+        // Catalog mutations may have introduced new defs; refresh the
+        // autocomplete suggestions so the next dialog open sees them.
+        RefreshAutocomplete();
         TimersView.Refresh();
     }
+
+    private void OnActiveCharacterChanged(object? sender, EventArgs e) =>
+        ApplyElapsedWhileAwayBadges();
 
     /// <summary>
     /// Mark timers whose theoretical completion (StartedAt + Duration) fell between the
@@ -239,17 +244,13 @@ public sealed partial class TimerListViewModel : ObservableObject
         foreach (var m in maps) KnownMaps.Add(m);
     }
 
-    private void Tick()
+    public void Dispose()
     {
-        _progress?.CheckExpirations();
-        // Re-join with latest progress in case CheckExpirations stamped a CompletedAt.
-        var progress = _source.Progress;
-        var catalog = _source.Catalog.ToDictionary(c => c.Key, StringComparer.Ordinal);
-        foreach (var vm in Timers)
-        {
-            if (!catalog.TryGetValue(vm.Key, out var entry)) continue;
-            progress.TryGetValue(vm.Key, out var p);
-            vm.UpdateRow(new TimerRow(entry, p) { Clock = _time });
-        }
+        if (_disposed) return;
+        _disposed = true;
+        if (_active is not null) _active.ActiveCharacterChanged -= OnActiveCharacterChanged;
+        _binder.RefreshRequired -= OnBinderRefreshRequired;
+        _binder.Dispose();
+        _scheduler.Dispose();
     }
 }

--- a/tests/Gandalf.Tests/DashboardAggregatorTests.cs
+++ b/tests/Gandalf.Tests/DashboardAggregatorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Gandalf.Domain;
 using Gandalf.Services;
@@ -14,9 +15,17 @@ public sealed class DashboardAggregatorTests
         public IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; set; } =
             new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal);
 
+        public bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress)
+        {
+            if (Progress.TryGetValue(key, out var p)) { progress = p; return true; }
+            progress = null;
+            return false;
+        }
+
         public event EventHandler? CatalogChanged;
         public event EventHandler? ProgressChanged;
         public event EventHandler<TimerReadyEventArgs>? TimerReady;
+        public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
         public FakeSource(string sourceId) => SourceId = sourceId;
 
@@ -27,6 +36,8 @@ public sealed class DashboardAggregatorTests
             {
                 SourceId = SourceId, Key = "_", DisplayName = "_", ReadyAt = DateTimeOffset.UtcNow,
             });
+        public void RaiseRowsChanged(IReadOnlyList<TimerRowDelta> deltas) =>
+            RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });
     }
 
     private sealed class ManualTime : TimeProvider

--- a/tests/Gandalf.Tests/DashboardAggregatorTests.cs
+++ b/tests/Gandalf.Tests/DashboardAggregatorTests.cs
@@ -22,15 +22,11 @@ public sealed class DashboardAggregatorTests
             return false;
         }
 
-        public event EventHandler? CatalogChanged;
-        public event EventHandler? ProgressChanged;
         public event EventHandler<TimerReadyEventArgs>? TimerReady;
         public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
         public FakeSource(string sourceId) => SourceId = sourceId;
 
-        public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
-        public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
         public void RaiseTimerReady() =>
             TimerReady?.Invoke(this, new TimerReadyEventArgs
             {
@@ -146,23 +142,32 @@ public sealed class DashboardAggregatorTests
     }
 
     [Fact]
-    public void Updated_event_fires_when_a_source_raises_ProgressChanged()
+    public void Updated_event_fires_when_a_source_raises_RowsChanged_with_deltas()
     {
-        var src = new FakeSource("gandalf.test");
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null)],
+        };
         var time = new ManualTime(Origin);
 
         using var agg = new DashboardAggregator([src], time);
         var fired = 0;
         agg.Updated += (_, _) => fired++;
 
-        src.RaiseProgressChanged();
-        src.RaiseProgressChanged();
+        src.RaiseRowsChanged([
+            new TimerRowDelta("k1", TimerRowChangeKind.ProgressChanged, src.Catalog[0],
+                new TimerProgressEntry("k1", time.GetUtcNow(), null)),
+        ]);
+        src.RaiseRowsChanged([
+            new TimerRowDelta("k1", TimerRowChangeKind.ProgressChanged, src.Catalog[0],
+                new TimerProgressEntry("k1", time.GetUtcNow(), null)),
+        ]);
 
         fired.Should().Be(2);
     }
 
     [Fact]
-    public void Updated_event_fires_when_a_source_raises_CatalogChanged()
+    public void Updated_event_fires_when_a_source_emits_a_catalog_delta()
     {
         var src = new FakeSource("gandalf.test");
         var time = new ManualTime(Origin);
@@ -171,7 +176,11 @@ public sealed class DashboardAggregatorTests
         var fired = 0;
         agg.Updated += (_, _) => fired++;
 
-        src.RaiseCatalogChanged();
+        var newEntry = new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null);
+        src.Catalog = [newEntry];
+        src.RaiseRowsChanged([
+            new TimerRowDelta("k1", TimerRowChangeKind.Added, newEntry, null),
+        ]);
 
         fired.Should().Be(1);
     }
@@ -212,7 +221,11 @@ public sealed class DashboardAggregatorTests
         agg.Updated += (_, _) => fired++;
 
         agg.Dispose();
-        src.RaiseProgressChanged();
+        var entry = new TimerCatalogEntry("k1", "Daily", "Serbule", TimeSpan.FromHours(1), null);
+        src.Catalog = [entry];
+        src.RaiseRowsChanged([
+            new TimerRowDelta("k1", TimerRowChangeKind.Added, entry, null),
+        ]);
 
         fired.Should().Be(0);
     }

--- a/tests/Gandalf.Tests/FakeTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/FakeTimerSourceTests.cs
@@ -32,15 +32,11 @@ public class FakeTimerSourceTests
             return false;
         }
 
-        public event EventHandler? CatalogChanged;
-        public event EventHandler? ProgressChanged;
         public event EventHandler<TimerReadyEventArgs>? TimerReady;
         public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
         public FakeTimerSource(string sourceId = "tests.fake") => SourceId = sourceId;
 
-        public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
-        public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
         public void RaiseTimerReady(TimerReadyEventArgs e) => TimerReady?.Invoke(this, e);
         public void RaiseRowsChanged(IReadOnlyList<TimerRowDelta> deltas) =>
             RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });

--- a/tests/Gandalf.Tests/FakeTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/FakeTimerSourceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Gandalf.Domain;
 using Gandalf.ViewModels;
@@ -24,15 +25,25 @@ public class FakeTimerSourceTests
         public IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; set; } =
             new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal);
 
+        public bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress)
+        {
+            if (Progress.TryGetValue(key, out var p)) { progress = p; return true; }
+            progress = null;
+            return false;
+        }
+
         public event EventHandler? CatalogChanged;
         public event EventHandler? ProgressChanged;
         public event EventHandler<TimerReadyEventArgs>? TimerReady;
+        public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
         public FakeTimerSource(string sourceId = "tests.fake") => SourceId = sourceId;
 
         public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
         public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
         public void RaiseTimerReady(TimerReadyEventArgs e) => TimerReady?.Invoke(this, e);
+        public void RaiseRowsChanged(IReadOnlyList<TimerRowDelta> deltas) =>
+            RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });
     }
 
     [Fact]

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -467,6 +467,69 @@ public class LootSourceTests : IDisposable
         derivedView.Dispose();
     }
 
+    [Fact]
+    public void OnChestInteraction_emits_RowsChanged_with_added_delta()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            src.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
+
+            // EnsureCatalogReprojected (Added with null progress) followed by
+            // _derived.Start (ProgressChanged with the new progress). Two batches
+            // for one logical interaction is acceptable; the binder applies them
+            // sequentially without visible flicker.
+            batches.Should().NotBeEmpty();
+            var addedDelta = batches.SelectMany(b => b)
+                .FirstOrDefault(d => d.Key == LootSource.ChestKey("GoblinStaticChest1")
+                                     && d.Kind == TimerRowChangeKind.Added);
+            addedDelta.Should().NotBeNull();
+            addedDelta!.Catalog.Should().NotBeNull();
+
+            var progressDelta = batches.SelectMany(b => b)
+                .FirstOrDefault(d => d.Key == LootSource.ChestKey("GoblinStaticChest1")
+                                     && d.Kind == TimerRowChangeKind.ProgressChanged);
+            progressDelta.Should().NotBeNull();
+            progressDelta!.Progress.Should().NotBeNull();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void OverlayDefeatCalibration_emits_one_batched_RowsChanged()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            // Pre-populate the catalog with a few learned defeats so the overlay
+            // refresh produces a meaningful diff.
+            src.OnBossKillCredit("Den Mother", time.GetUtcNow().UtcDateTime);
+            src.OnBossKillCredit("Olugax", time.GetUtcNow().UtcDateTime);
+
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            src.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            // Single overlay refresh updates region + duration for both defeats.
+            src.OverlayDefeatCalibration(new[]
+            {
+                new DefeatCatalogEntry("Den Mother", TimeSpan.FromHours(6), "Sun Vale"),
+                new DefeatCatalogEntry("Olugax", TimeSpan.FromHours(6), "Sun Vale"),
+            });
+
+            // The whole calibration applies in a single RowsChanged event with
+            // N deltas (not N events). This is the contract the binder relies on
+            // to call ICollectionView.Refresh once per batch.
+            batches.Should().HaveCount(1);
+            batches[0].Should().HaveCount(2);
+            batches[0].Should().AllSatisfy(d =>
+                d.Kind.Should().Be(TimerRowChangeKind.CatalogChanged));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
     private sealed class ManualTime : TimeProvider
     {
         private DateTimeOffset _now;

--- a/tests/Gandalf.Tests/QuestSourceTests.cs
+++ b/tests/Gandalf.Tests/QuestSourceTests.cs
@@ -234,14 +234,14 @@ public class QuestSourceTests : IDisposable
         {
             src.Catalog.Should().BeEmpty();
 
-            var raised = false;
-            src.CatalogChanged += (_, _) => raised = true;
+            var deltas = new List<TimerRowDelta>();
+            src.RowsChanged += (_, e) => deltas.AddRange(e.Deltas);
 
             // Stage new data, then raise the event the way the real service would.
             refData.SetQuests([QuestEntryFactory.Repeatable("quest_1", "Q1", "Late Arrival", TimeSpan.FromHours(2))]);
             refData.RaiseQuestsUpdated();
 
-            raised.Should().BeTrue();
+            deltas.Should().ContainSingle(d => d.Kind == TimerRowChangeKind.Added);
             src.Catalog.Should().HaveCount(1);
             src.Catalog[0].DisplayName.Should().Be("Late Arrival");
         }

--- a/tests/Gandalf.Tests/QuestSourceTests.cs
+++ b/tests/Gandalf.Tests/QuestSourceTests.cs
@@ -305,6 +305,26 @@ public class QuestSourceTests : IDisposable
         finally { src.Dispose(); derived.Dispose(); }
     }
 
+    [Fact]
+    public void OnQuestCompleted_emits_RowsChanged_with_progress_delta_for_that_key()
+    {
+        var quest = QuestEntryFactory.Repeatable("quest_50208", "Quest_WO_50208", "Work Order 50208", TimeSpan.FromHours(2));
+        var (src, derived, _, time) = Build(quest);
+        try
+        {
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            src.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            src.OnQuestCompleted("Quest_WO_50208", time.GetUtcNow().UtcDateTime);
+
+            batches.SelectMany(b => b)
+                .Should().ContainSingle(d =>
+                    d.Key == QuestSource.QuestKey("Quest_WO_50208")
+                    && d.Kind == TimerRowChangeKind.ProgressChanged);
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
     private sealed class ManualTime : TimeProvider
     {
         private DateTimeOffset _now;

--- a/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
+++ b/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
@@ -158,26 +158,12 @@ public class QuestTimersViewModelTests : IDisposable
         finally { src.Dispose(); derived.Dispose(); }
     }
 
-    [Fact]
-    public void Tick_does_not_refresh_view_when_no_state_changed()
-    {
-        var q = QuestEntryFactory.Repeatable("k1", "Q1", "Daily", TimeSpan.FromHours(10));
-        var (vm, src, derived, time) = Build(q);
-        try
-        {
-            src.OnQuestCompleted("Q1", time.GetUtcNow().UtcDateTime);
-            var refreshes = 0;
-            ((System.ComponentModel.ICollectionView)vm.TimersView).CollectionChanged += (_, _) => refreshes++;
-
-            // Advance only seconds — still Running.
-            time.Advance(TimeSpan.FromSeconds(5));
-            vm.Tick();
-
-            refreshes.Should().Be(0, "no state transition means no Refresh() — the freeze bug came from doing this every second");
-            vm.Timers[0].State.Should().Be(TimerState.Running);
-        }
-        finally { src.Dispose(); derived.Dispose(); }
-    }
+    // The "Tick does not Refresh on text-only changes" regression test moved
+    // out of this VM with the timer-model redesign — the per-tab tick now
+    // lives in TimerDisplayScheduler. Coverage is preserved via
+    // TimerDisplaySchedulerTests.Slow_tick_does_not_fire_RefreshRequired_for_text_only_changes
+    // and the binder's once-per-batch RefreshRequired guarantee
+    // (TimerSourceBinderTests.RefreshRequired_fires_at_most_once_per_batched_RowsChanged).
 
     private sealed class ManualTime : TimeProvider
     {

--- a/tests/Gandalf.Tests/TimerDisplaySchedulerTests.cs
+++ b/tests/Gandalf.Tests/TimerDisplaySchedulerTests.cs
@@ -1,0 +1,255 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Gandalf.ViewModels;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+public class TimerDisplaySchedulerTests
+{
+    private static readonly DateTimeOffset Anchor =
+        new(2026, 5, 9, 14, 30, 0, TimeSpan.Zero);
+
+    private static TimerItemViewModel BuildVm(
+        TimeSpan duration,
+        DateTimeOffset? startedAt,
+        TimeProvider clock,
+        DateTimeOffset? dismissedAt = null)
+    {
+        var catalog = new TimerCatalogEntry(
+            "k", "Display", "R", duration, SourceMetadata: null);
+        var progress = startedAt is null
+            ? null
+            : new TimerProgressEntry("k", startedAt.Value, dismissedAt);
+        return new TimerItemViewModel(new TimerRow(catalog, progress) { Clock = clock });
+    }
+
+    [Fact]
+    public void NextSlowTickAt_returns_null_when_no_rows_registered()
+    {
+        using var sched = new TimerDisplayScheduler(new ManualTime(Anchor));
+        sched.NextSlowTickAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void NextSlowTickAt_picks_the_earliest_across_registered_rows()
+    {
+        var clock = new ManualTime(Anchor);
+        // Two Running rows; Row A flips first, Row B is much later.
+        var rowA = BuildVm(TimeSpan.FromSeconds(20), startedAt: Anchor, clock);
+        var rowB = BuildVm(TimeSpan.FromHours(2), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(rowA);
+        sched.Register(rowB);
+
+        // Row A's NextDisplayChangeAt is its state-flip moment (Anchor + 20s),
+        // which is earlier than Row B's next minute boundary.
+        sched.NextSlowTickAt.Should().Be(Anchor + TimeSpan.FromSeconds(20));
+    }
+
+    [Fact]
+    public void Idle_rows_do_not_contribute_to_NextSlowTickAt()
+    {
+        var clock = new ManualTime(Anchor);
+        var idle = BuildVm(TimeSpan.FromHours(1), startedAt: null, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(idle);
+
+        sched.NextSlowTickAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void AnyRunningWithProgressBar_reflects_visible_running_rows()
+    {
+        var clock = new ManualTime(Anchor);
+        var idle = BuildVm(TimeSpan.FromHours(1), startedAt: null, clock);
+        var running = BuildVm(TimeSpan.FromHours(1), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(idle);
+        sched.AnyRunningWithProgressBar.Should().BeFalse();
+
+        sched.Register(running);
+        sched.AnyRunningWithProgressBar.Should().BeTrue();
+
+        sched.Unregister(running);
+        sched.AnyRunningWithProgressBar.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Slow_tick_refreshes_only_rows_whose_moment_has_arrived()
+    {
+        var clock = new ManualTime(Anchor);
+        var earlyRow = BuildVm(TimeSpan.FromSeconds(20), startedAt: Anchor, clock);
+        var lateRow = BuildVm(TimeSpan.FromHours(2), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(earlyRow);
+        sched.Register(lateRow);
+
+        var earlyNotifications = 0;
+        var lateNotifications = 0;
+        earlyRow.PropertyChanged += CountTimeDisplayChanges(() => earlyNotifications++);
+        lateRow.PropertyChanged += CountTimeDisplayChanges(() => lateNotifications++);
+
+        // Advance past earlyRow's flip but well before lateRow's.
+        clock.Advance(TimeSpan.FromSeconds(25));
+        sched.TickSlowForTests();
+
+        earlyNotifications.Should().BeGreaterThan(0, "earlyRow's NextDisplayChangeAt has elapsed");
+        lateNotifications.Should().Be(0, "lateRow's NextDisplayChangeAt is still in the future");
+    }
+
+    [Fact]
+    public void Slow_tick_fires_RefreshRequired_when_state_flips()
+    {
+        var clock = new ManualTime(Anchor);
+        var row = BuildVm(TimeSpan.FromSeconds(20), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(row);
+
+        var refreshes = 0;
+        sched.RefreshRequired += (_, _) => refreshes++;
+
+        // Advance past state flip moment — Running → Done.
+        clock.Advance(TimeSpan.FromSeconds(25));
+        sched.TickSlowForTests();
+
+        row.State.Should().Be(TimerState.Done);
+        refreshes.Should().Be(1);
+    }
+
+    [Fact]
+    public void Slow_tick_does_not_fire_RefreshRequired_for_text_only_changes()
+    {
+        // A Running row whose minute boundary rolls but state stays Running:
+        // the "Xh Ym remaining" text changes but no sort/group/filter input
+        // moved, so RefreshRequired should NOT fire.
+        var clock = new ManualTime(Anchor);
+        // 2-hour duration; minute boundary at Anchor + 1m flips before state.
+        var row = BuildVm(TimeSpan.FromHours(2), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(row);
+
+        var refreshes = 0;
+        sched.RefreshRequired += (_, _) => refreshes++;
+
+        clock.Advance(TimeSpan.FromMinutes(1) + TimeSpan.FromSeconds(1));
+        sched.TickSlowForTests();
+
+        row.State.Should().Be(TimerState.Running);
+        refreshes.Should().Be(0, "minute roll on a Running row doesn't change sort/group/filter inputs");
+    }
+
+    [Fact]
+    public void Fast_tick_refreshes_Running_rows_with_progress_bars()
+    {
+        var clock = new ManualTime(Anchor);
+        var running = BuildVm(TimeSpan.FromHours(1), startedAt: Anchor, clock);
+        var idle = BuildVm(TimeSpan.FromHours(1), startedAt: null, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(running);
+        sched.Register(idle);
+
+        var runningNotifications = 0;
+        var idleNotifications = 0;
+        running.PropertyChanged += CountFractionChanges(() => runningNotifications++);
+        idle.PropertyChanged += CountFractionChanges(() => idleNotifications++);
+
+        sched.TickFastForTests();
+
+        runningNotifications.Should().BeGreaterThan(0);
+        idleNotifications.Should().Be(0, "idle rows don't get fast-tick refreshes");
+    }
+
+    [Fact]
+    public void Fast_tick_fires_RefreshRequired_when_running_row_crosses_to_done()
+    {
+        var clock = new ManualTime(Anchor);
+        var row = BuildVm(TimeSpan.FromSeconds(20), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(row);
+
+        var refreshes = 0;
+        sched.RefreshRequired += (_, _) => refreshes++;
+
+        clock.Advance(TimeSpan.FromSeconds(25));
+        sched.TickFastForTests();
+
+        row.State.Should().Be(TimerState.Done);
+        refreshes.Should().Be(1);
+    }
+
+    [Fact]
+    public void Disposed_scheduler_ignores_subsequent_ticks()
+    {
+        var clock = new ManualTime(Anchor);
+        var row = BuildVm(TimeSpan.FromSeconds(20), startedAt: Anchor, clock);
+
+        var sched = new TimerDisplayScheduler(clock);
+        sched.Register(row);
+        sched.Dispose();
+
+        var refreshes = 0;
+        sched.RefreshRequired += (_, _) => refreshes++;
+
+        clock.Advance(TimeSpan.FromSeconds(25));
+        sched.TickSlowForTests();
+        sched.TickFastForTests();
+
+        refreshes.Should().Be(0);
+    }
+
+    [Fact]
+    public void Refresh_after_UpdateRow_picks_up_new_NextDisplayChangeAt()
+    {
+        // Models the binder→scheduler integration: binder applies UpdateRow,
+        // then asks the scheduler to re-read the row's NextDisplayChangeAt.
+        var clock = new ManualTime(Anchor);
+        var row = BuildVm(TimeSpan.FromHours(2), startedAt: Anchor, clock);
+
+        using var sched = new TimerDisplayScheduler(clock);
+        sched.Register(row);
+
+        sched.NextSlowTickAt.Should().Be(Anchor + TimeSpan.FromMinutes(1));
+
+        // Simulate a re-stamp: update the row to a 30s timer that just started.
+        var newCatalog = new TimerCatalogEntry("k", "Display", "R", TimeSpan.FromSeconds(30), null);
+        var newProgress = new TimerProgressEntry("k", Anchor, DismissedAt: null);
+        row.UpdateRow(new TimerRow(newCatalog, newProgress) { Clock = clock });
+
+        sched.Refresh(row);
+
+        // NextDisplayChangeAt should now be the state-flip moment (30s),
+        // which is sooner than the next minute boundary.
+        sched.NextSlowTickAt.Should().Be(Anchor + TimeSpan.FromSeconds(30));
+    }
+
+    private static PropertyChangedEventHandler CountTimeDisplayChanges(Action onMatch) =>
+        (_, e) =>
+        {
+            if (e.PropertyName == nameof(TimerItemViewModel.TimeDisplay)) onMatch();
+        };
+
+    private static PropertyChangedEventHandler CountFractionChanges(Action onMatch) =>
+        (_, e) =>
+        {
+            if (e.PropertyName == nameof(TimerItemViewModel.Fraction)) onMatch();
+        };
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTimeOffset utcStart) => _now = utcStart;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Gandalf.Tests/TimerDisplaySchedulerTests.cs
+++ b/tests/Gandalf.Tests/TimerDisplaySchedulerTests.cs
@@ -163,6 +163,12 @@ public class TimerDisplaySchedulerTests
         running.PropertyChanged += CountFractionChanges(() => runningNotifications++);
         idle.PropertyChanged += CountFractionChanges(() => idleNotifications++);
 
+        // Advance the clock so the Running row's Fraction actually moves
+        // between scheduler registration and fast-tick. The per-property
+        // diff in TimerItemViewModel only fires Fraction PropertyChanged
+        // when the value materially changes — which is the perf win, but
+        // also means tests that expect a fire must produce a real delta.
+        clock.Advance(TimeSpan.FromMinutes(5));
         sched.TickFastForTests();
 
         runningNotifications.Should().BeGreaterThan(0);

--- a/tests/Gandalf.Tests/TimerExpirationSchedulerTests.cs
+++ b/tests/Gandalf.Tests/TimerExpirationSchedulerTests.cs
@@ -1,0 +1,192 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Character;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class TimerExpirationSchedulerTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _defsPath;
+    private readonly string _charactersDir;
+
+    public TimerExpirationSchedulerTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_expiration_scheduler");
+        _defsPath = Path.Combine(_dir, "definitions.json");
+        _charactersDir = Path.Combine(_dir, "characters");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private (TimerExpirationScheduler scheduler, TimerProgressService progress, TimerDefinitionsService defs, ManualTime time)
+        Build()
+    {
+        var defStore = new JsonSettingsStore<GandalfDefinitions>(_defsPath,
+            GandalfDefinitionsJsonContext.Default.GandalfDefinitions);
+        var defs = defStore.Load();
+        var defsSvc = new TimerDefinitionsService(defStore, defs);
+
+        var active = new FakeActiveCharacterService();
+        active.SetActiveCharacter("Arthur", "Kwatoxi");
+        var store = new PerCharacterStore<GandalfProgress>(_charactersDir, "gandalf.json",
+            GandalfProgressJsonContext.Default.GandalfProgress);
+        var view = new PerCharacterView<GandalfProgress>(active, store);
+        var progressSvc = new TimerProgressService(view, defsSvc,
+            new PerCharacterStoreOptions { CharactersRootDir = _charactersDir });
+
+        var time = new ManualTime(new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc));
+        var scheduler = new TimerExpirationScheduler(progressSvc, defsSvc, time);
+        return (scheduler, progressSvc, defsSvc, time);
+    }
+
+    [Fact]
+    public void NextExpirationAt_is_null_when_no_timers_running()
+    {
+        var (sched, progress, defs, _) = Build();
+        try
+        {
+            sched.NextExpirationAt.Should().BeNull();
+
+            defs.Add(new GandalfTimerDef { Name = "Idle", Duration = TimeSpan.FromHours(1) });
+            sched.NextExpirationAt.Should().BeNull("a defined-but-not-started timer doesn't expire");
+        }
+        finally
+        {
+            sched.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void NextExpirationAt_picks_soonest_StartedAt_plus_Duration()
+    {
+        var (sched, progress, defs, _) = Build();
+        try
+        {
+            // Started in the past; one expires sooner than the other.
+            // Use real wall-clock UtcNow because TimerProgressService.Start
+            // stamps StartedAt = DateTimeOffset.UtcNow internally — not
+            // an injected clock. Both timers start ~now; the 30-second one
+            // expires first.
+            defs.Add(new GandalfTimerDef { Name = "Soon", Duration = TimeSpan.FromSeconds(30) });
+            defs.Add(new GandalfTimerDef { Name = "Later", Duration = TimeSpan.FromHours(2) });
+            var soonId = defs.Definitions[0].Id;
+            var laterId = defs.Definitions[1].Id;
+
+            progress.Start(soonId);
+            progress.Start(laterId);
+
+            var soon = progress.GetProgress(soonId);
+            soon!.StartedAt.Should().NotBeNull();
+            var expectedSoonest = soon.StartedAt!.Value + TimeSpan.FromSeconds(30);
+
+            sched.NextExpirationAt.Should().BeCloseTo(expectedSoonest, TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            sched.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Tick_runs_CheckExpirations_and_fires_TimerExpired_for_past_due_rows()
+    {
+        var (sched, progress, defs, _) = Build();
+        try
+        {
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "Quick",
+                Duration = TimeSpan.FromMilliseconds(1),
+            });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+
+            // Wait past the duration so CheckExpirations sees the row as Done.
+            // The TimerProgressService uses real wall-clock for state checks.
+            System.Threading.Thread.Sleep(20);
+
+            var expired = new List<TimerExpiredEventArgs>();
+            progress.TimerExpired += (_, e) => expired.Add(e);
+
+            sched.TickForTests();
+
+            expired.Should().ContainSingle();
+            expired[0].Def.Id.Should().Be(id);
+            progress.GetProgress(id)!.CompletedAt.Should().NotBeNull();
+        }
+        finally
+        {
+            sched.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Removing_a_definition_clears_NextExpirationAt()
+    {
+        var (sched, progress, defs, _) = Build();
+        try
+        {
+            defs.Add(new GandalfTimerDef { Name = "X", Duration = TimeSpan.FromHours(1) });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+
+            sched.NextExpirationAt.Should().NotBeNull();
+
+            defs.Remove(id);
+            sched.NextExpirationAt.Should().BeNull();
+        }
+        finally
+        {
+            sched.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Disposed_scheduler_ignores_ticks()
+    {
+        var (sched, progress, defs, _) = Build();
+        try
+        {
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "Quick",
+                Duration = TimeSpan.FromMilliseconds(1),
+            });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+            System.Threading.Thread.Sleep(20);
+
+            sched.Dispose();
+
+            var expired = new List<TimerExpiredEventArgs>();
+            progress.TimerExpired += (_, e) => expired.Add(e);
+
+            sched.TickForTests();
+
+            expired.Should().BeEmpty();
+        }
+        finally
+        {
+            progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTime utcStart) => _now = new DateTimeOffset(utcStart, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Gandalf.Tests/TimerItemViewModelTests.cs
+++ b/tests/Gandalf.Tests/TimerItemViewModelTests.cs
@@ -1,0 +1,171 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.ViewModels;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+public class TimerItemViewModelTests
+{
+    private static readonly DateTimeOffset Anchor =
+        new(2026, 5, 9, 14, 30, 0, TimeSpan.Zero);
+
+    private static TimerCatalogEntry Entry(string key, string region, TimeSpan duration) =>
+        new(key, $"Display {key}", region, duration, SourceMetadata: null);
+
+    private static TimerRow MakeRow(
+        TimerCatalogEntry catalog,
+        TimerProgressEntry? progress,
+        TimeProvider clock) =>
+        new(catalog, progress) { Clock = clock };
+
+    private static List<string> RecordPropertyChanges(TimerItemViewModel vm)
+    {
+        var changes = new List<string>();
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName is not null) changes.Add(e.PropertyName); };
+        return changes;
+    }
+
+    [Fact]
+    public void Refresh_with_no_change_fires_nothing()
+    {
+        var clock = new ManualTime(Anchor);
+        var entry = Entry("k", "R", TimeSpan.FromHours(1));
+        var vm = new TimerItemViewModel(MakeRow(entry, null, clock));
+
+        var changes = RecordPropertyChanges(vm);
+        vm.Refresh();
+
+        changes.Should().BeEmpty("nothing in the row's projection changed since construction");
+    }
+
+    [Fact]
+    public void State_transition_fires_the_State_cluster_only()
+    {
+        var clock = new ManualTime(Anchor);
+        var entry = Entry("k", "R", TimeSpan.FromSeconds(20));
+        var progress = new TimerProgressEntry("k", Anchor, DismissedAt: null);
+        var vm = new TimerItemViewModel(MakeRow(entry, progress, clock));
+        vm.State.Should().Be(TimerState.Running);
+
+        var changes = RecordPropertyChanges(vm);
+
+        // Advance past the state-flip moment.
+        clock.Advance(TimeSpan.FromSeconds(25));
+        vm.Refresh();
+
+        // The full State cluster should fire — but no others (Name / GroupKey /
+        // DurationLabel are catalog-derived; TimeDisplay also changes since
+        // "Xs remaining" → "done!").
+        var expectedClusterMembers = new[]
+        {
+            nameof(TimerItemViewModel.State),
+            nameof(TimerItemViewModel.IsIdle),
+            nameof(TimerItemViewModel.IsRunning),
+            nameof(TimerItemViewModel.IsDone),
+            nameof(TimerItemViewModel.StatusColor),
+            nameof(TimerItemViewModel.StatusLabel),
+            nameof(TimerItemViewModel.ShowStartButton),
+            nameof(TimerItemViewModel.ShowRestartButton),
+            nameof(TimerItemViewModel.ShowProgressBar),
+        };
+
+        changes.Should().Contain(expectedClusterMembers);
+        changes.Should().NotContain(nameof(TimerItemViewModel.Name));
+        changes.Should().NotContain(nameof(TimerItemViewModel.GroupKey));
+        changes.Should().NotContain(nameof(TimerItemViewModel.DurationLabel));
+    }
+
+    [Fact]
+    public void Minute_roll_fires_TimeDisplay_only_no_State_cluster()
+    {
+        // 2-hour Running row crossing the minute boundary at Anchor + 1 min.
+        // State stays Running, Fraction barely moves but is past the 0.0001
+        // tolerance, TimeDisplay text bucket flips.
+        var clock = new ManualTime(Anchor);
+        var entry = Entry("k", "R", TimeSpan.FromHours(2));
+        var progress = new TimerProgressEntry("k", Anchor, DismissedAt: null);
+        var vm = new TimerItemViewModel(MakeRow(entry, progress, clock));
+
+        var changes = RecordPropertyChanges(vm);
+
+        // Advance one minute + a sliver to ensure we cross the minute bucket
+        // (FormatDuration rounds to "Xh Ym" so "2h 0m" → "1h 59m").
+        clock.Advance(TimeSpan.FromMinutes(1) + TimeSpan.FromSeconds(1));
+        vm.Refresh();
+
+        changes.Should().Contain(nameof(TimerItemViewModel.TimeDisplay));
+        changes.Should().Contain(nameof(TimerItemViewModel.Fraction));
+        // State cluster should NOT fire — row stayed Running.
+        changes.Should().NotContain(nameof(TimerItemViewModel.State));
+        changes.Should().NotContain(nameof(TimerItemViewModel.IsRunning));
+    }
+
+    [Fact]
+    public void TimeDisplay_uses_injected_clock_not_wall_clock()
+    {
+        // Regression guard for the pre-existing bug TimeDisplay's
+        // "done X ago" computation read DateTimeOffset.UtcNow directly.
+        // Under ManualTime, the row's CompletedAt is at Anchor + 30s but
+        // wall-clock UtcNow is whatever the test process time is —
+        // potentially years off from Anchor. The clock-routing fix
+        // ensures the displayed string is computed against the injected
+        // TimeProvider, so a Done row 5 s past completion reads "done!"
+        // regardless of real-world clock skew.
+        var clock = new ManualTime(Anchor);
+        var entry = Entry("k", "R", TimeSpan.FromSeconds(30));
+        var progress = new TimerProgressEntry("k", Anchor, DismissedAt: null);
+        var vm = new TimerItemViewModel(MakeRow(entry, progress, clock));
+
+        // Move past completion by 5 seconds — within the "done!" bucket.
+        clock.Advance(TimeSpan.FromSeconds(35));
+        vm.Refresh();
+
+        vm.State.Should().Be(TimerState.Done);
+        vm.TimeDisplay.Should().Be("done!", "5 s past completion is within the 60 s 'done!' window per the injected clock");
+    }
+
+    [Fact]
+    public void TimeDisplay_uses_injected_clock_for_done_X_ago_bucket()
+    {
+        var clock = new ManualTime(Anchor);
+        var entry = Entry("k", "R", TimeSpan.FromSeconds(30));
+        var progress = new TimerProgressEntry("k", Anchor, DismissedAt: null);
+        var vm = new TimerItemViewModel(MakeRow(entry, progress, clock));
+
+        // Move 5 minutes past completion. Should read "done 5m 0s ago" or similar.
+        clock.Advance(TimeSpan.FromSeconds(30) + TimeSpan.FromMinutes(5));
+        vm.Refresh();
+
+        vm.State.Should().Be(TimerState.Done);
+        vm.TimeDisplay.Should().StartWith("done ");
+        vm.TimeDisplay.Should().EndWith(" ago");
+    }
+
+    [Fact]
+    public void UpdateRow_with_changed_catalog_fires_only_changed_catalog_properties()
+    {
+        var clock = new ManualTime(Anchor);
+        var oldEntry = Entry("k", region: "Old", TimeSpan.FromHours(1));
+        var vm = new TimerItemViewModel(MakeRow(oldEntry, null, clock));
+
+        var changes = RecordPropertyChanges(vm);
+
+        // Same Name + Duration; only Region (GroupKey) differs.
+        var newEntry = oldEntry with { Region = "New" };
+        vm.UpdateRow(MakeRow(newEntry, null, clock));
+
+        changes.Should().Contain(nameof(TimerItemViewModel.GroupKey));
+        changes.Should().NotContain(nameof(TimerItemViewModel.Name));
+        changes.Should().NotContain(nameof(TimerItemViewModel.DurationLabel));
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTimeOffset utcStart) => _now = utcStart;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Gandalf.Tests/TimerRowDeltaDifferTests.cs
+++ b/tests/Gandalf.Tests/TimerRowDeltaDifferTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Gandalf.Domain;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+public class TimerRowDeltaDifferTests
+{
+    private static TimerCatalogEntry Entry(string key, TimeSpan duration, string? region = "R") =>
+        new(key, $"Display {key}", region, duration, SourceMetadata: null);
+
+    private static TimerProgressEntry Progress(string key, DateTimeOffset startedAt) =>
+        new(key, startedAt, DismissedAt: null);
+
+    private static IReadOnlyDictionary<string, TimerCatalogEntry> CatalogMap(params TimerCatalogEntry[] entries) =>
+        entries.ToDictionary(e => e.Key, StringComparer.Ordinal);
+
+    private static IReadOnlyDictionary<string, TimerProgressEntry> ProgressMap(params TimerProgressEntry[] entries) =>
+        entries.ToDictionary(e => e.Key, StringComparer.Ordinal);
+
+    private static readonly DateTimeOffset Anchor =
+        new(2026, 5, 9, 14, 30, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Empty_to_empty_produces_no_deltas()
+    {
+        var deltas = TimerRowDeltaDiffer.Diff(CatalogMap(), CatalogMap(), ProgressMap(), ProgressMap());
+        deltas.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void New_catalog_entry_emits_added_delta_with_progress_attached()
+    {
+        var newCat = CatalogMap(Entry("k", TimeSpan.FromHours(1)));
+        var newProg = ProgressMap(Progress("k", Anchor));
+
+        var deltas = TimerRowDeltaDiffer.Diff(CatalogMap(), newCat, ProgressMap(), newProg);
+
+        deltas.Should().HaveCount(1);
+        deltas[0].Key.Should().Be("k");
+        deltas[0].Kind.Should().Be(TimerRowChangeKind.Added);
+        deltas[0].Catalog.Should().Be(newCat["k"]);
+        deltas[0].Progress.Should().Be(newProg["k"]);
+    }
+
+    [Fact]
+    public void Removed_catalog_entry_emits_removed_delta_with_null_payload()
+    {
+        var oldCat = CatalogMap(Entry("k", TimeSpan.FromHours(1)));
+        var oldProg = ProgressMap(Progress("k", Anchor));
+
+        var deltas = TimerRowDeltaDiffer.Diff(oldCat, CatalogMap(), oldProg, ProgressMap());
+
+        deltas.Should().HaveCount(1);
+        deltas[0].Key.Should().Be("k");
+        deltas[0].Kind.Should().Be(TimerRowChangeKind.Removed);
+        deltas[0].Catalog.Should().BeNull();
+        deltas[0].Progress.Should().BeNull();
+    }
+
+    [Fact]
+    public void Catalog_duration_change_emits_catalog_changed_delta()
+    {
+        var oldCat = CatalogMap(Entry("k", TimeSpan.FromHours(1)));
+        var newCat = CatalogMap(Entry("k", TimeSpan.FromHours(3)));
+
+        var deltas = TimerRowDeltaDiffer.Diff(oldCat, newCat, ProgressMap(), ProgressMap());
+
+        deltas.Should().ContainSingle();
+        deltas[0].Kind.Should().Be(TimerRowChangeKind.CatalogChanged);
+        deltas[0].Catalog!.Duration.Should().Be(TimeSpan.FromHours(3));
+    }
+
+    [Fact]
+    public void Progress_change_alone_emits_progress_changed_delta()
+    {
+        var cat = CatalogMap(Entry("k", TimeSpan.FromHours(1)));
+        var oldProg = ProgressMap();
+        var newProg = ProgressMap(Progress("k", Anchor));
+
+        var deltas = TimerRowDeltaDiffer.Diff(cat, cat, oldProg, newProg);
+
+        deltas.Should().ContainSingle();
+        deltas[0].Kind.Should().Be(TimerRowChangeKind.ProgressChanged);
+        deltas[0].Progress!.StartedAt.Should().Be(Anchor);
+    }
+
+    [Fact]
+    public void Catalog_change_subsumes_progress_change_into_one_delta()
+    {
+        // When both catalog and progress shifted in the same diff window, emit
+        // one CatalogChanged delta carrying both pieces — receivers see the
+        // latest state regardless of which kind they branch on. Avoids
+        // duplicate deltas for the same key in one batch.
+        var oldCat = CatalogMap(Entry("k", TimeSpan.FromHours(1)));
+        var newCat = CatalogMap(Entry("k", TimeSpan.FromHours(3)));
+        var oldProg = ProgressMap();
+        var newProg = ProgressMap(Progress("k", Anchor));
+
+        var deltas = TimerRowDeltaDiffer.Diff(oldCat, newCat, oldProg, newProg);
+
+        deltas.Should().ContainSingle();
+        deltas[0].Kind.Should().Be(TimerRowChangeKind.CatalogChanged);
+        deltas[0].Catalog!.Duration.Should().Be(TimeSpan.FromHours(3));
+        deltas[0].Progress!.StartedAt.Should().Be(Anchor);
+    }
+
+    [Fact]
+    public void Mixed_batch_yields_multiple_deltas_in_iteration_order()
+    {
+        // Calibration-overlay-style scenario: many rows mutate at once.
+        var oldCat = CatalogMap(
+            Entry("a", TimeSpan.FromHours(1)),
+            Entry("b", TimeSpan.FromHours(2)));
+        var newCat = CatalogMap(
+            Entry("b", TimeSpan.FromHours(2)),                    // unchanged
+            Entry("c", TimeSpan.FromHours(3)));                   // added
+        // 'a' removed, 'c' added.
+
+        var deltas = TimerRowDeltaDiffer.Diff(oldCat, newCat, ProgressMap(), ProgressMap());
+
+        deltas.Should().HaveCount(2);
+        deltas.Should().Contain(d => d.Key == "c" && d.Kind == TimerRowChangeKind.Added);
+        deltas.Should().Contain(d => d.Key == "a" && d.Kind == TimerRowChangeKind.Removed);
+    }
+}

--- a/tests/Gandalf.Tests/TimerRowTests.cs
+++ b/tests/Gandalf.Tests/TimerRowTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Gandalf.Domain;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+public class TimerRowTests
+{
+    private static readonly DateTimeOffset Anchor =
+        new(2026, 5, 9, 14, 30, 0, TimeSpan.Zero);
+
+    private static TimerRow MakeRow(
+        TimeSpan duration,
+        DateTimeOffset? startedAt,
+        DateTimeOffset? dismissedAt,
+        TimeProvider clock)
+    {
+        var catalog = new TimerCatalogEntry(
+            Key: "test:row",
+            DisplayName: "Test",
+            Region: "Test",
+            Duration: duration,
+            SourceMetadata: null);
+        var progress = startedAt is null
+            ? null
+            : new TimerProgressEntry("test:row", startedAt.Value, dismissedAt);
+        return new TimerRow(catalog, progress) { Clock = clock };
+    }
+
+    [Fact]
+    public void Idle_with_no_progress_has_no_next_change()
+    {
+        var clock = new ManualTime(Anchor);
+        var row = MakeRow(TimeSpan.FromHours(1), startedAt: null, dismissedAt: null, clock);
+
+        row.State.Should().Be(TimerState.Idle);
+        row.NextDisplayChangeAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dismissed_row_has_no_next_change()
+    {
+        var clock = new ManualTime(Anchor);
+        var row = MakeRow(
+            TimeSpan.FromHours(1),
+            startedAt: Anchor - TimeSpan.FromMinutes(15),
+            dismissedAt: Anchor - TimeSpan.FromSeconds(30),
+            clock);
+
+        row.State.Should().Be(TimerState.Idle);
+        row.NextDisplayChangeAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Running_returns_state_flip_when_sooner_than_next_minute()
+    {
+        // Anchor is on a minute boundary (14:30:00). State flips at 14:30:20.
+        var clock = new ManualTime(Anchor);
+        var row = MakeRow(
+            TimeSpan.FromSeconds(20),
+            startedAt: Anchor,
+            dismissedAt: null,
+            clock);
+
+        row.State.Should().Be(TimerState.Running);
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromSeconds(20));
+    }
+
+    [Fact]
+    public void Running_returns_next_minute_when_state_flip_is_far()
+    {
+        // Now: 14:30:15. State flips at 15:30:15 (1 h later). Next minute at 14:31:00.
+        var now = Anchor + TimeSpan.FromSeconds(15);
+        var clock = new ManualTime(now);
+        var row = MakeRow(
+            TimeSpan.FromHours(1),
+            startedAt: now,
+            dismissedAt: null,
+            clock);
+
+        row.State.Should().Be(TimerState.Running);
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void Running_at_minute_boundary_returns_next_minute_one_minute_out()
+    {
+        // Now: 14:30:00 exactly. State flips at 15:30:00. Next minute at 14:31:00.
+        var clock = new ManualTime(Anchor);
+        var row = MakeRow(
+            TimeSpan.FromHours(1),
+            startedAt: Anchor,
+            dismissedAt: null,
+            clock);
+
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void Just_done_returns_completed_plus_sixty_seconds()
+    {
+        // Started at 14:29:30, duration 30s → completed at 14:30:00. Now: 14:30:10
+        // (10 s into the "done!" bucket). Next change: 14:31:00 (the
+        // "done 1m ago" flip at completedAt + 60 s).
+        var startedAt = Anchor - TimeSpan.FromSeconds(30);
+        var completedAt = Anchor;
+        var now = Anchor + TimeSpan.FromSeconds(10);
+        var clock = new ManualTime(now);
+        var row = MakeRow(
+            TimeSpan.FromSeconds(30),
+            startedAt: startedAt,
+            dismissedAt: null,
+            clock);
+
+        row.State.Should().Be(TimerState.Done);
+        row.NextDisplayChangeAt.Should().Be(completedAt + TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public void Old_done_returns_next_minute_boundary()
+    {
+        // Completed at 14:00:00, now 14:30:15 (~30 min ago). The "done Xm ago"
+        // string rolls each minute, so next change is at 14:31:00.
+        var completedAt = Anchor - TimeSpan.FromMinutes(30);
+        var startedAt = completedAt - TimeSpan.FromHours(1);
+        var now = Anchor + TimeSpan.FromSeconds(15);
+        var clock = new ManualTime(now);
+        var row = MakeRow(
+            TimeSpan.FromHours(1),
+            startedAt: startedAt,
+            dismissedAt: null,
+            clock);
+
+        row.State.Should().Be(TimerState.Done);
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void Done_at_exactly_sixty_seconds_uses_minute_boundary_path()
+    {
+        // CompletedAt + 60s == now → elapsed >= 60s → minute-boundary branch.
+        var completedAt = Anchor;
+        var startedAt = completedAt - TimeSpan.FromMinutes(5);
+        var now = completedAt + TimeSpan.FromSeconds(60);
+        var clock = new ManualTime(now);
+        var row = MakeRow(
+            TimeSpan.FromMinutes(5),
+            startedAt: startedAt,
+            dismissedAt: null,
+            clock);
+
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public void Advancing_clock_past_state_flip_changes_next_display()
+    {
+        var clock = new ManualTime(Anchor);
+        var row = MakeRow(
+            TimeSpan.FromSeconds(20),
+            startedAt: Anchor,
+            dismissedAt: null,
+            clock);
+
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromSeconds(20));
+
+        clock.Advance(TimeSpan.FromSeconds(25));
+
+        row.State.Should().Be(TimerState.Done);
+        row.NextDisplayChangeAt.Should().Be(Anchor + TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(60));
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTimeOffset utcStart) => _now = utcStart;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Gandalf.Tests/TimerSourceBinderTests.cs
+++ b/tests/Gandalf.Tests/TimerSourceBinderTests.cs
@@ -384,15 +384,11 @@ public class TimerSourceBinderTests
             return false;
         }
 
-        public event EventHandler? CatalogChanged;
-        public event EventHandler? ProgressChanged;
         public event EventHandler<TimerReadyEventArgs>? TimerReady;
         public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
 
         public RecordingFakeSource(string sourceId) => SourceId = sourceId;
 
-        public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
-        public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
         public void RaiseTimerReady(TimerReadyEventArgs e) => TimerReady?.Invoke(this, e);
         public void RaiseRowsChanged(IReadOnlyList<TimerRowDelta> deltas) =>
             RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });

--- a/tests/Gandalf.Tests/TimerSourceBinderTests.cs
+++ b/tests/Gandalf.Tests/TimerSourceBinderTests.cs
@@ -303,6 +303,57 @@ public class TimerSourceBinderTests
     }
 
     [Fact]
+    public void Binder_registers_added_rows_with_scheduler()
+    {
+        var clock = new ManualTime(Anchor);
+        var source = new RecordingFakeSource("test");
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var scheduler = new TimerDisplayScheduler(clock);
+
+        using var binder = new TimerSourceBinder(source, target, clock, scheduler: scheduler);
+
+        // Initial sync — empty catalog, nothing scheduled.
+        scheduler.NextSlowTickAt.Should().BeNull();
+
+        // Adding a Running row through a delta must register with the scheduler.
+        var entry = Entry("k", duration: TimeSpan.FromMinutes(30));
+        source.Catalog = [entry];
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.Added, entry, Started("k", Anchor)),
+        ]);
+
+        scheduler.NextSlowTickAt.Should().NotBeNull();
+        scheduler.AnyRunningWithProgressBar.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Binder_unregisters_removed_rows_from_scheduler()
+    {
+        var clock = new ManualTime(Anchor);
+        var entry = Entry("k", duration: TimeSpan.FromMinutes(30));
+        var source = new RecordingFakeSource("test")
+        {
+            Catalog = [entry],
+            Progress = new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal)
+            {
+                ["k"] = Started("k", Anchor),
+            },
+        };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var scheduler = new TimerDisplayScheduler(clock);
+        using var binder = new TimerSourceBinder(source, target, clock, scheduler: scheduler);
+
+        scheduler.AnyRunningWithProgressBar.Should().BeTrue();
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.Removed, null, null),
+        ]);
+
+        scheduler.NextSlowTickAt.Should().BeNull();
+        scheduler.AnyRunningWithProgressBar.Should().BeFalse();
+    }
+
+    [Fact]
     public void Disposed_binder_stops_applying_deltas()
     {
         var entry = Entry("k");

--- a/tests/Gandalf.Tests/TimerSourceBinderTests.cs
+++ b/tests/Gandalf.Tests/TimerSourceBinderTests.cs
@@ -1,0 +1,357 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Gandalf.ViewModels;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+public class TimerSourceBinderTests
+{
+    private static readonly DateTimeOffset Anchor =
+        new(2026, 5, 9, 14, 30, 0, TimeSpan.Zero);
+
+    private static TimerCatalogEntry Entry(string key, string region = "R", TimeSpan? duration = null) =>
+        new(key, $"Display {key}", region, duration ?? TimeSpan.FromHours(1), SourceMetadata: null);
+
+    private static TimerProgressEntry Started(string key, DateTimeOffset at) =>
+        new(key, at, DismissedAt: null);
+
+    [Fact]
+    public void Initial_sync_materialises_all_catalog_rows_when_no_relevance_filter()
+    {
+        var source = new RecordingFakeSource("test")
+        {
+            Catalog = [Entry("a"), Entry("b"), Entry("c")],
+        };
+        var target = new ObservableCollection<TimerItemViewModel>();
+
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        target.Should().HaveCount(3);
+        binder.ByKey.Keys.Should().BeEquivalentTo(["a", "b", "c"]);
+    }
+
+    [Fact]
+    public void Initial_sync_filters_out_irrelevant_rows()
+    {
+        var source = new RecordingFakeSource("test")
+        {
+            Catalog = [Entry("relevant"), Entry("filtered")],
+        };
+        var target = new ObservableCollection<TimerItemViewModel>();
+
+        using var binder = new TimerSourceBinder(
+            source, target, new ManualTime(Anchor),
+            isRelevant: (entry, _) => entry.Key == "relevant");
+
+        target.Should().ContainSingle();
+        binder.ByKey.Keys.Should().BeEquivalentTo(["relevant"]);
+    }
+
+    [Fact]
+    public void Added_delta_materialises_the_row()
+    {
+        var source = new RecordingFakeSource("test");
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        var entry = Entry("k");
+        source.Catalog = [entry];
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.Added, entry, Progress: null),
+        ]);
+
+        target.Should().ContainSingle();
+        target[0].Key.Should().Be("k");
+    }
+
+    [Fact]
+    public void Added_delta_filtered_out_does_not_materialise()
+    {
+        var source = new RecordingFakeSource("test");
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(
+            source, target, new ManualTime(Anchor),
+            isRelevant: (e, _) => e.Region == "Visible");
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.Added, Entry("k", region: "Hidden"), null),
+        ]);
+
+        target.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProgressChanged_delta_updates_existing_row_in_place()
+    {
+        var entry = Entry("k", duration: TimeSpan.FromHours(2));
+        var source = new RecordingFakeSource("test") { Catalog = [entry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        var vmBefore = target[0];
+        vmBefore.State.Should().Be(TimerState.Idle);
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.ProgressChanged, entry, Started("k", Anchor)),
+        ]);
+
+        target.Should().ContainSingle();
+        target[0].Should().BeSameAs(vmBefore, "ProgressChanged updates the existing VM in place — no churn");
+        target[0].State.Should().Be(TimerState.Running);
+    }
+
+    [Fact]
+    public void Removed_delta_drops_the_row()
+    {
+        var entry = Entry("k");
+        var source = new RecordingFakeSource("test") { Catalog = [entry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.Removed, Catalog: null, Progress: null),
+        ]);
+
+        target.Should().BeEmpty();
+        binder.ByKey.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProgressChanged_can_drop_a_row_when_relevance_flips_off()
+    {
+        // QuestSource pattern: a quest with progress is relevant; once
+        // dismissed and removed from journal, it becomes irrelevant and
+        // the binder must drop it from the collection.
+        var entry = Entry("k");
+        var source = new RecordingFakeSource("test") { Catalog = [entry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        var inJournal = true;
+        using var binder = new TimerSourceBinder(
+            source, target, new ManualTime(Anchor),
+            isRelevant: (_, p) => p is { DismissedAt: null } || inJournal);
+
+        target.Should().HaveCount(1);
+
+        // Mark dismissed AND drop from journal.
+        inJournal = false;
+        var dismissedProgress = new TimerProgressEntry("k", Anchor, DismissedAt: Anchor + TimeSpan.FromMinutes(10));
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.ProgressChanged, entry, dismissedProgress),
+        ]);
+
+        target.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProgressChanged_can_add_a_row_when_relevance_flips_on()
+    {
+        var entry = Entry("k");
+        var source = new RecordingFakeSource("test") { Catalog = [entry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(
+            source, target, new ManualTime(Anchor),
+            isRelevant: (_, p) => p is not null);  // only relevant once started
+
+        target.Should().BeEmpty("not relevant until progress exists");
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.ProgressChanged, entry, Started("k", Anchor)),
+        ]);
+
+        target.Should().ContainSingle();
+        target[0].Key.Should().Be("k");
+    }
+
+    [Fact]
+    public void RefreshRequired_fires_when_State_changes_on_existing_row()
+    {
+        var entry = Entry("k", duration: TimeSpan.FromMinutes(30));
+        var source = new RecordingFakeSource("test") { Catalog = [entry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        var refreshes = 0;
+        binder.RefreshRequired += (_, _) => refreshes++;
+
+        // Idle → Running (progress arrives).
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.ProgressChanged, entry, Started("k", Anchor)),
+        ]);
+
+        refreshes.Should().Be(1);
+    }
+
+    [Fact]
+    public void RefreshRequired_fires_when_GroupKey_changes_via_CatalogChanged()
+    {
+        // Calibration-overlay scenario: a defeat row's Region flips from
+        // "Defeats" to "Tagamogi". The binder must signal Refresh because
+        // the CollectionView groups by GroupKey (= Region).
+        var oldEntry = Entry("k", region: "Defeats");
+        var source = new RecordingFakeSource("test") { Catalog = [oldEntry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        var refreshes = 0;
+        binder.RefreshRequired += (_, _) => refreshes++;
+
+        var newEntry = Entry("k", region: "Tagamogi");
+        source.Catalog = [newEntry];
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.CatalogChanged, newEntry, Progress: null),
+        ]);
+
+        refreshes.Should().Be(1);
+        target[0].GroupKey.Should().Be("Tagamogi");
+    }
+
+    [Fact]
+    public void RefreshRequired_fires_at_most_once_per_batched_RowsChanged()
+    {
+        // Calibration overlay applied: ~hundreds of rows mutate at once,
+        // arriving as a single batch. The binder must call host's Refresh
+        // exactly once for the entire batch, not N times.
+        var entries = Enumerable.Range(0, 50)
+            .Select(i => Entry($"k{i}", region: "Old"))
+            .ToArray();
+        var source = new RecordingFakeSource("test") { Catalog = entries };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        var refreshes = 0;
+        binder.RefreshRequired += (_, _) => refreshes++;
+
+        var newEntries = entries
+            .Select(e => Entry(e.Key, region: "New"))
+            .ToArray();
+        source.Catalog = newEntries;
+        var deltas = newEntries
+            .Select(e => new TimerRowDelta(e.Key, TimerRowChangeKind.CatalogChanged, e, Progress: null))
+            .ToList();
+        source.RaiseRowsChanged(deltas);
+
+        refreshes.Should().Be(1, "one batch of N deltas must call RefreshRequired exactly once");
+    }
+
+    [Fact]
+    public void Removed_delta_for_unknown_key_is_a_noop()
+    {
+        var source = new RecordingFakeSource("test");
+        var target = new ObservableCollection<TimerItemViewModel>();
+        using var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        var refreshes = 0;
+        binder.RefreshRequired += (_, _) => refreshes++;
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("ghost", TimerRowChangeKind.Removed, null, null),
+        ]);
+
+        target.Should().BeEmpty();
+        refreshes.Should().Be(0);
+    }
+
+    [Fact]
+    public void RecheckRelevance_adds_rows_that_became_relevant()
+    {
+        // Models the QuestSource pending-set pattern: a quest is in catalog
+        // but not yet rendered because it's not in the journal. Player
+        // accepts the quest (pending now contains it) → host VM calls
+        // RecheckRelevance() → binder iterates catalog, finds the row is
+        // newly relevant, materialises it.
+        var entries = new[] { Entry("a"), Entry("b") };
+        var source = new RecordingFakeSource("test") { Catalog = entries };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        var pending = new HashSet<string>(StringComparer.Ordinal);
+
+        using var binder = new TimerSourceBinder(
+            source, target, new ManualTime(Anchor),
+            isRelevant: (e, _) => pending.Contains(e.Key));
+
+        target.Should().BeEmpty();
+
+        pending.Add("a");
+        binder.RecheckRelevance();
+
+        target.Should().ContainSingle();
+        target[0].Key.Should().Be("a");
+    }
+
+    [Fact]
+    public void RecheckRelevance_removes_rows_that_became_irrelevant()
+    {
+        var entries = new[] { Entry("a"), Entry("b") };
+        var source = new RecordingFakeSource("test") { Catalog = entries };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        var pending = new HashSet<string>(StringComparer.Ordinal) { "a", "b" };
+
+        using var binder = new TimerSourceBinder(
+            source, target, new ManualTime(Anchor),
+            isRelevant: (e, _) => pending.Contains(e.Key));
+
+        target.Should().HaveCount(2);
+
+        pending.Remove("a");
+        binder.RecheckRelevance();
+
+        target.Should().ContainSingle();
+        target[0].Key.Should().Be("b");
+    }
+
+    [Fact]
+    public void Disposed_binder_stops_applying_deltas()
+    {
+        var entry = Entry("k");
+        var source = new RecordingFakeSource("test") { Catalog = [entry] };
+        var target = new ObservableCollection<TimerItemViewModel>();
+        var binder = new TimerSourceBinder(source, target, new ManualTime(Anchor));
+
+        binder.Dispose();
+
+        source.RaiseRowsChanged([
+            new TimerRowDelta("k", TimerRowChangeKind.Removed, null, null),
+        ]);
+
+        target.Should().HaveCount(1, "events arriving after Dispose must not mutate the target");
+    }
+
+    private sealed class RecordingFakeSource : ITimerSource
+    {
+        public string SourceId { get; }
+        public IReadOnlyList<TimerCatalogEntry> Catalog { get; set; } = [];
+        public IReadOnlyDictionary<string, TimerProgressEntry> Progress { get; set; } =
+            new Dictionary<string, TimerProgressEntry>(StringComparer.Ordinal);
+
+        public bool TryGetProgress(string key, [NotNullWhen(true)] out TimerProgressEntry? progress)
+        {
+            if (Progress.TryGetValue(key, out var p)) { progress = p; return true; }
+            progress = null;
+            return false;
+        }
+
+        public event EventHandler? CatalogChanged;
+        public event EventHandler? ProgressChanged;
+        public event EventHandler<TimerReadyEventArgs>? TimerReady;
+        public event EventHandler<TimerRowsChangedEventArgs>? RowsChanged;
+
+        public RecordingFakeSource(string sourceId) => SourceId = sourceId;
+
+        public void RaiseCatalogChanged() => CatalogChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseProgressChanged() => ProgressChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseTimerReady(TimerReadyEventArgs e) => TimerReady?.Invoke(this, e);
+        public void RaiseRowsChanged(IReadOnlyList<TimerRowDelta> deltas) =>
+            RowsChanged?.Invoke(this, new TimerRowsChangedEventArgs { Deltas = deltas });
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTimeOffset utcStart) => _now = utcStart;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Gandalf.Tests/UserTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/UserTimerSourceTests.cs
@@ -173,4 +173,60 @@ public class UserTimerSourceTests : IDisposable
             source.Dispose(); progress.Dispose(); defs.Dispose();
         }
     }
+
+    [Fact]
+    public void Adding_a_definition_emits_RowsChanged_with_added_delta()
+    {
+        var (source, defs, progress, active) = BuildServices();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            source.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "Chest", Duration = TimeSpan.FromHours(3),
+                Region = "Goblin Dungeon", Map = "Lower",
+            });
+
+            batches.Should().ContainSingle();
+            batches[0].Should().ContainSingle(d => d.Kind == TimerRowChangeKind.Added);
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Starting_a_timer_emits_RowsChanged_with_progress_changed_delta()
+    {
+        var (source, defs, progress, active) = BuildServices();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "Chest", Duration = TimeSpan.FromHours(3),
+                Region = "Goblin Dungeon", Map = "Lower",
+            });
+            var id = defs.Definitions[0].Id;
+
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            source.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            progress.Start(id);
+
+            batches.SelectMany(b => b)
+                .Should().ContainSingle(d =>
+                    d.Key == id && d.Kind == TimerRowChangeKind.ProgressChanged);
+        }
+        finally
+        {
+            source.Dispose(); progress.Dispose(); defs.Dispose();
+        }
+    }
 }

--- a/tests/Gandalf.Tests/UserTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/UserTimerSourceTests.cs
@@ -126,17 +126,17 @@ public class UserTimerSourceTests : IDisposable
     }
 
     [Fact]
-    public void DefinitionsChanged_raises_CatalogChanged()
+    public void DefinitionsChanged_raises_RowsChanged()
     {
         var (source, defs, progress, _) = BuildServices();
         try
         {
-            var fired = 0;
-            source.CatalogChanged += (_, _) => fired++;
+            var batches = 0;
+            source.RowsChanged += (_, _) => batches++;
 
             defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1) });
 
-            fired.Should().Be(1);
+            batches.Should().Be(1);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Closes #154. Redesigns Gandalf's timer model to fix two structural flaws surfaced while diagnosing UI lag on the Loot tab:

- **Time isn't first-class.** Adds `TimerRow.NextDisplayChangeAt` so the model knows when each row's visible display next flips. Replaces every per-tab 1 Hz `DispatcherTimer` with a `TimerDisplayScheduler` that wakes only at those moments. Idle tabs do zero per-second work; a Done row whose "done X ago" rolls once per minute is touched once per minute.
- **Source change events were coarse and snapshot-shaped.** Replaces `ITimerSource.CatalogChanged` / `ProgressChanged` with a single `RowsChanged` event carrying batched per-key `TimerRowDelta`s. A `TimerSourceBinder` translates deltas into add / update-in-place / remove ops on the host VM's `ObservableCollection` — no clear-and-rebuild, no thrashing of `ICollectionView` grouping/sorting. A 165-quest journal-load fires exactly one `Refresh()`.

Sibling: #155 (extract `IQuestService` to retire the residual `PendingChanged` wart).

## What landed

| Commit | Scope |
|---|---|
| `9f0e513` | Design notebook ([docs/gandalf-timer-model-redesign.md](docs/gandalf-timer-model-redesign.md)) |
| `3763a72` | `TimerRow.NextDisplayChangeAt` + delta types |
| `6860374` | `RowsChanged` + `TryGetProgress` on `ITimerSource`; per-source snapshot-diffing emission |
| `f1fcbcd` | `TimerSourceBinder` (diff-in-place, dispatcher-marshalled, optional relevance predicate) |
| `aaa06d7` | `TimerDisplayScheduler` (NextDisplayChangeAt-driven slow tick + gated 1 Hz fast tick) |
| `2413ee6` | Binder↔scheduler wiring + `TimerExpirationScheduler` for the user-timer alarm path |
| `f08af5e` | Migrate `LootTimersViewModel` / `QuestTimersViewModel` / `TimerListViewModel` |
| `59a54fd` | `TimerItemViewModel.UpdateRow` per-property diff + `TimeDisplay` clock-routing fix |
| `dd2a989` | `DashboardAggregator` migration; remove `CatalogChanged`/`ProgressChanged` from `ITimerSource` |

**Net:** ~1,800 lines added (incl. 6 new test files, +83 new tests), ~280 removed. 239 Gandalf tests pass; full solution clean (1,497 tests across all modules).

## Side-fixes folded in

- **`TimerItemViewModel.TimeDisplay` was reading `DateTimeOffset.UtcNow` directly** instead of `_row.Clock`. Pre-existing bug that broke determinism under `ManualTime`/`FakeTimeProvider` — the row's `State` would read as Done at frozen-time T while `TimeDisplay`'s "X ago" computed against real wall-clock would drift. Fixed in commit 6.
- **Latent WPF cross-thread `ObservableCollection` mutation** in the three tab VMs (per `memory/wpf_crossthread_collection_mutations.md` — Pippin's prior incident). The new `TimerSourceBinder` captures the dispatcher in its ctor and routes every mutation through `CheckAccess`/`BeginInvoke`, retiring the latent bug as a side-effect of the migration.
- **`TimerListViewModel.Tick`'s `CheckExpirations` call** was the load-bearing path firing user-timer alarms. Relocated into a new `TimerExpirationScheduler` that schedules its own dispatcher timer at the soonest known expiration moment — preserves the alarm path while removing the 1 Hz polling.

## Out of scope (filed for follow-up or noted)

- **#155** — extract `IQuestService` into `Mithril.Shared` (mirrors `IInventoryService`). Reshapes `QuestSource.Catalog` to be the active set, retiring the relevance predicate + `PendingChanged` event.
- **`DashboardAggregator` 1 Hz `Recompute()` tick** — kept as-is. The aggregator now applies deltas incrementally, but state-flip transitions on time alone (no source event) still need a wakeup signal. Driving it from a `NextStateFlipAt` schedule is a clean follow-up; not urgent.
- **`ListBox` + `WrapPanel` virtualization** — out of scope. Once the binder + scheduler stop the per-tick catalog rebuild, virtualization is a no-op for current row counts (sub-thousand).

## Test plan

- [x] `dotnet build Mithril.slnx` — clean
- [x] `dotnet test Mithril.slnx` — 1,497 pass / 0 fail / 0 skip across every module
- [x] Manual UI: launch the shell, open Loot tab with a stale catalog, watch CPU usage on the Mithril process. Should be ~0% with no Running rows; pre-PR baseline was steady ~few-percent burn from the per-row 1 Hz tick.
- [ ] Manual UI: state-flip moment — chest cooldown crosses ready while the Loot tab is open. Row flips Running → Done at the exact moment, not on the next 1 Hz boundary.
- [ ] Manual UI: calibration overlay — trigger a refresh of `aggregated/gandalf.json`. Hundreds of defeat rows mutate; the UI should update without visible jank.
- [ ] Manual UI: character switch — switch the active character. Rows for the prior character clear; new character's rows appear. No leaked VMs or scheduler entries.
- [ ] Manual UI: user-timer alarm — create a 5-second user timer on the User tab, lock the screen, wait for the alarm to fire. Proves `CheckExpirations` relocation didn't break the alarm path.
- [ ] Manual UI: Quest tab "In journal" filter still works; quest dismiss-all still works.
- [ ] Manual UI: Dashboard's Ready Now / Coming Up sections update at the correct moments; per-source chip counters refresh on source mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
