### PR TITLE
gandalf: flatten timer Region+Map into single Area with areas.json autocomplete

### DIFF
--- a/src/Gandalf.Module/Domain/GandalfDefinitions.cs
+++ b/src/Gandalf.Module/Domain/GandalfDefinitions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Mithril.Shared.Character;
 
 namespace Gandalf.Domain;
 
@@ -6,10 +7,34 @@ namespace Gandalf.Domain;
 /// Global set of timer definitions shared across every character. Persisted flat at
 /// <c>%LocalAppData%/Mithril/Gandalf/definitions.json</c> via <see cref="Mithril.Shared.Settings.ISettingsStore{T}"/>.
 /// Per-character progress lives separately in <see cref="GandalfProgress"/>.
+///
+/// Schema v3 collapsed the legacy v2 <c>Region</c> + <c>Map</c> pair on each
+/// <see cref="GandalfTimerDef"/> into a single <c>Area</c> with an optional canonical
+/// <c>AreaKey</c>. v1→v2 is handled by <c>GandalfSplitMigration</c>; v2→v3 by
+/// <c>GandalfAreaFlattenMigration</c> — both pre-startup file-rewriters, so the typed
+/// model never has to carry deprecated fields.
 /// </summary>
-public sealed class GandalfDefinitions
+public sealed class GandalfDefinitions : IVersionedState<GandalfDefinitions>
 {
-    public const int Version = 2;
+    public const int Version = 3;
+
+    public static int CurrentVersion => Version;
+
+    /// <summary>
+    /// Defensive identity. The real v2→v3 migration runs in the
+    /// <c>GandalfAreaFlattenMigration</c> hosted service before the typed store reads
+    /// the file; anything reaching this hook should already be at the current version.
+    /// If it isn't, the JSON-level migration didn't run (or didn't see the file) —
+    /// stamp the version and accept the loss of legacy Region/Map values.
+    /// </summary>
+    public static GandalfDefinitions Migrate(GandalfDefinitions loaded)
+    {
+        if (loaded.SchemaVersion < Version)
+        {
+            loaded.SchemaVersion = Version;
+        }
+        return loaded;
+    }
 
     public int SchemaVersion { get; set; } = Version;
     public List<GandalfTimerDef> Timers { get; set; } = [];

--- a/src/Gandalf.Module/Domain/GandalfTimerDef.cs
+++ b/src/Gandalf.Module/Domain/GandalfTimerDef.cs
@@ -28,8 +28,21 @@ public sealed class GandalfTimerDef
     public int? GameHour { get; set; }
     public int? GameMinute { get; set; }
     public bool Recurring { get; set; }
-    public string Region { get; set; } = "";
-    public string Map { get; set; } = "";
+
+    /// <summary>
+    /// Free-form area label as displayed/typed by the user — e.g. "Serbule",
+    /// "Hogan's Keep", "My Hideout". Used as the dashboard group header.
+    /// </summary>
+    public string Area { get; set; } = "";
+
+    /// <summary>
+    /// Canonical PG area key (e.g. <c>"AreaSerbule"</c>) when <see cref="Area"/>
+    /// resolves to a known <c>areas.json</c> entry by FriendlyName. <c>null</c>
+    /// for free-form values that don't match the reference data. Side-channel —
+    /// the user never sees this, but it lets future consumers cross-reference
+    /// PG area metadata without re-doing the lookup.
+    /// </summary>
+    public string? AreaKey { get; set; }
 
     /// <summary>
     /// Per-timer alarm sound path. <c>null</c> falls back to the global default
@@ -39,7 +52,5 @@ public sealed class GandalfTimerDef
     public string? SoundFilePath { get; set; }
 
     [JsonIgnore]
-    public string GroupKey => string.IsNullOrWhiteSpace(Map)
-        ? Region
-        : $"{Region} > {Map}";
+    public string GroupKey => Area;
 }

--- a/src/Gandalf.Module/Domain/TimerClipboard.cs
+++ b/src/Gandalf.Module/Domain/TimerClipboard.cs
@@ -7,8 +7,8 @@ public sealed class TimerClipboardEntry
 {
     public string Name { get; set; } = "";
     public string Duration { get; set; } = "";
-    public string Region { get; set; } = "";
-    public string Map { get; set; } = "";
+    public string Area { get; set; } = "";
+    public string? AreaKey { get; set; }
     public string? SoundFilePath { get; set; }
 }
 
@@ -25,8 +25,8 @@ public static class TimerClipboard
         {
             Name = d.Name,
             Duration = d.Duration.ToString(),
-            Region = d.Region,
-            Map = d.Map,
+            Area = d.Area,
+            AreaKey = d.AreaKey,
             SoundFilePath = d.SoundFilePath,
         }).ToList();
         return JsonSerializer.Serialize(entries, TimerClipboardJsonContext.Default.ListTimerClipboardEntry);
@@ -60,8 +60,8 @@ public static class TimerClipboard
         {
             Name = entry.Name,
             Duration = dur,
-            Region = entry.Region,
-            Map = entry.Map,
+            Area = entry.Area,
+            AreaKey = string.IsNullOrWhiteSpace(entry.AreaKey) ? null : entry.AreaKey,
             SoundFilePath = string.IsNullOrWhiteSpace(entry.SoundFilePath) ? null : entry.SoundFilePath,
         };
     }

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -96,6 +96,16 @@ public sealed class GandalfModule : IMithrilModule
         services.AddHostedService<DefeatCalibrationBridge>();
         services.AddSingleton<LootTimersViewModel>();
 
+        // One-shot v2→v3 file rewrite: collapse legacy Region+Map on each timer into a
+        // single Area + canonical AreaKey resolved from areas.json. Must run BEFORE
+        // GandalfSplitMigration: the split reads/writes definitions.json through the
+        // typed model, which has already dropped Region/Map — so without this first
+        // pass any pre-existing v2 timers would lose their location data.
+        services.AddHostedService(sp => new GandalfAreaFlattenMigration(
+            defsPath,
+            sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
+            sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
+
         // One-shot startup fanout: split the old combined per-char gandalf.json into the
         // global definitions file + per-char progress files. Runs before module gates open.
         services.AddHostedService<GandalfSplitMigration>();
@@ -146,7 +156,8 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<IDialogService>(),
             sp.GetRequiredService<IActiveCharacterService>(),
             sp.GetRequiredService<ICharacterPresenceService>(),
-            sp.GetRequiredService<Mithril.Shared.Settings.UserPreferences>()));
+            sp.GetRequiredService<Mithril.Shared.Settings.UserPreferences>(),
+            sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>()));
 
         services.AddSingleton<GandalfShellViewModel>();
         services.AddSingleton<GandalfShellView>(sp =>

--- a/src/Gandalf.Module/Services/GandalfAreaFlattenMigration.cs
+++ b/src/Gandalf.Module/Services/GandalfAreaFlattenMigration.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Gandalf.Domain;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Microsoft.Extensions.Hosting;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// One-shot v2→v3 startup migration for the global Gandalf <c>definitions.json</c>.
+/// v2 timers carried a free-form <c>region</c> + <c>map</c> pair; v3 collapses those
+/// into a single <c>area</c> string with an optional canonical <c>areaKey</c> resolved
+/// against <c>areas.json</c>.
+///
+/// Operates at the JSON level (<see cref="JsonNode"/>) instead of going through the typed
+/// <see cref="GandalfDefinitions"/> model — that model has already dropped Region/Map, so
+/// a typed round-trip would silently lose them. Mirrors <see cref="GandalfSplitMigration"/>'s
+/// pre-startup file-rewrite pattern. Idempotent: schemaVersion ≥ <see cref="GandalfDefinitions.Version"/>
+/// or missing-file early-returns.
+/// </summary>
+public sealed class GandalfAreaFlattenMigration : IHostedService
+{
+    private readonly string _defsPath;
+    private readonly IReferenceDataService _refData;
+    private readonly IDiagnosticsSink? _diag;
+
+    public GandalfAreaFlattenMigration(
+        string defsPath,
+        IReferenceDataService refData,
+        IDiagnosticsSink? diag = null)
+    {
+        _defsPath = defsPath;
+        _refData = refData;
+        _diag = diag;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try { Run(); }
+        catch (Exception ex) { _diag?.Warn("Gandalf.AreaFlatten", $"Failed: {ex.Message}"); }
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    internal void Run()
+    {
+        if (!File.Exists(_defsPath)) return;
+
+        JsonNode? root;
+        using (var stream = File.OpenRead(_defsPath))
+        {
+            root = JsonNode.Parse(stream);
+        }
+        if (root is not JsonObject obj) return;
+
+        var schemaVersion = obj["schemaVersion"]?.GetValue<int>() ?? 0;
+        if (schemaVersion >= GandalfDefinitions.Version) return;
+
+        if (obj["timers"] is not JsonArray timers) return;
+
+        var lookup = GandalfAreaResolver.BuildLookup(_refData);
+        int migrated = 0;
+        foreach (var node in timers)
+        {
+            if (node is not JsonObject t) continue;
+            var region = (string?)t["region"] ?? "";
+            var map = (string?)t["map"] ?? "";
+            var (area, areaKey) = GandalfAreaResolver.FlattenLegacy(region, map, lookup);
+
+            t.Remove("region");
+            t.Remove("map");
+            t["area"] = area;
+            // null is preserved verbatim by JsonObject — matches AreaKey's nullable JSON shape.
+            t["areaKey"] = areaKey;
+            migrated++;
+        }
+
+        obj["schemaVersion"] = GandalfDefinitions.Version;
+
+        var serialized = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(_defsPath, serialized);
+        _diag?.Info("Gandalf.AreaFlatten",
+            $"Migrated {migrated} timer definition(s) from v{schemaVersion} to v{GandalfDefinitions.Version}.");
+    }
+}

--- a/src/Gandalf.Module/Services/GandalfAreaResolver.cs
+++ b/src/Gandalf.Module/Services/GandalfAreaResolver.cs
@@ -1,0 +1,70 @@
+using Mithril.Shared.Reference;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Helpers for resolving free-form area text against <c>areas.json</c> reference data,
+/// shared by the timer dialog (live save-time resolution) and the v2→v3 area-flatten
+/// migration. Keeps both consumers in sync on what counts as a "known area".
+/// </summary>
+internal static class GandalfAreaResolver
+{
+    /// <summary>
+    /// Build a case-insensitive <c>FriendlyName → AreaEntry</c> dictionary from
+    /// <see cref="IReferenceDataService.Areas"/>. First-wins on collisions
+    /// (e.g. <c>AreaFaeRealm1</c> + <c>AreaFaeRealm1Caves</c> both share
+    /// <c>"Fae Realm"</c>) — the iteration order of <c>refData.Areas</c> is stable
+    /// per process, so the choice is deterministic across a single run.
+    /// </summary>
+    public static Dictionary<string, AreaEntry> BuildLookup(IReferenceDataService refData)
+    {
+        var dict = new Dictionary<string, AreaEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var area in refData.Areas.Values)
+        {
+            dict.TryAdd(area.FriendlyName, area);
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// Look up <paramref name="text"/> against the FriendlyName index. Returns the
+    /// canonical-cased FriendlyName + key on a match, else the trimmed input + null.
+    /// Empty/whitespace input maps to ("", null).
+    /// </summary>
+    public static (string Area, string? AreaKey) Resolve(
+        string? text,
+        IReadOnlyDictionary<string, AreaEntry> friendlyNameLookup)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return ("", null);
+        var trimmed = text.Trim();
+        return friendlyNameLookup.TryGetValue(trimmed, out var entry)
+            ? (entry.FriendlyName, entry.Key)
+            : (trimmed, null);
+    }
+
+    /// <summary>
+    /// Collapse a legacy v2 region+map pair into a single <c>(Area, AreaKey)</c>.
+    /// Tries an exact FriendlyName match on Region first, then on Map. If neither
+    /// resolves, falls back to a lossless concat: <c>"Region > Map"</c>, dedup if
+    /// equal (case-insensitive), drop empty halves. AreaKey is non-null only when
+    /// the match path succeeded.
+    /// </summary>
+    public static (string Area, string? AreaKey) FlattenLegacy(
+        string? region,
+        string? map,
+        IReadOnlyDictionary<string, AreaEntry> friendlyNameLookup)
+    {
+        var r = Resolve(region, friendlyNameLookup);
+        if (r.AreaKey is not null) return r;
+        var m = Resolve(map, friendlyNameLookup);
+        if (m.AreaKey is not null) return m;
+
+        var rs = (region ?? "").Trim();
+        var ms = (map ?? "").Trim();
+        if (rs.Length == 0 && ms.Length == 0) return ("", null);
+        if (rs.Length == 0) return (ms, null);
+        if (ms.Length == 0) return (rs, null);
+        if (rs.Equals(ms, StringComparison.OrdinalIgnoreCase)) return (rs, null);
+        return ($"{rs} > {ms}", null);
+    }
+}

--- a/src/Gandalf.Module/Services/GandalfSplitMigration.cs
+++ b/src/Gandalf.Module/Services/GandalfSplitMigration.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization.Metadata;
 using Gandalf.Domain;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 using Microsoft.Extensions.Hosting;
 
@@ -28,6 +29,7 @@ public sealed class GandalfSplitMigration : IHostedService
     private readonly ISettingsStore<GandalfDefinitions> _defStore;
     private readonly PerCharacterStore<GandalfProgress> _progressStore;
     private readonly PerCharacterView<GandalfProgress> _progressView;
+    private readonly IReferenceDataService _refData;
     private readonly IDiagnosticsSink? _diag;
 
     public GandalfSplitMigration(
@@ -35,12 +37,14 @@ public sealed class GandalfSplitMigration : IHostedService
         ISettingsStore<GandalfDefinitions> defStore,
         PerCharacterStore<GandalfProgress> progressStore,
         PerCharacterView<GandalfProgress> progressView,
+        IReferenceDataService refData,
         IDiagnosticsSink? diag = null)
     {
         _charactersRootDir = options.CharactersRootDir;
         _defStore = defStore;
         _progressStore = progressStore;
         _progressView = progressView;
+        _refData = refData;
         _diag = diag;
     }
 
@@ -69,6 +73,9 @@ public sealed class GandalfSplitMigration : IHostedService
         }
 
         // Step 1: union every v1 blob's timers into a global GandalfDefinitions.
+        // Schema v3 uses Area+AreaKey instead of v1's Region+Map, so resolve as we go
+        // — same logic GandalfAreaFlattenMigration applies for v2-on-disk users.
+        var areaLookup = GandalfAreaResolver.BuildLookup(_refData);
         var defs = _defStore.Load();
         var byId = defs.Timers.ToDictionary(d => d.Id, StringComparer.Ordinal);
         foreach (var candidate in candidates.Where(c => !c.IsV2).OrderByDescending(c => c.LastWriteUtc))
@@ -76,7 +83,7 @@ public sealed class GandalfSplitMigration : IHostedService
             if (candidate.Legacy is null) continue;
             foreach (var timer in candidate.Legacy.Timers)
             {
-                if (!byId.TryAdd(timer.Id, LegacyToDef(timer)))
+                if (!byId.TryAdd(timer.Id, LegacyToDef(timer, areaLookup)))
                 {
                     // Earlier iteration already owns this id (newer mtime wins). Log if names
                     // or durations disagree so the user can tidy up later.
@@ -180,14 +187,20 @@ public sealed class GandalfSplitMigration : IHostedService
         }
     }
 
-    private static GandalfTimerDef LegacyToDef(LegacyGandalfTimerV1 legacy) => new()
+    private static GandalfTimerDef LegacyToDef(
+        LegacyGandalfTimerV1 legacy,
+        IReadOnlyDictionary<string, AreaEntry> areaLookup)
     {
-        Id = legacy.Id,
-        Name = legacy.Name,
-        Duration = legacy.Duration,
-        Region = legacy.Region,
-        Map = legacy.Map,
-    };
+        var (area, areaKey) = GandalfAreaResolver.FlattenLegacy(legacy.Region, legacy.Map, areaLookup);
+        return new GandalfTimerDef
+        {
+            Id = legacy.Id,
+            Name = legacy.Name,
+            Duration = legacy.Duration,
+            Area = area,
+            AreaKey = areaKey,
+        };
+    }
 
     private sealed record Candidate(
         string Character,

--- a/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerDialogViewModel.cs
@@ -2,6 +2,8 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Gandalf.Domain;
+using Gandalf.Services;
+using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf.Dialogs;
 
@@ -63,8 +65,11 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
     [ObservableProperty] private DateTime? _selectedGameDateTime;
     [ObservableProperty] private bool _recurring;
 
-    [ObservableProperty] private string _region = "";
-    [ObservableProperty] private string _map = "";
+    /// <summary>
+    /// Free-form area label as displayed/typed by the user. Resolved at save time
+    /// against <see cref="_areaLookup"/> to populate <see cref="ResultAreaKey"/>.
+    /// </summary>
+    [ObservableProperty] private string _area = "";
 
     /// <summary>
     /// Per-timer sound override. Null means "use the global default from
@@ -73,8 +78,18 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
     /// </summary>
     [ObservableProperty] private string? _soundFilePath;
 
-    public ObservableCollection<string> KnownRegions { get; } = [];
-    public ObservableCollection<string> KnownMaps { get; } = [];
+    /// <summary>
+    /// Suggestion pool for the Area combobox. Caller pre-populates with the union of
+    /// areas.json FriendlyNames and the user's existing Area values.
+    /// </summary>
+    public ObservableCollection<string> KnownAreas { get; } = [];
+
+    /// <summary>
+    /// Case-insensitive FriendlyName → AreaEntry index used to canonicalize the
+    /// typed area string at save time. Empty when the dialog is constructed without
+    /// reference data (test scenarios) — in that case AreaKey will always be null.
+    /// </summary>
+    private readonly IReadOnlyDictionary<string, AreaEntry> _areaLookup;
 
     /// <summary>
     /// Trigger / duration / game-time inputs are gated to idle-only on the
@@ -100,21 +115,20 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
     public TimerDialogViewModel(
         GandalfTimerDef? existing,
         bool isIdleOnActive,
-        IReadOnlyList<string> knownRegions,
-        IReadOnlyList<string> knownMaps,
+        IReadOnlyList<string> knownAreas,
+        IReadOnlyDictionary<string, AreaEntry> areaLookup,
         UserPreferences preferences)
     {
         PickerCulture = preferences.Use24HourClock ? TwentyFourHourCulture : TwelveHourCulture;
-        foreach (var r in knownRegions) KnownRegions.Add(r);
-        foreach (var m in knownMaps) KnownMaps.Add(m);
+        _areaLookup = areaLookup;
+        foreach (var a in knownAreas) KnownAreas.Add(a);
 
         if (existing is not null)
         {
             _isEditing = true;
             _areInputsEditable = isIdleOnActive;
             _name = existing.Name;
-            _region = existing.Region;
-            _map = existing.Map;
+            _area = existing.Area;
             _soundFilePath = existing.SoundFilePath;
 
             if (existing.Kind == GandalfTriggerKind.GameTimeOfDay)
@@ -175,14 +189,19 @@ public sealed partial class TimerDialogViewModel : DialogViewModelBase
 
     public bool ResultRecurring => Recurring;
 
-    public string ResultRegion => Region.Trim();
-    public string ResultMap => Map.Trim();
+    /// <summary>
+    /// Save-time canonicalized area string. When the typed text matches a known
+    /// FriendlyName from <c>areas.json</c> (case-insensitive), the canonical-cased
+    /// FriendlyName is used so reopening the dialog displays the reference spelling.
+    /// </summary>
+    public string ResultArea => GandalfAreaResolver.Resolve(Area, _areaLookup).Area;
+
+    /// <summary>
+    /// Canonical PG area key (e.g. <c>"AreaSerbule"</c>) when the typed text resolves
+    /// to a known area, else <c>null</c>. Side-channel — never shown to the user.
+    /// </summary>
+    public string? ResultAreaKey => GandalfAreaResolver.Resolve(Area, _areaLookup).AreaKey;
+
     public string? ResultSoundFilePath =>
         string.IsNullOrWhiteSpace(SoundFilePath) ? null : SoundFilePath.Trim();
-
-    partial void OnRegionChanged(string value)
-    {
-        KnownMaps.Clear();
-        // Maps will be filtered by the caller if needed — keep it simple for now.
-    }
 }

--- a/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/TimerListViewModel.cs
@@ -8,6 +8,7 @@ using Gandalf.Domain;
 using Gandalf.Services;
 using Gandalf.Views;
 using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf.Dialogs;
 
@@ -23,9 +24,20 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
     private readonly IActiveCharacterService? _active;
     private readonly ICharacterPresenceService? _presence;
     private readonly UserPreferences? _preferences;
+    private readonly IReferenceDataService? _refData;
     private readonly TimeProvider _time;
     private readonly TimerDisplayScheduler _scheduler;
     private readonly TimerSourceBinder _binder;
+
+    /// <summary>
+    /// Cached case-insensitive FriendlyName → AreaEntry index from
+    /// <see cref="IReferenceDataService.Areas"/>. Built once on construction; used by
+    /// the dialog to resolve typed text → canonical AreaKey at save time, and by
+    /// <see cref="RefreshAutocomplete"/> to seed the suggestion pool. Empty when
+    /// <c>_refData</c> is null (test scenarios).
+    /// </summary>
+    private IReadOnlyDictionary<string, AreaEntry> _areaLookup =
+        new Dictionary<string, AreaEntry>(StringComparer.OrdinalIgnoreCase);
     private bool _disposed;
 
     public TimerListViewModel(
@@ -37,6 +49,7 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         IActiveCharacterService? active = null,
         ICharacterPresenceService? presence = null,
         UserPreferences? preferences = null,
+        IReferenceDataService? refData = null,
         TimeProvider? time = null)
     {
         _source = source;
@@ -47,6 +60,8 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         _active = active;
         _presence = presence;
         _preferences = preferences;
+        _refData = refData;
+        if (_refData is not null) _areaLookup = GandalfAreaResolver.BuildLookup(_refData);
         _time = time ?? TimeProvider.System;
 
         TimersView = CollectionViewSource.GetDefaultView(Timers);
@@ -76,14 +91,19 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
     public ObservableCollection<TimerItemViewModel> Timers { get; } = [];
     public ICollectionView TimersView { get; }
 
-    public ObservableCollection<string> KnownRegions { get; } = [];
-    public ObservableCollection<string> KnownMaps { get; } = [];
+    /// <summary>
+    /// Autocomplete pool for the timer dialog's "Area" field. Union of canonical
+    /// PG area FriendlyNames (from <c>areas.json</c>) and the user's distinct
+    /// existing <see cref="GandalfTimerDef.Area"/> values. Sorted, case-insensitive
+    /// dedup. Refreshed on def-list mutations via <see cref="RefreshAutocomplete"/>.
+    /// </summary>
+    public ObservableCollection<string> KnownAreas { get; } = [];
 
     [RelayCommand]
     private void AddTimer()
     {
         if (_defs is null || _dialogService is null) return;
-        var vm = new TimerDialogViewModel(existing: null, isIdleOnActive: true, KnownRegions, KnownMaps,
+        var vm = new TimerDialogViewModel(existing: null, isIdleOnActive: true, KnownAreas, _areaLookup,
             _preferences ?? new UserPreferences());
         var content = new TimerDialogContent();
 
@@ -97,8 +117,8 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
             GameHour = vm.ResultGameHour,
             GameMinute = vm.ResultGameMinute,
             Recurring = vm.ResultRecurring,
-            Region = vm.ResultRegion,
-            Map = vm.ResultMap,
+            Area = vm.ResultArea,
+            AreaKey = vm.ResultAreaKey,
             SoundFilePath = vm.ResultSoundFilePath,
         });
     }
@@ -110,7 +130,7 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         if (item.Catalog.SourceMetadata is not GandalfTimerDef existing) return;
 
         var isIdleOnActive = item.State == TimerState.Idle;
-        var vm = new TimerDialogViewModel(existing, isIdleOnActive, KnownRegions, KnownMaps,
+        var vm = new TimerDialogViewModel(existing, isIdleOnActive, KnownAreas, _areaLookup,
             _preferences ?? new UserPreferences());
         var content = new TimerDialogContent();
 
@@ -118,8 +138,8 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
         _defs.Update(item.Key, d =>
         {
             d.Name = vm.ResultName;
-            d.Region = vm.ResultRegion;
-            d.Map = vm.ResultMap;
+            d.Area = vm.ResultArea;
+            d.AreaKey = vm.ResultAreaKey;
             d.SoundFilePath = vm.ResultSoundFilePath;
             if (isIdleOnActive)
             {
@@ -245,26 +265,27 @@ public sealed partial class TimerListViewModel : ObservableObject, IDisposable
 
     private void RefreshAutocomplete()
     {
-        // Autocomplete still reads the user-specific def list (Region+Map are user-only fields).
+        // Pool = (areas.json FriendlyNames) ∪ (distinct user-entered Area values),
+        // case-insensitive dedup, sorted alphabetically. Reference data covers PG's
+        // canonical regions; the user pool covers sub-locations and freeform labels
+        // ("Hogan's Keep", "My Hideout") that aren't in areas.json.
         if (_defs is null) return;
 
-        var regions = _defs.Definitions
-            .Select(d => d.Region)
-            .Where(r => !string.IsNullOrWhiteSpace(r))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(r => r);
+        var pool = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in _areaLookup.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(entry.FriendlyName))
+                pool.Add(entry.FriendlyName);
+        }
+        foreach (var d in _defs.Definitions)
+        {
+            if (!string.IsNullOrWhiteSpace(d.Area))
+                pool.Add(d.Area);
+        }
 
-        KnownRegions.Clear();
-        foreach (var r in regions) KnownRegions.Add(r);
-
-        var maps = _defs.Definitions
-            .Select(d => d.Map)
-            .Where(m => !string.IsNullOrWhiteSpace(m))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(m => m);
-
-        KnownMaps.Clear();
-        foreach (var m in maps) KnownMaps.Add(m);
+        KnownAreas.Clear();
+        foreach (var a in pool.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+            KnownAreas.Add(a);
     }
 
     public void Dispose()

--- a/src/Gandalf.Module/Views/TimerDialogContent.xaml
+++ b/src/Gandalf.Module/Views/TimerDialogContent.xaml
@@ -88,14 +88,9 @@
         </DockPanel>
 
         <DockPanel Margin="0,0,0,6">
-            <TextBlock Text="Region" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
-            <ComboBox IsEditable="True" Text="{Binding Region, UpdateSourceTrigger=PropertyChanged}"
-                      ItemsSource="{Binding KnownRegions}" Padding="4,2"/>
-        </DockPanel>
-        <DockPanel Margin="0,0,0,6">
-            <TextBlock Text="Map" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
-            <ComboBox IsEditable="True" Text="{Binding Map, UpdateSourceTrigger=PropertyChanged}"
-                      ItemsSource="{Binding KnownMaps}" Padding="4,2"/>
+            <TextBlock Text="Area" Width="70" VerticalAlignment="Center" Foreground="#FFE8E8E8"/>
+            <ComboBox IsEditable="True" Text="{Binding Area, UpdateSourceTrigger=PropertyChanged}"
+                      ItemsSource="{Binding KnownAreas}" Padding="4,2"/>
         </DockPanel>
 
         <!--

--- a/tests/Gandalf.Tests/ClipboardFormatTests.cs
+++ b/tests/Gandalf.Tests/ClipboardFormatTests.cs
@@ -13,8 +13,8 @@ public class ClipboardFormatTests
         {
             Name = "Mushroom Substrate",
             Duration = TimeSpan.FromHours(4) + TimeSpan.FromMinutes(30),
-            Region = "Serbule",
-            Map = "Serbule Sewers",
+            Area = "Serbule",
+            AreaKey = "AreaSerbule",
         };
 
         var json = TimerClipboard.Serialize([def]);
@@ -23,8 +23,8 @@ public class ClipboardFormatTests
         entries.Should().NotBeNull();
         entries.Should().HaveCount(1);
         entries![0].Name.Should().Be("Mushroom Substrate");
-        entries[0].Region.Should().Be("Serbule");
-        entries[0].Map.Should().Be("Serbule Sewers");
+        entries[0].Area.Should().Be("Serbule");
+        entries[0].AreaKey.Should().Be("AreaSerbule");
         TimeSpan.TryParse(entries[0].Duration, out var dur).Should().BeTrue();
         dur.Should().Be(TimeSpan.FromHours(4) + TimeSpan.FromMinutes(30));
     }
@@ -32,7 +32,7 @@ public class ClipboardFormatTests
     [Fact]
     public void Deserialize_single_object()
     {
-        var json = """{"name":"Test","duration":"1:00:00","region":"R","map":"M"}""";
+        var json = """{"name":"Test","duration":"1:00:00","area":"Serbule","areaKey":"AreaSerbule"}""";
         var entries = TimerClipboard.TryDeserialize(json);
 
         entries.Should().NotBeNull();
@@ -43,7 +43,7 @@ public class ClipboardFormatTests
     [Fact]
     public void Deserialize_array()
     {
-        var json = """[{"name":"A","duration":"0:30:00","region":"R1","map":"M1"},{"name":"B","duration":"1:00:00","region":"R2","map":"M2"}]""";
+        var json = """[{"name":"A","duration":"0:30:00","area":"Serbule","areaKey":"AreaSerbule"},{"name":"B","duration":"1:00:00","area":"My Hideout","areaKey":null}]""";
         var entries = TimerClipboard.TryDeserialize(json);
 
         entries.Should().NotBeNull();
@@ -60,7 +60,7 @@ public class ClipboardFormatTests
     [Fact]
     public void ToDef_rejects_zero_duration()
     {
-        var entry = new TimerClipboardEntry { Name = "X", Duration = "0:00:00", Region = "R", Map = "M" };
+        var entry = new TimerClipboardEntry { Name = "X", Duration = "0:00:00", Area = "Serbule" };
         TimerClipboard.ToDef(entry).Should().BeNull();
     }
 
@@ -71,8 +71,8 @@ public class ClipboardFormatTests
         {
             Name = "Leather Tanning",
             Duration = "2:30:00",
-            Region = "Eltibule",
-            Map = "Eltibule Keep",
+            Area = "Eltibule",
+            AreaKey = "AreaEltibule",
         };
 
         var def = TimerClipboard.ToDef(entry);
@@ -80,8 +80,8 @@ public class ClipboardFormatTests
         def.Should().NotBeNull();
         def!.Name.Should().Be("Leather Tanning");
         def.Duration.Should().Be(TimeSpan.FromHours(2) + TimeSpan.FromMinutes(30));
-        def.Region.Should().Be("Eltibule");
-        def.Map.Should().Be("Eltibule Keep");
+        def.Area.Should().Be("Eltibule");
+        def.AreaKey.Should().Be("AreaEltibule");
         def.Id.Should().NotBeNullOrEmpty();
     }
 }

--- a/tests/Gandalf.Tests/FakeRefData.cs
+++ b/tests/Gandalf.Tests/FakeRefData.cs
@@ -1,0 +1,44 @@
+using Mithril.Shared.Reference;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Minimal <see cref="IReferenceDataService"/> stub. Lets tests seed an Areas
+/// dictionary; everything else is empty. Mirrors the per-module fakes scattered
+/// across the test tree (e.g. Mithril.Shared.Tests' EmptyReferenceData).
+/// </summary>
+internal sealed class FakeRefData : IReferenceDataService
+{
+    public FakeRefData(params (string Key, string FriendlyName)[] areas)
+    {
+        var dict = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        foreach (var (key, friendly) in areas)
+        {
+            dict[key] = new AreaEntry(key, friendly, friendly);
+        }
+        Areas = dict;
+    }
+
+    public IReadOnlyList<string> Keys { get; } = [];
+    public IReadOnlyDictionary<long, ItemEntry> Items { get; } = new Dictionary<long, ItemEntry>();
+    public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; } = new Dictionary<string, ItemEntry>();
+    public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+    public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+    public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+    public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+    public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+    public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; }
+    public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+    public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+    public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+    public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+    public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+    public event EventHandler<string>? FileUpdated;
+    public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+    public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public void BeginBackgroundRefresh() { }
+    private void Suppress() => FileUpdated?.Invoke(this, "");
+}

--- a/tests/Gandalf.Tests/GandalfAreaFlattenMigrationTests.cs
+++ b/tests/Gandalf.Tests/GandalfAreaFlattenMigrationTests.cs
@@ -1,0 +1,203 @@
+using System.IO;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Gandalf.Domain;
+using Gandalf.Services;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public class GandalfAreaFlattenMigrationTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _defsPath;
+
+    public GandalfAreaFlattenMigrationTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_area_flatten");
+        _defsPath = Path.Combine(_dir, "definitions.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private static FakeRefData StandardAreas() => new FakeRefData(
+        ("AreaSerbule", "Serbule"),
+        ("AreaEltibule", "Eltibule"),
+        ("AreaCasino", "Red Wing Casino"));
+
+    private static string V2Payload(params (string Region, string Map)[] timers)
+    {
+        var arr = new JsonArray();
+        for (var i = 0; i < timers.Length; i++)
+        {
+            var (region, map) = timers[i];
+            arr.Add(new JsonObject
+            {
+                ["id"] = $"id-{i}",
+                ["name"] = $"Timer {i}",
+                ["kind"] = 0,
+                ["duration"] = "01:00:00",
+                ["recurring"] = false,
+                ["region"] = region,
+                ["map"] = map,
+                ["soundFilePath"] = null,
+            });
+        }
+        var root = new JsonObject
+        {
+            ["schemaVersion"] = 2,
+            ["timers"] = arr,
+        };
+        return root.ToJsonString();
+    }
+
+    private void Seed(string json) => File.WriteAllText(_defsPath, json);
+
+    private JsonObject ReadDefs()
+    {
+        var node = JsonNode.Parse(File.ReadAllText(_defsPath));
+        return node!.AsObject();
+    }
+
+    private void Run(FakeRefData? refData = null)
+    {
+        var migration = new GandalfAreaFlattenMigration(_defsPath, refData ?? StandardAreas());
+        migration.Run();
+    }
+
+    [Fact]
+    public void Region_only_matching_areas_json_resolves_to_FriendlyName_and_AreaKey()
+    {
+        Seed(V2Payload(("Serbule", "")));
+        Run();
+
+        var obj = ReadDefs();
+        ((int)obj["schemaVersion"]!).Should().Be(GandalfDefinitions.Version);
+        var t = obj["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Serbule");
+        ((string?)t["areaKey"]).Should().Be("AreaSerbule");
+        t.ContainsKey("region").Should().BeFalse("legacy region key is removed");
+        t.ContainsKey("map").Should().BeFalse("legacy map key is removed");
+    }
+
+    [Fact]
+    public void Region_matches_when_map_is_a_sublocation_unknown_to_areas_json()
+    {
+        Seed(V2Payload(("Serbule", "Hogan's Keep")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Serbule");
+        ((string?)t["areaKey"]).Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void Both_unknown_falls_back_to_concat_with_null_AreaKey()
+    {
+        Seed(V2Payload(("MyHouse", "Statehome")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("MyHouse > Statehome");
+        ((string?)t["areaKey"]).Should().BeNull();
+    }
+
+    [Fact]
+    public void Region_and_map_equal_collapse_to_single_value()
+    {
+        Seed(V2Payload(("Serbule", "Serbule")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Serbule");
+        ((string?)t["areaKey"]).Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void Map_only_unknown_passes_through_with_null_AreaKey()
+    {
+        Seed(V2Payload(("", "Hogan's Keep")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Hogan's Keep");
+        ((string?)t["areaKey"]).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_only_matching_areas_json_resolves_to_FriendlyName_and_AreaKey()
+    {
+        // Region is empty, so we fall through to checking Map; "Eltibule" is known.
+        Seed(V2Payload(("", "Eltibule")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Eltibule");
+        ((string?)t["areaKey"]).Should().Be("AreaEltibule");
+    }
+
+    [Fact]
+    public void Both_blank_yields_empty_area_and_null_AreaKey()
+    {
+        Seed(V2Payload(("", "")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("");
+        ((string?)t["areaKey"]).Should().BeNull();
+    }
+
+    [Fact]
+    public void V3_payload_is_idempotent()
+    {
+        // Already-migrated v3 file must not be touched.
+        var v3 = """
+        {
+          "schemaVersion": 3,
+          "timers": [
+            { "id": "x", "name": "Already", "kind": 0, "duration": "01:00:00",
+              "recurring": false, "area": "Serbule", "areaKey": "AreaSerbule",
+              "soundFilePath": null }
+          ]
+        }
+        """;
+        Seed(v3);
+        var before = File.GetLastWriteTimeUtc(_defsPath);
+
+        Run();
+
+        // Schema unchanged + content untouched (allow tiny clock skew on slow CI).
+        var obj = ReadDefs();
+        ((int)obj["schemaVersion"]!).Should().Be(3);
+        var t = obj["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Serbule");
+        ((string?)t["areaKey"]).Should().Be("AreaSerbule");
+        t.ContainsKey("region").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Missing_file_is_a_noop()
+    {
+        File.Exists(_defsPath).Should().BeFalse();
+        Run();
+        File.Exists(_defsPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Case_insensitive_FriendlyName_match_canonicalizes_casing()
+    {
+        // User typed "serbule" lowercase — migration must recognize it and stamp
+        // the canonical "Serbule" casing.
+        Seed(V2Payload(("serbule", "")));
+        Run();
+
+        var t = ReadDefs()["timers"]!.AsArray()[0]!.AsObject();
+        ((string?)t["area"]).Should().Be("Serbule");
+        ((string?)t["areaKey"]).Should().Be("AreaSerbule");
+    }
+}

--- a/tests/Gandalf.Tests/GandalfDefinitionsTests.cs
+++ b/tests/Gandalf.Tests/GandalfDefinitionsTests.cs
@@ -19,16 +19,16 @@ public class GandalfDefinitionsTests
                     Id = "abc123",
                     Name = "Chest",
                     Duration = TimeSpan.FromHours(1),
-                    Region = "Serbule",
-                    Map = "Serbule",
+                    Area = "Serbule",
+                    AreaKey = "AreaSerbule",
                 },
                 new GandalfTimerDef
                 {
                     Id = "def456",
                     Name = "Crypt",
                     Duration = TimeSpan.FromMinutes(30),
-                    Region = "Eltibule",
-                    Map = "",
+                    Area = "Eltibule",
+                    AreaKey = null,
                 },
             ],
         };
@@ -44,7 +44,11 @@ public class GandalfDefinitionsTests
         restored.Timers[0].Id.Should().Be("abc123");
         restored.Timers[0].Name.Should().Be("Chest");
         restored.Timers[0].Duration.Should().Be(TimeSpan.FromHours(1));
-        restored.Timers[0].GroupKey.Should().Be("Serbule > Serbule");
+        restored.Timers[0].Area.Should().Be("Serbule");
+        restored.Timers[0].AreaKey.Should().Be("AreaSerbule");
+        restored.Timers[0].GroupKey.Should().Be("Serbule");
+        restored.Timers[1].Area.Should().Be("Eltibule");
+        restored.Timers[1].AreaKey.Should().BeNull();
         restored.Timers[1].GroupKey.Should().Be("Eltibule");
     }
 

--- a/tests/Gandalf.Tests/GandalfSplitMigrationTests.cs
+++ b/tests/Gandalf.Tests/GandalfSplitMigrationTests.cs
@@ -51,10 +51,13 @@ public class GandalfSplitMigrationTests : IDisposable
             GandalfProgressJsonContext.Default.GandalfProgress);
         var active = new FakeActiveCharacterService();
         var view = new PerCharacterView<GandalfProgress>(active, progressStore);
+        // Seeded so the legacy Region="Serbule" used by V1Blob() resolves to a real
+        // AreaKey via GandalfAreaResolver — exercises the full v1→v3 path.
+        var refData = new FakeRefData(("AreaSerbule", "Serbule"));
 
         var migration = new GandalfSplitMigration(
             new PerCharacterStoreOptions { CharactersRootDir = _charactersDir },
-            defStore, progressStore, view);
+            defStore, progressStore, view, refData);
 
         await migration.StartAsync(CancellationToken.None);
         view.Dispose();

--- a/tests/Gandalf.Tests/PerTimerSoundTests.cs
+++ b/tests/Gandalf.Tests/PerTimerSoundTests.cs
@@ -92,8 +92,8 @@ public class PerTimerSoundTests
         {
             Name = "Sounded",
             Duration = TimeSpan.FromMinutes(15),
-            Region = "Serbule",
-            Map = "Serbule",
+            Area = "Serbule",
+            AreaKey = "AreaSerbule",
             SoundFilePath = @"C:\custom\chime.wav",
         };
 

--- a/tests/Gandalf.Tests/TimerServicesTests.cs
+++ b/tests/Gandalf.Tests/TimerServicesTests.cs
@@ -54,7 +54,7 @@ public class TimerServicesTests : IDisposable
         var (defs, progress, view, active) = BuildServices();
         active.SetActiveCharacter("Arthur", "Kwatoxi");
 
-        defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1), Region = "Serbule", Map = "Serbule" });
+        defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1), Area = "Serbule", AreaKey = "AreaSerbule" });
         var id = defs.Definitions[0].Id;
         progress.Start(id);
         defs.Dispose(); // flush definitions
@@ -80,7 +80,7 @@ public class TimerServicesTests : IDisposable
         var (defs, progress, view, active) = BuildServices();
 
         active.SetActiveCharacter("Arthur", "Kwatoxi");
-        defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1), Region = "Serbule", Map = "Serbule" });
+        defs.Add(new GandalfTimerDef { Name = "Chest", Duration = TimeSpan.FromHours(1), Area = "Serbule", AreaKey = "AreaSerbule" });
         var id = defs.Definitions[0].Id;
         progress.Start(id);
         progress.GetProgress(id).Should().NotBeNull();

--- a/tests/Gandalf.Tests/TimerViewTests.cs
+++ b/tests/Gandalf.Tests/TimerViewTests.cs
@@ -63,20 +63,20 @@ public class TimerViewTests
     }
 
     [Fact]
-    public void GroupKey_includes_region_and_map()
+    public void GroupKey_returns_area()
     {
         var view = new TimerView(
-            new GandalfTimerDef { Region = "Serbule", Map = "Serbule Sewers" },
+            new GandalfTimerDef { Area = "Serbule", AreaKey = "AreaSerbule" },
             new TimerProgress());
-        view.GroupKey.Should().Be("Serbule > Serbule Sewers");
+        view.GroupKey.Should().Be("Serbule");
     }
 
     [Fact]
-    public void GroupKey_region_only_when_map_blank()
+    public void GroupKey_returns_empty_when_area_blank()
     {
         var view = new TimerView(
-            new GandalfTimerDef { Region = "Serbule", Map = "" },
+            new GandalfTimerDef { Area = "" },
             new TimerProgress());
-        view.GroupKey.Should().Be("Serbule");
+        view.GroupKey.Should().BeEmpty();
     }
 }

--- a/tests/Gandalf.Tests/UserTimerSourceTests.cs
+++ b/tests/Gandalf.Tests/UserTimerSourceTests.cs
@@ -71,12 +71,12 @@ public class UserTimerSourceTests : IDisposable
             defs.Add(new GandalfTimerDef
             {
                 Name = "Chest", Duration = TimeSpan.FromHours(3),
-                Region = "Goblin Dungeon", Map = "Lower",
+                Area = "Goblin Dungeon",
             });
 
             source.Catalog.Should().HaveCount(1);
             source.Catalog[0].DisplayName.Should().Be("Chest");
-            source.Catalog[0].Region.Should().Be("Goblin Dungeon > Lower");
+            source.Catalog[0].Region.Should().Be("Goblin Dungeon");
             source.Catalog[0].Duration.Should().Be(TimeSpan.FromHours(3));
             source.Catalog[0].SourceMetadata.Should().BeOfType<GandalfTimerDef>();
         }
@@ -188,7 +188,7 @@ public class UserTimerSourceTests : IDisposable
             defs.Add(new GandalfTimerDef
             {
                 Name = "Chest", Duration = TimeSpan.FromHours(3),
-                Region = "Goblin Dungeon", Map = "Lower",
+                Area = "Goblin Dungeon",
             });
 
             batches.Should().ContainSingle();
@@ -211,7 +211,7 @@ public class UserTimerSourceTests : IDisposable
             defs.Add(new GandalfTimerDef
             {
                 Name = "Chest", Duration = TimeSpan.FromHours(3),
-                Region = "Goblin Dungeon", Map = "Lower",
+                Area = "Goblin Dungeon",
             });
             var id = defs.Definitions[0].Id;
 


### PR DESCRIPTION
## Summary

- User-defined timers now carry a single free-form `Area` (plus hidden canonical `AreaKey`) instead of separate `Region` + `Map` strings.
- The Add/Edit Timer dialog's autocomplete pool is the union of every PG area FriendlyName from `areas.json` and the user's distinct existing `Area` values — canonical regions sit alongside sub-locations the user has typed before (e.g. "Hogan's Keep").
- Save-time canonicalization: typing "serbule" or picking "Serbule" both stamp `Area = "Serbule"`, `AreaKey = "AreaSerbule"`. Free-form values pass through with `AreaKey = null`.

## Migration

`GandalfDefinitions` schema bumps to v3. Two paths:

- **v2 → v3**: New `GandalfAreaFlattenMigration` hosted service runs at startup before any consumer reads `definitions.json`. Rewrites the file at the `JsonNode` level — best-effort match against `areas.json` FriendlyName (Region tried first, then Map), falls back to a lossless `Region > Map` concat when neither resolves.
- **v1 → v3**: Existing `GandalfSplitMigration` (v1→v2) now goes straight to v3 via the same shared `GandalfAreaResolver`. Both migrations are idempotent.

The flatten migration is wired *before* the split migration in `GandalfModule.Register` so a v2 file with pre-existing data isn't silently lost when the split migration loads it through the (post-rename) typed model.

## Why a JSON-level migration

`IVersionedState<T>.Migrate(T loaded)` runs after `JsonSerializer` has already discarded fields not on the new model — `Region`/`Map` would be gone before the hook fires. Mirrors the existing pre-startup file-rewrite pattern from `GandalfSplitMigration`. Keeps `GandalfTimerDef` clean of deprecated/`[JsonIgnore]` fields.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — 1591 tests pass across the solution; 247 in Gandalf.Tests
- [x] New `GandalfAreaFlattenMigrationTests` covers the migration matrix:
  - Region matches → resolves to FriendlyName + AreaKey
  - Region matches, Map is unknown sub-location → Region wins
  - Both unknown → concat fallback, null AreaKey
  - Region == Map → collapses to single value
  - Map-only known → resolves via Map fallback
  - Empty Region+Map → empty Area
  - v3 payload → idempotent
  - Missing file → no-op
  - Case-insensitive match → canonicalizes casing ("serbule" → "Serbule")
- [x] **Manual UI verification owed** — I haven't launched the WPF app. Worth checking before merge:
  - Real `definitions.json` with mixed v2 Region/Map data migrates correctly on first launch (`schemaVersion: 3` after, every timer has expected `area`/`areaKey`).
  - Add Timer dialog shows a single "Area" field; typing "Ser" narrows to Serbule/Serbule Hills/etc.
  - Picking "Serbule" → reopen → persisted timer has `areaKey: "AreaSerbule"`.
  - Free-form ("My Hideout") → reopen → `area: "My Hideout"`, `areaKey: null`.
  - Dashboard grouping uses the new Area string as the group header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)