### PR TITLE
fix(gandalf): DashboardAggregator must marshal Updated to UI thread

### DIFF
--- a/src/Gandalf.Module/Services/DashboardAggregator.cs
+++ b/src/Gandalf.Module/Services/DashboardAggregator.cs
@@ -1,3 +1,5 @@
+using System.Windows;
+using System.Windows.Threading;
 using Gandalf.Domain;
 
 namespace Gandalf.Services;
@@ -15,19 +17,39 @@ namespace Gandalf.Services;
 /// Driving that tick from a <see cref="Domain.TimerRow.NextDisplayChangeAt"/>-style
 /// schedule on the aggregator is a clean follow-up; out of scope for the
 /// timer-model PR.</para>
+///
+/// <para>Threading: source <see cref="ITimerSource.RowsChanged"/> events
+/// fire on whichever thread the source happened to mutate on — for
+/// QuestSource/LootSource that's the log-tail background thread when a
+/// completion is observed live. <see cref="Updated"/> consumers
+/// (<c>DashboardViewModel.Refresh</c>) mutate WPF-bound
+/// <c>ObservableCollection</c>s, which require the UI thread. We capture
+/// a <see cref="Dispatcher"/> in the ctor and marshal the entire delta
+/// application + <see cref="Updated"/> fire through it. Without this,
+/// CollectionView throws <c>"...does not support changes...from a
+/// thread different from the Dispatcher thread"</c>, and worse — that
+/// throw aborts the multicast invocation, so subsequent
+/// <see cref="ITimerSource.RowsChanged"/> subscribers (the per-tab
+/// <see cref="TimerSourceBinder"/>) never run and tab rows go stale
+/// (issue #191; see <c>memory/wpf_crossthread_collection_mutations.md</c>).</para>
 /// </summary>
 public sealed class DashboardAggregator : IDisposable
 {
     private readonly IReadOnlyList<ITimerSource> _sources;
     private readonly TimeProvider _time;
+    private readonly Dispatcher _dispatcher;
     private readonly object _lock = new();
     private readonly Dictionary<(string SourceId, string Key), TimerSummary> _byKey = [];
     private IReadOnlyList<TimerSummary> _summaries = [];
 
-    public DashboardAggregator(IEnumerable<ITimerSource> sources, TimeProvider? time = null)
+    public DashboardAggregator(
+        IEnumerable<ITimerSource> sources,
+        TimeProvider? time = null,
+        Dispatcher? dispatcher = null)
     {
         _sources = sources.ToArray();
         _time = time ?? TimeProvider.System;
+        _dispatcher = dispatcher ?? Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
 
         var now = _time.GetUtcNow();
         foreach (var source in _sources)
@@ -82,11 +104,20 @@ public sealed class DashboardAggregator : IDisposable
     {
         if (sender is not ITimerSource source) return;
 
+        // Snapshot deltas before dispatch — the source may mutate further
+        // before the dispatcher pump gets to the work item. Mirrors the
+        // TimerSourceBinder pattern.
+        var deltas = e.Deltas;
+        Dispatch(() => ApplyDeltas(source, deltas));
+    }
+
+    private void ApplyDeltas(ITimerSource source, IReadOnlyList<TimerRowDelta> deltas)
+    {
         var any = false;
         var now = _time.GetUtcNow();
         lock (_lock)
         {
-            foreach (var delta in e.Deltas)
+            foreach (var delta in deltas)
             {
                 var compositeKey = (source.SourceId, delta.Key);
                 if (delta.Kind == TimerRowChangeKind.Removed)
@@ -102,6 +133,12 @@ public sealed class DashboardAggregator : IDisposable
             if (any) SnapshotSummaries();
         }
         if (any) Updated?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Dispatch(Action action)
+    {
+        if (_dispatcher.CheckAccess()) action();
+        else _dispatcher.BeginInvoke(action);
     }
 
     private void SnapshotSummaries() => _summaries = _byKey.Values.ToArray();

--- a/tests/Gandalf.Tests/DashboardAggregatorTests.cs
+++ b/tests/Gandalf.Tests/DashboardAggregatorTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Windows.Threading;
 using FluentAssertions;
 using Gandalf.Domain;
 using Gandalf.Services;
@@ -208,6 +209,94 @@ public sealed class DashboardAggregatorTests
         agg.Recompute();
 
         agg.Summaries.Single().State.Should().Be(TimerState.Done);
+    }
+
+    [Fact]
+    public void Updated_marshals_to_captured_dispatcher_when_RowsChanged_fires_off_thread()
+    {
+        // Regression for #191: prior to the fix, OnSourceRowsChanged ran
+        // synchronously on the source's calling thread. For QuestSource /
+        // LootSource that's the log-tail background thread when a completion
+        // is observed live — DashboardViewModel.Refresh then mutated WPF-bound
+        // ObservableCollections off the UI thread, which CollectionView throws
+        // on. Worse, the throw aborted the multicast invocation so the per-tab
+        // TimerSourceBinder (a later subscriber) never ran — tab rows kept
+        // showing the previous cooldown's state even though the JSON had the
+        // new startedAt. Fix: capture a Dispatcher in the ctor and marshal
+        // the delta application + Updated fire through it.
+        //
+        // Test runs synchronously (not async Task) and uses a raw Thread
+        // (not Task.Run) so PushFrame stays on the test thread that owns
+        // the dispatcher — async/await would resume the continuation on a
+        // pool thread, and PushFrame on a non-owner thread blocks forever.
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "R", TimeSpan.FromHours(1), null)],
+        };
+        var time = new ManualTime(Origin);
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var dispatcherThread = Environment.CurrentManagedThreadId;
+
+        using var agg = new DashboardAggregator([src], time, dispatcher);
+
+        var observedThread = -1;
+        agg.Updated += (_, _) => observedThread = Environment.CurrentManagedThreadId;
+
+        // Fire RowsChanged from a non-dispatcher thread.
+        var workerThread = -1;
+        var worker = new Thread(() =>
+        {
+            workerThread = Environment.CurrentManagedThreadId;
+            src.RaiseRowsChanged([
+                new TimerRowDelta("k1", TimerRowChangeKind.ProgressChanged,
+                    src.Catalog[0],
+                    new TimerProgressEntry("k1", time.GetUtcNow(), null)),
+            ]);
+        });
+        worker.Start();
+        worker.Join();
+
+        observedThread.Should().Be(-1,
+            "Updated must NOT fire synchronously on the calling thread when it differs from the dispatcher");
+
+        // Pump the dispatcher (on its owning test thread) to drain the
+        // queued ApplyDeltas + Updated fire.
+        var frame = new DispatcherFrame();
+        _ = dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, () => frame.Continue = false);
+        Dispatcher.PushFrame(frame);
+
+        observedThread.Should().Be(dispatcherThread,
+            "Updated must marshal to the captured dispatcher's thread, not the calling thread");
+        workerThread.Should().NotBe(dispatcherThread,
+            "regression-test sanity: RowsChanged really did fire from a different thread");
+    }
+
+    [Fact]
+    public void Updated_runs_synchronously_when_RowsChanged_fires_on_dispatcher_thread()
+    {
+        // The other half of the dispatch contract: when a source happens to
+        // raise RowsChanged on the dispatcher thread itself (e.g. user-driven
+        // events that originate on the UI thread), Updated should fire
+        // synchronously — no extra dispatcher hop, no observable latency.
+        var src = new FakeSource("gandalf.test")
+        {
+            Catalog = [new TimerCatalogEntry("k1", "Daily", "R", TimeSpan.FromHours(1), null)],
+        };
+        var time = new ManualTime(Origin);
+        var dispatcher = Dispatcher.CurrentDispatcher;
+
+        using var agg = new DashboardAggregator([src], time, dispatcher);
+
+        var fired = 0;
+        agg.Updated += (_, _) => fired++;
+
+        src.RaiseRowsChanged([
+            new TimerRowDelta("k1", TimerRowChangeKind.ProgressChanged,
+                src.Catalog[0],
+                new TimerProgressEntry("k1", time.GetUtcNow(), null)),
+        ]);
+
+        fired.Should().Be(1, "synchronous fire keeps the dispatcher hop count at zero on the hot path");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `DashboardAggregator.OnSourceRowsChanged` ran synchronously on the source's calling thread; for `QuestSource`/`LootSource` that's the log-tail background thread on a live completion. `DashboardViewModel.Refresh` then mutated WPF-bound `ObservableCollection`s off the UI thread → `CollectionView` threw, and the throw aborted the `RowsChanged` multicast so the per-tab `TimerSourceBinder` never ran. Result: JSON updated correctly, tab rows stayed stuck on the previous cooldown's "done X ago" label.
- Capture a `Dispatcher` in the aggregator ctor (same `Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher` fallback as `TimerSourceBinder`); route both the delta application and the `Updated` fire through it. `Recompute()` stays direct because it's already called from `DispatcherTimer.Tick` on the UI thread.
- Regression test fires `RowsChanged` from a raw `Thread` (`Task.Run`/`async` would land the continuation off the dispatcher's owning thread and `PushFrame` would deadlock) and asserts `Updated` runs on the captured dispatcher, not on the calling thread.

Closes #191.

## Test plan

- [x] `dotnet build Mithril.slnx` — green
- [x] `dotnet test tests/Gandalf.Tests` — 326 pass (incl. 2 new dispatch tests)
- [x] `dotnet test Mithril.slnx` — full solution green
- [ ] Smoke test live: complete a repeatable quest, confirm Quests-tab card flips Done → Running with the new `startedAt` instead of staying stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)