### PR TITLE
gandalf: per-shift alarm sounds for PG's published time-of-day periods

### DIFF
--- a/src/Gandalf.Module/Domain/GandalfShiftSettings.cs
+++ b/src/Gandalf.Module/Domain/GandalfShiftSettings.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+
+namespace Gandalf.Domain;
+
+/// <summary>
+/// Per-shift alarm configuration. Both fields default to "no alarm, no
+/// override" — disabled by default and inheriting the global sound when
+/// enabled. INPC so the WPF settings view re-renders rows on toggle.
+/// </summary>
+public sealed class ShiftAlarmConfig : INotifyPropertyChanged
+{
+    private bool _enabled;
+    private string? _soundFilePath;
+
+    public bool Enabled { get => _enabled; set => Set(ref _enabled, value); }
+    public string? SoundFilePath { get => _soundFilePath; set => Set(ref _soundFilePath, value); }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}
+
+/// <summary>
+/// Map of in-game-time-of-day shift slug → per-shift alarm config. Keyed by
+/// the slug from <see cref="Mithril.Shared.Game.TimeOfDayShifts.All"/>.
+/// Persisted globally at <c>%LocalAppData%/Mithril/Gandalf/shifts.json</c>;
+/// shift transitions are character-agnostic.
+/// </summary>
+public sealed class GandalfShiftSettings : INotifyPropertyChanged
+{
+    public Dictionary<string, ShiftAlarmConfig> ByShiftSlug { get; set; } =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Lookup-or-create. Used by the settings view and by
+    /// <c>ShiftAlarmService</c> at fire time. Newly-minted entries inherit
+    /// the disabled default, so reading a previously-untouched shift does
+    /// not silently enable an alarm.
+    /// </summary>
+    public ShiftAlarmConfig GetOrCreate(string slug)
+    {
+        if (!ByShiftSlug.TryGetValue(slug, out var config))
+        {
+            config = new ShiftAlarmConfig();
+            ByShiftSlug[slug] = config;
+            // Re-fire change so subscribers re-render the row.
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ByShiftSlug)));
+        }
+        return config;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(GandalfShiftSettings))]
+public partial class GandalfShiftSettingsJsonContext : JsonSerializerContext { }

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -37,9 +37,15 @@ public sealed class GandalfModule : IMithrilModule
         var settingsPath = Path.Combine(gandalfDir, "settings.json");
         var defsPath = Path.Combine(gandalfDir, "definitions.json");
         var lootCatalogPath = Path.Combine(gandalfDir, "loot-catalog.json");
+        var shiftsPath = Path.Combine(gandalfDir, "shifts.json");
 
         // Global user preferences (alarm volume, sound picker, etc) stay app-wide.
         services.AddMithrilSettings<GandalfSettings>(settingsPath, GandalfSettingsJsonContext.Default.GandalfSettings);
+
+        // Per-shift alarm config (enabled + per-shift sound override) for the
+        // six published time-of-day shifts. Character-agnostic — one file
+        // shared across all characters, parallel to GandalfSettings.
+        services.AddMithrilSettings<GandalfShiftSettings>(shiftsPath, GandalfShiftSettingsJsonContext.Default.GandalfShiftSettings);
 
         // Global timer definitions — one file, shared across every character.
         services.AddSingleton<ISettingsStore<GandalfDefinitions>>(_ =>
@@ -114,6 +120,13 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<ITimerSource>(sp => sp.GetRequiredService<LootSource>());
         services.AddSingleton<TimerAlarmService>();
 
+        // Time-of-day shift alarms — character-agnostic, runs whenever the
+        // shell is open. Listens to the in-game clock and fires per-shift
+        // alarms based on GandalfShiftSettings. Eager because it owns its
+        // own DispatcherTimer; it must wake on schedule even if the user
+        // never opens the Gandalf tab.
+        services.AddSingleton<ShiftAlarmService>();
+
         // Drives TimerProgressService.CheckExpirations on a one-shot timer
         // scheduled at the soonest known user-timer expiration. Replaces
         // the 1 Hz tick that used to live in TimerListViewModel.Tick. Owns
@@ -144,6 +157,10 @@ public sealed class GandalfModule : IMithrilModule
             // resolves it. This is the same eager-singleton idiom that pulls
             // TimerAlarmService in via TimerListViewModel's factory above.
             _ = sp.GetRequiredService<TimerExpirationScheduler>();
+            // ShiftAlarmService likewise owns a DispatcherTimer for the
+            // time-of-day shift alarm path; eager-resolve here so it starts
+            // running as soon as Gandalf activates (Eager module).
+            _ = sp.GetRequiredService<ShiftAlarmService>();
             return new GandalfShellView
             {
                 DataContext = sp.GetRequiredService<GandalfShellViewModel>(),

--- a/src/Gandalf.Module/Services/ShiftAlarmService.cs
+++ b/src/Gandalf.Module/Services/ShiftAlarmService.cs
@@ -1,0 +1,152 @@
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Threading;
+using Gandalf.Domain;
+using Mithril.Shared.Audio;
+using Mithril.Shared.Game;
+using Mithril.Shared.Wpf;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Fires alarms at Project Gorgon's six published in-game-time-of-day shift
+/// transitions (Midnight / Dawn / Morning / Afternoon / Dusk / Night;
+/// see <see cref="TimeOfDayShifts"/>). Distinct from the user-curated timer
+/// pipeline (<see cref="TimerAlarmService"/>) — shifts are global,
+/// character-agnostic, and have no Start/Done lifecycle, so an
+/// <see cref="Domain.ITimerSource"/>-style projection is over-scope. Owns
+/// one <see cref="DispatcherTimer"/> scheduled at the next transition;
+/// reschedules on tick + on settings changes.
+/// </summary>
+public sealed class ShiftAlarmService : IDisposable
+{
+    private readonly IGameClock _gameClock;
+    private readonly GandalfSettings _globalSettings;
+    private readonly GandalfShiftSettings _shiftSettings;
+    private readonly TimeProvider _time;
+    private readonly Dispatcher _dispatcher;
+    private readonly DispatcherTimer _timer;
+    private readonly Dictionary<string, IPlaybackHandle> _playback = new(StringComparer.Ordinal);
+    private ShiftDefinition? _scheduledFor;
+    private bool _disposed;
+
+    public ShiftAlarmService(
+        IGameClock gameClock,
+        GandalfSettings globalSettings,
+        GandalfShiftSettings shiftSettings,
+        TimeProvider? time = null,
+        Dispatcher? dispatcher = null)
+    {
+        _gameClock = gameClock;
+        _globalSettings = globalSettings;
+        _shiftSettings = shiftSettings;
+        _time = time ?? TimeProvider.System;
+        _dispatcher = dispatcher ?? Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+
+        _timer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher);
+        _timer.Tick += (_, _) => OnTick();
+
+        // Toggling a shift's Enabled or sound never changes *which* transition
+        // is next (that's a function of the in-game clock alone), but it can
+        // change whether the next tick should actually play. We don't need
+        // to reschedule on settings change — OnTick re-reads config at fire
+        // time. Subscriptions kept minimal.
+        Reschedule();
+    }
+
+    /// <summary>Test hook — drive one tick without waiting on the dispatcher pump.</summary>
+    internal void TickForTests() => OnTick();
+
+    /// <summary>The shift the dispatcher timer will fire on next, or <c>null</c> when disposed.</summary>
+    public ShiftDefinition? NextScheduledShift => _scheduledFor;
+
+    /// <summary>Wall-clock instant of the next scheduled transition, or <c>null</c> when disposed.</summary>
+    public DateTimeOffset? NextScheduledAt =>
+        _disposed ? null : _timer.IsEnabled ? _time.GetUtcNow() + _timer.Interval : null;
+
+    /// <summary>
+    /// Stop any in-flight alarm playback for this shift (and any others) and
+    /// reset state. Symmetric with <see cref="TimerAlarmService.DismissAll"/>.
+    /// </summary>
+    public void DismissAll()
+    {
+        foreach (var h in _playback.Values) h.Stop();
+        _playback.Clear();
+    }
+
+    /// <summary>
+    /// Decision logic for "should this shift transition fire an alarm right
+    /// now?" — extracted as a static so unit tests can exercise it without
+    /// driving the dispatcher pump or hitting <c>AudioPlayer.Play</c>.
+    /// </summary>
+    internal static bool ShouldAlarm(ShiftAlarmConfig config, GandalfSettings global) =>
+        global.AlarmEnabled && config.Enabled;
+
+    /// <summary>
+    /// Per-shift <see cref="ShiftAlarmConfig.SoundFilePath"/> wins; null falls
+    /// back to the global <see cref="GandalfSettings.SoundFilePath"/>. Mirrors
+    /// <see cref="TimerAlarmService.ResolveSoundPath"/> so the per-row /
+    /// per-shift override behavior is identical.
+    /// </summary>
+    internal static string? ResolveSoundPath(ShiftAlarmConfig config, GandalfSettings global) =>
+        config.SoundFilePath ?? global.SoundFilePath;
+
+    private void OnTick()
+    {
+        if (_disposed) return;
+
+        var fired = _scheduledFor;
+        if (fired is not null)
+        {
+            var config = _shiftSettings.GetOrCreate(fired.Slug);
+            if (ShouldAlarm(config, _globalSettings))
+            {
+                var path = ResolveSoundPath(config, _globalSettings);
+                Dispatch(() =>
+                {
+                    if (_playback.Remove(fired.Slug, out var prior)) prior.Stop();
+                    _playback[fired.Slug] = AudioPlayer.Play(
+                        path, (float)_globalSettings.AlarmVolume, "gandalf");
+                    if (_globalSettings.FlashWindow)
+                    {
+                        var win = Application.Current?.MainWindow;
+                        if (win is not null) WindowFlasher.Flash(win);
+                    }
+                });
+            }
+        }
+
+        Reschedule();
+    }
+
+    private void Reschedule()
+    {
+        if (_disposed) return;
+
+        var floor = _time.GetUtcNow();
+        var (at, shift) = TimeOfDayShifts.NextTransition(_gameClock, floor);
+        _scheduledFor = shift;
+
+        var delay = at - floor;
+        // Same epsilon rationale as TimerExpirationScheduler.cs:103 — below
+        // human perception, above the dispatcher's resolution noise floor.
+        if (delay < TimeSpan.FromMilliseconds(50)) delay = TimeSpan.FromMilliseconds(50);
+
+        _timer.Interval = delay;
+        if (!_timer.IsEnabled) _timer.Start();
+    }
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatcher.CheckAccess()) action();
+        else _dispatcher.BeginInvoke(action);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _timer.Stop();
+        DismissAll();
+    }
+}

--- a/src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs
@@ -3,8 +3,30 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Gandalf.Domain;
 using Gandalf.Services;
+using Mithril.Shared.Game;
 
 namespace Gandalf.ViewModels;
+
+/// <summary>
+/// Per-shift binding row in the settings view. Wraps the static
+/// <see cref="ShiftDefinition"/> (display data) with the live
+/// <see cref="ShiftAlarmConfig"/> (Enabled + SoundFilePath, INPC).
+/// The XAML <c>ItemsControl</c> binds to one of these per shift.
+/// </summary>
+public sealed class ShiftAlarmRow
+{
+    public ShiftAlarmRow(ShiftDefinition shift, ShiftAlarmConfig config)
+    {
+        Shift = shift;
+        Config = config;
+    }
+
+    public ShiftDefinition Shift { get; }
+    public ShiftAlarmConfig Config { get; }
+
+    public string Slug => Shift.Slug;
+    public string Display => $"{Shift.Emoji}  {Shift.Label}  ({Shift.StartHour}:00 in-game)";
+}
 
 /// <summary>
 /// Settings view's binding target. Re-exposes <see cref="GandalfSettings"/> as
@@ -19,14 +41,21 @@ public sealed partial class GandalfSettingsViewModel : ObservableObject
     public GandalfSettingsViewModel(
         GandalfSettings settings,
         TimerDefinitionsService defs,
-        TimerProgressService progress)
+        TimerProgressService progress,
+        GandalfShiftSettings shiftSettings)
     {
         Settings = settings;
         _defs = defs;
         _progress = progress;
+        ShiftRows = TimeOfDayShifts.All
+            .Select(s => new ShiftAlarmRow(s, shiftSettings.GetOrCreate(s.Slug)))
+            .ToArray();
     }
 
     public GandalfSettings Settings { get; }
+
+    /// <summary>One row per published in-game-time-of-day shift, in time order.</summary>
+    public IReadOnlyList<ShiftAlarmRow> ShiftRows { get; }
 
     [RelayCommand]
     private void DeleteAll()

--- a/src/Gandalf.Module/Views/GandalfSettingsView.xaml
+++ b/src/Gandalf.Module/Views/GandalfSettingsView.xaml
@@ -49,6 +49,35 @@
                 <TextBox Text="{Binding Settings.SoundFilePath, UpdateSourceTrigger=LostFocus}" Padding="6,4"/>
             </DockPanel>
 
+            <!-- Time-of-day shift alarms -->
+            <TextBlock Text="Time-of-day alarms" Foreground="#88FFFFFF" Margin="0,24,0,4" FontWeight="SemiBold"/>
+            <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,8">
+                Project Gorgon's in-game day has six named periods. Enable a shift to ring an alarm when
+                it begins (every ~2 real hours per shift). Picking a sound here overrides the global
+                default for that shift only; leave it blank to inherit the global default above.
+            </TextBlock>
+            <ItemsControl ItemsSource="{Binding ShiftRows}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <DockPanel Margin="0,0,0,4" LastChildFill="True">
+                            <CheckBox DockPanel.Dock="Left" Width="180"
+                                      IsChecked="{Binding Config.Enabled}"
+                                      Content="{Binding Display}"
+                                      Foreground="#FFE8E8E8" VerticalAlignment="Center"/>
+                            <Button DockPanel.Dock="Right" Content="Browse..." Padding="10,4" Margin="6,0,0,0"
+                                    Click="BrowseShift_Click"/>
+                            <Button DockPanel.Dock="Right" Content="Test" Padding="10,4" Margin="6,0,0,0"
+                                    Click="TestShift_Click"/>
+                            <Button DockPanel.Dock="Right" Content="Clear" Padding="8,4" Margin="6,0,0,0"
+                                    Click="ClearShift_Click" ToolTip="Reset to global default sound"/>
+                            <TextBox Text="{Binding Config.SoundFilePath, UpdateSourceTrigger=LostFocus, TargetNullValue=''}"
+                                     Padding="6,4"
+                                     IsEnabled="{Binding Config.Enabled}"/>
+                        </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
             <!-- Danger zone -->
             <Border Margin="0,24,0,0" Padding="0,12,0,0" BorderBrush="#33FFFFFF" BorderThickness="0,1,0,0">
                 <StackPanel>

--- a/src/Gandalf.Module/Views/GandalfSettingsView.xaml.cs
+++ b/src/Gandalf.Module/Views/GandalfSettingsView.xaml.cs
@@ -42,4 +42,34 @@ public partial class GandalfSettingsView : System.Windows.Controls.UserControl
         var s = CurrentSettings;
         if (s is not null) s.SoundFilePath = null;
     }
+
+    private static Gandalf.ViewModels.ShiftAlarmRow? RowFor(object sender) =>
+        (sender as System.Windows.FrameworkElement)?.DataContext
+            as Gandalf.ViewModels.ShiftAlarmRow;
+
+    private void BrowseShift_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowFor(sender) is not { } row) return;
+        var dlg = new OpenFileDialog
+        {
+            Title = $"Choose an alarm sound for {row.Shift.Label}",
+            Filter = AudioPlayer.OpenFileFilter,
+        };
+        if (dlg.ShowDialog() == true) row.Config.SoundFilePath = dlg.FileName;
+    }
+
+    private void TestShift_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowFor(sender) is not { } row) return;
+        var s = CurrentSettings;
+        var path = row.Config.SoundFilePath ?? s?.SoundFilePath;
+        var volume = (float?)s?.AlarmVolume ?? 1.0f;
+        _testHandle?.Stop();
+        _testHandle = AudioPlayer.Play(path, volume, "gandalf");
+    }
+
+    private void ClearShift_Click(object sender, RoutedEventArgs e)
+    {
+        if (RowFor(sender) is { } row) row.Config.SoundFilePath = null;
+    }
 }

--- a/src/Mithril.Shared/Game/TimeOfDayShifts.cs
+++ b/src/Mithril.Shared/Game/TimeOfDayShifts.cs
@@ -1,0 +1,59 @@
+namespace Mithril.Shared.Game;
+
+/// <summary>
+/// One named portion of the in-game day. <see cref="StartHour"/> is the
+/// in-game hour at which the shift begins; the shift runs until the next
+/// shift's start hour.
+/// </summary>
+public sealed record ShiftDefinition(string Slug, string Label, string Emoji, int StartHour);
+
+/// <summary>
+/// The six named in-game-time-of-day shifts published by Project Gorgon's
+/// community tooling.
+///
+/// <para>Source: <c>https://pgemissary.com/static/js/game_clock.js</c> — the
+/// <c>TIME_OF_DAY</c> constant. Snapshotted here on 2026-05-09 because
+/// pgemissary publishes the table only as a JS constant on a page that
+/// loads dynamically — there's no API surface to fetch it from at runtime.
+/// If pgemissary updates the schedule (re-anchoring a shift's start hour,
+/// renaming a label), mirror the change here in coordination with
+/// whatever Gorgon release prompts it. Same trust model as the in-game
+/// clock anchor in <see cref="GameClock"/>.</para>
+/// </summary>
+public static class TimeOfDayShifts
+{
+    public static readonly IReadOnlyList<ShiftDefinition> All =
+    [
+        new("midnight",  "Midnight",  "\U0001F311",            0),  // 0:00–4:59
+        new("dawn",      "Dawn",      "\U0001F305",            5),  // 5:00–7:59
+        new("morning",   "Morning",   "☀️",          8),  // 8:00–11:59
+        new("afternoon", "Afternoon", "\U0001F324️",     12),  // 12:00–16:59
+        new("dusk",      "Dusk",      "\U0001F307",           17),  // 17:00–19:59
+        new("night",     "Night",     "\U0001F319",           20),  // 20:00–23:59
+    ];
+
+    /// <summary>
+    /// The earliest real-time instant ≥ <paramref name="floor"/> at which
+    /// any shift's <c>StartHour</c> is reached, plus the shift definition
+    /// that begins at that moment. Built on
+    /// <see cref="IGameClock.NextOccurrence"/>: each shift's transition is
+    /// "the next real-time moment the in-game clock reads <c>StartHour:00</c>",
+    /// and we return the soonest across all six.
+    /// </summary>
+    public static (DateTimeOffset At, ShiftDefinition Shift) NextTransition(
+        IGameClock clock, DateTimeOffset floor)
+    {
+        DateTimeOffset? soonestAt = null;
+        ShiftDefinition? soonestShift = null;
+        foreach (var shift in All)
+        {
+            var at = clock.NextOccurrence(new GameTimeOfDay(shift.StartHour, 0), floor);
+            if (soonestAt is null || at < soonestAt)
+            {
+                soonestAt = at;
+                soonestShift = shift;
+            }
+        }
+        return (soonestAt!.Value, soonestShift!);
+    }
+}

--- a/tests/Gandalf.Tests/ShiftAlarmServiceTests.cs
+++ b/tests/Gandalf.Tests/ShiftAlarmServiceTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Coverage for <see cref="ShiftAlarmService"/>. Exercise the resolution
+/// helpers (<c>ShouldAlarm</c> / <c>ResolveSoundPath</c>) and the scheduling
+/// state (<c>NextScheduledShift</c>) without driving the WPF dispatcher pump
+/// or invoking <c>AudioPlayer.Play</c> — global <c>AlarmEnabled = false</c>
+/// short-circuits the audio path on tick.
+/// </summary>
+public class ShiftAlarmServiceTests
+{
+    private static readonly DateTime PgEmissaryAnchorUtc =
+        new(2026, 3, 11, 1, 45, 1, 212, DateTimeKind.Utc);
+
+    private sealed class ManualTime : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public ManualTime(DateTime utc) => _now = new DateTimeOffset(utc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+
+    [Fact]
+    public void ShouldAlarm_requires_both_global_enabled_and_per_shift_enabled()
+    {
+        var on = new GandalfSettings { AlarmEnabled = true };
+        var off = new GandalfSettings { AlarmEnabled = false };
+        var enabled = new ShiftAlarmConfig { Enabled = true };
+        var disabled = new ShiftAlarmConfig { Enabled = false };
+
+        ShiftAlarmService.ShouldAlarm(enabled, on).Should().BeTrue();
+        ShiftAlarmService.ShouldAlarm(disabled, on).Should().BeFalse("per-shift toggle is off");
+        ShiftAlarmService.ShouldAlarm(enabled, off).Should().BeFalse("global alarms are off");
+        ShiftAlarmService.ShouldAlarm(disabled, off).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResolveSoundPath_prefers_per_shift_over_global()
+    {
+        var global = new GandalfSettings { SoundFilePath = @"C:\global\default.wav" };
+        var withOverride = new ShiftAlarmConfig { SoundFilePath = @"C:\custom\dawn.wav" };
+        ShiftAlarmService.ResolveSoundPath(withOverride, global).Should().Be(@"C:\custom\dawn.wav");
+    }
+
+    [Fact]
+    public void ResolveSoundPath_falls_back_to_global_when_per_shift_is_null()
+    {
+        var global = new GandalfSettings { SoundFilePath = @"C:\global\default.wav" };
+        var bare = new ShiftAlarmConfig { SoundFilePath = null };
+        ShiftAlarmService.ResolveSoundPath(bare, global).Should().Be(@"C:\global\default.wav");
+    }
+
+    [Fact]
+    public void ResolveSoundPath_returns_null_when_neither_is_set()
+    {
+        ShiftAlarmService.ResolveSoundPath(new ShiftAlarmConfig(), new GandalfSettings()).Should().BeNull();
+    }
+
+    [Fact]
+    public void Initial_schedule_picks_the_next_transition_after_construction()
+    {
+        // At anchor, in-game = 21:00 (Night). Next transition is Midnight at 0:00,
+        // 3 in-game hours away = 15 real minutes.
+        var time = new ManualTime(PgEmissaryAnchorUtc);
+        var clock = new GameClock(time);
+        var settings = new GandalfSettings { AlarmEnabled = false };  // suppress audio path
+        var shifts = new GandalfShiftSettings();
+
+        using var svc = new ShiftAlarmService(clock, settings, shifts, time);
+        svc.NextScheduledShift.Should().NotBeNull();
+        svc.NextScheduledShift!.Slug.Should().Be("midnight");
+    }
+
+    [Fact]
+    public void After_tick_reschedules_for_the_following_shift()
+    {
+        // At anchor, scheduledFor = midnight. Advance time past the midnight
+        // transition (15 real minutes + 1 second) and force a tick. The
+        // service should re-arm for Dawn (the next transition).
+        var time = new ManualTime(PgEmissaryAnchorUtc);
+        var clock = new GameClock(time);
+        var settings = new GandalfSettings { AlarmEnabled = false };
+        var shifts = new GandalfShiftSettings();
+
+        using var svc = new ShiftAlarmService(clock, settings, shifts, time);
+        svc.NextScheduledShift!.Slug.Should().Be("midnight");
+
+        time.Advance(TimeSpan.FromMinutes(15) + TimeSpan.FromSeconds(1));
+        svc.TickForTests();
+
+        // Midnight (00:00) → Dawn (05:00) is 5 in-game hours = 25 real minutes;
+        // we just used 15 min + 1s so the rescheduled instant is ~25 minutes
+        // out from the new "now", anchored on Dawn.
+        svc.NextScheduledShift!.Slug.Should().Be("dawn");
+    }
+
+    [Fact]
+    public void GetOrCreate_returns_a_disabled_default_for_an_untouched_shift()
+    {
+        var shifts = new GandalfShiftSettings();
+        // Ensure no auto-enable lurking — the user must opt in per shift.
+        foreach (var s in TimeOfDayShifts.All)
+        {
+            var c = shifts.GetOrCreate(s.Slug);
+            c.Enabled.Should().BeFalse();
+            c.SoundFilePath.Should().BeNull();
+        }
+    }
+}

--- a/tests/Mithril.Shared.Tests/TimeOfDayShiftsTests.cs
+++ b/tests/Mithril.Shared.Tests/TimeOfDayShiftsTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Mithril.Shared.Game;
+using Xunit;
+
+namespace Mithril.Shared.Tests;
+
+public class TimeOfDayShiftsTests
+{
+    private static readonly DateTime PgEmissaryAnchorUtc =
+        new(2026, 3, 11, 1, 45, 1, 212, DateTimeKind.Utc);
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTimeProvider(DateTime utc) => _now = new DateTimeOffset(utc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    [Fact]
+    public void All_six_shifts_are_published_in_StartHour_order()
+    {
+        var slugs = TimeOfDayShifts.All.Select(s => s.Slug).ToArray();
+        slugs.Should().Equal("midnight", "dawn", "morning", "afternoon", "dusk", "night");
+        TimeOfDayShifts.All.Select(s => s.StartHour).Should().Equal(0, 5, 8, 12, 17, 20);
+    }
+
+    [Fact]
+    public void NextTransition_at_anchor_returns_midnight_at_3_real_hours_out()
+    {
+        // At anchor, in-game time = 21:00 (Night). The next shift transition is
+        // midnight at 0:00 in-game = 3 in-game hours later = 15 real minutes.
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc, TimeSpan.Zero);
+        var clock = new GameClock(new FixedTimeProvider(PgEmissaryAnchorUtc));
+        var (at, shift) = TimeOfDayShifts.NextTransition(clock, floor);
+
+        shift.Slug.Should().Be("midnight");
+        (at - floor).Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public void NextTransition_just_after_a_transition_skips_to_the_following_shift()
+    {
+        // 1 real second after anchor: in-game ≈ 21:00:12. Next transition is
+        // still midnight (we crossed nothing in 1 s). Conversely, 16 real minutes
+        // after anchor → in-game = 0:12 (already past midnight) → next transition
+        // is dawn at 5:00 in-game = 4h48m in-game later = 24 real minutes.
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc.AddMinutes(16), TimeSpan.Zero);
+        var clock = new GameClock(new FixedTimeProvider(floor.UtcDateTime));
+        var (at, shift) = TimeOfDayShifts.NextTransition(clock, floor);
+
+        shift.Slug.Should().Be("dawn");
+        // 5:00 - 0:12 = 4h48m in-game = 288 in-game minutes / 12 = 24 real minutes.
+        (at - floor).Should().Be(TimeSpan.FromMinutes(24));
+    }
+
+    [Theory]
+    [InlineData(0, "dawn")]       // Midnight start → next is Dawn
+    [InlineData(4, "dawn")]       // Mid-Midnight → next is Dawn
+    [InlineData(5, "morning")]    // Dawn start → next is Morning
+    [InlineData(11, "afternoon")] // End of Morning → next is Afternoon
+    [InlineData(12, "dusk")]      // Afternoon start → next is Dusk
+    [InlineData(16, "dusk")]      // End of Afternoon → next is Dusk
+    [InlineData(17, "night")]     // Dusk start → next is Night
+    [InlineData(20, "midnight")]  // Night start → next is Midnight (next day)
+    [InlineData(23, "midnight")]  // End of Night → next is Midnight
+    public void NextTransition_picks_the_subsequent_shift_for_each_in_game_hour(
+        int gameHour, string expectedNextSlug)
+    {
+        // Construct a real-time floor whose in-game-hour matches the test case.
+        // From anchor (21:00 in-game), we need to advance Δ real minutes such
+        // that in-game = gameHour:30 (mid-shift, to avoid the 50ms epsilon edge).
+        // Δ_game_minutes = ((gameHour * 60 + 30) - 21*60 + 24*60) % (24*60)
+        var deltaGameMinutes = ((gameHour * 60 + 30) - 21 * 60 + 24 * 60) % (24 * 60);
+        var deltaRealMinutes = deltaGameMinutes / 12.0;
+        var floor = new DateTimeOffset(PgEmissaryAnchorUtc, TimeSpan.Zero)
+                        .AddMinutes(deltaRealMinutes);
+        var clock = new GameClock(new FixedTimeProvider(floor.UtcDateTime));
+
+        var (_, shift) = TimeOfDayShifts.NextTransition(clock, floor);
+        shift.Slug.Should().Be(expectedNextSlug);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds alarms tied to Project Gorgon's six in-game time-of-day shifts (**Midnight / Dawn / Morning / Afternoon / Dusk / Night**) with a per-shift custom sound. Source: pgemissary's [\`static/js/game_clock.js\` \`TIME_OF_DAY\` constant](https://pgemissary.com/static/js/game_clock.js), bundled here as [\`TimeOfDayShifts.All\`](src/Mithril.Shared/Game/TimeOfDayShifts.cs).
- Settings UI gains a \"Time-of-day alarms\" section in [\`GandalfSettingsView.xaml\`](src/Gandalf.Module/Views/GandalfSettingsView.xaml) — six rows with enable checkbox + sound textbox + Browse / Test / Clear, mirroring the per-timer Sound row from #166.
- Closes #167.

## Architecture decision

The issue sketch suggested implementing this as \`ShiftSource : ITimerSource\`. I deviated — shifts have no per-character state, no Start/Done lifecycle, and no user CRUD, so the \`ITimerSource\` ceremony was over-scope. Instead:

- [\`ShiftAlarmService\`](src/Gandalf.Module/Services/ShiftAlarmService.cs) owns one \`DispatcherTimer\` scheduled at the next transition, computed via [\`TimeOfDayShifts.NextTransition\`](src/Mithril.Shared/Game/TimeOfDayShifts.cs) (a soonest-of-six sweep over [\`IGameClock.NextOccurrence\`](src/Mithril.Shared/Game/GameClock.cs)).
- Captures \`_scheduledFor\` at scheduling time so the fire decision is \"play this specific shift\", not \"figure out which shift just transitioned.\"
- Eager singleton — resolved by the Gandalf shell view factory so the timer starts running as soon as the Eager-activation module loads.
- Trust model for the shift table mirrors the in-game-clock anchor: it's a snapshot from pgemissary's published data, with a comment pointing back to the source. Re-mirror here if pgemissary changes the schedule.

## What changed

- **New** [\`Mithril.Shared/Game/TimeOfDayShifts.cs\`](src/Mithril.Shared/Game/TimeOfDayShifts.cs) — \`ShiftDefinition\` record + the six-entry \`All\` list + \`NextTransition\` helper.
- **New** [\`Gandalf.Module/Domain/GandalfShiftSettings.cs\`](src/Gandalf.Module/Domain/GandalfShiftSettings.cs) — per-shift-slug map of \`{ Enabled, SoundFilePath }\`, JSON-source-gen context. Persists to \`%LocalAppData%/Mithril/Gandalf/shifts.json\`.
- **New** [\`Gandalf.Module/Services/ShiftAlarmService.cs\`](src/Gandalf.Module/Services/ShiftAlarmService.cs) — the dispatcher-timer-driven service. Static \`ShouldAlarm\` + \`ResolveSoundPath\` helpers extracted for testability without driving the WPF pump.
- **Wiring** in [\`GandalfModule.cs\`](src/Gandalf.Module/GandalfModule.cs) — \`AddMithrilSettings<GandalfShiftSettings>\` for persistence, \`AddSingleton<ShiftAlarmService>\`, and an eager-resolve in the shell view factory parallel to \`TimerExpirationScheduler\`.
- **Settings UI** in [\`GandalfSettingsView.xaml\` + \`.xaml.cs\`](src/Gandalf.Module/Views/GandalfSettingsView.xaml) — new \"Time-of-day alarms\" section with an \`ItemsControl\` over the new \`ShiftRows\` collection on [\`GandalfSettingsViewModel\`](src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs).

## Test plan

- [x] **Unit:** all 1550 tests green. New coverage:
  - [\`TimeOfDayShiftsTests.cs\`](tests/Mithril.Shared.Tests/TimeOfDayShiftsTests.cs) — table integrity (six shifts in start-hour order), \`NextTransition\` correctness at anchor + just-after-transition + nine theory-driven mid-shift hours.
  - [\`ShiftAlarmServiceTests.cs\`](tests/Gandalf.Tests/ShiftAlarmServiceTests.cs) — \`ShouldAlarm\` truth table, \`ResolveSoundPath\` per-shift-vs-global precedence, initial scheduling picks the right next shift, post-tick reschedules to the *following* shift, untouched shifts default to disabled.
- [ ] **Manual E2E (owner verifies before merge):**
  - [ ] Open Gandalf settings — confirm the new \"Time-of-day alarms\" section renders six rows with the right emoji + label + start hour.
  - [ ] Enable Dawn, hit Test — confirm the global default sound plays.
  - [ ] Pick a custom sound for Dawn via Browse, hit Test again — confirm the custom one plays.
  - [ ] Wait until the next Dawn transition (or pick a shift that's coming up soon) — confirm the alarm fires once at the transition.
  - [ ] Close + relaunch Mithril — confirm the per-shift toggles + sound paths persist and the service rearms for the next transition.
  - [ ] Toggle the global \"Enabled\" alarm switch off — confirm shift alarms also go silent (global gates per-shift).

## Follow-ups

- Filing a separate issue for **moon-phase alarms** (Arthur's other ask) — different cadence (multi-day cycles), different data source (\`/moon\` endpoint on pgemissary), but same per-event-sound pattern this PR establishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)