### PR TITLE
feat(gandalf): chest area capture + friendly display name resolution + rejection-anchored rows

### DIFF
--- a/src/Gandalf.Module/Domain/LootCatalogCache.cs
+++ b/src/Gandalf.Module/Domain/LootCatalogCache.cs
@@ -58,11 +58,21 @@ public sealed class LootCatalogCache
 /// <see cref="LearnedDefeat"/>; the chest's duration lives in
 /// <see cref="LootCatalogCache.ChestDurationByInternalName"/> only once a
 /// rejection has confirmed it.
+///
+/// <para><see cref="Area"/> records the player's current area at the moment
+/// the chest was first committed (#178). Used both for grouping in the UI
+/// and for friendly-name resolution via
+/// <c>strings_all.json[npc_&lt;Area&gt;/&lt;InternalName&gt;_Name]</c>.
+/// Sticky-once-known: once stamped, later commits don't overwrite — handles
+/// the rare case where a chest internal name lives in multiple zones.
+/// Older cache entries serialised before #178 deserialise with
+/// <see cref="Area"/> = <c>null</c> and self-heal on the next loot.</para>
 /// </summary>
 public sealed class LearnedChest
 {
     public DateTime FirstObservedAt { get; set; }
     public DateTime LastObservedAt { get; set; }
+    public string? Area { get; set; }
 }
 
 /// <summary>

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -85,6 +85,8 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<InteractionEndParser>();
         services.AddSingleton<InteractionDelayLoopParser>();
         services.AddSingleton<InteractionWaitParser>();
+        services.AddSingleton<AreaTransitionParser>();
+        services.AddSingleton<PlayerAreaTracker>();
         services.AddSingleton<BossKillCreditParser>();
         services.AddSingleton<DefeatCooldownParser>();
         services.AddSingleton<LootBracketTracker>();
@@ -92,6 +94,8 @@ public sealed class GandalfModule : IMithrilModule
             sp.GetRequiredService<DerivedTimerProgressService>(),
             sp.GetRequiredService<ISettingsStore<LootCatalogCache>>(),
             sp.GetRequiredService<LootCatalogCache>(),
+            areaTracker: sp.GetService<PlayerAreaTracker>(),
+            refData: sp.GetService<Mithril.Shared.Reference.IReferenceDataService>(),
             time: null,
             diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
         services.AddHostedService<LootIngestionService>();

--- a/src/Gandalf.Module/Parsing/AreaTransitionParser.cs
+++ b/src/Gandalf.Module/Parsing/AreaTransitionParser.cs
@@ -1,0 +1,69 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Gandalf.Parsing;
+
+/// <summary>
+/// Parses Project Gorgon's <c>LOADING LEVEL Area&lt;Name&gt;</c> log line into
+/// an <see cref="AreaTransitionEvent"/>. Fires on initial spawn (after
+/// character select) and on every zone transition during gameplay. The area
+/// code matches <c>areas.json</c> keys exactly (e.g. <c>"AreaSerbule"</c>,
+/// <c>"AreaEltibule"</c>, <c>"AreaTomb1"</c>).
+///
+/// Three discriminable forms (#178 wiki):
+/// <list type="bullet">
+///   <item><c>LOADING LEVEL Area&lt;Name&gt;</c> — real game area; emits a
+///   non-null <see cref="AreaTransitionEvent.AreaKey"/>.</item>
+///   <item><c>LOADING LEVEL ChooseCharacter</c> — character-select screen;
+///   emits a null AreaKey so the tracker clears its current-area state (no
+///   chest interactions can fire from this screen).</item>
+///   <item><c>LOADING LEVEL </c> (empty) — disconnect; same null-AreaKey
+///   handling as ChooseCharacter.</item>
+/// </list>
+///
+/// Live capture (#178):
+/// <code>
+/// [17:11:10] LOADING LEVEL AreaSerbule
+/// [17:28:06] LOADING LEVEL AreaEltibule
+/// [18:30:35] LOADING LEVEL                  ← empty body on disconnect
+/// [19:13:54] LOADING LEVEL ChooseCharacter
+/// </code>
+///
+/// The line is unprefixed (no <c>LocalPlayer:</c>) and may or may not carry
+/// the <c>[HH:MM:SS]</c> timestamp prefix that <see cref="PlayerLogTailReader"/>
+/// strips before passing to parsers. The regex is permissive about leading
+/// whitespace.
+/// </summary>
+public sealed partial class AreaTransitionParser : ILogParser
+{
+    [GeneratedRegex(
+        """^\s*LOADING LEVEL\s*(?<area>\S*)\s*$""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex AreaRx();
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (!line.Contains("LOADING LEVEL", StringComparison.Ordinal)) return null;
+        var m = AreaRx().Match(line);
+        if (!m.Success) return null;
+
+        var area = m.Groups["area"].Value;
+
+        // ChooseCharacter and empty body both indicate "not in a real game
+        // area"; emit null so the tracker clears.
+        if (string.IsNullOrEmpty(area) ||
+            string.Equals(area, "ChooseCharacter", StringComparison.Ordinal))
+        {
+            return new AreaTransitionEvent(timestamp, AreaKey: null);
+        }
+
+        // Real area names always start with "Area" by PG convention. Anything
+        // else (defensive — unknown intermediate level loads) emits null too.
+        if (!area.StartsWith("Area", StringComparison.Ordinal))
+        {
+            return new AreaTransitionEvent(timestamp, AreaKey: null);
+        }
+
+        return new AreaTransitionEvent(timestamp, AreaKey: area);
+    }
+}

--- a/src/Gandalf.Module/Parsing/LootEvents.cs
+++ b/src/Gandalf.Module/Parsing/LootEvents.cs
@@ -61,3 +61,18 @@ public sealed record InteractionDelayLoopEvent(DateTime Timestamp, string Verb, 
 /// </summary>
 public sealed record InteractionWaitEvent(DateTime Timestamp, long InteractorId, string Body)
     : LogEvent(Timestamp);
+
+/// <summary>
+/// Player transitioned to a new area (or out of game-world, e.g. character
+/// select / disconnect). Parsed from the <c>LOADING LEVEL Area&lt;Name&gt;</c>
+/// line every PG zone change emits.
+///
+/// <see cref="AreaKey"/> is the area code (matches <c>areas.json</c> keys
+/// exactly: <c>"AreaSerbule"</c>, <c>"AreaEltibule"</c>, …) when in a real
+/// area, or <c>null</c> for the character-select screen, disconnect, or any
+/// non-Area level load. Consumers should treat <c>null</c> as "current area
+/// is unknown" — chest commits during a null-area window persist with
+/// <c>Area = null</c> and self-heal on the next portal.
+/// </summary>
+public sealed record AreaTransitionEvent(DateTime Timestamp, string? AreaKey)
+    : LogEvent(Timestamp);

--- a/src/Gandalf.Module/Services/LootBracketTracker.cs
+++ b/src/Gandalf.Module/Services/LootBracketTracker.cs
@@ -135,7 +135,7 @@ public sealed partial class LootBracketTracker
             && _rejectionParser.TryParse(line, timestamp) is ChestCooldownObservedEvent rejection
             && _bracketName is not null)
         {
-            _source.OnChestCooldownObserved(_bracketName, rejection.Duration);
+            _source.OnChestCooldownObserved(_bracketName, rejection.Duration, rejection.Timestamp);
             ResetIdle();
             return;
         }
@@ -143,8 +143,12 @@ public sealed partial class LootBracketTracker
         // 3b. Cow milking cooldown rejection — different log channel
         // (ErrorMessage vs GeneralInfo) and different grammar (relative-past
         // "in the past hour" vs forward-looking "will refill N hours after").
-        // Same downstream contract as the chest rejection: cache the duration
-        // by the bracket's internal name, close the bracket. Gated by the
+        // Same downstream contract as the chest rejection EXCEPT for the
+        // anchor handling: the cow grammar gives us no info about when the
+        // last successful milking happened (only that it's within the
+        // cooldown window), so we pass anchorFromRejection=true to let
+        // LootSource conservatively anchor at rejectionTime when no row
+        // exists or the existing anchor is stale (#178). Gated by the
         // "Cow_" name prefix so a stray ErrorMessage from a non-cow bracket
         // (e.g. "You're too encumbered!" inside an unrelated chest bracket)
         // doesn't poison the chest's cooldown by 1 hour. Wiki: #181.
@@ -153,7 +157,11 @@ public sealed partial class LootBracketTracker
             && _bracketName.StartsWith("Cow_", StringComparison.Ordinal)
             && _milkingRejectionParser.TryParse(line, timestamp) is ChestCooldownObservedEvent milkRejection)
         {
-            _source.OnChestCooldownObserved(_bracketName, milkRejection.Duration);
+            _source.OnChestCooldownObserved(
+                _bracketName,
+                milkRejection.Duration,
+                milkRejection.Timestamp,
+                anchorFromRejection: true);
             ResetIdle();
             return;
         }

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -1,7 +1,8 @@
 using Gandalf.Parsing;
-using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Logging;
 using Microsoft.Extensions.Hosting;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
 
 namespace Gandalf.Services;
 
@@ -16,6 +17,12 @@ namespace Gandalf.Services;
 /// anchor (the <see cref="DefeatCooldownParser"/> rejection text remains as
 /// a diagnostic-only "cooldown still active" observation).
 ///
+/// Also feeds <see cref="PlayerAreaTracker"/> so chest commits stamp the
+/// player's current area on <c>LearnedChest.Area</c> (#178). The tracker is
+/// reverse-scan-seeded at startup to close the gap where
+/// <c>PlayerLogStream.SeedToSessionStart</c> lands ~9 s after the
+/// <c>LOADING LEVEL</c> line for the current area.
+///
 /// No <c>ModuleGate</c> wait — Gandalf is eager; derived-source log replay
 /// must run as soon as the host starts.
 /// </summary>
@@ -25,7 +32,9 @@ public sealed class LootIngestionService : BackgroundService
     private readonly LootBracketTracker _bracket;
     private readonly BossKillCreditParser _bossKill;
     private readonly DefeatCooldownParser _defeatCooldown;
+    private readonly PlayerAreaTracker _areaTracker;
     private readonly LootSource _source;
+    private readonly GameConfig _config;
     private readonly IDiagnosticsSink? _diag;
     private bool _firstObservationLogged;
 
@@ -34,19 +43,33 @@ public sealed class LootIngestionService : BackgroundService
         LootBracketTracker bracket,
         BossKillCreditParser bossKill,
         DefeatCooldownParser defeatCooldown,
+        PlayerAreaTracker areaTracker,
         LootSource source,
+        GameConfig config,
         IDiagnosticsSink? diag = null)
     {
         _stream = stream;
         _bracket = bracket;
         _bossKill = bossKill;
         _defeatCooldown = defeatCooldown;
+        _areaTracker = areaTracker;
         _source = source;
+        _config = config;
         _diag = diag;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // One-shot reverse-scan for the most recent LOADING LEVEL Area* line
+        // before the live tail kicks in. PlayerLogStream's SessionMarker
+        // (ProcessAddPlayer) lands ~9 s after the area-load line, so the
+        // live replay window misses it; this seed closes the gap. Best-
+        // effort — failures don't block ingestion.
+        if (!string.IsNullOrEmpty(_config.PlayerLogPath))
+        {
+            _areaTracker.SeedFromLog(_config.PlayerLogPath);
+        }
+
         await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
             try { Dispatch(raw); }
@@ -56,6 +79,10 @@ public sealed class LootIngestionService : BackgroundService
 
     private void Dispatch(RawLogLine raw)
     {
+        // Area transitions update the tracker BEFORE the bracket sees the
+        // line, so any subsequent chest interaction in the same dispatch
+        // batch reads the correct CurrentArea.
+        _areaTracker.Observe(raw);
         _bracket.Observe(raw);
 
         if (_bossKill.TryParse(raw.Line, raw.Timestamp) is BossKillCreditEvent kill)

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
 using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 
 namespace Gandalf.Services;
@@ -46,6 +47,8 @@ public sealed class LootSource : ITimerSource, IDisposable
     private readonly DerivedTimerProgressService _derived;
     private readonly ISettingsStore<LootCatalogCache> _cacheStore;
     private readonly LootCatalogCache _cache;
+    private readonly PlayerAreaTracker? _areaTracker;
+    private readonly IReferenceDataService? _refData;
     private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
     private readonly object _catalogLock = new();
@@ -59,12 +62,16 @@ public sealed class LootSource : ITimerSource, IDisposable
         DerivedTimerProgressService derived,
         ISettingsStore<LootCatalogCache> cacheStore,
         LootCatalogCache cache,
+        PlayerAreaTracker? areaTracker = null,
+        IReferenceDataService? refData = null,
         TimeProvider? time = null,
         IDiagnosticsSink? diag = null)
     {
         _derived = derived;
         _cacheStore = cacheStore;
         _cache = cache;
+        _areaTracker = areaTracker;
+        _refData = refData;
         _time = time ?? TimeProvider.System;
         _diag = diag;
         _catalog = BuildCatalog();
@@ -109,7 +116,10 @@ public sealed class LootSource : ITimerSource, IDisposable
 
         // Persist the discovery so the row survives across sessions even if
         // the rejection screen never fires (placeholder behaviour mirrors the
-        // defeat-cooldown auto-learn path).
+        // defeat-cooldown auto-learn path). Area is stamped sticky-once-known
+        // (#178) — first commit wins so the same internal name in two zones
+        // doesn't ping-pong its area attribution.
+        var currentArea = _areaTracker?.CurrentArea;
         var learnedChanged = false;
         lock (_catalogLock)
         {
@@ -119,13 +129,22 @@ public sealed class LootSource : ITimerSource, IDisposable
                 {
                     FirstObservedAt = timestampUtc,
                     LastObservedAt = timestampUtc,
+                    Area = currentArea,
                 };
                 learnedChanged = true;
             }
-            else if (timestampUtc > entry.LastObservedAt)
+            else
             {
-                entry.LastObservedAt = timestampUtc;
-                learnedChanged = true;
+                if (timestampUtc > entry.LastObservedAt)
+                {
+                    entry.LastObservedAt = timestampUtc;
+                    learnedChanged = true;
+                }
+                if (entry.Area is null && currentArea is not null)
+                {
+                    entry.Area = currentArea;
+                    learnedChanged = true;
+                }
             }
         }
         if (learnedChanged)
@@ -145,46 +164,126 @@ public sealed class LootSource : ITimerSource, IDisposable
     }
 
     /// <summary>
-    /// Apply a chest rejection observation: cache the discovered duration
-    /// against the chest template name. Future loots of any chest of this
-    /// template will start with the verified duration.
+    /// Apply a cooldown-rejection observation: cache the discovered duration
+    /// and (optionally) anchor a row from the rejection timestamp.
     ///
-    /// If a placeholder row is already in flight from an earlier loot, the
-    /// row's <c>StartedAt</c> is preserved (it's anchored on the original
-    /// <c>ProcessStartInteraction</c> timestamp). The catalog re-projection
-    /// upgrades the duration and flips <c>IsDurationVerified</c> to <c>true</c>;
-    /// if the new ready time has already elapsed,
-    /// <see cref="TimerReady"/> fires so downstream listeners notice.
+    /// <para><b>Default (chest grammar — forward-looking).</b> The
+    /// rejection text says <c>"It will refill N hours after you looted
+    /// it."</c>, so the cooldown is anchored at the loot time the row's
+    /// existing <c>StartedAt</c> already records. Just update the duration;
+    /// re-fire <see cref="TimerReady"/> if the new FiringAt has already
+    /// elapsed. Today's behaviour preserved.</para>
+    ///
+    /// <para><b><paramref name="anchorFromRejection"/> = true (cow / other
+    /// relative-past grammars).</b> The rejection text says
+    /// <c>"in the past hour"</c> — the actual cooldown anchor is unknown
+    /// (somewhere in <c>(rejectionTime - duration, rejectionTime]</c>) and
+    /// the existing row's <c>StartedAt</c> may not be trustworthy. Three
+    /// states (#178):
+    /// <list type="bullet">
+    ///   <item><b>No prior row</b> — create one anchored at the rejection
+    ///   timestamp. Conservative: overstates remaining time by up to
+    ///   <paramref name="duration"/> but won't fire <c>Ready</c> early.
+    ///   Self-corrects on the next successful loot.</item>
+    ///   <item><b>Prior row, still in flight</b> (StartedAt + duration &gt; now)
+    ///   — leave anchor alone.</item>
+    ///   <item><b>Prior row, already past FiringAt but rejection says
+    ///   cooldown is still active</b> (stale anchor) — refresh
+    ///   <c>StartedAt</c> to the rejection timestamp. Trust the rejection
+    ///   over a recorded loot Mithril may have missed.</item>
+    /// </list>
+    /// </para>
     /// </summary>
     public void OnChestCooldownObserved(string chestInternalName, TimeSpan duration)
+        => OnChestCooldownObserved(chestInternalName, duration, _time.GetUtcNow().UtcDateTime);
+
+    public void OnChestCooldownObserved(
+        string chestInternalName,
+        TimeSpan duration,
+        DateTime rejectionTimestampUtc,
+        bool anchorFromRejection = false)
     {
         if (string.IsNullOrEmpty(chestInternalName) || duration <= TimeSpan.Zero) return;
-        var changed = false;
+
+        // 1. Cache the duration so future first-time loots stamp with the
+        // verified value.
+        var durationChanged = false;
         lock (_catalogLock)
         {
             if (!_cache.ChestDurationByInternalName.TryGetValue(chestInternalName, out var existing)
                 || existing != duration)
             {
                 _cache.ChestDurationByInternalName[chestInternalName] = duration;
-                changed = true;
+                durationChanged = true;
             }
         }
-        if (changed)
+
+        var key = ChestKey(chestInternalName);
+        var prior = _derived.GetProgress(Id, key);
+        var rejectionAt = new DateTimeOffset(rejectionTimestampUtc, TimeSpan.Zero);
+        var rowChanged = false;
+        var learnedAreaStamped = false;
+
+        // 2. Anchor / refresh the row from the rejection timestamp — only
+        // for relative-past grammars where the loot time isn't recoverable
+        // from the rejection text. For forward-looking grammars (chest),
+        // the existing StartedAt is more accurate so we leave it alone.
+        if (anchorFromRejection)
+        {
+            if (prior is null)
+            {
+                var currentArea = _areaTracker?.CurrentArea;
+                lock (_catalogLock)
+                {
+                    if (!_cache.LearnedChests.TryGetValue(chestInternalName, out var entry))
+                    {
+                        _cache.LearnedChests[chestInternalName] = new LearnedChest
+                        {
+                            FirstObservedAt = rejectionTimestampUtc,
+                            LastObservedAt = rejectionTimestampUtc,
+                            Area = currentArea,
+                        };
+                        learnedAreaStamped = true;
+                    }
+                    else if (entry.Area is null && currentArea is not null)
+                    {
+                        entry.Area = currentArea;
+                        learnedAreaStamped = true;
+                    }
+                }
+                _derived.Start(Id, key, rejectionAt);
+                rowChanged = true;
+            }
+            else if (prior.DismissedAt is null && prior.StartedAt + duration <= _time.GetUtcNow())
+            {
+                // Stale anchor — recorded loot is older than this rejection
+                // implies. Refresh the anchor; the rejection guarantees the
+                // cooldown is active right now.
+                if (prior.StartedAt != rejectionAt)
+                {
+                    _derived.Start(Id, key, rejectionAt);
+                    rowChanged = true;
+                }
+            }
+            // else: prior row still in flight — leave alone.
+        }
+
+        if (durationChanged || learnedAreaStamped || rowChanged)
         {
             try { _cacheStore.Save(_cache); } catch { /* best-effort */ }
             EnsureCatalogReprojected();
+        }
 
-            // Re-fire ready for an in-flight row whose anchor + new duration
-            // has already elapsed. StartedAt stays put — only the duration
-            // upgrade matters.
-            var key = ChestKey(chestInternalName);
-            var prior = _derived.GetProgress(Id, key);
-            if (prior is not null && prior.DismissedAt is null)
-            {
-                FireReady(key, chestInternalName,
-                    durationOverride: duration,
-                    atUtc: prior.StartedAt + duration);
-            }
+        // 3. Re-fire ready for any in-flight row whose new effective
+        // FiringAt has already elapsed. Covers both the chest "duration
+        // upgrade unmasks a past anchor" case and the cow "newly-anchored
+        // row already past" case.
+        var current = _derived.GetProgress(Id, key);
+        if (current is not null && current.DismissedAt is null)
+        {
+            FireReady(key, chestInternalName,
+                durationOverride: duration,
+                atUtc: current.StartedAt + duration);
         }
     }
 
@@ -334,6 +433,57 @@ public sealed class LootSource : ITimerSource, IDisposable
         return (PlaceholderChestDuration, false);
     }
 
+    /// <summary>
+    /// Resolve a chest's user-facing display name from <c>strings_all.json</c>
+    /// (#178). Lookup order:
+    /// <list type="number">
+    ///   <item><c>npc_&lt;Area&gt;/&lt;InternalName&gt;_Name</c> — area-scoped
+    ///   form. Required for prefabs whose friendly name varies by zone, e.g.
+    ///   <c>LootChest1</c> in <c>AreaCave1</c> (<i>"Goblin Storage Chest"</i>)
+    ///   vs <c>AreaTomb1</c> (<i>"Old Storage Chest"</i>).</item>
+    ///   <item><c>npc_&lt;InternalName&gt;_Name</c> — no-area fallback. Used
+    ///   for area-agnostic prefabs (the <c>LootBackpackN</c> family) and for
+    ///   chests we haven't yet learned the area for.</item>
+    ///   <item>The internal name itself — final fallback so an unknown
+    ///   entity still renders a legible string.</item>
+    /// </list>
+    /// </summary>
+    private string ResolveChestDisplayName(string internalName, string? area)
+    {
+        if (_refData is not null)
+        {
+            if (!string.IsNullOrEmpty(area)
+                && _refData.Strings.TryGetValue($"npc_{area}/{internalName}_Name", out var areaScoped)
+                && !string.IsNullOrEmpty(areaScoped))
+            {
+                return areaScoped;
+            }
+            if (_refData.Strings.TryGetValue($"npc_{internalName}_Name", out var bare)
+                && !string.IsNullOrEmpty(bare))
+            {
+                return bare;
+            }
+        }
+        return internalName;
+    }
+
+    /// <summary>
+    /// Map a chest's recorded <see cref="LearnedChest.Area"/> to a UI region
+    /// label. Area code resolves to its friendly name via
+    /// <see cref="IReferenceDataService.Areas"/>; falls back to the raw area
+    /// code and ultimately to <c>"Chests"</c> when no area is known yet.
+    /// </summary>
+    private string ResolveRegion(string? area)
+    {
+        if (string.IsNullOrEmpty(area)) return "Chests";
+        if (_refData?.Areas.TryGetValue(area, out var entry) == true
+            && !string.IsNullOrEmpty(entry.FriendlyName))
+        {
+            return entry.FriendlyName;
+        }
+        return area;
+    }
+
     private void OnDerivedProgressChanged(object? sender, EventArgs e) => EmitDeltas();
 
     /// <summary>
@@ -381,13 +531,17 @@ public sealed class LootSource : ITimerSource, IDisposable
         foreach (var internalName in chestNames)
         {
             var (duration, verified) = ResolveChestDuration(internalName);
+            _cache.LearnedChests.TryGetValue(internalName, out var learned);
+            var area = learned?.Area;
+            var displayName = ResolveChestDisplayName(internalName, area);
+            var region = ResolveRegion(area);
             list.Add(new TimerCatalogEntry(
                 Key: ChestKey(internalName),
-                DisplayName: internalName,
-                Region: "Chests",
+                DisplayName: displayName,
+                Region: region,
                 Duration: duration,
                 SourceMetadata: new LootCatalogPayload(
-                    LootKind.Chest, internalName, Region: null, IsDurationVerified: verified)));
+                    LootKind.Chest, internalName, Region: area, IsDurationVerified: verified)));
         }
 
         foreach (var displayName in _cache.LearnedDefeats.Keys)

--- a/src/Gandalf.Module/Services/PlayerAreaTracker.cs
+++ b/src/Gandalf.Module/Services/PlayerAreaTracker.cs
@@ -1,0 +1,143 @@
+using System.IO;
+using System.Text;
+using Gandalf.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+
+namespace Gandalf.Services;
+
+/// <summary>
+/// Holds the player's current area code, parsed from
+/// <c>LOADING LEVEL Area&lt;Name&gt;</c> log lines via
+/// <see cref="AreaTransitionParser"/>. Consumed by <see cref="LootSource"/>
+/// at chest-commit time to stamp <c>LearnedChest.Area</c>.
+///
+/// <para><b>Startup seeding.</b> <see cref="PlayerLogTailReader.SeedToSessionStart"/>
+/// rewinds the live replay window to the most recent <c>ProcessAddPlayer(</c>
+/// line, which lands ~9 s <em>after</em> the <c>LOADING LEVEL</c> line for the
+/// current area — so the area code is just upstream of where playback
+/// begins. <see cref="SeedFromLog"/> closes that gap with its own one-shot
+/// reverse-scan for the most recent <c>LOADING LEVEL</c> line, applied
+/// before the live stream starts. Local change scope; no impact on other
+/// consumers tuned against <see cref="PlayerLogStream"/>'s seed.</para>
+///
+/// <para><b>Threading.</b> <see cref="Observe"/> is called from the log
+/// ingestion background thread; <see cref="CurrentArea"/> is read from
+/// chest-commit paths on whichever thread routes the bracket. A simple
+/// lock suffices — the contention is low (one area transition per
+/// minute-ish, vs. dozens of reads per chest interaction).</para>
+/// </summary>
+public sealed class PlayerAreaTracker
+{
+    private readonly AreaTransitionParser _parser;
+    private readonly IDiagnosticsSink? _diag;
+    private readonly object _lock = new();
+    private string? _currentArea;
+
+    public PlayerAreaTracker(AreaTransitionParser parser, IDiagnosticsSink? diag = null)
+    {
+        _parser = parser;
+        _diag = diag;
+    }
+
+    /// <summary>
+    /// Latest area key parsed from a <c>LOADING LEVEL Area*</c> line, or
+    /// <c>null</c> if the player is at character-select / disconnected /
+    /// before the first observed transition. Consumers should treat
+    /// <c>null</c> as "current area is unknown" — chest commits during a
+    /// null-area window persist with <c>Area = null</c> and self-heal on
+    /// the next portal.
+    /// </summary>
+    public string? CurrentArea
+    {
+        get { lock (_lock) return _currentArea; }
+    }
+
+    /// <summary>
+    /// Feed one log line through the area parser. Idempotent for unrelated
+    /// lines (the parser's substring fast-path returns null without touching
+    /// state).
+    /// </summary>
+    public void Observe(string line, DateTime timestamp)
+    {
+        if (_parser.TryParse(line, timestamp) is AreaTransitionEvent evt)
+        {
+            lock (_lock)
+            {
+                if (_currentArea != evt.AreaKey)
+                {
+                    _currentArea = evt.AreaKey;
+                    _diag?.Trace("Gandalf.Area",
+                        $"Player area transition → {evt.AreaKey ?? "(none)"} at {timestamp:O}");
+                }
+            }
+        }
+    }
+
+    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp);
+
+    /// <summary>
+    /// One-shot startup seed. Reads <paramref name="logPath"/> backward in
+    /// chunks looking for the most recent <c>LOADING LEVEL</c> line, parses
+    /// it, and sets <see cref="CurrentArea"/>. No-op if the file is missing
+    /// or no <c>LOADING LEVEL</c> line exists in the scanned region.
+    /// </summary>
+    /// <remarks>
+    /// Scan bound: <see cref="ScanChunkBytes"/> (10 MB, mirrored from
+    /// <see cref="PlayerLogTailReader.SessionScanChunkBytes"/>) per chunk.
+    /// The full file is walked in chunks until the marker is found or the
+    /// start of the file is reached, so the scan is bounded by file size,
+    /// not the chunk constant.
+    /// </remarks>
+    public void SeedFromLog(string logPath)
+    {
+        if (!File.Exists(logPath)) return;
+
+        var size = new FileInfo(logPath).Length;
+        if (size == 0) return;
+
+        try
+        {
+            using var fs = new FileStream(
+                logPath, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+
+            var overlap = Marker.Length;
+            var end = size;
+            while (end > 0)
+            {
+                var chunkSize = (int)Math.Min(ScanChunkBytes, end);
+                var scanFrom = end - chunkSize;
+                fs.Seek(scanFrom, SeekOrigin.Begin);
+                var buf = new byte[chunkSize];
+                var read = fs.Read(buf, 0, buf.Length);
+                var text = Encoding.UTF8.GetString(buf, 0, read);
+                var idx = text.LastIndexOf(Marker, StringComparison.Ordinal);
+                if (idx >= 0)
+                {
+                    var lineStart = text.LastIndexOf('\n', idx);
+                    var startInChunk = lineStart < 0 ? 0 : lineStart + 1;
+                    var lineEnd = text.IndexOf('\n', idx);
+                    if (lineEnd < 0) lineEnd = text.Length;
+                    var line = text.Substring(startInChunk, lineEnd - startInChunk).TrimEnd('\r');
+
+                    // Best-effort timestamp. The line itself may carry an
+                    // "[HH:MM:SS]" prefix but PlayerLogTailReader strips it
+                    // before normal parsing; for the seed we only care about
+                    // the AreaKey, not the timestamp, so wall-clock-now is fine.
+                    Observe(line, DateTime.UtcNow);
+                    return;
+                }
+                if (scanFrom == 0) break;
+                end = scanFrom + overlap;
+            }
+        }
+        catch (IOException ex)
+        {
+            _diag?.Warn("Gandalf.Area", $"SeedFromLog failed: {ex.Message}");
+        }
+    }
+
+    private const string Marker = "LOADING LEVEL";
+    private const int ScanChunkBytes = 10 * 1024 * 1024;
+}

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -81,6 +81,17 @@ public interface IReferenceDataService
     /// <summary>InternalName → <see cref="QuestEntry"/> lookup. Matches Quest sources in <c>sources_items.json</c>.</summary>
     IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; }
 
+    /// <summary>
+    /// All localizable strings from <c>strings_all.json</c>, keyed by their
+    /// dotted/slashed string ID. Primary use today is friendly-name resolution
+    /// for chest / NPC / cow / tree prefabs via the
+    /// <c>npc_&lt;Area&gt;/&lt;InternalName&gt;_Name</c> convention (with
+    /// <c>npc_&lt;InternalName&gt;_Name</c> fallback for area-agnostic
+    /// prefabs). See [Player-Log-Signals#display-name-resolution-strings_all]
+    /// in the wiki.
+    /// </summary>
+    IReadOnlyDictionary<string, string> Strings { get; }
+
     ReferenceFileSnapshot GetSnapshot(string key);
 
     Task RefreshAsync(string key, CancellationToken ct = default);

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -106,6 +106,12 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, QuestEntry>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _questsSnapshot;
 
+    // strings_all.json — flat dictionary of localizable string IDs → display
+    // text. Used for friendly-name resolution of chest / cow / tree prefabs
+    // (see #178 / Player-Log-Signals wiki).
+    private IReadOnlyDictionary<string, string> _strings = new Dictionary<string, string>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _stringsSnapshot;
+
     public ReferenceDataService(string cacheDir, HttpClient http, IDiagnosticsSink? diag = null, string? bundledDir = null)
     {
         _cacheDir = cacheDir;
@@ -129,6 +135,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _powersSnapshot = new ReferenceFileSnapshot("tsysclientinfo", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _profilesSnapshot = new ReferenceFileSnapshot("tsysprofiles", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _questsSnapshot = new ReferenceFileSnapshot("quests", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _stringsSnapshot = new ReferenceFileSnapshot("strings_all", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
 
         LoadItems();
         LoadRecipes();
@@ -141,9 +148,10 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadAttributes();
         LoadPowers();
         LoadProfiles();
+        LoadStrings();
     }
 
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "attributes", "tsysclientinfo", "tsysprofiles", "quests"];
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all"];
 
     public IReadOnlyDictionary<long, ItemEntry> Items => _items;
     public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName => _itemsByInternalName;
@@ -160,6 +168,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
     public IReadOnlyDictionary<string, QuestEntry> Quests => _quests;
     public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName => _questsByInternalName;
+    public IReadOnlyDictionary<string, string> Strings => _strings;
 
     public ReferenceFileSnapshot GetSnapshot(string key) => key switch
     {
@@ -174,6 +183,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "tsysclientinfo" => _powersSnapshot,
         "tsysprofiles" => _profilesSnapshot,
         "quests" => _questsSnapshot,
+        "strings_all" => _stringsSnapshot,
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -192,6 +202,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "tsysclientinfo" => RefreshFileAsync("tsysclientinfo", ReferenceDeserializer.ParseTsysClientInfo, ParseAndSwapPowers, ct),
         "tsysprofiles" => RefreshFileAsync("tsysprofiles", ReferenceDeserializer.ParseTsysProfiles, ParseAndSwapProfiles, ct),
         "quests" => RefreshFileAsync("quests", ReferenceDeserializer.ParseQuests, ParseAndSwapQuests, ct),
+        "strings_all" => RefreshFileAsync("strings_all", ReferenceDeserializer.ParseStringsAll, ParseAndSwapStrings, ct),
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -208,6 +219,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         await RefreshAsync("tsysclientinfo", ct);
         await RefreshAsync("tsysprofiles", ct);
         await RefreshAsync("quests", ct);
+        await RefreshAsync("strings_all", ct);
     }
 
     public void BeginBackgroundRefresh()
@@ -370,6 +382,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void LoadPowers() => LoadFile("tsysclientinfo", ReferenceDeserializer.ParseTsysClientInfo, ParseAndSwapPowers);
     private void LoadProfiles() => LoadFile("tsysprofiles", ReferenceDeserializer.ParseTsysProfiles, ParseAndSwapProfiles);
     private void LoadQuests() => LoadFile("quests", ReferenceDeserializer.ParseQuests, ParseAndSwapQuests);
+    private void LoadStrings() => LoadFile("strings_all", ReferenceDeserializer.ParseStringsAll, ParseAndSwapStrings);
 
     // ── Per-type parse-and-swap ──────────────────────────────────────────
 
@@ -628,6 +641,15 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _areas = byKey;
         _areasSnapshot = new ReferenceFileSnapshot("areas", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
+    }
+
+    private void ParseAndSwapStrings(IReadOnlyDictionary<string, string> raw, ReferenceFileMetadata meta)
+    {
+        // Parsed dictionary is already string→string; just take a defensive
+        // copy with Ordinal comparer to match the rest of the service's
+        // dictionary conventions and freeze it as IReadOnlyDictionary.
+        _strings = new Dictionary<string, string>(raw, StringComparer.Ordinal);
+        _stringsSnapshot = new ReferenceFileSnapshot("strings_all", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, _strings.Count);
     }
 
     /// <summary>Parses <c>"Despised:5000:Armor,Weapon,CorpseTrophy"</c> strings.</summary>

--- a/tests/Arwen.Tests/FakeRefData.cs
+++ b/tests/Arwen.Tests/FakeRefData.cs
@@ -31,6 +31,7 @@ internal sealed class FakeRefData : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
     public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
     public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
     public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
     public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
     public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Bilbo.Tests/CraftableRecipeCalculatorTests.cs
+++ b/tests/Bilbo.Tests/CraftableRecipeCalculatorTests.cs
@@ -269,6 +269,7 @@ public class CraftableRecipeCalculatorTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "v469", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Bilbo.Tests/StorageReportLoaderTests.cs
+++ b/tests/Bilbo.Tests/StorageReportLoaderTests.cs
@@ -152,6 +152,7 @@ public class StorageReportLoaderTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "v469", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Celebrimbor.Tests/FakeReferenceData.cs
+++ b/tests/Celebrimbor.Tests/FakeReferenceData.cs
@@ -49,6 +49,7 @@ internal sealed class FakeReferenceData : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
     public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
     public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
     public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
     public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Elrond.Tests/LevelingSimulatorTests.cs
+++ b/tests/Elrond.Tests/LevelingSimulatorTests.cs
@@ -464,6 +464,7 @@ public class LevelingSimulatorTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorEngineTests.cs
@@ -642,6 +642,7 @@ public class SkillAdvisorEngineTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -209,6 +209,7 @@ public class SkillAdvisorViewModelTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Gandalf.Tests/FakeRefData.cs
+++ b/tests/Gandalf.Tests/FakeRefData.cs
@@ -35,6 +35,9 @@ internal sealed class FakeRefData : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
     public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
     public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+    /// <summary>Mutable in tests that need friendly-name resolution coverage.</summary>
+    public Dictionary<string, string> StringsRaw { get; } = new(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> Strings => StringsRaw;
     public event EventHandler<string>? FileUpdated;
     public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
     public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Gandalf.Tests/LootBracketTrackerTests.cs
+++ b/tests/Gandalf.Tests/LootBracketTrackerTests.cs
@@ -45,7 +45,7 @@ public class LootBracketTrackerTests : IDisposable
         var cacheStore = new JsonSettingsStore<LootCatalogCache>(_cachePath,
             LootCatalogCacheJsonContext.Default.LootCatalogCache);
         var cache = cacheStore.Load();
-        var src = new LootSource(derived, cacheStore, cache, time);
+        var src = new LootSource(derived, cacheStore, cache, time: time);
         var tracker = new LootBracketTracker(
             src,
             new ChestInteractionParser(),

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using FluentAssertions;
 using Gandalf.Domain;
+using Gandalf.Parsing;
 using Gandalf.Services;
 using Mithril.Shared.Character;
+using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 using Xunit;
 
@@ -30,7 +32,7 @@ public class LootSourceTests : IDisposable
     }
 
     private (LootSource src, DerivedTimerProgressService derived, FakeActiveCharacterService active, ManualTime time)
-        Build()
+        Build(PlayerAreaTracker? areaTracker = null, IReferenceDataService? refData = null)
     {
         var active = new FakeActiveCharacterService();
         active.SetActiveCharacter("Arthur", "Kwatoxi");
@@ -44,7 +46,8 @@ public class LootSourceTests : IDisposable
         var cacheStore = new JsonSettingsStore<LootCatalogCache>(_cachePath,
             LootCatalogCacheJsonContext.Default.LootCatalogCache);
         var cache = cacheStore.Load();
-        var src = new LootSource(derived, cacheStore, cache, time);
+        var src = new LootSource(derived, cacheStore, cache,
+            areaTracker: areaTracker, refData: refData, time: time);
 
         return (src, derived, active, time);
     }
@@ -449,7 +452,7 @@ public class LootSourceTests : IDisposable
         var cacheStore1 = new JsonSettingsStore<LootCatalogCache>(_cachePath,
             LootCatalogCacheJsonContext.Default.LootCatalogCache);
         var cache1 = cacheStore1.Load();
-        var src1 = new LootSource(derived1, cacheStore1, cache1, time);
+        var src1 = new LootSource(derived1, cacheStore1, cache1, time: time);
         src1.OnChestCooldownObserved("GoblinStaticChest1", TimeSpan.FromHours(3));
         src1.OnBossKillCredit("Den Mother", time.GetUtcNow().UtcDateTime);
         src1.Dispose();
@@ -675,4 +678,295 @@ public class LootSourceTests : IDisposable
         public override DateTimeOffset GetUtcNow() => _now;
         public void Advance(TimeSpan delta) => _now = _now.Add(delta);
     }
+
+    // ── #178: chest area capture, friendly-name resolution, rejection-anchored rows ──
+
+    [Fact]
+    public void OnChestInteraction_stamps_current_area_on_LearnedChest()
+    {
+        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+
+        var (src, derived, _, time) = Build(areaTracker);
+        try
+        {
+            src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
+
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedChests.Should().ContainKey("EltibuleSecretChest");
+            cache.LearnedChests["EltibuleSecretChest"].Area.Should().Be("AreaSerbule");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void OnChestInteraction_with_unknown_area_persists_null()
+    {
+        // No area tracker injected → CurrentArea is null path.
+        var (src, derived, _, time) = Build();
+        try
+        {
+            src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
+
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedChests["EltibuleSecretChest"].Area.Should().BeNull();
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void OnChestInteraction_area_is_sticky_once_known()
+    {
+        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var (src, derived, _, time) = Build(areaTracker);
+        try
+        {
+            // First commit while in AreaSerbule.
+            areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+            src.OnChestInteraction("LootChest1", time.GetUtcNow().UtcDateTime);
+
+            // Player ports to AreaTomb1, then loots a same-named chest. Sticky:
+            // first commit's area wins so the cache doesn't ping-pong.
+            areaTracker.Observe("LOADING LEVEL AreaTomb1", DateTime.UtcNow);
+            time.Advance(TimeSpan.FromMinutes(5));
+            src.OnChestInteraction("LootChest1", time.GetUtcNow().UtcDateTime);
+
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedChests["LootChest1"].Area.Should().Be("AreaSerbule");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void OnChestInteraction_stamps_area_late_when_first_commit_was_unknown()
+    {
+        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var (src, derived, _, time) = Build(areaTracker);
+        try
+        {
+            // First commit happens before any LOADING LEVEL → Area is null.
+            src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
+
+            // Player transitions, then re-loots the same chest. Sticky-once-known
+            // means we DON'T overwrite known Area, but we DO populate from null.
+            areaTracker.Observe("LOADING LEVEL AreaEltibule", DateTime.UtcNow);
+            time.Advance(TimeSpan.FromHours(4));
+            src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
+
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedChests["EltibuleSecretChest"].Area.Should().Be("AreaEltibule");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void BuildCatalog_resolves_area_scoped_friendly_name_from_strings_all()
+    {
+        var refData = new Mithril.TestSupport.FakeReferenceData();
+        refData.StringsRaw["npc_AreaSerbule/Cow_Moolanda_Name"] = "Wanda";
+        refData.StringsRaw["npc_AreaSerbule/Cow_Bessie_Name"] = "Bessie";
+
+        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+
+        var (src, derived, _, time) = Build(areaTracker, refData);
+        try
+        {
+            src.OnChestInteraction("Cow_Moolanda", time.GetUtcNow().UtcDateTime);
+            src.OnChestInteraction("Cow_Bessie", time.GetUtcNow().UtcDateTime);
+
+            var moolanda = src.Catalog.Single(c => c.Key == LootSource.ChestKey("Cow_Moolanda"));
+            var bessie = src.Catalog.Single(c => c.Key == LootSource.ChestKey("Cow_Bessie"));
+
+            moolanda.DisplayName.Should().Be("Wanda");
+            bessie.DisplayName.Should().Be("Bessie");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void BuildCatalog_falls_back_to_no_area_form_when_area_scoped_missing()
+    {
+        var refData = new Mithril.TestSupport.FakeReferenceData();
+        refData.StringsRaw["npc_LootBackpack1_Name"] = "Adventurer's Pack";
+        // No npc_AreaSerbule/LootBackpack1_Name entry — global prefab.
+
+        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+
+        var (src, derived, _, time) = Build(areaTracker, refData);
+        try
+        {
+            src.OnChestInteraction("LootBackpack1", time.GetUtcNow().UtcDateTime);
+            var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("LootBackpack1"));
+            entry.DisplayName.Should().Be("Adventurer's Pack");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void BuildCatalog_falls_back_to_internal_name_when_strings_all_misses_entirely()
+    {
+        var refData = new Mithril.TestSupport.FakeReferenceData(); // empty Strings
+        var (src, derived, _, time) = Build(refData: refData);
+        try
+        {
+            src.OnChestInteraction("UnknownChest1", time.GetUtcNow().UtcDateTime);
+            var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("UnknownChest1"));
+            entry.DisplayName.Should().Be("UnknownChest1");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void BuildCatalog_uses_area_friendly_name_for_region()
+    {
+        var refData = new Mithril.TestSupport.FakeReferenceData();
+        refData.AreasRaw["AreaSerbule"] = new AreaEntry("AreaSerbule", "Serbule", "Serbule");
+
+        var areaTracker = new PlayerAreaTracker(new AreaTransitionParser());
+        areaTracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+
+        var (src, derived, _, time) = Build(areaTracker, refData);
+        try
+        {
+            src.OnChestInteraction("EltibuleSecretChest", time.GetUtcNow().UtcDateTime);
+            var entry = src.Catalog.Single(c => c.Key == LootSource.ChestKey("EltibuleSecretChest"));
+            entry.Region.Should().Be("Serbule");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Cow_rejection_with_no_prior_row_anchors_at_rejection_time()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            var rejectionAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestCooldownObserved(
+                "Cow_Elsie", TimeSpan.FromHours(1),
+                rejectionAt, anchorFromRejection: true);
+
+            // Row created at rejection time → countdown is full duration ahead.
+            src.Progress.Should().ContainKey(LootSource.ChestKey("Cow_Elsie"));
+            src.Progress[LootSource.ChestKey("Cow_Elsie")].StartedAt
+                .Should().Be(new DateTimeOffset(rejectionAt, TimeSpan.Zero));
+
+            // LearnedChests entry persists so the row survives restart.
+            var cache = new JsonSettingsStore<LootCatalogCache>(_cachePath,
+                LootCatalogCacheJsonContext.Default.LootCatalogCache).Load();
+            cache.LearnedChests.Should().ContainKey("Cow_Elsie");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Cow_rejection_leaves_active_prior_row_alone()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            // Successful milking 10 min ago.
+            var milkAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("Cow_Bessie", milkAt);
+            time.Advance(TimeSpan.FromMinutes(10));
+
+            // Rejection arrives. Cooldown is 1 h, so row is still in flight
+            // (FiringAt = milkAt + 1 h, which is still 50 min in the future).
+            // Anchor must NOT be refreshed.
+            var rejectionAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestCooldownObserved(
+                "Cow_Bessie", TimeSpan.FromHours(1),
+                rejectionAt, anchorFromRejection: true);
+
+            src.Progress[LootSource.ChestKey("Cow_Bessie")].StartedAt
+                .Should().Be(new DateTimeOffset(milkAt, TimeSpan.Zero),
+                    "active row's anchor must not be refreshed by rejection");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Cow_rejection_refreshes_stale_prior_anchor_to_rejection_time()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            // Milking 2 h ago — cooldown of 1 h would have made the row Done at +1 h.
+            var milkAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("Cow_Bessie", milkAt);
+            // Pre-seed the verified duration so prior+duration is 1 h after milkAt.
+            src.OnChestCooldownObserved("Cow_Bessie", TimeSpan.FromHours(1));
+            time.Advance(TimeSpan.FromHours(2));
+
+            // Rejection now — row's FiringAt = milkAt + 1 h is 1 h in the past
+            // (stale). Refresh anchor to rejection time so the user sees a
+            // fresh 1 h countdown rather than a stale "Done" badge.
+            var rejectionAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestCooldownObserved(
+                "Cow_Bessie", TimeSpan.FromHours(1),
+                rejectionAt, anchorFromRejection: true);
+
+            src.Progress[LootSource.ChestKey("Cow_Bessie")].StartedAt
+                .Should().Be(new DateTimeOffset(rejectionAt, TimeSpan.Zero));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Cow_rejection_replays_idempotently_when_row_still_active()
+    {
+        var (src, derived, _, time) = Build();
+        try
+        {
+            // Milking 10 min ago, 1 h cooldown — row is still in flight.
+            var milkAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("Cow_Bessie", milkAt);
+            time.Advance(TimeSpan.FromMinutes(10));
+
+            // Rejection at the same timestamp (replay scenario) — idempotency
+            // via the active-row branch (anchor unchanged).
+            var rejectionAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestCooldownObserved(
+                "Cow_Bessie", TimeSpan.FromHours(1),
+                rejectionAt, anchorFromRejection: true);
+            src.OnChestCooldownObserved(
+                "Cow_Bessie", TimeSpan.FromHours(1),
+                rejectionAt, anchorFromRejection: true);
+
+            src.Progress[LootSource.ChestKey("Cow_Bessie")].StartedAt
+                .Should().Be(new DateTimeOffset(milkAt, TimeSpan.Zero));
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
+    [Fact]
+    public void Chest_rejection_default_does_not_refresh_anchor()
+    {
+        // Forward-looking chest grammar gives us absolute info — the row's
+        // existing StartedAt is more accurate than the rejection timestamp.
+        // Default anchorFromRejection=false preserves today's behaviour.
+        var (src, derived, _, time) = Build();
+        try
+        {
+            var lootAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestInteraction("EltibuleSecretChest", lootAt);
+            time.Advance(TimeSpan.FromHours(4));
+
+            var rejectionAt = time.GetUtcNow().UtcDateTime;
+            src.OnChestCooldownObserved(
+                "EltibuleSecretChest", TimeSpan.FromHours(3), rejectionAt);
+
+            src.Progress[LootSource.ChestKey("EltibuleSecretChest")].StartedAt
+                .Should().Be(new DateTimeOffset(lootAt, TimeSpan.Zero),
+                    "chest grammar: rejection only updates duration, never the anchor");
+        }
+        finally { src.Dispose(); derived.Dispose(); }
+    }
+
 }

--- a/tests/Gandalf.Tests/Parsing/AreaTransitionParserTests.cs
+++ b/tests/Gandalf.Tests/Parsing/AreaTransitionParserTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Gandalf.Parsing;
+using Xunit;
+
+namespace Gandalf.Tests.Parsing;
+
+public sealed class AreaTransitionParserTests
+{
+    private readonly AreaTransitionParser _parser = new();
+
+    [Theory]
+    [InlineData("LOADING LEVEL AreaSerbule", "AreaSerbule")]
+    [InlineData("LOADING LEVEL AreaEltibule", "AreaEltibule")]
+    [InlineData("LOADING LEVEL AreaTomb1", "AreaTomb1")]
+    [InlineData("LOADING LEVEL AreaCave1", "AreaCave1")]
+    [InlineData("LOADING LEVEL AreaCasino", "AreaCasino")]
+    public void Parses_real_area_keys(string line, string expectedArea)
+    {
+        var evt = (AreaTransitionEvent?)_parser.TryParse(line, DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.AreaKey.Should().Be(expectedArea);
+    }
+
+    [Fact]
+    public void Parses_ChooseCharacter_as_null_area()
+    {
+        var evt = (AreaTransitionEvent?)_parser.TryParse("LOADING LEVEL ChooseCharacter", DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.AreaKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parses_empty_body_as_null_area()
+    {
+        // Disconnect emits "LOADING LEVEL " with empty body — captured 2026-05-09.
+        var evt = (AreaTransitionEvent?)_parser.TryParse("LOADING LEVEL ", DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.AreaKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parses_unknown_non_area_level_as_null()
+    {
+        // Defensive — anything that doesn't start with "Area" isn't a real
+        // game area for our purposes (e.g. menu / loading screens).
+        var evt = (AreaTransitionEvent?)_parser.TryParse("LOADING LEVEL StartupMenu", DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.AreaKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parses_with_leading_whitespace()
+    {
+        // PlayerLogTailReader strips the [HH:MM:SS] prefix; defensive against
+        // any leading whitespace that might survive.
+        var evt = (AreaTransitionEvent?)_parser.TryParse("  LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.AreaKey.Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void Returns_null_for_unrelated_line()
+    {
+        _parser.TryParse("LocalPlayer: ProcessAddItem(Apple(123), -1, True)", DateTime.UtcNow)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_loading_text_inside_quoted_payload()
+    {
+        // "LOADING LEVEL" appearing as substring inside an unrelated message
+        // body — regex anchors ensure we only match a true area-load line.
+        _parser.TryParse("ProcessChat(General, \"It says LOADING LEVEL on the screen\")", DateTime.UtcNow)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_empty_line() =>
+        _parser.TryParse("", DateTime.UtcNow).Should().BeNull();
+
+    [Fact]
+    public void Preserves_event_timestamp()
+    {
+        var ts = new DateTime(2026, 5, 10, 17, 11, 10, DateTimeKind.Utc);
+        var evt = (AreaTransitionEvent?)_parser.TryParse("LOADING LEVEL AreaSerbule", ts);
+        evt!.Timestamp.Should().Be(ts);
+    }
+}

--- a/tests/Gandalf.Tests/PlayerAreaTrackerTests.cs
+++ b/tests/Gandalf.Tests/PlayerAreaTrackerTests.cs
@@ -1,0 +1,149 @@
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Gandalf.Parsing;
+using Gandalf.Services;
+using Xunit;
+
+namespace Gandalf.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class PlayerAreaTrackerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PlayerAreaTrackerTests()
+    {
+        _tempDir = Mithril.TestSupport.TestPaths.CreateTempDir("gandalf_area_tracker");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private static PlayerAreaTracker Build() => new(new AreaTransitionParser());
+
+    [Fact]
+    public void Initial_state_is_null()
+    {
+        Build().CurrentArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void Observe_real_area_sets_CurrentArea()
+    {
+        var tracker = Build();
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.CurrentArea.Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void Observe_portal_transition_replaces_area()
+    {
+        var tracker = Build();
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.Observe("LOADING LEVEL AreaEltibule", DateTime.UtcNow);
+        tracker.CurrentArea.Should().Be("AreaEltibule");
+    }
+
+    [Fact]
+    public void Observe_ChooseCharacter_clears_area()
+    {
+        var tracker = Build();
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.Observe("LOADING LEVEL ChooseCharacter", DateTime.UtcNow);
+        tracker.CurrentArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void Observe_disconnect_clears_area()
+    {
+        var tracker = Build();
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.Observe("LOADING LEVEL ", DateTime.UtcNow);
+        tracker.CurrentArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void Observe_unrelated_line_is_noop()
+    {
+        var tracker = Build();
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.Observe("LocalPlayer: ProcessAddItem(Apple(1), -1, True)", DateTime.UtcNow);
+        tracker.Observe("ProcessChat(General, \"hi\")", DateTime.UtcNow);
+        tracker.CurrentArea.Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void SeedFromLog_picks_up_most_recent_area()
+    {
+        var path = WriteLog(
+            "LocalPlayer: ProcessAddItem(Apple(1), -1, True)",
+            "LOADING LEVEL AreaSerbule",
+            "LocalPlayer: ProcessAddPlayer(...)",
+            "LOADING LEVEL AreaEltibule",
+            "LocalPlayer: ProcessAddPlayer(...)",
+            "(more game noise)");
+        var tracker = Build();
+        tracker.SeedFromLog(path);
+        tracker.CurrentArea.Should().Be("AreaEltibule");
+    }
+
+    [Fact]
+    public void SeedFromLog_with_disconnect_clears_area()
+    {
+        var path = WriteLog(
+            "LOADING LEVEL AreaSerbule",
+            "(player plays for a while)",
+            "LOADING LEVEL ");
+        var tracker = Build();
+        tracker.SeedFromLog(path);
+        tracker.CurrentArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void SeedFromLog_with_no_marker_is_noop()
+    {
+        var path = WriteLog(
+            "LocalPlayer: ProcessAddItem(Apple(1), -1, True)",
+            "LocalPlayer: ProcessAddPlayer(...)",
+            "(no area transition lines)");
+        var tracker = Build();
+        tracker.SeedFromLog(path);
+        tracker.CurrentArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void SeedFromLog_missing_file_is_noop()
+    {
+        var tracker = Build();
+        tracker.SeedFromLog(Path.Combine(_tempDir, "does-not-exist.log"));
+        tracker.CurrentArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void SeedFromLog_then_live_observe_advances_state()
+    {
+        var path = WriteLog(
+            "LOADING LEVEL AreaSerbule");
+        var tracker = Build();
+        tracker.SeedFromLog(path);
+        tracker.CurrentArea.Should().Be("AreaSerbule");
+
+        // Live tail then observes a fresh portal.
+        tracker.Observe("LOADING LEVEL AreaTomb1", DateTime.UtcNow);
+        tracker.CurrentArea.Should().Be("AreaTomb1");
+    }
+
+    private string WriteLog(params string[] lines)
+    {
+        var path = Path.Combine(_tempDir, $"player_{Guid.NewGuid():N}.log");
+        // Real Player.log doesn't carry a UTF-8 BOM; Encoding.UTF8 in .NET
+        // emits one by default (﻿ prefix), which would defeat the
+        // parser's "^" anchor. Use BOM-less UTF-8 to mirror live shape.
+        File.WriteAllText(path, string.Join('\n', lines) + "\n", new UTF8Encoding(false));
+        return path;
+    }
+}

--- a/tests/Legolas.Tests/Sharing/LegolasReportServiceTests.cs
+++ b/tests/Legolas.Tests/Sharing/LegolasReportServiceTests.cs
@@ -322,6 +322,7 @@ public class LegolasReportServiceTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public event EventHandler<string>? FileUpdated;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs
@@ -537,6 +537,7 @@ public sealed class InventoryServiceStackSizeTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
@@ -699,6 +699,7 @@ public sealed class InventoryServiceTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new("items", ReferenceFileSource.Bundled, "test", null, 1);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
+++ b/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
@@ -163,6 +163,7 @@ public sealed class IconCachePreloadTests : IDisposable
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public event EventHandler<string>? FileUpdated;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Mithril.Shared.Tests/Reference/AugmentParserTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/AugmentParserTests.cs
@@ -253,6 +253,7 @@ public class AugmentParserTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Mithril.Shared.Tests/Reference/Phase7Fixture.cs
+++ b/tests/Mithril.Shared.Tests/Reference/Phase7Fixture.cs
@@ -18,6 +18,7 @@ internal sealed class Phase7Fixture : IReferenceDataService
 
     public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
     public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
     public IReadOnlyList<string> Keys => [];
     public ItemKeywordIndex KeywordIndex => new(Items);

--- a/tests/Mithril.Shared.Tests/Reference/ResultEffectsParserTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ResultEffectsParserTests.cs
@@ -199,6 +199,7 @@ public class ResultEffectsParserTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
@@ -357,6 +357,7 @@ public class IngredientSourcesViewModelTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
+++ b/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
@@ -173,6 +173,7 @@ public sealed class LiveInventoryViewModelTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Pippin.Tests/FoodCatalogTests.cs
+++ b/tests/Pippin.Tests/FoodCatalogTests.cs
@@ -120,6 +120,7 @@ public class FoodCatalogTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public event EventHandler<string>? FileUpdated;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Pippin.Tests/GourmandStateMachineTests.cs
+++ b/tests/Pippin.Tests/GourmandStateMachineTests.cs
@@ -176,6 +176,7 @@ public class GourmandStateMachineTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public event EventHandler<string>? FileUpdated;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Pippin.Tests/GourmandStateServiceMigrationTests.cs
+++ b/tests/Pippin.Tests/GourmandStateServiceMigrationTests.cs
@@ -198,6 +198,7 @@ public sealed class GourmandStateServiceMigrationTests : IDisposable
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public event EventHandler<string>? FileUpdated;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Pippin.Tests/Sharing/PippinShareViewModelTests.cs
+++ b/tests/Pippin.Tests/Sharing/PippinShareViewModelTests.cs
@@ -203,6 +203,7 @@ public class PippinShareViewModelTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public event EventHandler<string>? FileUpdated;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Samwise.Tests/GardenStateMachineTests.cs
+++ b/tests/Samwise.Tests/GardenStateMachineTests.cs
@@ -452,6 +452,7 @@ public class GardenStateMachineTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key)
             => new("items", ReferenceFileSource.Bundled, "test", null, _items.Count);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
+++ b/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
@@ -216,6 +216,7 @@ public class TwoBarleyRegressionTest
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
         public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public ReferenceFileSnapshot GetSnapshot(string key)
             => new("items", ReferenceFileSource.Bundled, "test", null, 1);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/TestSupport/FakeReferenceData.cs
+++ b/tests/TestSupport/FakeReferenceData.cs
@@ -34,13 +34,19 @@ internal sealed class FakeReferenceData : IReferenceDataService
     public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
     public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
-    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+    /// <summary>Mutable in tests that need area-friendly-name resolution.</summary>
+    public Dictionary<string, AreaEntry> AreasRaw { get; } = new(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, AreaEntry> Areas => AreasRaw;
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
     public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
     public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
     public IReadOnlyDictionary<string, QuestEntry> Quests => _quests;
     public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName => _byInternalName;
+
+    /// <summary>Mutable for tests that need friendly-name resolution coverage.</summary>
+    public Dictionary<string, string> StringsRaw { get; } = new(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> Strings => StringsRaw;
 
     public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
     public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

Closes #178. Three folded scopes — area capture, friendly display name resolution, and rejection-anchored rows — all sharing the new `LOADING LEVEL` parser dependency and all surfacing in the same Loot tab UX moment.

## Implementation

### 1. Area capture (`LOADING LEVEL Area*` parser)

- New `AreaTransitionParser` recognises three forms: real area (`LOADING LEVEL AreaSerbule` → emits the area key), `ChooseCharacter` (character-select → null), empty body (disconnect → null).
- New `PlayerAreaTracker` holds the player's current area code, updated on every transition. `SeedFromLog(path)` does a one-shot reverse-scan-back for the most recent `LOADING LEVEL Area*` line at startup, closing the ~9 s gap between `PlayerLogStream.SeedToSessionStart` (which lands on `ProcessAddPlayer`) and the actual area-load line just upstream.
- `LootIngestionService` observes the tracker *before* the bracket tracker in `Dispatch`, so any chest commit in the same dispatch batch reads the correct area.
- `LearnedChest` schema gains a nullable `Area` field. Sticky-once-known invariant: first commit wins, later commits don't overwrite (a chest's internal name might appear in multiple zones — first-discovered wins). Older cache entries serialised pre-#178 deserialise with `Area = null` and self-heal on the next loot.

### 2. Friendly display name resolution (`strings_all.json`)

- `IReferenceDataService` exposes the full `strings_all.json` dictionary via a new `Strings` property (~175k entries; in-memory, single load, same lifecycle as `Areas`/`Npcs`).
- `LootSource.BuildCatalog` resolves `DisplayName` via a three-step fallback chain:
  1. `npc_<Area>/<InternalName>_Name` — area-scoped form. Required for the `LootChestN` family where the same prefab is `"Goblin Storage Chest"` in `AreaCave1` vs `"Old Storage Chest"` in `AreaTomb1`.
  2. `npc_<InternalName>_Name` — no-area fallback. Used for area-agnostic prefabs like the `LootBackpackN` family.
  3. The internal name itself — final fallback so unknown entities still render legible.
- Region uses the area's friendly name from `IReferenceDataService.Areas` (e.g. `AreaSerbule` → `"Serbule"`); falls back to the raw area code, then to `"Chests"` when no area is known.
- Cows render as `Bessie`/`Wanda`/`Elsie`/`Jammy` instead of `Cow_Bessie`/`Cow_Moolanda`/`Cow_Elsie`/`Cow_Jammy`.

### 3. Rejection-anchored rows

- `OnChestCooldownObserved` gets a new `anchorFromRejection` flag. Two grammars need different handling:
  - **Chest (forward-looking)**: `"will refill N hours after you looted it"` gives us absolute timing — the row's existing `StartedAt` (the loot timestamp) is the right anchor; we only update duration. **`anchorFromRejection: false` (default)** preserves today's behaviour.
  - **Cow (relative-past)**: `"in the past hour"` only tells us the cooldown is active right now; the actual last-milking time is unknown. **`anchorFromRejection: true`** handles three row states:
    - No prior row → create one anchored at `rejectionTime`. Conservative — overstates remaining time by up to `duration` but bounds it correctly (won't fire `Ready` before the actual cooldown ends).
    - Prior row, still in flight → leave anchor alone.
    - Prior row, already past `FiringAt` but rejection says cooldown is active (stale) → refresh `StartedAt = rejectionTime`. Trust the rejection over a loot Mithril missed.
- `LootBracketTracker`'s cow-rejection branch passes `anchorFromRejection: true`; the chest branch defaults to `false`. No other call sites changed.

## Test plan

- [x] `dotnet test tests/Gandalf.Tests` — **324 / 324 pass** (+13 new for #178).
- [x] `dotnet test tests/Mithril.Shared.Tests` — 664 / 664.
- [x] `dotnet test tests/Mithril.GameState.Tests` — 81 / 81.
- [x] `dotnet test tests/Samwise.Tests` — 71 / 71.
- [x] `dotnet test tests/Pippin.Tests` — 42 / 42.
- [x] `dotnet test tests/Elrond.Tests` — 48 / 48.
- [x] `dotnet test tests/Bilbo.Tests` — 31 / 31.
- [x] `dotnet test tests/Legolas.Tests` — 195 / 195.
- [x] `dotnet test tests/Palantir.Tests` — 7 / 7.
- [x] `dotnet test tests/Celebrimbor.Tests` — 52 / 52.
- [x] `dotnet test tests/Arwen.Tests` — 96 / 96.
- [x] **1,611 tests across 11 suites pass.**

### New test coverage

- **`AreaTransitionParserTests`** (9 cases): real area keys (parameterised across Serbule/Eltibule/Tomb1/Cave1/Casino), `ChooseCharacter` → null, empty body → null, unknown non-Area level → null, leading whitespace, unrelated line, `"LOADING LEVEL"` inside a quoted payload, empty line, timestamp preservation.
- **`PlayerAreaTrackerTests`** (11 cases): initial state, real-area observe, portal-transition replace, ChooseCharacter clears, disconnect clears, unrelated-line no-op, SeedFromLog picks most-recent area, SeedFromLog with disconnect clears, SeedFromLog with no marker / missing file / then live observe chains, BOM-less UTF-8 test fixture writer.
- **`LootSourceTests`** (+13 cases for #178): chest commit stamps current area, unknown-area persists null, sticky-once-known across portal, late-stamp from null to known, area-scoped friendly-name resolution (cow display), no-area fallback (`LootBackpack1`), final fallback to internal name, area friendly name as region, cow rejection no-prior anchors at rejection time, cow rejection leaves active prior alone, cow rejection refreshes stale prior, cow rejection idempotent replay, chest rejection default does NOT refresh anchor (preserves old behaviour).

## References

- Wiki [Player-Log-Signals#wild-gathering-cooldowns-cows-trees](https://github.com/arthur-conde/project-gorgon/wiki/Player-Log-Signals#wild-gathering-cooldowns-cows-trees) — captured grammars + the three-rejection-channel summary.
- Wiki [Player-Log-Signals#display-name-resolution-strings_all](https://github.com/arthur-conde/project-gorgon/wiki/Player-Log-Signals#display-name-resolution-strings_all) — strings_all lookup pattern.
- #177 — bracket discriminator widening (the foundation this builds on).
- #182 — cow milking rejection parser (the cause of `Cow_Elsie` / `Cow_Jammy` rejection-only cache entries this PR now anchors as rows).
- #188 — deferred: verify whether cow rejection grammar ever emits a numeric remaining/elapsed form. If yes, we can sharpen the rejection-anchor bound; for now it's conservative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
