### PR TITLE
IGameSessionService + session-keyed calibration dedup

### DIFF
--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -8,6 +8,7 @@ using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics;
 using Mithril.GameState.Inventory;
+using Mithril.GameState.Sessions;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
@@ -76,7 +77,8 @@ public sealed class ArwenModule : IMithrilModule
                 settings.Calibration,
                 sp.GetService<IDiagnosticsSink>(),
                 pendingTtl: settings.PendingObservationTtl,
-                dispatch: UiDispatch);
+                dispatch: UiDispatch,
+                session: sp.GetService<IGameSessionService>());
         });
         services.AddSingleton<IAttentionSource, ArwenAttentionSource>();
 

--- a/src/Arwen.Module/Domain/CalibrationService.cs
+++ b/src/Arwen.Module/Domain/CalibrationService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Mithril.Shared.Collections;
 using Mithril.Shared.Diagnostics;
 using Mithril.GameState.Inventory;
+using Mithril.GameState.Sessions;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 
@@ -26,7 +27,7 @@ public sealed record EstimateResult(double Value, string Tier, int SampleCount);
 public sealed class CalibrationService
 {
     /// <summary>Local schema version: shape of <see cref="GiftObservation"/> records on disk.</summary>
-    public const int CurrentSchemaVersion = 3;
+    public const int CurrentSchemaVersion = 4;
 
     /// <summary>
     /// Wire schema version stamped into <see cref="GiftRatesPayload.SchemaVersion"/> when
@@ -40,12 +41,18 @@ public sealed class CalibrationService
     private readonly IReferenceDataService _refData;
     private readonly GiftIndex _giftIndex;
     private readonly IInventoryService _inventory;
+    private readonly IGameSessionService? _session;
     private readonly ICommunityCalibrationService? _community;
     private readonly CalibrationSettings? _calibrationSettings;
     private readonly IDiagnosticsSink? _diag;
+    private readonly TimeProvider _time;
     private readonly string _dataPath;
     private readonly string _observationsPath;
     private readonly TtlObservableCollection<PendingGiftObservation> _pending;
+    // Fast-path dedup set: rebuilt on Load and updated incrementally on every
+    // persist / delete. Replay-on-relaunch produces the same key shape, so the
+    // short-circuit fires without scanning Observations.
+    private readonly HashSet<string> _observationKeys = new(StringComparer.Ordinal);
 
     // Resolved (local ⊕ community) lookup tables. EstimateFavor reads from these.
     // Rebuilt after RecomputeRates, on community FileUpdated, on settings Source change.
@@ -58,10 +65,14 @@ public sealed class CalibrationService
     // The game emits DeleteItem and DeltaFavor in EITHER order:
     //   Order A: DeleteItem → DeltaFavor  (item removed first)
     //   Order B: DeltaFavor → DeleteItem  (favor delta first)
-    // We handle both by tracking a pending item OR a pending delta.
+    // We handle both by tracking a pending item OR a pending delta. Each
+    // transient also carries the log-line timestamp so the persisted
+    // GiftObservation.Timestamp is anchored on log truth, not on
+    // DateTimeOffset.UtcNow at record time (which would diverge across
+    // replays and defeat the dedup key).
     private string? _activeNpcKey;
-    private (long InstanceId, string InternalName)? _pendingDeletedItem;
-    private (string NpcKey, double Delta)? _pendingDelta;
+    private (long InstanceId, string InternalName, DateTimeOffset Timestamp)? _pendingDeletedItem;
+    private (string NpcKey, double Delta, DateTimeOffset Timestamp)? _pendingDelta;
 
     private CalibrationData _data = new();
 
@@ -99,14 +110,17 @@ public sealed class CalibrationService
         IDiagnosticsSink? diag = null,
         TimeSpan? pendingTtl = null,
         Action<Action>? dispatch = null,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        IGameSessionService? session = null)
     {
         _refData = refData;
         _giftIndex = giftIndex;
         _inventory = inventory;
+        _session = session;
         _community = community;
         _calibrationSettings = calibrationSettings;
         _diag = diag;
+        _time = time ?? TimeProvider.System;
         _dataPath = Path.Combine(dataDir, "calibration.json");
         _observationsPath = Path.Combine(dataDir, "observations.json");
 
@@ -142,14 +156,30 @@ public sealed class CalibrationService
 
     // ── Log event handlers (called by FavorIngestionService) ─────────
 
+    /// <summary>
+    /// Test-friendly entry point that stamps observations with the current
+    /// wall clock. Production code paths use the timestamp-aware overloads
+    /// below; the no-timestamp form preserves the pre-#201 contract for
+    /// existing test suites that don't care about replay idempotency.
+    /// </summary>
     public void OnStartInteraction(string npcKey)
+        => OnStartInteraction(npcKey, _time.GetUtcNow());
+
+    public void OnStartInteraction(string npcKey, DateTimeOffset _)
     {
+        // Timestamp on StartInteraction is informational only — the actual
+        // observation Timestamp is taken from the DeltaFavor event (the
+        // log line that carries the favor change). Accepted here so callers
+        // can plumb a single timestamp from raw.Timestamp without branching.
         _activeNpcKey = npcKey;
         _pendingDeletedItem = null;
         _pendingDelta = null;
     }
 
     public void OnItemDeleted(long instanceId)
+        => OnItemDeleted(instanceId, _time.GetUtcNow());
+
+    public void OnItemDeleted(long instanceId, DateTimeOffset timestamp)
     {
         if (_activeNpcKey is null) return;
         if (!_inventory.TryResolve(instanceId, out var internalName))
@@ -158,33 +188,37 @@ public sealed class CalibrationService
             return;
         }
 
-        if (_pendingDelta is var (npcKey, delta))
+        if (_pendingDelta is var (npcKey, delta, deltaTs))
         {
             _pendingDelta = null;
-            RecordObservation(npcKey, instanceId, internalName, delta);
+            // DeltaFavor's timestamp is the canonical stamp for the gift.
+            RecordObservation(npcKey, instanceId, internalName, delta, deltaTs);
             return;
         }
 
-        _pendingDeletedItem = (instanceId, internalName);
+        _pendingDeletedItem = (instanceId, internalName, timestamp);
     }
 
     public void OnDeltaFavor(string npcKey, double delta)
+        => OnDeltaFavor(npcKey, delta, _time.GetUtcNow());
+
+    public void OnDeltaFavor(string npcKey, double delta, DateTimeOffset timestamp)
     {
         if (delta <= 0) return;
         if (_activeNpcKey != npcKey) return;
 
-        if (_pendingDeletedItem is var (instanceId, internalName))
+        if (_pendingDeletedItem is var (instanceId, internalName, _))
         {
             _pendingDeletedItem = null;
             _pendingDelta = null;
-            RecordObservation(npcKey, instanceId, internalName, delta);
+            RecordObservation(npcKey, instanceId, internalName, delta, timestamp);
             return;
         }
 
-        _pendingDelta = (npcKey, delta);
+        _pendingDelta = (npcKey, delta, timestamp);
     }
 
-    private void RecordObservation(string npcKey, long instanceId, string internalName, double delta)
+    private void RecordObservation(string npcKey, long instanceId, string internalName, double delta, DateTimeOffset timestamp)
     {
         if (!_refData.ItemsByInternalName.TryGetValue(internalName, out var item))
         {
@@ -233,6 +267,8 @@ public sealed class CalibrationService
             return;
         }
 
+        var sessionId = _session?.Current?.SessionId ?? "";
+
         if (isPending)
         {
             var pending = new PendingGiftObservation
@@ -248,7 +284,8 @@ public sealed class CalibrationService
                 MaxStackSize = item.MaxStackSize,
                 MatchedPreferences = [.. matchedPrefs],
                 ItemKeywords = [.. item.Keywords.Select(k => k.Tag)],
-                Timestamp = DateTimeOffset.UtcNow,
+                Timestamp = timestamp,
+                SessionId = sessionId,
             };
             _pending.Add(pending);
             _diag?.Info("Arwen.Calibration",
@@ -256,16 +293,19 @@ public sealed class CalibrationService
             return;
         }
 
-        PersistObservation(npcKey, internalName, item, matchedPrefs, delta, quantity);
+        PersistObservation(npcKey, instanceId, internalName, item, matchedPrefs, delta, quantity, timestamp, sessionId);
     }
 
     private void PersistObservation(
         string npcKey,
+        long instanceId,
         string internalName,
         ItemEntry item,
         IReadOnlyList<MatchedPreference> matchedPrefs,
         double delta,
-        int quantity)
+        int quantity,
+        DateTimeOffset timestamp,
+        string sessionId)
     {
         var observation = new GiftObservation
         {
@@ -276,8 +316,22 @@ public sealed class CalibrationService
             ItemValue = (double)item.Value,
             FavorDelta = delta,
             Quantity = quantity,
-            Timestamp = DateTimeOffset.UtcNow,
+            Timestamp = timestamp,
+            SessionId = sessionId,
+            InstanceId = instanceId,
         };
+
+        var key = ObservationKey(observation);
+        if (!_observationKeys.Add(key))
+        {
+            // Replay-on-relaunch: PG re-emits the same DeleteItem + DeltaFavor
+            // pair on every Mithril attach within the same session. The first
+            // pass persisted this observation; the second pass produces an
+            // identical key (same SessionId + InstanceId + log-line ts). Drop
+            // silently so SampleCount stays clean.
+            _diag?.Trace("Arwen.Calibration", $"Skipped replay of observation {key}");
+            return;
+        }
 
         _data.Observations.Add(observation);
         RecomputeRates();
@@ -312,7 +366,8 @@ public sealed class CalibrationService
         }
 
         _pending.Remove(p => p.Id == id);
-        PersistObservation(entry.NpcKey, entry.InternalName, item, entry.MatchedPreferences, entry.FavorDelta, quantity);
+        PersistObservation(entry.NpcKey, entry.InstanceId, entry.InternalName, item, entry.MatchedPreferences,
+            entry.FavorDelta, quantity, entry.Timestamp, entry.SessionId);
         return true;
     }
 
@@ -323,6 +378,18 @@ public sealed class CalibrationService
     public bool DiscardPending(Guid id)
     {
         return _pending.Remove(p => p.Id == id) > 0;
+    }
+
+    /// <summary>
+    /// Rebuild <see cref="_observationKeys"/> from <see cref="_data"/>.
+    /// Called on every <see cref="Load"/> and on import/merge paths so the
+    /// fast-path dedup set in <see cref="PersistObservation"/> stays in sync
+    /// with on-disk state.
+    /// </summary>
+    private void RebuildObservationKeySet()
+    {
+        _observationKeys.Clear();
+        foreach (var obs in _data.Observations) _observationKeys.Add(ObservationKey(obs));
     }
 
     // ── Rate computation ────────────────────────────────────────────
@@ -531,8 +598,27 @@ public sealed class CalibrationService
                     _data.Observations = kept;
                     _data.Version = 3;
                 }
+
+                if (_data.Version < 4)
+                {
+                    // v3 → v4 introduces SessionId + InstanceId on GiftObservation.
+                    // Legacy records get SessionId="" and InstanceId=0 — they keep
+                    // their (wall-clock-stamped) Timestamp so ObservationKey still
+                    // collapses to a stable identity for them. We accept the bloat
+                    // pre-fix: existing duplicates stay on disk; future replays
+                    // dedup correctly under the new v4 key shape.
+                    foreach (var obs in _data.Observations)
+                    {
+                        obs.SessionId ??= "";
+                        // InstanceId defaults to 0 on the property — no-op for clarity.
+                    }
+                    _diag?.Info("Arwen.Calibration",
+                        $"Migrating calibration v{_data.Version} → v4: {_data.Observations.Count} observations carried forward (legacy session/instance fields default).");
+                    _data.Version = 4;
+                }
             }
 
+            RebuildObservationKeySet();
             RecomputeRates();
 
             if (legacyHadObservations)
@@ -889,18 +975,17 @@ public sealed class CalibrationService
         {
             var count = incoming.Observations.Count;
             _data = incoming;
+            RebuildObservationKeySet();
             RecomputeRates();
             Save();
             DataChanged?.Invoke(this, EventArgs.Empty);
             return count;
         }
 
-        var existingKeys = new HashSet<string>(
-            _data.Observations.Select(ObservationKey));
         var added = 0;
         foreach (var obs in incoming.Observations)
         {
-            if (existingKeys.Add(ObservationKey(obs)))
+            if (_observationKeys.Add(ObservationKey(obs)))
             {
                 _data.Observations.Add(obs);
                 added++;
@@ -918,8 +1003,23 @@ public sealed class CalibrationService
         return added;
     }
 
+    /// <summary>
+    /// Stable observation identity. Includes <see cref="GiftObservation.SessionId"/>
+    /// and <see cref="GiftObservation.InstanceId"/> alongside the legacy
+    /// <c>NpcKey|Item|FavorDelta|Timestamp:O</c> shape:
+    /// <list type="bullet">
+    ///   <item><b>v4 records</b> (<c>SessionId</c> non-empty) dedup on
+    ///   session + instance — replay-on-relaunch within the same PG session
+    ///   collapses to the original key.</item>
+    ///   <item><b>v3 legacy records</b> (<c>SessionId</c> empty,
+    ///   <c>InstanceId</c> 0) keep their original key shape — the leading
+    ///   <c>|</c>s plus zero are stable, and the trailing
+    ///   <c>NpcKey|Item|FavorDelta|Timestamp:O</c> is identical to the
+    ///   pre-#201 key, so import-dedup against older exports still works.</item>
+    /// </list>
+    /// </summary>
     internal static string ObservationKey(GiftObservation o) =>
-        $"{o.NpcKey}|{o.ItemInternalName}|{o.FavorDelta}|{o.Timestamp:O}";
+        $"{o.SessionId}|{o.InstanceId}|{o.NpcKey}|{o.ItemInternalName}|{o.FavorDelta}|{o.Timestamp:O}";
 
     /// <summary>
     /// Max stack size for the item by <c>InternalName</c>, clamped to a floor of 1 so callers
@@ -978,6 +1078,7 @@ public sealed class CalibrationService
         if (idx < 0) return false;
         var removed = _data.Observations[idx];
         _data.Observations.RemoveAt(idx);
+        _observationKeys.Remove(observationKey);
         RecomputeRates();
         Save();
         _diag?.Info("Arwen.Calibration",
@@ -1003,6 +1104,7 @@ public sealed class CalibrationService
         if (obs.Quantity == quantity) return false;
         var oldQuantity = obs.Quantity;
         obs.Quantity = quantity;
+        // Quantity isn't part of ObservationKey, so the key set doesn't change.
         RecomputeRates();
         Save();
         _diag?.Info("Arwen.Calibration",
@@ -1020,6 +1122,7 @@ public sealed class CalibrationService
     {
         var removed = _data.Observations.RemoveAll(o => predicate(o));
         if (removed == 0) return 0;
+        RebuildObservationKeySet();
         RecomputeRates();
         Save();
         _diag?.Info("Arwen.Calibration", $"Bulk-deleted {removed} observation(s)");

--- a/src/Arwen.Module/Domain/GiftCalibration.cs
+++ b/src/Arwen.Module/Domain/GiftCalibration.cs
@@ -32,6 +32,23 @@ public sealed class GiftObservation
     /// </summary>
     public int Quantity { get; set; } = 1;
 
+    /// <summary>
+    /// PG session identity at the moment the gift was observed, sourced from the
+    /// login banner via <c>IGameSessionService</c>. Combined with
+    /// <see cref="InstanceId"/> it forms the dedup key that lets log-replay-on-
+    /// relaunch short-circuit without writing a second copy of the same gift.
+    /// Empty for legacy (pre-v4) observations migrated forward — they keep their
+    /// wall-clock-stamped key shape.
+    /// </summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>
+    /// In-session game-side item id of the gifted instance (the value the game
+    /// emits in <c>ProcessDeleteItem(N)</c>). Unique within a PG session by
+    /// construction. Zero for legacy (pre-v4) observations.
+    /// </summary>
+    public long InstanceId { get; set; }
+
     public DateTimeOffset Timestamp { get; set; }
 
     [JsonIgnore]
@@ -93,7 +110,7 @@ public sealed class CategoryRate
 /// </summary>
 public sealed class CalibrationData
 {
-    public int Version { get; set; } = 3;
+    public int Version { get; set; } = 4;
     public string? ContributorNote { get; set; }
     public DateTimeOffset ExportedAt { get; set; }
     public List<GiftObservation> Observations { get; set; } = [];
@@ -121,7 +138,7 @@ public sealed class CalibrationData
 /// </summary>
 public sealed class AggregatesData
 {
-    public int Version { get; set; } = 3;
+    public int Version { get; set; } = 4;
     public DateTimeOffset ExportedAt { get; set; }
     public Dictionary<string, CategoryRate> ItemRates { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, CategoryRate> SignatureRates { get; set; } = new(StringComparer.Ordinal);
@@ -136,7 +153,7 @@ public sealed class AggregatesData
 /// </summary>
 public sealed class ObservationLog
 {
-    public int Version { get; set; } = 3;
+    public int Version { get; set; } = 4;
     public List<GiftObservation> Observations { get; set; } = [];
 }
 

--- a/src/Arwen.Module/Domain/PendingGiftObservation.cs
+++ b/src/Arwen.Module/Domain/PendingGiftObservation.cs
@@ -25,5 +25,13 @@ public sealed partial class PendingGiftObservation : ObservableObject
     public required IReadOnlyList<string> ItemKeywords { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
 
+    /// <summary>
+    /// PG session id captured at the moment the pending observation was parked
+    /// (sourced from <c>IGameSessionService.Current</c>). Empty when no session
+    /// was active. Propagates to the persisted <c>GiftObservation</c> on confirm
+    /// so dedup behaves identically to live-recorded observations.
+    /// </summary>
+    public required string SessionId { get; init; }
+
     [ObservableProperty] private int _quantity = 1;
 }

--- a/src/Arwen.Module/State/FavorIngestionService.cs
+++ b/src/Arwen.Module/State/FavorIngestionService.cs
@@ -54,11 +54,15 @@ public sealed class FavorIngestionService : BackgroundService
             var evt = _parser.TryParse(raw.Line, raw.Timestamp);
             if (evt is null) continue;
 
+            // raw.Timestamp is the log-line UTC (post-#183 + #201 session anchor),
+            // stable across Mithril restarts. Plumb it through so replay produces
+            // the same persisted GiftObservation.Timestamp and dedup short-circuits.
+            var ts = new DateTimeOffset(raw.Timestamp, TimeSpan.Zero);
             switch (evt)
             {
                 case FavorUpdate update:
                     _diag?.Trace("Arwen.Parse", $"FavorUpdate npc={update.NpcKey} favor={update.AbsoluteFavor:F1}");
-                    _calibration.OnStartInteraction(update.NpcKey);
+                    _calibration.OnStartInteraction(update.NpcKey, ts);
                     Dispatch(() =>
                     {
                         var favor = _favorView.Current;
@@ -70,12 +74,12 @@ public sealed class FavorIngestionService : BackgroundService
                     break;
 
                 case ItemDeleted deleted:
-                    _calibration.OnItemDeleted(deleted.InstanceId);
+                    _calibration.OnItemDeleted(deleted.InstanceId, ts);
                     break;
 
                 case FavorDelta delta:
                     _diag?.Trace("Arwen.Parse", $"FavorDelta npc={delta.NpcKey} delta={delta.Delta:F1}");
-                    _calibration.OnDeltaFavor(delta.NpcKey, delta.Delta);
+                    _calibration.OnDeltaFavor(delta.NpcKey, delta.Delta, ts);
                     break;
             }
         }

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
 using Mithril.GameState.Sessions;
 using Mithril.Shared.DependencyInjection;
-using Mithril.Shared.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -21,10 +20,12 @@ public static class GameStateServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddMithrilGameState(this IServiceCollection services)
     {
+        // ISessionAnchor is registered in AddMithrilGameServices as a leaf
+        // (SessionAnchor). GameSessionService pushes to it on every parsed
+        // banner — see SessionAnchor.cs and GameSessionService.Publish.
         services
             .AddSingleton<GameSessionService>()
             .AddSingleton<IGameSessionService>(sp => sp.GetRequiredService<GameSessionService>())
-            .AddSingleton<ISessionAnchor>(sp => sp.GetRequiredService<GameSessionService>())
             .AddHostedService(sp => sp.GetRequiredService<GameSessionService>());
 
         services

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
+using Mithril.GameState.Sessions;
 using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -19,6 +21,12 @@ public static class GameStateServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddMithrilGameState(this IServiceCollection services)
     {
+        services
+            .AddSingleton<GameSessionService>()
+            .AddSingleton<IGameSessionService>(sp => sp.GetRequiredService<GameSessionService>())
+            .AddSingleton<ISessionAnchor>(sp => sp.GetRequiredService<GameSessionService>())
+            .AddHostedService(sp => sp.GetRequiredService<GameSessionService>());
+
         services
             .AddSingleton<InventoryService>()
             .AddSingleton<IInventoryService>(sp => sp.GetRequiredService<InventoryService>())

--- a/src/Mithril.GameState/Sessions/GameSession.cs
+++ b/src/Mithril.GameState/Sessions/GameSession.cs
@@ -1,0 +1,18 @@
+namespace Mithril.GameState.Sessions;
+
+/// <summary>
+/// Identity + temporal metadata for a single PG game session, parsed from the
+/// <c>Logged in as character … Time UTC=… Timezone Offset …</c> banner that
+/// PG emits at every login.
+///
+/// <see cref="SessionId"/> is the natural dedup key for log-derived
+/// observations (Arwen gifts, Smaug sells, …). It collapses to the same value
+/// every time the same banner is parsed, so replay-on-relaunch attributes the
+/// same physical login to the same id and downstream services short-circuit
+/// duplicate writes.
+/// </summary>
+public sealed record GameSession(
+    string SessionId,
+    string CharacterName,
+    DateTime LoggedInUtc,
+    TimeSpan TimezoneOffset);

--- a/src/Mithril.GameState/Sessions/GameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/GameSessionService.cs
@@ -5,33 +5,45 @@ using Microsoft.Extensions.Hosting;
 namespace Mithril.GameState.Sessions;
 
 /// <summary>
-/// Hosted-service implementation of <see cref="IGameSessionService"/> and
-/// <see cref="ISessionAnchor"/>. Tails <see cref="IPlayerLogStream"/>, parses
-/// the login banner via <see cref="LoginBannerParser"/>, and publishes session
-/// transitions to subscribers + the anchor consumer.
+/// Hosted-service implementation of <see cref="IGameSessionService"/>. Tails
+/// <see cref="IPlayerLogStream"/>, parses the login banner via
+/// <see cref="LoginBannerParser"/>, and publishes session transitions to
+/// subscribers + the shared <see cref="SessionAnchor"/> consumer.
 ///
-/// Threading: ingestion runs on the hosted-service loop thread; subscriber
+/// <para>The anchor is pushed-to, not implemented-by, to avoid a DI cycle:
+/// the streams that consume the anchor are in <c>Mithril.Shared</c>, and
+/// this service consumes the streams — wiring the anchor through the service
+/// would form stream → anchor → service → stream. <see cref="SessionAnchor"/>
+/// is a Mithril.Shared leaf that both depend on; only this service writes to
+/// it.</para>
+///
+/// <para>Threading: ingestion runs on the hosted-service loop thread; subscriber
 /// dispatch happens under <c>_lock</c> both during replay (on the subscriber's
 /// thread) and during live publish (on the ingestion thread). Subscribers
-/// doing non-trivial work should dispatch off-thread immediately.
+/// doing non-trivial work should dispatch off-thread immediately.</para>
 ///
-/// Idempotency: a banner whose parsed <see cref="GameSession.SessionId"/>
+/// <para>Idempotency: a banner whose parsed <see cref="GameSession.SessionId"/>
 /// equals the current one (replay-on-relaunch within the same PG session) is
-/// dropped at this layer — neither <see cref="SessionStarted"/> nor
-/// <see cref="ISessionAnchor.AnchorChanged"/> re-fires.
+/// dropped at this layer — neither <see cref="SessionStarted"/> nor the
+/// anchor's <c>AnchorChanged</c> re-fires.</para>
 /// </summary>
-public sealed class GameSessionService : BackgroundService, IGameSessionService, ISessionAnchor
+public sealed class GameSessionService : BackgroundService, IGameSessionService
 {
     private readonly IPlayerLogStream _stream;
+    private readonly SessionAnchor? _anchor;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly object _lock = new();
     private readonly List<Action<GameSession>> _handlers = [];
     private GameSession? _current;
 
-    public GameSessionService(IPlayerLogStream stream, IDiagnosticsSink? diag = null)
+    public GameSessionService(
+        IPlayerLogStream stream,
+        SessionAnchor? anchor = null,
+        IDiagnosticsSink? diag = null)
     {
         _stream = stream;
+        _anchor = anchor;
         _diag = diag;
     }
 
@@ -40,13 +52,7 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService,
         get { lock (_lock) return _current; }
     }
 
-    public DateTime? LoggedInUtc
-    {
-        get { lock (_lock) return _current?.LoggedInUtc; }
-    }
-
     public event EventHandler<GameSession>? SessionStarted;
-    public event EventHandler? AnchorChanged;
 
     public IDisposable Subscribe(Action<GameSession> handler)
     {
@@ -76,7 +82,6 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService,
     {
         Action<GameSession>[] toFire;
         EventHandler<GameSession>? sessionStartedSnapshot;
-        EventHandler? anchorChangedSnapshot;
         lock (_lock)
         {
             if (_current is not null && _current.SessionId == session.SessionId)
@@ -89,14 +94,17 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService,
             _current = session;
             toFire = _handlers.ToArray();
             sessionStartedSnapshot = SessionStarted;
-            anchorChangedSnapshot = AnchorChanged;
             _diag?.Info("Session",
                 $"Login observed: {session.CharacterName} at {session.LoggedInUtc:O} (offset {session.TimezoneOffset})");
         }
 
+        // Push to the shared anchor so the sequencer re-anchors the date for
+        // subsequent log lines. SessionAnchor.SetLoggedInUtc is no-op when the
+        // value is unchanged, so we don't need to gate it here.
+        _anchor?.SetLoggedInUtc(session.LoggedInUtc);
+
         foreach (var h in toFire) Invoke(h, session);
         sessionStartedSnapshot?.Invoke(this, session);
-        anchorChangedSnapshot?.Invoke(this, EventArgs.Empty);
     }
 
     private void Invoke(Action<GameSession> handler, GameSession session)

--- a/src/Mithril.GameState/Sessions/GameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/GameSessionService.cs
@@ -1,0 +1,126 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Sessions;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IGameSessionService"/> and
+/// <see cref="ISessionAnchor"/>. Tails <see cref="IPlayerLogStream"/>, parses
+/// the login banner via <see cref="LoginBannerParser"/>, and publishes session
+/// transitions to subscribers + the anchor consumer.
+///
+/// Threading: ingestion runs on the hosted-service loop thread; subscriber
+/// dispatch happens under <c>_lock</c> both during replay (on the subscriber's
+/// thread) and during live publish (on the ingestion thread). Subscribers
+/// doing non-trivial work should dispatch off-thread immediately.
+///
+/// Idempotency: a banner whose parsed <see cref="GameSession.SessionId"/>
+/// equals the current one (replay-on-relaunch within the same PG session) is
+/// dropped at this layer — neither <see cref="SessionStarted"/> nor
+/// <see cref="ISessionAnchor.AnchorChanged"/> re-fires.
+/// </summary>
+public sealed class GameSessionService : BackgroundService, IGameSessionService, ISessionAnchor
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly List<Action<GameSession>> _handlers = [];
+    private GameSession? _current;
+
+    public GameSessionService(IPlayerLogStream stream, IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _diag = diag;
+    }
+
+    public GameSession? Current
+    {
+        get { lock (_lock) return _current; }
+    }
+
+    public DateTime? LoggedInUtc
+    {
+        get { lock (_lock) return _current?.LoggedInUtc; }
+    }
+
+    public event EventHandler<GameSession>? SessionStarted;
+    public event EventHandler? AnchorChanged;
+
+    public IDisposable Subscribe(Action<GameSession> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // Replay the current session before going live so the subscriber
+            // observes the same `Current` view that already-attached handlers
+            // see. Mirrors InventoryService.Subscribe / QuestService.Subscribe.
+            if (_current is not null) Invoke(handler, _current);
+            _handlers.Add(handler);
+            return new Subscription(this, handler);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("Session", "Subscribing to Player.log for login banner");
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            if (!LoginBannerParser.TryParse(raw.Line, out var session)) continue;
+            Publish(session);
+        }
+    }
+
+    private void Publish(GameSession session)
+    {
+        Action<GameSession>[] toFire;
+        EventHandler<GameSession>? sessionStartedSnapshot;
+        EventHandler? anchorChangedSnapshot;
+        lock (_lock)
+        {
+            if (_current is not null && _current.SessionId == session.SessionId)
+            {
+                // Replay of an already-known banner. Idempotent: no event,
+                // no anchor flip, no subscriber dispatch.
+                return;
+            }
+
+            _current = session;
+            toFire = _handlers.ToArray();
+            sessionStartedSnapshot = SessionStarted;
+            anchorChangedSnapshot = AnchorChanged;
+            _diag?.Info("Session",
+                $"Login observed: {session.CharacterName} at {session.LoggedInUtc:O} (offset {session.TimezoneOffset})");
+        }
+
+        foreach (var h in toFire) Invoke(h, session);
+        sessionStartedSnapshot?.Invoke(this, session);
+        anchorChangedSnapshot?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Invoke(Action<GameSession> handler, GameSession session)
+    {
+        try { handler(session); }
+        catch (Exception ex) { _diag?.Warn("Session", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private GameSessionService? _owner;
+        private readonly Action<GameSession> _handler;
+
+        public Subscription(GameSessionService owner, Action<GameSession> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
+        }
+    }
+}

--- a/src/Mithril.GameState/Sessions/IGameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/IGameSessionService.cs
@@ -1,0 +1,41 @@
+namespace Mithril.GameState.Sessions;
+
+/// <summary>
+/// Live PG session identity. Tails <see cref="Mithril.Shared.Logging.IPlayerLogStream"/>
+/// for the <c>Logged in as character X. Time UTC=… Timezone Offset …</c> banner,
+/// publishes the current <see cref="GameSession"/>, and re-anchors on every
+/// fresh login. Sibling of <see cref="Mithril.GameState.Inventory.IInventoryService"/>
+/// and <see cref="Mithril.GameState.Quests.IQuestService"/>: same atomic-replay
+/// Subscribe pattern so late joiners observe the current session synchronously.
+///
+/// Also surfaces as <see cref="Mithril.Shared.Logging.ISessionAnchor"/> so
+/// <see cref="Mithril.Shared.Logging.LogLineTimestampSequencer"/> can anchor
+/// log-line dates on the banner's UTC instead of file mtime.
+/// </summary>
+public interface IGameSessionService
+{
+    /// <summary>
+    /// Current session, or <c>null</c> if no banner has been parsed yet
+    /// (e.g. Mithril attached before any login this run).
+    /// </summary>
+    GameSession? Current { get; }
+
+    /// <summary>
+    /// Raised when a new session is observed — first-time observation or PG
+    /// re-login during the same Mithril run. Replaying the same banner does
+    /// not re-fire (the service compares <see cref="GameSession.SessionId"/>
+    /// before raising).
+    /// </summary>
+    event EventHandler<GameSession>? SessionStarted;
+
+    /// <summary>
+    /// Attach a handler that synchronously receives the current session (if
+    /// any) followed by every subsequent <see cref="SessionStarted"/>. Replay
+    /// and live delivery are atomic under an internal lock — no session is
+    /// lost, duplicated, or reordered relative to the canonical
+    /// <see cref="Current"/> view.
+    ///
+    /// Dispose the returned subscription to stop receiving further events.
+    /// </summary>
+    IDisposable Subscribe(Action<GameSession> handler);
+}

--- a/src/Mithril.GameState/Sessions/LoginBannerParser.cs
+++ b/src/Mithril.GameState/Sessions/LoginBannerParser.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Mithril.GameState.Sessions;
+
+/// <summary>
+/// Parses PG's per-session login banner:
+/// <code>
+/// [12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00
+/// </code>
+/// The bracketed prefix is tolerated but not required (any leading whitespace
+/// or other text before <c>Logged in as character</c> is ignored).
+///
+/// Extracts the character name, the absolute UTC datetime (the only authoritative
+/// in-file source of a calendar date for any subsequent <c>[HH:MM:SS]</c>-only
+/// line), and the timezone offset (which closes the Player.log-UTC vs
+/// ChatLogs-local asymmetry documented in <c>pg_log_timezones</c>).
+/// </summary>
+internal static partial class LoginBannerParser
+{
+    // PG emits dates as M/D/YYYY (US client formatting). Live captures
+    // observed both `05/11/2026 12:25:04` (zero-padded throughout) and
+    // single-digit variants on month / day / hour / minute / second when
+    // the value is < 10. TryParseExact accepts each variant separately, so
+    // we list every combination of `M` vs `MM`, `d` vs `dd`, `H` vs `HH`,
+    // `m` vs `mm`, `s` vs `ss` we expect to see.
+    private static readonly string[] UtcDateFormats =
+    [
+        "M/d/yyyy H:m:s",
+        "M/d/yyyy H:m:ss",
+        "M/d/yyyy H:mm:s",
+        "M/d/yyyy H:mm:ss",
+        "M/d/yyyy HH:m:s",
+        "M/d/yyyy HH:m:ss",
+        "M/d/yyyy HH:mm:s",
+        "M/d/yyyy HH:mm:ss",
+        "MM/dd/yyyy H:m:s",
+        "MM/dd/yyyy H:m:ss",
+        "MM/dd/yyyy H:mm:s",
+        "MM/dd/yyyy H:mm:ss",
+        "MM/dd/yyyy HH:m:s",
+        "MM/dd/yyyy HH:m:ss",
+        "MM/dd/yyyy HH:mm:s",
+        "MM/dd/yyyy HH:mm:ss",
+    ];
+
+    // Name allows everything up to the period that delimits the next field.
+    // UTC capture is the literal <date> <time> after "Time UTC=" up to the next period.
+    // Offset is signed HH:MM:SS — PG uses unsigned in the East-of-UTC case (no '+').
+    [GeneratedRegex(
+        @"Logged in as character (?<name>[^.]+)\.\s*Time UTC=(?<utc>[^.]+)\.\s*Timezone Offset (?<off>-?\d{1,2}:\d{2}:\d{2})",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex BannerRx();
+
+    /// <summary>
+    /// Try to extract a session banner from <paramref name="line"/>. Returns
+    /// <c>true</c> only when every field parses successfully — a malformed
+    /// banner is treated as "not a banner" and lets the rest of the pipeline
+    /// fall through normally.
+    /// </summary>
+    public static bool TryParse(string line, out GameSession session)
+    {
+        session = null!;
+        if (string.IsNullOrEmpty(line)) return false;
+
+        var m = BannerRx().Match(line);
+        if (!m.Success) return false;
+
+        var name = m.Groups["name"].Value.Trim();
+        if (name.Length == 0) return false;
+
+        var utcRaw = m.Groups["utc"].Value.Trim();
+        if (!DateTime.TryParseExact(utcRaw, UtcDateFormats, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var utc))
+            return false;
+        // AdjustToUniversal yields a DateTime with Kind=Utc.
+        utc = DateTime.SpecifyKind(utc, DateTimeKind.Utc);
+
+        var offRaw = m.Groups["off"].Value.Trim();
+        if (!TimeSpan.TryParse(offRaw, CultureInfo.InvariantCulture, out var offset))
+            return false;
+
+        // SessionId is a stable, parser-derived natural key — two replays of
+        // the same banner collapse to the same id even across Mithril restarts.
+        var sessionId = $"{name}|{utc:O}";
+        session = new GameSession(sessionId, name, utc, offset);
+        return true;
+    }
+}

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -63,6 +63,12 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IShiftCatalog>(sp => new JsonShiftCatalog(
                 bundledDir: null,
                 diag: sp.GetService<IDiagnosticsSink>()))
+            // SessionAnchor is a leaf so PlayerLogStream / ChatLogStream can
+            // resolve ISessionAnchor without forming a cycle with the higher-
+            // level GameSessionService (which CONSUMES the stream and PUSHES
+            // to the anchor — see SessionAnchor.cs).
+            .AddSingleton<SessionAnchor>()
+            .AddSingleton<ISessionAnchor>(sp => sp.GetRequiredService<SessionAnchor>())
             .AddSingleton<IPlayerLogStream, PlayerLogStream>()
             .AddSingleton<IChatLogStream, ChatLogStream>()
             .AddSingleton<IActiveCharacterService>(sp => new ActiveCharacterService(

--- a/src/Mithril.Shared/Logging/ChatLogStream.cs
+++ b/src/Mithril.Shared/Logging/ChatLogStream.cs
@@ -18,16 +18,22 @@ public sealed class ChatLogStream : IChatLogStream, IDisposable
     private readonly GameConfig _config;
     private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
+    private readonly ISessionAnchor? _sessionAnchor;
     private readonly object _gate = new();
     private readonly List<Channel<RawLogLine>> _subs = new();
     private CancellationTokenSource? _runCts;
     private Task? _runTask;
 
-    public ChatLogStream(GameConfig config, IDiagnosticsSink? diag = null, TimeProvider? time = null)
+    public ChatLogStream(
+        GameConfig config,
+        IDiagnosticsSink? diag = null,
+        TimeProvider? time = null,
+        ISessionAnchor? sessionAnchor = null)
     {
         _config = config;
         _diag = diag;
         _time = time ?? TimeProvider.System;
+        _sessionAnchor = sessionAnchor;
         _config.PropertyChanged += OnConfigChanged;
     }
 
@@ -95,7 +101,7 @@ public sealed class ChatLogStream : IChatLogStream, IDisposable
     private async Task RunAsync(string directory, CancellationToken ct)
     {
         _diag?.Info("ChatLog", $"Subscribing to {directory}");
-        var reader = new ChatLogTailReader(_time);
+        var reader = new ChatLogTailReader(_time, _sessionAnchor);
         reader.SeedDirectoryToCurrentEnd(directory);
 
         FileSystemWatcher? watcher = null;

--- a/src/Mithril.Shared/Logging/ChatLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/ChatLogTailReader.cs
@@ -16,11 +16,13 @@ namespace Mithril.Shared.Logging;
 public sealed class ChatLogTailReader
 {
     private readonly TimeProvider _time;
+    private readonly ISessionAnchor? _sessionAnchor;
     private readonly Dictionary<string, FileState> _files = new(StringComparer.OrdinalIgnoreCase);
 
-    public ChatLogTailReader(TimeProvider? time = null)
+    public ChatLogTailReader(TimeProvider? time = null, ISessionAnchor? sessionAnchor = null)
     {
         _time = time ?? TimeProvider.System;
+        _sessionAnchor = sessionAnchor;
     }
 
     /// <summary>
@@ -37,7 +39,7 @@ public sealed class ChatLogTailReader
                 _files[path] = new FileState
                 {
                     Offset = new FileInfo(path).Length,
-                    Sequencer = new LogLineTimestampSequencer(_time),
+                    Sequencer = new LogLineTimestampSequencer(_time, _sessionAnchor),
                 };
             }
             catch (IOException) { }
@@ -50,7 +52,7 @@ public sealed class ChatLogTailReader
 
         if (!_files.TryGetValue(path, out var state))
         {
-            state = new FileState { Sequencer = new LogLineTimestampSequencer(_time) };
+            state = new FileState { Sequencer = new LogLineTimestampSequencer(_time, _sessionAnchor) };
             _files[path] = state;
         }
 

--- a/src/Mithril.Shared/Logging/ISessionAnchor.cs
+++ b/src/Mithril.Shared/Logging/ISessionAnchor.cs
@@ -8,12 +8,14 @@ namespace Mithril.Shared.Logging;
 /// (which drifts on copies, runs across midnight, and depends on system clock
 /// state).
 ///
-/// Lives in <c>Mithril.Shared</c> rather than <c>Mithril.GameState</c> so the
-/// sequencer can depend on it without inverting the project graph. The
-/// implementation (a <c>GameSessionService</c> sibling of
-/// <c>IInventoryService</c> / <c>IQuestService</c>) ships in
-/// <c>Mithril.GameState.Sessions</c> and is registered as both this interface
-/// and the richer <c>IGameSessionService</c>.
+/// <para>The concrete implementation is the leaf class <see cref="SessionAnchor"/>
+/// in <c>Mithril.Shared</c> — kept here rather than in <c>Mithril.GameState</c>
+/// so <see cref="LogLineTimestampSequencer"/> and <c>PlayerLogStream</c>
+/// (also Mithril.Shared) can depend on it without inverting the project
+/// graph or forming a DI cycle. <c>GameSessionService</c> in
+/// <c>Mithril.GameState.Sessions</c> consumes the same concrete anchor and
+/// calls <see cref="SessionAnchor.SetLoggedInUtc(DateTime)"/> on every parsed
+/// banner — pushing state in rather than implementing the interface itself.</para>
 /// </summary>
 public interface ISessionAnchor
 {

--- a/src/Mithril.Shared/Logging/ISessionAnchor.cs
+++ b/src/Mithril.Shared/Logging/ISessionAnchor.cs
@@ -1,0 +1,34 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Provides an authoritative UTC datetime anchor for the current PG session,
+/// parsed from the in-file <c>Logged in as character … Time UTC=… Timezone Offset …</c>
+/// banner. Consumed by <see cref="LogLineTimestampSequencer"/> to anchor the
+/// date for <c>[HH:MM:SS]</c> prefixes; this beats anchoring on file mtime
+/// (which drifts on copies, runs across midnight, and depends on system clock
+/// state).
+///
+/// Lives in <c>Mithril.Shared</c> rather than <c>Mithril.GameState</c> so the
+/// sequencer can depend on it without inverting the project graph. The
+/// implementation (a <c>GameSessionService</c> sibling of
+/// <c>IInventoryService</c> / <c>IQuestService</c>) ships in
+/// <c>Mithril.GameState.Sessions</c> and is registered as both this interface
+/// and the richer <c>IGameSessionService</c>.
+/// </summary>
+public interface ISessionAnchor
+{
+    /// <summary>
+    /// UTC instant of the most recent <c>Logged in as character</c> banner
+    /// observed in the live log, or <c>null</c> if no banner has been seen yet.
+    /// Once non-null, only re-assigned on a fresh PG login (second banner) —
+    /// not cleared on logout.
+    /// </summary>
+    DateTime? LoggedInUtc { get; }
+
+    /// <summary>
+    /// Raised when <see cref="LoggedInUtc"/> changes (first-time set, or
+    /// PG re-login during the same Mithril run). Subscribers re-anchor any
+    /// date-dependent state.
+    /// </summary>
+    event EventHandler? AnchorChanged;
+}

--- a/src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs
+++ b/src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs
@@ -7,11 +7,28 @@ namespace Mithril.Shared.Logging;
 /// (Player.log mtime minus the player's TZ offset matches the prefix's
 /// time-of-day) and against the ChatLog login banner's reported
 /// <c>Timezone Offset</c>, which equals the offset between Player.log
-/// prefixes and ChatLog lines. State is per-file: the date is anchored on
-/// file mtime (UTC) for the first content batch and folded forward across
-/// rollovers in subsequent batches. Lines without the prefix inherit the
-/// previous line's stamp, or fall through to <see cref="TimeProvider.GetUtcNow"/>
-/// if nothing has been seen yet.
+/// prefixes and ChatLog lines.
+///
+/// <para><b>Date anchoring.</b> Two anchor strategies, picked dynamically:</para>
+/// <list type="bullet">
+///   <item><b>Session anchor (preferred).</b> If an <see cref="ISessionAnchor"/>
+///   has observed a <c>Logged in as character … Time UTC=…</c> banner, the
+///   sequencer pins <c>_currentUtcDate</c> to <c>LoggedInUtc.Date</c> and
+///   primes <c>_prevUtcTimeOfDay</c> with the login time-of-day. The login
+///   instant is the earliest known point in the relevant window, so
+///   <see cref="StampForLine"/>'s existing forward-rollover detection
+///   (HH-wraps-backward &gt; 12h ⇒ +1 day) carries the date across every
+///   subsequent midnight without further intervention. On
+///   <see cref="ISessionAnchor.AnchorChanged"/> (PG re-login), the sequencer
+///   re-anchors to the new banner's date. Self-describing from inside the
+///   file — robust to copies, runs spanning midnight, and clock drift.</item>
+///   <item><b>mtime anchor (fallback).</b> No session known: walk the date
+///   <i>backward</i> from the LAST timestamped line in the first batch,
+///   subtracting in-batch rollover count, so the last line lines up with
+///   the file's mtime (or mtime - 1 day if the line's tod is past mtime's
+///   tod). Preserves pre-<c>ISessionAnchor</c> behaviour for pre-banner
+///   lines (engine boot) and for chat logs that never emit a banner.</item>
+/// </list>
 ///
 /// Shared by <see cref="PlayerLogTailReader"/> (single-file Player.log)
 /// and <see cref="ChatLogTailReader"/> (per-channel chat logs); each chat
@@ -25,31 +42,76 @@ namespace Mithril.Shared.Logging;
 internal sealed class LogLineTimestampSequencer
 {
     private readonly TimeProvider _time;
+    private readonly ISessionAnchor? _sessionAnchor;
     private DateOnly? _currentUtcDate;
     private TimeSpan? _prevUtcTimeOfDay;
     private DateTime _lastEmittedUtc;
+    // Tracks the session-anchor instant we've already aligned with so an
+    // AnchorChanged event for a transition we've already absorbed doesn't
+    // re-anchor mid-stream. Null when running under the mtime fallback.
+    private DateTime? _appliedSessionAnchor;
 
-    public LogLineTimestampSequencer(TimeProvider time)
+    public LogLineTimestampSequencer(TimeProvider time, ISessionAnchor? sessionAnchor = null)
     {
         _time = time;
+        _sessionAnchor = sessionAnchor;
+        if (_sessionAnchor is not null)
+            _sessionAnchor.AnchorChanged += OnAnchorChanged;
+    }
+
+    private void OnAnchorChanged(object? sender, EventArgs e)
+    {
+        // Drop the current anchor; the next StampForLine / EnsureAnchored
+        // call will re-pick from the (now updated) session anchor.
+        var anchor = _sessionAnchor?.LoggedInUtc;
+        if (anchor is null) return;
+        if (_appliedSessionAnchor == anchor) return;
+
+        _currentUtcDate = DateOnly.FromDateTime(anchor.Value);
+        _prevUtcTimeOfDay = anchor.Value.TimeOfDay;
+        _appliedSessionAnchor = anchor;
     }
 
     /// <summary>
-    /// Anchor the date for the first content batch. Pre-scans <paramref name="lines"/>
-    /// for <c>[HH:MM:SS]</c> prefixes, counts midnight rollovers in the
-    /// batch, and walks the start back so the LAST timestamped line lines
-    /// up with file mtime (or mtime - 1 day if its tod is past mtime's
-    /// tod, which happens when the file ticks over to the next UTC day
-    /// shortly after the line was written). Caller passes a UTC mtime —
-    /// both <see cref="PlayerLogTailReader"/> and <see cref="ChatLogTailReader"/>
-    /// use <see cref="File.GetLastWriteTimeUtc"/> so the comparison
-    /// against the UTC prefix is in one frame. No-op once anchored, and
-    /// no-op for batches with no prefixed lines (defers init to a later
-    /// batch that has at least one).
+    /// Anchor the date for the first content batch. Two strategies:
+    ///
+    /// <para><b>Session anchor.</b> If an <see cref="ISessionAnchor"/> has
+    /// already observed the <c>Logged in as character</c> banner, pin the
+    /// date to <c>LoggedInUtc.Date</c> directly. The banner is the
+    /// authoritative earliest known instant in the session, so no
+    /// back-walk is needed and pre-banner lines in the same batch
+    /// (engine boot) inherit <c>LoggedInUtc.Date</c> too — slight
+    /// imprecision on pre-session lines is benign because no ingestion
+    /// service consumes them.</para>
+    ///
+    /// <para><b>mtime fallback.</b> No session known: pre-scan
+    /// <paramref name="lines"/> for <c>[HH:MM:SS]</c> prefixes, count
+    /// midnight rollovers in the batch, and walk the start back so the
+    /// LAST timestamped line lines up with file mtime (or mtime - 1 day
+    /// if its tod is past mtime's tod). Preserves pre-session-anchor
+    /// behaviour for chat logs and for any state where the banner
+    /// hasn't been parsed yet.</para>
+    ///
+    /// No-op once anchored, and no-op for batches with no prefixed lines
+    /// (defers init to a later batch that has at least one).
     /// </summary>
     public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor)
     {
         if (_currentUtcDate is not null) return;
+
+        // Prefer session anchor when available. EnsureAnchored runs at the
+        // first batch from the tail reader; the session service's seed-replay
+        // subscription typically lands the banner immediately, but if not we
+        // fall through to the mtime path and OnAnchorChanged retros the date
+        // when the banner does land.
+        var anchor = _sessionAnchor?.LoggedInUtc;
+        if (anchor is not null)
+        {
+            _currentUtcDate = DateOnly.FromDateTime(anchor.Value);
+            _prevUtcTimeOfDay = anchor.Value.TimeOfDay;
+            _appliedSessionAnchor = anchor;
+            return;
+        }
 
         var rollovers = 0;
         TimeSpan? prev = null;

--- a/src/Mithril.Shared/Logging/PlayerLogStream.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogStream.cs
@@ -20,6 +20,7 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
     private readonly GameConfig _config;
     private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
+    private readonly ISessionAnchor? _sessionAnchor;
     private readonly object _gate = new();
     private readonly List<Channel<RawLogLine>> _subs = new();
     // Accumulated lines from session start to "now". Null until RunAsync has
@@ -31,11 +32,16 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
     private Task? _runTask;
     private string? _activePath;
 
-    public PlayerLogStream(GameConfig config, IDiagnosticsSink? diag = null, TimeProvider? time = null)
+    public PlayerLogStream(
+        GameConfig config,
+        IDiagnosticsSink? diag = null,
+        TimeProvider? time = null,
+        ISessionAnchor? sessionAnchor = null)
     {
         _config = config;
         _diag = diag;
         _time = time ?? TimeProvider.System;
+        _sessionAnchor = sessionAnchor;
         _config.PropertyChanged += OnConfigChanged;
     }
 
@@ -122,7 +128,7 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
     private async Task RunAsync(string path, CancellationToken ct)
     {
         _diag?.Info("PlayerLog", $"Subscribing to {path}");
-        var reader = new PlayerLogTailReader(path, _time);
+        var reader = new PlayerLogTailReader(path, _time, _sessionAnchor);
         reader.SeedToSessionStart();
 
         // Initial flush (catch up from session start)

--- a/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
@@ -6,8 +6,23 @@ namespace Mithril.Shared.Logging;
 /// <summary>
 /// Single-file tail with session-start seek. Mirrors ws_bridge.py's
 /// _find_session_start: scans the last 10 MB for the most recent
-/// ProcessAddPlayer( occurrence so the consumer always receives the
-/// login event regardless of how long ago the session began.
+/// session-start marker so the consumer always receives the login event
+/// regardless of how long ago the session began.
+///
+/// <para><b>Session markers.</b> Two markers identify a session start:</para>
+/// <list type="bullet">
+///   <item><c>Logged in as character </c> — the user-facing login banner that
+///   carries the authoritative UTC datetime + timezone offset. Consumed by
+///   <c>GameSessionService</c> to mint a <c>GameSession</c> and feed
+///   <see cref="ISessionAnchor"/>.</item>
+///   <item><c>ProcessAddPlayer(</c> — the engine spawn event. Consumed by
+///   <c>ActiveCharacterLogSynchronizer</c> to set the active character name.</item>
+/// </list>
+/// PG emits both within a few lines of one another at the start of each
+/// session, but ordering between them isn't guaranteed. The seed picks the
+/// <b>earlier</b> of the two recent occurrences so both lines appear in the
+/// replay regardless of PG's emission order. If neither is found, the seed
+/// falls through to byte 0 (replay everything).
 ///
 /// Each emitted <see cref="RawLogLine"/> carries the absolute UTC of the
 /// log line itself (recovered from the <c>[HH:MM:SS]</c> prefix every PG
@@ -20,7 +35,11 @@ namespace Mithril.Shared.Logging;
 public sealed class PlayerLogTailReader
 {
     private const int SessionScanChunkBytes = 10 * 1024 * 1024;
-    private const string SessionMarker = "ProcessAddPlayer(";
+    private static readonly string[] SessionMarkers =
+    [
+        "Logged in as character ",
+        "ProcessAddPlayer(",
+    ];
 
     private readonly string _path;
     private readonly TimeProvider _time;
@@ -28,11 +47,11 @@ public sealed class PlayerLogTailReader
     private long _offset;
     private byte[] _residual = Array.Empty<byte>();
 
-    public PlayerLogTailReader(string path, TimeProvider? time = null)
+    public PlayerLogTailReader(string path, TimeProvider? time = null, ISessionAnchor? sessionAnchor = null)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
         _time = time ?? TimeProvider.System;
-        _sequencer = new LogLineTimestampSequencer(_time);
+        _sequencer = new LogLineTimestampSequencer(_time, sessionAnchor);
     }
 
     public void SeedToSessionStart()
@@ -41,10 +60,15 @@ public sealed class PlayerLogTailReader
         var size = new FileInfo(_path).Length;
         using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
 
-        // Scan backward in chunks so we find the most recent ProcessAddPlayer even
-        // in a 100MB+ log. Each chunk overlaps the previous by the marker length
-        // so a login at a chunk boundary isn't missed.
-        var overlap = SessionMarker.Length;
+        // Scan backward in chunks so we find the most recent session marker
+        // even in a 100MB+ log. Each chunk overlaps the previous by the longest
+        // marker length so a hit at a chunk boundary isn't missed. For each
+        // chunk, locate the latest occurrence of EACH marker and keep the
+        // smallest resulting line-start offset (the chronologically earlier
+        // of the two), so both the banner and ProcessAddPlayer always land
+        // in the replay regardless of which PG emits first.
+        var overlap = 0;
+        foreach (var m in SessionMarkers) if (m.Length > overlap) overlap = m.Length;
         var end = size;
         while (end > 0)
         {
@@ -54,18 +78,27 @@ public sealed class PlayerLogTailReader
             var buf = new byte[chunkSize];
             var read = fs.Read(buf, 0, buf.Length);
             var text = Encoding.UTF8.GetString(buf, 0, read);
-            var idx = text.LastIndexOf(SessionMarker, StringComparison.Ordinal);
-            if (idx >= 0)
+
+            long? bestOffset = null;
+            foreach (var marker in SessionMarkers)
             {
+                var idx = text.LastIndexOf(marker, StringComparison.Ordinal);
+                if (idx < 0) continue;
                 var lineStart = text.LastIndexOf('\n', idx);
                 var startInChunk = lineStart < 0 ? 0 : lineStart + 1;
-                _offset = scanFrom + Encoding.UTF8.GetByteCount(text.AsSpan(0, startInChunk));
+                var fileOffset = scanFrom + Encoding.UTF8.GetByteCount(text.AsSpan(0, startInChunk));
+                if (bestOffset is null || fileOffset < bestOffset.Value) bestOffset = fileOffset;
+            }
+
+            if (bestOffset is not null)
+            {
+                _offset = bestOffset.Value;
                 return;
             }
             if (scanFrom == 0) break;
             end = scanFrom + overlap; // keep overlap so a marker spanning chunks is caught
         }
-        _offset = 0; // no login found anywhere — replay from the top
+        _offset = 0; // no marker found anywhere — replay from the top
     }
 
     public void SeedToEnd()

--- a/src/Mithril.Shared/Logging/SessionAnchor.cs
+++ b/src/Mithril.Shared/Logging/SessionAnchor.cs
@@ -1,0 +1,45 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Concrete leaf implementation of <see cref="ISessionAnchor"/>. Holds the
+/// most recent <c>LoggedInUtc</c> instant and raises <see cref="AnchorChanged"/>
+/// on every transition.
+///
+/// <para><b>Why a separate class instead of having <c>GameSessionService</c>
+/// implement <see cref="ISessionAnchor"/> directly</b>: the streams that
+/// consume the anchor (<c>PlayerLogStream</c>, <c>ChatLogStream</c>) live in
+/// <c>Mithril.Shared</c>, and <c>GameSessionService</c> in turn consumes
+/// <c>IPlayerLogStream</c>. Wiring the anchor through the service forms a DI
+/// cycle (stream → anchor → service → stream). Splitting the anchor out as a
+/// leaf class breaks the cycle: both <c>PlayerLogStream</c> and
+/// <c>GameSessionService</c> consume the leaf; only the service writes to it.</para>
+/// </summary>
+public sealed class SessionAnchor : ISessionAnchor
+{
+    private readonly object _lock = new();
+    private DateTime? _loggedInUtc;
+
+    public DateTime? LoggedInUtc
+    {
+        get { lock (_lock) return _loggedInUtc; }
+    }
+
+    public event EventHandler? AnchorChanged;
+
+    /// <summary>
+    /// Set the current session anchor. No-op (no <see cref="AnchorChanged"/>
+    /// fire) when the value is unchanged — keeps replay-on-relaunch quiet at
+    /// the anchor layer the same way <c>GameSessionService</c> stays quiet at
+    /// the session layer.
+    /// </summary>
+    public void SetLoggedInUtc(DateTime loggedInUtc)
+    {
+        bool changed;
+        lock (_lock)
+        {
+            changed = _loggedInUtc != loggedInUtc;
+            _loggedInUtc = loggedInUtc;
+        }
+        if (changed) AnchorChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Smaug.Module/Domain/PriceCalibration.cs
+++ b/src/Smaug.Module/Domain/PriceCalibration.cs
@@ -13,7 +13,7 @@ namespace Smaug.Domain;
 /// </summary>
 public sealed class PriceCalibrationData
 {
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
     public DateTimeOffset? ExportedAt { get; set; }
     public string? ContributorNote { get; set; }
 
@@ -34,7 +34,7 @@ public sealed class PriceCalibrationData
 /// </summary>
 public sealed class SmaugAggregatesData
 {
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
     public DateTimeOffset? ExportedAt { get; set; }
     public Dictionary<string, PriceRate> AbsoluteRates { get; set; } = new(StringComparer.Ordinal);
     public Dictionary<string, RatioRate> RatioRates { get; set; } = new(StringComparer.Ordinal);
@@ -45,7 +45,7 @@ public sealed class SmaugAggregatesData
 /// </summary>
 public sealed class SmaugObservationLog
 {
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
     public List<PriceObservation> Observations { get; set; } = [];
 }
 
@@ -66,6 +66,15 @@ public sealed class PriceObservation
     public string FavorTier { get; set; } = "";
     public int CivicPrideLevel { get; set; }
     public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>
+    /// PG session identity at the moment the sell was observed (sourced from
+    /// <c>IGameSessionService.Current</c>). Used by <c>ObservationKey</c> to
+    /// dedup replays of the same vendor sell across Mithril restarts within
+    /// the same PG session. Empty for legacy (pre-v2) observations migrated
+    /// forward — they keep their wall-clock-stamped key shape.
+    /// </summary>
+    public string SessionId { get; set; } = "";
 
     /// <summary>Ratio of price paid to base Value; undefined when Value is zero.</summary>
     [JsonIgnore]

--- a/src/Smaug.Module/Domain/PriceCalibrationService.cs
+++ b/src/Smaug.Module/Domain/PriceCalibrationService.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.IO;
 using System.Text.Json;
+using Mithril.GameState.Sessions;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
@@ -21,7 +22,7 @@ public sealed record PriceEstimateResult(double Price, string Tier, int SampleCo
 public sealed class PriceCalibrationService
 {
     /// <summary>Local schema version: shape of <see cref="PriceObservation"/> records on disk.</summary>
-    public const int CurrentSchemaVersion = 1;
+    public const int CurrentSchemaVersion = 2;
 
     /// <summary>
     /// Wire schema version stamped into <see cref="VendorRatesPayload.SchemaVersion"/> when
@@ -34,11 +35,15 @@ public sealed class PriceCalibrationService
     public const int CommunityWireSchemaVersion = 1;
 
     private readonly IReferenceDataService _refData;
+    private readonly IGameSessionService? _session;
     private readonly ICommunityCalibrationService? _community;
     private readonly CalibrationSettings? _calibrationSettings;
     private readonly IDiagnosticsSink? _diag;
     private readonly string _dataPath;
     private readonly string _observationsPath;
+    // Fast-path dedup set: rebuilt on Load, updated on every persist. Replays
+    // produce identical keys → short-circuit fires before touching Observations.
+    private readonly HashSet<string> _observationKeys = new(StringComparer.Ordinal);
 
     private PriceCalibrationData _data = new();
 
@@ -56,9 +61,11 @@ public sealed class PriceCalibrationService
         string dataDir,
         ICommunityCalibrationService? community = null,
         CalibrationSettings? calibrationSettings = null,
-        IDiagnosticsSink? diag = null)
+        IDiagnosticsSink? diag = null,
+        IGameSessionService? session = null)
     {
         _refData = refData;
+        _session = session;
         _community = community;
         _calibrationSettings = calibrationSettings;
         _diag = diag;
@@ -120,7 +127,17 @@ public sealed class PriceCalibrationService
             FavorTier = favorTier,
             CivicPrideLevel = civicPrideLevel,
             Timestamp = timestamp,
+            SessionId = _session?.Current?.SessionId ?? "",
         };
+
+        var key = ObservationKey(observation);
+        if (!_observationKeys.Add(key))
+        {
+            // Replay-on-relaunch: same session, same log-line timestamp, same
+            // npc/item/price. Drop silently so SampleCount stays clean.
+            _diag?.Trace("Smaug.Calibration", $"Skipped replay of observation {key}");
+            return;
+        }
 
         _data.Observations.Add(observation);
         RecomputeRates();
@@ -311,6 +328,19 @@ public sealed class PriceCalibrationService
             _data.Observations = mergedObservations;
             _data.Version = loadedVersion;
 
+            // v1 → v2: metadata-only migration. Existing records get
+            // SessionId="" (the legacy default). They keep their original
+            // (wall-clock-stamped) Timestamp so ObservationKey collapses to
+            // a stable identity for them; new records get session-keyed ones.
+            if (_data.Version < 2)
+            {
+                foreach (var obs in _data.Observations) obs.SessionId ??= "";
+                _diag?.Info("Smaug.Calibration",
+                    $"Migrating calibration v{_data.Version} → v2: {_data.Observations.Count} observations carried forward (legacy session field defaults).");
+                _data.Version = 2;
+            }
+
+            RebuildObservationKeySet();
             RecomputeRates();
 
             if (legacyHadObservations)
@@ -470,15 +500,21 @@ public sealed class PriceCalibrationService
     }
 
     /// <summary>
-    /// Stable identifier used to dedup observations when both files carry data
-    /// (the downgrade-then-upgrade case). PriceObservation has no Quantity or
-    /// sequence id; two genuine consecutive sells of the same item to the same
-    /// NPC at the same price within the same OS clock tick (~15.6ms on Windows)
-    /// will collide on this key. Acceptable: aggregates barely move from one
-    /// dropped duplicate, and the alternative is a schema bump for a sequence id.
+    /// Stable observation identity. Includes <see cref="PriceObservation.SessionId"/>
+    /// so log-replay-on-relaunch within the same PG session produces the same key
+    /// and dedup short-circuits in <see cref="RecordObservation"/>. Legacy v1
+    /// records (no SessionId on disk) get <c>SessionId = ""</c> from migration —
+    /// they keep their wall-clock-stamped key shape, identical to the pre-#201
+    /// import-dedup form, so existing community exports still merge correctly.
     /// </summary>
     private static string ObservationKey(PriceObservation o) =>
-        $"{o.NpcKey}|{o.InternalName}|{o.PricePaid}|{o.Timestamp:O}";
+        $"{o.SessionId}|{o.NpcKey}|{o.InternalName}|{o.PricePaid}|{o.Timestamp:O}";
+
+    private void RebuildObservationKeySet()
+    {
+        _observationKeys.Clear();
+        foreach (var obs in _data.Observations) _observationKeys.Add(ObservationKey(obs));
+    }
 
     // ── Community export ────────────────────────────────────────────────
 

--- a/src/Smaug.Module/Smaug.Module.csproj
+++ b/src/Smaug.Module/Smaug.Module.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+    <ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\smaug.ico" />

--- a/src/Smaug.Module/SmaugModule.cs
+++ b/src/Smaug.Module/SmaugModule.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Mithril.GameState.Sessions;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
@@ -42,7 +43,8 @@ public sealed class SmaugModule : IMithrilModule
             Path.Combine(localApp, "Mithril", "Smaug"),
             sp.GetService<ICommunityCalibrationService>(),
             sp.GetRequiredService<SmaugSettings>().Calibration,
-            sp.GetService<IDiagnosticsSink>()));
+            sp.GetService<IDiagnosticsSink>(),
+            sp.GetService<IGameSessionService>()));
 
         services.AddSingleton<VendorCatalogViewModel>();
         services.AddSingleton<VendorShopViewModel>();

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -90,7 +90,10 @@ public sealed class VendorIngestionService : BackgroundService
                         sold.Price,
                         _context.ActiveFavorTier!,
                         _context.CivicPrideLevel,
-                        DateTimeOffset.UtcNow);
+                        // Use the log-line timestamp (post-#183 + #201 session anchor) so
+                        // replay-on-relaunch produces the same persisted Timestamp and
+                        // dedup short-circuits. UtcNow at record time would diverge.
+                        new DateTimeOffset(raw.Timestamp, TimeSpan.Zero));
                     break;
             }
         }

--- a/tests/Arwen.Tests/CalibrationServiceTests.cs
+++ b/tests/Arwen.Tests/CalibrationServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Arwen.Domain;
 using FluentAssertions;
 using Mithril.GameState.Inventory;
+using Mithril.GameState.Sessions;
 using Mithril.Shared.Reference;
 using Xunit;
 
@@ -540,12 +541,16 @@ public sealed class CalibrationServiceTests
             survivor.ItemInternalName.Should().Be("Moonstone");
             survivor.Quantity.Should().Be(1);
 
-            // File rewritten at v3.
-            svc.Data.Version.Should().Be(3);
+            // Migration chain runs v2 → v3 → v4. Survivor has its v4 metadata
+            // (SessionId, InstanceId) default-initialised — legacy records keep
+            // their original key shape but coexist with future session-keyed ones.
+            svc.Data.Version.Should().Be(4);
+            survivor.SessionId.Should().Be("");
+            survivor.InstanceId.Should().Be(0);
             using var doc = JsonDocument.Parse(File.ReadAllBytes(v2Path));
-            doc.RootElement.GetProperty("version").GetInt32().Should().Be(3);
+            doc.RootElement.GetProperty("version").GetInt32().Should().Be(4);
 
-            // Pre-migration backup exists.
+            // Pre-migration backup exists (one-shot snapshot before the migration ladder ran).
             File.Exists(v2Path + ".v2.bak").Should().BeTrue();
         }
         finally
@@ -1249,5 +1254,208 @@ public sealed class CalibrationServiceTests
         {
             SafeDeleteDir(dir);
         }
+    }
+
+    // ── Session-keyed dedup (#201) ──────────────────────────────────────
+
+    private static (CalibrationService svc, GiftIndex index, FakeInventory inv) BuildServiceWithSession(
+        string dataDir, FakeSession session)
+    {
+        var refData = BuildRefData();
+        var index = new GiftIndex();
+        index.Build(refData.Items, refData.Npcs);
+        var inv = new FakeInventory();
+        var svc = new CalibrationService(refData, index, inv, dataDir, session: session);
+        return (svc, index, inv);
+    }
+
+    [Fact]
+    public void Replay_OfSameGiftInSameSession_DedupsToOneObservation()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var (svc, _, inv) = BuildServiceWithSession(dir, session);
+            inv.Add(12345, "Moonstone");
+
+            // Simulate the live ingestion of one gift, then a replay of the
+            // same sequence (Mithril relaunched mid-PG-session and the seed
+            // buffer re-emits the same lines).
+            var ts = new DateTimeOffset(2026, 5, 11, 12, 30, 0, TimeSpan.Zero);
+            svc.OnStartInteraction("NPC_Sanja", ts);
+            svc.OnItemDeleted(12345, ts);
+            svc.OnDeltaFavor("NPC_Sanja", 22.5, ts);
+
+            svc.OnStartInteraction("NPC_Sanja", ts);
+            svc.OnItemDeleted(12345, ts);
+            svc.OnDeltaFavor("NPC_Sanja", 22.5, ts);
+
+            svc.Data.Observations.Should().HaveCount(1,
+                "second triplet is a replay — session id + instance id collide on the key");
+            var obs = svc.Data.Observations[0];
+            obs.SessionId.Should().Be(session.Current!.SessionId);
+            obs.InstanceId.Should().Be(12345);
+            obs.Timestamp.Should().Be(ts);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void NewSession_AfterRelogin_RecordsSeparateObservation()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var (svc, _, inv) = BuildServiceWithSession(dir, session);
+            inv.Add(12345, "Moonstone");
+
+            var ts1 = new DateTimeOffset(2026, 5, 11, 12, 30, 0, TimeSpan.Zero);
+            svc.OnStartInteraction("NPC_Sanja", ts1);
+            svc.OnItemDeleted(12345, ts1);
+            svc.OnDeltaFavor("NPC_Sanja", 22.5, ts1);
+
+            // PG re-login: same instance id will appear again (PG reuses ids per
+            // session). A new session must produce a distinct observation.
+            session.Set("char|2026-05-11T14:00:00Z");
+
+            var ts2 = new DateTimeOffset(2026, 5, 11, 14, 10, 0, TimeSpan.Zero);
+            inv.Add(12345, "Moonstone");
+            svc.OnStartInteraction("NPC_Sanja", ts2);
+            svc.OnItemDeleted(12345, ts2);
+            svc.OnDeltaFavor("NPC_Sanja", 22.5, ts2);
+
+            svc.Data.Observations.Should().HaveCount(2,
+                "different session id — same instance/npc/delta is a genuinely new gift");
+            svc.Data.Observations[0].SessionId.Should().NotBe(svc.Data.Observations[1].SessionId);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void Replay_AfterPersistAndReload_StillDedups()
+    {
+        // End-to-end: gift → relaunch → seed replays the same triplet. The
+        // restarted CalibrationService loads from disk, rebuilds the dedup
+        // set, and the replayed triplet collides on key load → no duplicate.
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var refData = BuildRefData();
+            var index = new GiftIndex();
+            index.Build(refData.Items, refData.Npcs);
+            var inv = new FakeInventory();
+            inv.Add(12345, "Moonstone");
+
+            var ts = new DateTimeOffset(2026, 5, 11, 12, 30, 0, TimeSpan.Zero);
+            var first = new CalibrationService(refData, index, inv, dir, session: session);
+            first.OnStartInteraction("NPC_Sanja", ts);
+            first.OnItemDeleted(12345, ts);
+            first.OnDeltaFavor("NPC_Sanja", 22.5, ts);
+            first.Data.Observations.Should().HaveCount(1);
+
+            // Simulate Mithril relaunch: new CalibrationService instance reads
+            // from the same dataDir, then the seed replay re-fires the events.
+            var second = new CalibrationService(refData, index, inv, dir, session: session);
+            second.Data.Observations.Should().HaveCount(1, "loaded from disk");
+            second.OnStartInteraction("NPC_Sanja", ts);
+            second.OnItemDeleted(12345, ts);
+            second.OnDeltaFavor("NPC_Sanja", 22.5, ts);
+            second.Data.Observations.Should().HaveCount(1, "replay short-circuited on key collision");
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void LegacyV3Observation_DoesNotCollideWithV4SessionKeyedObservation()
+    {
+        // A pre-v4 record on disk carries SessionId="" InstanceId=0. A
+        // freshly-recorded v4 observation for the same npc/item/delta MUST
+        // produce a distinct key (it's genuinely a new gift in a session).
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("arwen_test");
+        try
+        {
+            // Seed a v3-shape file (the migration ladder fills the v4 fields with defaults).
+            var path = Path.Combine(dir, "calibration.json");
+            var v3Json = """
+                {
+                  "version": 3,
+                  "observations": [
+                    {
+                      "npcKey": "NPC_Sanja",
+                      "itemInternalName": "Moonstone",
+                      "itemKeywords": ["Crystal", "Moonstone"],
+                      "matchedPreferences": [
+                        { "name": "Moonstones", "desire": "Love", "pref": 1.5, "keywords": ["Moonstone"] }
+                      ],
+                      "itemValue": 100,
+                      "favorDelta": 22.5,
+                      "quantity": 1,
+                      "timestamp": "2026-04-20T00:00:00+00:00"
+                    }
+                  ]
+                }
+                """;
+            File.WriteAllText(path, v3Json);
+
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var (svc, _, inv) = BuildServiceWithSession(dir, session);
+            svc.Data.Observations.Should().HaveCount(1, "loaded the v3 record");
+            svc.Data.Observations[0].SessionId.Should().Be("");
+
+            // Record a genuinely new gift in a v4 session. Same npc/item/delta
+            // but in-session InstanceId is non-zero → distinct key.
+            inv.Add(12345, "Moonstone");
+            var ts = new DateTimeOffset(2026, 5, 11, 12, 30, 0, TimeSpan.Zero);
+            svc.OnStartInteraction("NPC_Sanja", ts);
+            svc.OnItemDeleted(12345, ts);
+            svc.OnDeltaFavor("NPC_Sanja", 22.5, ts);
+
+            svc.Data.Observations.Should().HaveCount(2, "v3 legacy + v4 new — different keys");
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IGameSessionService"/> stub: holds a single
+    /// <see cref="GameSession"/> and lets tests flip to a new one via
+    /// <see cref="Set"/>. Subscribe is implemented for shape but not used
+    /// by CalibrationService today (it just reads <c>Current</c>).
+    /// </summary>
+    private sealed class FakeSession : IGameSessionService
+    {
+        public GameSession? Current { get; private set; }
+        public event EventHandler<GameSession>? SessionStarted;
+        public FakeSession(string sessionId)
+        {
+            Set(sessionId);
+        }
+        public void Set(string sessionId)
+        {
+            // Synthesize a plausible login instant from the id for shape; only
+            // SessionId matters for the dedup key.
+            Current = new GameSession(sessionId, "char", new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc), TimeSpan.Zero);
+            SessionStarted?.Invoke(this, Current);
+        }
+        public IDisposable Subscribe(Action<GameSession> handler)
+        {
+            if (Current is not null) handler(Current);
+            return new Sub();
+        }
+        private sealed class Sub : IDisposable { public void Dispose() { } }
     }
 }

--- a/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
@@ -1,0 +1,249 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Sessions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Sessions;
+
+public sealed class GameSessionServiceTests
+{
+    private const string BannerEmraell =
+        "[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00";
+
+    private const string BannerSecond =
+        "[14:00:00] Logged in as character Emraell. Time UTC=05/11/2026 14:00:00. Timezone Offset 01:00:00";
+
+    private const string BannerOtherCharacter =
+        "[14:00:00] Logged in as character Frodo. Time UTC=05/11/2026 14:00:00. Timezone Offset 01:00:00";
+
+    [Fact]
+    public async Task First_banner_populates_Current_and_raises_SessionStarted()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        try
+        {
+            GameSession? captured = null;
+            svc.SessionStarted += (_, s) => captured = s;
+
+            stream.Push(BannerEmraell);
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.CharacterName.Should().Be("Emraell");
+            svc.LoggedInUtc.Should().Be(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+            captured.Should().NotBeNull();
+            captured!.SessionId.Should().Be(svc.Current.SessionId);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Replaying_same_banner_does_not_re_fire()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        try
+        {
+            var startedCount = 0;
+            var anchorChangedCount = 0;
+            svc.SessionStarted += (_, _) => startedCount++;
+            svc.AnchorChanged += (_, _) => anchorChangedCount++;
+
+            stream.Push(BannerEmraell);
+            stream.Push(BannerEmraell);
+            stream.Push(BannerEmraell);
+            await RunUntilDrainedAsync(svc, stream);
+
+            startedCount.Should().Be(1);
+            anchorChangedCount.Should().Be(1);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Second_banner_with_new_login_mints_new_session()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        try
+        {
+            var sessions = new List<GameSession>();
+            svc.SessionStarted += (_, s) => sessions.Add(s);
+
+            stream.Push(BannerEmraell);
+            stream.Push(BannerSecond);
+            await RunUntilDrainedAsync(svc, stream);
+
+            sessions.Should().HaveCount(2);
+            sessions[0].LoggedInUtc.Should().Be(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+            sessions[1].LoggedInUtc.Should().Be(new DateTime(2026, 5, 11, 14, 0, 0, DateTimeKind.Utc));
+            sessions[1].SessionId.Should().NotBe(sessions[0].SessionId);
+            svc.Current!.SessionId.Should().Be(sessions[1].SessionId);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Different_character_mints_new_session_id()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        try
+        {
+            var sessions = new List<GameSession>();
+            svc.SessionStarted += (_, s) => sessions.Add(s);
+
+            stream.Push(BannerEmraell);
+            stream.Push(BannerOtherCharacter);
+            await RunUntilDrainedAsync(svc, stream);
+
+            sessions.Should().HaveCount(2);
+            sessions[0].CharacterName.Should().Be("Emraell");
+            sessions[1].CharacterName.Should().Be("Frodo");
+            sessions[1].SessionId.Should().NotBe(sessions[0].SessionId);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Subscribe_after_session_observed_replays_current_synchronously()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(BannerEmraell);
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var replayed = new List<GameSession>();
+            using var sub = svc.Subscribe(replayed.Add);
+
+            replayed.Should().HaveCount(1);
+            replayed[0].SessionId.Should().Be(svc.Current!.SessionId);
+
+            // Live event still arrives without re-subscribing — the service is
+            // still running and a second banner mints + delivers a new session.
+            stream.Push(BannerSecond);
+            await stream.WaitForDrainAsync(cts.Token);
+
+            replayed.Should().HaveCount(2);
+            replayed[1].SessionId.Should().NotBe(replayed[0].SessionId);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Subscribe_with_no_current_session_does_not_invoke_handler()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        try
+        {
+            // Service started but no banner yet.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var runTask = svc.StartAsync(cts.Token);
+
+            var seen = 0;
+            using var sub = svc.Subscribe(_ => seen++);
+
+            seen.Should().Be(0);
+            await cts.CancelAsync();
+            _ = runTask;
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Non_banner_lines_do_not_affect_session()
+    {
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var svc = new GameSessionService(stream);
+        try
+        {
+            var starts = 0;
+            svc.SessionStarted += (_, _) => starts++;
+
+            stream.Push("[12:25:00] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")");
+            stream.Push("[12:25:01] Some unrelated engine log line.");
+            stream.Push(BannerEmraell);
+            stream.Push("[12:25:05] LocalPlayer: ProcessAddItem(Barley(1), 0, False)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            starts.Should().Be(1);
+            svc.Current!.CharacterName.Should().Be("Emraell");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    private static async Task RunUntilDrainedAsync(GameSessionService svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(GameSessionService svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public ScriptedStream(params string[] lines)
+        {
+            if (lines.Length == 0)
+            {
+                _drained.TrySetResult();
+                return;
+            }
+            Interlocked.Add(ref _pending, lines.Length);
+            foreach (var line in lines) _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+        }
+
+        public void Push(string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+        public Task WaitForDrainAsync(TimeSpan timeout) => _drained.Task.WaitAsync(timeout);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
@@ -18,10 +18,11 @@ public sealed class GameSessionServiceTests
         "[14:00:00] Logged in as character Frodo. Time UTC=05/11/2026 14:00:00. Timezone Offset 01:00:00";
 
     [Fact]
-    public async Task First_banner_populates_Current_and_raises_SessionStarted()
+    public async Task First_banner_populates_Current_and_raises_SessionStarted_and_pushes_to_anchor()
     {
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new GameSessionService(stream);
+        var anchor = new SessionAnchor();
+        var svc = new GameSessionService(stream, anchor);
         try
         {
             GameSession? captured = null;
@@ -32,7 +33,9 @@ public sealed class GameSessionServiceTests
 
             svc.Current.Should().NotBeNull();
             svc.Current!.CharacterName.Should().Be("Emraell");
-            svc.LoggedInUtc.Should().Be(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+            // Shared anchor was pushed-to so the sequencer (Mithril.Shared) can
+            // re-anchor without depending on GameSessionService directly.
+            anchor.LoggedInUtc.Should().Be(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
             captured.Should().NotBeNull();
             captured!.SessionId.Should().Be(svc.Current.SessionId);
         }
@@ -43,13 +46,14 @@ public sealed class GameSessionServiceTests
     public async Task Replaying_same_banner_does_not_re_fire()
     {
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new GameSessionService(stream);
+        var anchor = new SessionAnchor();
+        var svc = new GameSessionService(stream, anchor);
         try
         {
             var startedCount = 0;
             var anchorChangedCount = 0;
             svc.SessionStarted += (_, _) => startedCount++;
-            svc.AnchorChanged += (_, _) => anchorChangedCount++;
+            anchor.AnchorChanged += (_, _) => anchorChangedCount++;
 
             stream.Push(BannerEmraell);
             stream.Push(BannerEmraell);

--- a/tests/Mithril.GameState.Tests/Sessions/LoginBannerParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/LoginBannerParserTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Mithril.GameState.Sessions;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Sessions;
+
+public class LoginBannerParserTests
+{
+    [Fact]
+    public void Parses_canonical_banner()
+    {
+        var line = "[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00";
+
+        LoginBannerParser.TryParse(line, out var session).Should().BeTrue();
+
+        session.CharacterName.Should().Be("Emraell");
+        session.LoggedInUtc.Should().Be(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+        session.LoggedInUtc.Kind.Should().Be(DateTimeKind.Utc);
+        session.TimezoneOffset.Should().Be(TimeSpan.FromHours(1));
+        session.SessionId.Should().Be($"Emraell|{session.LoggedInUtc:O}");
+    }
+
+    [Fact]
+    public void Parses_banner_without_log_prefix()
+    {
+        var line = "Logged in as character Foo. Time UTC=1/2/2026 3:4:5. Timezone Offset 00:00:00";
+
+        LoginBannerParser.TryParse(line, out var session).Should().BeTrue();
+
+        session.CharacterName.Should().Be("Foo");
+        session.LoggedInUtc.Should().Be(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+        session.TimezoneOffset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Parses_negative_offset()
+    {
+        var line = "[00:00:00] Logged in as character Bar. Time UTC=12/31/2025 23:59:59. Timezone Offset -05:00:00";
+
+        LoginBannerParser.TryParse(line, out var session).Should().BeTrue();
+
+        session.TimezoneOffset.Should().Be(TimeSpan.FromHours(-5));
+    }
+
+    [Fact]
+    public void Same_banner_collapses_to_same_session_id()
+    {
+        var line = "[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00";
+
+        LoginBannerParser.TryParse(line, out var first).Should().BeTrue();
+        LoginBannerParser.TryParse(line, out var second).Should().BeTrue();
+
+        second.SessionId.Should().Be(first.SessionId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("LocalPlayer: ProcessAddPlayer(123, 456, \"\", \"Emraell\")")]
+    [InlineData("[12:25:04] Logged in as character . Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00")]
+    [InlineData("[12:25:04] Logged in as character Emraell. Time UTC=not-a-date. Timezone Offset 01:00:00")]
+    [InlineData("[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset garbage")]
+    public void Rejects_non_banner_lines(string line)
+    {
+        LoginBannerParser.TryParse(line, out _).Should().BeFalse();
+    }
+}

--- a/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
@@ -172,10 +172,201 @@ public sealed class PlayerLogTailReaderTests : IDisposable
             .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 59, 0, DateTimeKind.Utc));
     }
 
+    // ── Session-anchor scenarios ────────────────────────────────────
+
+    [Fact]
+    public void ReadNew_WithSessionAnchor_PinsDateToLoggedInUtcInsteadOfMtime()
+    {
+        // The session banner pins 2026-05-11. Even if the file's mtime is a
+        // year off, the session anchor wins. Catches the mtime-drift case
+        // (copied file, system clock skew, stale on-disk metadata).
+        File.WriteAllText(_logPath,
+            "[12:25:04] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")\n" +
+            "[12:30:00] LocalPlayer: ProcessCompleteQuest(1, 1)\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var anchor = new FakeSessionAnchor(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+        var reader = new PlayerLogTailReader(_logPath, sessionAnchor: anchor);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(2);
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 11, 12, 30, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ReadNew_WithSessionAnchor_CrossesMidnightInLiveStream()
+    {
+        // Login at 22:00; live stream at 23:59:55 then 00:00:05. Verifies
+        // the forward-rollover detection still fires under session anchoring,
+        // and that priming _prevUtcTimeOfDay with the login tod doesn't
+        // mis-fire a rollover on the first stamped line.
+        File.WriteAllText(_logPath, "[22:00:00] LocalPlayer: login moment\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 22, 0, 0, DateTimeKind.Utc));
+
+        var anchor = new FakeSessionAnchor(new DateTime(2026, 5, 10, 22, 0, 0, DateTimeKind.Utc));
+        var reader = new PlayerLogTailReader(_logPath, sessionAnchor: anchor);
+        reader.ReadNew();
+
+        File.AppendAllText(_logPath, "[23:59:55] just-before-midnight\n[00:00:05] just-after-midnight\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 0, 0, 5, DateTimeKind.Utc));
+
+        var second = reader.ReadNew();
+        second.Should().HaveCount(2);
+        second[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 59, 55, DateTimeKind.Utc));
+        second[1].Timestamp.Should().Be(new DateTime(2026, 5, 11, 0, 0, 5, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ReadNew_AnchorChanged_ReAnchorsToNewSession()
+    {
+        // First batch under session A. Then a second login (PG re-login)
+        // raises AnchorChanged with a different LoggedInUtc — possibly on a
+        // different calendar day. Subsequent lines must stamp against the
+        // new date.
+        File.WriteAllText(_logPath, "[12:00:00] LocalPlayer: line-one\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 12, 0, 0, DateTimeKind.Utc));
+
+        var anchor = new FakeSessionAnchor(new DateTime(2026, 5, 10, 11, 0, 0, DateTimeKind.Utc));
+        var reader = new PlayerLogTailReader(_logPath, sessionAnchor: anchor);
+        var first = reader.ReadNew();
+        first.Should().ContainSingle()
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 12, 0, 0, DateTimeKind.Utc));
+
+        // Simulate PG re-login on the next UTC day.
+        anchor.Set(new DateTime(2026, 5, 11, 10, 0, 0, DateTimeKind.Utc));
+
+        File.AppendAllText(_logPath, "[10:30:00] LocalPlayer: post-relogin\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 10, 30, 0, DateTimeKind.Utc));
+
+        var second = reader.ReadNew();
+        second.Should().ContainSingle()
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 11, 10, 30, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ReadNew_WithSessionAnchor_DoesNotMisFireRolloverOnFirstStampedLine()
+    {
+        // First gameplay line's tod is *earlier* than the login tod (e.g. the
+        // engine emits a quick scripted line at 12:25:03 right after the
+        // 12:25:04 banner). The seed `_prevUtcTimeOfDay = LoggedInUtc.tod`
+        // means the next StampForLine sees `tod < prev` — but the delta is
+        // ~1 second, far below the 12h threshold, so no rollover should
+        // fire. The line stays on the same calendar day as the login.
+        File.WriteAllText(_logPath, "[12:25:03] LocalPlayer: scripted-before-login-stamp\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 12, 25, 3, DateTimeKind.Utc));
+
+        var anchor = new FakeSessionAnchor(new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc));
+        var reader = new PlayerLogTailReader(_logPath, sessionAnchor: anchor);
+        var lines = reader.ReadNew();
+
+        lines.Should().ContainSingle()
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 11, 12, 25, 3, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ReadNew_WithoutSessionAnchor_FallsBackToMtimeAnchoring()
+    {
+        // Same setup as the pre-existing mtime tests, but constructed with
+        // sessionAnchor: null explicitly to pin the contract. mtime path
+        // remains the fallback for pre-banner lines and the no-session case.
+        File.WriteAllText(_logPath, "[14:30:00] LocalPlayer: line\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath, sessionAnchor: null);
+        var lines = reader.ReadNew();
+
+        lines.Should().ContainSingle()
+            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
+    }
+
+    // ── Seed-marker scenarios ───────────────────────────────────────
+
+    [Fact]
+    public void SeedToSessionStart_PrefersEarlierOfBannerAndProcessAddPlayer()
+    {
+        // Banner emitted first, ProcessAddPlayer a moment later. The seed
+        // anchors at the BANNER so GameSessionService can parse it from the
+        // replay; ProcessAddPlayer is still in the replay because it comes
+        // after.
+        File.WriteAllText(_logPath,
+            "[00:00:00] stale-pre-session-noise\n" +
+            "[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00\n" +
+            "[12:25:05] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")\n" +
+            "[12:25:10] LocalPlayer: ProcessCompleteQuest(1, 1)\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 12, 25, 10, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        reader.SeedToSessionStart();
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(3);
+        lines[0].Line.Should().Contain("Logged in as character");
+        lines[1].Line.Should().Contain("ProcessAddPlayer");
+        lines[2].Line.Should().Contain("ProcessCompleteQuest");
+    }
+
+    [Fact]
+    public void SeedToSessionStart_FallsBackToProcessAddPlayerWhenBannerMissing()
+    {
+        // Pre-banner clients or pathological log states with no banner still
+        // anchor on ProcessAddPlayer. Pre-existing behaviour preserved.
+        File.WriteAllText(_logPath,
+            "[00:00:00] stale-pre-session-noise\n" +
+            "[12:25:05] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")\n" +
+            "[12:25:10] LocalPlayer: ProcessCompleteQuest(1, 1)\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 12, 25, 10, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        reader.SeedToSessionStart();
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(2);
+        lines[0].Line.Should().Contain("ProcessAddPlayer");
+        lines[1].Line.Should().Contain("ProcessCompleteQuest");
+    }
+
+    [Fact]
+    public void SeedToSessionStart_WithProcessAddPlayerBeforeBanner_StillStartsAtTheEarlierOne()
+    {
+        // Defensive: if some PG client variant emits ProcessAddPlayer FIRST
+        // and the banner later, picking the earlier marker keeps both in
+        // the replay regardless. (Today's expected ordering has the banner
+        // first, but the seed is order-agnostic.)
+        File.WriteAllText(_logPath,
+            "[00:00:00] stale-pre-session-noise\n" +
+            "[12:25:03] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")\n" +
+            "[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00\n" +
+            "[12:25:10] LocalPlayer: ProcessCompleteQuest(1, 1)\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 12, 25, 10, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        reader.SeedToSessionStart();
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(3);
+        lines[0].Line.Should().Contain("ProcessAddPlayer");
+        lines[1].Line.Should().Contain("Logged in as character");
+        lines[2].Line.Should().Contain("ProcessCompleteQuest");
+    }
+
     private sealed class FixedTimeProvider : TimeProvider
     {
         private readonly DateTimeOffset _now;
         public FixedTimeProvider(DateTime utc) => _now = new DateTimeOffset(utc, TimeSpan.Zero);
         public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class FakeSessionAnchor : ISessionAnchor
+    {
+        private DateTime? _loggedInUtc;
+        public FakeSessionAnchor(DateTime? loggedInUtc) { _loggedInUtc = loggedInUtc; }
+        public DateTime? LoggedInUtc => _loggedInUtc;
+        public event EventHandler? AnchorChanged;
+        public void Set(DateTime? loggedInUtc)
+        {
+            _loggedInUtc = loggedInUtc;
+            AnchorChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 }

--- a/tests/Smaug.Tests/PriceCalibrationReplayTests.cs
+++ b/tests/Smaug.Tests/PriceCalibrationReplayTests.cs
@@ -1,0 +1,190 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.GameState.Sessions;
+using Mithril.Shared.Reference;
+using Smaug.Domain;
+using Xunit;
+
+namespace Smaug.Tests;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class PriceCalibrationReplayTests
+{
+    private static void SafeDeleteDir(string dir)
+    {
+        if (!Directory.Exists(dir)) return;
+        try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private static PriceCalibrationService BuildService(string dataDir, FakeSession? session = null) =>
+        new(refData: new FakeRefData(), dataDir, session: session);
+
+    private static DateTimeOffset Ts(int hour, int min) =>
+        new(2026, 5, 11, hour, min, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Replay_OfSameSellInSameSession_DedupsToOneObservation()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("smaug_test");
+        try
+        {
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var svc = BuildService(dir, session);
+
+            // Live ingestion of one sell, then replay of the same (Mithril
+            // relaunched mid-PG-session and the seed buffer re-emits).
+            var ts = Ts(13, 0);
+            svc.RecordObservation("NPC_Therese", "BottleOfWater", 100, FavorTierName.Neutral, 0, ts);
+            svc.RecordObservation("NPC_Therese", "BottleOfWater", 100, FavorTierName.Neutral, 0, ts);
+
+            svc.Data.Observations.Should().HaveCount(1,
+                "second call has the same session + log-line timestamp → key collision");
+            svc.Data.Observations[0].SessionId.Should().Be(session.Current!.SessionId);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void NewSession_RecordsSeparateObservation()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("smaug_test");
+        try
+        {
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var svc = BuildService(dir, session);
+
+            svc.RecordObservation("NPC_Therese", "BottleOfWater", 100, FavorTierName.Neutral, 0, Ts(13, 0));
+            session.Set("char|2026-05-11T14:00:00Z");
+            svc.RecordObservation("NPC_Therese", "BottleOfWater", 100, FavorTierName.Neutral, 0, Ts(15, 0));
+
+            svc.Data.Observations.Should().HaveCount(2);
+            svc.Data.Observations[0].SessionId.Should().NotBe(svc.Data.Observations[1].SessionId);
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void Replay_AfterPersistAndReload_StillDedups()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("smaug_test");
+        try
+        {
+            var session = new FakeSession("char|2026-05-11T12:25:04Z");
+            var ts = Ts(13, 0);
+
+            var first = BuildService(dir, session);
+            first.RecordObservation("NPC_Therese", "BottleOfWater", 100, FavorTierName.Neutral, 0, ts);
+            first.Data.Observations.Should().HaveCount(1);
+
+            // Mithril relaunch: fresh service loads the observation from disk,
+            // then the seed re-fires.
+            var second = BuildService(dir, session);
+            second.Data.Observations.Should().HaveCount(1);
+            second.RecordObservation("NPC_Therese", "BottleOfWater", 100, FavorTierName.Neutral, 0, ts);
+            second.Data.Observations.Should().HaveCount(1, "replay short-circuited on key collision");
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    [Fact]
+    public void V1Legacy_MigratesToV2_WithEmptySessionId()
+    {
+        var dir = Mithril.TestSupport.TestPaths.CreateTempDir("smaug_test");
+        try
+        {
+            // Pre-v2 single-file shape (also exercises the split migration).
+            File.WriteAllText(Path.Combine(dir, "calibration.json"), """
+                {
+                  "version": 1,
+                  "observations": [
+                    {
+                      "npcKey": "NPC_Therese",
+                      "internalName": "BottleOfWater",
+                      "baseValue": 11,
+                      "pricePaid": 100,
+                      "favorTier": "Neutral",
+                      "civicPrideLevel": 0,
+                      "timestamp": "2026-04-20T00:00:00+00:00"
+                    }
+                  ]
+                }
+                """);
+
+            var svc = new PriceCalibrationService(new FakeRefData(), dir);
+
+            svc.Data.Observations.Should().HaveCount(1);
+            svc.Data.Version.Should().Be(PriceCalibrationService.CurrentSchemaVersion);
+            svc.Data.Observations[0].SessionId.Should().Be("");
+        }
+        finally
+        {
+            SafeDeleteDir(dir);
+        }
+    }
+
+    private sealed class FakeSession : IGameSessionService
+    {
+        public GameSession? Current { get; private set; }
+        public event EventHandler<GameSession>? SessionStarted;
+        public FakeSession(string sessionId) { Set(sessionId); }
+        public void Set(string sessionId)
+        {
+            Current = new GameSession(sessionId, "char",
+                new DateTime(2026, 5, 11, 12, 25, 4, DateTimeKind.Utc), TimeSpan.Zero);
+            SessionStarted?.Invoke(this, Current);
+        }
+        public IDisposable Subscribe(Action<GameSession> handler)
+        {
+            if (Current is not null) handler(Current);
+            return new Sub();
+        }
+        private sealed class Sub : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class FakeRefData : IReferenceDataService
+    {
+        public IReadOnlyList<string> Keys { get; } = ["items"];
+        public IReadOnlyDictionary<long, ItemEntry> Items { get; }
+        public IReadOnlyDictionary<string, ItemEntry> ItemsByInternalName { get; }
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, ItemEntry>());
+        public IReadOnlyDictionary<string, RecipeEntry> Recipes { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, RecipeEntry> RecipesByInternalName { get; } = new Dictionary<string, RecipeEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        public FakeRefData()
+        {
+            var water = new ItemEntry(
+                1, "BottleOfWater", "Bottle of Water", MaxStackSize: 10, IconId: 0,
+                [new ItemKeyword("Drink", 0)],
+                Value: 11m);
+            Items = new Dictionary<long, ItemEntry> { [1] = water };
+            ItemsByInternalName = new Dictionary<string, ItemEntry>(StringComparer.Ordinal) { ["BottleOfWater"] = water };
+        }
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new("items", ReferenceFileSource.Bundled, "test", null, 1);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **`IGameSessionService`** in `Mithril.GameState` — parses the PG `Logged in as character X. Time UTC=… Timezone Offset …` banner into a `GameSession` (`SessionId`, `CharacterName`, `LoggedInUtc`, `TimezoneOffset`) and publishes it via an atomic-replay Subscribe pattern matching `IInventoryService` / `IQuestService`.
- Surfaces as **`ISessionAnchor`** (new in `Mithril.Shared.Logging`); `LogLineTimestampSequencer` now anchors `[HH:MM:SS]` dates on `LoggedInUtc` instead of file mtime when a session has been observed, and re-anchors on PG re-login. mtime fallback is preserved for pre-banner lines and chat logs.
- Broadens **`PlayerLogTailReader.SeedToSessionStart`** to scan back for the **earlier** of `Logged in as character ` and `ProcessAddPlayer(`, so both lines always land in the replay regardless of PG's emission order.
- **Arwen** (`GiftObservation`): adds `SessionId` + `InstanceId`, bumps v3 → v4, new `ObservationKey` shape, short-circuits `RecordObservation` on key collision, plumbs `raw.Timestamp` through `OnStartInteraction`/`OnItemDeleted`/`OnDeltaFavor` so the persisted `Timestamp` is log-truth (replacing `DateTimeOffset.UtcNow`).
- **Smaug** (`PriceObservation`): adds `SessionId`, bumps v1 → v2, new `ObservationKey` shape, short-circuits on collision, `VendorIngestionService` now passes `raw.Timestamp` instead of `UtcNow` to `RecordObservation`.

Closes the log-replay-on-relaunch double-count: when Mithril restarts mid-PG-session, the seed buffer re-emits every line since the most recent session marker. Pre-fix, both Arwen and Smaug minted fresh wall-clock-stamped duplicates on every replay. Post-fix, the session + instance form a stable dedup key and replays short-circuit silently.

Gandalf is already idempotent (`prior.StartedAt == startedAt` guard in `LootSource` / `QuestSource`); issue #86 can be closed as superseded by the audit in this PR. Saruman's `MarkSpent` is also idempotent (state-machine short-circuit + log-line timestamp).

## Migrations

Metadata-only on both modules. Pre-fix records keep their existing key shape (`SessionId=""` / `InstanceId=0` from migration), so they coexist with new session-keyed records without colliding. **Accepts the bloat** — no one-shot dedup pass.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean.
- [x] `dotnet test Mithril.slnx` — full suite passes (1,771 tests across 15 projects, including 32 new tests added in this PR).
- [x] `dotnet test tests/Mithril.GameState.Tests --filter "FullyQualifiedName~Sessions"` — 16 new tests covering banner parsing, session lifecycle, replay-idempotency.
- [x] `dotnet test tests/Mithril.Shared.Tests --filter "FullyQualifiedName~PlayerLogTailReader"` — 15 tests including 8 new for session-anchored date stamping, midnight crossings in the live stream, `AnchorChanged` re-anchor, and the multi-marker seed scan.
- [x] `dotnet test tests/Arwen.Tests --filter "FullyQualifiedName~Calibration"` — 110 tests including 4 new replay-dedup tests.
- [x] `dotnet test tests/Smaug.Tests` — 25 tests including 4 new replay-dedup tests.
- [ ] **Manual smoke (Windows, live PG client)** — run after merge:
  1. Launch PG, log in to a test character.
  2. Gift one non-stackable item to any NPC; verify Arwen records 1 observation.
  3. Close Mithril; relaunch (PG still running). Open Arwen calibration tab — observation count unchanged.
  4. Sell one item at a vendor; verify Smaug records 1 observation.
  5. Restart Mithril — Smaug observation count unchanged.
  6. Log out + re-login in PG → restart Mithril → new gift/sell creates new observations tied to the new `SessionId`.

## Files of note

- New abstraction: [`src/Mithril.Shared/Logging/ISessionAnchor.cs`](src/Mithril.Shared/Logging/ISessionAnchor.cs), [`src/Mithril.GameState/Sessions/`](src/Mithril.GameState/Sessions/).
- Sequencer integration: [`src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs`](src/Mithril.Shared/Logging/LogLineTimestampSequencer.cs).
- Seed marker change: [`src/Mithril.Shared/Logging/PlayerLogTailReader.cs`](src/Mithril.Shared/Logging/PlayerLogTailReader.cs).
- Arwen rewrite: [`src/Arwen.Module/Domain/CalibrationService.cs`](src/Arwen.Module/Domain/CalibrationService.cs), [`src/Arwen.Module/State/FavorIngestionService.cs`](src/Arwen.Module/State/FavorIngestionService.cs).
- Smaug rewrite: [`src/Smaug.Module/Domain/PriceCalibrationService.cs`](src/Smaug.Module/Domain/PriceCalibrationService.cs), [`src/Smaug.Module/State/VendorIngestionService.cs`](src/Smaug.Module/State/VendorIngestionService.cs).

## Follow-ups

- Close #86 — already-fixed, superseded by the audit notes in #201.
- Optional Gandalf polish: rebase `StartedAt`-equality guards on `SessionId`-equality. No behavioural change today; cleaner conceptually.

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)