### PR TITLE
feat(gandalf): hard-delete loot rows for false-positive parser entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ tests/.tmp/
 src/temp
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/tmp/
+.claude/worktrees/
 
 # Legacy browser-based garden helper (superseded by Samwise module)
 garden/

--- a/src/Gandalf.Module/Services/DerivedTimerProgressService.cs
+++ b/src/Gandalf.Module/Services/DerivedTimerProgressService.cs
@@ -107,6 +107,22 @@ public sealed class DerivedTimerProgressService : IDisposable
     }
 
     /// <summary>
+    /// Hard-delete the progress row outright (vs. <see cref="Dismiss"/> which
+    /// only stamps <c>DismissedAt</c>). Used by sources that hard-delete a
+    /// catalog entry — the progress row goes with it so a later re-discovery
+    /// of the same key starts from a clean slate.
+    /// </summary>
+    public void Remove(string sourceId, string key)
+    {
+        var current = _view.Current;
+        if (current is null) return;
+        if (!current.BySource.TryGetValue(sourceId, out var inner)) return;
+        if (!inner.Remove(key)) return;
+        SaveNow();
+        ProgressChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
     /// Drop progress entries whose key is no longer in the live catalog. Called by
     /// each source on <c>CatalogChanged</c> so removed quests/chests don't leak
     /// progress rows forever.

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -259,6 +259,49 @@ public sealed class LootSource : ITimerSource, IDisposable
     }
 
     /// <summary>
+    /// Hard-delete a row from the catalog and progress. Used by the UI to
+    /// clean up false-positive entries the bracket tracker accreted before
+    /// its discrimination signals were complete (e.g. <c>Chair</c>,
+    /// <c>NPC_Otis</c>, <c>AppleTree</c>). Unlike <see cref="DerivedTimerProgressService.Dismiss"/>,
+    /// which only stamps <c>DismissedAt</c> and lets the next observation
+    /// resurrect the row, <c>Forget</c> drops the catalog cache entry too —
+    /// the row will only return if a new observation re-discovers it.
+    ///
+    /// Intentionally no blocklist: re-discovery is a useful signal that the
+    /// parser regressed, and a silent suppression list would mask that.
+    /// </summary>
+    public void Forget(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return;
+
+        var changed = false;
+        lock (_catalogLock)
+        {
+            if (key.StartsWith("chest:", StringComparison.Ordinal))
+            {
+                var internalName = key["chest:".Length..];
+                if (_cache.LearnedChests.Remove(internalName)) changed = true;
+                if (_cache.ChestDurationByInternalName.Remove(internalName)) changed = true;
+            }
+            else if (key.StartsWith("defeat:", StringComparison.Ordinal))
+            {
+                var displayName = key["defeat:".Length..];
+                if (_cache.LearnedDefeats.Remove(displayName)) changed = true;
+            }
+        }
+
+        if (!changed) return;
+        try { _cacheStore.Save(_cache); } catch { /* best-effort */ }
+
+        // Order: re-project first so the catalog drops the key and the diff
+        // emits a single Removed delta. The subsequent progress Remove fires
+        // ProgressChanged but produces no delta because the differ only
+        // tracks rows present in the (now-empty) new catalog.
+        EnsureCatalogReprojected();
+        _derived.Remove(Id, key);
+    }
+
+    /// <summary>
     /// Replace the calibration overlay (durations + region for known bosses).
     /// Intended for the Gandalf calibration bridge that subscribes to
     /// <see cref="Mithril.Shared.Reference.ICommunityCalibrationService"/> and

--- a/src/Gandalf.Module/ViewModels/LootTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/LootTimersViewModel.cs
@@ -71,6 +71,20 @@ public sealed partial class LootTimersViewModel : ObservableObject, IDisposable
         _derived.Dismiss(_source.SourceId, vm.Key);
     }
 
+    /// <summary>
+    /// Hard-delete: drop the catalog cache entry and the progress row outright.
+    /// Distinct from <see cref="DismissOne"/>, which only stamps
+    /// <c>DismissedAt</c> and lets re-observation resurrect the row.
+    /// Intended for false-positive entries the bracket tracker accreted before
+    /// its discrimination signals were complete.
+    /// </summary>
+    [RelayCommand]
+    private void RemoveOne(TimerItemViewModel? vm)
+    {
+        if (vm is null) return;
+        _source.Forget(vm.Key);
+    }
+
     partial void OnKindFilterChanged(LootKindFilter value) => TimersView.Refresh();
     partial void OnStateFilterChanged(LootStateFilter value) => TimersView.Refresh();
 

--- a/src/Gandalf.Module/Views/LootTimersView.xaml
+++ b/src/Gandalf.Module/Views/LootTimersView.xaml
@@ -112,13 +112,24 @@
                                                        Visibility="{Binding IsDurationVerified, Converter={StaticResource InverseBoolToVis}}"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <Button Grid.Column="1" Width="20" Height="20" Padding="0"
-                                            Background="Transparent" BorderThickness="0"
-                                            Cursor="Hand" ToolTip="Dismiss this cooldown"
-                                            Command="{Binding DataContext.DismissOneCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                            CommandParameter="{Binding}">
-                                        <icon:PackIconLucide Kind="X" Width="11" Height="11" Foreground="#66FFFFFF"/>
-                                    </Button>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                        <Button Width="20" Height="20" Padding="0"
+                                                Background="Transparent" BorderThickness="0"
+                                                Cursor="Hand"
+                                                ToolTip="Remove permanently — drops the catalog entry. Use for false-positive rows the parser shouldn't have created (e.g. NPCs, workstations)."
+                                                Command="{Binding DataContext.RemoveOneCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                CommandParameter="{Binding}">
+                                            <icon:PackIconLucide Kind="Trash2" Width="11" Height="11" Foreground="#66FFFFFF"/>
+                                        </Button>
+                                        <Button Width="20" Height="20" Padding="0"
+                                                Background="Transparent" BorderThickness="0"
+                                                Cursor="Hand"
+                                                ToolTip="Dismiss this cooldown — clears it from view. The row will return on next observation with a fresh cooldown."
+                                                Command="{Binding DataContext.DismissOneCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                CommandParameter="{Binding}">
+                                            <icon:PackIconLucide Kind="X" Width="11" Height="11" Foreground="#66FFFFFF"/>
+                                        </Button>
+                                    </StackPanel>
                                 </Grid>
 
                                 <TextBlock Margin="0,6,0,0">

--- a/tests/Gandalf.Tests/DerivedTimerProgressServiceTests.cs
+++ b/tests/Gandalf.Tests/DerivedTimerProgressServiceTests.cs
@@ -132,6 +132,48 @@ public class DerivedTimerProgressServiceTests : IDisposable
     }
 
     [Fact]
+    public void Remove_drops_row_outright_unlike_Dismiss()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            svc.Start("gandalf.loot", "k1", time.GetUtcNow() - TimeSpan.FromHours(1));
+            svc.GetProgress("gandalf.loot", "k1").Should().NotBeNull();
+
+            svc.Remove("gandalf.loot", "k1");
+
+            // Hard-delete: row gone from storage, not just stamped DismissedAt.
+            svc.GetProgress("gandalf.loot", "k1").Should().BeNull();
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Remove_of_unknown_key_is_noop()
+    {
+        var (svc, view, active, time) = BuildService();
+        try
+        {
+            active.SetActiveCharacter("Arthur", "Kwatoxi");
+
+            // No throw, no event fire.
+            var fired = 0;
+            svc.ProgressChanged += (_, _) => fired++;
+            svc.Remove("gandalf.loot", "never-existed");
+            fired.Should().Be(0);
+        }
+        finally
+        {
+            svc.Dispose(); view.Dispose();
+        }
+    }
+
+    [Fact]
     public void Dismiss_uses_TimeProvider_clock_not_DateTimeOffset_UtcNow()
     {
         var (svc, view, active, time) = BuildService();

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -468,6 +468,144 @@ public class LootSourceTests : IDisposable
     }
 
     [Fact]
+    public void Forget_chest_drops_catalog_progress_and_cache_entries()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
+            src.OnChestInteraction("GoblinStaticChest1", time.GetUtcNow().UtcDateTime);
+
+            var key = LootSource.ChestKey("GoblinStaticChest1");
+            src.Catalog.Should().Contain(c => c.Key == key);
+            src.Progress.Should().ContainKey(key);
+
+            src.Forget(key);
+
+            src.Catalog.Should().NotContain(c => c.Key == key,
+                "Forget drops the catalog row entirely, not just hides it");
+            src.Progress.Should().NotContainKey(key,
+                "Forget removes the progress row outright (vs. Dismiss which only stamps DismissedAt)");
+
+            // Both cache dictionaries are cleared so the row doesn't resurrect on restart.
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedChests.Should().NotContainKey("GoblinStaticChest1");
+            cache.ChestDurationByInternalName.Should().NotContainKey("GoblinStaticChest1");
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Forget_defeat_drops_learned_entry_and_progress()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnBossKillCredit("Den Mother", time.GetUtcNow().UtcDateTime);
+
+            var key = LootSource.DefeatKey("Den Mother");
+            src.Catalog.Should().Contain(c => c.Key == key);
+            src.Progress.Should().ContainKey(key);
+
+            src.Forget(key);
+
+            src.Catalog.Should().NotContain(c => c.Key == key);
+            src.Progress.Should().NotContainKey(key);
+
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedDefeats.Should().NotContainKey("Den Mother");
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Forget_emits_single_Removed_delta()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnChestInteraction("Chair", time.GetUtcNow().UtcDateTime);
+            var key = LootSource.ChestKey("Chair");
+
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            src.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            src.Forget(key);
+
+            // Single Removed delta — the catalog re-projection drops the row;
+            // the subsequent progress Remove fires ProgressChanged but produces
+            // no delta because the differ only tracks rows present in the
+            // (now-empty) new catalog.
+            var removedDeltas = batches.SelectMany(b => b)
+                .Where(d => d.Key == key && d.Kind == TimerRowChangeKind.Removed)
+                .ToList();
+            removedDeltas.Should().HaveCount(1);
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Forget_then_re_observe_resurrects_cleanly()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            // User wipes a false-positive entry. If the parser later re-emits
+            // the same key (i.e. there's a regression), the row should come
+            // back — that's the deliberate non-blocklist design: re-discovery
+            // is a useful regression signal.
+            src.OnChestInteraction("Portal", time.GetUtcNow().UtcDateTime);
+            src.Forget(LootSource.ChestKey("Portal"));
+            src.Catalog.Should().BeEmpty();
+
+            time.Advance(TimeSpan.FromMinutes(10));
+            var newLoot = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("Portal", newLoot);
+
+            src.Catalog.Should().ContainSingle()
+                .Which.Key.Should().Be(LootSource.ChestKey("Portal"));
+            src.Progress[LootSource.ChestKey("Portal")].StartedAt
+                .Should().Be(new DateTimeOffset(newLoot, TimeSpan.Zero));
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Forget_of_unknown_key_is_noop()
+    {
+        var (src, derived, _, _) = Build();
+        try
+        {
+            var batches = new List<IReadOnlyList<TimerRowDelta>>();
+            src.RowsChanged += (_, e) => batches.Add(e.Deltas);
+
+            src.Forget(LootSource.ChestKey("NeverExisted"));
+            src.Forget(LootSource.DefeatKey("NeverExisted"));
+            src.Forget("malformed-key");
+
+            batches.Should().BeEmpty();
+        }
+        finally
+        {
+            src.Dispose(); derived.Dispose();
+        }
+    }
+
+    [Fact]
     public void OnChestInteraction_emits_RowsChanged_with_added_delta()
     {
         var (src, derived, _, time) = Build();


### PR DESCRIPTION
## Summary
- Adds a per-card hard-delete button to the Gandalf Loot tab — the existing `x` (Dismiss) is preserved unchanged, and a new trash icon next to it calls `LootSource.Forget` to drop the catalog cache entry and progress row outright.
- Fixes the long-standing case where the Loot tab accumulates false-positive rows (Chair, Fireplace, NPC_*, Teleport_*, AppleTree, Portal, etc.) committed by `LootBracketTracker` before its discrimination signals were complete (#73, #174, #177, #181). Dismiss alone could never clean these up because the catalog row is persisted in `LootCatalogCache.LearnedChests` independently of progress state.
- No blocklist by design — re-discovery of a removed key is a useful regression signal for parser changes.

Closes #186.

## Implementation notes
- `DerivedTimerProgressService.Remove(sourceId, key)` — sibling to `Dismiss`; deletes the row outright instead of stamping `DismissedAt`.
- `LootSource.Forget(key)` — parses the `chest:` / `defeat:` prefix, drops `LearnedChests` + `ChestDurationByInternalName` (or `LearnedDefeats` for boss rows), saves the cache, re-projects, then removes progress. Order chosen so the catalog re-projection emits a single `Removed` delta and the subsequent progress remove fires `ProgressChanged` but produces no delta (the differ only tracks rows present in the new catalog).
- `LootTimersViewModel.RemoveOneCommand` wired to the new trash button. No bulk "Remove All" — too easy to nuke a year of legitimate calibration data by misclick.
- Quest tab untouched. Quest catalog is curated upstream so hard-delete has no use case there.

## Test plan
- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — full suite green
- [x] `Gandalf.Tests` — 287 passed including 7 new tests:
  - `DerivedTimerProgressServiceTests.Remove_drops_row_outright_unlike_Dismiss`
  - `DerivedTimerProgressServiceTests.Remove_of_unknown_key_is_noop`
  - `LootSourceTests.Forget_chest_drops_catalog_progress_and_cache_entries`
  - `LootSourceTests.Forget_defeat_drops_learned_entry_and_progress`
  - `LootSourceTests.Forget_emits_single_Removed_delta`
  - `LootSourceTests.Forget_then_re_observe_resurrects_cleanly`
  - `LootSourceTests.Forget_of_unknown_key_is_noop`
- [ ] **Manual UI verification** — run `dotnet run --project src/Mithril.Shell`, open the Loot tab, confirm the trash icon renders next to the X, hover-check both tooltips read sensibly, click the trash on a real row and confirm it disappears + survives a Mithril restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
