### PR TITLE
fix(shared): recover absolute UTC from log [HH:MM:SS] prefix in PlayerLogTailReader

### DIFF
--- a/src/Mithril.Shared/Logging/ChatLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/ChatLogTailReader.cs
@@ -7,6 +7,11 @@ namespace Mithril.Shared.Logging;
 /// Directory-based tail. Keeps a byte offset per file so we can pick up
 /// where we left off, and buffers partial lines as residual bytes across
 /// reads in case a line is flushed mid-write.
+///
+/// Each file gets its own <see cref="LogLineTimestampSequencer"/> so the
+/// per-channel chat logs (which can rotate independently and interleave at
+/// different rates) fold dates over their own mtimes. See
+/// <see cref="PlayerLogTailReader"/> for the same fix on the gameplay log.
 /// </summary>
 public sealed class ChatLogTailReader
 {
@@ -29,7 +34,11 @@ public sealed class ChatLogTailReader
         {
             try
             {
-                _files[path] = new FileState { Offset = new FileInfo(path).Length };
+                _files[path] = new FileState
+                {
+                    Offset = new FileInfo(path).Length,
+                    Sequencer = new LogLineTimestampSequencer(_time),
+                };
             }
             catch (IOException) { }
         }
@@ -41,7 +50,7 @@ public sealed class ChatLogTailReader
 
         if (!_files.TryGetValue(path, out var state))
         {
-            state = new FileState();
+            state = new FileState { Sequencer = new LogLineTimestampSequencer(_time) };
             _files[path] = state;
         }
 
@@ -70,13 +79,17 @@ public sealed class ChatLogTailReader
         state.Residual = buf[(lastNl + 1)..total];
         state.Offset += read;
 
-        var ts = _time.GetUtcNow().UtcDateTime;
         var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length == 0) return Array.Empty<RawLogLine>();
+
+        state.Sequencer.EnsureAnchored(lines, () => File.GetLastWriteTime(path));
+
         var result = new List<RawLogLine>(lines.Length);
         foreach (var line in lines)
         {
             var trimmed = line.EndsWith('\r') ? line[..^1] : line;
-            if (trimmed.Length > 0) result.Add(new RawLogLine(ts, trimmed));
+            if (trimmed.Length == 0) continue;
+            result.Add(new RawLogLine(state.Sequencer.StampForLine(trimmed), trimmed));
         }
         return result;
     }
@@ -85,5 +98,6 @@ public sealed class ChatLogTailReader
     {
         public long Offset { get; set; }
         public byte[] Residual { get; set; } = Array.Empty<byte>();
+        public required LogLineTimestampSequencer Sequencer { get; init; }
     }
 }

--- a/src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs
+++ b/src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs
@@ -1,0 +1,125 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Recovers absolute UTC timestamps for log lines whose only embedded time
+/// information is a <c>[HH:MM:SS]</c> prefix (PG's gameplay log format).
+/// State is per-file: the date is anchored on file mtime for the first
+/// content batch and folded forward across rollovers in subsequent batches.
+/// Lines without the prefix inherit the previous line's stamp, or fall
+/// through to <see cref="TimeProvider.GetUtcNow"/> if nothing has been seen
+/// yet.
+///
+/// Shared by <see cref="PlayerLogTailReader"/> (single-file Player.log)
+/// and <see cref="ChatLogTailReader"/> (per-channel chat logs); each chat
+/// file gets its own sequencer instance so dates fold independently.
+/// </summary>
+internal sealed class LogLineTimestampSequencer
+{
+    private readonly TimeProvider _time;
+    private DateOnly? _currentLocalDate;
+    private TimeSpan? _prevLocalTimeOfDay;
+    private DateTime _lastEmittedUtc;
+
+    public LogLineTimestampSequencer(TimeProvider time)
+    {
+        _time = time;
+    }
+
+    /// <summary>
+    /// Anchor the date for the first content batch. Pre-scans <paramref name="lines"/>
+    /// for <c>[HH:MM:SS]</c> prefixes, counts midnight rollovers in the
+    /// batch, and walks the start back so the LAST timestamped line lines
+    /// up with file mtime (or mtime - 1 day if its tod is past mtime's
+    /// tod, which happens when the file ticks over to the next calendar
+    /// day shortly after the line was written). No-op once anchored, and
+    /// no-op for batches with no prefixed lines (defers init to a later
+    /// batch that has at least one).
+    /// </summary>
+    public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeAccessor)
+    {
+        if (_currentLocalDate is not null) return;
+
+        var rollovers = 0;
+        TimeSpan? prev = null;
+        TimeSpan? lastSeen = null;
+        foreach (var line in lines)
+        {
+            if (!TryParseTimestampPrefix(line, out var tod)) continue;
+            if (prev.HasValue && tod < prev.Value && (prev.Value - tod) > TimeSpan.FromHours(12))
+                rollovers++;
+            prev = tod;
+            lastSeen = tod;
+        }
+
+        if (lastSeen is null) return;
+
+        DateTime mtime;
+        try { mtime = mtimeAccessor(); }
+        catch { mtime = _time.GetUtcNow().LocalDateTime; }
+        var anchorDate = DateOnly.FromDateTime(mtime);
+        if (lastSeen.Value > mtime.TimeOfDay) anchorDate = anchorDate.AddDays(-1);
+
+        _currentLocalDate = anchorDate.AddDays(-rollovers);
+    }
+
+    /// <summary>
+    /// Compute the UTC stamp for a single log line. Parses the
+    /// <c>[HH:MM:SS]</c> prefix and folds it over the current date,
+    /// detecting midnight rollovers (HH wraps backward by &gt;12h).
+    /// Lines without the prefix inherit the prior stamp; a leading run
+    /// of unprefixed lines falls through to <see cref="TimeProvider.GetUtcNow"/>.
+    /// </summary>
+    public DateTime StampForLine(string line)
+    {
+        if (TryParseTimestampPrefix(line, out var tod) && _currentLocalDate.HasValue)
+        {
+            // Smaller backward jumps (the 1-hour DST fall-back overlap,
+            // out-of-order writes within the same minute) keep the same
+            // calendar date; only a >12h backward gap signals a real
+            // midnight rollover.
+            if (_prevLocalTimeOfDay.HasValue
+                && tod < _prevLocalTimeOfDay.Value
+                && (_prevLocalTimeOfDay.Value - tod) > TimeSpan.FromHours(12))
+            {
+                _currentLocalDate = _currentLocalDate.Value.AddDays(1);
+            }
+            _prevLocalTimeOfDay = tod;
+
+            var date = _currentLocalDate.Value;
+            var local = new DateTime(date.Year, date.Month, date.Day,
+                tod.Hours, tod.Minutes, tod.Seconds, DateTimeKind.Local);
+            _lastEmittedUtc = local.ToUniversalTime();
+        }
+        else if (_lastEmittedUtc == default)
+        {
+            _lastEmittedUtc = _time.GetUtcNow().UtcDateTime;
+        }
+        // else: inherit prior _lastEmittedUtc (engine noise interleaved
+        // with gameplay lines stays anchored on the most recent gameplay tod).
+
+        return _lastEmittedUtc;
+    }
+
+    /// <summary>
+    /// Parse the <c>[HH:MM:SS] </c> prefix every PG gameplay line carries.
+    /// Hand-rolled (vs regex) because this runs once per line on the seed
+    /// replay path and the format is fixed-width.
+    /// </summary>
+    public static bool TryParseTimestampPrefix(string line, out TimeSpan tod)
+    {
+        tod = default;
+        if (line.Length < 11) return false;
+        if (line[0] != '[' || line[3] != ':' || line[6] != ':' || line[9] != ']' || line[10] != ' ') return false;
+        if (!IsAsciiDigit(line[1]) || !IsAsciiDigit(line[2])) return false;
+        if (!IsAsciiDigit(line[4]) || !IsAsciiDigit(line[5])) return false;
+        if (!IsAsciiDigit(line[7]) || !IsAsciiDigit(line[8])) return false;
+        var h = (line[1] - '0') * 10 + (line[2] - '0');
+        var m = (line[4] - '0') * 10 + (line[5] - '0');
+        var s = (line[7] - '0') * 10 + (line[8] - '0');
+        if (h >= 24 || m >= 60 || s >= 60) return false;
+        tod = new TimeSpan(h, m, s);
+        return true;
+    }
+
+    private static bool IsAsciiDigit(char c) => (uint)(c - '0') <= 9;
+}

--- a/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
@@ -14,7 +14,8 @@ namespace Mithril.Shared.Logging;
 /// gameplay line carries) rather than wall-clock-at-read. Past-anchored
 /// cooldown sources (Gandalf Quest/Loot) rely on this to correctly anchor
 /// rows when Mithril launches mid-session and the seed replay surfaces
-/// hours-old completions.
+/// hours-old completions. See <see cref="LogLineTimestampSequencer"/> for
+/// the date-folding logic.
 /// </summary>
 public sealed class PlayerLogTailReader
 {
@@ -23,24 +24,15 @@ public sealed class PlayerLogTailReader
 
     private readonly string _path;
     private readonly TimeProvider _time;
+    private readonly LogLineTimestampSequencer _sequencer;
     private long _offset;
     private byte[] _residual = Array.Empty<byte>();
-
-    // Date-folding state, threaded across ReadNew batches. PG's [HH:MM:SS]
-    // prefix lacks a date, so the first content batch anchors on file mtime
-    // (counting any midnight rollovers in the batch and walking the start
-    // back), and subsequent batches keep walking forward — incrementing
-    // _currentLocalDate whenever the time-of-day jumps backward by >12h
-    // (the threshold distinguishes a real midnight rollover from a DST
-    // fall-back's <=1h overlap).
-    private DateOnly? _currentLocalDate;
-    private TimeSpan? _prevLocalTimeOfDay;
-    private DateTime _lastEmittedUtc;
 
     public PlayerLogTailReader(string path, TimeProvider? time = null)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
         _time = time ?? TimeProvider.System;
+        _sequencer = new LogLineTimestampSequencer(_time);
     }
 
     public void SeedToSessionStart()
@@ -112,109 +104,15 @@ public sealed class PlayerLogTailReader
         var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         if (lines.Length == 0) return Array.Empty<RawLogLine>();
 
-        // First batch with at least one [HH:MM:SS] prefix anchors the date.
-        // Subsequent batches keep _currentLocalDate as-is and continue folding.
-        if (_currentLocalDate is null) InitializeDateAnchor(lines);
+        _sequencer.EnsureAnchored(lines, () => File.GetLastWriteTime(_path));
 
         var result = new List<RawLogLine>(lines.Length);
         foreach (var line in lines)
         {
             var trimmed = line.EndsWith('\r') ? line[..^1] : line;
             if (trimmed.Length == 0) continue;
-            result.Add(new RawLogLine(StampForLine(trimmed), trimmed));
+            result.Add(new RawLogLine(_sequencer.StampForLine(trimmed), trimmed));
         }
         return result;
     }
-
-    /// <summary>
-    /// Pre-scan the first batch: count midnight rollovers and capture the
-    /// last <c>[HH:MM:SS]</c> tod, then anchor on file mtime so the LAST
-    /// timestamped line lines up with mtime (or mtime - 1 day if its tod
-    /// is past mtime's tod, which happens when the file rolls over to the
-    /// next calendar day shortly after the line was written).
-    /// </summary>
-    private void InitializeDateAnchor(string[] lines)
-    {
-        var rollovers = 0;
-        TimeSpan? prev = null;
-        TimeSpan? lastSeen = null;
-        foreach (var rawLine in lines)
-        {
-            var trimmed = rawLine.EndsWith('\r') ? rawLine[..^1] : rawLine;
-            if (!TryParseTimestampPrefix(trimmed, out var tod)) continue;
-            if (prev.HasValue && tod < prev.Value && (prev.Value - tod) > TimeSpan.FromHours(12))
-                rollovers++;
-            prev = tod;
-            lastSeen = tod;
-        }
-
-        // No timestamped lines anywhere in the batch: leave _currentLocalDate
-        // null so each line falls through to the wall-clock fallback. The
-        // next batch with a prefixed line will re-trigger init.
-        if (lastSeen is null) return;
-
-        DateTime mtime;
-        try { mtime = File.GetLastWriteTime(_path); }
-        catch { mtime = _time.GetUtcNow().LocalDateTime; }
-        var anchorDate = DateOnly.FromDateTime(mtime);
-        if (lastSeen.Value > mtime.TimeOfDay) anchorDate = anchorDate.AddDays(-1);
-
-        _currentLocalDate = anchorDate.AddDays(-rollovers);
-    }
-
-    private DateTime StampForLine(string line)
-    {
-        if (TryParseTimestampPrefix(line, out var tod) && _currentLocalDate.HasValue)
-        {
-            // Midnight rollover: HH wrapped backward by >12h. Smaller backward
-            // jumps (the 1-hour DST fall-back overlap, out-of-order writes
-            // within the same minute) keep the same calendar date.
-            if (_prevLocalTimeOfDay.HasValue
-                && tod < _prevLocalTimeOfDay.Value
-                && (_prevLocalTimeOfDay.Value - tod) > TimeSpan.FromHours(12))
-            {
-                _currentLocalDate = _currentLocalDate.Value.AddDays(1);
-            }
-            _prevLocalTimeOfDay = tod;
-
-            var date = _currentLocalDate.Value;
-            var local = new DateTime(date.Year, date.Month, date.Day,
-                tod.Hours, tod.Minutes, tod.Seconds, DateTimeKind.Local);
-            _lastEmittedUtc = local.ToUniversalTime();
-        }
-        else if (_lastEmittedUtc == default)
-        {
-            // No prefix has been seen yet at all in this stream — fall through
-            // to wall-clock-now. Engine init banners and stack traces are the
-            // typical non-prefixed lines and no parser cares about them.
-            _lastEmittedUtc = _time.GetUtcNow().UtcDateTime;
-        }
-        // else: inherit prior _lastEmittedUtc (engine noise interleaved with
-        // gameplay lines stays anchored on the most recent gameplay tod).
-
-        return _lastEmittedUtc;
-    }
-
-    /// <summary>
-    /// Parse the <c>[HH:MM:SS] </c> prefix every PG gameplay line carries.
-    /// Hand-rolled (vs regex) because this runs once per line on the seed
-    /// replay path and the format is fixed-width.
-    /// </summary>
-    private static bool TryParseTimestampPrefix(string line, out TimeSpan tod)
-    {
-        tod = default;
-        if (line.Length < 11) return false;
-        if (line[0] != '[' || line[3] != ':' || line[6] != ':' || line[9] != ']' || line[10] != ' ') return false;
-        if (!IsAsciiDigit(line[1]) || !IsAsciiDigit(line[2])) return false;
-        if (!IsAsciiDigit(line[4]) || !IsAsciiDigit(line[5])) return false;
-        if (!IsAsciiDigit(line[7]) || !IsAsciiDigit(line[8])) return false;
-        var h = (line[1] - '0') * 10 + (line[2] - '0');
-        var m = (line[4] - '0') * 10 + (line[5] - '0');
-        var s = (line[7] - '0') * 10 + (line[8] - '0');
-        if (h >= 24 || m >= 60 || s >= 60) return false;
-        tod = new TimeSpan(h, m, s);
-        return true;
-    }
-
-    private static bool IsAsciiDigit(char c) => (uint)(c - '0') <= 9;
 }

--- a/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
@@ -8,6 +8,13 @@ namespace Mithril.Shared.Logging;
 /// _find_session_start: scans the last 10 MB for the most recent
 /// ProcessAddPlayer( occurrence so the consumer always receives the
 /// login event regardless of how long ago the session began.
+///
+/// Each emitted <see cref="RawLogLine"/> carries the absolute UTC of the
+/// log line itself (recovered from the <c>[HH:MM:SS]</c> prefix every PG
+/// gameplay line carries) rather than wall-clock-at-read. Past-anchored
+/// cooldown sources (Gandalf Quest/Loot) rely on this to correctly anchor
+/// rows when Mithril launches mid-session and the seed replay surfaces
+/// hours-old completions.
 /// </summary>
 public sealed class PlayerLogTailReader
 {
@@ -18,6 +25,17 @@ public sealed class PlayerLogTailReader
     private readonly TimeProvider _time;
     private long _offset;
     private byte[] _residual = Array.Empty<byte>();
+
+    // Date-folding state, threaded across ReadNew batches. PG's [HH:MM:SS]
+    // prefix lacks a date, so the first content batch anchors on file mtime
+    // (counting any midnight rollovers in the batch and walking the start
+    // back), and subsequent batches keep walking forward — incrementing
+    // _currentLocalDate whenever the time-of-day jumps backward by >12h
+    // (the threshold distinguishes a real midnight rollover from a DST
+    // fall-back's <=1h overlap).
+    private DateOnly? _currentLocalDate;
+    private TimeSpan? _prevLocalTimeOfDay;
+    private DateTime _lastEmittedUtc;
 
     public PlayerLogTailReader(string path, TimeProvider? time = null)
     {
@@ -91,14 +109,112 @@ public sealed class PlayerLogTailReader
         _residual = buf[(lastNl + 1)..total];
         _offset += read;
 
-        var ts = _time.GetUtcNow().UtcDateTime;
         var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length == 0) return Array.Empty<RawLogLine>();
+
+        // First batch with at least one [HH:MM:SS] prefix anchors the date.
+        // Subsequent batches keep _currentLocalDate as-is and continue folding.
+        if (_currentLocalDate is null) InitializeDateAnchor(lines);
+
         var result = new List<RawLogLine>(lines.Length);
         foreach (var line in lines)
         {
             var trimmed = line.EndsWith('\r') ? line[..^1] : line;
-            if (trimmed.Length > 0) result.Add(new RawLogLine(ts, trimmed));
+            if (trimmed.Length == 0) continue;
+            result.Add(new RawLogLine(StampForLine(trimmed), trimmed));
         }
         return result;
     }
+
+    /// <summary>
+    /// Pre-scan the first batch: count midnight rollovers and capture the
+    /// last <c>[HH:MM:SS]</c> tod, then anchor on file mtime so the LAST
+    /// timestamped line lines up with mtime (or mtime - 1 day if its tod
+    /// is past mtime's tod, which happens when the file rolls over to the
+    /// next calendar day shortly after the line was written).
+    /// </summary>
+    private void InitializeDateAnchor(string[] lines)
+    {
+        var rollovers = 0;
+        TimeSpan? prev = null;
+        TimeSpan? lastSeen = null;
+        foreach (var rawLine in lines)
+        {
+            var trimmed = rawLine.EndsWith('\r') ? rawLine[..^1] : rawLine;
+            if (!TryParseTimestampPrefix(trimmed, out var tod)) continue;
+            if (prev.HasValue && tod < prev.Value && (prev.Value - tod) > TimeSpan.FromHours(12))
+                rollovers++;
+            prev = tod;
+            lastSeen = tod;
+        }
+
+        // No timestamped lines anywhere in the batch: leave _currentLocalDate
+        // null so each line falls through to the wall-clock fallback. The
+        // next batch with a prefixed line will re-trigger init.
+        if (lastSeen is null) return;
+
+        DateTime mtime;
+        try { mtime = File.GetLastWriteTime(_path); }
+        catch { mtime = _time.GetUtcNow().LocalDateTime; }
+        var anchorDate = DateOnly.FromDateTime(mtime);
+        if (lastSeen.Value > mtime.TimeOfDay) anchorDate = anchorDate.AddDays(-1);
+
+        _currentLocalDate = anchorDate.AddDays(-rollovers);
+    }
+
+    private DateTime StampForLine(string line)
+    {
+        if (TryParseTimestampPrefix(line, out var tod) && _currentLocalDate.HasValue)
+        {
+            // Midnight rollover: HH wrapped backward by >12h. Smaller backward
+            // jumps (the 1-hour DST fall-back overlap, out-of-order writes
+            // within the same minute) keep the same calendar date.
+            if (_prevLocalTimeOfDay.HasValue
+                && tod < _prevLocalTimeOfDay.Value
+                && (_prevLocalTimeOfDay.Value - tod) > TimeSpan.FromHours(12))
+            {
+                _currentLocalDate = _currentLocalDate.Value.AddDays(1);
+            }
+            _prevLocalTimeOfDay = tod;
+
+            var date = _currentLocalDate.Value;
+            var local = new DateTime(date.Year, date.Month, date.Day,
+                tod.Hours, tod.Minutes, tod.Seconds, DateTimeKind.Local);
+            _lastEmittedUtc = local.ToUniversalTime();
+        }
+        else if (_lastEmittedUtc == default)
+        {
+            // No prefix has been seen yet at all in this stream — fall through
+            // to wall-clock-now. Engine init banners and stack traces are the
+            // typical non-prefixed lines and no parser cares about them.
+            _lastEmittedUtc = _time.GetUtcNow().UtcDateTime;
+        }
+        // else: inherit prior _lastEmittedUtc (engine noise interleaved with
+        // gameplay lines stays anchored on the most recent gameplay tod).
+
+        return _lastEmittedUtc;
+    }
+
+    /// <summary>
+    /// Parse the <c>[HH:MM:SS] </c> prefix every PG gameplay line carries.
+    /// Hand-rolled (vs regex) because this runs once per line on the seed
+    /// replay path and the format is fixed-width.
+    /// </summary>
+    private static bool TryParseTimestampPrefix(string line, out TimeSpan tod)
+    {
+        tod = default;
+        if (line.Length < 11) return false;
+        if (line[0] != '[' || line[3] != ':' || line[6] != ':' || line[9] != ']' || line[10] != ' ') return false;
+        if (!IsAsciiDigit(line[1]) || !IsAsciiDigit(line[2])) return false;
+        if (!IsAsciiDigit(line[4]) || !IsAsciiDigit(line[5])) return false;
+        if (!IsAsciiDigit(line[7]) || !IsAsciiDigit(line[8])) return false;
+        var h = (line[1] - '0') * 10 + (line[2] - '0');
+        var m = (line[4] - '0') * 10 + (line[5] - '0');
+        var s = (line[7] - '0') * 10 + (line[8] - '0');
+        if (h >= 24 || m >= 60 || s >= 60) return false;
+        tod = new TimeSpan(h, m, s);
+        return true;
+    }
+
+    private static bool IsAsciiDigit(char c) => (uint)(c - '0') <= 9;
 }

--- a/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class ChatLogTailReaderTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ChatLogTailReaderTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-chattailreader");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void ReadNew_RecoversAbsoluteTimestampFromBracketedPrefix()
+    {
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        File.WriteAllText(path,
+            "[14:30:00] [Global] Alice: hi\n" +
+            "[15:30:00] [Global] Bob: hey\n");
+        var mtime = new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local);
+        File.SetLastWriteTime(path, mtime);
+
+        var reader = new ChatLogTailReader();
+        var lines = reader.ReadNew(path);
+
+        lines.Should().HaveCount(2);
+        lines[0].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Local));
+        lines[1].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_PerFileSequencerStateIsIndependent()
+    {
+        // Two channel files with overlapping but non-aligned timestamps —
+        // each file's date-folding must be independent. If they shared
+        // sequencer state, the second file's earlier timestamp could trip
+        // the first file's rollover detector or vice versa.
+        var globalPath = Path.Combine(_dir, "Chat.Global.log");
+        var partyPath = Path.Combine(_dir, "Chat.Party.log");
+
+        File.WriteAllText(globalPath, "[23:55:00] global pre-midnight\n");
+        File.SetLastWriteTime(globalPath,
+            new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+
+        File.WriteAllText(partyPath, "[10:00:00] party morning\n");
+        File.SetLastWriteTime(partyPath,
+            new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+
+        var reader = new ChatLogTailReader();
+        var globalLines = reader.ReadNew(globalPath);
+        var partyLines = reader.ReadNew(partyPath);
+
+        globalLines.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+
+        partyLines.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_AcrossBatches_PreservesPerFileRolloverState()
+    {
+        // A single file's first batch ends just before midnight, second batch
+        // starts just after. The reader must carry per-file date state across
+        // ReadNew calls so the post-midnight line gets the next day.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        File.WriteAllText(path, "[23:55:00] pre-midnight\n");
+        File.SetLastWriteTime(path,
+            new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+
+        var reader = new ChatLogTailReader();
+        var first = reader.ReadNew(path);
+        first.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+
+        File.AppendAllText(path, "[00:05:00] post-midnight\n");
+        File.SetLastWriteTime(path,
+            new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+
+        var second = reader.ReadNew(path);
+        second.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+    }
+}

--- a/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
@@ -1,0 +1,198 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class PlayerLogTailReaderTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _logPath;
+
+    public PlayerLogTailReaderTests()
+    {
+        _dir = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-tailreader");
+        _logPath = Path.Combine(_dir, "Player.log");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void ReadNew_RecoversAbsoluteTimestampFromBracketedPrefix()
+    {
+        // Anchors the regression: PlayerLogTailReader used to stamp every line
+        // with wall-clock-now, breaking past-anchored cooldown rows. After the
+        // fix, each line's [HH:MM:SS] is folded over the file's mtime date so
+        // a quest completed an hour before launch anchors at the right wall
+        // clock — not at "now."
+        File.WriteAllText(_logPath,
+            "[14:30:00] LocalPlayer: ProcessAddPlayer(1, 2, \"desc\", \"TestChar\")\n" +
+            "[15:30:00] LocalPlayer: ProcessCompleteQuest(17415332, 28505)\n");
+        var mtime = new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local);
+        File.SetLastWriteTime(_logPath, mtime);
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(2);
+        lines[0].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Local));
+        lines[1].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_AcrossMidnight_FoldsDateForward()
+    {
+        // Marathon session crossing midnight. The pre-midnight line's [HH:MM:SS]
+        // (23:55) is greater than the post-midnight line's (00:05); the >12h
+        // backward gap is the rollover signal, so the post-midnight line gets
+        // tagged with the next calendar day.
+        File.WriteAllText(_logPath,
+            "[23:55:00] line-pre-midnight\n" +
+            "[00:05:00] line-post-midnight\n");
+        var mtime = new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local);
+        File.SetLastWriteTime(_logPath, mtime);
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(2);
+        lines[0].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+        lines[1].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_BackwardJumpUnder12h_StaysInSameDay()
+    {
+        // A DST fall-back creates a 1h backward overlap (e.g. 02:30 → 01:35).
+        // The rollover heuristic requires a >12h backward gap, so the second
+        // line stays on the same calendar date — we don't push it 24h forward.
+        File.WriteAllText(_logPath,
+            "[02:30:00] line-before-fallback\n" +
+            "[01:35:00] line-after-fallback\n");
+        var mtime = new DateTime(2026, 11, 1, 1, 35, 0, DateTimeKind.Local);
+        File.SetLastWriteTime(_logPath, mtime);
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(2);
+        lines[0].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 11, 1, 2, 30, 0, DateTimeKind.Local));
+        lines[1].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 11, 1, 1, 35, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_UnprefixedLine_InheritsPreviousTimestamp()
+    {
+        // Unity engine noise (stack traces, init banners) lacks the [HH:MM:SS]
+        // prefix. No parser cares about these lines but the contract is
+        // "stamp consistently": inherit the most recent gameplay-line tod
+        // rather than re-stamp with wall-clock-now mid-batch.
+        File.WriteAllText(_logPath,
+            "[10:00:00] LocalPlayer: ProcessAddPlayer(1, 2, \"desc\", \"TestChar\")\n" +
+            "NullReferenceException: Object reference not set to an instance of an object.\n" +
+            "[10:00:05] LocalPlayer: next gameplay line\n");
+        var mtime = new DateTime(2026, 5, 10, 10, 0, 5, DateTimeKind.Local);
+        File.SetLastWriteTime(_logPath, mtime);
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(3);
+        lines[0].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+        lines[1].Timestamp.Should().Be(lines[0].Timestamp);  // inherited
+        lines[2].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 5, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_LeadingUnprefixedLines_FallThroughToTimeProviderNow()
+    {
+        // Engine init banners arrive before any [HH:MM:SS]. With no prior
+        // gameplay tod to inherit, fall through to wall-clock-now. Fakable so
+        // CI doesn't have to depend on real-time progression.
+        File.WriteAllText(_logPath,
+            "Initialize engine version: 6000.3.11f1\n" +
+            "[Physics::Module] Initialized fallback backend.\n" +
+            "[10:00:00] LocalPlayer: first gameplay line\n");
+        var mtime = new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local);
+        File.SetLastWriteTime(_logPath, mtime);
+
+        var fixedNow = new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc);
+        var time = new FixedTimeProvider(fixedNow);
+
+        var reader = new PlayerLogTailReader(_logPath, time);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(3);
+        lines[0].Timestamp.Should().Be(fixedNow);
+        lines[1].Timestamp.Should().Be(fixedNow);  // inherited from line 0's fallback
+        lines[2].Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_AcrossBatches_PreservesRolloverState()
+    {
+        // First batch ends just before midnight, second batch starts just
+        // after. The reader must carry _currentLocalDate + _prevLocalTimeOfDay
+        // across the batch boundary so the post-midnight line gets the next
+        // day — not the same day as the pre-midnight line.
+        File.WriteAllText(_logPath, "[23:55:00] pre-midnight\n");
+        File.SetLastWriteTime(_logPath,
+            new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var first = reader.ReadNew();
+        first.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+
+        File.AppendAllText(_logPath, "[00:05:00] post-midnight\n");
+        File.SetLastWriteTime(_logPath,
+            new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+
+        var second = reader.ReadNew();
+        second.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+    }
+
+    [Fact]
+    public void ReadNew_LastLineTodPastMtimeTimeOfDay_BacksAnchorUpOneDay()
+    {
+        // Late-night session: the final [HH:MM:SS] is at 23:59 but the file's
+        // mtime ticked over to 00:01 the next calendar day (write-buffer flush
+        // happens after midnight). The line was actually written yesterday;
+        // the anchor must back up one day so we don't tag it with tomorrow.
+        File.WriteAllText(_logPath, "[23:59:00] last-line\n");
+        var mtime = new DateTime(2026, 5, 11, 0, 1, 0, DateTimeKind.Local);
+        File.SetLastWriteTime(_logPath, mtime);
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().ContainSingle()
+            .Which.Timestamp.ToLocalTime()
+            .Should().Be(new DateTime(2026, 5, 10, 23, 59, 0, DateTimeKind.Local));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTimeProvider(DateTime utc) => _now = new DateTimeOffset(utc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}


### PR DESCRIPTION
Closes #183.

## Summary

- Both `PlayerLogTailReader` and `ChatLogTailReader` were stamping every line with wall-clock-now, ignoring the `[HH:MM:SS]` prefix every PG gameplay line carries. On Mithril startup `SeedToSessionStart` rewinds to the most recent `ProcessAddPlayer(` and republishes the entire seed batch — all of those historical lines got "now" as their `RawLogLine.Timestamp`, silently defeating the past-anchoring contract that `DerivedTimerProgressService` is explicitly designed around.
- Quest/Loot cooldown rows in Gandalf were the visible symptom: a quest completed 8 h before launch anchored at "now" and showed ~20 h remaining instead of ~12 h.
- Fix: extract a shared `LogLineTimestampSequencer` that parses the prefix, anchors the first content batch on file mtime (counting midnight rollovers in the batch and walking the start back), then folds forward — incrementing the date whenever HH wraps backward by >12 h. The threshold distinguishes a real midnight rollover from a DST fall-back's <=1 h overlap. Lines without the prefix (Unity engine noise — ~75k lines in a typical 130 MB log, none of them parsed by anything in Mithril) inherit the previous gameplay line's stamp, or fall through to `TimeProvider.GetUtcNow()` if nothing has been seen yet.
- `ChatLogTailReader` is multi-file (per-channel), so it gets one sequencer instance per file. Today's chat consumers (Saruman, Arwen) don't past-anchor on chat timestamps, so this side of the fix is preventative — but the seam was the same trap and a future derived chat-source would have inherited it.

Every parser already takes a `DateTime timestamp` argument, so no parser-level edits are needed once the readers produce the right value.

## Test plan

- [x] `LogLineTimestampSequencer` exercised through both readers' integration tests.
- [x] `PlayerLogTailReaderTests`: single-day recovery, midnight rollover, DST fall-back NOT triggering rollover, unprefixed-line inheritance, leading-unprefixed fallback to `TimeProvider`, state preservation across `ReadNew()` batches, and the late-night case where last `[HH:MM:SS]` is past mtime time-of-day. (7 tests)
- [x] `ChatLogTailReaderTests`: timestamp recovery, per-file state independence (two channels with overlapping but non-aligned tods don't cross-contaminate), batch-boundary state preservation. (3 tests)
- [x] Full `dotnet test Mithril.slnx` green (1654 tests, 0 failures).
- [x] Local `dotnet build` clean (0 warnings, 0 errors — warnings-as-errors is on).
- [ ] **In-game verification owed:** launch Mithril after completing a known repeatable quest several hours earlier; the Gandalf Quest tab card should reflect the actual elapsed time, not "freshly started." (Can't validate in CI; it's the original repro path.)