### PR TITLE
gandalf: in-game clock alarm — fire timers at PG time-of-day

### DIFF
--- a/docs/agent-plans/gandalf-in-game-clock-alarm.md
+++ b/docs/agent-plans/gandalf-in-game-clock-alarm.md
@@ -1,0 +1,178 @@
+# Gandalf — in-game clock alarm
+
+**Tracked in:** #164
+
+## Context
+
+Project Gorgon has its own day/night cycle that advances at 12× wall-clock (1 in-game hour = 5 real minutes). The game's `IGameClock` is already wired and tested in [GameClock.cs](../../src/Mithril.Shared/Game/GameClock.cs); the shell already displays the in-game time in 12-hour format.
+
+Gandalf today only supports **countdown** timers (`StartedAt + Duration`). The user wants a second timer kind: **fire when the in-game clock reaches a target hour:minute** (e.g., "6:00 PM in-game"), with a per-timer toggle for one-shot vs recurring (re-arms each in-game day).
+
+Why this works cleanly: Gandalf's just-redesigned scheduler ([TimerExpirationScheduler.cs](../../src/Gandalf.Module/Services/TimerExpirationScheduler.cs)) is keyed by **real-time** `DateTimeOffset` — and the in-game-time → real-time inverse of the 12× formula is closed-form. So an in-game-time alarm just resolves to "the real-time instant the clock next reads HH:MM" and slots into the existing scheduler with no new event-loop machinery.
+
+## Approach
+
+**One central abstraction**: every timer row exposes a single `FiringAt: DateTimeOffset` instant that represents "when this Running timer fires." Countdowns compute `StartedAt + Duration`; game-clock timers compute the next in-game-time occurrence after `StartedAt`. The scheduler, view, row, and progress check all dispatch off `FiringAt` — kind-specific math happens once at Start/Restart.
+
+**Schema bloat is contained**:
+- `TimerProgress.FiringAt` is `[JsonIgnore]` (not persisted — recomputed on load so a future re-anchor of `GameClock` doesn't poison stored state).
+- `TimerProgressEntry.FiringAt` is a nullable derived projection. User source stamps it; Quest/Loot leave it null. Consumers fall back to `StartedAt + Catalog.Duration` — so Quest/Loot/`DashboardAggregator` (and their tests) compile and behave identically to today.
+
+## Files to modify
+
+### 1. `IGameClock` — inverse formula
+
+[GameClock.cs](../../src/Mithril.Shared/Game/GameClock.cs)
+
+Add to the interface and concrete class:
+
+```csharp
+DateTimeOffset NextOccurrence(GameTimeOfDay target, DateTimeOffset floor);
+```
+
+Returns the earliest real-time instant ≥ `floor` where the in-game clock reads `target`. One in-game day = 7200 real seconds, so occurrences recur on a 7200s real-time grid.
+
+**Edge rule**: if the candidate firing instant is within 50 ms of `floor`, advance one full in-game day (`+7200s`). Same rationale as the floor at [TimerExpirationScheduler.cs:103](../../src/Gandalf.Module/Services/TimerExpirationScheduler.cs#L103). Prevents fire-on-Start when the player presses Start at exactly the target time, which would otherwise double-fire recurring alarms.
+
+**Reuse `AnchorUtc`/`AnchorGameSeconds`/`Ratio`/`SecondsPerGameDay` constants** — extract to `internal const` so the inverse uses the same literals as `GetCurrent`. Add unit tests in [GameClockTests.cs](../../tests/Mithril.Shared.Tests/GameClockTests.cs).
+
+### 2. `GandalfTimerDef` — trigger kind + game-time fields
+
+[GandalfTimerDef.cs](../../src/Gandalf.Module/Domain/GandalfTimerDef.cs)
+
+```csharp
+public enum GandalfTriggerKind { Countdown = 0, GameTimeOfDay = 1 }
+
+public sealed class GandalfTimerDef
+{
+    public string Id { get; set; } = ...;
+    public string Name { get; set; } = "";
+    public GandalfTriggerKind Kind { get; set; } = GandalfTriggerKind.Countdown;
+    public TimeSpan Duration { get; set; }            // Countdown
+    public int? GameHour { get; set; }                // GameTimeOfDay (0–23)
+    public int? GameMinute { get; set; }              // GameTimeOfDay (0–59)
+    public bool Recurring { get; set; }               // GameTimeOfDay only in v1
+    public string Region { get; set; } = "";
+    public string Map { get; set; } = "";
+}
+```
+
+Bump [GandalfDefinitions.Version](../../src/Gandalf.Module/Domain/GandalfDefinitions.cs#L12) `1 → 2`. Identity migrate — `System.Text.Json` source-gen handles new optional fields cleanly; v1 files load with `Kind=Countdown`, null game fields, `Recurring=false`. Validate on save: if `Kind=GameTimeOfDay`, both `GameHour` and `GameMinute` must be set.
+
+### 3. `TimerProgress` — cache `FiringAt`
+
+[GandalfProgress.cs](../../src/Gandalf.Module/Domain/GandalfProgress.cs)
+
+```csharp
+public sealed class TimerProgress
+{
+    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    [JsonIgnore]
+    public DateTimeOffset? FiringAt { get; set; }
+}
+```
+
+Why `[JsonIgnore]`: the comment at [GameClock.cs:32–35](../../src/Mithril.Shared/Game/GameClock.cs#L32-L35) explicitly anticipates re-anchoring. Persisting `FiringAt` for game-clock timers would silently rot if a future patch shifts the day/night cycle. Recompute on load via a `RehydrateFiringAt` step in `TimerProgressService` after `_view.Current` is first observed (and on `OnCurrentChanged`).
+
+### 4. `TimerProgressService` — stamp on Start/Restart, dispatch on Check, re-arm on recurring
+
+[TimerProgressService.cs](../../src/Gandalf.Module/Services/TimerProgressService.cs)
+
+- Inject `IGameClock`.
+- Add `static DateTimeOffset ComputeFiringAt(GandalfTimerDef def, DateTimeOffset startedAt, IGameClock clock)`:
+  - `Countdown` → `startedAt + def.Duration`
+  - `GameTimeOfDay` → `clock.NextOccurrence(new GameTimeOfDay(def.GameHour ?? 0, def.GameMinute ?? 0), startedAt)`
+- `Start`/`Restart` ([lines 70–104](../../src/Gandalf.Module/Services/TimerProgressService.cs#L70)): stamp `progress.FiringAt = ComputeFiringAt(...)` after setting `StartedAt`.
+- `CheckExpirations` ([lines 201–221](../../src/Gandalf.Module/Services/TimerProgressService.cs#L201)): replace the `view.State == TimerState.Done` test with `now >= progress.FiringAt`. **Recurring branch** (highest-risk subtask):
+  1. Fire `TimerExpired` first (so the alarm plays on the just-completed run).
+  2. If `def.Kind == GameTimeOfDay && def.Recurring`, re-arm: `progress.StartedAt = progress.FiringAt; progress.CompletedAt = null; progress.FiringAt = ComputeFiringAt(def, progress.StartedAt.Value, _clock); _expiredNotified.Remove(id);` then `MarkDirty()`. **Forgetting `_expiredNotified.Remove` silently swallows the next fire** — add a unit test that drives two consecutive fires.
+  3. Otherwise stamp `CompletedAt = now` as today.
+- After `_view.Current` swap on `OnCurrentChanged`, walk progress and rehydrate `FiringAt`.
+
+### 5. `TimerView` and `TimerRow` — use `FiringAt` everywhere
+
+[TimerView.cs](../../src/Gandalf.Module/Domain/TimerView.cs) — `State`/`Remaining`/`Fraction` use `Progress.FiringAt ?? (Progress.StartedAt + Def.Duration)` as the firing instant. Effective duration for `Fraction` denominator = `firingAt - StartedAt`.
+
+[TimerRow.cs](../../src/Gandalf.Module/Domain/TimerRow.cs) — add a single computed property `DateTimeOffset? FiringAt => Progress is null ? null : (Progress.FiringAt ?? Progress.StartedAt + Catalog.Duration);` and route `State` (line 32), `Remaining` (line 42), `CompletedAt` (line 52), `Fraction` (line 63), and `NextDisplayChangeAt` (line 96) through it. With the fallback, Quest/Loot rendering is byte-identical to today.
+
+### 6. `TimerProgressEntry` — derived `FiringAt`
+
+[ITimerSource.cs:67](../../src/Gandalf.Module/Domain/ITimerSource.cs#L67)
+
+```csharp
+public sealed record TimerProgressEntry(
+    string Key,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? DismissedAt,
+    DateTimeOffset? FiringAt = null);
+```
+
+[UserTimerSource.ProjectProgress](../../src/Gandalf.Module/Services/UserTimerSource.cs#L108) stamps `FiringAt: p.FiringAt`. `QuestSource.SnapshotProgress`, `LootSource.SnapshotProgress`, and `DashboardAggregator` leave the parameter at default null — record equality in [TimerRowDeltaDiffer.ProgressEquals](../../src/Gandalf.Module/Domain/TimerRowDeltaDiffer.cs) keeps working unchanged.
+
+### 7. `TimerExpirationScheduler.ComputeSoonest` — read `FiringAt`
+
+[TimerExpirationScheduler.cs:109–121](../../src/Gandalf.Module/Services/TimerExpirationScheduler.cs#L109)
+
+Replace `var expiresAt = p.StartedAt.Value + def.Duration;` with `var expiresAt = p.FiringAt ?? p.StartedAt.Value + def.Duration;`. Single-line change.
+
+### 8. `TimerAlarmService` — fix recurring re-fire dedup
+
+[TimerAlarmService.cs:22](../../src/Gandalf.Module/Services/TimerAlarmService.cs#L22)
+
+The current `HashSet<string> _firedKeys` swallows the second fire of the same key — a recurring game-clock alarm would alarm at 6 PM today and silently fail at 6 PM tomorrow.
+
+Fix: change `_firedKeys` to `Dictionary<string, DateTimeOffset>` of last-fire-time. Gate re-fires on "not fired in the last ~30 s" (debounces accidental same-tick double-fires while allowing the ~2-real-hour recurring cadence). Forward-leaning for any future recurring source.
+
+### 9. `ElapsedWhileAwayClassifier` — accept `firingAt`, not `duration`
+
+[ElapsedWhileAwayClassifier.cs](../../src/Gandalf.Module/Domain/ElapsedWhileAwayClassifier.cs)
+
+Today the classifier takes `TimeSpan duration` and computes `theoreticalDone = started + duration` ([line 31](../../src/Gandalf.Module/Domain/ElapsedWhileAwayClassifier.cs#L31)). For game-clock timers `Catalog.Duration` is meaningless — a recurring 6 PM alarm would produce the wrong "elapsed while away" badge.
+
+Change the signature to:
+
+```csharp
+public static bool IsElapsedWhileAway(
+    TimerProgress progress,
+    DateTimeOffset firingAt,
+    DateTimeOffset? lastActiveAt,
+    DateTimeOffset now)
+```
+
+Body: `theoreticalDone = firingAt;` — caller is now responsible for picking the right firing instant.
+
+Single call site: [TimerListViewModel.cs:218](../../src/Gandalf.Module/ViewModels/TimerListViewModel.cs#L218). Swap `vm.Row.Duration` for `vm.Row.FiringAt` (the new computed property added in step 5). Skip rows where `vm.Row.FiringAt is null`.
+
+Update [ElapsedWhileAwayClassifierTests.cs](../../tests/Gandalf.Module.Tests/ElapsedWhileAwayClassifierTests.cs) to pass `firingAt = started + duration` for existing cases, and add one new case for a game-clock timer where `firingAt` is *not* `started + duration` (verifies the classifier no longer assumes a fixed catalog duration).
+
+### 10. Dialog UI
+
+[TimerDialogViewModel.cs](../../src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs) and [TimerDialogContent.xaml](../../src/Gandalf.Module/Views/TimerDialogContent.xaml)
+
+- Add a top "Trigger" radio: **Countdown** / **In-game time**.
+- When **In-game time**: swap Hours/Minutes/Seconds for `GameHour` (0–23) + `GameMinute` (0–59) inputs; show a 12-hour preview using [`GameTimeOfDay.ToString12Hour()`](../../src/Mithril.Shared/Game/GameClock.cs#L21); add **Recurring** checkbox.
+- Apply the same `IsDurationEditable = isIdleOnActive` gate to the game-time inputs ([rationale at TimerDialogViewModel.cs:42–44](../../src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs#L42)).
+- `OnPrimaryAction` validation: GameTimeOfDay requires both fields in valid range.
+
+## Known v1 limitations (document, don't fix)
+
+- "Edit while running" for `GameHour/GameMinute` is gated to idle-only, matching today's countdown rule. Re-stamping `FiringAt` mid-run for the active character is a UX win to revisit if anyone asks.
+
+## Verification
+
+**Unit tests**:
+- `GameClockTests` — `NextOccurrence` round-trip: for many `target`/`floor` pairs, `clock.GetCurrent(at: returnedInstant) == target`. Edge: `floor` exactly at `target` → returns `floor + 7200s`. Edge: `floor` is one tick after `target` → returns `floor + 7199.99…s`.
+- `TimerProgressService` — Start a `Countdown` (existing tests should pass unchanged with the `FiringAt` substitution). Start a `GameTimeOfDay` recurring with a fake `IGameClock`, advance fake `TimeProvider` past `FiringAt` once, assert `TimerExpired` fires; advance past the next in-game day, assert `TimerExpired` fires **again** (this is the regression test for the `_expiredNotified.Remove` and `_firedKeys` dedup fixes).
+- `TimerExpirationScheduler` — assert `NextExpirationAt` for a GameTimeOfDay timer matches `IGameClock.NextOccurrence`.
+- `TimerRow` — with `Progress.FiringAt = null`, behavior matches today's `Catalog.Duration` math (Quest/Loot regression guard).
+- `ElapsedWhileAwayClassifier` — existing cases re-cast as `firingAt = started + duration`; new case where `firingAt ≠ started + duration` (game-clock semantics).
+
+**End-to-end manual**:
+1. `dotnet build Mithril.slnx` and `dotnet run --project src/Mithril.Shell`.
+2. Create a `Countdown` timer with a 30 s duration. Confirm it fires (no regression).
+3. Create a `GameTimeOfDay` timer with `Recurring=false`, target = the in-game time displayed in the shell + ~10 in-game minutes (~50 real seconds). Press Start. Confirm: idle list shows the target time; alarm fires at the right moment; row goes Done.
+4. Same setup but `Recurring=true`. Confirm: alarm fires; row immediately re-arms (StartedAt updates, no Done state stuck on screen for >1 frame); 2 real hours later, alarm fires again.
+5. Editing the def while Running for the active character: confirm hour/minute inputs are disabled (matches countdown behavior).
+6. Restart the app while a GameTimeOfDay timer is Running: confirm it re-arms correctly on load (rehydrate path).

--- a/src/Gandalf.Module/Domain/ElapsedWhileAwayClassifier.cs
+++ b/src/Gandalf.Module/Domain/ElapsedWhileAwayClassifier.cs
@@ -14,13 +14,17 @@ public static class ElapsedWhileAwayClassifier
     /// flag everything as catch-up noise).
     /// </summary>
     /// <remarks>
-    /// Uses theoretical completion (<c>StartedAt + Duration</c>), not <c>CompletedAt</c>.
-    /// <c>CompletedAt</c> is stamped by the tick loop which may not have run on the
-    /// newly-active character yet — theoretical completion is tick-order-independent.
+    /// Uses the row's pre-computed firing instant (<paramref name="firingAt"/>),
+    /// not <c>CompletedAt</c>. <c>CompletedAt</c> is stamped by the tick loop
+    /// which may not have run on the newly-active character yet — the firing
+    /// instant is tick-order-independent. Game-clock alarms have a firing
+    /// instant that isn't <c>StartedAt + Duration</c>, which is why this took
+    /// a <c>TimeSpan duration</c> parameter historically and now takes the
+    /// instant directly.
     /// </remarks>
     public static bool IsElapsedWhileAway(
         TimerProgress progress,
-        TimeSpan duration,
+        DateTimeOffset firingAt,
         DateTimeOffset? lastActiveAt,
         DateTimeOffset now)
     {
@@ -28,9 +32,8 @@ public static class ElapsedWhileAwayClassifier
         if (progress.StartedAt is null) return false;
 
         var started = progress.StartedAt.Value;
-        var theoreticalDone = started + duration;
         return started <= lastActiveAt.Value
-            && theoreticalDone > lastActiveAt.Value
-            && theoreticalDone <= now;
+            && firingAt > lastActiveAt.Value
+            && firingAt <= now;
     }
 }

--- a/src/Gandalf.Module/Domain/GandalfDefinitions.cs
+++ b/src/Gandalf.Module/Domain/GandalfDefinitions.cs
@@ -9,7 +9,7 @@ namespace Gandalf.Domain;
 /// </summary>
 public sealed class GandalfDefinitions
 {
-    public const int Version = 1;
+    public const int Version = 2;
 
     public int SchemaVersion { get; set; } = Version;
     public List<GandalfTimerDef> Timers { get; set; } = [];

--- a/src/Gandalf.Module/Domain/GandalfProgress.cs
+++ b/src/Gandalf.Module/Domain/GandalfProgress.cs
@@ -12,6 +12,18 @@ public sealed class TimerProgress
 {
     public DateTimeOffset? StartedAt { get; set; }
     public DateTimeOffset? CompletedAt { get; set; }
+
+    /// <summary>
+    /// Cached wall-clock instant when the running timer fires. For
+    /// <see cref="GandalfTriggerKind.Countdown"/> this is just <c>StartedAt + Duration</c>;
+    /// for <see cref="GandalfTriggerKind.GameTimeOfDay"/> it's the next real-time
+    /// occurrence of the target in-game time, computed at Start/Restart time.
+    /// Not persisted: re-anchoring <c>GameClock</c> after a future Project Gorgon
+    /// patch would otherwise leave stale game-clock firing instants in the file.
+    /// Rehydrated on character switch.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset? FiringAt { get; set; }
 }
 
 /// <summary>

--- a/src/Gandalf.Module/Domain/GandalfTimerDef.cs
+++ b/src/Gandalf.Module/Domain/GandalfTimerDef.cs
@@ -3,6 +3,18 @@ using System.Text.Json.Serialization;
 namespace Gandalf.Domain;
 
 /// <summary>
+/// What kind of trigger fires this timer. <see cref="Countdown"/> uses
+/// <see cref="GandalfTimerDef.Duration"/>; <see cref="GameTimeOfDay"/> uses
+/// <see cref="GandalfTimerDef.GameHour"/>/<see cref="GandalfTimerDef.GameMinute"/>
+/// (Project Gorgon in-game wall-clock time, 24h).
+/// </summary>
+public enum GandalfTriggerKind
+{
+    Countdown = 0,
+    GameTimeOfDay = 1,
+}
+
+/// <summary>
 /// Immutable shape of a timer definition — what the user configured, shared across every character.
 /// Lives in the global <see cref="GandalfDefinitions"/> blob. Progress for this timer is tracked
 /// per-character in <see cref="GandalfProgress"/> keyed by <see cref="Id"/>.
@@ -11,7 +23,11 @@ public sealed class GandalfTimerDef
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
     public string Name { get; set; } = "";
+    public GandalfTriggerKind Kind { get; set; } = GandalfTriggerKind.Countdown;
     public TimeSpan Duration { get; set; }
+    public int? GameHour { get; set; }
+    public int? GameMinute { get; set; }
+    public bool Recurring { get; set; }
     public string Region { get; set; } = "";
     public string Map { get; set; } = "";
 

--- a/src/Gandalf.Module/Domain/ITimerSource.cs
+++ b/src/Gandalf.Module/Domain/ITimerSource.cs
@@ -64,10 +64,18 @@ public sealed record TimerCatalogEntry(
     TimeSpan Duration,
     object? SourceMetadata);
 
+/// <summary>
+/// <para><see cref="FiringAt"/> is an optional per-row firing instant — used by
+/// the User feed for game-clock alarms whose firing moment isn't <c>StartedAt +
+/// Catalog.Duration</c>. Derived sources (Quest, Loot, Dashboard) leave it null
+/// and consumers fall back to that default arithmetic, so their behavior is
+/// unchanged.</para>
+/// </summary>
 public sealed record TimerProgressEntry(
     string Key,
     DateTimeOffset StartedAt,
-    DateTimeOffset? DismissedAt);
+    DateTimeOffset? DismissedAt,
+    DateTimeOffset? FiringAt = null);
 
 public sealed class TimerReadyEventArgs : EventArgs
 {

--- a/src/Gandalf.Module/Domain/TimerRow.cs
+++ b/src/Gandalf.Module/Domain/TimerRow.cs
@@ -23,13 +23,26 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
     public TimeSpan Duration => Catalog.Duration;
     public string GroupKey => Catalog.Region ?? "";
 
+    /// <summary>
+    /// Wall-clock instant this Running timer fires. For sources that stamp a
+    /// per-row firing instant (User feed's game-clock alarms), this comes from
+    /// <see cref="TimerProgressEntry.FiringAt"/>. Falls back to
+    /// <c>StartedAt + Duration</c> for derived sources (Quest/Loot) whose firing
+    /// moment is always exactly that — they leave the field null and inherit
+    /// today's behavior verbatim.
+    /// </summary>
+    public DateTimeOffset? FiringAt =>
+        Progress is null
+            ? null
+            : Progress.FiringAt ?? Progress.StartedAt + Catalog.Duration;
+
     public TimerState State
     {
         get
         {
             if (Progress is null) return TimerState.Idle;
             if (Progress.DismissedAt is not null) return TimerState.Idle;
-            if (Clock.GetUtcNow() - Progress.StartedAt >= Catalog.Duration) return TimerState.Done;
+            if (FiringAt is { } at && Clock.GetUtcNow() >= at) return TimerState.Done;
             return TimerState.Running;
         }
     }
@@ -38,8 +51,8 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
     {
         get
         {
-            if (Progress is null) return Catalog.Duration;
-            var left = Catalog.Duration - (Clock.GetUtcNow() - Progress.StartedAt);
+            if (FiringAt is not { } at) return Catalog.Duration;
+            var left = at - Clock.GetUtcNow();
             return left < TimeSpan.Zero ? TimeSpan.Zero : left;
         }
     }
@@ -48,9 +61,8 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
     {
         get
         {
-            if (Progress is null) return null;
-            var stamped = Progress.StartedAt + Catalog.Duration;
-            return Clock.GetUtcNow() >= stamped ? stamped : null;
+            if (FiringAt is not { } at) return null;
+            return Clock.GetUtcNow() >= at ? at : null;
         }
     }
 
@@ -58,9 +70,10 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
     {
         get
         {
-            if (Progress is null) return 0.0;
-            if (Catalog.Duration <= TimeSpan.Zero) return 1.0;
-            return Math.Clamp((Clock.GetUtcNow() - Progress.StartedAt) / Catalog.Duration, 0.0, 1.0);
+            if (Progress is null || FiringAt is not { } at) return 0.0;
+            var total = at - Progress.StartedAt;
+            if (total <= TimeSpan.Zero) return 1.0;
+            return Math.Clamp((Clock.GetUtcNow() - Progress.StartedAt) / total, 0.0, 1.0);
         }
     }
 
@@ -93,7 +106,7 @@ public sealed record TimerRow(TimerCatalogEntry Catalog, TimerProgressEntry? Pro
             if (Progress.DismissedAt is not null) return null;
 
             var now = Clock.GetUtcNow();
-            var stateFlipAt = Progress.StartedAt + Catalog.Duration;
+            if (FiringAt is not { } stateFlipAt) return null;
 
             if (now < stateFlipAt)
             {

--- a/src/Gandalf.Module/Domain/TimerView.cs
+++ b/src/Gandalf.Module/Domain/TimerView.cs
@@ -8,13 +8,25 @@ namespace Gandalf.Domain;
 /// </summary>
 public sealed record TimerView(GandalfTimerDef Def, TimerProgress Progress)
 {
+    /// <summary>
+    /// The instant this Running timer fires. Falls back to
+    /// <c>StartedAt + Def.Duration</c> when <see cref="TimerProgress.FiringAt"/>
+    /// hasn't been stamped yet — keeps countdown semantics unchanged for any
+    /// caller that constructs a <c>TimerView</c> outside the
+    /// <c>TimerProgressService</c> lifecycle (e.g. tests).
+    /// </summary>
+    private DateTimeOffset? FiringAt =>
+        Progress.StartedAt is null
+            ? null
+            : Progress.FiringAt ?? Progress.StartedAt.Value + Def.Duration;
+
     public TimerState State
     {
         get
         {
             if (Progress.StartedAt is null) return TimerState.Idle;
             if (Progress.CompletedAt is not null) return TimerState.Done;
-            if (DateTimeOffset.UtcNow - Progress.StartedAt.Value >= Def.Duration) return TimerState.Done;
+            if (FiringAt is { } at && DateTimeOffset.UtcNow >= at) return TimerState.Done;
             return TimerState.Running;
         }
     }
@@ -23,8 +35,8 @@ public sealed record TimerView(GandalfTimerDef Def, TimerProgress Progress)
     {
         get
         {
-            if (Progress.StartedAt is null) return Def.Duration;
-            var left = Def.Duration - (DateTimeOffset.UtcNow - Progress.StartedAt.Value);
+            if (FiringAt is not { } at) return Def.Duration;
+            var left = at - DateTimeOffset.UtcNow;
             return left < TimeSpan.Zero ? TimeSpan.Zero : left;
         }
     }
@@ -33,9 +45,10 @@ public sealed record TimerView(GandalfTimerDef Def, TimerProgress Progress)
     {
         get
         {
-            if (Progress.StartedAt is null) return 0.0;
-            if (Def.Duration <= TimeSpan.Zero) return 1.0;
-            return Math.Clamp((DateTimeOffset.UtcNow - Progress.StartedAt.Value) / Def.Duration, 0.0, 1.0);
+            if (Progress.StartedAt is null || FiringAt is not { } at) return 0.0;
+            var total = at - Progress.StartedAt.Value;
+            if (total <= TimeSpan.Zero) return 1.0;
+            return Math.Clamp((DateTimeOffset.UtcNow - Progress.StartedAt.Value) / total, 0.0, 1.0);
         }
     }
 

--- a/src/Gandalf.Module/Gandalf.Module.csproj
+++ b/src/Gandalf.Module/Gandalf.Module.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="MahApps.Metro" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Gandalf.Module/Services/TimerAlarmService.cs
+++ b/src/Gandalf.Module/Services/TimerAlarmService.cs
@@ -17,36 +17,47 @@ namespace Gandalf.Services;
 /// </summary>
 public sealed class TimerAlarmService : IDisposable
 {
+    /// <summary>
+    /// How long after a fire to suppress a same-key re-fire. Long enough to
+    /// debounce accidental duplicates (a tick that fires and stamps then a
+    /// rapid follow-up tick before the row is dismissed) but short enough
+    /// not to interfere with recurring game-clock alarms whose natural
+    /// cadence is ~7200 real seconds.
+    /// </summary>
+    private static readonly TimeSpan RefireSuppressionWindow = TimeSpan.FromSeconds(30);
+
     private readonly UserTimerSource _source;
     private readonly GandalfSettings _settings;
-    private readonly HashSet<string> _firedKeys = new(StringComparer.Ordinal);
+    private readonly TimeProvider _time;
+    private readonly Dictionary<string, DateTimeOffset> _firedAt = new(StringComparer.Ordinal);
     private readonly Dictionary<string, DateTimeOffset> _snoozedUntil = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IPlaybackHandle> _playback = new(StringComparer.Ordinal);
 
-    public TimerAlarmService(UserTimerSource source, GandalfSettings settings)
+    public TimerAlarmService(UserTimerSource source, GandalfSettings settings, TimeProvider? time = null)
     {
         _source = source;
         _settings = settings;
+        _time = time ?? TimeProvider.System;
         _source.TimerReady += OnTimerReady;
     }
 
     public void SnoozeAll()
     {
-        var until = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(_settings.SnoozeMinutes);
-        foreach (var key in _firedKeys.ToArray()) _snoozedUntil[key] = until;
-        _firedKeys.Clear();
+        var until = _time.GetUtcNow() + TimeSpan.FromMinutes(_settings.SnoozeMinutes);
+        foreach (var key in _firedAt.Keys.ToArray()) _snoozedUntil[key] = until;
+        _firedAt.Clear();
         StopAllPlayback();
     }
 
     public void DismissAll()
     {
-        _firedKeys.Clear();
+        _firedAt.Clear();
         StopAllPlayback();
     }
 
     public void Dismiss(string key)
     {
-        _firedKeys.Remove(key);
+        _firedAt.Remove(key);
         if (_playback.Remove(key, out var handle))
             handle.Stop();
     }
@@ -55,10 +66,13 @@ public sealed class TimerAlarmService : IDisposable
     {
         if (!_settings.AlarmEnabled) return;
         var key = e.Key;
-        if (_firedKeys.Contains(key)) return;
-        if (_snoozedUntil.TryGetValue(key, out var until) && until > DateTimeOffset.UtcNow) return;
+        var now = _time.GetUtcNow();
+        // Time-based dedup, not the old "fired once, never again" set —
+        // recurring game-clock alarms reach this path on every cycle.
+        if (_firedAt.TryGetValue(key, out var last) && now - last < RefireSuppressionWindow) return;
+        if (_snoozedUntil.TryGetValue(key, out var until) && until > now) return;
 
-        _firedKeys.Add(key);
+        _firedAt[key] = now;
         Dispatch(() =>
         {
             var handle = AudioPlayer.Play(_settings.SoundFilePath, (float)_settings.AlarmVolume, "gandalf");

--- a/src/Gandalf.Module/Services/TimerExpirationScheduler.cs
+++ b/src/Gandalf.Module/Services/TimerExpirationScheduler.cs
@@ -114,7 +114,11 @@ public sealed class TimerExpirationScheduler : IDisposable
             var p = _progress.GetProgress(def.Id);
             if (p?.StartedAt is null) continue;
             if (p.CompletedAt is not null) continue;  // already stamped — no further expiration to fire
-            var expiresAt = p.StartedAt.Value + def.Duration;
+            // FiringAt is the canonical firing instant (StartedAt + Duration for
+            // countdowns, or the next in-game-time occurrence for game-clock
+            // timers). Falls back to the legacy arithmetic when a TimerProgress
+            // wasn't stamped by the service (e.g. mid-rollout test fixtures).
+            var expiresAt = p.FiringAt ?? p.StartedAt.Value + def.Duration;
             if (soonest is null || expiresAt < soonest) soonest = expiresAt;
         }
         return soonest;

--- a/src/Gandalf.Module/Services/TimerProgressService.cs
+++ b/src/Gandalf.Module/Services/TimerProgressService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Gandalf.Domain;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Game;
 
 namespace Gandalf.Services;
 
@@ -33,6 +34,8 @@ public sealed class TimerProgressService : IDisposable
     private readonly TimerDefinitionsService _defs;
     private readonly PerCharacterStoreOptions _storeOptions;
     private readonly IDiagnosticsSink? _diag;
+    private readonly IGameClock _gameClock;
+    private readonly TimeProvider _time;
     private readonly System.Timers.Timer _debounce;
     private readonly Lock _flushLock = new();
     private readonly HashSet<string> _expiredNotified = new(StringComparer.Ordinal);
@@ -42,15 +45,24 @@ public sealed class TimerProgressService : IDisposable
         PerCharacterView<GandalfProgress> view,
         TimerDefinitionsService defs,
         PerCharacterStoreOptions storeOptions,
-        IDiagnosticsSink? diag = null)
+        IDiagnosticsSink? diag = null,
+        IGameClock? gameClock = null,
+        TimeProvider? time = null)
     {
         _view = view;
         _defs = defs;
         _storeOptions = storeOptions;
         _diag = diag;
+        _time = time ?? TimeProvider.System;
+        _gameClock = gameClock ?? new GameClock(_time);
         _view.CurrentChanged += OnCurrentChanged;
         _debounce = new System.Timers.Timer(500) { AutoReset = false };
         _debounce.Elapsed += (_, _) => Flush();
+        // Initial rehydrate — covers the case where a character was already
+        // active when the service was constructed (no CurrentChanged fires
+        // for that). Without this, a Running game-clock timer loaded from
+        // disk would have FiringAt=null until the user switched characters.
+        RehydrateFiringAt();
     }
 
     /// <summary>Progress for a specific timer id on the active character, or null if none.</summary>
@@ -78,8 +90,10 @@ public sealed class TimerProgressService : IDisposable
         var view = new TimerView(def, progress);
         if (view.State != TimerState.Idle) return;
 
-        progress.StartedAt = DateTimeOffset.UtcNow;
+        var startedAt = _time.GetUtcNow();
+        progress.StartedAt = startedAt;
         progress.CompletedAt = null;
+        progress.FiringAt = ComputeFiringAt(def, startedAt, _gameClock);
         _expiredNotified.Remove(id);
         SaveNow();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
@@ -96,8 +110,10 @@ public sealed class TimerProgressService : IDisposable
         var view = new TimerView(def, progress);
         if (view.State != TimerState.Done) return;
 
-        progress.StartedAt = DateTimeOffset.UtcNow;
+        var startedAt = _time.GetUtcNow();
+        progress.StartedAt = startedAt;
         progress.CompletedAt = null;
+        progress.FiringAt = ComputeFiringAt(def, startedAt, _gameClock);
         _expiredNotified.Remove(id);
         SaveNow();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
@@ -112,6 +128,7 @@ public sealed class TimerProgressService : IDisposable
         if (progress.StartedAt is null && progress.CompletedAt is null) return;
         progress.StartedAt = null;
         progress.CompletedAt = null;
+        progress.FiringAt = null;
         _expiredNotified.Remove(id);
         MarkDirty();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
@@ -184,6 +201,7 @@ public sealed class TimerProgressService : IDisposable
 
             progress.StartedAt = null;
             progress.CompletedAt = null;
+            progress.FiringAt = null;
             _expiredNotified.Remove(id);
             changed = true;
         }
@@ -196,34 +214,105 @@ public sealed class TimerProgressService : IDisposable
     /// <summary>
     /// Scan the active character's progress; stamp <c>CompletedAt</c> and fire
     /// <see cref="TimerExpired"/> for any running-but-past-due timers. Idempotent within
-    /// the same lifecycle — each id fires at most once per run cycle.
+    /// the same lifecycle — each id fires at most once per run cycle. For
+    /// <see cref="GandalfTriggerKind.GameTimeOfDay"/> timers with
+    /// <see cref="GandalfTimerDef.Recurring"/>, the row is re-armed to the next
+    /// in-game day instead of latching <c>CompletedAt</c> — the alarm event still
+    /// fires so consumers (TimerAlarmService) ring on each cycle.
     /// </summary>
     public void CheckExpirations()
     {
         var current = _view.Current;
         if (current is null) return;
 
+        var now = _time.GetUtcNow();
         foreach (var (id, progress) in current.ByTimerId)
         {
             var def = _defs.Definitions.FirstOrDefault(d => d.Id == id);
             if (def is null) continue;
-
-            var view = new TimerView(def, progress);
             if (progress.StartedAt is null || progress.CompletedAt is not null) continue;
-            if (view.State != TimerState.Done) continue;
 
-            progress.CompletedAt = DateTimeOffset.UtcNow;
-            MarkDirty();
+            var firingAt = progress.FiringAt ?? progress.StartedAt.Value + def.Duration;
+            if (now < firingAt) continue;
 
-            if (_expiredNotified.Add(id))
-                TimerExpired?.Invoke(this, new TimerExpiredEventArgs(def, progress));
+            var firstFire = _expiredNotified.Add(id);
+
+            if (def.Kind == GandalfTriggerKind.GameTimeOfDay && def.Recurring)
+            {
+                // Fire the alarm event for the just-completed run *before* mutating
+                // — handlers run synchronously and read the pre-rearm state. Then
+                // re-arm in place: anchor at now (so the next cycle is computed
+                // against current real time, skipping any cycles missed while the
+                // app was suspended), and reset _expiredNotified so the *next*
+                // fire is allowed. Forgetting that reset silently swallows the
+                // second fire, which is the regression test in the recurring path.
+                if (firstFire)
+                    TimerExpired?.Invoke(this, new TimerExpiredEventArgs(def, progress));
+
+                progress.StartedAt = now;
+                progress.CompletedAt = null;
+                progress.FiringAt = ComputeFiringAt(def, now, _gameClock);
+                _expiredNotified.Remove(id);
+                MarkDirty();
+            }
+            else
+            {
+                progress.CompletedAt = now;
+                MarkDirty();
+
+                if (firstFire)
+                    TimerExpired?.Invoke(this, new TimerExpiredEventArgs(def, progress));
+            }
         }
+    }
+
+    /// <summary>
+    /// Recompute <see cref="TimerProgress.FiringAt"/> for every Running entry on
+    /// the active character. Called on construction and on character-switch.
+    /// FiringAt is <c>[JsonIgnore]</c> so it isn't carried across app restarts —
+    /// rehydrating here is what restores it.
+    /// </summary>
+    private void RehydrateFiringAt()
+    {
+        var current = _view.Current;
+        if (current is null) return;
+
+        foreach (var (id, progress) in current.ByTimerId)
+        {
+            if (progress.StartedAt is null || progress.CompletedAt is not null) continue;
+            var def = _defs.Definitions.FirstOrDefault(d => d.Id == id);
+            if (def is null) continue;
+            progress.FiringAt = ComputeFiringAt(def, progress.StartedAt.Value, _gameClock);
+        }
+    }
+
+    /// <summary>
+    /// Wall-clock instant at which a Running timer of this <paramref name="def"/>
+    /// fires, given when it started. Single dispatch point for the
+    /// <see cref="GandalfTriggerKind.Countdown"/>/<see cref="GandalfTriggerKind.GameTimeOfDay"/>
+    /// branch — every other code path reads the cached
+    /// <see cref="TimerProgress.FiringAt"/>.
+    /// </summary>
+    public static DateTimeOffset ComputeFiringAt(
+        GandalfTimerDef def, DateTimeOffset startedAt, IGameClock gameClock)
+    {
+        return def.Kind switch
+        {
+            GandalfTriggerKind.GameTimeOfDay => gameClock.NextOccurrence(
+                new GameTimeOfDay(def.GameHour ?? 0, def.GameMinute ?? 0),
+                startedAt),
+            _ => startedAt + def.Duration,
+        };
     }
 
     private void OnCurrentChanged(object? sender, EventArgs e)
     {
         // Each character has its own notification ledger — clear on switch.
         _expiredNotified.Clear();
+        // Restore FiringAt for the new active character's running timers — it
+        // isn't persisted, and downstream consumers (scheduler, TimerView, row
+        // render) all dispatch off it.
+        RehydrateFiringAt();
         ProgressChanged?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/Gandalf.Module/Services/UserTimerSource.cs
+++ b/src/Gandalf.Module/Services/UserTimerSource.cs
@@ -114,7 +114,7 @@ public sealed class UserTimerSource : ITimerSource, IDisposable
         {
             var p = progress.GetProgress(def.Id);
             if (p?.StartedAt is null) continue;
-            map[def.Id] = new TimerProgressEntry(def.Id, p.StartedAt.Value, DismissedAt: null);
+            map[def.Id] = new TimerProgressEntry(def.Id, p.StartedAt.Value, DismissedAt: null, FiringAt: p.FiringAt);
         }
         return map;
     }

--- a/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Gandalf.Domain;
-using Mithril.Shared.Game;
 using Mithril.Shared.Wpf.Dialogs;
 
 namespace Gandalf.ViewModels;
@@ -20,14 +19,15 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
     [ObservableProperty] private string _minutes = "";
     [ObservableProperty] private string _seconds = "";
 
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(GameTimePreview))]
-    private string _gameHour = "";
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(GameTimePreview))]
-    private string _gameMinute = "";
-
+    /// <summary>
+    /// Bound to the MahApps <c>TimePicker.SelectedDateTime</c>. The picker only
+    /// exposes a <see cref="DateTime"/>-typed property — we ignore the date
+    /// component and read <c>Hour</c>/<c>Minute</c>. Null means the user hasn't
+    /// picked an in-game time yet (required when <see cref="IsGameTimeOfDay"/>
+    /// is set). The picker enforces 0–23h / 0–59m structurally, so no
+    /// per-component range validation is needed in <see cref="OnPrimaryAction"/>.
+    /// </summary>
+    [ObservableProperty] private DateTime? _selectedGameDateTime;
     [ObservableProperty] private bool _recurring;
 
     [ObservableProperty] private string _region = "";
@@ -43,17 +43,6 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
     /// other character with in-flight progress for the same def.
     /// </summary>
     public bool AreInputsEditable => _areInputsEditable;
-
-    /// <summary>12-hour preview that mirrors the shell's in-game-clock display.</summary>
-    public string GameTimePreview
-    {
-        get
-        {
-            if (!int.TryParse(GameHour, out var h) || h < 0 || h > 23) return "";
-            if (!int.TryParse(GameMinute, out var m) || m < 0 || m > 59) return "";
-            return new GameTimeOfDay(h, m).ToString12Hour() + " in-game";
-        }
-    }
 
     public override string Title => _isEditing ? "Edit Timer" : "Add Timer";
     public override string PrimaryButtonText => _isEditing ? "Update" : "Save";
@@ -89,8 +78,7 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
             {
                 _isCountdown = false;
                 _isGameTimeOfDay = true;
-                _gameHour = (existing.GameHour ?? 0).ToString();
-                _gameMinute = (existing.GameMinute ?? 0).ToString("D2");
+                _selectedGameDateTime = DateTime.Today.AddHours(existing.GameHour ?? 0).AddMinutes(existing.GameMinute ?? 0);
                 _recurring = existing.Recurring;
             }
             else
@@ -114,12 +102,7 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
         // kind validation below applies symmetrically with Add mode.
         if (_isEditing && !_areInputsEditable) return true;
 
-        if (IsGameTimeOfDay)
-        {
-            if (!int.TryParse(GameHour, out var h) || h < 0 || h > 23) return false;
-            if (!int.TryParse(GameMinute, out var m) || m < 0 || m > 59) return false;
-            return true;
-        }
+        if (IsGameTimeOfDay) return SelectedGameDateTime is not null;
 
         // Countdown: positive duration required.
         int.TryParse(Hours, out var hr);
@@ -144,11 +127,8 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
         }
     }
 
-    public int? ResultGameHour =>
-        int.TryParse(GameHour, out var h) ? h : null;
-
-    public int? ResultGameMinute =>
-        int.TryParse(GameMinute, out var m) ? m : null;
+    public int? ResultGameHour => SelectedGameDateTime?.Hour;
+    public int? ResultGameMinute => SelectedGameDateTime?.Minute;
 
     public bool ResultRecurring => Recurring;
 

--- a/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Gandalf.Domain;
+using Mithril.Shared.Game;
 using Mithril.Shared.Wpf.Dialogs;
 
 namespace Gandalf.ViewModels;
@@ -8,22 +9,64 @@ namespace Gandalf.ViewModels;
 public sealed partial class TimerDialogViewModel : DialogViewModelBase
 {
     private readonly bool _isEditing;
-    private readonly bool _isDurationEditable;
+    private readonly bool _areInputsEditable;
 
     [ObservableProperty] private string _name = "";
+
+    [ObservableProperty] private bool _isCountdown = true;
+    [ObservableProperty] private bool _isGameTimeOfDay;
+
     [ObservableProperty] private string _hours = "";
     [ObservableProperty] private string _minutes = "";
     [ObservableProperty] private string _seconds = "";
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(GameTimePreview))]
+    private string _gameHour = "";
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(GameTimePreview))]
+    private string _gameMinute = "";
+
+    [ObservableProperty] private bool _recurring;
+
     [ObservableProperty] private string _region = "";
     [ObservableProperty] private string _map = "";
 
     public ObservableCollection<string> KnownRegions { get; } = [];
     public ObservableCollection<string> KnownMaps { get; } = [];
 
-    public bool IsDurationEditable => _isDurationEditable;
+    /// <summary>
+    /// Trigger / duration / game-time inputs are gated to idle-only on the
+    /// active character, matching the pre-existing rule for Duration: changing
+    /// the firing semantics mid-run would reinterpret remaining time on every
+    /// other character with in-flight progress for the same def.
+    /// </summary>
+    public bool AreInputsEditable => _areInputsEditable;
+
+    /// <summary>12-hour preview that mirrors the shell's in-game-clock display.</summary>
+    public string GameTimePreview
+    {
+        get
+        {
+            if (!int.TryParse(GameHour, out var h) || h < 0 || h > 23) return "";
+            if (!int.TryParse(GameMinute, out var m) || m < 0 || m > 59) return "";
+            return new GameTimeOfDay(h, m).ToString12Hour() + " in-game";
+        }
+    }
 
     public override string Title => _isEditing ? "Edit Timer" : "Add Timer";
     public override string PrimaryButtonText => _isEditing ? "Update" : "Save";
+
+    partial void OnIsCountdownChanged(bool value)
+    {
+        if (value) IsGameTimeOfDay = false;
+    }
+
+    partial void OnIsGameTimeOfDayChanged(bool value)
+    {
+        if (value) IsCountdown = false;
+    }
 
     public TimerDialogViewModel(
         GandalfTimerDef? existing,
@@ -37,40 +80,58 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
         if (existing is not null)
         {
             _isEditing = true;
-            // Duration is editable only when the active character's progress is idle —
-            // changing Duration mid-run would reinterpret remaining time. Other characters
-            // with in-flight progress for the same def accept the new duration on their
-            // next render (rare corner case; users can Restart).
-            _isDurationEditable = isIdleOnActive;
+            _areInputsEditable = isIdleOnActive;
             _name = existing.Name;
-            _hours = existing.Duration.Hours > 0 || existing.Duration.Days > 0
-                ? ((int)existing.Duration.TotalHours).ToString() : "";
-            _minutes = existing.Duration.Minutes > 0 ? existing.Duration.Minutes.ToString() : "";
-            _seconds = existing.Duration.Seconds > 0 ? existing.Duration.Seconds.ToString() : "";
             _region = existing.Region;
             _map = existing.Map;
+
+            if (existing.Kind == GandalfTriggerKind.GameTimeOfDay)
+            {
+                _isCountdown = false;
+                _isGameTimeOfDay = true;
+                _gameHour = (existing.GameHour ?? 0).ToString();
+                _gameMinute = (existing.GameMinute ?? 0).ToString("D2");
+                _recurring = existing.Recurring;
+            }
+            else
+            {
+                _hours = existing.Duration.Hours > 0 || existing.Duration.Days > 0
+                    ? ((int)existing.Duration.TotalHours).ToString() : "";
+                _minutes = existing.Duration.Minutes > 0 ? existing.Duration.Minutes.ToString() : "";
+                _seconds = existing.Duration.Seconds > 0 ? existing.Duration.Seconds.ToString() : "";
+            }
         }
         else
         {
-            _isDurationEditable = true;
+            _areInputsEditable = true;
         }
     }
 
     public override bool OnPrimaryAction()
     {
-        if (!_isEditing)
+        // Edit mode skips re-validation: when the inputs are gated to idle and
+        // the user can't change them, accept any state. When they can, the per-
+        // kind validation below applies symmetrically with Add mode.
+        if (_isEditing && !_areInputsEditable) return true;
+
+        if (IsGameTimeOfDay)
         {
-            int.TryParse(Hours, out var h);
-            int.TryParse(Minutes, out var m);
-            int.TryParse(Seconds, out var s);
-            if (new TimeSpan(h, m, s) <= TimeSpan.Zero)
-                return false;
+            if (!int.TryParse(GameHour, out var h) || h < 0 || h > 23) return false;
+            if (!int.TryParse(GameMinute, out var m) || m < 0 || m > 59) return false;
+            return true;
         }
 
-        return true;
+        // Countdown: positive duration required.
+        int.TryParse(Hours, out var hr);
+        int.TryParse(Minutes, out var mi);
+        int.TryParse(Seconds, out var se);
+        return new TimeSpan(hr, mi, se) > TimeSpan.Zero;
     }
 
     public string ResultName => string.IsNullOrWhiteSpace(Name) ? "Timer" : Name.Trim();
+
+    public GandalfTriggerKind ResultKind =>
+        IsGameTimeOfDay ? GandalfTriggerKind.GameTimeOfDay : GandalfTriggerKind.Countdown;
 
     public TimeSpan ResultDuration
     {
@@ -82,6 +143,14 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
             return new TimeSpan(h, m, s);
         }
     }
+
+    public int? ResultGameHour =>
+        int.TryParse(GameHour, out var h) ? h : null;
+
+    public int? ResultGameMinute =>
+        int.TryParse(GameMinute, out var m) ? m : null;
+
+    public bool ResultRecurring => Recurring;
 
     public string ResultRegion => Region.Trim();
     public string ResultMap => Map.Trim();

--- a/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Gandalf.Domain;
 using Mithril.Shared.Wpf.Dialogs;
@@ -7,6 +8,23 @@ namespace Gandalf.ViewModels;
 
 public sealed partial class TimerDialogViewModel : DialogViewModelBase
 {
+    /// <summary>
+    /// Locked-down culture for the in-game-time picker. Forces zero-padded
+    /// 12-hour format (<c>hh:mm tt</c>) regardless of the user's system
+    /// locale. Vanilla <c>en-US</c> uses <c>h:mm:ss tt</c> — single-digit
+    /// hour and a stray seconds component the picker can't actually edit
+    /// (we hide the seconds spinner via <c>PickerVisibility="HourMinute"</c>).
+    /// </summary>
+    public static CultureInfo PickerCulture { get; } = BuildPickerCulture();
+
+    private static CultureInfo BuildPickerCulture()
+    {
+        var c = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
+        c.DateTimeFormat.ShortTimePattern = "hh:mm tt";
+        c.DateTimeFormat.LongTimePattern = "hh:mm tt";
+        return c;
+    }
+
     private readonly bool _isEditing;
     private readonly bool _areInputsEditable;
 

--- a/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
@@ -87,7 +87,11 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         _defs.Add(new GandalfTimerDef
         {
             Name = vm.ResultName,
+            Kind = vm.ResultKind,
             Duration = vm.ResultDuration,
+            GameHour = vm.ResultGameHour,
+            GameMinute = vm.ResultGameMinute,
+            Recurring = vm.ResultRecurring,
             Region = vm.ResultRegion,
             Map = vm.ResultMap,
         });
@@ -111,9 +115,19 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
             d.Map = vm.ResultMap;
             if (isIdleOnActive)
             {
-                var duration = vm.ResultDuration;
-                if (duration > TimeSpan.Zero)
-                    d.Duration = duration;
+                d.Kind = vm.ResultKind;
+                d.Recurring = vm.ResultRecurring;
+                if (vm.ResultKind == GandalfTriggerKind.GameTimeOfDay)
+                {
+                    d.GameHour = vm.ResultGameHour;
+                    d.GameMinute = vm.ResultGameMinute;
+                }
+                else
+                {
+                    var duration = vm.ResultDuration;
+                    if (duration > TimeSpan.Zero)
+                        d.Duration = duration;
+                }
             }
         });
     }
@@ -213,9 +227,10 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         foreach (var vm in Timers)
         {
             if (vm.Row.Progress is null) continue;
+            if (vm.Row.FiringAt is not { } firingAt) continue;
             // Bridge the source-shape progress into the classifier's TimerProgress shape.
             var progress = new TimerProgress { StartedAt = vm.Row.Progress.StartedAt };
-            if (ElapsedWhileAwayClassifier.IsElapsedWhileAway(progress, vm.Row.Duration, lastActive, now))
+            if (ElapsedWhileAwayClassifier.IsElapsedWhileAway(progress, firingAt, lastActive, now))
                 vm.ElapsedWhileAway = true;
         }
     }

--- a/src/Gandalf.Module/Views/TimerDialogContent.xaml
+++ b/src/Gandalf.Module/Views/TimerDialogContent.xaml
@@ -3,7 +3,20 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls">
     <UserControl.Resources>
-        <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
+        <ResourceDictionary>
+            <!-- MahApps Controls + Fonts + Dark theme are needed for mah:TimePicker
+                 to render its clock-spinner popup; the rest of the shell deliberately
+                 doesn't merge these globally. Scoped to this dialog so other dialogs
+                 keep their custom styling untouched. App-shared converters (BoolToVis)
+                 come last so any key collisions favor our resource. Same pattern as
+                 Legolas/Sharing/LegolasShareDialog.xaml. -->
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Steel.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
     <StackPanel MinWidth="320">
         <DockPanel Margin="0,0,0,6">

--- a/src/Gandalf.Module/Views/TimerDialogContent.xaml
+++ b/src/Gandalf.Module/Views/TimerDialogContent.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="Gandalf.Views.TimerDialogContent"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls">
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:vm="clr-namespace:Gandalf.ViewModels">
     <UserControl.Resources>
         <ResourceDictionary>
             <!-- MahApps Controls + Fonts + Dark theme are needed for mah:TimePicker
@@ -58,16 +59,20 @@
                    Visibility="{Binding IsGameTimeOfDay, Converter={StaticResource BoolToVis}}">
             <TextBlock Text="In-game" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
             <!--
-                Culture="en-US" forces 12-hour AM/PM display regardless of the
-                user's system locale, matching the shell's GameTimeOfDay
-                renderer (which is hard-coded to 12h via ToString12Hour). The
-                underlying SelectedTime is still a 24h TimeSpan, so storage
-                and IGameClock arithmetic are unaffected.
+                PickerCulture is a customized en-US that forces 12-hour
+                "hh:mm tt" (zero-padded, no seconds) for the read-only
+                display. HoursItemStringFormat / MinutesItemStringFormat
+                zero-pad the dropdown items themselves so the popup reads
+                "06" / "00" instead of "6" / "0". The underlying
+                SelectedDateTime is still 24h, so storage and IGameClock
+                arithmetic are unaffected.
             -->
             <mah:TimePicker SelectedDateTime="{Binding SelectedGameDateTime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            Culture="en-US"
+                            Culture="{x:Static vm:TimerDialogViewModel.PickerCulture}"
                             PickerVisibility="HourMinute"
                             HandVisibility="HourMinute"
+                            HoursItemStringFormat="{}{0:D2}"
+                            MinutesItemStringFormat="{}{0:D2}"
                             IsEnabled="{Binding AreInputsEditable}"
                             HorizontalAlignment="Left"
                             Width="170" Padding="6,4"/>

--- a/src/Gandalf.Module/Views/TimerDialogContent.xaml
+++ b/src/Gandalf.Module/Views/TimerDialogContent.xaml
@@ -1,25 +1,68 @@
 <UserControl x:Class="Gandalf.Views.TimerDialogContent"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
+    </UserControl.Resources>
     <StackPanel MinWidth="320">
         <DockPanel Margin="0,0,0,6">
             <TextBlock Text="Name" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
             <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"/>
         </DockPanel>
+
         <DockPanel Margin="0,0,0,6">
+            <TextBlock Text="Trigger" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
+            <StackPanel Orientation="Horizontal">
+                <RadioButton Content="Countdown" GroupName="TimerKind"
+                             IsChecked="{Binding IsCountdown, Mode=TwoWay}"
+                             IsEnabled="{Binding AreInputsEditable}"
+                             Foreground="#FFE8E8E8" Margin="0,0,16,0"/>
+                <RadioButton Content="In-game time" GroupName="TimerKind"
+                             IsChecked="{Binding IsGameTimeOfDay, Mode=TwoWay}"
+                             IsEnabled="{Binding AreInputsEditable}"
+                             Foreground="#FFE8E8E8"/>
+            </StackPanel>
+        </DockPanel>
+
+        <DockPanel Margin="0,0,0,6"
+                   Visibility="{Binding IsCountdown, Converter={StaticResource BoolToVis}}">
             <TextBlock Text="Duration" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
             <StackPanel Orientation="Horizontal">
                 <TextBox Width="50" Text="{Binding Hours, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
-                         IsEnabled="{Binding IsDurationEditable}"/>
+                         IsEnabled="{Binding AreInputsEditable}"/>
                 <TextBlock Text="h" VerticalAlignment="Center" Foreground="#88FFFFFF" Margin="4,0,12,0"/>
                 <TextBox Width="50" Text="{Binding Minutes, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
-                         IsEnabled="{Binding IsDurationEditable}"/>
+                         IsEnabled="{Binding AreInputsEditable}"/>
                 <TextBlock Text="m" VerticalAlignment="Center" Foreground="#88FFFFFF" Margin="4,0,12,0"/>
                 <TextBox Width="50" Text="{Binding Seconds, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
-                         IsEnabled="{Binding IsDurationEditable}"/>
+                         IsEnabled="{Binding AreInputsEditable}"/>
                 <TextBlock Text="s" VerticalAlignment="Center" Foreground="#88FFFFFF" Margin="4,0,0,0"/>
             </StackPanel>
         </DockPanel>
+
+        <DockPanel Margin="0,0,0,6"
+                   Visibility="{Binding IsGameTimeOfDay, Converter={StaticResource BoolToVis}}">
+            <TextBlock Text="In-game" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBox Width="50" Text="{Binding GameHour, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
+                         IsEnabled="{Binding AreInputsEditable}"/>
+                <TextBlock Text=":" VerticalAlignment="Center" Foreground="#88FFFFFF" Margin="4,0,4,0"/>
+                <TextBox Width="50" Text="{Binding GameMinute, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
+                         IsEnabled="{Binding AreInputsEditable}"/>
+                <TextBlock Text="(24h)" VerticalAlignment="Center" Foreground="#66FFFFFF" Margin="8,0,12,0"/>
+                <TextBlock Text="{Binding GameTimePreview}" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
+            </StackPanel>
+        </DockPanel>
+
+        <DockPanel Margin="0,0,0,6"
+                   Visibility="{Binding IsGameTimeOfDay, Converter={StaticResource BoolToVis}}">
+            <TextBlock Text="" Width="70"/>
+            <CheckBox Content="Re-arm each in-game day"
+                      IsChecked="{Binding Recurring, Mode=TwoWay}"
+                      IsEnabled="{Binding AreInputsEditable}"
+                      Foreground="#FFE8E8E8"/>
+        </DockPanel>
+
         <DockPanel Margin="0,0,0,6">
             <TextBlock Text="Region" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
             <ComboBox IsEditable="True" Text="{Binding Region, UpdateSourceTrigger=PropertyChanged}"

--- a/src/Gandalf.Module/Views/TimerDialogContent.xaml
+++ b/src/Gandalf.Module/Views/TimerDialogContent.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Gandalf.Views.TimerDialogContent"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls">
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Converters.xaml"/>
     </UserControl.Resources>
@@ -43,15 +44,20 @@
         <DockPanel Margin="0,0,0,6"
                    Visibility="{Binding IsGameTimeOfDay, Converter={StaticResource BoolToVis}}">
             <TextBlock Text="In-game" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
-            <StackPanel Orientation="Horizontal">
-                <TextBox Width="50" Text="{Binding GameHour, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
-                         IsEnabled="{Binding AreInputsEditable}"/>
-                <TextBlock Text=":" VerticalAlignment="Center" Foreground="#88FFFFFF" Margin="4,0,4,0"/>
-                <TextBox Width="50" Text="{Binding GameMinute, UpdateSourceTrigger=PropertyChanged}" Padding="6,4"
-                         IsEnabled="{Binding AreInputsEditable}"/>
-                <TextBlock Text="(24h)" VerticalAlignment="Center" Foreground="#66FFFFFF" Margin="8,0,12,0"/>
-                <TextBlock Text="{Binding GameTimePreview}" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
-            </StackPanel>
+            <!--
+                Culture="en-US" forces 12-hour AM/PM display regardless of the
+                user's system locale, matching the shell's GameTimeOfDay
+                renderer (which is hard-coded to 12h via ToString12Hour). The
+                underlying SelectedTime is still a 24h TimeSpan, so storage
+                and IGameClock arithmetic are unaffected.
+            -->
+            <mah:TimePicker SelectedDateTime="{Binding SelectedGameDateTime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            Culture="en-US"
+                            PickerVisibility="HourMinute"
+                            HandVisibility="HourMinute"
+                            IsEnabled="{Binding AreInputsEditable}"
+                            HorizontalAlignment="Left"
+                            Width="170" Padding="6,4"/>
         </DockPanel>
 
         <DockPanel Margin="0,0,0,6"

--- a/src/Mithril.Shared/Game/GameClock.cs
+++ b/src/Mithril.Shared/Game/GameClock.cs
@@ -10,6 +10,20 @@ public interface IGameClock
 {
     /// <summary>Current in-game time of day.</summary>
     GameTimeOfDay GetCurrent();
+
+    /// <summary>
+    /// Earliest real-time instant ≥ <paramref name="floor"/> at which the in-game
+    /// clock reads <paramref name="target"/>. The in-game day is 7200 real seconds
+    /// long, so occurrences recur on a 7200-second real-time grid.
+    /// </summary>
+    /// <remarks>
+    /// Edge: when <paramref name="floor"/> sits at the target instant (or within
+    /// ~50 ms before it), the result is bumped one full in-game day forward. This
+    /// prevents fire-on-Start for an alarm started at exactly its target time —
+    /// the user expects "next 6 PM," not "right now," and a recurring alarm would
+    /// otherwise double-fire at arm time.
+    /// </remarks>
+    DateTimeOffset NextOccurrence(GameTimeOfDay target, DateTimeOffset floor);
 }
 
 /// <summary>
@@ -54,5 +68,27 @@ public sealed class GameClock : IGameClock
         if (gameSecs < 0) gameSecs += SecondsPerGameDay;
         var total = (int)gameSecs;
         return new GameTimeOfDay(total / 3600, total % 3600 / 60);
+    }
+
+    public DateTimeOffset NextOccurrence(GameTimeOfDay target, DateTimeOffset floor)
+    {
+        // One in-game day == 7200 real seconds. Both targets and the anchor align
+        // to whole-minute game-second boundaries (multiples of 60), so dividing by
+        // Ratio (12) yields exact 5-real-second multiples — no float drift.
+        const long RealCycleTicks = 7200L * TimeSpan.TicksPerSecond;
+        const long EpsilonTicks = TimeSpan.TicksPerMillisecond * 50;
+
+        long targetGameSecs = target.Hour * 3600L + target.Minute * 60L;
+        long diffGameSecs = (targetGameSecs - AnchorGameSeconds) % SecondsPerGameDay;
+        if (diffGameSecs < 0) diffGameSecs += SecondsPerGameDay;
+        long targetOffsetTicks = diffGameSecs * TimeSpan.TicksPerSecond / Ratio;
+
+        long floorAnchorTicks = (floor.UtcDateTime - AnchorUtc).Ticks;
+        long floorOffsetTicks = ((floorAnchorTicks % RealCycleTicks) + RealCycleTicks) % RealCycleTicks;
+
+        long deltaTicks = ((targetOffsetTicks - floorOffsetTicks) % RealCycleTicks + RealCycleTicks) % RealCycleTicks;
+        if (deltaTicks < EpsilonTicks) deltaTicks += RealCycleTicks;
+
+        return floor + TimeSpan.FromTicks(deltaTicks);
     }
 }

--- a/tests/Gandalf.Tests/ElapsedWhileAwayClassifierTests.cs
+++ b/tests/Gandalf.Tests/ElapsedWhileAwayClassifierTests.cs
@@ -11,25 +11,29 @@ public class ElapsedWhileAwayClassifierTests
     [Fact]
     public void Elapsed_while_away_when_started_before_last_active_and_finished_after()
     {
-        // Started 2h ago, duration 1h30m → theoretical done at (Now - 30m).
+        // Started 2h ago, duration 1h30m → firing instant at (Now - 30m).
         // LastActive 1h ago — so the timer finished 30m after the user switched away.
-        var progress = new TimerProgress { StartedAt = Now - TimeSpan.FromHours(2) };
+        var started = Now - TimeSpan.FromHours(2);
+        var progress = new TimerProgress { StartedAt = started };
+        var firingAt = started + TimeSpan.FromMinutes(90);
         var lastActive = Now - TimeSpan.FromHours(1);
 
         ElapsedWhileAwayClassifier
-            .IsElapsedWhileAway(progress, TimeSpan.FromMinutes(90), lastActive, Now)
+            .IsElapsedWhileAway(progress, firingAt, lastActive, Now)
             .Should().BeTrue();
     }
 
     [Fact]
     public void Not_elapsed_if_still_running_past_last_active()
     {
-        // Started 10m ago, duration 1h → theoretical done in ~50m (future). LastActive 5m ago.
-        var progress = new TimerProgress { StartedAt = Now - TimeSpan.FromMinutes(10) };
+        // Started 10m ago, duration 1h → firing in ~50m (future). LastActive 5m ago.
+        var started = Now - TimeSpan.FromMinutes(10);
+        var progress = new TimerProgress { StartedAt = started };
+        var firingAt = started + TimeSpan.FromHours(1);
         var lastActive = Now - TimeSpan.FromMinutes(5);
 
         ElapsedWhileAwayClassifier
-            .IsElapsedWhileAway(progress, TimeSpan.FromHours(1), lastActive, Now)
+            .IsElapsedWhileAway(progress, firingAt, lastActive, Now)
             .Should().BeFalse("timer hasn't finished yet");
     }
 
@@ -38,11 +42,13 @@ public class ElapsedWhileAwayClassifierTests
     {
         // User returned to this character, restarted a timer, then switched again.
         // Timer started after the LastActive stamp — they saw the start, not a catch-up.
-        var progress = new TimerProgress { StartedAt = Now - TimeSpan.FromMinutes(10) };
+        var started = Now - TimeSpan.FromMinutes(10);
+        var progress = new TimerProgress { StartedAt = started };
+        var firingAt = started + TimeSpan.FromMinutes(5);
         var lastActive = Now - TimeSpan.FromMinutes(30);
 
         ElapsedWhileAwayClassifier
-            .IsElapsedWhileAway(progress, TimeSpan.FromMinutes(5), lastActive, Now)
+            .IsElapsedWhileAway(progress, firingAt, lastActive, Now)
             .Should().BeFalse("timer started after the last active session");
     }
 
@@ -50,10 +56,11 @@ public class ElapsedWhileAwayClassifierTests
     public void Not_elapsed_if_last_active_is_null()
     {
         // First-ever session on this character: no noise.
-        var progress = new TimerProgress { StartedAt = Now - TimeSpan.FromHours(5) };
+        var started = Now - TimeSpan.FromHours(5);
+        var progress = new TimerProgress { StartedAt = started };
 
         ElapsedWhileAwayClassifier
-            .IsElapsedWhileAway(progress, TimeSpan.FromMinutes(5), lastActiveAt: null, Now)
+            .IsElapsedWhileAway(progress, started + TimeSpan.FromMinutes(5), lastActiveAt: null, Now)
             .Should().BeFalse();
     }
 
@@ -62,7 +69,26 @@ public class ElapsedWhileAwayClassifierTests
     {
         var progress = new TimerProgress();  // StartedAt null
         ElapsedWhileAwayClassifier
-            .IsElapsedWhileAway(progress, TimeSpan.FromMinutes(5), Now - TimeSpan.FromHours(1), Now)
+            .IsElapsedWhileAway(progress, Now, Now - TimeSpan.FromHours(1), Now)
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Game_clock_alarm_fires_at_an_instant_decoupled_from_StartedAt_plus_Duration()
+    {
+        // A game-clock-of-day alarm started at LastActive - 30m, configured to
+        // fire at "next 6 PM in-game". The classifier doesn't know about
+        // GameTimeOfDay arithmetic — the caller resolves a per-row firing
+        // instant (here: between LastActive and Now) and hands it in. Verifies
+        // the v1 fix where Catalog.Duration would have produced the wrong
+        // theoretical-done for game-clock timers.
+        var started = Now - TimeSpan.FromMinutes(30);
+        var progress = new TimerProgress { StartedAt = started };
+        var firingAt = Now - TimeSpan.FromMinutes(10);  // Not started + any obvious duration
+        var lastActive = Now - TimeSpan.FromMinutes(20);
+
+        ElapsedWhileAwayClassifier
+            .IsElapsedWhileAway(progress, firingAt, lastActive, Now)
+            .Should().BeTrue("firing instant fell between LastActive and Now");
     }
 }

--- a/tests/Gandalf.Tests/TimerProgressServiceRecurringTests.cs
+++ b/tests/Gandalf.Tests/TimerProgressServiceRecurringTests.cs
@@ -1,0 +1,195 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Character;
+using Mithril.Shared.Game;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Regression coverage for the GameTimeOfDay + Recurring path through
+/// <see cref="TimerProgressService"/>. The scheduler dispatches off
+/// <c>FiringAt</c>; on expiration, recurring rows must:
+///   - fire <c>TimerExpired</c> for the just-completed run,
+///   - re-arm with a fresh <c>StartedAt</c>/<c>FiringAt</c>,
+///   - reset <c>_expiredNotified</c> so the next cycle's fire is allowed.
+/// Forgetting that final reset is the silent-second-fire bug the Plan agent
+/// flagged as the highest-risk subtask.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class TimerProgressServiceRecurringTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _defsPath;
+    private readonly string _charactersDir;
+
+    public TimerProgressServiceRecurringTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_progress_recurring");
+        _defsPath = Path.Combine(_dir, "definitions.json");
+        _charactersDir = Path.Combine(_dir, "characters");
+        Directory.CreateDirectory(_charactersDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private (TimerDefinitionsService defs, TimerProgressService progress, ManualTime time)
+        Build(DateTime startUtc)
+    {
+        var defStore = new JsonSettingsStore<GandalfDefinitions>(_defsPath,
+            GandalfDefinitionsJsonContext.Default.GandalfDefinitions);
+        var defs = defStore.Load();
+        var defsSvc = new TimerDefinitionsService(defStore, defs);
+
+        var active = new FakeActiveCharacterService();
+        active.SetActiveCharacter("Arthur", "Kwatoxi");
+        var store = new PerCharacterStore<GandalfProgress>(_charactersDir, "gandalf.json",
+            GandalfProgressJsonContext.Default.GandalfProgress);
+        var view = new PerCharacterView<GandalfProgress>(active, store);
+
+        var time = new ManualTime(startUtc);
+        // Use a real GameClock backed by the same TimeProvider so in-game-time
+        // arithmetic stays consistent with the test's wall-clock advances.
+        var gameClock = new GameClock(time);
+        var progressSvc = new TimerProgressService(view, defsSvc,
+            new PerCharacterStoreOptions { CharactersRootDir = _charactersDir },
+            diag: null, gameClock: gameClock, time: time);
+        return (defsSvc, progressSvc, time);
+    }
+
+    [Fact]
+    public void Countdown_Start_stamps_FiringAt_at_StartedAt_plus_Duration()
+    {
+        var (defs, progress, time) = Build(new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc));
+        try
+        {
+            defs.Add(new GandalfTimerDef { Name = "Soon", Duration = TimeSpan.FromMinutes(15) });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+
+            var p = progress.GetProgress(id)!;
+            p.StartedAt.Should().Be(time.GetUtcNow());
+            p.FiringAt.Should().Be(time.GetUtcNow() + TimeSpan.FromMinutes(15));
+        }
+        finally { progress.Dispose(); defs.Dispose(); }
+    }
+
+    [Fact]
+    public void GameTimeOfDay_Start_stamps_FiringAt_at_next_in_game_occurrence()
+    {
+        // Pgemissary anchor: 2026-03-11T01:45:01.212Z = 21:00 in-game. Five real
+        // minutes later → 22:00 in-game. Asking for "next 23:00 in-game" should
+        // land 5 real minutes further on (= 10 real min after anchor).
+        var startUtc = new DateTime(2026, 3, 11, 1, 50, 1, 212, DateTimeKind.Utc);
+        var (defs, progress, time) = Build(startUtc);
+        try
+        {
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "11 PM in-game",
+                Kind = GandalfTriggerKind.GameTimeOfDay,
+                GameHour = 23, GameMinute = 0,
+                Recurring = false,
+            });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+
+            var p = progress.GetProgress(id)!;
+            p.FiringAt.Should().NotBeNull();
+            (p.FiringAt!.Value - p.StartedAt!.Value)
+                .Should().Be(TimeSpan.FromMinutes(5));
+        }
+        finally { progress.Dispose(); defs.Dispose(); }
+    }
+
+    [Fact]
+    public void GameTimeOfDay_one_shot_fires_once_then_latches_Done()
+    {
+        var startUtc = new DateTime(2026, 3, 11, 1, 50, 1, 212, DateTimeKind.Utc);
+        var (defs, progress, time) = Build(startUtc);
+        var fires = 0;
+        progress.TimerExpired += (_, _) => fires++;
+        try
+        {
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "11 PM (one-shot)",
+                Kind = GandalfTriggerKind.GameTimeOfDay,
+                GameHour = 23, GameMinute = 0,
+                Recurring = false,
+            });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+
+            time.Advance(TimeSpan.FromMinutes(5) + TimeSpan.FromSeconds(1));
+            progress.CheckExpirations();
+            fires.Should().Be(1);
+            progress.GetProgress(id)!.CompletedAt.Should().NotBeNull("one-shot latches Done");
+
+            // Subsequent checks must not re-fire.
+            time.Advance(TimeSpan.FromHours(3));
+            progress.CheckExpirations();
+            fires.Should().Be(1);
+        }
+        finally { progress.Dispose(); defs.Dispose(); }
+    }
+
+    [Fact]
+    public void GameTimeOfDay_recurring_fires_each_cycle_and_re_arms()
+    {
+        // The bug this guards against: forgetting to reset _expiredNotified
+        // (or _firedKeys in the alarm service) silently swallows the second
+        // fire. Drive two consecutive cycles and assert two fires.
+        var startUtc = new DateTime(2026, 3, 11, 1, 50, 1, 212, DateTimeKind.Utc);
+        var (defs, progress, time) = Build(startUtc);
+        var fires = 0;
+        progress.TimerExpired += (_, _) => fires++;
+        try
+        {
+            defs.Add(new GandalfTimerDef
+            {
+                Name = "11 PM (recurring)",
+                Kind = GandalfTriggerKind.GameTimeOfDay,
+                GameHour = 23, GameMinute = 0,
+                Recurring = true,
+            });
+            var id = defs.Definitions[0].Id;
+            progress.Start(id);
+
+            // Cycle 1.
+            time.Advance(TimeSpan.FromMinutes(5) + TimeSpan.FromSeconds(1));
+            progress.CheckExpirations();
+            fires.Should().Be(1, "first cycle should have fired");
+            var p = progress.GetProgress(id)!;
+            p.CompletedAt.Should().BeNull("recurring re-arms instead of latching Done");
+            p.StartedAt.Should().Be(time.GetUtcNow(), "recurring StartedAt anchors at re-arm wall-clock");
+            p.FiringAt.Should().NotBeNull();
+            // Next FiringAt should be one full real cycle (~7200 s) ahead. The
+            // exact offset depends on where in the cycle we landed, but it
+            // must be at least an hour out.
+            (p.FiringAt!.Value - time.GetUtcNow()).Should().BeGreaterThan(TimeSpan.FromHours(1));
+
+            // Cycle 2 — advance to just past the second FiringAt.
+            time.Advance(p.FiringAt.Value - time.GetUtcNow() + TimeSpan.FromSeconds(1));
+            progress.CheckExpirations();
+            fires.Should().Be(2, "the second cycle must fire — regression on the silent-second-fire bug");
+            progress.GetProgress(id)!.CompletedAt.Should().BeNull();
+        }
+        finally { progress.Dispose(); defs.Dispose(); }
+    }
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTime utcStart) => _now = new DateTimeOffset(utcStart, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+}

--- a/tests/Mithril.Shared.Tests/GameClockTests.cs
+++ b/tests/Mithril.Shared.Tests/GameClockTests.cs
@@ -62,6 +62,78 @@ public class GameClockTests
     }
 
     [Fact]
+    public void NextOccurrence_TargetEqualsCurrent_AdvancesFullCycle()
+    {
+        // At the anchor, in-game time is 9:00 PM. Asking for the next 9:00 PM
+        // should jump one full real cycle (7200 s) forward — the alternative
+        // would silently fire-on-arm for a 9:00 PM alarm started at 9:00 PM.
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc, TimeSpan.Zero);
+        var clock = new GameClock(new FixedTimeProvider(PgEmissaryAnchorUtc));
+        var next = clock.NextOccurrence(new GameTimeOfDay(21, 0), floor);
+        (next - floor).Should().Be(TimeSpan.FromSeconds(7200));
+    }
+
+    [Fact]
+    public void NextOccurrence_TargetSoonAfterCurrent_RoundTripsThroughGetCurrent()
+    {
+        // 5 real minutes after anchor → in-game 10:00 PM. Asking for next
+        // 11:00 PM should land 5 real minutes further on (= 10 min after anchor),
+        // and a clock fixed at that instant should report exactly 11:00 PM.
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc.AddMinutes(5), TimeSpan.Zero);
+        var clock = new GameClock(new FixedTimeProvider(floor.UtcDateTime));
+        var next = clock.NextOccurrence(new GameTimeOfDay(23, 0), floor);
+        (next - floor).Should().Be(TimeSpan.FromMinutes(5));
+        new GameClock(new FixedTimeProvider(next.UtcDateTime))
+            .GetCurrent().Should().Be(new GameTimeOfDay(23, 0));
+    }
+
+    [Fact]
+    public void NextOccurrence_TargetJustPassed_ReturnsNearlyFullCycle()
+    {
+        // Floor is one tick after the anchor's 9:00 PM moment → "next 9:00 PM"
+        // should be almost a full real cycle out (7200 s minus one tick).
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc, TimeSpan.Zero) + TimeSpan.FromTicks(1);
+        var clock = new GameClock(new FixedTimeProvider(floor.UtcDateTime));
+        var next = clock.NextOccurrence(new GameTimeOfDay(21, 0), floor);
+        (next - floor).Should().Be(TimeSpan.FromSeconds(7200) - TimeSpan.FromTicks(1));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(6, 0)]
+    [InlineData(12, 0)]
+    [InlineData(18, 0)]
+    [InlineData(3, 27)]
+    [InlineData(20, 59)]
+    public void NextOccurrence_RoundTrip_ManyTargets(int hour, int minute)
+    {
+        // For an arbitrary floor strictly after anchor, the returned instant
+        // must satisfy GetCurrent(returned) == target — modulo the 1-minute
+        // resolution of GameTimeOfDay.
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc, TimeSpan.Zero).AddMinutes(17.3);
+        var clock = new GameClock(new FixedTimeProvider(floor.UtcDateTime));
+        var target = new GameTimeOfDay(hour, minute);
+        var next = clock.NextOccurrence(target, floor);
+
+        next.Should().BeOnOrAfter(floor);
+        new GameClock(new FixedTimeProvider(next.UtcDateTime))
+            .GetCurrent().Should().Be(target);
+    }
+
+    [Fact]
+    public void NextOccurrence_FloorBeforeAnchor_HandlesNegativeElapsed()
+    {
+        // Inverse formula must cope with floors that pre-date the anchor — same
+        // negative-modulo case GetCurrent handles.
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc.AddHours(-3), TimeSpan.Zero);
+        var clock = new GameClock(new FixedTimeProvider(floor.UtcDateTime));
+        var next = clock.NextOccurrence(new GameTimeOfDay(0, 0), floor);
+        next.Should().BeOnOrAfter(floor);
+        new GameClock(new FixedTimeProvider(next.UtcDateTime))
+            .GetCurrent().Should().Be(new GameTimeOfDay(0, 0));
+    }
+
+    [Fact]
     public void OurTickFlipObservation_AgreesWithinSeconds()
     {
         // On 2026-05-04T21:00:08.78Z we observed the in-game clock flip to 12:00 PM.


### PR DESCRIPTION
## Summary

- Adds a second Gandalf timer kind that fires when Project Gorgon's in-game clock reaches a target hour:minute, with a per-timer one-shot / recurring toggle (recurring re-arms each in-game day ≈ 7200 real seconds).
- Unifies firing semantics behind a single \`FiringAt\` real-time instant — countdowns set \`StartedAt + Duration\`, game-clock timers compute the next in-game-time occurrence via the new \`IGameClock.NextOccurrence\`. \`TimerView\`, \`TimerRow\`, the scheduler, and \`CheckExpirations\` all dispatch off it.
- Quest/Loot/Dashboard sources are behaviorally unchanged: \`TimerProgressEntry.FiringAt\` is optional and consumers fall back to \`StartedAt + Catalog.Duration\` when null.
- Closes #164. Detailed implementation spec lives at [docs/agent-plans/gandalf-in-game-clock-alarm.md](docs/agent-plans/gandalf-in-game-clock-alarm.md).

## What changed (highlights)

- **\`IGameClock.NextOccurrence\`** ([GameClock.cs](src/Mithril.Shared/Game/GameClock.cs)) — closed-form inverse of the 12× formula, with a 50 ms epsilon that bumps to next in-game day so a timer started at exactly its target time doesn't fire-on-arm.
- **Recurring re-arm** ([TimerProgressService.cs](src/Gandalf.Module/Services/TimerProgressService.cs#L201)) — fires \`TimerExpired\` first (synchronous handlers see pre-rearm state), then mutates in place. Critically resets \`_expiredNotified\` so the next cycle's fire isn't silently swallowed.
- **Time-based alarm dedup** ([TimerAlarmService.cs](src/Gandalf.Module/Services/TimerAlarmService.cs)) — \`HashSet<string>\` flipped to \`Dictionary<string, DateTimeOffset>\` of last-fire-time; gates re-fires on a 30 s suppression window so recurring alarms actually ring on every cycle (not just the first).
- **\`ElapsedWhileAwayClassifier\`** now takes \`firingAt\` directly instead of \`duration\` — fixes the badge for game-clock timers across in-game day boundaries.
- **Schema v2** ([GandalfDefinitions.cs](src/Gandalf.Module/Domain/GandalfDefinitions.cs)) — additive only: new optional \`Kind\` / \`GameHour\` / \`GameMinute\` / \`Recurring\` fields. v1 files load with \`Kind=Countdown\` defaults; no migrator needed.
- **Dialog UI** — \"Trigger\" radio (Countdown / In-game time) at the top; conditional rows for hour/minute (24h input + 12h preview) and the Recurring checkbox.

## Test plan

- [x] **Unit / integration:** all 1525 tests green. Highlights:
  - 6 new \`GameClockTests\` cases for \`NextOccurrence\` (round-trip, edge: target == floor → +cycle, target just-passed → ≈full cycle, negative-elapsed floor).
  - New \`TimerProgressServiceRecurringTests\` — drives two consecutive recurring fires through a \`ManualTime\` + \`GameClock\`. The second-fire assertion is the regression guard for the \`_expiredNotified\` / \`_firedAt\` dedup-reset bug the planning agent flagged as the highest-risk subtask.
  - \`ElapsedWhileAwayClassifierTests\` adds a game-clock case where \`firingAt ≠ started + duration\` to verify the classifier no longer assumes a fixed catalog duration.
- [ ] **Manual E2E (owner verifies before merge):**
  - [ ] Create a Countdown timer, 30 s — fires correctly (no countdown regression).
  - [ ] Create an In-game time timer, Recurring = false, target ≈ shell's current in-game time + 10 in-game minutes (~50 real seconds). Confirm the alarm fires and the row goes Done.
  - [ ] Same setup, Recurring = true. Confirm: alarm fires; row immediately re-arms (StartedAt jumps forward, no Done state lingers); ~2 real hours later, alarm fires again.
  - [ ] Edit a Running timer for the active character: confirm hour/minute (and duration) inputs are disabled, matching the existing rule.
  - [ ] Restart the app while a Running game-clock timer exists: confirm \`FiringAt\` rehydrates correctly (the row keeps counting down to the right moment after restart).

## Notes / known v1 limitations

- "Edit while running" gates In-game time inputs to idle-only on the active character, matching today's countdown rule. Re-stamping \`FiringAt\` mid-run for the active character is a UX win to revisit if anyone asks.
- Clipboard import/export still only carries countdown timers — copying an in-game-time timer drops the kind back to Countdown on paste. Acceptable for v1; can extend the clipboard format later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)