### PR TITLE
feat(arwen): editable calibration observations + outlier detector

### DIFF
--- a/src/Arwen.Module/Arwen.Module.csproj
+++ b/src/Arwen.Module/Arwen.Module.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="MahApps.Metro" />
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -101,8 +101,12 @@ public sealed class ArwenModule : IMithrilModule
             view.AddTab("Item Lookup", new ItemLookupTab { DataContext = sp.GetRequiredService<ItemLookupViewModel>() });
             view.AddTab("Storage Gifts", new StorageGiftsTab { DataContext = sp.GetRequiredService<StorageGiftsViewModel>() });
             var calibrationVm = sp.GetRequiredService<CalibrationViewModel>();
-            var calibrationTab = view.AddTab("Calibration", new CalibrationTab { DataContext = calibrationVm });
-            calibrationTab.SetBinding(TabBadge.CountProperty,
+            view.AddTab("Calibration", new CalibrationTab { DataContext = calibrationVm });
+            // Editor shares the same VM — every change recomputes rates via the VM's Refresh()
+            // wired to CalibrationService.DataChanged, so both tabs stay in sync automatically.
+            // Pending observations live here too, so the PendingCount badge follows.
+            var editorTab = view.AddTab("Edit Observations", new ObservationsEditorTab { DataContext = calibrationVm });
+            editorTab.SetBinding(TabBadge.CountProperty,
                 new System.Windows.Data.Binding(nameof(CalibrationViewModel.PendingCount)) { Source = calibrationVm });
             sp.GetRequiredService<FavorViewNavigatorHolder>().Inner = view;
             return view;

--- a/src/Arwen.Module/Domain/CalibrationService.cs
+++ b/src/Arwen.Module/Domain/CalibrationService.cs
@@ -918,6 +918,112 @@ public sealed class CalibrationService
         return added;
     }
 
-    private static string ObservationKey(GiftObservation o) =>
+    internal static string ObservationKey(GiftObservation o) =>
         $"{o.NpcKey}|{o.ItemInternalName}|{o.FavorDelta}|{o.Timestamp:O}";
+
+    /// <summary>
+    /// Max stack size for the item by <c>InternalName</c>, clamped to a floor of 1 so callers
+    /// can use it as the upper bound of a Quantity edit without special-casing non-stackables
+    /// (whose reference-data <c>MaxStackSize</c> may be 0 or 1).
+    /// Returns 1 if the item is no longer in reference data.
+    /// </summary>
+    public int GetMaxStackSize(string itemInternalName) =>
+        _refData.ItemsByInternalName.TryGetValue(itemInternalName, out var item)
+            ? Math.Max(1, item.MaxStackSize)
+            : 1;
+
+    /// <summary>
+    /// CDN icon id for the item by <c>InternalName</c>. Returns 0 if the item is no longer
+    /// in reference data; the icon control treats 0 as "no icon" and renders a placeholder.
+    /// </summary>
+    public int GetIconId(string itemInternalName) =>
+        _refData.ItemsByInternalName.TryGetValue(itemInternalName, out var item)
+            ? item.IconId
+            : 0;
+
+    /// <summary>
+    /// Display name for the item (e.g. "Rubbery Tongue"), falling back to <paramref name="itemInternalName"/>
+    /// when the item has dropped out of reference data. Matches the fallback pattern used elsewhere
+    /// in <c>CalibrationService</c> (see <see cref="PendingGiftObservation.DisplayName"/> construction).
+    /// </summary>
+    public string GetItemDisplayName(string itemInternalName) =>
+        _refData.ItemsByInternalName.TryGetValue(itemInternalName, out var item) && !string.IsNullOrEmpty(item.Name)
+            ? item.Name
+            : itemInternalName;
+
+    /// <summary>
+    /// Display name for an NPC. Looks up <see cref="NpcEntry.Name"/> by key; if the NPC is no
+    /// longer in reference data, falls back to a key-formatted name (strip <c>NPC_</c> prefix,
+    /// underscores → spaces).
+    /// </summary>
+    public string GetNpcDisplayName(string npcKey)
+    {
+        if (_refData.Npcs.TryGetValue(npcKey, out var npc) && !string.IsNullOrEmpty(npc.Name))
+            return npc.Name;
+        var stripped = npcKey.StartsWith("NPC_", StringComparison.Ordinal) ? npcKey[4..] : npcKey;
+        return stripped.Replace('_', ' ');
+    }
+
+    // ── Edits / Deletes ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Delete a single confirmed observation by its <see cref="ObservationKey"/>.
+    /// Returns false if the key isn't present. On success, rebuilds aggregates,
+    /// persists both files, and fires <see cref="DataChanged"/> — same path
+    /// <see cref="PersistObservation"/> takes after recording a new gift.
+    /// </summary>
+    public bool DeleteObservation(string observationKey)
+    {
+        var idx = _data.Observations.FindIndex(o => ObservationKey(o) == observationKey);
+        if (idx < 0) return false;
+        var removed = _data.Observations[idx];
+        _data.Observations.RemoveAt(idx);
+        RecomputeRates();
+        Save();
+        _diag?.Info("Arwen.Calibration",
+            $"Deleted observation: {removed.ItemInternalName} → {removed.NpcKey} (+{removed.FavorDelta} favor, {removed.Timestamp:O})");
+        DataChanged?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    /// <summary>
+    /// Update <see cref="GiftObservation.Quantity"/> on a confirmed observation. Returns
+    /// false if the key isn't present, the item is no longer in reference data, the
+    /// quantity is outside <c>[1, MaxStackSize]</c>, or the value is unchanged. On
+    /// success, rebuilds aggregates, persists, and fires <see cref="DataChanged"/>.
+    /// </summary>
+    public bool UpdateObservationQuantity(string observationKey, int quantity)
+    {
+        var idx = _data.Observations.FindIndex(o => ObservationKey(o) == observationKey);
+        if (idx < 0) return false;
+        var obs = _data.Observations[idx];
+        if (!_refData.ItemsByInternalName.TryGetValue(obs.ItemInternalName, out var item)) return false;
+        var maxStack = Math.Max(1, item.MaxStackSize);
+        if (quantity < 1 || quantity > maxStack) return false;
+        if (obs.Quantity == quantity) return false;
+        var oldQuantity = obs.Quantity;
+        obs.Quantity = quantity;
+        RecomputeRates();
+        Save();
+        _diag?.Info("Arwen.Calibration",
+            $"Updated quantity: {obs.ItemInternalName} → {obs.NpcKey} qty {oldQuantity} → {quantity}");
+        DataChanged?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    /// <summary>
+    /// Delete every confirmed observation matching <paramref name="predicate"/>. Returns
+    /// the count of removed observations. Only triggers recompute/save/DataChanged when
+    /// at least one observation was removed.
+    /// </summary>
+    public int DeleteObservationsByPredicate(Func<GiftObservation, bool> predicate)
+    {
+        var removed = _data.Observations.RemoveAll(o => predicate(o));
+        if (removed == 0) return 0;
+        RecomputeRates();
+        Save();
+        _diag?.Info("Arwen.Calibration", $"Bulk-deleted {removed} observation(s)");
+        DataChanged?.Invoke(this, EventArgs.Empty);
+        return removed;
+    }
 }

--- a/src/Arwen.Module/Domain/ObservationFlags.cs
+++ b/src/Arwen.Module/Domain/ObservationFlags.cs
@@ -1,0 +1,82 @@
+namespace Arwen.Domain;
+
+/// <summary>
+/// Why an individual <see cref="GiftObservation"/> looks suspicious. <see cref="None"/>
+/// means it doesn't trigger any of the checks; anything else is a hint for the user
+/// that this row may be worth reviewing before it keeps weighing on the per-(NPC,item)
+/// rate.
+/// </summary>
+public enum ObservationFlag
+{
+    None = 0,
+
+    /// <summary>
+    /// <see cref="GiftObservation.DerivedRate"/> is more than the configured σ-threshold
+    /// away from the mean of its (NPC, item) group, where the group has at least the
+    /// configured minimum number of samples and a non-zero standard deviation.
+    /// </summary>
+    OutlierInItemGroup = 1,
+}
+
+/// <summary>Per-observation outlier verdict plus the stats that produced it, so the UI can build a tooltip.</summary>
+public sealed record ObservationFlagInfo(
+    ObservationFlag Flag,
+    double GroupMean,
+    double GroupStdDev,
+    int GroupSampleCount,
+    double SigmasFromMean);
+
+/// <summary>
+/// Statistical outlier detector for <see cref="GiftObservation"/>. Pure function: no
+/// state, no side effects, no I/O. The view-model calls <see cref="Detect"/> once per
+/// refresh and looks up each row's verdict by <see cref="CalibrationService.ObservationKey"/>.
+/// </summary>
+public static class ObservationFlagDetector
+{
+    /// <summary>
+    /// Flag every observation whose <see cref="GiftObservation.DerivedRate"/> deviates by
+    /// more than <paramref name="stdDevThreshold"/> standard deviations from the mean of
+    /// its (NpcKey, ItemInternalName) group. Groups with fewer than
+    /// <paramref name="minGroupSize"/> samples — or with a zero standard deviation
+    /// (perfect agreement; nothing to flag) — produce no flags.
+    /// </summary>
+    /// <param name="observations">Source observations. Each one is keyed via <see cref="CalibrationService.ObservationKey"/>.</param>
+    /// <param name="stdDevThreshold">σ threshold above/below the group mean.</param>
+    /// <param name="minGroupSize">Minimum samples in a group before any flag is emitted.</param>
+    /// <returns>Map of observation-key → flag info for every observation that fires a flag. Unflagged observations are absent from the dictionary (caller treats missing as <see cref="ObservationFlag.None"/>).</returns>
+    public static IReadOnlyDictionary<string, ObservationFlagInfo> Detect(
+        IReadOnlyList<GiftObservation> observations,
+        double stdDevThreshold = 3.0,
+        int minGroupSize = 3)
+    {
+        var result = new Dictionary<string, ObservationFlagInfo>(StringComparer.Ordinal);
+        if (observations.Count == 0) return result;
+
+        var groups = observations.GroupBy(o => (o.NpcKey, o.ItemInternalName));
+        foreach (var group in groups)
+        {
+            var members = group.ToList();
+            if (members.Count < minGroupSize) continue;
+
+            var rates = members.Select(o => o.DerivedRate).ToList();
+            var mean = rates.Average();
+            var variance = rates.Sum(r => (r - mean) * (r - mean)) / (rates.Count - 1); // sample variance (Bessel's correction)
+            var stdDev = Math.Sqrt(variance);
+            if (stdDev <= 0) continue;
+
+            foreach (var obs in members)
+            {
+                var sigmas = Math.Abs(obs.DerivedRate - mean) / stdDev;
+                if (sigmas <= stdDevThreshold) continue;
+                result[CalibrationService.ObservationKey(obs)] = new ObservationFlagInfo(
+                    Flag: ObservationFlag.OutlierInItemGroup,
+                    GroupMean: mean,
+                    GroupStdDev: stdDev,
+                    GroupSampleCount: members.Count,
+                    SigmasFromMean: sigmas);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Arwen.Module/ViewModels/CalibrationViewModel.cs
+++ b/src/Arwen.Module/ViewModels/CalibrationViewModel.cs
@@ -40,18 +40,71 @@ public sealed class NpcBaselineRow
     public required double MaxRate { get; init; }
 }
 
-/// <summary>Row for the raw observations grid.</summary>
-public sealed class ObservationRow
+/// <summary>
+/// Row for the raw observations grid and the editable observations tab. Display fields
+/// (NpcName/ItemName/Signature/ItemValue/EffectivePref/FavorDelta/DerivedRate/Timestamp)
+/// are init-only — they're built from the underlying <see cref="GiftObservation"/> on every
+/// <see cref="CalibrationViewModel.Refresh"/>. Only <see cref="Quantity"/> is observable so
+/// the editor TextBox can two-way bind; the canonical Quantity lives on the underlying
+/// observation and only changes when <see cref="CalibrationService.UpdateObservationQuantity"/>
+/// succeeds. <see cref="OriginalQuantity"/> is the value we revert to if the commit fails.
+/// </summary>
+public sealed partial class ObservationRow : ObservableObject
 {
+    public required string ObservationKey { get; init; }
     public required string NpcName { get; init; }
     public required string ItemName { get; init; }
-    public required int Quantity { get; init; }
+    public required int IconId { get; init; }
     public required string Signature { get; init; }
+    public required IReadOnlyList<MatchedPreference> MatchedPreferences { get; init; }
     public required double ItemValue { get; init; }
     public required double EffectivePref { get; init; }
     public required double FavorDelta { get; init; }
     public required double DerivedRate { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
+    public required int MaxStackSize { get; init; }
+    public required int OriginalQuantity { get; init; }
+    public required ObservationFlag Flag { get; init; }
+    public required string? FlagTooltip { get; init; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsQuantityValid))]
+    [NotifyPropertyChangedFor(nameof(IsQuantityEdited))]
+    [NotifyPropertyChangedFor(nameof(PreviewedRate))]
+    [NotifyPropertyChangedFor(nameof(TotalValue))]
+    private int _quantity;
+
+    public bool IsQuantityValid => Quantity >= 1 && Quantity <= MaxStackSize;
+
+    public bool IsQuantityEditable => MaxStackSize > 1;
+
+    public bool IsFlagged => Flag != ObservationFlag.None;
+
+    /// <summary>True when the user has typed a different Quantity than what's persisted.</summary>
+    public bool IsQuantityEdited => Quantity != OriginalQuantity;
+
+    /// <summary>
+    /// Total gold worth of the gifted stack: <see cref="ItemValue"/> × <see cref="Quantity"/>.
+    /// Live: follows the in-progress edit so the preview moves while the user adjusts Quantity.
+    /// Note this is the stack's market value, not the calibration "score" — Arwen's GiftScanner
+    /// "Score" column (<see cref="Arwen.Domain.GiftMatch.RelativeScore"/>) is <c>Pref × ItemValue</c>;
+    /// the rate-denominator factor (<c>EffectivePref × ItemValue × Quantity</c>) isn't surfaced
+    /// directly because the headline Rate already conveys it.
+    /// </summary>
+    public double TotalValue => ItemValue * Quantity;
+
+    /// <summary>
+    /// Live preview of <see cref="DerivedRate"/> using the current edit-in-progress
+    /// <see cref="Quantity"/>. Equals <see cref="DerivedRate"/> when nothing's been edited.
+    /// Same formula as <see cref="GiftObservation.DerivedRate"/>:
+    /// <c>FavorDelta / (EffectivePref × ItemValue × Quantity)</c>.
+    /// </summary>
+    public double PreviewedRate =>
+        EffectivePref == 0 || ItemValue == 0 || Quantity == 0
+            ? 0
+            : FavorDelta / (EffectivePref * ItemValue * Quantity);
+
+    public void RevertQuantity() => Quantity = OriginalQuantity;
 }
 
 /// <summary>
@@ -151,6 +204,27 @@ public sealed partial class CalibrationViewModel : ObservableObject
     [ObservableProperty]
     private ObservableCollection<ObservationRow> _observations = [];
 
+    /// <summary>
+    /// Subset of <see cref="Observations"/> matching <see cref="ObservationsFilter"/>.
+    /// Drives the editable observations tab. When the filter is empty this is a copy of
+    /// <see cref="Observations"/>; <see cref="BulkDeleteFilteredCommand"/> operates on
+    /// exactly this set so what-you-see is what-gets-deleted.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ObservationRow> _filteredObservations = [];
+
+    /// <summary>Case-insensitive substring filter matched against NpcName and ItemName.</summary>
+    [ObservableProperty]
+    private string _observationsFilter = "";
+
+    [ObservableProperty]
+    private int _flaggedCount;
+
+    [ObservableProperty]
+    private int _filteredCount;
+
+    partial void OnObservationsFilterChanged(string value) => RebuildFilteredObservations();
+
     public ObservableCollection<PendingObservationRow> PendingRows { get; } = [];
 
     [ObservableProperty]
@@ -174,6 +248,85 @@ public sealed partial class CalibrationViewModel : ObservableObject
     {
         if (row is null) return;
         _calibration.DiscardPending(row.Id);
+    }
+
+    [RelayCommand]
+    private void DeleteObservation(ObservationRow? row)
+    {
+        if (row is null) return;
+        if (_calibration.DeleteObservation(row.ObservationKey))
+        {
+            StatusMessage = $"Deleted observation: {row.ItemName} → {row.NpcName}";
+        }
+        else
+        {
+            StatusMessage = "Observation no longer present — nothing to delete.";
+        }
+    }
+
+    /// <summary>
+    /// Called when the Quantity TextBox loses focus on the editor tab. Pushes the row's
+    /// edited Quantity into the canonical observation. On failure (out-of-range, item
+    /// missing from reference data, unchanged value), reverts the row to its original
+    /// quantity so the UI doesn't display a value that wasn't accepted.
+    /// </summary>
+    [RelayCommand]
+    private void CommitQuantity(ObservationRow? row)
+    {
+        if (row is null) return;
+        if (row.Quantity == row.OriginalQuantity) return;
+        if (!row.IsQuantityValid)
+        {
+            row.Quantity = row.OriginalQuantity;
+            StatusMessage = $"Quantity must be between 1 and {row.MaxStackSize}; reverted.";
+            return;
+        }
+        if (_calibration.UpdateObservationQuantity(row.ObservationKey, row.Quantity))
+        {
+            // Successful update fires DataChanged → Refresh() rebuilds every row from the
+            // canonical observation list, so OriginalQuantity on the new row will reflect
+            // the change. Set a status message before that rebuild discards this row.
+            StatusMessage = $"Updated quantity: {row.ItemName} → {row.NpcName} = {row.Quantity}";
+        }
+        else
+        {
+            row.Quantity = row.OriginalQuantity;
+            StatusMessage = "Quantity update rejected — observation may have changed; reverted.";
+        }
+    }
+
+    [RelayCommand]
+    private void BulkDeleteFiltered()
+    {
+        var filter = (ObservationsFilter ?? "").Trim();
+        if (filter.Length == 0)
+        {
+            StatusMessage = "Type a filter first; bulk delete only operates on filtered rows.";
+            return;
+        }
+
+        var targets = FilteredObservations.ToList();
+        if (targets.Count == 0)
+        {
+            StatusMessage = "No observations match the current filter.";
+            return;
+        }
+
+        // Confirmation is required for destructive bulk action. When _dialogService is null
+        // (test path) we proceed — tests construct the VM directly and assert via the
+        // CalibrationService API rather than driving the bulk-delete flow end-to-end.
+        if (_dialogService is not null)
+        {
+            var confirmed = _dialogService.Confirm(
+                title: "Delete observations",
+                message: $"Delete {targets.Count} observation(s) matching \"{filter}\"?\n\nThis cannot be undone.");
+            if (!confirmed) return;
+        }
+
+        var keys = new HashSet<string>(targets.Select(r => r.ObservationKey), StringComparer.Ordinal);
+        var removed = _calibration.DeleteObservationsByPredicate(
+            o => keys.Contains(CalibrationService.ObservationKey(o)));
+        StatusMessage = $"Deleted {removed} observation(s) matching \"{filter}\".";
     }
 
     [RelayCommand]
@@ -250,28 +403,73 @@ public sealed partial class CalibrationViewModel : ObservableObject
             .OrderByDescending(r => r.SampleCount)
             .ThenBy(r => r.NpcName, StringComparer.OrdinalIgnoreCase));
 
+        var flags = ObservationFlagDetector.Detect(data.Observations);
+
         Observations = new(data.Observations
             .OrderByDescending(o => o.Timestamp)
-            .Select(o => new ObservationRow
+            .Select(o =>
             {
-                NpcName = FormatNpcName(o.NpcKey),
-                ItemName = o.ItemInternalName,
-                Quantity = o.Quantity,
-                Signature = string.IsNullOrEmpty(o.Signature) ? "(none)" : o.Signature,
-                ItemValue = o.ItemValue,
-                EffectivePref = o.EffectivePref,
-                FavorDelta = o.FavorDelta,
-                DerivedRate = o.DerivedRate,
-                Timestamp = o.Timestamp,
+                var key = CalibrationService.ObservationKey(o);
+                var flag = flags.TryGetValue(key, out var info) ? info : null;
+                var row = new ObservationRow
+                {
+                    ObservationKey = key,
+                    NpcName = _calibration.GetNpcDisplayName(o.NpcKey),
+                    ItemName = _calibration.GetItemDisplayName(o.ItemInternalName),
+                    IconId = _calibration.GetIconId(o.ItemInternalName),
+                    Signature = string.IsNullOrEmpty(o.Signature) ? "(none)" : o.Signature,
+                    MatchedPreferences = o.MatchedPreferences,
+                    ItemValue = o.ItemValue,
+                    EffectivePref = o.EffectivePref,
+                    FavorDelta = o.FavorDelta,
+                    DerivedRate = o.DerivedRate,
+                    Timestamp = o.Timestamp,
+                    MaxStackSize = _calibration.GetMaxStackSize(o.ItemInternalName),
+                    OriginalQuantity = o.Quantity,
+                    Flag = flag?.Flag ?? ObservationFlag.None,
+                    FlagTooltip = flag is null ? null : BuildFlagTooltip(o.DerivedRate, flag),
+                };
+                row.Quantity = o.Quantity;
+                return row;
             }));
+
+        FlaggedCount = Observations.Count(r => r.IsFlagged);
+
+        RebuildFilteredObservations();
 
         StatusMessage =
             $"{data.Observations.Count} observation(s) · " +
             $"{data.ItemRates.Count} item rate(s) · " +
             $"{data.SignatureRates.Count} signature rate(s) · " +
-            $"{data.NpcRates.Count} NPC baseline(s)";
+            $"{data.NpcRates.Count} NPC baseline(s)" +
+            (FlaggedCount > 0 ? $" · {FlaggedCount} flagged" : "");
 
         UpdateCommunitySummary();
+    }
+
+    private void RebuildFilteredObservations()
+    {
+        var filter = (ObservationsFilter ?? "").Trim();
+        if (filter.Length == 0)
+        {
+            FilteredObservations = new(Observations);
+        }
+        else
+        {
+            FilteredObservations = new(Observations.Where(r => MatchesFilter(r, filter)));
+        }
+        FilteredCount = FilteredObservations.Count;
+    }
+
+    private static bool MatchesFilter(ObservationRow row, string filter) =>
+        row.NpcName.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+        row.ItemName.Contains(filter, StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildFlagTooltip(double observedRate, ObservationFlagInfo info)
+    {
+        var direction = observedRate > info.GroupMean ? "above" : "below";
+        return $"Rate {observedRate:F4} is {info.SigmasFromMean:F1}σ {direction} mean " +
+               $"{info.GroupMean:F4} (group of {info.GroupSampleCount}, σ={info.GroupStdDev:F4}).";
     }
 
     private void RefreshPending()

--- a/src/Arwen.Module/Views/CalibrationTab.xaml
+++ b/src/Arwen.Module/Views/CalibrationTab.xaml
@@ -67,70 +67,6 @@
                 </StackPanel>
             </StackPanel>
 
-            <!-- Pending observations (carryover stacks awaiting user confirmation) -->
-            <Expander IsExpanded="True"
-                      Margin="0,4,0,8" Foreground="#FFD4A847"
-                      Visibility="{Binding PendingCount, Converter={StaticResource PositiveIntToVis}}">
-                <Expander.Header>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="Pending observations · " FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold"/>
-                        <TextBlock Text="{Binding PendingCount}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold"/>
-                        <TextBlock Text="  (waiting on stack size)" FontSize="{DynamicResource AppFontSizeHint}"
-                                   Foreground="#88FFFFFF" VerticalAlignment="Center" Margin="6,0,0,0"/>
-                    </StackPanel>
-                </Expander.Header>
-                <ItemsControl x:Name="PendingList" ItemsSource="{Binding PendingRows}" Margin="0,6,0,0">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                                    CornerRadius="4" Padding="10" Margin="0,0,0,6">
-                                <DockPanel>
-                                    <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                   Width="32" Height="32" Margin="0,0,10,0" VerticalAlignment="Center"/>
-                                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
-                                        <TextBox Width="60" Margin="0,0,8,0"
-                                                 Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
-                                                 ToolTip="Stack size at the time of the gift">
-                                            <TextBox.Style>
-                                                <Style TargetType="TextBox">
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsQuantityValid}" Value="False">
-                                                            <Setter Property="BorderBrush" Value="#FFCC6666"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBox.Style>
-                                        </TextBox>
-                                        <Button Content="Confirm" Margin="0,0,4,0" Padding="10,3"
-                                                Background="#FFD4A847" BorderBrush="#FFD4A847" Foreground="#FF1A1A1A"
-                                                FontWeight="SemiBold"
-                                                IsEnabled="{Binding IsQuantityValid}"
-                                                Command="{Binding DataContext.ConfirmCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                CommandParameter="{Binding}"/>
-                                        <Button Content="Discard" Padding="10,3"
-                                                Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"
-                                                Command="{Binding DataContext.DiscardCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                CommandParameter="{Binding}"/>
-                                    </StackPanel>
-                                    <StackPanel>
-                                        <TextBlock>
-                                            <Run Text="{Binding DisplayName, Mode=OneWay}" FontWeight="SemiBold" Foreground="#FFE8E8E8"/>
-                                            <Run Text=" → " Foreground="#88FFFFFF"/>
-                                            <Run Text="{Binding NpcName, Mode=OneWay}" Foreground="#FFD4A847"/>
-                                        </TextBlock>
-                                        <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
-                                            <Run Text="+"/><Run Text="{Binding FavorDelta, Mode=OneWay, StringFormat={}{0:F1}}"/>
-                                            <Run Text=" favor · max stack "/><Run Text="{Binding MaxStackSize, Mode=OneWay}"/>
-                                            <Run Text=" · expires "/><Run Text="{Binding ExpiresIn, Mode=OneWay}"/>
-                                        </TextBlock>
-                                    </StackPanel>
-                                </DockPanel>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </Expander>
-
             <!-- Per-item rates -->
             <Expander IsExpanded="True" Margin="0,4,0,8" Foreground="#FFD4A847">
                 <Expander.Header>
@@ -204,55 +140,8 @@
                 </wpf:MithrilDataGrid>
             </Expander>
 
-            <!-- Observations -->
-            <TextBlock Text="Observations" Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeMedium}"
-                       FontWeight="SemiBold" Margin="0,8,0,4"/>
-            <Grid Margin="0,0,0,4">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="Filter" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                           VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <wpf:MithrilQueryBox Grid.Column="1"
-                                    Grid="{Binding ElementName=ObservationsGrid}"
-                                    QueryText="{Binding ElementName=ObservationsGrid, Path=QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                    Watermark="type text, or grammar like Signature CONTAINS 'Ring'"/>
-            </Grid>
-            <TextBlock Text="{Binding ElementName=ObservationsGrid, Path=QueryError}"
-                       Foreground="#FFCC6666" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,4,0,0"
-                       Visibility="{Binding ElementName=ObservationsGrid, Path=QueryError,
-                           Converter={StaticResource NullOrEmptyToVis}}"/>
-            <wpf:MithrilDataGrid x:Name="ObservationsGrid" ItemsSource="{Binding Observations}"
-                                Mode="ReadOnly" CanUserResizeRows="False"
-                                MaxHeight="320" Margin="0,4,0,0">
-                <wpf:MithrilDataGrid.Columns>
-                    <DataGridTextColumn Header="NPC" Binding="{Binding NpcName}" Width="140"
-                                        ElementStyle="{StaticResource RateTextCol}"/>
-                    <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="160"
-                                        ElementStyle="{StaticResource SubtleCol}"/>
-                    <DataGridTextColumn Header="Qty" Binding="{Binding Quantity}" Width="50"
-                                        ElementStyle="{StaticResource RateMinMaxCol}"/>
-                    <DataGridTextColumn Header="Signature" Binding="{Binding Signature}" Width="200"
-                                        ElementStyle="{StaticResource RateMinMaxCol}"/>
-                    <DataGridTextColumn Header="Value" Binding="{Binding ItemValue, StringFormat=N0}" Width="70"
-                                        ElementStyle="{StaticResource SubtleCol}"/>
-                    <DataGridTextColumn Header="Pref" Binding="{Binding EffectivePref, StringFormat=+0.#;-0.#;0}" Width="55"
-                                        ElementStyle="{StaticResource RateNumCol}"/>
-                    <DataGridTextColumn Header="Favor" Binding="{Binding FavorDelta, StringFormat=+0.0;-0.0;0}" Width="70"
-                                        ElementStyle="{StaticResource RateSampleCol}"/>
-                    <DataGridTextColumn Header="Rate" Binding="{Binding DerivedRate, StringFormat=F4}" Width="80"
-                                        ElementStyle="{StaticResource RateNumCol}"/>
-                    <DataGridTextColumn Header="Time" Binding="{Binding Timestamp, StringFormat=yyyy-MM-dd HH:mm}" Width="130">
-                        <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="#66FFFFFF"/>
-                                <Setter Property="Padding" Value="6,4"/>
-                            </Style>
-                        </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
-                </wpf:MithrilDataGrid.Columns>
-            </wpf:MithrilDataGrid>
+            <!-- Per-observation list lives on the "Edit Observations" tab now. This tab is for
+                 the aggregated rates only — see ObservationsEditorTab.xaml for the editable cards. -->
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/Arwen.Module/Views/ObservationsEditorTab.xaml
+++ b/src/Arwen.Module/Views/ObservationsEditorTab.xaml
@@ -1,0 +1,433 @@
+<UserControl x:Class="Arwen.Views.ObservationsEditorTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Arwen.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:CalibrationViewModel}"
+             Background="#FF1A1A1A">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <!-- MahApps Controls + Fonts + Dark.Steel theme are needed for mah:NumericUpDown
+                 to render its spinner buttons. The shell deliberately doesn't merge these
+                 globally — so we scope them here. Mithril.Shared resources are last so any
+                 local key (e.g. BoolToVis) wins over MahApps versions. Same pattern as
+                 Gandalf/Views/TimerDialogContent.xaml. -->
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Steel.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared;component/Wpf/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Preference pip: one chip per MatchedPreference. Background tints by Desire. -->
+            <DataTemplate x:Key="PreferencePipTemplate">
+                <Border CornerRadius="3" Padding="6,2" Margin="0,0,4,4" BorderThickness="1">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="Background" Value="#FF3A3328"/>
+                            <Setter Property="BorderBrush" Value="#55D4A847"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Desire}" Value="Love">
+                                    <Setter Property="Background" Value="#FF3A2D28"/>
+                                    <Setter Property="BorderBrush" Value="#88E07A5F"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Desire}" Value="Like">
+                                    <Setter Property="Background" Value="#FF293A28"/>
+                                    <Setter Property="BorderBrush" Value="#557AB880"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Desire}" Value="Dislike">
+                                    <Setter Property="Background" Value="#FF3A2828"/>
+                                    <Setter Property="BorderBrush" Value="#88CC6666"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Desire}" Value="Hate">
+                                    <Setter Property="Background" Value="#FF3A2222"/>
+                                    <Setter Property="BorderBrush" Value="#AACC4444"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                    <TextBlock FontSize="{DynamicResource AppFontSizeHint}"
+                               ToolTip="{Binding Desire, StringFormat='Desire: {0}'}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="#FFD4A847"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Desire}" Value="Love">
+                                        <Setter Property="Foreground" Value="#FFE0A57F"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Desire}" Value="Like">
+                                        <Setter Property="Foreground" Value="#FFAAD8AF"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Desire}" Value="Dislike">
+                                        <Setter Property="Foreground" Value="#FFE39999"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Desire}" Value="Hate">
+                                        <Setter Property="Foreground" Value="#FFFF8888"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                        <Run Text="{Binding Name, Mode=OneWay}" FontWeight="SemiBold"/>
+                        <Run Text=" "/>
+                        <Run Text="{Binding Pref, Mode=OneWay, StringFormat=+0.#;-0.#;0}"/>
+                    </TextBlock>
+                </Border>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel Margin="12">
+        <!-- Header / status -->
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Edit Observations · " FontSize="{DynamicResource AppFontSizeMedium}"
+                           FontWeight="SemiBold" Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding StatusMessage}" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center"/>
+            </StackPanel>
+            <TextBlock Foreground="#66FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,4,0,0"
+                       TextWrapping="Wrap">
+                Confirm pending stack sizes, edit Quantity to fix mis-recorded gifts, or delete observations whose
+                derived rate has drifted the per-(NPC,item) average. Every change recomputes rates and saves.
+                The ⚠ glyph marks observations whose rate sits more than 3σ from their group mean.
+            </TextBlock>
+        </StackPanel>
+
+        <!-- Pending observations (carryover stacks awaiting user confirmation).
+             Sits above the confirmed list as a DockPanel.Dock=Top region so it doesn't
+             interfere with the ListBox's own virtualization. Pending count is bounded by
+             the 24h TTL — typically 0-3 entries — so it doesn't need recycling itself. -->
+        <Expander DockPanel.Dock="Top" IsExpanded="True"
+                  Margin="0,0,0,12" Foreground="#FFD4A847"
+                  Visibility="{Binding PendingCount, Converter={StaticResource PositiveIntToVis}}">
+            <Expander.Header>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Pending · " FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding PendingCount}" FontSize="{DynamicResource AppFontSizeMedium}" FontWeight="SemiBold"/>
+                    <TextBlock Text="  (waiting on stack size)" FontSize="{DynamicResource AppFontSizeHint}"
+                               Foreground="#88FFFFFF" VerticalAlignment="Center" Margin="6,0,0,0"/>
+                </StackPanel>
+            </Expander.Header>
+            <ItemsControl x:Name="PendingList" ItemsSource="{Binding PendingRows}" Margin="0,6,0,0">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
+                                CornerRadius="6" Padding="12" Margin="0,0,0,6">
+                            <DockPanel>
+                                <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                               Width="40" Height="40" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBox Width="60" Margin="0,0,8,0" Padding="4,3" TextAlignment="Center"
+                                             Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                                             ToolTip="Stack size at the time of the gift">
+                                        <TextBox.Style>
+                                            <Style TargetType="TextBox">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsQuantityValid}" Value="False">
+                                                        <Setter Property="BorderBrush" Value="#FFCC6666"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBox.Style>
+                                    </TextBox>
+                                    <Button Content="Confirm" Margin="0,0,4,0" Padding="10,3"
+                                            Background="#FFD4A847" BorderBrush="#FFD4A847" Foreground="#FF1A1A1A"
+                                            FontWeight="SemiBold"
+                                            IsEnabled="{Binding IsQuantityValid}"
+                                            Command="{Binding DataContext.ConfirmCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                            CommandParameter="{Binding}"/>
+                                    <Button Content="Discard" Padding="10,3"
+                                            Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"
+                                            Command="{Binding DataContext.DiscardCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                            CommandParameter="{Binding}"/>
+                                </StackPanel>
+                                <StackPanel>
+                                    <TextBlock>
+                                        <Run Text="{Binding DisplayName, Mode=OneWay}" FontWeight="SemiBold" Foreground="#FFE8E8E8"/>
+                                        <Run Text=" → " Foreground="#88FFFFFF"/>
+                                        <Run Text="{Binding NpcName, Mode=OneWay}" Foreground="#FFD4A847"/>
+                                    </TextBlock>
+                                    <TextBlock Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0">
+                                        <Run Text="+"/><Run Text="{Binding FavorDelta, Mode=OneWay, StringFormat={}{0:F1}}"/>
+                                        <Run Text=" favor · max stack "/><Run Text="{Binding MaxStackSize, Mode=OneWay}"/>
+                                        <Run Text=" · expires "/><Run Text="{Binding ExpiresIn, Mode=OneWay}"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </DockPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Expander>
+
+        <!-- Filter row -->
+        <Grid DockPanel.Dock="Top" Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="Filter" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBox Grid.Column="1"
+                             Text="{Binding ObservationsFilter, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                             Background="#FF2A2A2A" Foreground="#FFE8E8E8" BorderBrush="#FF444444"
+                             Padding="6,3" FontSize="{DynamicResource AppFontSize}"
+                             ToolTip="Substring match on NPC name or item internal name (case-insensitive)"/>
+                    <TextBlock Grid.Column="2" Margin="10,0,0,0" VerticalAlignment="Center"
+                               Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}">
+                        <Run Text="Showing "/><Run Text="{Binding FilteredCount, Mode=OneWay}"/><Run Text=" row(s)"/>
+                    </TextBlock>
+                    <Button Grid.Column="3" Margin="10,0,0,0" Padding="10,3"
+                            Command="{Binding BulkDeleteFilteredCommand}"
+                            Background="#FF553333" Foreground="#FFE8E8E8" BorderBrush="#FF884444"
+                            FontSize="{DynamicResource AppFontSizeHint}" FontWeight="SemiBold"
+                            ToolTip="Delete every observation matching the current filter (with confirmation)">
+                        <TextBlock>
+                            <Run Text="Delete "/><Run Text="{Binding FilteredCount, Mode=OneWay}"/><Run Text=" filtered"/>
+                        </TextBlock>
+                    </Button>
+                </Grid>
+
+        <!-- Confirmed observation cards — virtualizing wrap panel for a 2-column grid.
+             Uses MithrilVirtualizingWrapPanel so a long observation log (hundreds of rows)
+             stays responsive. Cards are uniform size; the flag indicator is a corner glyph
+             with tooltip rather than an inline callout, which keeps the layout dense. -->
+        <ListBox x:Name="ObservationsList" ItemsSource="{Binding FilteredObservations}"
+                 Background="Transparent" BorderThickness="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="True"
+                 VirtualizingPanel.IsVirtualizing="True"
+                 VirtualizingPanel.VirtualizationMode="Recycling">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <wpf:MithrilVirtualizingWrapPanel ItemWidth="560" ItemHeight="160"/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="Margin" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Focusable" Value="False"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="ListBoxItem">
+                                <ContentPresenter/>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate DataType="{x:Type vm:ObservationRow}">
+                    <Border CornerRadius="6" BorderThickness="1" Padding="10" Margin="4">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Background" Value="#FF252525"/>
+                                <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsFlagged}" Value="True">
+                                        <Setter Property="Background" Value="#FF2A2722"/>
+                                        <Setter Property="BorderBrush" Value="#88D4A847"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsQuantityEdited}" Value="True">
+                                        <Setter Property="BorderBrush" Value="#88E0B468"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <!-- Icon (spans all rows on the left) -->
+                            <wpf:IconImage Grid.Column="0" Grid.RowSpan="4" IconId="{Binding IconId}"
+                                           Width="40" Height="40" Margin="0,2,12,0"
+                                           VerticalAlignment="Top"/>
+
+                            <!-- Row 0: heading (item → npc on left, time + flag on right) -->
+                            <Grid Grid.Column="1" Grid.Row="0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" TextTrimming="CharacterEllipsis"
+                                           ToolTip="{Binding ObservationKey}">
+                                    <Run Text="{Binding ItemName, Mode=OneWay}" FontWeight="SemiBold" Foreground="#FFE8E8E8"
+                                         FontSize="{DynamicResource AppFontSizeMedium}"/>
+                                    <Run Text="   →   " Foreground="#66FFFFFF"/>
+                                    <Run Text="{Binding NpcName, Mode=OneWay}" FontWeight="SemiBold" Foreground="#FFD4A847"
+                                         FontSize="{DynamicResource AppFontSizeMedium}"/>
+                                </TextBlock>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock Text="⚠" Foreground="#FFD4A847" Margin="0,0,6,0"
+                                               FontWeight="SemiBold" FontSize="{DynamicResource AppFontSize}"
+                                               VerticalAlignment="Center"
+                                               Visibility="{Binding IsFlagged, Converter={StaticResource BoolToVis}}"
+                                               ToolTip="{Binding FlagTooltip}"/>
+                                    <TextBlock Text="{Binding Timestamp, Mode=OneWay, StringFormat=yyyy-MM-dd HH:mm}"
+                                               Foreground="#55FFFFFF"
+                                               VerticalAlignment="Center"
+                                               FontSize="{DynamicResource AppFontSizeHint}"/>
+                                </StackPanel>
+                            </Grid>
+
+                            <!-- Row 1: pips beside the heading (keywords identify the item) -->
+                            <ItemsControl Grid.Column="1" Grid.Row="1"
+                                          ItemsSource="{Binding MatchedPreferences}"
+                                          ItemTemplate="{StaticResource PreferencePipTemplate}"
+                                          Margin="0,4,0,0">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                            </ItemsControl>
+
+                            <!-- Row 2: numeric facts (Total value · Favor · Rate w/ live preview when edited) -->
+                            <StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal" Margin="0,6,0,0">
+                                <TextBlock Foreground="#66FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
+                                    <Run Text="Total value "/>
+                                </TextBlock>
+                                <TextBlock Text="{Binding TotalValue, Mode=OneWay, StringFormat=N0}"
+                                           Foreground="#FFD4A847" FontWeight="SemiBold"
+                                           VerticalAlignment="Center" FontSize="{DynamicResource AppFontSize}"
+                                           ToolTip="Item value × stack quantity — total gold worth of the gifted stack"/>
+                                <TextBlock Foreground="#66FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
+                                    <Run Text="   ·   Favor "/>
+                                </TextBlock>
+                                <TextBlock Text="{Binding FavorDelta, Mode=OneWay, StringFormat=+0.0;-0.0;0}"
+                                           Foreground="#FF7AB880" FontWeight="SemiBold"
+                                           VerticalAlignment="Center" FontSize="{DynamicResource AppFontSize}"/>
+                                <TextBlock Foreground="#66FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" VerticalAlignment="Center">
+                                    <Run Text="   ·   Rate "/>
+                                </TextBlock>
+                                <TextBlock Text="{Binding DerivedRate, Mode=OneWay, StringFormat=F4}"
+                                           VerticalAlignment="Center" FontSize="{DynamicResource AppFontSize}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Foreground" Value="#FFD4A847"/>
+                                            <Setter Property="FontWeight" Value="SemiBold"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsQuantityEdited}" Value="True">
+                                                    <Setter Property="Foreground" Value="#66FFFFFF"/>
+                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <StackPanel Orientation="Horizontal" Margin="6,0,0,0"
+                                            Visibility="{Binding IsQuantityEdited, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock Text="→" Foreground="#66FFFFFF" Margin="0,0,6,0"
+                                               FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding PreviewedRate, Mode=OneWay, StringFormat=F4}"
+                                               Foreground="#FF7AB880" FontWeight="SemiBold"
+                                               FontSize="{DynamicResource AppFontSize}" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!-- Row 3: Qty spinner + save/revert + delete -->
+                            <Grid Grid.Column="1" Grid.Row="3" Margin="0,8,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <!-- Spinner for stackable items — MahApps NumericUpDown ships
+                                     a theme-driven default size that fits Segoe UI glyphs cleanly. -->
+                                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center"
+                                            Visibility="{Binding IsQuantityEditable, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock Text="Qty" Foreground="#88FFFFFF"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <mah:NumericUpDown Width="110" MinHeight="28"
+                                                       Value="{Binding Quantity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                       Minimum="1"
+                                                       Maximum="{Binding MaxStackSize}"
+                                                       NumericInputMode="Numbers"
+                                                       StringFormat="N0"
+                                                       Interval="1"
+                                                       PreviewKeyDown="QuantityTextBox_PreviewKeyDown"
+                                                       ToolTip="Enter to save · Esc to revert">
+                                        <mah:NumericUpDown.Style>
+                                            <Style TargetType="mah:NumericUpDown">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsQuantityValid}" Value="False">
+                                                        <Setter Property="BorderBrush" Value="#FFCC6666"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsQuantityEdited}" Value="True">
+                                                        <Setter Property="BorderBrush" Value="#FFE0B468"/>
+                                                        <Setter Property="BorderThickness" Value="2"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </mah:NumericUpDown.Style>
+                                    </mah:NumericUpDown>
+                                    <TextBlock Text="{Binding MaxStackSize, Mode=OneWay, StringFormat='/ {0}'}"
+                                               Foreground="#55FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                                               VerticalAlignment="Center" Margin="6,0,0,0"/>
+                                </StackPanel>
+
+                                <!-- Static qty label for non-stackable items -->
+                                <TextBlock Grid.Column="0" Text="Qty 1 (non-stackable)" Foreground="#55FFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           VerticalAlignment="Center"
+                                           Visibility="{Binding IsQuantityEditable, Converter={StaticResource InverseBoolToVis}}"/>
+
+                                <!-- Save/Revert (only when edited) -->
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="10,0,0,0"
+                                            Visibility="{Binding IsQuantityEdited, Converter={StaticResource BoolToVis}}">
+                                    <Button Padding="8,2" Margin="0,0,4,0"
+                                            Background="#FFD4A847" Foreground="#FF1A1A1A" BorderBrush="#FFD4A847"
+                                            FontWeight="SemiBold" FontSize="{DynamicResource AppFontSizeHint}"
+                                            IsEnabled="{Binding IsQuantityValid}"
+                                            Command="{Binding DataContext.CommitQuantityCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                            CommandParameter="{Binding}"
+                                            ToolTip="Commit the edit · Enter">
+                                        <TextBlock><Run Text="✓"/><Run Text=" Save"/></TextBlock>
+                                    </Button>
+                                    <Button Padding="8,2"
+                                            Background="#FF2A2A2A" Foreground="#CCFFFFFF" BorderBrush="#FF444444"
+                                            FontSize="{DynamicResource AppFontSizeHint}"
+                                            Click="RevertButton_Click"
+                                            ToolTip="Discard the edit · Esc">
+                                        <TextBlock><Run Text="↺"/><Run Text=" Revert"/></TextBlock>
+                                    </Button>
+                                </StackPanel>
+
+                                <!-- Delete button (right-aligned) -->
+                                <Button Grid.Column="3" Padding="0" Width="26" Height="22"
+                                        Content="✕" Background="Transparent" Foreground="#FFCC6666" BorderBrush="#33FFFFFF"
+                                        FontSize="{DynamicResource AppFontSize}"
+                                        Command="{Binding DataContext.DeleteObservationCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding}"
+                                        ToolTip="Delete this observation (recomputes rates immediately)"/>
+                            </Grid>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </DockPanel>
+</UserControl>

--- a/src/Arwen.Module/Views/ObservationsEditorTab.xaml.cs
+++ b/src/Arwen.Module/Views/ObservationsEditorTab.xaml.cs
@@ -1,0 +1,41 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Arwen.ViewModels;
+
+namespace Arwen.Views;
+
+public partial class ObservationsEditorTab : UserControl
+{
+    public ObservationsEditorTab()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Keyboard shortcuts for the Quantity TextBox: Enter commits, Escape reverts.
+    /// LostFocus does NOT auto-commit — accidental tab-out shouldn't persist an edit.
+    /// </summary>
+    private void QuantityTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (sender is not FrameworkElement fe) return;
+        if (fe.DataContext is not ObservationRow row) return;
+        if (e.Key == Key.Enter)
+        {
+            if (DataContext is CalibrationViewModel vm && vm.CommitQuantityCommand.CanExecute(row))
+                vm.CommitQuantityCommand.Execute(row);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            row.RevertQuantity();
+            e.Handled = true;
+        }
+    }
+
+    private void RevertButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe && fe.DataContext is ObservationRow row)
+            row.RevertQuantity();
+    }
+}

--- a/src/Mithril.Shared/Wpf/Dialogs/DialogService.cs
+++ b/src/Mithril.Shared/Wpf/Dialogs/DialogService.cs
@@ -12,4 +12,16 @@ public sealed class DialogService : IDialogService
         };
         return window.ShowDialog();
     }
+
+    public bool Confirm(string title, string message)
+    {
+        var result = MessageBox.Show(
+            Application.Current.MainWindow,
+            message,
+            title,
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning,
+            MessageBoxResult.No);
+        return result == MessageBoxResult.Yes;
+    }
 }

--- a/src/Mithril.Shared/Wpf/Dialogs/IDialogService.cs
+++ b/src/Mithril.Shared/Wpf/Dialogs/IDialogService.cs
@@ -5,4 +5,11 @@ namespace Mithril.Shared.Wpf.Dialogs;
 public interface IDialogService
 {
     bool? ShowDialog(DialogViewModelBase viewModel, FrameworkElement content);
+
+    /// <summary>
+    /// Modal yes/no confirmation. Returns true when the user explicitly confirms
+    /// (clicks Yes / OK), false on No / Cancel / dismiss. Use for destructive
+    /// actions that need an "are you sure?" gate.
+    /// </summary>
+    bool Confirm(string title, string message);
 }

--- a/tests/Arwen.Tests/CalibrationServiceTests.cs
+++ b/tests/Arwen.Tests/CalibrationServiceTests.cs
@@ -1097,4 +1097,157 @@ public sealed class CalibrationServiceTests
             SafeDeleteDir(dir);
         }
     }
+
+    [Fact]
+    public void DeleteObservation_RemovesAndRecomputesRates()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var (svc, _, inv) = BuildService(dir);
+            for (var i = 0; i < 3; i++)
+            {
+                inv.Add(2000 + i, "Moonstone");
+                svc.OnStartInteraction("NPC_Sanja");
+                svc.OnItemDeleted(2000 + i);
+                svc.OnDeltaFavor("NPC_Sanja", 22.5);
+            }
+            svc.Data.Observations.Should().HaveCount(3);
+            var itemKey = CalibrationService.ItemRateKey("NPC_Sanja", "Moonstone");
+            svc.Data.ItemRates[itemKey].SampleCount.Should().Be(3);
+
+            var key = CalibrationService.ObservationKey(svc.Data.Observations[1]);
+            var dataChangedCount = 0;
+            svc.DataChanged += (_, _) => dataChangedCount++;
+
+            svc.DeleteObservation(key).Should().BeTrue();
+
+            svc.Data.Observations.Should().HaveCount(2);
+            svc.Data.ItemRates[itemKey].SampleCount.Should().Be(2);
+            dataChangedCount.Should().Be(1);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void DeleteObservation_ReturnsFalseForUnknownKey()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var (svc, _, inv) = BuildService(dir);
+            inv.Add(3000, "Moonstone");
+            svc.OnStartInteraction("NPC_Sanja");
+            svc.OnItemDeleted(3000);
+            svc.OnDeltaFavor("NPC_Sanja", 22.5);
+
+            svc.DeleteObservation("bogus|key|0|0").Should().BeFalse();
+            svc.Data.Observations.Should().HaveCount(1);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void UpdateObservationQuantity_RecomputesDerivedRate()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var (svc, _, inv) = BuildService(dir);
+            // Phlogiston1 is stackable (MaxStackSize=10); seed inventory with stackSize=1
+            // so the observation lands confirmed, then bump quantity to 5.
+            inv.Add(4000, "Phlogiston1", stackSize: 1);
+            svc.OnStartInteraction("NPC_Sanja");
+            svc.OnItemDeleted(4000);
+            svc.OnDeltaFavor("NPC_Sanja", 10.0);
+            svc.Data.Observations.Should().HaveCount(1, "stack size known → no pending path");
+            var obs = svc.Data.Observations[0];
+            obs.Quantity.Should().Be(1);
+            var originalRate = obs.DerivedRate;
+
+            var key = CalibrationService.ObservationKey(obs);
+            svc.UpdateObservationQuantity(key, 5).Should().BeTrue();
+
+            obs.Quantity.Should().Be(5);
+            obs.DerivedRate.Should().BeApproximately(originalRate / 5.0, 1e-9,
+                "DerivedRate = FavorDelta / (Pref × Value × Quantity)");
+            var itemKey = CalibrationService.ItemRateKey("NPC_Sanja", "Phlogiston1");
+            svc.Data.ItemRates[itemKey].Rate.Should().BeApproximately(obs.DerivedRate, 1e-9,
+                "single-observation group rate equals the observation's derived rate");
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void UpdateObservationQuantity_RejectsOutOfRange()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var (svc, _, inv) = BuildService(dir);
+            inv.Add(5000, "Phlogiston1", stackSize: 3);
+            svc.OnStartInteraction("NPC_Sanja");
+            svc.OnItemDeleted(5000);
+            svc.OnDeltaFavor("NPC_Sanja", 10.0);
+            var obs = svc.Data.Observations[0];
+            var key = CalibrationService.ObservationKey(obs);
+
+            svc.UpdateObservationQuantity(key, 0).Should().BeFalse("quantity < 1");
+            svc.UpdateObservationQuantity(key, 99).Should().BeFalse("quantity > MaxStackSize (10)");
+            svc.UpdateObservationQuantity(key, 3).Should().BeFalse("unchanged value");
+
+            obs.Quantity.Should().Be(3, "rejected updates must not mutate");
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void DeleteObservationsByPredicate_ReportsCount()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var (svc, _, inv) = BuildService(dir);
+            // 3 gifts to Sanja, 2 gifts to Test
+            for (var i = 0; i < 3; i++)
+            {
+                inv.Add(6000 + i, "Moonstone");
+                svc.OnStartInteraction("NPC_Sanja");
+                svc.OnItemDeleted(6000 + i);
+                svc.OnDeltaFavor("NPC_Sanja", 22.5);
+            }
+            for (var i = 0; i < 2; i++)
+            {
+                inv.Add(7000 + i, "Apple");
+                svc.OnStartInteraction("NPC_Test");
+                svc.OnItemDeleted(7000 + i);
+                svc.OnDeltaFavor("NPC_Test", 8.0);
+            }
+            svc.Data.Observations.Should().HaveCount(5);
+
+            var removed = svc.DeleteObservationsByPredicate(o => o.NpcKey == "NPC_Sanja");
+            removed.Should().Be(3);
+            svc.Data.Observations.Should().HaveCount(2);
+            svc.Data.Observations.Should().OnlyContain(o => o.NpcKey == "NPC_Test");
+
+            var noopRemoved = svc.DeleteObservationsByPredicate(o => o.NpcKey == "NPC_NoSuchOne");
+            noopRemoved.Should().Be(0);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
 }

--- a/tests/Arwen.Tests/ObservationFlagDetectorTests.cs
+++ b/tests/Arwen.Tests/ObservationFlagDetectorTests.cs
@@ -1,0 +1,103 @@
+using Arwen.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace Arwen.Tests;
+
+public sealed class ObservationFlagDetectorTests
+{
+    private static GiftObservation Obs(string npc, string item, double favor, double value, double pref, int quantity = 1, DateTimeOffset? at = null) =>
+        new()
+        {
+            NpcKey = npc,
+            ItemInternalName = item,
+            ItemValue = value,
+            FavorDelta = favor,
+            Quantity = quantity,
+            Timestamp = at ?? DateTimeOffset.UtcNow,
+            MatchedPreferences = [new MatchedPreference { Name = "X", Pref = pref, Keywords = ["X"] }],
+            ItemKeywords = [],
+        };
+
+    [Fact]
+    public void Detect_FlagsOutlierWhenGroupHasMinSamples()
+    {
+        // Three "normal" observations with favor=20 each, one outlier at favor=120.
+        // DerivedRate for normal = 20 / (100 * 1 * 1) = 0.2; outlier = 1.2.
+        // Mean ≈ 0.45, σ ≈ 0.5 — outlier is ~1.5σ away, but with stdDevThreshold=1 it should flag.
+        var observations = new List<GiftObservation>
+        {
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(1)),
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(2)),
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(3)),
+            Obs("NPC_A", "Item1", favor: 120, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(4)),
+        };
+
+        var flags = ObservationFlagDetector.Detect(observations, stdDevThreshold: 1.0, minGroupSize: 3);
+
+        flags.Should().HaveCount(1, "only the high-favor observation is more than 1σ from the mean");
+        var outlierKey = CalibrationService.ObservationKey(observations[3]);
+        flags.Should().ContainKey(outlierKey);
+        flags[outlierKey].Flag.Should().Be(ObservationFlag.OutlierInItemGroup);
+        flags[outlierKey].GroupSampleCount.Should().Be(4);
+        flags[outlierKey].SigmasFromMean.Should().BeGreaterThan(1.0);
+    }
+
+    [Fact]
+    public void Detect_SkipsGroupsBelowMinSize()
+    {
+        // 2 observations, one a wild outlier — but below minGroupSize=3 → no flag.
+        var observations = new List<GiftObservation>
+        {
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(1)),
+            Obs("NPC_A", "Item1", favor: 500, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(2)),
+        };
+
+        var flags = ObservationFlagDetector.Detect(observations, stdDevThreshold: 1.0, minGroupSize: 3);
+
+        flags.Should().BeEmpty("two-sample groups have no statistical signal");
+    }
+
+    [Fact]
+    public void Detect_HandlesZeroStdev()
+    {
+        // 3 observations with identical rates → stdev = 0 → no flag, no divide-by-zero.
+        var observations = new List<GiftObservation>
+        {
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(1)),
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(2)),
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(3)),
+        };
+
+        var flags = ObservationFlagDetector.Detect(observations);
+
+        flags.Should().BeEmpty("perfect agreement → no outliers");
+    }
+
+    [Fact]
+    public void Detect_PartitionsGroupsByNpcAndItem()
+    {
+        // Same item to two different NPCs — the outlier-vs-baseline shouldn't bleed across.
+        var observations = new List<GiftObservation>
+        {
+            // NPC_A: baseline rate ≈ 0.2
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(1)),
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(2)),
+            Obs("NPC_A", "Item1", favor: 20, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(3)),
+            // NPC_B: baseline rate ≈ 1.0 — would look like outliers if grouped with NPC_A
+            Obs("NPC_B", "Item1", favor: 100, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(4)),
+            Obs("NPC_B", "Item1", favor: 100, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(5)),
+            Obs("NPC_B", "Item1", favor: 100, value: 100, pref: 1, at: DateTimeOffset.UnixEpoch.AddSeconds(6)),
+        };
+
+        var flags = ObservationFlagDetector.Detect(observations);
+
+        flags.Should().BeEmpty("each NPC group has zero variance internally");
+    }
+
+    [Fact]
+    public void Detect_EmptyInputProducesEmptyResult()
+    {
+        ObservationFlagDetector.Detect([]).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- New **Edit Observations** tab in Arwen with editable per-row cards for every confirmed `GiftObservation`. Until now the observations grid was read-only and a contaminated row silently poisoned every downstream rate tier — there was no way to delete, edit, or even spot a bad observation.
- **3σ outlier flag** against each (NPC, item) group's mean rate. Cards whose `DerivedRate` deviates more than the threshold get a ⚠ corner glyph with a tooltip explaining the deviation. Catches the "one gift gave 10× the rate of its siblings" case directly.
- **Pending Observations moved** to the new tab (the `TabBadge` follows them) and the duplicated Observations grid is removed from the Calibration tab, which now shows only the four aggregated rate tables.

## What changed under the hood

`CalibrationService` gained three public mutation methods (`DeleteObservation`, `UpdateObservationQuantity`, `DeleteObservationsByPredicate`) plus four read helpers (`GetMaxStackSize`, `GetIconId`, `GetItemDisplayName`, `GetNpcDisplayName`). Every mutation flows through the existing `RecomputeRates → Save → DataChanged` path that `PersistObservation` already uses, so aggregates stay consistent with no extra plumbing and the existing VM `Refresh()` subscription does the UI update.

`ObservationKey` is now `internal static` so the VM can construct keys without re-implementing the format.

## UI notes

- **Virtualizing card grid** via `MithrilVirtualizingWrapPanel` (560×160) — same control Samwise GardenView and Pippin GourmandView use. Two cards per typical-monitor row, three on wide displays.
- Item icon + display name (looks up `ItemEntry.Name`, falls back to internal name) + signature preference **pips** color-coded by `Desire` (Love=warm-orange, Like=green, Dislike=red, Hate=brighter red, neutral=gold). Pips sit immediately under the heading because keywords are part of item identity.
- Numeric facts line: **Total value** (item value × quantity — the gold worth of the stack) · **Favor** · **Rate**. When Quantity is edited the current Rate gets a strikethrough and a `→ previewed` value appears live next to it, derived from the same formula `GiftObservation.DerivedRate` uses.
- `mah:NumericUpDown` for Qty. **Enter** saves, **Escape** reverts. Explicit `✓ Save` / `↺ Revert` buttons appear only when edited — no `LostFocus` auto-commit so accidental tab-outs don't mutate calibration. Non-stackable items show \"Qty 1 (non-stackable)\" instead of the spinner.
- Substring filter with **bulk-delete-by-filter** (`IDialogService.Confirm`-gated) — delete every row matching the filter in one action.
- ⚠ flag glyph + timestamp share the top-right corner; the tooltip carries the full \"Rate X.XXXX is Nσ above/below mean Y.YYYY (group of N, σ=Z.ZZZZ).\" string.

## Theming

`MahApps.Metro` is now referenced by `Arwen.Module` for `NumericUpDown`. The theme dictionaries (Controls + Fonts + Dark.Steel) are merged at the editor tab's `UserControl.Resources` only — same pattern Gandalf's `TimerDialogContent` uses, since the shell deliberately doesn't merge MahApps globally. No global theming change.

## Tests

- **5 new `CalibrationServiceTests`**: delete + recompute, delete-unknown-key, update-quantity recomputes derived rate, update-quantity rejects out-of-range, predicate-bulk-delete reports count.
- **5 new `ObservationFlagDetectorTests`**: flags outlier when group has min samples, skips groups below min size, handles zero stdev without dividing, partitions by NPC (cross-NPC rates don't bleed), empty input returns empty.

Full solution: `dotnet build Mithril.slnx` — 0 warnings / 0 errors. `dotnet test Mithril.slnx` — **1700 tests pass, 0 failures**.

## Test plan
- [ ] `dotnet build Mithril.slnx` is clean
- [ ] `dotnet test Mithril.slnx` is green
- [ ] Open Arwen → **Edit Observations** tab; card grid renders against \`%LocalAppData%/Mithril/Arwen/observations.json\`
- [ ] Scroll through a large observation set; virtualization stays smooth
- [ ] Flagged cards (if any) show ⚠ in the corner; tooltip text is sensible
- [ ] Edit Qty on a stackable card — Total value / Rate preview update live; Save commits, Revert reverts, accidental tab-out does not commit
- [ ] Delete a single row (✕) — list and Calibration-tab rates both update
- [ ] Type a filter, click \"Delete N filtered\" — confirmation dialog shows correct N, OK removes rows
- [ ] Pending observations badge moved from Calibration tab to Edit Observations tab
- [ ] Calibration tab now shows only the four aggregated rate grids; pending + raw observations are gone
- [ ] Restart the app and confirm changes persisted

— drafted by Claude (Opus 4.7), posted by @arthur-conde