### PR TITLE
shell: 12/24h clock preference, respected throughout

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -145,7 +145,8 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<TimerAlarmService>(),
             sp.GetRequiredService<IDialogService>(),
             sp.GetRequiredService<IActiveCharacterService>(),
-            sp.GetRequiredService<ICharacterPresenceService>()));
+            sp.GetRequiredService<ICharacterPresenceService>(),
+            sp.GetRequiredService<Mithril.Shared.Settings.UserPreferences>()));
 
         services.AddSingleton<GandalfShellViewModel>();
         services.AddSingleton<GandalfShellView>(sp =>

--- a/src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs
@@ -1,9 +1,11 @@
+using System.ComponentModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Gandalf.Domain;
 using Gandalf.Services;
 using Mithril.Shared.Game;
+using Mithril.Shared.Settings;
 
 namespace Gandalf.ViewModels;
 
@@ -12,20 +14,41 @@ namespace Gandalf.ViewModels;
 /// <see cref="ShiftDefinition"/> (display data) with the live
 /// <see cref="ShiftAlarmConfig"/> (Enabled + SoundFilePath, INPC).
 /// The XAML <c>ItemsControl</c> binds to one of these per shift.
+/// <see cref="Display"/> re-fires INPC when the user flips the
+/// 12/24h preference, so the rows reformat live in the open settings panel.
 /// </summary>
-public sealed class ShiftAlarmRow
+public sealed class ShiftAlarmRow : INotifyPropertyChanged
 {
-    public ShiftAlarmRow(ShiftDefinition shift, ShiftAlarmConfig config)
+    private readonly UserPreferences _preferences;
+
+    public ShiftAlarmRow(ShiftDefinition shift, ShiftAlarmConfig config, UserPreferences preferences)
     {
         Shift = shift;
         Config = config;
+        _preferences = preferences;
+        _preferences.PropertyChanged += OnPreferencesChanged;
     }
 
     public ShiftDefinition Shift { get; }
     public ShiftAlarmConfig Config { get; }
 
     public string Slug => Shift.Slug;
-    public string Display => $"{Shift.Emoji}  {Shift.Label}  ({Shift.StartHour}:00 in-game)";
+    public string Display
+    {
+        get
+        {
+            var formatted = new GameTimeOfDay(Shift.StartHour, 0).Format(_preferences.Use24HourClock);
+            return $"{Shift.Emoji}  {Shift.Label}  ({formatted} in-game)";
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPreferencesChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(UserPreferences.Use24HourClock))
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Display)));
+    }
 }
 
 /// <summary>
@@ -42,13 +65,14 @@ public sealed partial class GandalfSettingsViewModel : ObservableObject
         GandalfSettings settings,
         TimerDefinitionsService defs,
         TimerProgressService progress,
-        GandalfShiftSettings shiftSettings)
+        GandalfShiftSettings shiftSettings,
+        UserPreferences preferences)
     {
         Settings = settings;
         _defs = defs;
         _progress = progress;
         ShiftRows = TimeOfDayShifts.All
-            .Select(s => new ShiftAlarmRow(s, shiftSettings.GetOrCreate(s.Slug)))
+            .Select(s => new ShiftAlarmRow(s, shiftSettings.GetOrCreate(s.Slug), preferences))
             .ToArray();
     }
 

--- a/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Gandalf.Domain;
+using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf.Dialogs;
 
 namespace Gandalf.ViewModels;
@@ -9,21 +10,35 @@ namespace Gandalf.ViewModels;
 public sealed partial class TimerDialogViewModel : DialogViewModelBase
 {
     /// <summary>
-    /// Locked-down culture for the in-game-time picker. Forces zero-padded
-    /// 12-hour format (<c>hh:mm tt</c>) regardless of the user's system
-    /// locale. Vanilla <c>en-US</c> uses <c>h:mm:ss tt</c> — single-digit
-    /// hour and a stray seconds component the picker can't actually edit
-    /// (we hide the seconds spinner via <c>PickerVisibility="HourMinute"</c>).
+    /// Locked-down 12-hour culture for the picker — zero-padded
+    /// <c>hh:mm tt</c>. Vanilla <c>en-US</c> uses <c>h:mm:ss tt</c>
+    /// (single-digit hour, plus a stray seconds component the picker
+    /// can't actually edit since we hide the seconds spinner).
     /// </summary>
-    public static CultureInfo PickerCulture { get; } = BuildPickerCulture();
+    private static readonly CultureInfo TwelveHourCulture = BuildCulture("hh:mm tt");
 
-    private static CultureInfo BuildPickerCulture()
+    /// <summary>
+    /// Zero-padded 24-hour culture for the picker. Built from the same
+    /// <c>en-US</c> base so the date layout is unchanged — only the time
+    /// pattern flips.
+    /// </summary>
+    private static readonly CultureInfo TwentyFourHourCulture = BuildCulture("HH:mm");
+
+    private static CultureInfo BuildCulture(string timePattern)
     {
         var c = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
-        c.DateTimeFormat.ShortTimePattern = "hh:mm tt";
-        c.DateTimeFormat.LongTimePattern = "hh:mm tt";
+        c.DateTimeFormat.ShortTimePattern = timePattern;
+        c.DateTimeFormat.LongTimePattern = timePattern;
         return c;
     }
+
+    /// <summary>
+    /// Picker culture for *this* dialog. Latched at construction from the
+    /// user's <see cref="UserPreferences.Use24HourClock"/> preference. The
+    /// dialog is short-lived; toggling the global preference while a
+    /// dialog is open is an edge case we don't try to live-react to.
+    /// </summary>
+    public CultureInfo PickerCulture { get; }
 
     private readonly bool _isEditing;
     private readonly bool _areInputsEditable;
@@ -86,8 +101,10 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
         GandalfTimerDef? existing,
         bool isIdleOnActive,
         IReadOnlyList<string> knownRegions,
-        IReadOnlyList<string> knownMaps)
+        IReadOnlyList<string> knownMaps,
+        UserPreferences preferences)
     {
+        PickerCulture = preferences.Use24HourClock ? TwentyFourHourCulture : TwelveHourCulture;
         foreach (var r in knownRegions) KnownRegions.Add(r);
         foreach (var m in knownMaps) KnownMaps.Add(m);
 

--- a/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
@@ -8,6 +8,7 @@ using Gandalf.Domain;
 using Gandalf.Services;
 using Gandalf.Views;
 using Mithril.Shared.Character;
+using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf.Dialogs;
 
 namespace Gandalf.ViewModels;
@@ -21,6 +22,7 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
     private readonly IDialogService? _dialogService;
     private readonly IActiveCharacterService? _active;
     private readonly ICharacterPresenceService? _presence;
+    private readonly UserPreferences? _preferences;
     private readonly TimeProvider _time;
     private readonly TimerDisplayScheduler _scheduler;
     private readonly TimerSourceBinder _binder;
@@ -34,6 +36,7 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         IDialogService? dialogService = null,
         IActiveCharacterService? active = null,
         ICharacterPresenceService? presence = null,
+        UserPreferences? preferences = null,
         TimeProvider? time = null)
     {
         _source = source;
@@ -43,6 +46,7 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         _dialogService = dialogService;
         _active = active;
         _presence = presence;
+        _preferences = preferences;
         _time = time ?? TimeProvider.System;
 
         TimersView = CollectionViewSource.GetDefaultView(Timers);
@@ -79,7 +83,8 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
     private void AddTimer()
     {
         if (_defs is null || _dialogService is null) return;
-        var vm = new TimerDialogViewModel(existing: null, isIdleOnActive: true, KnownRegions, KnownMaps);
+        var vm = new TimerDialogViewModel(existing: null, isIdleOnActive: true, KnownRegions, KnownMaps,
+            _preferences ?? new UserPreferences());
         var content = new TimerDialogContent();
 
         if (_dialogService.ShowDialog(vm, content) != true) return;
@@ -105,7 +110,8 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         if (item.Catalog.SourceMetadata is not GandalfTimerDef existing) return;
 
         var isIdleOnActive = item.State == TimerState.Idle;
-        var vm = new TimerDialogViewModel(existing, isIdleOnActive, KnownRegions, KnownMaps);
+        var vm = new TimerDialogViewModel(existing, isIdleOnActive, KnownRegions, KnownMaps,
+            _preferences ?? new UserPreferences());
         var content = new TimerDialogContent();
 
         if (_dialogService.ShowDialog(vm, content) != true) return;

--- a/src/Gandalf.Module/Views/TimerDialogContent.xaml
+++ b/src/Gandalf.Module/Views/TimerDialogContent.xaml
@@ -68,7 +68,7 @@
                 arithmetic are unaffected.
             -->
             <mah:TimePicker SelectedDateTime="{Binding SelectedGameDateTime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            Culture="{x:Static vm:TimerDialogViewModel.PickerCulture}"
+                            Culture="{Binding PickerCulture}"
                             PickerVisibility="HourMinute"
                             HandVisibility="HourMinute"
                             HoursItemStringFormat="{}{0:D2}"

--- a/src/Mithril.Shared/Game/GameClock.cs
+++ b/src/Mithril.Shared/Game/GameClock.cs
@@ -39,6 +39,17 @@ public readonly record struct GameTimeOfDay(int Hour, int Minute)
         var ampm = Hour < 12 ? "AM" : "PM";
         return $"{h12}:{Minute:D2} {ampm}";
     }
+
+    public string ToString24Hour() => $"{Hour:D2}:{Minute:D2}";
+
+    /// <summary>
+    /// Format this time-of-day according to the user's
+    /// <see cref="Settings.UserPreferences.Use24HourClock"/> preference.
+    /// Centralized here so every consumer (shell label, picker preview,
+    /// settings rows) routes through the same logic.
+    /// </summary>
+    public string Format(bool use24Hour) =>
+        use24Hour ? ToString24Hour() : ToString12Hour();
 }
 
 public sealed class GameClock : IGameClock

--- a/src/Mithril.Shared/Settings/UserPreferences.cs
+++ b/src/Mithril.Shared/Settings/UserPreferences.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+
+namespace Mithril.Shared.Settings;
+
+/// <summary>
+/// Cross-cutting display + behavior preferences that span more than one
+/// module. Lives in <c>Mithril.Shared</c> (not the shell) so module-level
+/// consumers — Gandalf's TimerDialog picker, ShiftAlarmRow display strings,
+/// shell's in-game-clock label, etc. — can read it without taking a
+/// dependency on <c>Mithril.Shell</c>.
+///
+/// <para>Persisted to <c>%LocalAppData%/Mithril/preferences.json</c>. Loaded
+/// via <see cref="DependencyInjection.ServiceCollectionExtensions.AddMithrilSettings{T}"/>.</para>
+/// </summary>
+public sealed class UserPreferences : INotifyPropertyChanged
+{
+    private bool _use24HourClock;
+
+    /// <summary>
+    /// When <c>true</c>, in-game time is rendered as <c>HH:mm</c> (24-hour);
+    /// otherwise <c>h:mm AM/PM</c>. Defaults to <c>false</c> so existing
+    /// users see the same display they had before this preference shipped.
+    /// </summary>
+    public bool Use24HourClock
+    {
+        get => _use24HourClock;
+        set => Set(ref _use24HourClock, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(UserPreferences))]
+public partial class UserPreferencesJsonContext : JsonSerializerContext { }

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -129,7 +129,15 @@ public static class Program
             var builder = Host.CreateApplicationBuilder(args);
             var audioSettings = new AudioSettings { ConcurrentAlarms = shellSettings.ConcurrentAlarms };
 
+            // Cross-cutting user preferences (12/24h clock, future display
+            // toggles). Lives in Mithril.Shared so modules can read it
+            // without depending on Mithril.Shell. Persisted to
+            // %LocalAppData%/Mithril/preferences.json — top-level so it's
+            // shared across modules, not nested under Shell/.
+            var preferencesPath = Path.Combine(localApp, "Mithril", "preferences.json");
+
             builder.Services
+                .AddMithrilSettings<UserPreferences>(preferencesPath, UserPreferencesJsonContext.Default.UserPreferences)
                 .AddSingleton<ISettingsStore<ShellSettings>>(shellStore)
                 .AddSingleton(shellSettings)
                 .AddSingleton<IActiveCharacterPersistence>(shellSettings)

--- a/src/Mithril.Shell/ViewModels/AppearanceSettingsViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/AppearanceSettingsViewModel.cs
@@ -1,16 +1,19 @@
 using System.Collections.ObjectModel;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Shared.Settings;
 
 namespace Mithril.Shell.ViewModels;
 
 public sealed partial class AppearanceSettingsViewModel : ObservableObject
 {
     public ShellSettings Settings { get; }
+    public UserPreferences Preferences { get; }
 
-    public AppearanceSettingsViewModel(ShellSettings settings)
+    public AppearanceSettingsViewModel(ShellSettings settings, UserPreferences preferences)
     {
         Settings = settings;
+        Preferences = preferences;
         AvailableFonts = new ObservableCollection<string>(
             Fonts.SystemFontFamilies
                 .Select(f => f.Source)

--- a/src/Mithril.Shell/ViewModels/ShellViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/ShellViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Character;
 using Mithril.Shared.Game;
 using Mithril.Shared.Modules;
+using Mithril.Shared.Settings;
 using Mithril.Shell.Updates;
 using MahApps.Metro.IconPacks;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,6 +46,7 @@ public sealed partial class ShellViewModel : ObservableObject
 {
     private readonly IServiceProvider _services;
     private readonly ShellSettings _settings;
+    private readonly UserPreferences _preferences;
     private readonly IActiveCharacterService _activeChar;
     private readonly IUpdateStatusService _updateStatus;
     private readonly IUpdateApplier _updateApplier;
@@ -59,6 +61,7 @@ public sealed partial class ShellViewModel : ObservableObject
         IServiceProvider services,
         IEnumerable<IMithrilModule> modules,
         ShellSettings settings,
+        UserPreferences preferences,
         ModuleGates gates,
         IActiveCharacterService activeChar,
         IUpdateStatusService updateStatus,
@@ -68,6 +71,7 @@ public sealed partial class ShellViewModel : ObservableObject
     {
         _services = services;
         _settings = settings;
+        _preferences = preferences;
         _gates = gates;
         _activeChar = activeChar;
         _updateStatus = updateStatus;
@@ -84,6 +88,7 @@ public sealed partial class ShellViewModel : ObservableObject
         _activeChar.CharacterExportsChanged += (_, _) => DispatchRefreshCharacter();
         _updateStatus.StateChanged += (_, _) => RefreshUpdateStatus();
         _settings.PropertyChanged += OnSettingsChanged;
+        _preferences.PropertyChanged += OnPreferencesChanged;
         _attention.AttentionChanged += OnAttentionChanged;
         RefreshCharacter();
         RefreshUpdateStatus();
@@ -98,7 +103,19 @@ public sealed partial class ShellViewModel : ObservableObject
 
     private void RefreshGameTime()
     {
-        GameTimeText = _gameClock.GetCurrent().ToString12Hour();
+        GameTimeText = _gameClock.GetCurrent().Format(_preferences.Use24HourClock);
+    }
+
+    private void OnPreferencesChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        // The 12/24h toggle should preview live — re-render the label as soon as
+        // the user flips it, instead of waiting up to 5 s for the next tick.
+        if (e.PropertyName == nameof(UserPreferences.Use24HourClock))
+        {
+            var d = System.Windows.Application.Current?.Dispatcher;
+            if (d is null || d.CheckAccess()) RefreshGameTime();
+            else d.InvokeAsync(RefreshGameTime);
+        }
     }
 
     private void OnAttentionChanged(object? sender, AttentionChangedEventArgs e)

--- a/src/Mithril.Shell/Views/AppearanceSettingsView.xaml
+++ b/src/Mithril.Shell/Views/AppearanceSettingsView.xaml
@@ -36,6 +36,13 @@
                         VerticalAlignment="Center"/>
             </DockPanel>
 
+            <TextBlock Text="In-game clock format" Foreground="#88FFFFFF" Margin="0,24,0,4" FontWeight="SemiBold"/>
+            <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,6"
+                       Text="How in-game time-of-day is displayed across the app — the shell's clock, Gandalf's in-game-time picker, and the time-of-day shift labels."/>
+            <CheckBox Content="Use 24-hour format (HH:mm) instead of 12-hour (h:mm AM/PM)"
+                      IsChecked="{Binding Preferences.Use24HourClock, Mode=TwoWay}"
+                      Foreground="#FFE8E8E8"/>
+
             <TextBlock Text="Developer mode" Foreground="#88FFFFFF" Margin="0,24,0,4" FontWeight="SemiBold"/>
             <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,6"
                        Text="Show developer/diagnostic modules in the sidebar (e.g. live inventory inspector). Off by default."/>

--- a/tests/Mithril.Shared.Tests/GameClockTests.cs
+++ b/tests/Mithril.Shared.Tests/GameClockTests.cs
@@ -61,6 +61,27 @@ public class GameClockTests
         new GameTimeOfDay(hour, minute).ToString12Hour().Should().Be(expected);
     }
 
+    [Theory]
+    [InlineData(0, 0, "00:00")]
+    [InlineData(0, 5, "00:05")]
+    [InlineData(8, 7, "08:07")]
+    [InlineData(13, 30, "13:30")]
+    [InlineData(23, 59, "23:59")]
+    public void ToString24Hour_FormatsCorrectly(int hour, int minute, string expected)
+    {
+        new GameTimeOfDay(hour, minute).ToString24Hour().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(false, 13, 30, "1:30 PM")]
+    [InlineData(true, 13, 30, "13:30")]
+    [InlineData(false, 0, 0, "12:00 AM")]
+    [InlineData(true, 0, 0, "00:00")]
+    public void Format_routes_through_the_correct_format(bool use24Hour, int hour, int minute, string expected)
+    {
+        new GameTimeOfDay(hour, minute).Format(use24Hour).Should().Be(expected);
+    }
+
     [Fact]
     public void NextOccurrence_TargetEqualsCurrent_AdvancesFullCycle()
     {


### PR DESCRIPTION
## Summary

- Adds a single shared user preference, [\`UserPreferences.Use24HourClock\`](src/Mithril.Shared/Settings/UserPreferences.cs), that every consumer of in-game time-of-day display routes through.
- One toggle UI in [\`AppearanceSettingsView\`](src/Mithril.Shell/Views/AppearanceSettingsView.xaml) (alongside font family / size).
- Default is **off** (12-hour) so existing installs see no display change.

## Where it's respected

| Consumer | Behavior |
|---|---|
| Shell's \"In-Game Time\" label | Live re-renders on toggle (subscribes to \`UserPreferences.PropertyChanged\`) |
| Gandalf's TimerDialog \`mah:TimePicker\` | Picker culture flips between zero-padded \`hh:mm tt\` and \`HH:mm\`. Latched at dialog construction since the dialog is short-lived |
| Gandalf settings → time-of-day shift rows | Live re-renders via INPC on \`ShiftAlarmRow.Display\` so the user can flip 12/24h while looking at the panel and see rows reformat immediately |

## Architecture

- **Setting lives in \`Mithril.Shared\`** so module-level consumers (Gandalf's TimerDialog, ShiftAlarmRow) can read it without depending on \`Mithril.Shell\`.
- **Persistence:** \`%LocalAppData%/Mithril/preferences.json\`, loaded via the existing [\`AddMithrilSettings<T>\`](src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs#L118) pattern — same machinery the icon settings, audio settings, and Gandalf's per-shift settings use.
- **Single decision point:** [\`GameTimeOfDay.Format(bool use24Hour)\`](src/Mithril.Shared/Game/GameClock.cs) — the toggle flip lives in exactly one method. Sibling \`ToString24Hour\` parallels the existing \`ToString12Hour\`.

## What changed

- **New** [\`Mithril.Shared/Settings/UserPreferences.cs\`](src/Mithril.Shared/Settings/UserPreferences.cs) — INPC class + JSON source-gen context.
- **New register** in [\`Program.cs\`](src/Mithril.Shell/Program.cs) — \`AddMithrilSettings<UserPreferences>\` near the top of DI.
- [\`GameClock.cs\`](src/Mithril.Shared/Game/GameClock.cs) — added \`ToString24Hour()\` and \`Format(bool)\`.
- [\`ShellViewModel\`](src/Mithril.Shell/ViewModels/ShellViewModel.cs) — \`RefreshGameTime\` routes through \`Format(_preferences.Use24HourClock)\`; subscribes to \`PropertyChanged\` so the label flips immediately.
- [\`TimerDialogViewModel\`](src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs) — \`PickerCulture\` is now an instance property latched at construction; XAML binds to \`{Binding PickerCulture}\` instead of \`{x:Static ...}\`. Two private static \`CultureInfo\`s (12h, 24h) selected by the preference.
- [\`TimerListViewModel\`](src/Gandalf.Module/ViewModels/TimerListViewModel.cs) — accepts \`UserPreferences\` and threads it to dialog construction.
- [\`ShiftAlarmRow\`](src/Gandalf.Module/ViewModels/GandalfSettingsViewModel.cs) — implements \`INotifyPropertyChanged\`, subscribes to \`UserPreferences\`, re-fires \`Display\` change when the toggle flips.
- [\`AppearanceSettingsView\`](src/Mithril.Shell/Views/AppearanceSettingsView.xaml) — new \"In-game clock format\" section with a checkbox; VM gains \`Preferences\` property.

## Test plan

- [x] **Unit:** all 1559 tests green. New theory cases on \`GameTimeOfDay\` cover \`ToString24Hour\` boundary values (00:00, 23:59, etc.) and the \`Format(bool)\` dispatch.
- [ ] **Manual E2E (owner verifies before merge):**
  - [x] Open Appearance settings — confirm the new \"In-game clock format\" section renders below \"Font size.\"
  - [x] Toggle the checkbox — confirm the shell's in-game time label flips between \`8:35 PM\` and \`20:35\` immediately (no need to wait for the 5s tick).
  - [ ] Open Gandalf settings → \"Time-of-day alarms\" section. Confirm shift rows show \`(5:00 AM in-game)\` style by default; toggle the preference and confirm they flip to \`(05:00 in-game)\` live.
  - [ ] Open Gandalf → Add Timer → pick \"In-game time.\" Confirm the picker displays in 12h or 24h matching the preference. Toggle preference, close + reopen the dialog, confirm the picker now uses the other format.
  - [ ] Restart Mithril and confirm the preference persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)