### PR TITLE
fix(shared): Player.log [HH:MM:SS] prefix is UTC, not local

### DIFF
--- a/src/Mithril.Shared/Logging/ChatLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/ChatLogTailReader.cs
@@ -82,7 +82,7 @@ public sealed class ChatLogTailReader
         var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         if (lines.Length == 0) return Array.Empty<RawLogLine>();
 
-        state.Sequencer.EnsureAnchored(lines, () => File.GetLastWriteTime(path));
+        state.Sequencer.EnsureAnchored(lines, () => File.GetLastWriteTimeUtc(path));
 
         var result = new List<RawLogLine>(lines.Length);
         foreach (var line in lines)

--- a/src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs
+++ b/src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs
@@ -3,21 +3,30 @@ namespace Mithril.Shared.Logging;
 /// <summary>
 /// Recovers absolute UTC timestamps for log lines whose only embedded time
 /// information is a <c>[HH:MM:SS]</c> prefix (PG's gameplay log format).
-/// State is per-file: the date is anchored on file mtime for the first
-/// content batch and folded forward across rollovers in subsequent batches.
-/// Lines without the prefix inherit the previous line's stamp, or fall
-/// through to <see cref="TimeProvider.GetUtcNow"/> if nothing has been seen
-/// yet.
+/// The prefix is in <b>UTC</b> — verified against the same file's mtime
+/// (Player.log mtime minus the player's TZ offset matches the prefix's
+/// time-of-day) and against the ChatLog login banner's reported
+/// <c>Timezone Offset</c>, which equals the offset between Player.log
+/// prefixes and ChatLog lines. State is per-file: the date is anchored on
+/// file mtime (UTC) for the first content batch and folded forward across
+/// rollovers in subsequent batches. Lines without the prefix inherit the
+/// previous line's stamp, or fall through to <see cref="TimeProvider.GetUtcNow"/>
+/// if nothing has been seen yet.
 ///
 /// Shared by <see cref="PlayerLogTailReader"/> (single-file Player.log)
 /// and <see cref="ChatLogTailReader"/> (per-channel chat logs); each chat
 /// file gets its own sequencer instance so dates fold independently.
+/// Note: real chat-log lines don't carry the <c>[HH:MM:SS]</c> prefix
+/// (their format is <c>yy-MM-dd HH:MM:SS\t...</c> in <i>local</i> time),
+/// so chat lines fall through the prefix parse and rely on the inherited
+/// stamp or wall-clock-now. A future chat-content parser that wants
+/// absolute past-anchored stamps needs its own extraction path.
 /// </summary>
 internal sealed class LogLineTimestampSequencer
 {
     private readonly TimeProvider _time;
-    private DateOnly? _currentLocalDate;
-    private TimeSpan? _prevLocalTimeOfDay;
+    private DateOnly? _currentUtcDate;
+    private TimeSpan? _prevUtcTimeOfDay;
     private DateTime _lastEmittedUtc;
 
     public LogLineTimestampSequencer(TimeProvider time)
@@ -30,14 +39,17 @@ internal sealed class LogLineTimestampSequencer
     /// for <c>[HH:MM:SS]</c> prefixes, counts midnight rollovers in the
     /// batch, and walks the start back so the LAST timestamped line lines
     /// up with file mtime (or mtime - 1 day if its tod is past mtime's
-    /// tod, which happens when the file ticks over to the next calendar
-    /// day shortly after the line was written). No-op once anchored, and
+    /// tod, which happens when the file ticks over to the next UTC day
+    /// shortly after the line was written). Caller passes a UTC mtime —
+    /// both <see cref="PlayerLogTailReader"/> and <see cref="ChatLogTailReader"/>
+    /// use <see cref="File.GetLastWriteTimeUtc"/> so the comparison
+    /// against the UTC prefix is in one frame. No-op once anchored, and
     /// no-op for batches with no prefixed lines (defers init to a later
     /// batch that has at least one).
     /// </summary>
-    public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeAccessor)
+    public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor)
     {
-        if (_currentLocalDate is not null) return;
+        if (_currentUtcDate is not null) return;
 
         var rollovers = 0;
         TimeSpan? prev = null;
@@ -53,42 +65,45 @@ internal sealed class LogLineTimestampSequencer
 
         if (lastSeen is null) return;
 
-        DateTime mtime;
-        try { mtime = mtimeAccessor(); }
-        catch { mtime = _time.GetUtcNow().LocalDateTime; }
-        var anchorDate = DateOnly.FromDateTime(mtime);
-        if (lastSeen.Value > mtime.TimeOfDay) anchorDate = anchorDate.AddDays(-1);
+        DateTime mtimeUtc;
+        try { mtimeUtc = mtimeUtcAccessor(); }
+        catch { mtimeUtc = _time.GetUtcNow().UtcDateTime; }
+        var anchorDate = DateOnly.FromDateTime(mtimeUtc);
+        if (lastSeen.Value > mtimeUtc.TimeOfDay) anchorDate = anchorDate.AddDays(-1);
 
-        _currentLocalDate = anchorDate.AddDays(-rollovers);
+        _currentUtcDate = anchorDate.AddDays(-rollovers);
     }
 
     /// <summary>
     /// Compute the UTC stamp for a single log line. Parses the
-    /// <c>[HH:MM:SS]</c> prefix and folds it over the current date,
-    /// detecting midnight rollovers (HH wraps backward by &gt;12h).
-    /// Lines without the prefix inherit the prior stamp; a leading run
-    /// of unprefixed lines falls through to <see cref="TimeProvider.GetUtcNow"/>.
+    /// <c>[HH:MM:SS]</c> prefix (interpreted as UTC) and folds it over
+    /// the current date, detecting midnight rollovers (HH wraps backward
+    /// by &gt;12h). Lines without the prefix inherit the prior stamp; a
+    /// leading run of unprefixed lines falls through to
+    /// <see cref="TimeProvider.GetUtcNow"/>.
     /// </summary>
     public DateTime StampForLine(string line)
     {
-        if (TryParseTimestampPrefix(line, out var tod) && _currentLocalDate.HasValue)
+        if (TryParseTimestampPrefix(line, out var tod) && _currentUtcDate.HasValue)
         {
-            // Smaller backward jumps (the 1-hour DST fall-back overlap,
-            // out-of-order writes within the same minute) keep the same
-            // calendar date; only a >12h backward gap signals a real
-            // midnight rollover.
-            if (_prevLocalTimeOfDay.HasValue
-                && tod < _prevLocalTimeOfDay.Value
-                && (_prevLocalTimeOfDay.Value - tod) > TimeSpan.FromHours(12))
+            // Small backward jumps (out-of-order writes within the same
+            // second, sub-second flush ordering) keep the same calendar
+            // date; only a >12h backward gap signals a real midnight
+            // rollover. UTC doesn't observe DST, so this threshold no
+            // longer has to tolerate a 1h fall-back overlap — the slack
+            // is kept as defense against pathological out-of-order log
+            // writes the client could plausibly produce.
+            if (_prevUtcTimeOfDay.HasValue
+                && tod < _prevUtcTimeOfDay.Value
+                && (_prevUtcTimeOfDay.Value - tod) > TimeSpan.FromHours(12))
             {
-                _currentLocalDate = _currentLocalDate.Value.AddDays(1);
+                _currentUtcDate = _currentUtcDate.Value.AddDays(1);
             }
-            _prevLocalTimeOfDay = tod;
+            _prevUtcTimeOfDay = tod;
 
-            var date = _currentLocalDate.Value;
-            var local = new DateTime(date.Year, date.Month, date.Day,
-                tod.Hours, tod.Minutes, tod.Seconds, DateTimeKind.Local);
-            _lastEmittedUtc = local.ToUniversalTime();
+            var date = _currentUtcDate.Value;
+            _lastEmittedUtc = new DateTime(date.Year, date.Month, date.Day,
+                tod.Hours, tod.Minutes, tod.Seconds, DateTimeKind.Utc);
         }
         else if (_lastEmittedUtc == default)
         {

--- a/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
@@ -104,7 +104,7 @@ public sealed class PlayerLogTailReader
         var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         if (lines.Length == 0) return Array.Empty<RawLogLine>();
 
-        _sequencer.EnsureAnchored(lines, () => File.GetLastWriteTime(_path));
+        _sequencer.EnsureAnchored(lines, () => File.GetLastWriteTimeUtc(_path));
 
         var result = new List<RawLogLine>(lines.Length);
         foreach (var line in lines)

--- a/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
@@ -24,21 +24,23 @@ public sealed class ChatLogTailReaderTests : IDisposable
     [Fact]
     public void ReadNew_RecoversAbsoluteTimestampFromBracketedPrefix()
     {
+        // The shared sequencer treats [HH:MM:SS] as UTC. Real chat-log lines
+        // don't carry this prefix (their format is "yy-MM-dd HH:MM:SS\t..."
+        // in local time, parsed elsewhere), but the chat reader still routes
+        // through the same sequencer plumbing — these tests exercise that
+        // plumbing using synthetic prefix-shaped input.
         var path = Path.Combine(_dir, "Chat.Global.log");
         File.WriteAllText(path,
             "[14:30:00] [Global] Alice: hi\n" +
             "[15:30:00] [Global] Bob: hey\n");
-        var mtime = new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local);
-        File.SetLastWriteTime(path, mtime);
+        File.SetLastWriteTimeUtc(path, new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
 
         var reader = new ChatLogTailReader();
         var lines = reader.ReadNew(path);
 
         lines.Should().HaveCount(2);
-        lines[0].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Local));
-        lines[1].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local));
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
+        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
     }
 
     [Fact]
@@ -52,24 +54,20 @@ public sealed class ChatLogTailReaderTests : IDisposable
         var partyPath = Path.Combine(_dir, "Chat.Party.log");
 
         File.WriteAllText(globalPath, "[23:55:00] global pre-midnight\n");
-        File.SetLastWriteTime(globalPath,
-            new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+        File.SetLastWriteTimeUtc(globalPath, new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
 
         File.WriteAllText(partyPath, "[10:00:00] party morning\n");
-        File.SetLastWriteTime(partyPath,
-            new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+        File.SetLastWriteTimeUtc(partyPath, new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
 
         var reader = new ChatLogTailReader();
         var globalLines = reader.ReadNew(globalPath);
         var partyLines = reader.ReadNew(partyPath);
 
         globalLines.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
 
         partyLines.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
     }
 
     [Fact]
@@ -80,22 +78,18 @@ public sealed class ChatLogTailReaderTests : IDisposable
         // ReadNew calls so the post-midnight line gets the next day.
         var path = Path.Combine(_dir, "Chat.Global.log");
         File.WriteAllText(path, "[23:55:00] pre-midnight\n");
-        File.SetLastWriteTime(path,
-            new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+        File.SetLastWriteTimeUtc(path, new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
 
         var reader = new ChatLogTailReader();
         var first = reader.ReadNew(path);
         first.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
 
         File.AppendAllText(path, "[00:05:00] post-midnight\n");
-        File.SetLastWriteTime(path,
-            new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+        File.SetLastWriteTimeUtc(path, new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
 
         var second = reader.ReadNew(path);
         second.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
     }
 }

--- a/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
@@ -26,70 +26,64 @@ public sealed class PlayerLogTailReaderTests : IDisposable
     [Fact]
     public void ReadNew_RecoversAbsoluteTimestampFromBracketedPrefix()
     {
-        // Anchors the regression: PlayerLogTailReader used to stamp every line
-        // with wall-clock-now, breaking past-anchored cooldown rows. After the
-        // fix, each line's [HH:MM:SS] is folded over the file's mtime date so
-        // a quest completed an hour before launch anchors at the right wall
-        // clock — not at "now."
+        // Anchors the contract: the [HH:MM:SS] prefix is in UTC (PG writes
+        // UTC into Player.log; verified against the file's own mtime and
+        // against ChatLog's "Timezone Offset" login banner). The sequencer
+        // folds the tod over file-mtime-UTC to produce an absolute UTC stamp.
         File.WriteAllText(_logPath,
             "[14:30:00] LocalPlayer: ProcessAddPlayer(1, 2, \"desc\", \"TestChar\")\n" +
             "[15:30:00] LocalPlayer: ProcessCompleteQuest(17415332, 28505)\n");
-        var mtime = new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local);
-        File.SetLastWriteTime(_logPath, mtime);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var lines = reader.ReadNew();
 
         lines.Should().HaveCount(2);
-        lines[0].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Local));
-        lines[1].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Local));
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
+        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
     }
 
     [Fact]
     public void ReadNew_AcrossMidnight_FoldsDateForward()
     {
-        // Marathon session crossing midnight. The pre-midnight line's [HH:MM:SS]
-        // (23:55) is greater than the post-midnight line's (00:05); the >12h
-        // backward gap is the rollover signal, so the post-midnight line gets
-        // tagged with the next calendar day.
+        // Marathon session crossing UTC midnight. The pre-midnight line's
+        // [HH:MM:SS] (23:55) is greater than the post-midnight line's
+        // (00:05); the >12h backward gap is the rollover signal, so the
+        // post-midnight line gets tagged with the next calendar day.
         File.WriteAllText(_logPath,
             "[23:55:00] line-pre-midnight\n" +
             "[00:05:00] line-post-midnight\n");
-        var mtime = new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local);
-        File.SetLastWriteTime(_logPath, mtime);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var lines = reader.ReadNew();
 
         lines.Should().HaveCount(2);
-        lines[0].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
-        lines[1].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
+        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
     }
 
     [Fact]
-    public void ReadNew_BackwardJumpUnder12h_StaysInSameDay()
+    public void ReadNew_SmallBackwardJump_DoesNotTriggerRollover()
     {
-        // A DST fall-back creates a 1h backward overlap (e.g. 02:30 → 01:35).
-        // The rollover heuristic requires a >12h backward gap, so the second
-        // line stays on the same calendar date — we don't push it 24h forward.
+        // Sub-12h backward jumps (e.g. out-of-order flushes within the same
+        // hour, or any pathological non-monotonic write the client could
+        // produce) must not be misread as midnight rollovers. Only a >12h
+        // backward gap counts as a real rollover. The threshold used to
+        // exist to tolerate a 1h DST fall-back overlap; now that the
+        // prefix is UTC (DST-free) the slack is purely defense against
+        // out-of-order writes.
         File.WriteAllText(_logPath,
-            "[02:30:00] line-before-fallback\n" +
-            "[01:35:00] line-after-fallback\n");
-        var mtime = new DateTime(2026, 11, 1, 1, 35, 0, DateTimeKind.Local);
-        File.SetLastWriteTime(_logPath, mtime);
+            "[02:30:00] line-earlier-tod\n" +
+            "[02:25:00] line-later-but-tod-rewound\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 2, 30, 0, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var lines = reader.ReadNew();
 
         lines.Should().HaveCount(2);
-        lines[0].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 11, 1, 2, 30, 0, DateTimeKind.Local));
-        lines[1].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 11, 1, 1, 35, 0, DateTimeKind.Local));
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 2, 30, 0, DateTimeKind.Utc));
+        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 10, 2, 25, 0, DateTimeKind.Utc));
     }
 
     [Fact]
@@ -103,18 +97,15 @@ public sealed class PlayerLogTailReaderTests : IDisposable
             "[10:00:00] LocalPlayer: ProcessAddPlayer(1, 2, \"desc\", \"TestChar\")\n" +
             "NullReferenceException: Object reference not set to an instance of an object.\n" +
             "[10:00:05] LocalPlayer: next gameplay line\n");
-        var mtime = new DateTime(2026, 5, 10, 10, 0, 5, DateTimeKind.Local);
-        File.SetLastWriteTime(_logPath, mtime);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 5, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var lines = reader.ReadNew();
 
         lines.Should().HaveCount(3);
-        lines[0].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
         lines[1].Timestamp.Should().Be(lines[0].Timestamp);  // inherited
-        lines[2].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 5, DateTimeKind.Local));
+        lines[2].Timestamp.Should().Be(new DateTime(2026, 5, 10, 10, 0, 5, DateTimeKind.Utc));
     }
 
     [Fact]
@@ -127,8 +118,7 @@ public sealed class PlayerLogTailReaderTests : IDisposable
             "Initialize engine version: 6000.3.11f1\n" +
             "[Physics::Module] Initialized fallback backend.\n" +
             "[10:00:00] LocalPlayer: first gameplay line\n");
-        var mtime = new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local);
-        File.SetLastWriteTime(_logPath, mtime);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
 
         var fixedNow = new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc);
         var time = new FixedTimeProvider(fixedNow);
@@ -139,54 +129,47 @@ public sealed class PlayerLogTailReaderTests : IDisposable
         lines.Should().HaveCount(3);
         lines[0].Timestamp.Should().Be(fixedNow);
         lines[1].Timestamp.Should().Be(fixedNow);  // inherited from line 0's fallback
-        lines[2].Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Local));
+        lines[2].Timestamp.Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
     }
 
     [Fact]
     public void ReadNew_AcrossBatches_PreservesRolloverState()
     {
-        // First batch ends just before midnight, second batch starts just
-        // after. The reader must carry _currentLocalDate + _prevLocalTimeOfDay
+        // First batch ends just before UTC midnight, second batch starts just
+        // after. The reader must carry _currentUtcDate + _prevUtcTimeOfDay
         // across the batch boundary so the post-midnight line gets the next
         // day — not the same day as the pre-midnight line.
         File.WriteAllText(_logPath, "[23:55:00] pre-midnight\n");
-        File.SetLastWriteTime(_logPath,
-            new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var first = reader.ReadNew();
         first.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
 
         File.AppendAllText(_logPath, "[00:05:00] post-midnight\n");
-        File.SetLastWriteTime(_logPath,
-            new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
 
         var second = reader.ReadNew();
         second.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
     }
 
     [Fact]
     public void ReadNew_LastLineTodPastMtimeTimeOfDay_BacksAnchorUpOneDay()
     {
         // Late-night session: the final [HH:MM:SS] is at 23:59 but the file's
-        // mtime ticked over to 00:01 the next calendar day (write-buffer flush
+        // mtime ticked over to 00:01 the next UTC day (write-buffer flush
         // happens after midnight). The line was actually written yesterday;
         // the anchor must back up one day so we don't tag it with tomorrow.
         File.WriteAllText(_logPath, "[23:59:00] last-line\n");
-        var mtime = new DateTime(2026, 5, 11, 0, 1, 0, DateTimeKind.Local);
-        File.SetLastWriteTime(_logPath, mtime);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 0, 1, 0, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var lines = reader.ReadNew();
 
         lines.Should().ContainSingle()
-            .Which.Timestamp.ToLocalTime()
-            .Should().Be(new DateTime(2026, 5, 10, 23, 59, 0, DateTimeKind.Local));
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 59, 0, DateTimeKind.Utc));
     }
 
     private sealed class FixedTimeProvider : TimeProvider


### PR DESCRIPTION
Closes #183.

## Summary

- PR #184 wired the `[HH:MM:SS]` prefix in as the absolute-time source but assumed it was local time and applied `.ToUniversalTime()`. The prefix is actually already UTC, so every persisted timestamp ended up shifted backward by the player's local offset.
- Concrete symptom from the reopened #183: Gandalf Quest tab marked repeatable kills as available 1h before the in-game cooldown actually elapsed, because the stored `startedAt` was 1h earlier than the real completion time. The unchecked "in-game verification" item from PR #184's checklist would have caught this.
- Fix: construct the `DateTime` with `DateTimeKind.Utc` directly in `LogLineTimestampSequencer.StampForLine`, drop `.ToUniversalTime()`, and switch both readers' mtime accessors to `File.GetLastWriteTimeUtc` so the date-anchoring comparison stays in one frame.

## Evidence the prefix is UTC

| Source | Latest sample on a BST client | Frame |
|---|---|---|
| `Player.log` last prefix | `[21:56:00]` | UTC |
| `Player.log` mtime | `22:57:40 +0100` (BST) → `21:57:40 UTC` | matches Player.log prefix → UTC |
| `Chat-26-05-10.log` last line | `26-05-10 22:55:45` | matches wall-clock BST → local |
| `Chat-26-04-06.log` login banner | `Logged In As ... Timezone Offset 01:00:00` | client reports +1h offset to server |

Player.log and ChatLog timestamps differ by exactly the `Timezone Offset` the client reports. Player.log is the data path Gandalf cooldown anchoring actually uses.

## Test plan

- [x] `PlayerLogTailReaderTests` rewritten to assert against `DateTimeKind.Utc` directly and use `File.SetLastWriteTimeUtc`. Suite is now TZ-independent on CI.
- [x] `ChatLogTailReaderTests` likewise.
- [x] Repurposed the DST-fall-back test: UTC doesn't observe DST, so a 1h-backward-overlap scenario isn't realistic. The `>12h` rollover threshold is retained as defense against out-of-order client writes; the test now exercises that property directly via a 5min backward jump.
- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors — warnings-as-errors is on).
- [x] `dotnet test Mithril.slnx` green (1654 tests, 0 failures).
- [ ] **In-game verification owed:** rerun the original repro from #183 — complete a known repeatable quest, leave Mithril off for several hours, launch it, confirm the Gandalf Quest tab card reflects actual elapsed time AND that the "available" state matches the in-game offer (i.e. the off-by-one-hour symptom is gone). This is the verification step PR #184 left open.

## Data impact

Existing `gandalf-derived.json` rows recorded before this PR have already been shifted by the player's local offset. After this lands, fresh observations are correct, but pre-existing in-flight rows remain anchored by their offset (1h early on BST) until they cycle naturally. No migration shipped — the affected window is just whatever rows happen to be live at the moment the fix is deployed, and cooldowns expire on their own. Worth flagging in release notes if there's a downstream user-visible change log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)