### PR TITLE
shell: add Force quit Mithril hotkey command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Module DLLs are copied into `src/Mithril.Shell/{Configuration}/modules/` automat
 
 The script whitelists exactly two paths — `tests\.tmp\` inside this repo and `%TEMP%\mithril-tests-fallback` (the fallback used when `TestPaths` can't locate the repo). Nothing broader: no repo-wide exclusion, no `dotnet.exe` process exclusion. Without it, expect the FileIO-category tests under `Mithril.Shared.Tests` and a few file-IO heavy tests in `Samwise.Tests` / `Gandalf.Tests` to flake intermittently when run as part of the full suite; in isolation they still pass.
 
+### Force-quit hotkey
+
+When Mithril or the machine is bogged down enough that finding the tray icon, right-clicking it, and clicking **Exit** is painful — but the dispatcher is still pumping messages — a single global keypress can land faster than the mouse round-trip. The `Force quit Mithril` command is that fallback: it triggers the same shutdown path as the tray's Exit (host stops, settings save, mutex releases) and ships **unbound**, so you have to assign a combo before you can use it.
+
+To bind it:
+
+1. Settings → Appearance → enable **Developer mode**.
+2. Open the **Hotkeys** page (gear icon in the sidebar).
+3. Find **Force quit Mithril** under *Shell · Diagnostics*, click the chip, press the combo you want.
+
+The binding survives turning Developer mode back off — that flag only gates whether the row is visible in the Hotkeys UI, not whether the hotkey fires.
+
+**What this is not:** if the UI thread is fully wedged (deadlocked lock, infinite loop, modal sync-wait), `WM_HOTKEY` sits in the queue and the hotkey never delivers — the same freeze that locked the UI locks the rescue. Task Manager is the only way out of that case; `Process.Kill` from inside Mithril wouldn't help either, since we can't run code the dispatcher won't dispatch.
+
 ## Repository layout
 
 ```

--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using System.Reflection;
 using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Wpf;
+using Mithril.Shell.Hotkeys;
 using Mithril.Shell.Updates;
 using Mithril.Shell.ViewModels;
 using Mithril.Shell.Views;
@@ -89,6 +91,9 @@ public static class ShellServiceCollectionExtensions
 
     public static IServiceCollection AddMithrilIngredientSources(this IServiceCollection services) =>
         services.AddSingleton<IIngredientSourcesPresenter, IngredientSourcesPresenter>();
+
+    public static IServiceCollection AddMithrilShellCommands(this IServiceCollection services) =>
+        services.AddSingleton<IHotkeyCommand, ForceQuitCommand>();
 
     public static IServiceCollection AddMithrilShellViews(this IServiceCollection services) =>
         services

--- a/src/Mithril.Shell/Hotkeys/ForceQuitCommand.cs
+++ b/src/Mithril.Shell/Hotkeys/ForceQuitCommand.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Threading;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Hotkeys;
+
+namespace Mithril.Shell.Hotkeys;
+
+/// <summary>
+/// Emergency-exit hotkey. Triggers the same shutdown path as the tray "Exit"
+/// menu — <see cref="System.Windows.Application.Shutdown()"/> — so the WPF
+/// window-close chain runs (saves window position) and Program.cs's finally
+/// block tears down the IHost, persists settings, and releases the
+/// single-instance mutex. Marked diagnostic / developer-only because most
+/// users should reach for the tray's Exit; the global hotkey is here for the
+/// case where the UI is wedged or hidden. Ships unbound — the user picks a
+/// combo from the Hotkeys settings under <c>Shell · Diagnostics</c>.
+/// </summary>
+public sealed class ForceQuitCommand : IHotkeyCommand
+{
+    private readonly IDiagnosticsSink _diagnostics;
+
+    public ForceQuitCommand(IDiagnosticsSink diagnostics)
+    {
+        _diagnostics = diagnostics;
+    }
+
+    public string Id => "mithril.shell.force-quit";
+    public string DisplayName => "Force quit Mithril";
+    public string? Category => "Shell · Diagnostics";
+    public HotkeyBinding? DefaultBinding => null;
+    public bool RespectsFocusGate => false;
+    public bool IsDeveloperOnly => true;
+
+    public Task ExecuteAsync(CancellationToken ct)
+    {
+        _diagnostics.Write(DiagnosticLevel.Warn, "Shell", "Force-quit hotkey triggered — shutting down.");
+
+        var app = System.Windows.Application.Current;
+        if (app is null) return Task.CompletedTask;
+
+        if (app.Dispatcher.CheckAccess()) app.Shutdown();
+        else app.Dispatcher.InvokeAsync(app.Shutdown, DispatcherPriority.Send);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -148,7 +148,8 @@ public static class Program
                 .AddMithrilShellUpdates()
                 .AddMithrilShellViews()
                 .AddMithrilItemDetail()
-                .AddMithrilIngredientSources();
+                .AddMithrilIngredientSources()
+                .AddMithrilShellCommands();
 
             Boot($"modules discovered: {builder.Services.Count(d => d.ServiceType == typeof(IMithrilModule))}");
             host = builder.Build();


### PR DESCRIPTION
## Summary

Adds a `Force quit Mithril` hotkey command that triggers the same shutdown path as the tray's **Exit** menu (`Application.Shutdown`). Useful when the tray icon is hidden or a keyboard quit is faster than a mouse round-trip.

- `IsDeveloperOnly = true` — only visible in the Hotkeys page when Developer mode is on (Settings → Appearance).
- `DefaultBinding = null` — ships unbound; user assigns a combo before it can fire.
- `RespectsFocusGate = false` — works regardless of which window has focus.

## Honest scope note

This was originally drafted as an escape hatch for Gandalf's per-tick UI freeze. As the README explains:

> if the UI thread is fully wedged (deadlocked lock, infinite loop, modal sync-wait), `WM_HOTKEY` sits in the queue and the hotkey never delivers — the same freeze that locked the UI locks the rescue.

So it doesn't deliver on its original purpose. The Gandalf freeze is now retired at the source by #156 (timer-model redesign), so the original need has largely evaporated anyway. Shipping this regardless because a generic keyboard quit is a small, useful addition on its own merits.

## What changed

- New `src/Mithril.Shell/Hotkeys/ForceQuitCommand.cs` — `IHotkeyCommand` impl, dispatcher-marshalled `app.Shutdown` invocation, diagnostic log line on trigger.
- New DI extension `AddMithrilShellCommands()` registering the command as an `IHotkeyCommand` singleton; called from `Program.cs`'s host setup.
- README — new "Force-quit hotkey" section under the build/test reference.

## Test plan

- [x] Local build was blocked by a running Mithril instance holding DLL locks. CI will verify.
- [ ] Manual: launch Mithril → enable Developer mode → Hotkeys page → bind a combo to `Force quit Mithril` → press the combo → process exits cleanly (settings save, mutex released, no zombie processes).
- [ ] Manual: re-launch and confirm the binding survived persistence.
- [ ] Manual: turn Developer mode back off — binding still fires (only the row's visibility in the Hotkeys UI is gated, not the hotkey delivery itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
