### PR TITLE
fix(shared): force ref-data parse off the UI thread (#197)

### DIFF
--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -211,18 +211,18 @@ public sealed class ReferenceDataService : IReferenceDataService
 
     public async Task RefreshAllAsync(CancellationToken ct = default)
     {
-        await RefreshAsync("items", ct);
-        await RefreshAsync("recipes", ct);
-        await RefreshAsync("skills", ct);
-        await RefreshAsync("xptables", ct);
-        await RefreshAsync("npcs", ct);
-        await RefreshAsync("areas", ct);
-        await RefreshAsync("sources_items", ct);
-        await RefreshAsync("attributes", ct);
-        await RefreshAsync("tsysclientinfo", ct);
-        await RefreshAsync("tsysprofiles", ct);
-        await RefreshAsync("quests", ct);
-        await RefreshAsync("strings_all", ct);
+        await RefreshAsync("items", ct).ConfigureAwait(false);
+        await RefreshAsync("recipes", ct).ConfigureAwait(false);
+        await RefreshAsync("skills", ct).ConfigureAwait(false);
+        await RefreshAsync("xptables", ct).ConfigureAwait(false);
+        await RefreshAsync("npcs", ct).ConfigureAwait(false);
+        await RefreshAsync("areas", ct).ConfigureAwait(false);
+        await RefreshAsync("sources_items", ct).ConfigureAwait(false);
+        await RefreshAsync("attributes", ct).ConfigureAwait(false);
+        await RefreshAsync("tsysclientinfo", ct).ConfigureAwait(false);
+        await RefreshAsync("tsysprofiles", ct).ConfigureAwait(false);
+        await RefreshAsync("quests", ct).ConfigureAwait(false);
+        await RefreshAsync("strings_all", ct).ConfigureAwait(false);
     }
 
     public void BeginBackgroundRefresh()
@@ -291,7 +291,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         Action<T, ReferenceFileMetadata> swapper,
         CancellationToken ct)
     {
-        var version = await CdnVersionDetector.TryDetectAsync(_http, CdnRoot, ct)
+        var version = await CdnVersionDetector.TryDetectAsync(_http, CdnRoot, ct).ConfigureAwait(false)
                       ?? GetSnapshot(fileName).CdnVersion
                       ?? FallbackCdnVersion;
         var url = $"{CdnRoot}{version}/data/{fileName}.json";
@@ -301,9 +301,9 @@ public sealed class ReferenceDataService : IReferenceDataService
         var fetchSw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
-            using var resp = await _http.GetAsync(url, ct);
+            using var resp = await _http.GetAsync(url, ct).ConfigureAwait(false);
             resp.EnsureSuccessStatusCode();
-            body = await resp.Content.ReadAsByteArrayAsync(ct);
+            body = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -323,14 +323,25 @@ public sealed class ReferenceDataService : IReferenceDataService
         Directory.CreateDirectory(_cacheDir);
         var cachePath = Path.Combine(_cacheDir, $"{fileName}.json");
         var metaPath = Path.Combine(_cacheDir, $"{fileName}.meta.json");
-        await Settings.AtomicFile.WriteAllBytesAtomicAsync(cachePath, body, ct);
+        await Settings.AtomicFile.WriteAllBytesAtomicAsync(cachePath, body, ct).ConfigureAwait(false);
         await Settings.AtomicFile.WriteJsonAtomicAsync(metaPath, meta,
-            ReferenceJsonContext.Default.ReferenceFileMetadata, ct);
+            ReferenceJsonContext.Default.ReferenceFileMetadata, ct).ConfigureAwait(false);
 
-        var json = Encoding.UTF8.GetString(body);
-        var parsed = parser(json);
-        swapper(parsed, meta);
-        ReportUnknowns(fileName, parsed!, meta.CdnVersion);
+        // Parse + dictionary swap + drift walk are CPU-bound and collectively
+        // 500–1380 ms per file at full CDN payload (strings_all = 15 MB).
+        // Force them onto the thread pool — when this method runs under a
+        // captured sync context (e.g. the WPF dispatcher via the Settings
+        // panel's Refresh All button) those costs MUST NOT land on the UI
+        // thread. The swap mutates reference-typed snapshot fields with
+        // atomic reference assignment; readers tolerate seeing either the
+        // old or new dictionary. See #197.
+        await Task.Run(() =>
+        {
+            var json = Encoding.UTF8.GetString(body);
+            var parsed = parser(json);
+            swapper(parsed, meta);
+            ReportUnknowns(fileName, parsed!, meta.CdnVersion);
+        }, ct).ConfigureAwait(false);
         _diag?.Info("Reference", $"{fileName}.json refreshed: version {version}.");
         FileUpdated?.Invoke(this, fileName);
     }

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -100,6 +100,50 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RefreshAsync_DoesNotPostContinuationsToCallerSyncContext()
+    {
+        // Issue #197: When RefreshAsync runs under a captured SynchronizationContext
+        // (the WPF dispatcher, in the real Settings → Refresh All path), the post-fetch
+        // continuations — Encoding.UTF8.GetString + JSON parse + dictionary swap +
+        // unknown-discriminator walk — must NOT Post back to that context. On the
+        // 15 MB strings_all.json payload each of those steps takes 500–1380 ms, and
+        // landing them on the UI thread is what produced the ~14 s startup stall
+        // captured in perf-20260511-094631.jsonl.
+        WriteBundled("""{}""", version: "v100");
+        var rootHtml = """<html><meta http-equiv="refresh" content="2; URL=/v500/data/index.html"></html>""";
+        var freshJson = """{ "item_99": { "Name": "Fresh", "InternalName": "FreshSeeds" } }""";
+        var handler = new RoutingHandler(req =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+            if (path is "/" or "") return Respond(rootHtml, "text/html");
+            if (path == "/v500/data/items.json") return Respond(freshJson, "application/json");
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        var svc = new ReferenceDataService(_cacheDir, new HttpClient(handler), bundledDir: _bundledDir);
+
+        var ctx = new CountingSynchronizationContext();
+        var saved = SynchronizationContext.Current;
+        Task refresh;
+        SynchronizationContext.SetSynchronizationContext(ctx);
+        try
+        {
+            // Kick off under ctx so any captured continuations would Post here.
+            refresh = svc.RefreshAsync("items");
+        }
+        finally
+        {
+            // Uninstall before awaiting so the test's own await doesn't capture ctx.
+            SynchronizationContext.SetSynchronizationContext(saved);
+        }
+        await refresh;
+
+        ctx.PostCount.Should().Be(0,
+            "every Post would land on the UI dispatcher and contribute to the #197 stall");
+        svc.Items.Should().ContainKey(99L,
+            "the parse + swap must still have happened — just on the thread pool");
+    }
+
+    [Fact]
     public async Task FailedRefresh_KeepsExistingData()
     {
         WriteBundled("""{ "item_1": { "Name": "Bundled", "InternalName": "BundledSeeds" } }""", version: "v100");
@@ -564,5 +608,23 @@ public class ReferenceDataServiceTests : IDisposable
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
             => Task.FromResult(route(request));
+    }
+
+    private sealed class CountingSynchronizationContext : SynchronizationContext
+    {
+        private int _posts;
+        public int PostCount => Volatile.Read(ref _posts);
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            Interlocked.Increment(ref _posts);
+            ThreadPool.QueueUserWorkItem(_ => d(state));
+        }
+
+        public override void Send(SendOrPostCallback d, object? state)
+        {
+            Interlocked.Increment(ref _posts);
+            d(state);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wraps `Encoding.UTF8.GetString` + parse + dictionary swap + drift-walk in `Task.Run(..., ct).ConfigureAwait(false)` inside `ReferenceDataService.RefreshFileAsync`, so the 500–1380 ms per-file CPU tail can't land on a captured sync context (notably the WPF dispatcher via Settings → Refresh All).
- Adds `ConfigureAwait(false)` to the upstream awaits in the refresh path (CDN version detect, HTTP GET, body read, atomic file writes, each `await RefreshAsync(...)` in `RefreshAllAsync`) for defence in depth.
- Adds `RefreshAsync_DoesNotPostContinuationsToCallerSyncContext` — installs a counting `SynchronizationContext`, kicks off `RefreshAsync`, asserts zero Posts landed on it after the task completes.

Root cause matches the **CDN fetch on the UI thread** pattern in [docs/perf-trace-schema.md](../blob/main/docs/perf-trace-schema.md#diagnostic-patterns). The swap mutates reference-typed snapshot fields, so atomic reference assignment + existing reader patterns already tolerate the cross-thread swap.

Closes #197.

## Test plan
- [x] `dotnet test tests/Mithril.Shared.Tests` — 698/698 passing locally, including the new regression
- [ ] Capture a fresh perf-trace at startup post-merge; expect no `stall` event with `IntervalMs ≈ 14 000` and `frame_summary.MeanMs` under ~12 ms across the refresh window

## Followup not filed
The optional `RefreshAllAsync` pipelining (start fetch N+1 while N parses) was discussed in the issue and intentionally left out — once the UI stall is gone, the wall-clock improvement isn't user-visible. Easy to revisit if a startup-race scenario emerges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)