### PR TITLE
fix(settings): bubble nested-INPC mutations so shift alarms persist (#179)

### DIFF
--- a/src/Gandalf.Module/Domain/GandalfShiftSettings.cs
+++ b/src/Gandalf.Module/Domain/GandalfShiftSettings.cs
@@ -1,30 +1,22 @@
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
+using Mithril.Shared.Settings;
 
 namespace Gandalf.Domain;
 
 /// <summary>
 /// Per-shift alarm configuration. Both fields default to "no alarm, no
 /// override" — disabled by default and inheriting the global sound when
-/// enabled. INPC so the WPF settings view re-renders rows on toggle.
+/// enabled. Inherits <see cref="SettingsNode"/> so toggle mutations bubble
+/// through the parent <see cref="GandalfShiftSettings"/> to the autosaver
+/// at the root.
 /// </summary>
-public sealed class ShiftAlarmConfig : INotifyPropertyChanged
+public sealed class ShiftAlarmConfig : SettingsNode
 {
     private bool _enabled;
     private string? _soundFilePath;
 
     public bool Enabled { get => _enabled; set => Set(ref _enabled, value); }
     public string? SoundFilePath { get => _soundFilePath; set => Set(ref _soundFilePath, value); }
-
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
-    {
-        if (EqualityComparer<T>.Default.Equals(field, value)) return;
-        field = value;
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-    }
 }
 
 /// <summary>
@@ -34,8 +26,15 @@ public sealed class ShiftAlarmConfig : INotifyPropertyChanged
 /// schema versions so user-toggled rows don't orphan on update. Persisted
 /// globally at <c>%LocalAppData%/Mithril/Gandalf/shifts.json</c>; shift
 /// transitions are character-agnostic.
+///
+/// <para>Implements <see cref="IPostLoadInit"/> because STJ source-gen
+/// populates <see cref="ByShiftSlug"/> without going through
+/// <see cref="GetOrCreate"/> — without re-wiring bubbling on the
+/// freshly-loaded children, toggling an existing shift's <c>Enabled</c>
+/// would fire on the child only and the autosaver would never see it
+/// (the regression that motivated <see cref="SettingsNode"/>).</para>
 /// </summary>
-public sealed class GandalfShiftSettings : INotifyPropertyChanged
+public sealed class GandalfShiftSettings : SettingsNode, IPostLoadInit
 {
     public Dictionary<string, ShiftAlarmConfig> ByShiftSlug { get; set; } =
         new(StringComparer.Ordinal);
@@ -44,7 +43,8 @@ public sealed class GandalfShiftSettings : INotifyPropertyChanged
     /// Lookup-or-create. Used by the settings view and by
     /// <c>ShiftAlarmService</c> at fire time. Newly-minted entries inherit
     /// the disabled default, so reading a previously-untouched shift does
-    /// not silently enable an alarm.
+    /// not silently enable an alarm. Bubbling is wired on the new child so
+    /// later <c>Enabled</c> / <c>SoundFilePath</c> mutations propagate.
     /// </summary>
     public ShiftAlarmConfig GetOrCreate(string slug)
     {
@@ -52,13 +52,23 @@ public sealed class GandalfShiftSettings : INotifyPropertyChanged
         {
             config = new ShiftAlarmConfig();
             ByShiftSlug[slug] = config;
-            // Re-fire change so subscribers re-render the row.
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ByShiftSlug)));
+            Bubble(config);
+            // Re-fire so the settings view re-renders the row list.
+            RaisePropertyChanged(nameof(ByShiftSlug));
         }
         return config;
     }
 
-    public event PropertyChangedEventHandler? PropertyChanged;
+    public void PostLoadInit()
+    {
+        // Idempotent — Unbubble is a no-op for unsubscribed children, so a
+        // double-PostLoadInit (tests, hot-reload) won't double-wire.
+        foreach (var child in ByShiftSlug.Values)
+        {
+            Unbubble(child);
+            Bubble(child);
+        }
+    }
 }
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]

--- a/src/Mithril.Shared/Settings/IPostLoadInit.cs
+++ b/src/Mithril.Shared/Settings/IPostLoadInit.cs
@@ -1,0 +1,18 @@
+namespace Mithril.Shared.Settings;
+
+/// <summary>
+/// Hook called by <see cref="JsonSettingsStore{T}.Load"/> /
+/// <see cref="JsonSettingsStore{T}.LoadAsync"/> immediately after
+/// deserialization completes. Settings types use this to wire
+/// <see cref="SettingsNode.Bubble"/> subscriptions on freshly-loaded child
+/// nodes — STJ source-gen populates property values without invoking
+/// constructors that would have wired them, and <c>[OnDeserialized]</c>
+/// callbacks aren't supported by the source-generated path either.
+///
+/// Implementations must be idempotent: <c>Load</c> may be called multiple
+/// times in tests, and a stray re-call must not double-subscribe.
+/// </summary>
+public interface IPostLoadInit
+{
+    void PostLoadInit();
+}

--- a/src/Mithril.Shared/Settings/JsonSettingsStore.cs
+++ b/src/Mithril.Shared/Settings/JsonSettingsStore.cs
@@ -18,18 +18,29 @@ public sealed class JsonSettingsStore<T> : ISettingsStore<T> where T : class, ne
 
     public T Load()
     {
-        if (!File.Exists(FilePath)) return new T();
+        if (!File.Exists(FilePath)) return PostInit(new T());
         using var stream = File.OpenRead(FilePath);
         var result = JsonSerializer.Deserialize(stream, _typeInfo);
-        return result ?? new T();
+        return PostInit(result ?? new T());
     }
 
     public async Task<T> LoadAsync(CancellationToken ct = default)
     {
-        if (!File.Exists(FilePath)) return new T();
+        if (!File.Exists(FilePath)) return PostInit(new T());
         await using var stream = File.OpenRead(FilePath);
         var result = await JsonSerializer.DeserializeAsync(stream, _typeInfo, ct);
-        return result ?? new T();
+        return PostInit(result ?? new T());
+    }
+
+    // STJ source-gen populates property values without running ctors that
+    // would have wired SettingsNode.Bubble subscriptions on nested children.
+    // IPostLoadInit lets the loaded type re-wire after deserialize. A
+    // freshly-constructed `new T()` has no children, so the call is a
+    // safe no-op there — the symmetry keeps the load contract simple.
+    private static T PostInit(T value)
+    {
+        (value as IPostLoadInit)?.PostLoadInit();
+        return value;
     }
 
     public Task SaveAsync(T value, CancellationToken ct = default)

--- a/src/Mithril.Shared/Settings/SettingsAutoSaver.cs
+++ b/src/Mithril.Shared/Settings/SettingsAutoSaver.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Windows.Threading;
 using Microsoft.Extensions.Hosting;
+using Mithril.Shared.Diagnostics;
 
 namespace Mithril.Shared.Settings;
 
@@ -8,6 +9,7 @@ public sealed class SettingsAutoSaver<T> : IHostedService, IDisposable where T :
 {
     private readonly ISettingsStore<T> _store;
     private readonly T _instance;
+    private readonly IDiagnosticsSink? _diag;
     private readonly DispatcherTimer _timer;
     private bool _dirty;
 
@@ -18,10 +20,15 @@ public sealed class SettingsAutoSaver<T> : IHostedService, IDisposable where T :
     /// </summary>
     public event Action<DateTimeOffset>? Saved;
 
-    public SettingsAutoSaver(ISettingsStore<T> store, T instance, TimeSpan? debounce = null)
+    public SettingsAutoSaver(
+        ISettingsStore<T> store,
+        T instance,
+        IDiagnosticsSink? diag = null,
+        TimeSpan? debounce = null)
     {
         _store = store;
         _instance = instance;
+        _diag = diag;
         _timer = new DispatcherTimer { Interval = debounce ?? TimeSpan.FromMilliseconds(500) };
         _timer.Tick += OnTick;
         _instance.PropertyChanged += OnChanged;
@@ -68,7 +75,16 @@ public sealed class SettingsAutoSaver<T> : IHostedService, IDisposable where T :
             _store.Save(_instance);
             Saved?.Invoke(DateTimeOffset.Now);
         }
-        catch { /* best-effort autosave */ }
+        catch (Exception ex)
+        {
+            // Best-effort by design — a failed autosave shouldn't crash
+            // the host — but no longer silent. Without this surface every
+            // serialization / IO error in a settings type was invisible
+            // (same foot-gun that hid the GandalfShiftSettings nested-INPC
+            // bug for as long as it did).
+            _diag?.Warn("Settings.AutoSave",
+                $"Save failed for {typeof(T).Name}: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     public void Dispose()

--- a/src/Mithril.Shared/Settings/SettingsNode.cs
+++ b/src/Mithril.Shared/Settings/SettingsNode.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Mithril.Shared.Settings;
+
+/// <summary>
+/// Base for INPC settings nodes that participate in a parent ↔ child
+/// change-bubbling tree. <see cref="SettingsAutoSaver{T}"/> subscribes only
+/// to the <em>root</em> instance's <see cref="INotifyPropertyChanged.PropertyChanged"/>
+/// — without bubbling, a mutation on a nested INPC child fires on the
+/// child only, the saver's dirty flag never flips, and the edit is lost
+/// silently. (The bug that motivated this primitive: shift-alarm toggles
+/// in <c>GandalfShiftSettings</c> never reaching <c>shifts.json</c>.)
+///
+/// Bubbling is opt-in per child: parents call <see cref="Bubble"/> when a
+/// child is added (in property setters / dictionary <c>GetOrCreate</c> /
+/// list <c>Add</c>) and <see cref="Unbubble"/> on removal. Nested children
+/// loaded from JSON need to be re-wired post-deserialization — see
+/// <see cref="IPostLoadInit"/>.
+/// </summary>
+public abstract class SettingsNode : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Set <paramref name="field"/> to <paramref name="value"/>; if the
+    /// new value differs by <see cref="EqualityComparer{T}.Default"/>, fire
+    /// <see cref="PropertyChanged"/> with the caller's name and return
+    /// <c>true</c>.
+    /// </summary>
+    protected bool Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        return true;
+    }
+
+    /// <summary>Fire <see cref="PropertyChanged"/> for an explicit property name.</summary>
+    protected void RaisePropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    /// <summary>
+    /// Subscribe to <paramref name="child"/>'s <see cref="INotifyPropertyChanged.PropertyChanged"/>
+    /// so its mutations re-fire on this node. Pair every <see cref="Bubble"/>
+    /// with an <see cref="Unbubble"/> on removal — subscribing the same
+    /// child twice causes duplicate notifications.
+    /// </summary>
+    protected void Bubble(INotifyPropertyChanged? child)
+    {
+        if (child is null) return;
+        child.PropertyChanged += OnChildChanged;
+    }
+
+    /// <summary>Reverse of <see cref="Bubble"/>. No-op if the child wasn't subscribed.</summary>
+    protected void Unbubble(INotifyPropertyChanged? child)
+    {
+        if (child is null) return;
+        child.PropertyChanged -= OnChildChanged;
+    }
+
+    private void OnChildChanged(object? sender, PropertyChangedEventArgs e) =>
+        // Re-fire on this node. The saver only cares that *something*
+        // changed, so passing the child's PropertyName upward is fine —
+        // it doesn't conflict with any property on this parent.
+        PropertyChanged?.Invoke(this, e);
+}

--- a/tests/Gandalf.Tests/GandalfShiftSettingsBubbleTests.cs
+++ b/tests/Gandalf.Tests/GandalfShiftSettingsBubbleTests.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using FluentAssertions;
+using Gandalf.Domain;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+/// <summary>
+/// Regression net for #179. The bug: toggling a shift's Enabled checkbox
+/// fired PropertyChanged on the child ShiftAlarmConfig only, never on the
+/// parent GandalfShiftSettings, so SettingsAutoSaver (which only subscribes
+/// to the root) never marked dirty and shifts.json was never rewritten.
+/// </summary>
+public class GandalfShiftSettingsBubbleTests
+{
+    [Fact]
+    public void Toggling_Enabled_on_a_GetOrCreate_child_fires_root_PropertyChanged()
+    {
+        var settings = new GandalfShiftSettings();
+        var fired = 0;
+        settings.PropertyChanged += (_, _) => fired++;
+
+        var config = settings.GetOrCreate("midnight");
+        // GetOrCreate fires once for the structural change (a new slug entry).
+        var beforeToggle = fired;
+
+        config.Enabled = true;
+
+        (fired - beforeToggle).Should().Be(1,
+            "the child's PropertyChanged must bubble to the parent so the autosaver wakes up");
+    }
+
+    [Fact]
+    public void Toggling_SoundFilePath_on_a_GetOrCreate_child_fires_root_PropertyChanged()
+    {
+        var settings = new GandalfShiftSettings();
+        var config = settings.GetOrCreate("dawn");
+
+        var fired = 0;
+        settings.PropertyChanged += (_, _) => fired++;
+
+        config.SoundFilePath = "C:/sounds/bell.wav";
+
+        fired.Should().Be(1);
+    }
+
+    [Fact]
+    public void Loaded_children_bubble_after_PostLoadInit()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"mithril-shifts-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            // Seed: a settings instance with one shift entry, saved through
+            // the production store path.
+            var seed = new GandalfShiftSettings();
+            var seeded = seed.GetOrCreate("morning");
+            seeded.Enabled = true;
+            var store = new JsonSettingsStore<GandalfShiftSettings>(
+                tempPath, GandalfShiftSettingsJsonContext.Default.GandalfShiftSettings);
+            store.Save(seed);
+
+            // Reload — STJ source-gen populates ByShiftSlug directly,
+            // bypassing GetOrCreate. Without PostLoadInit (invoked by
+            // JsonSettingsStore.Load), the loaded child wouldn't bubble.
+            var loaded = store.Load();
+            loaded.ByShiftSlug.Should().ContainKey("morning");
+
+            var fired = 0;
+            loaded.PropertyChanged += (_, _) => fired++;
+
+            loaded.ByShiftSlug["morning"].Enabled = false;
+
+            fired.Should().Be(1,
+                "PostLoadInit must re-wire bubbling on every deserialized ShiftAlarmConfig");
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void GetOrCreate_is_idempotent_and_does_not_double_subscribe()
+    {
+        var settings = new GandalfShiftSettings();
+        var first = settings.GetOrCreate("dusk");
+        var second = settings.GetOrCreate("dusk");
+
+        second.Should().BeSameAs(first);
+
+        var fired = 0;
+        settings.PropertyChanged += (_, _) => fired++;
+
+        first.Enabled = true;
+
+        fired.Should().Be(1, "the second GetOrCreate must not have re-subscribed");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Settings/SettingsNodeTests.cs
+++ b/tests/Mithril.Shared.Tests/Settings/SettingsNodeTests.cs
@@ -1,0 +1,122 @@
+using System.ComponentModel;
+using System.IO;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Mithril.Shared.Settings;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Settings;
+
+/// <summary>
+/// Regression net for #179. SettingsAutoSaver subscribes only to the root
+/// instance's PropertyChanged; nested INPC children must bubble through
+/// SettingsNode.Bubble or their mutations are silently dropped on autosave.
+/// </summary>
+public class SettingsNodeTests
+{
+    [Fact]
+    public void Child_PropertyChanged_bubbles_to_parent_after_Bubble()
+    {
+        var parent = new TestParent();
+        var child = new TestChild();
+        parent.Adopt(child);
+
+        var fired = 0;
+        parent.PropertyChanged += (_, _) => fired++;
+
+        child.Value = "changed";
+
+        fired.Should().Be(1, "Bubble must re-fire the child's PropertyChanged on the parent");
+    }
+
+    [Fact]
+    public void Child_PropertyChanged_does_not_bubble_after_Unbubble()
+    {
+        var parent = new TestParent();
+        var child = new TestChild();
+        parent.Adopt(child);
+        parent.Disown(child);
+
+        var fired = 0;
+        parent.PropertyChanged += (_, _) => fired++;
+
+        child.Value = "changed";
+
+        fired.Should().Be(0);
+    }
+
+    [Fact]
+    public void Multiple_children_each_bubble_independently()
+    {
+        var parent = new TestParent();
+        var a = new TestChild();
+        var b = new TestChild();
+        parent.Adopt(a);
+        parent.Adopt(b);
+
+        var fired = 0;
+        parent.PropertyChanged += (_, _) => fired++;
+
+        a.Value = "x";
+        b.Value = "y";
+
+        fired.Should().Be(2);
+    }
+
+    [Fact]
+    public void PostLoadInit_rewires_bubbling_for_deserialized_children()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"mithril-settingsnode-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            // Seed a parent with one child, save through the store.
+            var seed = new TestRoot { Child = new TestChild { Value = "initial" } };
+            seed.PostLoadInit(); // wire bubbling on the seed instance
+            var store = new JsonSettingsStore<TestRoot>(tempPath, TestRootJsonContext.Default.TestRoot);
+            store.Save(seed);
+
+            // Reload — STJ source-gen will populate Child via the property
+            // setter, NOT through ctor wiring. Without IPostLoadInit being
+            // invoked by the store, the loaded child's mutations would fire
+            // on the child only.
+            var loaded = store.Load();
+
+            var fired = 0;
+            loaded.PropertyChanged += (_, _) => fired++;
+
+            loaded.Child!.Value = "after-load";
+
+            fired.Should().Be(1, "IPostLoadInit must re-wire bubbling on deserialized children");
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+}
+
+public sealed class TestParent : SettingsNode
+{
+    public void Adopt(INotifyPropertyChanged child) => Bubble(child);
+    public void Disown(INotifyPropertyChanged child) => Unbubble(child);
+}
+
+public sealed class TestChild : SettingsNode
+{
+    private string _value = "";
+    public string Value { get => _value; set => Set(ref _value, value); }
+}
+
+public sealed class TestRoot : SettingsNode, IPostLoadInit
+{
+    public TestChild? Child { get; set; }
+
+    public void PostLoadInit()
+    {
+        if (Child is not null) Bubble(Child);
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(TestRoot))]
+public partial class TestRootJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary

- Fixes #179. Adds `SettingsNode` base + `IPostLoadInit` hook so nested-INPC settings children bubble up to the autosave root instead of firing on the child and being silently lost.
- Wires `IDiagnosticsSink` into `SettingsAutoSaver`'s catch — future save failures show up under `Settings.AutoSave` instead of disappearing.
- Migrates `GandalfShiftSettings` + `ShiftAlarmConfig` to the primitive; this is the type that exposed the bug. Other settings types are deliberately untouched in this PR (most are flat INPC and unaffected; will audit/migrate in follow-up issues).

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors).
- [x] `dotnet test Mithril.slnx` — full suite passes.
  - 4 new `SettingsNodeTests` (bubble fires, unbubble suppresses, multi-child, `IPostLoadInit` round-trip).
  - 4 new `GandalfShiftSettingsBubbleTests` (Enabled / SoundFilePath / loaded-child / idempotent `GetOrCreate`).
  - Existing `SettingsAutoSaverActivationTests` still green — the `IDiagnosticsSink` ctor parameter is optional and DI-resolved.
  - One pre-existing flake in `Arwen.Tests.CalibrationServiceTests.RecordObservation_StackableItem_KnownSize_RecordsWithCorrectQuantity` (parallel-run race on `tests/.tmp/`); passes when re-run in isolation, unrelated to this PR.
- [ ] Manual smoke: enable a shift in Gandalf settings, restart the app, confirm `shifts.json` mtime advanced and the toggle survived. (User-side — needs a running game.)

## Notes

- `SettingsAutoSaver`'s ctor signature changed: added optional `IDiagnosticsSink? diag = null`. DI fills it where registered, leaves it null otherwise; existing test scaffolding using `new SettingsAutoSaver<T>(store, instance)` keeps working unchanged.
- Behavioural change for `GandalfShiftSettings.GetOrCreate`: same dictionary mutation, plus `Bubble(config)` on first add. No on-disk shape change.
- The equivalent silent `catch { }` in `TimerDefinitionsService.cs:87` / `:95` is **not** addressed here — separate path, separate fix, will track as a follow-up if it surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)