### PR TITLE
elrond: decouple simulator from active character; add constraints + chained forecasts

### DIFF
--- a/src/Elrond.Module/Domain/ElrondSettings.cs
+++ b/src/Elrond.Module/Domain/ElrondSettings.cs
@@ -83,6 +83,29 @@ public sealed class ElrondSettings : INotifyPropertyChanged
         set => Set(ref _viewMode, value);
     }
 
+    /// <summary>
+    /// Simulator constraint: when true, the leveling simulator may only pick recipes
+    /// already in the input snapshot's RecipeCompletions. Pessimistic — assumes the
+    /// player won't learn anything new mid-grind. Pre-decoupling default: false.
+    /// </summary>
+    private bool _simOnlyAlreadyLearnedRecipes;
+    public bool SimOnlyAlreadyLearnedRecipes
+    {
+        get => _simOnlyAlreadyLearnedRecipes;
+        set => Set(ref _simOnlyAlreadyLearnedRecipes, value);
+    }
+
+    /// <summary>
+    /// Simulator constraint: when true (default), first-time-bonus crafts are
+    /// prioritised. Toggle off to bank bonuses for a future scenario.
+    /// </summary>
+    private bool _simUseFirstTimeBonuses = true;
+    public bool SimUseFirstTimeBonuses
+    {
+        get => _simUseFirstTimeBonuses;
+        set => Set(ref _simUseFirstTimeBonuses, value);
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)

--- a/src/Elrond.Module/Domain/SkillAnalysis.cs
+++ b/src/Elrond.Module/Domain/SkillAnalysis.cs
@@ -1,3 +1,4 @@
+using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
 
 namespace Elrond.Domain;
@@ -102,6 +103,11 @@ public sealed record SimulationStep(
 
 /// <summary>
 /// Full result of the leveling simulation/optimization.
+/// <para/>
+/// <see cref="FinalState"/> is the snapshot the simulation arrives at: <see cref="CharacterSnapshot.Skills"/>
+/// reflects the terminal level/XP for the simulated skill, and <see cref="CharacterSnapshot.RecipeCompletions"/>
+/// is incremented for every recipe touched (first-time bonuses move the count from absent/0 → 1, plus any
+/// grind completions on top). Feeding it back into <c>Simulate</c> as the input snapshot chains forecasts.
 /// </summary>
 public sealed record SimulationResult(
     string SkillName,
@@ -109,4 +115,18 @@ public sealed record SimulationResult(
     int GoalLevel,
     long TotalXpNeeded,
     int TotalCompletions,
-    IReadOnlyList<SimulationStep> Steps);
+    IReadOnlyList<SimulationStep> Steps,
+    CharacterSnapshot FinalState);
+
+/// <summary>
+/// Knobs that bend the simulator's behaviour without changing the input snapshot.
+/// Default reproduces the simulator's pre-decoupling behaviour: any recipe whose
+/// level/prereq is met may be picked (treated as auto-learned mid-grind) and
+/// first-time bonuses are consumed.
+/// </summary>
+public sealed record SimulationConstraints(
+    bool OnlyAlreadyLearnedRecipes = false,
+    bool UseFirstTimeBonuses = true)
+{
+    public static SimulationConstraints Default { get; } = new();
+}

--- a/src/Elrond.Module/Services/LevelingSimulator.cs
+++ b/src/Elrond.Module/Services/LevelingSimulator.cs
@@ -21,11 +21,23 @@ public sealed class LevelingSimulator
     }
 
     /// <summary>
-    /// Simulate the optimal crafting path from the character's current level/XP
-    /// to <paramref name="goalLevel"/> for the given skill.
-    /// Returns <c>null</c> if the skill or character data is missing.
+    /// Simulate the optimal crafting path from <paramref name="character"/>'s level/XP
+    /// to <paramref name="goalLevel"/> for the given skill, using the default
+    /// (most-permissive) constraints.
     /// </summary>
     public SimulationResult? Simulate(string skillName, CharacterSnapshot character, int goalLevel)
+        => Simulate(skillName, character, goalLevel, SimulationConstraints.Default);
+
+    /// <summary>
+    /// Simulate the optimal crafting path from <paramref name="character"/>'s level/XP
+    /// to <paramref name="goalLevel"/> for the given skill, honouring <paramref name="constraints"/>.
+    /// Returns <c>null</c> if the skill or character data is missing.
+    /// </summary>
+    public SimulationResult? Simulate(
+        string skillName,
+        CharacterSnapshot character,
+        int goalLevel,
+        SimulationConstraints constraints)
     {
         if (!character.Skills.TryGetValue(skillName, out var charSkill))
             return null;
@@ -33,7 +45,7 @@ public sealed class LevelingSimulator
         var xpAmounts = _engine.ResolveXpTable(skillName);
         if (xpAmounts is null) return null;
 
-        if (goalLevel <= charSkill.Level) return MakeEmptyResult(skillName, charSkill.Level, goalLevel);
+        if (goalLevel <= charSkill.Level) return MakeEmptyResult(skillName, charSkill, goalLevel, character);
 
         // Gather all recipes that award XP for this skill
         var skillRecipes = _ref.Recipes.Values
@@ -45,13 +57,16 @@ public sealed class LevelingSimulator
 
         // Track which first-time bonuses are available.
         // Recipes already learned with 0 completions have the bonus ready.
-        // Recipes not yet learned are assumed learnable once level req + prereq are met.
+        // Recipes not yet learned are assumed learnable once level req + prereq are met
+        // — unless OnlyAlreadyLearnedRecipes is set, in which case we only consider
+        // recipes already in RecipeCompletions.
         var unusedBonuses = new HashSet<string>(StringComparer.Ordinal);
         // Track recipes already completed (bonus consumed)
         var completedRecipes = new HashSet<string>(StringComparer.Ordinal);
         foreach (var recipe in skillRecipes)
         {
             if (recipe.RewardSkillXpFirstTime <= 0) continue;
+            if (!constraints.UseFirstTimeBonuses) continue;
 
             if (character.RecipeCompletions.TryGetValue(recipe.InternalName, out var count))
             {
@@ -60,7 +75,7 @@ public sealed class LevelingSimulator
                 else
                     completedRecipes.Add(recipe.InternalName);
             }
-            else
+            else if (!constraints.OnlyAlreadyLearnedRecipes)
             {
                 // Not yet learned — will become available when prereqs are met
                 unusedBonuses.Add(recipe.Key);
@@ -81,6 +96,10 @@ public sealed class LevelingSimulator
         var totalXpNeeded = _engine.ComputeXpToGoal(skillName, level, xp, xpForLevel, goalLevel);
         var steps = new List<SimulationStep>();
 
+        // Per-recipe completion deltas built up during the run, merged into FinalState at the end.
+        // Keyed on RecipeEntry.InternalName (matching CharacterSnapshot.RecipeCompletions).
+        var deltaCompletions = new Dictionary<string, int>(StringComparer.Ordinal);
+
         while (level < goalLevel)
         {
             var xpToNextLevel = xpForLevel - xp;
@@ -93,10 +112,13 @@ public sealed class LevelingSimulator
             }
 
             // Get recipes available at this level, with effective XP.
-            // A recipe is available if level req is met AND prereq recipe (if any) has been completed.
+            // A recipe is available if level req is met AND prereq recipe (if any) has been completed,
+            // AND — when OnlyAlreadyLearnedRecipes is set — it's already in the input snapshot.
             var available = skillRecipes
                 .Where(r => r.SkillLevelReq <= level &&
-                            (r.PrereqRecipe is null || completedRecipes.Contains(r.PrereqRecipe)))
+                            (r.PrereqRecipe is null || completedRecipes.Contains(r.PrereqRecipe)) &&
+                            (!constraints.OnlyAlreadyLearnedRecipes
+                                || character.RecipeCompletions.ContainsKey(r.InternalName)))
                 .Select(r => (recipe: r, effXp: _engine.ComputeEffectiveXp(r, level)))
                 .Where(x => x.effXp > 0 || unusedBonuses.Contains(x.recipe.Key))
                 .ToList();
@@ -104,10 +126,12 @@ public sealed class LevelingSimulator
             if (available.Count == 0) break; // stuck, no usable recipes
 
             // Phase 1: Use first-time bonuses (highest bonus XP first)
-            var bonusRecipes = available
-                .Where(x => unusedBonuses.Contains(x.recipe.Key))
-                .OrderByDescending(x => x.recipe.RewardSkillXpFirstTime)
-                .ToList();
+            var bonusRecipes = constraints.UseFirstTimeBonuses
+                ? available
+                    .Where(x => unusedBonuses.Contains(x.recipe.Key))
+                    .OrderByDescending(x => x.recipe.RewardSkillXpFirstTime)
+                    .ToList()
+                : [];
 
             var usedBonus = false;
             foreach (var (recipe, effXp) in bonusRecipes)
@@ -120,6 +144,7 @@ public sealed class LevelingSimulator
                 xp += bonusXp;
                 unusedBonuses.Remove(recipe.Key);
                 completedRecipes.Add(recipe.InternalName);
+                AddDelta(deltaCompletions, recipe.InternalName, 1);
 
                 // Handle level-ups from this single bonus craft
                 var levelAfter = level;
@@ -166,6 +191,7 @@ public sealed class LevelingSimulator
             var totalGrindXp = (long)completions * grindEffXp;
             xp += totalGrindXp;
             completedRecipes.Add(best.recipe.InternalName);
+            AddDelta(deltaCompletions, best.recipe.InternalName, completions);
 
             // Handle level-ups
             while (xp >= xpForLevel && level < goalLevel)
@@ -194,13 +220,16 @@ public sealed class LevelingSimulator
         // Merge consecutive steps for the same recipe (non-bonus) to keep the list clean
         var merged = MergeConsecutiveSteps(steps);
 
+        var finalState = BuildFinalState(character, skillName, charSkill, level, xp, xpForLevel, deltaCompletions);
+
         return new SimulationResult(
             skillName,
             startLevel,
             goalLevel,
             totalXpNeeded,
             merged.Sum(s => s.Completions),
-            merged);
+            merged,
+            finalState);
     }
 
     private static bool TryLevelUp(IReadOnlyList<long> xpAmounts, ref int level, ref long xp, ref long xpForLevel)
@@ -213,6 +242,47 @@ public sealed class LevelingSimulator
             return true;
         }
         return false;
+    }
+
+    private static void AddDelta(Dictionary<string, int> deltas, string internalName, int amount)
+    {
+        if (deltas.TryGetValue(internalName, out var existing))
+            deltas[internalName] = existing + amount;
+        else
+            deltas[internalName] = amount;
+    }
+
+    private static CharacterSnapshot BuildFinalState(
+        CharacterSnapshot input,
+        string skillName,
+        CharacterSkill startSkill,
+        int finalLevel,
+        long finalXp,
+        long finalXpForLevel,
+        Dictionary<string, int> deltaCompletions)
+    {
+        // Skills: copy and overwrite the simulated skill. BonusLevels is unchanged —
+        // those come from non-XP rewards (favor, quests) the simulator doesn't model.
+        var newSkills = new Dictionary<string, CharacterSkill>(input.Skills, StringComparer.Ordinal)
+        {
+            [skillName] = new CharacterSkill(finalLevel, startSkill.BonusLevels, finalXp, finalXpForLevel),
+        };
+
+        // RecipeCompletions: copy + add per-recipe deltas.
+        var newCompletions = new Dictionary<string, int>(input.RecipeCompletions, StringComparer.Ordinal);
+        foreach (var (internalName, delta) in deltaCompletions)
+        {
+            newCompletions.TryGetValue(internalName, out var existing);
+            newCompletions[internalName] = existing + delta;
+        }
+
+        return new CharacterSnapshot(
+            input.Name,
+            input.Server,
+            input.ExportedAt,
+            newSkills,
+            newCompletions,
+            input.NpcFavor);
     }
 
     private static List<SimulationStep> MergeConsecutiveSteps(List<SimulationStep> steps)
@@ -245,6 +315,8 @@ public sealed class LevelingSimulator
         return merged;
     }
 
-    private static SimulationResult MakeEmptyResult(string skillName, int currentLevel, int goalLevel) =>
-        new(skillName, currentLevel, goalLevel, TotalXpNeeded: 0, TotalCompletions: 0, Steps: []);
+    private static SimulationResult MakeEmptyResult(
+        string skillName, CharacterSkill startSkill, int goalLevel, CharacterSnapshot input) =>
+        new(skillName, startSkill.Level, goalLevel,
+            TotalXpNeeded: 0, TotalCompletions: 0, Steps: [], FinalState: input);
 }

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -60,6 +60,8 @@ public sealed partial class SkillAdvisorViewModel
 
         _goalLevel = settings.LastGoalLevel;
         _viewMode = settings.ViewMode;
+        _onlyAlreadyLearnedRecipes = settings.SimOnlyAlreadyLearnedRecipes;
+        _useFirstTimeBonuses = settings.SimUseFirstTimeBonuses;
 
         // Filters declared here so each closure captures `this` and reads live state
         // (e.g. CraftableOnly compares against the current Analysis at predicate-call time).
@@ -175,10 +177,53 @@ public sealed partial class SkillAdvisorViewModel
     private int? _goalLevel;
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(UseResultAsNextStartCommand))]
     private SimulationResult? _simulationResult;
 
     [ObservableProperty]
     private string _viewMode = "Rows";
+
+    // ── Simulator decoupled state ────────────────────────────────────────
+    // The Recipes tab continues to read live from _activeChar; only the
+    // Simulation tab is decoupled so the user can forecast from a future
+    // hypothetical state, chain runs, and toggle constraints. Inputs are
+    // transient (no persistence beyond constraint toggles).
+
+    /// <summary>
+    /// Frozen snapshot the simulator runs against. <c>null</c> falls back to
+    /// the live active character — preserves the zero-click "from now" UX.
+    /// Populated by <see cref="CopyFromCurrentCharacterCommand"/> or
+    /// <see cref="UseResultAsNextStartCommand"/>.
+    /// </summary>
+    [ObservableProperty]
+    private CharacterSnapshot? _simulationStartState;
+
+    /// <summary>
+    /// User-supplied override for the selected skill's starting level. <c>null</c>
+    /// means "use whatever's in the snapshot" (active or chained). Empty TextBox
+    /// in the UI maps to <c>null</c>.
+    /// </summary>
+    [ObservableProperty]
+    private int? _simulationStartLevel;
+
+    /// <summary>
+    /// User-supplied override for the selected skill's starting XP-toward-next-level.
+    /// </summary>
+    [ObservableProperty]
+    private long? _simulationStartXpTowardNext;
+
+    /// <summary>
+    /// Caption describing where the working snapshot came from. Independent of the
+    /// level/XP override fields, which only modify the *selected skill's* row.
+    /// </summary>
+    [ObservableProperty]
+    private string _simulationStartSource = "Active character";
+
+    [ObservableProperty]
+    private bool _onlyAlreadyLearnedRecipes;
+
+    [ObservableProperty]
+    private bool _useFirstTimeBonuses = true;
 
     // ── Property change handlers ─────────────────────────────────────────
 
@@ -187,8 +232,15 @@ public sealed partial class SkillAdvisorViewModel
         if (value is not null)
             _settings.LastSkill = value;
         UpdateSelectedSkillSummary(value);
+        ResetSimulationStartState();
         Reanalyze();
     }
+
+    partial void OnOnlyAlreadyLearnedRecipesChanged(bool value)
+        => _settings.SimOnlyAlreadyLearnedRecipes = value;
+
+    partial void OnUseFirstTimeBonusesChanged(bool value)
+        => _settings.SimUseFirstTimeBonuses = value;
 
     partial void OnGoalLevelChanged(int? value)
     {
@@ -226,15 +278,73 @@ public sealed partial class SkillAdvisorViewModel
     [RelayCommand]
     private void Simulate()
     {
-        var active = _activeChar.ActiveCharacter;
-        if (active is null || string.IsNullOrEmpty(SelectedSkill) || GoalLevel is not { } goal)
+        if (string.IsNullOrEmpty(SelectedSkill) || GoalLevel is not { } goal)
         {
             SimulationResult = null;
             return;
         }
 
-        SimulationResult = _simulator.Simulate(SelectedSkill, active, goal);
+        var startState = BuildSimulationStartState(SelectedSkill);
+        if (startState is null)
+        {
+            SimulationResult = null;
+            return;
+        }
+
+        var constraints = new SimulationConstraints(
+            OnlyAlreadyLearnedRecipes: OnlyAlreadyLearnedRecipes,
+            UseFirstTimeBonuses: UseFirstTimeBonuses);
+
+        SimulationResult = _simulator.Simulate(SelectedSkill, startState, goal, constraints);
     }
+
+    /// <summary>
+    /// Snapshots the live active character into <see cref="SimulationStartState"/>
+    /// and seeds the Level / XP inputs from the selected skill. Lets the user edit
+    /// from a known starting point rather than typing values from scratch.
+    /// </summary>
+    [RelayCommand]
+    private void CopyFromCurrentCharacter()
+    {
+        var active = _activeChar.ActiveCharacter;
+        if (active is null) return;
+
+        SimulationStartState = active;
+        SimulationStartSource = "Active character (snapshot)";
+
+        if (!string.IsNullOrEmpty(SelectedSkill) && active.Skills.TryGetValue(SelectedSkill, out var s))
+        {
+            SimulationStartLevel = s.Level;
+            SimulationStartXpTowardNext = s.XpTowardNextLevel;
+        }
+    }
+
+    /// <summary>
+    /// Feeds the most recent <see cref="SimulationResult.FinalState"/> back in as
+    /// the next simulation's starting point. Enables chained forecasts (Lv 30 → 50,
+    /// then 50 → 70 *with* the recipes consumed by the first run already crossed
+    /// off the first-time-bonus list).
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanUseResultAsNextStart))]
+    private void UseResultAsNextStart()
+    {
+        if (SimulationResult is not { } result) return;
+
+        SimulationStartState = result.FinalState;
+        SimulationStartSource = "Previous simulation result";
+
+        if (!string.IsNullOrEmpty(SelectedSkill)
+            && result.FinalState.Skills.TryGetValue(SelectedSkill, out var s))
+        {
+            SimulationStartLevel = s.Level;
+            SimulationStartXpTowardNext = s.XpTowardNextLevel;
+        }
+
+        // Clear so the user clicks Simulate again with the carried-over inputs.
+        SimulationResult = null;
+    }
+
+    private bool CanUseResultAsNextStart() => SimulationResult is not null;
 
     // ── Sort wiring ──────────────────────────────────────────────────────
 
@@ -457,6 +567,62 @@ public sealed partial class SkillAdvisorViewModel
             : null;
     }
 
+    /// <summary>
+    /// Resolves the snapshot the simulator should run against, applying the
+    /// user-supplied level/XP overrides for the selected skill if set. Falls
+    /// back to the live active character when no snapshot has been captured.
+    /// Returns null when no character is available at all.
+    /// </summary>
+    private CharacterSnapshot? BuildSimulationStartState(string skillKey)
+    {
+        var baseSnapshot = SimulationStartState ?? _activeChar.ActiveCharacter;
+        if (baseSnapshot is null) return null;
+
+        // No overrides → return the snapshot as-is.
+        if (SimulationStartLevel is null && SimulationStartXpTowardNext is null)
+            return baseSnapshot;
+
+        if (!baseSnapshot.Skills.TryGetValue(skillKey, out var existingSkill))
+            return baseSnapshot;
+
+        var newLevel = SimulationStartLevel ?? existingSkill.Level;
+        var newXp = SimulationStartXpTowardNext ?? existingSkill.XpTowardNextLevel;
+
+        // Re-derive XpNeededForNextLevel from the XP table for the new level
+        // (otherwise editing level-up would carry the *old* level's curve point).
+        var xpAmounts = _engine.ResolveXpTable(skillKey);
+        long newXpNeeded = xpAmounts is not null && newLevel - 1 >= 0 && newLevel - 1 < xpAmounts.Count
+            ? xpAmounts[newLevel - 1]
+            : existingSkill.XpNeededForNextLevel;
+
+        var newSkills = new Dictionary<string, CharacterSkill>(baseSnapshot.Skills, StringComparer.Ordinal)
+        {
+            [skillKey] = new CharacterSkill(newLevel, existingSkill.BonusLevels, newXp, newXpNeeded),
+        };
+
+        return new CharacterSnapshot(
+            baseSnapshot.Name,
+            baseSnapshot.Server,
+            baseSnapshot.ExportedAt,
+            newSkills,
+            baseSnapshot.RecipeCompletions,
+            baseSnapshot.NpcFavor);
+    }
+
+    /// <summary>
+    /// Drops any captured snapshot and clears the level/XP overrides. Called
+    /// when the selected skill or active character changes — both invalidate
+    /// any in-flight "what-if" the user was building.
+    /// </summary>
+    private void ResetSimulationStartState()
+    {
+        SimulationStartState = null;
+        SimulationStartLevel = null;
+        SimulationStartXpTowardNext = null;
+        SimulationStartSource = "Active character";
+        SimulationResult = null;
+    }
+
     private void Reanalyze()
     {
         var active = _activeChar.ActiveCharacter;
@@ -502,6 +668,11 @@ public sealed partial class SkillAdvisorViewModel
     {
         OnUiThread(() =>
         {
+            // Different character → simulator's previous what-if is no longer
+            // meaningful (the snapshot was for the old character). Reset before
+            // rebuilding the skill list so OnSelectedSkillChanged doesn't have
+            // stale state to clear.
+            ResetSimulationStartState();
             BuildSkillNodes();
             Reanalyze();
         });

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -550,8 +550,69 @@
                     <!-- ── Simulation tab ─────────────────────────────────── -->
                     <TabItem Header="Simulation">
                         <DockPanel Margin="0,8,0,0">
-                            <!-- Sim controls -->
-                            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+                            <!-- Top control stack: starting-state Expander, constraints, goal/simulate row.
+                                 Starting state is collapsed by default so the zero-click "simulate from
+                                 now to goal" UX stays close to the original tab look. -->
+                            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+                                <Expander Margin="0,0,0,8" Foreground="{StaticResource TextSecondaryBrush}">
+                                    <Expander.Header>
+                                        <TextBlock VerticalAlignment="Center">
+                                            <Run Text="Starting state — "/>
+                                            <Run Text="{Binding SimulationStartSource, Mode=OneWay}" Foreground="{StaticResource AccentBrush}"/>
+                                        </TextBlock>
+                                    </Expander.Header>
+                                    <Border Background="{StaticResource BgSurfaceBrush}" BorderBrush="{StaticResource BorderSubtleBrush}"
+                                            BorderThickness="1" Padding="10" CornerRadius="3" Margin="0,4,0,0">
+                                        <StackPanel>
+                                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                                <Button Padding="8,4" Margin="0,0,6,0"
+                                                        Command="{Binding CopyFromCurrentCharacterCommand}"
+                                                        ToolTip="Snapshot the active character's current skills + recipes as the simulator's starting point">
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <icon:PackIconLucide Kind="Copy" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                                        <TextBlock Text="Copy from current" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </Button>
+                                                <Button Padding="8,4"
+                                                        Command="{Binding UseResultAsNextStartCommand}"
+                                                        ToolTip="Feed the most recent simulation's terminal state in as the next starting point — chains forecasts">
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <icon:PackIconLucide Kind="ChevronsRight" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                                        <TextBlock Text="Use last result as next start" VerticalAlignment="Center"/>
+                                                    </StackPanel>
+                                                </Button>
+                                            </StackPanel>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="Skill:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                                <TextBlock Text="{Binding SelectedSkillDisplayName, Mode=OneWay, FallbackValue='(none)'}"
+                                                           Foreground="{StaticResource TextPrimaryBrush}" VerticalAlignment="Center" Margin="0,0,16,0"/>
+                                                <TextBlock Text="Level:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                                <TextBox Width="60" Margin="0,0,16,0"
+                                                         Text="{Binding SimulationStartLevel, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
+                                                         ToolTip="Override the selected skill's starting level (blank = use snapshot value)"/>
+                                                <TextBlock Text="XP toward next:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                                <TextBox Width="80"
+                                                         Text="{Binding SimulationStartXpTowardNext, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
+                                                         ToolTip="Override XP banked toward the next level (blank = use snapshot value)"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Border>
+                                </Expander>
+
+                                <!-- Constraints: small enough to live inline; no Expander needed. -->
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                    <CheckBox Margin="0,0,16,0" VerticalAlignment="Center"
+                                              IsChecked="{Binding OnlyAlreadyLearnedRecipes}"
+                                              ToolTip="Restrict the simulator to recipes already in the character's cookbook (no auto-learning of new recipes mid-grind)">
+                                        <TextBlock Text="Only use already-learned recipes" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                    </CheckBox>
+                                    <CheckBox VerticalAlignment="Center"
+                                              IsChecked="{Binding UseFirstTimeBonuses}"
+                                              ToolTip="When off, the simulator skips first-time-bonus crafts entirely — useful for banking bonuses for a future scenario">
+                                        <TextBlock Text="Use first-time bonuses" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                    </CheckBox>
+                                </StackPanel>
+
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="Goal level:" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                                     <TextBox Width="60" Margin="0,0,6,0"
@@ -566,7 +627,7 @@
                                         </StackPanel>
                                     </Button>
                                 </StackPanel>
-                            </DockPanel>
+                            </StackPanel>
 
                             <!-- Result or empty state -->
                             <Grid>

--- a/tests/Elrond.Tests/LevelingSimulatorTests.cs
+++ b/tests/Elrond.Tests/LevelingSimulatorTests.cs
@@ -1,3 +1,4 @@
+using Elrond.Domain;
 using Elrond.Services;
 using FluentAssertions;
 using Mithril.Shared.Character;
@@ -244,6 +245,193 @@ public class LevelingSimulatorTests
 
         result.TotalCompletions.Should().Be(0);
         result.Steps.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Simulate_DefaultConstraints_BehaviourIdenticalToLegacyOverload()
+    {
+        // Regression guard: the 3-arg overload should produce the same result as
+        // calling the 4-arg overload with SimulationConstraints.Default. Use a
+        // setup with bonuses + grind so both phases of the simulator run.
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", 1, false, "TestTable", 25);
+        refData.AddXpTable("TestTable", [100, 200, 300]);
+        refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 10, 80, null, null, null);
+        refData.AddRecipe("recipe_2", "Bread", "Bread", "Cooking", 1, "Cooking", 10, 0, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(1, 0, 0, 100) },
+            recipes: new Dictionary<string, int> { ["Butter"] = 0, ["Bread"] = 5 });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+
+        var legacy = simulator.Simulate("Cooking", character, 2)!;
+        var explicitDefault = simulator.Simulate("Cooking", character, 2, SimulationConstraints.Default)!;
+
+        explicitDefault.TotalCompletions.Should().Be(legacy.TotalCompletions);
+        explicitDefault.Steps.Select(s => (s.RecipeKey, s.Completions, s.UsesFirstTimeBonus))
+            .Should().Equal(legacy.Steps.Select(s => (s.RecipeKey, s.Completions, s.UsesFirstTimeBonus)));
+    }
+
+    [Fact]
+    public void Simulate_OnlyAlreadyLearnedRecipes_RejectsUnknownRecipes()
+    {
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", 1, false, "TestTable", 25);
+        refData.AddXpTable("TestTable", [100, 100, 100, 100, 100]);
+        // Butter is known (in RecipeCompletions). Steak is NOT — would otherwise be
+        // the better pick at level 2 thanks to its first-time bonus.
+        refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 10, 0, null, null, null);
+        refData.AddRecipe("recipe_2", "Steak", "Steak", "Cooking", 2, "Cooking", 100, 500, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(1, 0, 0, 100) },
+            recipes: new Dictionary<string, int> { ["Butter"] = 5 });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+
+        var constraints = new SimulationConstraints(OnlyAlreadyLearnedRecipes: true);
+        var result = simulator.Simulate("Cooking", character, 5, constraints)!;
+
+        result.Should().NotBeNull();
+        result.Steps.Should().NotBeEmpty();
+        result.Steps.Should().OnlyContain(s => s.RecipeName == "Butter",
+            because: "Steak is not in RecipeCompletions and OnlyAlreadyLearnedRecipes is set");
+    }
+
+    [Fact]
+    public void Simulate_NoFirstTimeBonuses_SkipsBonusCrafts()
+    {
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", 1, false, "TestTable", 25);
+        refData.AddXpTable("TestTable", [100, 100]);
+        // Recipe with a sizeable first-time bonus that the default sim would consume.
+        refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 10, 80, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(1, 0, 0, 100) },
+            recipes: new Dictionary<string, int> { ["Butter"] = 0 });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+
+        var constraints = new SimulationConstraints(UseFirstTimeBonuses: false);
+        var result = simulator.Simulate("Cooking", character, 2, constraints)!;
+
+        result.Steps.Should().NotBeEmpty();
+        result.Steps.Should().OnlyContain(s => !s.UsesFirstTimeBonus);
+        // 100 XP needed, 10 per craft → 10 grind completions, no bonus shortcut.
+        result.TotalCompletions.Should().Be(10);
+    }
+
+    [Fact]
+    public void Simulate_FinalState_ReflectsTerminalLevelAndCompletions()
+    {
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", 1, false, "TestTable", 25);
+        refData.AddXpTable("TestTable", [100, 100]);
+        refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 10, 50, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(1, 0, 0, 100) },
+            recipes: new Dictionary<string, int> { ["Butter"] = 0 });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+
+        var result = simulator.Simulate("Cooking", character, 2)!;
+
+        result.FinalState.Should().NotBeNull();
+        result.FinalState.Skills["Cooking"].Level.Should().Be(2);
+
+        // Bonus craft (1) + grind crafts to fill the rest of level 1's XP.
+        // 100 needed - 50 from bonus = 50 remaining, /10 = 5 grind. Total 6 completions.
+        result.FinalState.RecipeCompletions.Should().ContainKey("Butter");
+        result.FinalState.RecipeCompletions["Butter"].Should().Be(6);
+    }
+
+    [Fact]
+    public void Simulate_FinalStatePreservesUntouchedSkillsAndCompletions()
+    {
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", 1, false, "TestTable", 25);
+        refData.AddXpTable("TestTable", [100]);
+        refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 50, 0, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill>
+            {
+                ["Cooking"] = new(1, 0, 0, 100),
+                ["Mycology"] = new(7, 2, 30, 200),
+            },
+            recipes: new Dictionary<string, int> { ["Butter"] = 5, ["Mushroom Soup"] = 3 });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+
+        var result = simulator.Simulate("Cooking", character, 2)!;
+
+        // Mycology untouched — same level/bonus/xp as input.
+        result.FinalState.Skills["Mycology"].Should().Be(character.Skills["Mycology"]);
+        // Mushroom Soup completion count unchanged.
+        result.FinalState.RecipeCompletions["Mushroom Soup"].Should().Be(3);
+        // Butter delta applied on top of the original 5.
+        result.FinalState.RecipeCompletions["Butter"].Should().BeGreaterThan(5);
+    }
+
+    [Fact]
+    public void Simulate_ChainingViaFinalState_MatchesDirectSimulation()
+    {
+        // A: Lv 1 → 3. B: feed FinalState as input, Lv 3 → 5. Compare to direct
+        // C: Lv 1 → 5. Total XP and per-recipe completion counts must reconcile.
+        // First-time bonuses make the comparison interesting — the chained run has
+        // the bonuses already consumed at the boundary, so it must NOT re-claim them.
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", 1, false, "TestTable", 25);
+        refData.AddXpTable("TestTable", [100, 100, 100, 100]);
+        refData.AddRecipe("recipe_1", "Butter", "Butter", "Cooking", 1, "Cooking", 50, 0, null, null, null);
+        refData.AddRecipe("recipe_2", "Bread", "Bread", "Cooking", 2, "Cooking", 50, 250, null, null, null);
+
+        var character = MakeCharacter(
+            skills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(1, 0, 0, 100) },
+            recipes: new Dictionary<string, int> { ["Butter"] = 5, ["Bread"] = 0 });
+
+        var engine = new SkillAdvisorEngine(refData);
+        var simulator = new LevelingSimulator(refData, engine);
+
+        var direct = simulator.Simulate("Cooking", character, 5)!;
+
+        var first = simulator.Simulate("Cooking", character, 3)!;
+        var second = simulator.Simulate("Cooking", first.FinalState, 5)!;
+
+        // Terminal level matches.
+        second.FinalState.Skills["Cooking"].Level.Should().Be(direct.FinalState.Skills["Cooking"].Level);
+
+        // The chained run's terminal recipe-completion counts equal the direct run's
+        // — chaining must not double-count or skip any completions.
+        var directButter = direct.FinalState.RecipeCompletions.GetValueOrDefault("Butter");
+        var chainedButter = second.FinalState.RecipeCompletions.GetValueOrDefault("Butter");
+        chainedButter.Should().Be(directButter);
+
+        var directBread = direct.FinalState.RecipeCompletions.GetValueOrDefault("Bread");
+        var chainedBread = second.FinalState.RecipeCompletions.GetValueOrDefault("Bread");
+        chainedBread.Should().Be(directBread);
+
+        // Bread's first-time bonus should be claimed exactly once across both runs
+        // (whichever leg crossed the level-2 boundary). Across direct + chained, the
+        // total count of bonus-using steps for Bread should match.
+        var chainedBreadBonusSteps = first.Steps.Concat(second.Steps)
+            .Count(s => s.RecipeName == "Bread" && s.UsesFirstTimeBonus);
+        var directBreadBonusSteps = direct.Steps.Count(s => s.RecipeName == "Bread" && s.UsesFirstTimeBonus);
+        chainedBreadBonusSteps.Should().Be(directBreadBonusSteps);
+
+        // Total crafts performed across the chain equals the direct run's. (XP
+        // totals are NOT additive: first.TotalXpNeeded is the gap at the start of
+        // first, and overshooting the boundary makes second's gap smaller — but
+        // the actual *completions* still reconcile.)
+        (first.TotalCompletions + second.TotalCompletions).Should().Be(direct.TotalCompletions);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Decouples the Elrond Simulation tab from the active character so users can forecast from a hypothetical starting state, chain forecasts (terminal state of one run feeds the next), and constrain which recipes the simulator may pick. The simulator engine was already snapshot-driven; this wires editable starting state through the ViewModel and surfaces it behind a collapsed Expander so the zero-click "from now to goal" flow stays default.

## What changed

- **`SimulationConstraints` record** (`src/Elrond.Module/Domain/SkillAnalysis.cs`): two toggles — `OnlyAlreadyLearnedRecipes` and `UseFirstTimeBonuses`. Default reproduces the previous behaviour.
- **`SimulationResult.FinalState`**: a `CharacterSnapshot` reflecting the terminal level/XP and incremented per-recipe completion counts. Feeds back into `Simulate` to chain forecasts.
- **`LevelingSimulator`**: new 4-arg overload taking constraints; the 3-arg call sites still work via `SimulationConstraints.Default`. Tracks per-recipe completion deltas during the run and merges them into the input snapshot to build `FinalState`.
- **`SkillAdvisorViewModel`**:
  - Editable `SimulationStartLevel`/`SimulationStartXpTowardNext` overrides (apply only to the selected skill's row).
  - `CopyFromCurrentCharacterCommand` snapshots the live active character; `UseResultAsNextStartCommand` chains forecasts.
  - Constraint toggles persist through `ElrondSettings`; starting-state inputs are transient (reset on character or skill change).
- **`SkillAdvisorView.xaml`**: Expander hosts the editable starting-state controls (collapsed by default — preserves zero-click UX). Inline constraint checkboxes above the goal-level row. Source caption surfaces "Active character" / "Active character (snapshot)" / "Previous simulation result".
- **6 new tests** covering: default-overload regression, `OnlyAlreadyLearnedRecipes` rejection, `UseFirstTimeBonuses=false` skipping bonus phase, terminal level + completion counts, untouched-skill preservation, chained-forecast reconciliation (terminal state and total completions match a direct simulation).

## Why this matters

Today the tab can only answer "from my current state to a goal" — it can't help with "if I push Cooking to 80, what's the cheapest path 80 → 100?" or "plan with only the recipes I already know" (the simulator is otherwise optimistic and treats every level/prereq-eligible recipe as auto-learned mid-grind, inflating expected XP via first-time bonuses on recipes the user hasn't actually unlocked).

## Test plan

- [x] `dotnet build Mithril.slnx` — clean
- [x] `dotnet test Mithril.slnx` — all suites pass (Elrond: 48/48; full: 1500+/1500+)
- [ ] Manual: open Elrond → Simulation; with no inputs touched, click Simulate → result identical to pre-refactor
- [ ] Manual: expand Starting state, click Copy from current, edit Level, Simulate → start level reflects edit
- [ ] Manual: click "Use last result as next start", bump goal, Simulate → terminal of run #1 == start of run #2
- [ ] Manual: toggle "Only use already-learned recipes" → step list contains only recipes from the cookbook
- [ ] Manual: toggle "Use first-time bonuses" off → no "1st time" badges appear
- [ ] Manual: restart app — constraint toggles persist; starting-state inputs reset

> Note: I haven't visually verified the WPF UI from this environment — only that the build is clean, all tests pass, and the new Lucide icon names (`Copy`, `ChevronsRight`) resolve in the assembly. The manual checks above are owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)