### PR TITLE
feat(shared): control-agnostic query filter — QueryFilter attached prop + QueryableSource<T>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ DI is composed via extension methods in `Mithril.Shared/DependencyInjection/Serv
 - **Settings**: `ISettingsStore<T>` / `JsonSettingsStore<T>` with `System.Text.Json` source-generated contexts; `SettingsAutoSaver<T>` for periodic persistence
 - **Hotkeys**: OS-level Win32 hotkey registration; modules provide `IHotkeyCommand` implementations; `HotkeyConflictDetector` validates uniqueness
 - **Diagnostics**: Serilog-backed `IDiagnosticsSink`
+- **Query system**: SQL-like filtering over data models — `MithrilDataGrid`/`MithrilQueryBox` (tabular UI), `QueryFilter` attached behaviour (any `ItemsControl`), `QueryableSource<T>` (VM-side, headless). See [docs/query-system.md](docs/query-system.md) before adding new filter UI.
 
 ### Patterns to Follow
 

--- a/docs/query-system.md
+++ b/docs/query-system.md
@@ -1,0 +1,220 @@
+# Query system — filtering data models with SQL-like syntax
+
+A bootstrap-context doc for contributors (human or LLM) reaching for the
+Mithril query system. It explains what's available, when to use which piece,
+and the things that bite.
+
+## What this is
+
+Mithril ships a SQL-WHERE-flavoured query engine in
+[`Mithril.Shared/Wpf/Query/`](../src/Mithril.Shared/Wpf/Query/). It parses a
+text query into an AST, compiles to a `Func<object, bool>` against a schema
+reflected from your row type's public properties, and offers three consumer
+surfaces depending on where you want filtering to apply.
+
+## The grammar at a glance
+
+```
+crop = 'Red Aster'                           — string equality (case-insensitive by default)
+samples > 5 AND active = TRUE                — boolean composition (AND > OR precedence)
+Name LIKE '%gold%'                           — SQL wildcards (% / _)
+Name CONTAINS 'fire' / STARTSWITH 'X'        — substring helpers (friendlier than LIKE)
+Power IN (10, 20, 30)                        — set membership
+Cost BETWEEN 5 AND 15                        — inclusive range
+MinLevel IS NULL / IS NOT NULL               — null check
+avg > 1m30s                                  — duration literals: 30s, 1m30s, 2h, 150ms
+Timestamp BEFORE NOW()                       — English-aliased <, >; NOW() and TODAY() functions
+NOT LIKE / NOT IN / NOT BETWEEN              — negation prefix
+```
+
+Full grammar lives in
+[`QueryParser.cs`](../src/Mithril.Shared/Wpf/Query/QueryParser.cs); per-type
+compilation lives in
+[`QueryCompiler.cs`](../src/Mithril.Shared/Wpf/Query/QueryCompiler.cs).
+
+## Three consumer surfaces
+
+```
+                      ┌─────────────────────────────────────┐
+                      │  QueryParser → QueryCompiler        │
+                      │  (engine — no WPF deps)             │
+                      └────────────┬────────────────────────┘
+                                   │
+              ┌────────────────────┼──────────────────────────┐
+              ▼                    ▼                          ▼
+    ┌─────────────────┐  ┌──────────────────┐    ┌────────────────────────┐
+    │ MithrilDataGrid │  │  QueryFilter     │    │  QueryableSource<T>    │
+    │ (themed grid +  │  │  (attached prop  │    │  (VM helper —          │
+    │  filter wired)  │  │  on ItemsControl)│    │  no WPF deps)          │
+    └─────────────────┘  └──────────────────┘    └────────────────────────┘
+              ▲                    ▲                          ▲
+              │                    │                          │
+        DataGrid view        ListBox / ListView /        VM owns the
+        with columns         TreeView / any             projection,
+        already declared     ItemsControl               filter → group
+                                                        → render
+```
+
+### Use `MithrilDataGrid` + `MithrilQueryBox` when
+the row data is naturally tabular and a `DataGrid` is the view. You bind
+`MithrilQueryBox.Grid` to the `MithrilDataGrid` and get filtering plus
+schema-aware syntax highlighting and autocompletion for free. This is what
+**Arwen, Bilbo, Celebrimbor, Palantir, Pippin, Samwise, Saruman, Smaug** all
+do today.
+
+### Use `QueryFilter` attached behaviour when
+the view is *not* a `DataGrid` — a `ListBox`, `ListView`, `TreeView`, or any
+other `ItemsControl`. The behaviour composes a predicate onto the bound
+`ICollectionView.Filter`, preserving any VM-set filter underneath.
+
+```xml
+<ListBox ItemsSource="{Binding Items}"
+         query:QueryFilter.QueryText="{Binding QueryText}"
+         query:QueryFilter.CaseSensitive="{Binding CaseSensitive}"
+         query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"/>
+```
+
+Schema is reflected automatically from the item type's public properties —
+no need to declare columns. Includes the same bare-text substring fallback
+that `MithrilDataGrid` does (matches across string properties when the input
+doesn't look like grammar).
+
+To get a `MithrilQueryBox` driving this control, bind its `Schema` property
+to a static schema source rather than `MithrilQueryBox.Grid`. There's a
+worked example in
+[`AugmentPoolView`](../src/Celebrimbor.Module/Views/AugmentPoolView.xaml) /
+[`AugmentPoolViewModel.SchemaSnapshot`](../src/Celebrimbor.Module/ViewModels/AugmentPoolViewModel.cs).
+
+### Use `QueryableSource<T>` when
+the VM needs to filter, then *group*, *sort*, *project*, or do other
+in-memory work that an `ICollectionView` filter can't express cleanly. Plain
+CLR class — no WPF references, headless-testable.
+
+```csharp
+public sealed class MyVm
+{
+    private readonly QueryableSource<Row> _query = new();
+    private readonly IReadOnlyList<Row> _all = LoadAll();
+
+    public IReadOnlyList<ColumnSchema> Schema => _query.Schema;
+
+    public string? QueryText
+    {
+        get => _query.QueryText;
+        set
+        {
+            _query.QueryText = value;
+            Rebuild();
+        }
+    }
+
+    public string? Error => _query.Error;
+    public ObservableCollection<Group> Groups { get; } = [];
+
+    private void Rebuild()
+    {
+        var filtered = _query.Apply(_all);
+        Groups.Clear();
+        foreach (var group in filtered.GroupBy(r => r.Skill).Select(g => new Group(g)))
+        {
+            Groups.Add(group);
+        }
+    }
+}
+```
+
+[Celebrimbor's `AugmentPoolViewModel`](../src/Celebrimbor.Module/ViewModels/AugmentPoolViewModel.cs)
+is the canonical example of this pattern (currently using
+`QueryCompiler.Compile` directly — migration to `QueryableSource<T>` is
+follow-up work).
+
+## Behaviour details you need to know
+
+### Case sensitivity affects column-name lookup too
+
+`CaseSensitive = true` tightens *both* column-name resolution and string
+value comparison to ordinal. So `Crop = 'daisy'` works in
+case-insensitive mode but `crop = 'daisy'` fails with `Unknown column 'crop'`
+once you flip case sensitivity. Use the actual property casing (`Crop`) in
+queries that need to survive a sensitivity toggle.
+
+### Last-good predicate on parse failure
+
+When the user is mid-typing and the current input doesn't parse, the system
+retains the *previous* successfully-compiled predicate so the visible row
+set doesn't flicker. `Error` (or `QueryError`) holds the parser message so
+the UI can show it without changing the filter. Both
+`QueryableSource<T>.Predicate` and `QueryFilter`'s `_lastGoodInputPredicate`
+implement this.
+
+### Bare-text fallback (UI surfaces only)
+
+`MithrilDataGrid` and `QueryFilter` use
+`QueryParser.LooksLikeGrammar` to decide between grammar and bare-text mode.
+Bare text becomes a case-insensitive substring search across the item type's
+*string* properties — convenient for users who don't know the grammar.
+
+`QueryableSource<T>` does **not** have this fallback. Garbage input
+populates `Error`. If your VM wants bare-text behaviour, compose it
+explicitly.
+
+### Schema is reflected, not declared
+
+`QueryableSource<T>()` and `QueryFilter` both reflect over the item type's
+public instance properties via
+[`ColumnBindingHelper.BuildFromProperties`](../src/Mithril.Shared/Wpf/Query/ColumnBindingHelper.cs).
+Indexer properties are skipped. Records' auto-generated `EqualityContract`
+is `protected` so it's excluded. If you need a different surface, pass an
+explicit `IReadOnlyDictionary<string, ColumnBinding>` to
+`QueryableSource<T>(columns, caseSensitive)`.
+
+`MithrilDataGrid` additionally lets you override individual column query
+names via the `QueryName` attached property on a `DataGridColumn`.
+
+### Composition with VM-side `ICollectionView.Filter`
+
+`MithrilDataGrid` and `QueryFilter` both capture whatever filter the VM has
+set on the bound `ICollectionView` *at attach time*, then re-apply it as
+part of the composite. If your VM mutates `view.Filter` after attach, the
+next rebuild from the query box will clobber it. Mutate the underlying
+collection or use `view.Refresh()` instead, or push your filter through
+`QueryableSource<T>.Predicate` instead of the view.
+
+### Debounce
+
+Both UI surfaces debounce input changes by 250ms before recompiling. For
+tests, call `QueryFilter.FlushPendingRebuildForTests(...)` (internal) to
+force a synchronous rebuild.
+
+## Files to know
+
+| File | Purpose |
+|---|---|
+| [`QueryParser.cs`](../src/Mithril.Shared/Wpf/Query/QueryParser.cs) | Lexer + recursive-descent parser → AST; also `LooksLikeGrammar` classifier |
+| [`QueryAst.cs`](../src/Mithril.Shared/Wpf/Query/QueryAst.cs) | AST node + value records |
+| [`QueryCompiler.cs`](../src/Mithril.Shared/Wpf/Query/QueryCompiler.cs) | AST → `Func<object, bool>` with type-aware coercion |
+| [`ColumnBindingHelper.cs`](../src/Mithril.Shared/Wpf/Query/ColumnBindingHelper.cs) | Reflection → `ColumnBinding` + `ColumnSchema` |
+| [`QueryHighlighter.cs`](../src/Mithril.Shared/Wpf/Query/QueryHighlighter.cs) | Permissive lex → syntax-colour runs |
+| [`QueryCompletionProvider.cs`](../src/Mithril.Shared/Wpf/Query/QueryCompletionProvider.cs) | Context-aware autocomplete; defines `ColumnSchema` |
+| [`MithrilDataGrid.cs`](../src/Mithril.Shared/Wpf/MithrilDataGrid.cs) | Themed `DataGrid` subclass; filter composition lives here |
+| [`MithrilQueryBox.cs`](../src/Mithril.Shared/Wpf/MithrilQueryBox.cs) | Single-line editor with overlay highlighting + completion popup |
+| [`QueryFilter.cs`](../src/Mithril.Shared/Wpf/Query/QueryFilter.cs) | Attached behaviour for any `ItemsControl` |
+| [`QueryableSource.cs`](../src/Mithril.Shared/Wpf/Query/QueryableSource.cs) | VM helper — no WPF deps |
+
+## When NOT to use this
+
+- **Server-side / `IQueryable` translation.** The engine produces an
+  in-memory predicate. If you need EF translation, reach for
+  `System.Linq.Dynamic.Core` instead — different syntax, different audience.
+- **As a JSON or text-search query language.** Use Lucene.NET / a search
+  index. The Mithril grammar is column-bound by design.
+
+## Out of scope, but on the horizon
+
+- Distinct-value sampling for completion against non-`DataGrid` controls.
+  Currently `MithrilDataGrid` samples up to 50 distinct values per string
+  column; `QueryFilter` doesn't yet. Workaround: drive
+  `MithrilQueryBox.DistinctValueSampler` from your VM.
+- AvalonEdit-based editor swap for multi-line queries / richer completion.
+- Migrating `AugmentPoolViewModel` to `QueryableSource<T>` — pure mechanical
+  refactor, follow-up after the helper has settled.

--- a/src/Mithril.Shared/Wpf/Query/QueryFilter.cs
+++ b/src/Mithril.Shared/Wpf/Query/QueryFilter.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Threading;
+
+namespace Mithril.Shared.Wpf.Query;
+
+/// <summary>
+/// Attached behaviour that lets any <see cref="ItemsControl"/> filter its
+/// items by a SQL-like <c>QueryText</c> string, using the same grammar and
+/// semantics as <c>MithrilDataGrid</c>/<c>MithrilQueryBox</c>. The schema is
+/// reflected from the item type's public properties. The behaviour composes
+/// onto any filter the VM has already set on the bound
+/// <see cref="ICollectionView"/>, so existing filtering is preserved.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Grammar input (detected via <see cref="QueryParser.LooksLikeGrammar"/>)
+/// runs through <see cref="QueryCompiler"/>. Bare text falls back to a
+/// case-insensitive substring search across the item type's string
+/// properties — same UX contract as <c>MithrilDataGrid</c>.
+/// </para>
+/// <para>
+/// Distinct-value sampling for completion is not part of this behaviour. If
+/// you need completion against a non-DataGrid control, drive
+/// <c>MithrilQueryBox.Schema</c> directly or pair this with
+/// <see cref="QueryableSource{T}"/>.
+/// </para>
+/// </remarks>
+public static class QueryFilter
+{
+    public static readonly DependencyProperty QueryTextProperty = DependencyProperty.RegisterAttached(
+        "QueryText", typeof(string), typeof(QueryFilter),
+        new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnQueryInputChanged));
+
+    public static readonly DependencyProperty CaseSensitiveProperty = DependencyProperty.RegisterAttached(
+        "CaseSensitive", typeof(bool), typeof(QueryFilter),
+        new FrameworkPropertyMetadata(false, OnQueryInputChanged));
+
+    public static readonly DependencyProperty QueryErrorProperty = DependencyProperty.RegisterAttached(
+        "QueryError", typeof(string), typeof(QueryFilter),
+        new FrameworkPropertyMetadata(null));
+
+    private static readonly DependencyProperty StateProperty = DependencyProperty.RegisterAttached(
+        "State", typeof(FilterState), typeof(QueryFilter),
+        new PropertyMetadata(null));
+
+    public static string GetQueryText(DependencyObject obj) => (string)obj.GetValue(QueryTextProperty);
+    public static void SetQueryText(DependencyObject obj, string value) => obj.SetValue(QueryTextProperty, value);
+
+    public static bool GetCaseSensitive(DependencyObject obj) => (bool)obj.GetValue(CaseSensitiveProperty);
+    public static void SetCaseSensitive(DependencyObject obj, bool value) => obj.SetValue(CaseSensitiveProperty, value);
+
+    public static string? GetQueryError(DependencyObject obj) => (string?)obj.GetValue(QueryErrorProperty);
+    public static void SetQueryError(DependencyObject obj, string? value) => obj.SetValue(QueryErrorProperty, value);
+
+    private static void OnQueryInputChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is ItemsControl ctrl)
+        {
+            EnsureState(ctrl).ScheduleRebuild();
+        }
+    }
+
+    private static FilterState EnsureState(ItemsControl control)
+    {
+        var state = (FilterState?)control.GetValue(StateProperty);
+        if (state is null)
+        {
+            state = new FilterState(control);
+            control.SetValue(StateProperty, state);
+        }
+        return state;
+    }
+
+    /// <summary>
+    /// For tests: synchronously flush any pending debounced rebuild. Returns
+    /// <c>true</c> if a rebuild ran. No-op in production paths.
+    /// </summary>
+    internal static bool FlushPendingRebuildForTests(DependencyObject obj)
+    {
+        if (obj.GetValue(StateProperty) is FilterState state)
+        {
+            return state.FlushForTests();
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// For tests: force the attach path that normally only runs on
+    /// <see cref="FrameworkElement.Loaded"/>. The control doesn't need to be
+    /// in a visual tree.
+    /// </summary>
+    internal static void ForceAttachForTests(ItemsControl control)
+    {
+        EnsureState(control).AttachForTests();
+    }
+
+    /// <summary>
+    /// For tests: force the detach path that normally only runs on
+    /// <see cref="FrameworkElement.Unloaded"/>.
+    /// </summary>
+    internal static void ForceDetachForTests(ItemsControl control)
+    {
+        if (control.GetValue(StateProperty) is FilterState state)
+        {
+            state.DetachForTests();
+        }
+    }
+
+    private sealed class FilterState
+    {
+        private const int DebounceMs = 250;
+        private readonly ItemsControl _control;
+        private readonly DispatcherTimer _debounce;
+        private ICollectionView? _attachedView;
+        private Predicate<object>? _vmFilter;
+        private Dictionary<string, ColumnBinding> _columns = new(StringComparer.OrdinalIgnoreCase);
+        private Predicate<object>? _lastGoodInputPredicate;
+        private bool _attached;
+
+        public FilterState(ItemsControl control)
+        {
+            _control = control;
+            _debounce = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(DebounceMs),
+            };
+            _debounce.Tick += (_, _) =>
+            {
+                _debounce.Stop();
+                RebuildFilter();
+            };
+
+            control.Loaded += OnLoaded;
+            control.Unloaded += OnUnloaded;
+            // DependencyPropertyDescriptor keeps a strong ref to `control` for
+            // the descriptor's lifetime; acceptable here because the state
+            // lives as long as the control. (This is the same trade-off WPF
+            // attached behaviours generally accept.)
+            DependencyPropertyDescriptor
+                .FromProperty(ItemsControl.ItemsSourceProperty, typeof(ItemsControl))
+                .AddValueChanged(control, OnItemsSourceChanged);
+
+            if (control.IsLoaded)
+            {
+                Attach();
+            }
+        }
+
+        public void ScheduleRebuild()
+        {
+            if (!_attached) return;
+            _debounce.Stop();
+            _debounce.Start();
+        }
+
+        public bool FlushForTests()
+        {
+            if (!_debounce.IsEnabled) return false;
+            _debounce.Stop();
+            RebuildFilter();
+            return true;
+        }
+
+        public void AttachForTests() => Attach();
+
+        public void DetachForTests() => Detach();
+
+        private void OnLoaded(object? sender, RoutedEventArgs e) => Attach();
+        private void OnUnloaded(object? sender, RoutedEventArgs e) => Detach();
+        private void OnItemsSourceChanged(object? sender, EventArgs e)
+        {
+            Detach();
+            if (_control.IsLoaded) Attach();
+        }
+
+        private void Attach()
+        {
+            // Defensive: WPF can re-fire Loaded on a control whose visual tree
+            // gets re-templated. Detach first so we re-capture the *VM's*
+            // filter rather than our previous composite filter (otherwise we'd
+            // wrap composites around composites and preserve stale predicates).
+            if (_attached) Detach();
+            if (_control.ItemsSource is null) return;
+
+            var itemType = InferItemType(_control.ItemsSource);
+            _columns = itemType is null
+                ? new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+                : ColumnBindingHelper.BuildFromProperties(itemType);
+
+            _attachedView = CollectionViewSource.GetDefaultView(_control.ItemsSource);
+            _vmFilter = _attachedView?.Filter;
+            _attached = true;
+            RebuildFilter();
+        }
+
+        private void Detach()
+        {
+            if (_attachedView is not null)
+            {
+                _attachedView.Filter = _vmFilter;
+                _attachedView = null;
+            }
+            _vmFilter = null;
+            _attached = false;
+        }
+
+        private void RebuildFilter()
+        {
+            if (_attachedView is null) return;
+            var input = GetQueryText(_control);
+            var caseSensitive = GetCaseSensitive(_control);
+            var queryPredicate = BuildInputPredicate(input, caseSensitive);
+            var vm = _vmFilter;
+
+            _attachedView.Filter = item =>
+            {
+                if (vm is not null && !vm(item)) return false;
+                if (queryPredicate is not null && !queryPredicate(item)) return false;
+                return true;
+            };
+        }
+
+        private Predicate<object>? BuildInputPredicate(string? text, bool caseSensitive)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                SetQueryError(_control, null);
+                return null;
+            }
+            var knownColumns = new HashSet<string>(_columns.Keys, StringComparer.OrdinalIgnoreCase);
+            if (QueryParser.LooksLikeGrammar(text, knownColumns))
+            {
+                try
+                {
+                    var compiled = QueryCompiler.Compile(text!, _columns, caseSensitive);
+                    SetQueryError(_control, null);
+                    var predicate = compiled is null ? null : (Predicate<object>)(item => compiled(item));
+                    _lastGoodInputPredicate = predicate;
+                    return predicate;
+                }
+                catch (QueryException ex)
+                {
+                    SetQueryError(_control, ex.Message);
+                    return _lastGoodInputPredicate;
+                }
+            }
+            SetQueryError(_control, null);
+            var bareTextPredicate = BuildBareTextPredicate(text!, caseSensitive);
+            _lastGoodInputPredicate = bareTextPredicate;
+            return bareTextPredicate;
+        }
+
+        private Predicate<object>? BuildBareTextPredicate(string text, bool caseSensitive)
+        {
+            var cmp = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            var needle = text.Trim();
+            if (needle.Length == 0) return null;
+            var stringBindings = _columns.Values
+                .Where(c => (Nullable.GetUnderlyingType(c.ValueType) ?? c.ValueType) == typeof(string))
+                .ToArray();
+            if (stringBindings.Length == 0)
+            {
+                return _ => false;
+            }
+            return item =>
+            {
+                foreach (var col in stringBindings)
+                {
+                    if (col.GetValue(item) is string s && s.Contains(needle, cmp))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            };
+        }
+
+        private static Type? InferItemType(IEnumerable source)
+        {
+            var type = source.GetType();
+            foreach (var iface in type.GetInterfaces())
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    return iface.GetGenericArguments()[0];
+                }
+            }
+            foreach (var item in source)
+            {
+                return item?.GetType();
+            }
+            return null;
+        }
+    }
+}

--- a/src/Mithril.Shared/Wpf/Query/QueryableSource.cs
+++ b/src/Mithril.Shared/Wpf/Query/QueryableSource.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Mithril.Shared.Wpf.Query;
+
+/// <summary>
+/// VM-side helper that turns a <c>QueryText</c> string into a typed
+/// <see cref="Predicate"/> against <typeparamref name="T"/> using the same
+/// query grammar as <c>MithrilQueryBox</c>/<c>MithrilDataGrid</c>. Owns its
+/// schema (reflected from <typeparamref name="T"/>'s public properties by
+/// default) and surfaces parse/compile errors so a view can display them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the <c>QueryFilter</c> attached behavior (which composes onto an
+/// <c>ICollectionView</c>), this helper is plain CLR — no WPF references — so
+/// it suits VMs that filter, group, and project a source list themselves
+/// (e.g. <c>Celebrimbor.AugmentPoolViewModel</c>) and any headless test.
+/// </para>
+/// <para>
+/// On a parse failure the last successfully compiled <see cref="Predicate"/>
+/// is retained, mirroring <c>MithrilDataGrid</c>'s "last-good" behaviour, so
+/// the visible row set doesn't flicker while the user is mid-typing.
+/// </para>
+/// </remarks>
+public sealed class QueryableSource<T> : INotifyPropertyChanged where T : class
+{
+    private readonly IReadOnlyDictionary<string, ColumnBinding> _bindings;
+    private string? _queryText;
+    private bool _caseSensitive;
+    private Func<T, bool>? _predicate;
+    private string? _error;
+
+    public QueryableSource(bool caseSensitive = false)
+        : this(ColumnBindingHelper.BuildFromProperties(typeof(T)), caseSensitive)
+    {
+    }
+
+    public QueryableSource(IReadOnlyDictionary<string, ColumnBinding> columns, bool caseSensitive = false)
+    {
+        _bindings = columns ?? throw new ArgumentNullException(nameof(columns));
+        Schema = ColumnBindingHelper.ToSchema(_bindings);
+        _caseSensitive = caseSensitive;
+    }
+
+    public IReadOnlyList<ColumnSchema> Schema { get; }
+
+    public string? QueryText
+    {
+        get => _queryText;
+        set
+        {
+            if (string.Equals(_queryText, value, StringComparison.Ordinal)) return;
+            _queryText = value;
+            OnPropertyChanged();
+            Recompile();
+        }
+    }
+
+    public bool CaseSensitive
+    {
+        get => _caseSensitive;
+        set
+        {
+            if (_caseSensitive == value) return;
+            _caseSensitive = value;
+            OnPropertyChanged();
+            Recompile();
+        }
+    }
+
+    /// <summary>
+    /// Last parse/compile error message, or <c>null</c> when the current
+    /// <see cref="QueryText"/> parsed cleanly (including empty/whitespace).
+    /// </summary>
+    public string? Error
+    {
+        get => _error;
+        private set
+        {
+            if (string.Equals(_error, value, StringComparison.Ordinal)) return;
+            _error = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Compiled predicate, or <c>null</c> when <see cref="QueryText"/> is
+    /// empty. On a parse failure this retains the previously good predicate
+    /// (see class remarks); inspect <see cref="Error"/> to detect that case.
+    /// </summary>
+    public Func<T, bool>? Predicate
+    {
+        get => _predicate;
+        private set
+        {
+            if (ReferenceEquals(_predicate, value)) return;
+            _predicate = value;
+            OnPropertyChanged();
+            PredicateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler? PredicateChanged;
+
+    /// <summary>
+    /// Convenience: filter <paramref name="source"/> by the current
+    /// <see cref="Predicate"/>, or pass through unchanged when no query is set.
+    /// </summary>
+    public IEnumerable<T> Apply(IEnumerable<T> source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var p = _predicate;
+        return p is null ? source : source.Where(p);
+    }
+
+    private void Recompile()
+    {
+        if (string.IsNullOrWhiteSpace(_queryText))
+        {
+            Error = null;
+            Predicate = null;
+            return;
+        }
+        try
+        {
+            var compiled = QueryCompiler.Compile(_queryText!, _bindings, _caseSensitive);
+            Error = null;
+            Predicate = compiled is null ? null : item => compiled(item);
+        }
+        catch (QueryException ex)
+        {
+            Error = ex.Message;
+            // Intentionally keep last-good Predicate so the UI doesn't flicker
+            // mid-typing; the error string is the signal that the live query
+            // didn't take effect.
+        }
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? property = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+}

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryFilterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryFilterTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Data;
+using FluentAssertions;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+/// <summary>
+/// STA-thread tests for the <c>QueryFilter</c> attached behaviour. WPF
+/// dependency objects require STA and a Dispatcher; we run each test inside
+/// a short-lived STA thread and use the internal <c>ForceAttach</c>/<c>Flush</c>
+/// hooks so we don't need a visual tree or a pumped dispatcher.
+/// </summary>
+public class QueryFilterTests
+{
+    private sealed record Row(string Crop, int Samples, bool Active);
+
+    private static readonly Row[] Dataset =
+    {
+        new("Red Aster",  19, true),
+        new("Daisy",       3, true),
+        new("Tundra Rye",  3, false),
+        new("Pumpkin",    12, true),
+    };
+
+    [Fact]
+    public void Grammar_querytext_filters_underlying_collectionview()
+    {
+        RunOnSta(() =>
+        {
+            var listBox = new ListBox { ItemsSource = new ObservableCollection<Row>(Dataset) };
+            QueryFilter.SetQueryText(listBox, "samples > 5 AND active = TRUE");
+            QueryFilter.ForceAttachForTests(listBox);
+
+            var view = CollectionViewSource.GetDefaultView(listBox.ItemsSource);
+            var visible = view.Cast<Row>().ToArray();
+
+            visible.Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Pumpkin");
+            QueryFilter.GetQueryError(listBox).Should().BeNull();
+        });
+    }
+
+    [Fact]
+    public void Bare_text_falls_back_to_substring_match_on_string_columns()
+    {
+        RunOnSta(() =>
+        {
+            var listBox = new ListBox { ItemsSource = new ObservableCollection<Row>(Dataset) };
+            QueryFilter.SetQueryText(listBox, "aster");
+            QueryFilter.ForceAttachForTests(listBox);
+
+            var view = CollectionViewSource.GetDefaultView(listBox.ItemsSource);
+            view.Cast<Row>().Select(r => r.Crop).Should().BeEquivalentTo("Red Aster");
+        });
+    }
+
+    [Fact]
+    public void Empty_querytext_does_not_remove_existing_vm_filter()
+    {
+        RunOnSta(() =>
+        {
+            var coll = new ObservableCollection<Row>(Dataset);
+            var listBox = new ListBox { ItemsSource = coll };
+            var view = CollectionViewSource.GetDefaultView(coll);
+
+            // VM sets its own filter first.
+            view.Filter = o => ((Row)o).Active;
+
+            QueryFilter.SetQueryText(listBox, string.Empty);
+            QueryFilter.ForceAttachForTests(listBox);
+
+            view.Cast<Row>().Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Daisy", "Pumpkin");
+        });
+    }
+
+    [Fact]
+    public void Querytext_composes_on_top_of_vm_filter()
+    {
+        RunOnSta(() =>
+        {
+            var coll = new ObservableCollection<Row>(Dataset);
+            var listBox = new ListBox { ItemsSource = coll };
+            var view = CollectionViewSource.GetDefaultView(coll);
+            view.Filter = o => ((Row)o).Active; // VM excludes Tundra Rye
+
+            QueryFilter.SetQueryText(listBox, "samples > 5");
+            QueryFilter.ForceAttachForTests(listBox);
+
+            view.Cast<Row>().Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Pumpkin");
+        });
+    }
+
+    [Fact]
+    public void Detach_restores_original_vm_filter()
+    {
+        RunOnSta(() =>
+        {
+            var coll = new ObservableCollection<Row>(Dataset);
+            var listBox = new ListBox { ItemsSource = coll };
+            var view = CollectionViewSource.GetDefaultView(coll);
+            Predicate<object> originalVmFilter = o => ((Row)o).Active;
+            view.Filter = originalVmFilter;
+
+            QueryFilter.SetQueryText(listBox, "samples > 5");
+            QueryFilter.ForceAttachForTests(listBox);
+            QueryFilter.ForceDetachForTests(listBox);
+
+            view.Filter.Should().BeSameAs(originalVmFilter);
+            view.Cast<Row>().Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Daisy", "Pumpkin");
+        });
+    }
+
+    [Fact]
+    public void Malformed_querytext_populates_queryerror_without_clearing_view()
+    {
+        RunOnSta(() =>
+        {
+            var listBox = new ListBox { ItemsSource = new ObservableCollection<Row>(Dataset) };
+            QueryFilter.SetQueryText(listBox, "samples > 5");
+            QueryFilter.ForceAttachForTests(listBox);
+
+            // Now make it malformed — should report an error and keep last-good predicate.
+            QueryFilter.SetQueryText(listBox, "samples > >>");
+            QueryFilter.FlushPendingRebuildForTests(listBox).Should().BeTrue();
+
+            QueryFilter.GetQueryError(listBox).Should().NotBeNullOrEmpty();
+            var view = CollectionViewSource.GetDefaultView(listBox.ItemsSource);
+            view.Cast<Row>().Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Pumpkin");
+        });
+    }
+
+    private static void RunOnSta(Action action)
+    {
+        Exception? captured = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+            finally
+            {
+                System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown();
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.IsBackground = true;
+        thread.Start();
+        thread.Join();
+        if (captured is not null) throw captured;
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryableSourceTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryableSourceTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+public class QueryableSourceTests
+{
+    private sealed record Row(string Crop, int Samples, bool Active);
+
+    private static readonly Row[] Dataset =
+    {
+        new("Red Aster",  19, true),
+        new("Daisy",       3, true),
+        new("Tundra Rye",  3, false),
+        new("Pumpkin",    12, true),
+    };
+
+    [Fact]
+    public void Empty_querytext_yields_null_predicate_and_passthrough_apply()
+    {
+        var qs = new QueryableSource<Row>();
+
+        qs.Predicate.Should().BeNull();
+        qs.Error.Should().BeNull();
+        qs.Apply(Dataset).Should().BeEquivalentTo(Dataset);
+
+        qs.QueryText = "   ";
+        qs.Predicate.Should().BeNull();
+        qs.Apply(Dataset).Should().BeEquivalentTo(Dataset);
+    }
+
+    [Fact]
+    public void Valid_query_compiles_to_matching_predicate()
+    {
+        var qs = new QueryableSource<Row> { QueryText = "samples > 5 AND active = TRUE" };
+
+        qs.Error.Should().BeNull();
+        qs.Predicate.Should().NotBeNull();
+        qs.Apply(Dataset).Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Pumpkin");
+    }
+
+    [Fact]
+    public void Malformed_query_populates_error_and_retains_last_good_predicate()
+    {
+        var qs = new QueryableSource<Row> { QueryText = "samples > 5" };
+        var lastGood = qs.Predicate;
+        lastGood.Should().NotBeNull();
+
+        qs.QueryText = "samples > >> oops";
+
+        qs.Error.Should().NotBeNullOrEmpty();
+        qs.Predicate.Should().BeSameAs(lastGood);
+        qs.Apply(Dataset).Select(r => r.Crop).Should().BeEquivalentTo("Red Aster", "Pumpkin");
+    }
+
+    [Fact]
+    public void Schema_auto_built_from_T_exposes_public_properties()
+    {
+        var qs = new QueryableSource<Row>();
+
+        qs.Schema.Select(c => c.Name).Should().BeEquivalentTo("Crop", "Samples", "Active");
+        qs.Schema.Single(c => c.Name == "Samples").ValueType.Should().Be<int>();
+        qs.Schema.Single(c => c.Name == "Crop").IsNullable.Should().BeTrue();
+        qs.Schema.Single(c => c.Name == "Active").IsNullable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Schema_override_via_explicit_bindings_is_respected()
+    {
+        // Only expose "name" — even though Row has more public properties.
+        var bindings = new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["name"] = new("name", typeof(string), r => ((Row)r).Crop),
+        };
+        var qs = new QueryableSource<Row>(bindings);
+
+        qs.Schema.Select(c => c.Name).Should().BeEquivalentTo("name");
+
+        qs.QueryText = "name = 'Daisy'";
+        qs.Error.Should().BeNull();
+        qs.Apply(Dataset).Select(r => r.Crop).Should().BeEquivalentTo("Daisy");
+    }
+
+    [Fact]
+    public void PredicateChanged_fires_when_querytext_changes()
+    {
+        var qs = new QueryableSource<Row>();
+        int fires = 0;
+        qs.PredicateChanged += (_, _) => fires++;
+
+        qs.QueryText = "samples > 5";
+        qs.QueryText = "samples > 5"; // unchanged — no fire
+        qs.QueryText = "samples < 5"; // recompile
+
+        fires.Should().Be(2);
+    }
+
+    [Fact]
+    public void CaseSensitive_setter_recompiles()
+    {
+        // Column name must match property casing here ("Crop") because CaseSensitive
+        // also tightens column-name lookup to Ordinal.
+        var qs = new QueryableSource<Row> { QueryText = "Crop = 'daisy'" };
+        qs.Apply(Dataset).Select(r => r.Crop).Should().BeEquivalentTo("Daisy");
+
+        qs.CaseSensitive = true;
+        qs.Error.Should().BeNull();
+        qs.Apply(Dataset).Should().BeEmpty(); // 'Daisy' != 'daisy' under Ordinal
+    }
+
+    [Fact]
+    public void PropertyChanged_fires_for_inputs_and_outputs()
+    {
+        var qs = new QueryableSource<Row>();
+        var changed = new List<string?>();
+        ((INotifyPropertyChanged)qs).PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        qs.QueryText = "samples > 5";
+
+        changed.Should().Contain("QueryText");
+        changed.Should().Contain("Predicate");
+        changed.Should().NotContain("Error"); // valid query, error already null → no change
+    }
+
+    [Fact]
+    public void Bare_text_input_throws_or_falls_through_per_engine_contract()
+    {
+        // QueryableSource does not have the bare-text fallback — that's a
+        // MithrilDataGrid / QueryFilter (attached behavior) UX concern.
+        // Bare text that doesn't parse as grammar is reported as an error,
+        // mirroring "the user wrote something that isn't a query".
+        var qs = new QueryableSource<Row> { QueryText = "totally not a query" };
+
+        // Either errors out, or the parser interprets it some weird way.
+        // The contract: caller can detect the problem via Error or empty
+        // result, and the helper doesn't crash.
+        qs.Error.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Two new components in [`Mithril.Shared.Wpf.Query`](src/Mithril.Shared/Wpf/Query/) that decouple the existing SQL-like query engine from `MithrilDataGrid`:

- **`QueryFilter`** — attached behaviour on any `ItemsControl` (`ListBox`, `ListView`, `TreeView`, etc.). Composes a predicate onto the bound `ICollectionView.Filter`, preserving any VM-set filter. Schema is reflected from item type. Includes the bare-text substring fallback to match `MithrilQueryBox` UX.
- **`QueryableSource<T>`** — VM-side helper, no WPF deps. Exposes `Predicate` / `Error` / `Apply` for VMs that filter → group → project (e.g. Celebrimbor's `AugmentPoolViewModel` pattern).

Both reuse the existing `QueryParser`/`QueryCompiler` engine — nothing in the grammar or compiler changed. Pure addition; no consumer of `MithrilDataGrid` is affected.

### XAML usage

```xml
<ListBox ItemsSource="{Binding Items}"
         query:QueryFilter.QueryText="{Binding QueryText}"
         query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"/>
```

## Drive-by fix

The "last-good predicate" logic in `QueryFilter` only retained bare-text predicates, not successful grammar predicates, so the view would flicker if you broke a working grammar query mid-typing. Now retained for both paths. `MithrilDataGrid` has the same latent bug — out of scope here, worth a follow-up issue.

## Documentation

- [`docs/query-system.md`](docs/query-system.md) — bootstrap-context doc covering the three consumer surfaces, the grammar, pitfalls (case-sensitivity tightens column-name lookup, last-good semantics, VM-filter composition, no bare-text in `QueryableSource<T>`), and out-of-scope follow-ups.
- [`CLAUDE.md`](CLAUDE.md) — Shared Infrastructure bullet points at the doc so future contributors land on it.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — all green, 15 new tests pass (9 headless `QueryableSource`, 6 STA-threaded `QueryFilter`)
- [ ] Smoke-test by binding `query:QueryFilter.QueryText` on a real non-DataGrid view (deferred to first consumer migration — `AugmentPoolViewModel` is the candidate)

## Out of scope

- Migrating `AugmentPoolViewModel` to `QueryableSource<T>` (follow-up; pure mechanical refactor)
- Distinct-value sampling for completion against non-DataGrid controls
- AvalonEdit-based editor swap for multi-line queries
- Fixing the same last-good bug in `MithrilDataGrid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)