### PR TITLE
chore(infra): carve out Mithril.GameState project

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/Mithril.Reference/Mithril.Reference.csproj" />
     <Project Path="src/Mithril.Shared/Mithril.Shared.csproj" />
+    <Project Path="src/Mithril.GameState/Mithril.GameState.csproj" />
     <Project Path="src/Mithril.Shell/Mithril.Shell.csproj" />
     <Project Path="src/Samwise.Module/Samwise.Module.csproj" />
     <Project Path="src/Legolas.Module/Legolas.Module.csproj" />
@@ -22,6 +23,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Mithril.Reference.Tests/Mithril.Reference.Tests.csproj" />
     <Project Path="tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj" />
+    <Project Path="tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj" />
     <Project Path="tests/Pippin.Tests/Pippin.Tests.csproj" />
     <Project Path="tests/Samwise.Tests/Samwise.Tests.csproj" />
     <Project Path="tests/Legolas.Tests/Legolas.Tests.csproj" />

--- a/src/Arwen.Module/Arwen.Module.csproj
+++ b/src/Arwen.Module/Arwen.Module.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -7,7 +7,7 @@ using Arwen.Views;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;

--- a/src/Arwen.Module/Domain/CalibrationService.cs
+++ b/src/Arwen.Module/Domain/CalibrationService.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Text.Json;
 using Mithril.Shared.Collections;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 

--- a/src/Mithril.GameState/AssemblyInfo.cs
+++ b/src/Mithril.GameState/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mithril.GameState.Tests")]

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Mithril.GameState.Inventory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.DependencyInjection;
+
+public static class GameStateServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the live game-state services that mirror in-game state derived
+    /// from <see cref="Mithril.Shared.Logging.IPlayerLogStream"/> /
+    /// <see cref="Mithril.Shared.Logging.IChatLogStream"/>. Must be called after
+    /// <c>AddMithrilGameServices()</c> so the log streams and active-character
+    /// service are registered first.
+    /// </summary>
+    public static IServiceCollection AddMithrilGameState(this IServiceCollection services) =>
+        services
+            .AddSingleton<InventoryService>()
+            .AddSingleton<IInventoryService>(sp => sp.GetRequiredService<InventoryService>())
+            .AddHostedService(sp => sp.GetRequiredService<InventoryService>());
+}

--- a/src/Mithril.GameState/Inventory/IInventoryService.cs
+++ b/src/Mithril.GameState/Inventory/IInventoryService.cs
@@ -1,4 +1,4 @@
-namespace Mithril.Shared.Inventory;
+namespace Mithril.GameState.Inventory;
 
 /// <summary>
 /// A live inventory transition. <paramref name="InstanceId"/> is the per-item

--- a/src/Mithril.GameState/Inventory/InventoryService.cs
+++ b/src/Mithril.GameState/Inventory/InventoryService.cs
@@ -8,7 +8,7 @@ using Mithril.Shared.Reference;
 using Mithril.Shared.Storage;
 using Microsoft.Extensions.Hosting;
 
-namespace Mithril.Shared.Inventory;
+namespace Mithril.GameState.Inventory;
 
 /// <summary>
 /// Eagerly subscribes to <see cref="IPlayerLogStream"/> at shell startup and

--- a/src/Mithril.GameState/Inventory/InventoryStatusChatParser.cs
+++ b/src/Mithril.GameState/Inventory/InventoryStatusChatParser.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace Mithril.Shared.Inventory;
+namespace Mithril.GameState.Inventory;
 
 /// <summary>
 /// Parses the chat <c>[Status]</c> channel for inventory-addition announcements.

--- a/src/Mithril.GameState/Mithril.GameState.csproj
+++ b/src/Mithril.GameState/Mithril.GameState.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.GameState</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+</Project>

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;
 using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Icons;
-using Mithril.Shared.Inventory;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
@@ -33,10 +32,7 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<Game.GameConfig>(),
                 sp.GetRequiredService<IActiveCharacterPersistence>(),
                 sp.GetRequiredService<IDiagnosticsSink>()))
-            .AddHostedService<ActiveCharacterLogSynchronizer>()
-            .AddSingleton<InventoryService>()
-            .AddSingleton<IInventoryService>(sp => sp.GetRequiredService<InventoryService>())
-            .AddHostedService(sp => sp.GetRequiredService<InventoryService>());
+            .AddHostedService<ActiveCharacterLogSynchronizer>();
 
     /// <summary>
     /// Register the root directory for per-character storage (typically

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -296,7 +296,7 @@
       "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+x(?<count>\\d+)\\s+added to inventory\\.",
       "source": "chat",
       "module": "shared",
-      "csharp": { "type": "Mithril.Shared.Inventory.InventoryStatusChatParser", "method": "CountedRx" },
+      "csharp": { "type": "Mithril.GameState.Inventory.InventoryStatusChatParser", "method": "CountedRx" },
       "eventType": "shared.InventoryAdded",
       "notes": "Counted form must be tried before SingleRx so 'Guava x42 added to inventory.' doesn't match with name='Guava x42'.",
       "fields": [
@@ -308,7 +308,7 @@
       "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+added to inventory\\.",
       "source": "chat",
       "module": "shared",
-      "csharp": { "type": "Mithril.Shared.Inventory.InventoryStatusChatParser", "method": "SingleRx" },
+      "csharp": { "type": "Mithril.GameState.Inventory.InventoryStatusChatParser", "method": "SingleRx" },
       "eventType": "shared.InventoryAdded",
       "notes": "Implicit count = 1.",
       "fields": [

--- a/src/Mithril.Shell/Mithril.Shell.csproj
+++ b/src/Mithril.Shell/Mithril.Shell.csproj
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+    <ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\Samwise.Module\Samwise.Module.csproj" />
     <ProjectReference Include="..\Legolas.Module\Legolas.Module.csproj" />
     <ProjectReference Include="..\Gandalf.Module\Gandalf.Module.csproj" />

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Interop;
 using Mithril.Shared.Audio;
 using Mithril.Shared.Character;
+using Mithril.GameState.DependencyInjection;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Game;
 using Mithril.Shared.Hotkeys;
@@ -136,6 +137,7 @@ public static class Program
                 .AddSingleton(gameConfig)
                 .AddMithrilDiagnostics(logDir)
                 .AddMithrilGameServices()
+                .AddMithrilGameState()
                 .AddMithrilPerCharacterStorage(charactersRootDir)
                 .AddMithrilReferenceData(referenceCacheDir)
                 .AddMithrilCommunityCalibration(communityCalibrationCacheDir)

--- a/src/Palantir.Module/Palantir.Module.csproj
+++ b/src/Palantir.Module/Palantir.Module.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Palantir.Module/ViewModels/LiveInventoryViewModel.cs
+++ b/src/Palantir.Module/ViewModels/LiveInventoryViewModel.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Reference;
 
 namespace Palantir.ViewModels;

--- a/src/Samwise.Module/Samwise.Module.csproj
+++ b/src/Samwise.Module/Samwise.Module.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -1,6 +1,6 @@
 using System.Windows;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Settings;

--- a/tests/Arwen.Tests/ArwenAttentionSourceTests.cs
+++ b/tests/Arwen.Tests/ArwenAttentionSourceTests.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Arwen.Domain;
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Reference;
 using Xunit;
 

--- a/tests/Arwen.Tests/CalibrationServiceTests.cs
+++ b/tests/Arwen.Tests/CalibrationServiceTests.cs
@@ -2,7 +2,7 @@ using System.IO;
 using System.Text.Json;
 using Arwen.Domain;
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Reference;
 using Xunit;
 

--- a/tests/Arwen.Tests/FakeInventory.cs
+++ b/tests/Arwen.Tests/FakeInventory.cs
@@ -1,4 +1,4 @@
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 
 namespace Arwen.Tests;
 

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs
@@ -1,11 +1,11 @@
 using System.Threading.Channels;
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Xunit;
 
-namespace Mithril.Shared.Tests.Inventory;
+namespace Mithril.GameState.Tests.Inventory;
 
 /// <summary>
 /// Stack-size tracking added in the live-tracker change. Test scenarios are drawn

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryStatusChatParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryStatusChatParserTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Xunit;
 
-namespace Mithril.Shared.Tests.Inventory;
+namespace Mithril.GameState.Tests.Inventory;
 
 public class InventoryStatusChatParserTests
 {

--- a/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
@@ -1,13 +1,13 @@
 using System.IO;
 using System.Threading.Channels;
 using FluentAssertions;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Game;
-using Mithril.Shared.Inventory;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Xunit;
 
-namespace Mithril.Shared.Tests;
+namespace Mithril.GameState.Tests;
 
 public sealed class InventoryServiceTests
 {

--- a/tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj
+++ b/tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
-    <RootNamespace>Arwen.Tests</RootNamespace>
+    <RootNamespace>Mithril.GameState.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -12,7 +11,6 @@
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Arwen.Module\Arwen.Module.csproj" />
     <ProjectReference Include="..\..\src\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>

--- a/tests/Mithril.Shared.Tests/Logging/LogPatternCatalogParityTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/LogPatternCatalogParityTests.cs
@@ -27,6 +27,7 @@ public class LogPatternCatalogParityTests
         TouchAssemblyForType("Saruman.Parsing.WordOfPowerChatParser");
         TouchAssemblyForType("Saruman.Parsing.WordOfPowerDiscoveredParser");
         TouchAssemblyForType("Legolas.Services.ChatLogParser");
+        TouchAssemblyForType("Mithril.GameState.Inventory.InventoryStatusChatParser");
 
         foreach (var (key, entry) in LogPatternCatalog.Current.Regexes)
         {
@@ -83,6 +84,7 @@ public class LogPatternCatalogParityTests
         var t when t.StartsWith("Pippin.", StringComparison.Ordinal) => "Pippin.Module",
         var t when t.StartsWith("Saruman.", StringComparison.Ordinal) => "Saruman.Module",
         var t when t.StartsWith("Legolas.", StringComparison.Ordinal) => "Legolas.Module",
+        var t when t.StartsWith("Mithril.GameState.", StringComparison.Ordinal) => "Mithril.GameState",
         _ => "Mithril.Shared",
     };
 

--- a/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
+++ b/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.GameState\Mithril.GameState.csproj" />
     <!-- Module references support both LogPatternCatalogParityTests (reflects over
          [GeneratedRegex] attributes in module-level parsers) and
          SettingsAutoSaverActivationTests (loops over every module's Register call

--- a/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
+++ b/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
@@ -1,5 +1,5 @@
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Reference;
 using Palantir.ViewModels;
 using Xunit;

--- a/tests/Palantir.Tests/Palantir.Tests.csproj
+++ b/tests/Palantir.Tests/Palantir.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Palantir.Module\Palantir.Module.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Samwise.Tests/StackChangedResilienceTest.cs
+++ b/tests/Samwise.Tests/StackChangedResilienceTest.cs
@@ -1,6 +1,6 @@
 using System.Threading.Channels;
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Logging;
 using Samwise.Parsing;
 using Xunit;

--- a/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
+++ b/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using FluentAssertions;
-using Mithril.Shared.Inventory;
+using Mithril.GameState.Inventory;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Samwise.Config;


### PR DESCRIPTION
## Summary

- Relocates `IInventoryService` + `InventoryService` + `InventoryStatusChatParser` from `Mithril.Shared` into a new `Mithril.GameState` project.
- No behaviour change — purely a project-boundary refactor. All existing tests pass with no logic edits.
- Prerequisite to #155 (`IQuestService` extraction): `Mithril.Shared` was already a kitchen sink, and adding `IQuestService` as a second live-state mirror crosses the line where a dedicated home is cleaner than another folder.

## Why now

`Mithril.Shared` mixes infrastructure (log streams, reference data, character storage, settings, hotkeys) with live game-state mirrors. The "live state" bucket today is just `Inventory/`. With #155 about to add a second one (`Quests/`), the natural project boundary is now visible — drawing it now keeps the next PR focused on the new service rather than bundling a project carve-out at the same time.

Dependency direction:

```
modules → Mithril.GameState → Mithril.Shared
modules → Mithril.Shared
```

`Mithril.GameState` depends on `Mithril.Shared` (for `IPlayerLogStream`, `IChatLogStream`, `IReferenceDataService`, `IActiveCharacterService`, `PerCharacterStore<T>`, `IDiagnosticsSink`) and is consumed by every module that needs live in-game state.

## What moved

| Source                                                                                           | Destination                                                                  |
|--------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
| `src/Mithril.Shared/Inventory/IInventoryService.cs`                                              | `src/Mithril.GameState/Inventory/IInventoryService.cs`                       |
| `src/Mithril.Shared/Inventory/InventoryService.cs`                                               | `src/Mithril.GameState/Inventory/InventoryService.cs`                        |
| `src/Mithril.Shared/Inventory/InventoryStatusChatParser.cs`                                      | `src/Mithril.GameState/Inventory/InventoryStatusChatParser.cs`               |
| `tests/Mithril.Shared.Tests/InventoryServiceTests.cs`                                            | `tests/Mithril.GameState.Tests/InventoryServiceTests.cs`                     |
| `tests/Mithril.Shared.Tests/Inventory/InventoryServiceStackSizeTests.cs`                         | `tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs`  |
| `tests/Mithril.Shared.Tests/Inventory/InventoryStatusChatParserTests.cs`                         | `tests/Mithril.GameState.Tests/Inventory/InventoryStatusChatParserTests.cs`  |

Namespaces: `Mithril.Shared.Inventory` → `Mithril.GameState.Inventory`.

## DI changes

The three lines that registered `InventoryService` inside `AddMithrilGameServices()` move into a new `GameStateServiceCollectionExtensions.AddMithrilGameState()`. The shell now calls both:

```csharp
.AddMithrilGameServices()
.AddMithrilGameState()
```

`InternalsVisibleTo("Mithril.GameState.Tests")` is set in the new project's `AssemblyInfo.cs` so the existing internal-only test hooks (`LoadExportSeeds`, `PendingCounts`) keep working without any test edits.

## Other touch points

- `log-patterns.json` — the two `csharp.type` entries for `InventoryStatusChatParser` flip to `Mithril.GameState.Inventory.*`.
- `LogPatternCatalogParityTests` — `TouchAssemblyForType` now also force-loads the new assembly; `InferAssemblyName` learns `Mithril.GameState.` → `Mithril.GameState`.
- Consumer csprojs (Arwen / Samwise / Palantir / Mithril.Shell + their test projects + Mithril.Shared.Tests) get an explicit `<ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />`.
- Every `using Mithril.Shared.Inventory;` flips to `using Mithril.GameState.Inventory;` (10 files).

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors).
- [x] `dotnet test Mithril.slnx` — full suite passes (1583 tests across 17 projects, including `Mithril.GameState.Tests` with 52).
- [ ] `dotnet run --project src/Mithril.Shell` — boot the app and exercise an inventory-dependent module (Samwise garden, Arwen calibration, or Palantir live inventory) to confirm the DI rewire works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)