### PR TITLE
feat: extend IReferenceNavigator with router-shaped history primitives (#217)

### DIFF
--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -27,3 +27,29 @@ public enum EntityKind
 /// <param name="Kind">The category of entity.</param>
 /// <param name="InternalName">The entity's unique internal name (e.g. <c>"CraftedLeatherBoots5"</c>).</param>
 public sealed record EntityRef(EntityKind Kind, string InternalName);
+
+/// <summary>
+/// Describes what kind of navigation action produced a <see cref="NavigatedEventArgs"/>.
+/// </summary>
+public enum NavigationKind
+{
+    /// <summary>A new entity was opened, pushing onto the back stack and clearing the forward stack.</summary>
+    Open,
+
+    /// <summary>The user navigated back through history.</summary>
+    Back,
+
+    /// <summary>The user navigated forward through history.</summary>
+    Forward,
+}
+
+/// <summary>
+/// Event data fired by <see cref="IReferenceNavigator.Navigated"/> on every state change.
+/// </summary>
+/// <param name="Previous">The entity that was current before this navigation, or <see langword="null"/> if there was none.</param>
+/// <param name="Current">The entity that is current after this navigation, or <see langword="null"/> if the history is now empty.</param>
+/// <param name="Kind">What kind of navigation produced this event.</param>
+public sealed record NavigatedEventArgs(
+    EntityRef? Previous,
+    EntityRef? Current,
+    NavigationKind Kind);

--- a/src/Mithril.Shared/Reference/IReferenceNavigator.cs
+++ b/src/Mithril.Shared/Reference/IReferenceNavigator.cs
@@ -15,12 +15,67 @@ namespace Mithril.Shared.Reference;
 /// </remarks>
 public interface IReferenceNavigator
 {
+    // ---- Navigation commands ---------------------------------------------------
+
     /// <summary>
     /// Navigate to the detail view for <paramref name="reference"/>.
+    /// Pushes <paramref name="reference"/> onto the back stack, clears the forward stack,
+    /// sets <see cref="Current"/> to <paramref name="reference"/>, and fires
+    /// <see cref="Navigated"/> with <see cref="NavigationKind.Open"/>.
     /// Returns <see langword="void"/> by design — this is a fire-and-forget navigation
     /// command, not a request for an embedded view.
     /// </summary>
     void Open(EntityRef reference);
+
+    /// <summary>
+    /// Navigate backward in history.
+    /// Pops the back stack onto the forward stack, updates <see cref="Current"/>, and fires
+    /// <see cref="Navigated"/> with <see cref="NavigationKind.Back"/>.
+    /// No-op if <see cref="CanGoBack"/> is <see langword="false"/>.
+    /// </summary>
+    void Back();
+
+    /// <summary>
+    /// Navigate forward in history.
+    /// Pops the forward stack onto the back stack, updates <see cref="Current"/>, and fires
+    /// <see cref="Navigated"/> with <see cref="NavigationKind.Forward"/>.
+    /// No-op if <see cref="CanGoForward"/> is <see langword="false"/>.
+    /// </summary>
+    void Forward();
+
+    // ---- State properties ------------------------------------------------------
+
+    /// <summary>
+    /// The entity currently displayed, or <see langword="null"/> if no navigation has occurred.
+    /// </summary>
+    EntityRef? Current { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the back stack is non-empty and <see cref="Back"/> would do work.
+    /// </summary>
+    bool CanGoBack { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the forward stack is non-empty and <see cref="Forward"/> would do work.
+    /// </summary>
+    bool CanGoForward { get; }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this implementation can display the detail view for
+    /// <paramref name="reference"/>. Drives cross-link click-vs-text rendering: when
+    /// <see langword="false"/>, callers should render the reference as plain text rather
+    /// than a clickable hyperlink.
+    /// </summary>
+    bool CanOpen(EntityRef reference);
+
+    // ---- Events ----------------------------------------------------------------
+
+    /// <summary>
+    /// Raised after every navigation that changes <see cref="Current"/>.
+    /// View subscribers re-evaluate command states and refresh the master-detail display.
+    /// Never raised by <see cref="NoOpReferenceNavigator"/>.
+    /// </summary>
+    event EventHandler<NavigatedEventArgs>? Navigated;
 }
 
 /// <summary>
@@ -38,4 +93,32 @@ public sealed class NoOpReferenceNavigator : IReferenceNavigator
         _logger.LogInformation(
             "IReferenceNavigator.Open({Kind}, {InternalName}) — no module registered",
             reference.Kind, reference.InternalName);
+
+    /// <inheritdoc />
+    public void Back() =>
+        _logger.LogInformation("IReferenceNavigator.Back() — no module registered");
+
+    /// <inheritdoc />
+    public void Forward() =>
+        _logger.LogInformation("IReferenceNavigator.Forward() — no module registered");
+
+    /// <inheritdoc />
+    public EntityRef? Current => null;
+
+    /// <inheritdoc />
+    public bool CanGoBack => false;
+
+    /// <inheritdoc />
+    public bool CanGoForward => false;
+
+    /// <inheritdoc />
+    public bool CanOpen(EntityRef reference) => false;
+
+    /// <inheritdoc />
+    /// <remarks>Never fired by <see cref="NoOpReferenceNavigator"/>.</remarks>
+    public event EventHandler<NavigatedEventArgs>? Navigated
+    {
+        add { /* no-op: no module registered */ }
+        remove { /* no-op: no module registered */ }
+    }
 }

--- a/tests/Mithril.Shared.Tests/Reference/NoOpReferenceNavigatorTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/NoOpReferenceNavigatorTests.cs
@@ -34,6 +34,104 @@ public class NoOpReferenceNavigatorTests
         act.Should().NotThrow();
     }
 
+    // ---- New members (history primitives) ------------------------------------
+
+    [Fact]
+    public void Current_IsNull()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+
+        navigator.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public void CanGoBack_IsFalse()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+
+        navigator.CanGoBack.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanGoForward_IsFalse()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+
+        navigator.CanGoForward.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanOpen_ReturnsFalse_ForAnyEntity()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+
+        navigator.CanOpen(new EntityRef(EntityKind.Item, "SomeItem")).Should().BeFalse();
+        navigator.CanOpen(new EntityRef(EntityKind.Npc, "SomeNpc")).Should().BeFalse();
+        navigator.CanOpen(new EntityRef(EntityKind.Quest, "SomeQuest")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Back_WritesOneInfoEntry_AndDoesNotThrow()
+    {
+        var logger = new CapturingLogger<NoOpReferenceNavigator>();
+        var navigator = new NoOpReferenceNavigator(logger);
+
+        var act = () => navigator.Back();
+
+        act.Should().NotThrow();
+        logger.Entries.Should().HaveCount(1);
+        logger.Entries[0].Level.Should().Be(LogLevel.Information);
+    }
+
+    [Fact]
+    public void Forward_WritesOneInfoEntry_AndDoesNotThrow()
+    {
+        var logger = new CapturingLogger<NoOpReferenceNavigator>();
+        var navigator = new NoOpReferenceNavigator(logger);
+
+        var act = () => navigator.Forward();
+
+        act.Should().NotThrow();
+        logger.Entries.Should().HaveCount(1);
+        logger.Entries[0].Level.Should().Be(LogLevel.Information);
+    }
+
+    [Fact]
+    public void Navigated_IsNeverFired_WhenOpenIsCalled()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+        var fired = false;
+        navigator.Navigated += (_, _) => fired = true;
+
+        navigator.Open(new EntityRef(EntityKind.Item, "AnyItem"));
+
+        fired.Should().BeFalse("NoOpReferenceNavigator never fires the Navigated event");
+    }
+
+    [Fact]
+    public void Navigated_IsNeverFired_WhenBackIsCalled()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+        var fired = false;
+        navigator.Navigated += (_, _) => fired = true;
+
+        navigator.Back();
+
+        fired.Should().BeFalse("NoOpReferenceNavigator never fires the Navigated event");
+    }
+
+    [Fact]
+    public void Navigated_IsNeverFired_WhenForwardIsCalled()
+    {
+        var navigator = new NoOpReferenceNavigator(new CapturingLogger<NoOpReferenceNavigator>());
+        var fired = false;
+        navigator.Navigated += (_, _) => fired = true;
+
+        navigator.Forward();
+
+        fired.Should().BeFalse("NoOpReferenceNavigator never fires the Navigated event");
+    }
+
     // ---- minimal ILogger<T> stub -----------------------------------------------
 
     private sealed class CapturingLogger<T> : ILogger<T>


### PR DESCRIPTION
Closes #217. Step 2b of #203.

## Summary

Extends the `IReferenceNavigator` interface (shipped in #213 as `Open` only) with router-shaped history primitives so #207's DB module can implement back/forward navigation. Tiny scope — interface extension + no-op stub updates + tests.

- `void Back()`, `void Forward()` — stack mechanics
- `EntityRef? Current`, `bool CanGoBack`, `bool CanGoForward` — derived state
- `bool CanOpen(EntityRef reference)` — drives cross-link click-vs-plain-text rendering (gap 6 contract for #207)
- `event EventHandler<NavigatedEventArgs>? Navigated` — fires on every state change; views re-evaluate command states
- `NavigatedEventArgs(EntityRef? Previous, EntityRef? Current, NavigationKind Kind)` record
- `NavigationKind { Open, Back, Forward }` enum

All new types co-located in `EntityRef.cs` rather than separate files — they're tightly coupled to `EntityRef`.

## Stub semantics

`NoOpReferenceNavigator` (shell-registered until #207's real impl overrides):
- `Current` → null
- `CanGoBack` / `CanGoForward` / `CanOpen(anything)` → false
- `Back()` / `Forward()` log one info-level entry and return
- `Navigated` event never fires

## One non-obvious judgment call

`NoOpReferenceNavigator.Navigated` uses explicit `add { } / remove { }` accessors (empty bodies) rather than a field-backed auto-event. Field-backed `public event ... Navigated;` with no raiser triggers `CS0067` ("event never used"), which warnings-as-errors promotes to a build failure. Explicit accessors satisfy the interface contract without compiler complaint.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — 717 tests in `Mithril.Shared.Tests` pass (+9 new facts in `NoOpReferenceNavigatorTests` covering each new member); other test projects also green
- [ ] No smoke-test of the shell needed — stub behaviour is unchanged from external observer's perspective; real-impl smoke-testing comes with #207

## Notes for #207

The DB module's real `ReferenceNavigator` implements all of these and tracks history internally. Its view subscribes to `Navigated` and updates master-detail accordingly. `CanOpen` returns `true` for entity kinds with tabs (`Item`, `Recipe` in v1) and `false` for the rest — drives the cross-link degradation contract from #207's spec.

---

*Drafted by Claude (Opus 4.7), opened by @arthur-conde via Claude Code.*
