### PR TITLE
Samwise: module-wide Stop all alarm sounds button

### DIFF
--- a/src/Samwise.Module/Alarms/AlarmService.cs
+++ b/src/Samwise.Module/Alarms/AlarmService.cs
@@ -49,6 +49,14 @@ public sealed class AlarmService : IDisposable
         StopAllChannelPlayback();
     }
 
+    /// <summary>
+    /// Stop every currently-playing Samwise alarm sound without touching the
+    /// dedup state. Plots flagged as already-fired stay flagged (no re-fire on
+    /// the next tick). Use this when a replay storm or other event burst floods
+    /// the audio path and you just want silence.
+    /// </summary>
+    public void StopAllPlayback() => Dispatch(StopAllChannelPlayback);
+
     private void OnPlotChanged(object? sender, PlotChangedArgs e)
     {
         if (e.OldStage is not null && e.NewStage != e.OldStage)

--- a/src/Samwise.Module/Views/SamwiseSettingsView.xaml
+++ b/src/Samwise.Module/Views/SamwiseSettingsView.xaml
@@ -31,7 +31,16 @@
             </TextBlock>
 
             <!-- Alarms: master toggles -->
-            <TextBlock Text="Alarms" Foreground="#88FFFFFF" Margin="0,0,0,6" FontWeight="SemiBold"/>
+            <DockPanel LastChildFill="False" Margin="0,0,0,6">
+                <TextBlock DockPanel.Dock="Left" Text="Alarms" Foreground="#88FFFFFF" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                <Button DockPanel.Dock="Right" Click="StopAllSounds_Click" Padding="10,4"
+                        ToolTip="Stop every currently-playing Samwise alarm sound (does not affect dedup or future alarms).">
+                    <StackPanel Orientation="Horizontal">
+                        <icon:PackIconLucide Kind="Square" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <TextBlock Text="Stop all alarm sounds"/>
+                    </StackPanel>
+                </Button>
+            </DockPanel>
             <CheckBox Content="Enabled" IsChecked="{Binding Alarms.Enabled}" Foreground="#FFE8E8E8" Margin="0,0,0,4"/>
             <CheckBox Content="Flash the Mithril window when firing" IsChecked="{Binding Alarms.FlashWindow}"
                       Foreground="#FFE8E8E8" Margin="0,0,0,4"/>

--- a/src/Samwise.Module/Views/SamwiseSettingsView.xaml.cs
+++ b/src/Samwise.Module/Views/SamwiseSettingsView.xaml.cs
@@ -36,6 +36,8 @@ public partial class SamwiseSettingsView : System.Windows.Controls.UserControl
             Alarms?.StopPreview(stage);
     }
 
+    private void StopAllSounds_Click(object sender, RoutedEventArgs e) => Alarms?.StopAllPlayback();
+
     private void ClearSound_Click(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement fe && fe.Tag is StageAlarmRule rule) rule.SoundFilePath = null;

--- a/tests/Samwise.Tests/Alarms/AlarmServiceTests.cs
+++ b/tests/Samwise.Tests/Alarms/AlarmServiceTests.cs
@@ -289,6 +289,20 @@ public class AlarmServiceTests
     }
 
     [Fact]
+    public void StopAllPlayback_SilencesAllOwners_ButPreservesFiredAtDedup()
+    {
+        var s = BuildSut(AlarmCollisionBehavior.Mix);
+        RipenPlot(s, "1", "Carrot");
+        RipenPlot(s, "2", "Onion");
+        s.Service.ActiveKeys.Should().HaveCount(2);
+
+        s.Service.StopAllPlayback();
+
+        s.Sink.Plays.Should().AllSatisfy(p => p.Handle.IsPlaying.Should().BeFalse());
+        s.Service.ActiveKeys.Should().HaveCount(2);   // dedup untouched
+    }
+
+    [Fact]
     public void StopPreview_DoesNotAffectRealAlarmsOnSameChannel()
     {
         var s = BuildSut(AlarmCollisionBehavior.Mix);


### PR DESCRIPTION
## Summary

Adds a "Stop all alarm sounds" button to the Samwise settings view, placed in the top-right of the Alarms section. Click silences every currently-playing Samwise alarm sound (looping or one-shot) without clearing the dedup state — so a flood of in-flight events (e.g., a log-replay storm) doesn't get its noise back the moment more transitions arrive.

## Why

Triggered by real-world feedback: a log replay produced a Samwise audio storm and there wasn't a clean way to silence just Samwise without affecting other modules' sounds. The existing options each had drawbacks:

| Affordance | Behavior | Problem here |
|---|---|---|
| `StopAllSoundsCommand` hotkey | `AudioPlayer.Stop()` — global | Kills Gandalf etc. too |
| `DismissAll()` | Stops audio + clears dedup | New events fire fresh sounds |
| `SnoozeAll()` | Stops audio + snoozes for N min | Heavy hammer; configured snooze may be too long |
| **New `StopAllPlayback()`** | Stops Samwise audio only; dedup intact | The surgical option |

## Test plan

- [x] New unit test: `StopAllPlayback_SilencesAllOwners_ButPreservesFiredAtDedup` — fires two alarms on a Mix channel, calls StopAllPlayback, asserts both handles stopped AND `ActiveKeys.Count == 2` (dedup retained).
- [x] Manual: trigger a few Samwise alarms in-game, click the button, confirm silence and that already-fired plots don't re-trigger sound on next transition tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)