### PR TITLE
feat: IReferenceNavigator + EntityRef + NoOpReferenceNavigator stub (#206)

### DIFF
--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -1,0 +1,29 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// Identifies a kind of game entity that can be navigated to via
+/// <see cref="IReferenceNavigator"/>.
+/// </summary>
+public enum EntityKind
+{
+    Item,
+    Recipe,
+    Ability,
+    Effect,
+    Npc,
+    Quest,
+    Lorebook,
+    Landmark,
+    Area,
+    PlayerTitle,
+    StorageVault,
+}
+
+/// <summary>
+/// A lightweight, serialization-friendly pointer to a specific game entity.
+/// Consumers pass this to <see cref="IReferenceNavigator.Open"/> to trigger
+/// navigation without coupling to any particular detail-view implementation.
+/// </summary>
+/// <param name="Kind">The category of entity.</param>
+/// <param name="InternalName">The entity's unique internal name (e.g. <c>"CraftedLeatherBoots5"</c>).</param>
+public sealed record EntityRef(EntityKind Kind, string InternalName);

--- a/src/Mithril.Shared/Reference/IReferenceNavigator.cs
+++ b/src/Mithril.Shared/Reference/IReferenceNavigator.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// Cross-module navigation contract. Call <see cref="Open"/> to direct the application
+/// to the detail view for an entity. The active implementation decides how (new panel,
+/// tab switch, overlay, etc.); callers are deliberately decoupled from that choice.
+/// </summary>
+/// <remarks>
+/// The shell registers <see cref="NoOpReferenceNavigator"/> as the default singleton.
+/// The DB module (#207) replaces this with a real implementation via its own
+/// <c>Register(IServiceCollection)</c>; the later <c>AddSingleton</c> call wins for
+/// non-keyed resolution.
+/// </remarks>
+public interface IReferenceNavigator
+{
+    /// <summary>
+    /// Navigate to the detail view for <paramref name="reference"/>.
+    /// Returns <see langword="void"/> by design — this is a fire-and-forget navigation
+    /// command, not a request for an embedded view.
+    /// </summary>
+    void Open(EntityRef reference);
+}
+
+/// <summary>
+/// No-op implementation registered by the shell until a real navigator module is present.
+/// Logs at <c>Information</c> level so missing-module cases are diagnosable without being noisy.
+/// </summary>
+public sealed class NoOpReferenceNavigator : IReferenceNavigator
+{
+    private readonly ILogger<NoOpReferenceNavigator> _logger;
+
+    public NoOpReferenceNavigator(ILogger<NoOpReferenceNavigator> logger) => _logger = logger;
+
+    /// <inheritdoc />
+    public void Open(EntityRef reference) =>
+        _logger.LogInformation(
+            "IReferenceNavigator.Open({Kind}, {InternalName}) — no module registered",
+            reference.Kind, reference.InternalName);
+}

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -163,6 +163,7 @@ public static class Program
                 .AddMithrilShellViews()
                 .AddMithrilItemDetail()
                 .AddMithrilIngredientSources()
+                .AddSingleton<IReferenceNavigator, NoOpReferenceNavigator>()
                 .AddMithrilShellCommands();
 
             Boot($"modules discovered: {builder.Services.Count(d => d.ServiceType == typeof(IMithrilModule))}");

--- a/tests/Mithril.Shared.Tests/Reference/NoOpReferenceNavigatorTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/NoOpReferenceNavigatorTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+public class NoOpReferenceNavigatorTests
+{
+    [Fact]
+    public void Open_WritesOneInfoEntry_ContainingKindAndInternalName()
+    {
+        var logger = new CapturingLogger<NoOpReferenceNavigator>();
+        var navigator = new NoOpReferenceNavigator(logger);
+        var entityRef = new EntityRef(EntityKind.Item, "CraftedLeatherBoots5");
+
+        navigator.Open(entityRef);
+
+        logger.Entries.Should().HaveCount(1);
+        var entry = logger.Entries[0];
+        entry.Level.Should().Be(LogLevel.Information);
+        entry.Message.Should().Contain("Item");
+        entry.Message.Should().Contain("CraftedLeatherBoots5");
+    }
+
+    [Fact]
+    public void Open_DoesNotThrow()
+    {
+        var logger = new CapturingLogger<NoOpReferenceNavigator>();
+        var navigator = new NoOpReferenceNavigator(logger);
+
+        var act = () => navigator.Open(new EntityRef(EntityKind.Quest, "quest_10001"));
+
+        act.Should().NotThrow();
+    }
+
+    // ---- minimal ILogger<T> stub -----------------------------------------------
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    }
+}


### PR DESCRIPTION
Closes #206. Step 2 of #203.

## Summary

Tiny cross-module navigation contract that #207's DB module will implement and consumers can begin coding against immediately.

- `Mithril.Shared.Reference.EntityKind` enum (11 entity types — Item, Recipe, Ability, Effect, Npc, Quest, Lorebook, Landmark, Area, PlayerTitle, StorageVault)
- `Mithril.Shared.Reference.EntityRef` record (`Kind` + `InternalName`)
- `Mithril.Shared.Reference.IReferenceNavigator` interface with `void Open(EntityRef reference)`
- `Mithril.Shared.Reference.NoOpReferenceNavigator` stub — logs the call at info level, returns
- Shell registers the stub via `services.AddSingleton<IReferenceNavigator, NoOpReferenceNavigator>()` in `Program.cs:166`; #207's module will override this with its real impl (last `AddSingleton<T>` wins for non-keyed singletons)

## Design notes

`Open(EntityRef)` returns void deliberately — encodes "navigate, don't hand back a reference." If a future use case wants to *embed* the detail view inline (rather than navigate to it), we'll add a separate `IReferenceDetailViewFactory.CreateDetailView(EntityRef) → FrameworkElement` interface — purely additive, no rework of existing code. #207's design constraint (detail UI built as a `UserControl`, not a `Window`) keeps that swap zero-cost.

`IResourceContribution` — originally bundled into this issue — was dropped during a design pass. Consumers compose small inline cards from shared POCOs + `Mithril.Shared.Wpf` primitives; the DB module owns the full detail view, reached via `Open(...)`. No global resource pool needed.

The 5 hardcoded shell-side `pack://` URIs (originally bundled here as a side-effect cleanup) are tracked independently as #212.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — all 708 tests in `Mithril.Shared.Tests` pass (includes 2 new facts in `NoOpReferenceNavigatorTests`); other 14 test projects also green
- [ ] Confirm `IReferenceNavigator` resolves from DI in the running shell — startup logs should show the stub registration (covered by smoke-test of any existing module's DI resolution path)

## Notes for #207

When the real impl lands, register via `services.AddSingleton<IReferenceNavigator, RealNavigator>()` in the module's `Register(IServiceCollection)`. Build the detail UI as a `UserControl`, not a `Window`, so we can later expose a `CreateDetailView(EntityRef)` factory without refactoring.

---

*Drafted by Claude (Opus 4.7), opened by @arthur-conde via Claude Code.*