### PR TITLE
fix(samwise): keep alarm loop going until every same-stage plot is resolved

### DIFF
--- a/src/Samwise.Module/Alarms/AlarmService.cs
+++ b/src/Samwise.Module/Alarms/AlarmService.cs
@@ -110,12 +110,40 @@ public sealed class AlarmService : IDisposable
     {
         var resolved = ResolveChannel(channelId).Id;
         if (!_channelPlayback.TryGetValue(resolved, out var owners)) return;
-        var mine = owners.FirstOrDefault(o => o.AlarmKey == alarmKey);
-        if (mine is not null)
+        var idx = owners.FindIndex(o => o.AlarmKey == alarmKey);
+        if (idx < 0) return;
+        var mine = owners[idx];
+
+        // If this is a looping alarm and another plot is still in the same stage
+        // but had its sound suppressed by the channel's collision policy, transfer
+        // the live handle to that survivor instead of stopping. Keeps the loop
+        // audibly continuous until every same-stage plot is resolved.
+        if (TryFindSurvivorKey(mine.Stage, owners, alarmKey) is { } survivor)
         {
-            mine.Handle.Stop();
-            owners.Remove(mine);
+            owners[idx] = mine with { AlarmKey = survivor };
+            return;
         }
+
+        mine.Handle.Stop();
+        owners.RemoveAt(idx);
+    }
+
+    private string? TryFindSurvivorKey(PlotStage stage, List<ChannelOwner> owners, string excludedKey)
+    {
+        if (!_settings.Alarms.Rules.TryGetValue(stage, out var rule) || !rule.Loop) return null;
+
+        var stageSuffix = "|" + stage;
+        var ownedByOthers = new HashSet<string>(
+            owners.Where(o => o.AlarmKey != excludedKey).Select(o => o.AlarmKey),
+            StringComparer.Ordinal);
+
+        return _firedAt
+            .Where(kvp => kvp.Key != excludedKey
+                          && kvp.Key.EndsWith(stageSuffix, StringComparison.Ordinal)
+                          && !ownedByOthers.Contains(kvp.Key))
+            .OrderBy(kvp => kvp.Value)
+            .Select(kvp => kvp.Key)
+            .FirstOrDefault();
     }
 
     private void StopAllChannelPlayback()

--- a/tests/Samwise.Tests/Alarms/AlarmServiceTests.cs
+++ b/tests/Samwise.Tests/Alarms/AlarmServiceTests.cs
@@ -343,4 +343,120 @@ public class AlarmServiceTests
         s.Sink.Plays.Should().HaveCount(2);
         s.Sink.Plays[1].Handle.IsPlaying.Should().BeTrue();
     }
+
+    [Fact]
+    public void Replace_Loop_HarvestCurrentOwner_TransfersHandleToSurvivor()
+    {
+        var s = BuildSut(AlarmCollisionBehavior.Replace);
+        s.Settings.Alarms.Rules[PlotStage.Ripe].Loop = true;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].StopOnInteraction = true;
+
+        RipenPlot(s, "1", "Carrot");
+        var firstHandle = s.Sink.Plays[0].Handle;
+        RipenPlot(s, "2", "Onion");
+        var secondHandle = s.Sink.Plays[1].Handle;
+        firstHandle.IsPlaying.Should().BeFalse();   // sanity: Replace stopped it
+        secondHandle.IsPlaying.Should().BeTrue();
+
+        // Harvest plot 2 (the current channel owner). Plot 1 is still Ripe.
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "2", "SummonedOnion"));
+
+        // Handle keeps playing (transferred to plot 1 — no fresh Play call).
+        secondHandle.IsPlaying.Should().BeTrue();
+        s.Sink.Plays.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Replace_Loop_HarvestAllSurvivors_FinallyStopsLoop()
+    {
+        var s = BuildSut(AlarmCollisionBehavior.Replace);
+        s.Settings.Alarms.Rules[PlotStage.Ripe].Loop = true;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].StopOnInteraction = true;
+
+        RipenPlot(s, "1", "Carrot");
+        RipenPlot(s, "2", "Onion");
+        var liveHandle = s.Sink.Plays[1].Handle;
+
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "2", "SummonedOnion"));
+        liveHandle.IsPlaying.Should().BeTrue();   // transferred to plot 1
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "1", "SummonedCarrot"));
+        liveHandle.IsPlaying.Should().BeFalse();  // last survivor resolved
+    }
+
+    [Fact]
+    public void Suppress_Loop_HarvestCurrentOwner_TransfersHandleToSurvivor()
+    {
+        var s = BuildSut(AlarmCollisionBehavior.Suppress);
+        s.Settings.Alarms.Rules[PlotStage.Ripe].Loop = true;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].StopOnInteraction = true;
+
+        RipenPlot(s, "1", "Carrot");
+        RipenPlot(s, "2", "Onion");          // suppressed — channel busy
+        s.Sink.Plays.Should().HaveCount(1);
+        var handle = s.Sink.Plays[0].Handle;
+
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "1", "SummonedCarrot"));
+
+        handle.IsPlaying.Should().BeTrue();
+        s.Sink.Plays.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Mix_SuppressIfStagePlaying_Loop_HarvestCurrentOwner_TransfersHandleToSurvivor()
+    {
+        var s = BuildSut(AlarmCollisionBehavior.Mix);
+        s.Settings.Alarms.Rules[PlotStage.Ripe].Loop = true;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].StopOnInteraction = true;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].SuppressIfStagePlaying = true;
+
+        RipenPlot(s, "1", "Carrot");
+        RipenPlot(s, "2", "Onion");          // dropped — same stage already playing
+        s.Sink.Plays.Should().HaveCount(1);
+        var handle = s.Sink.Plays[0].Handle;
+
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "1", "SummonedCarrot"));
+
+        handle.IsPlaying.Should().BeTrue();
+        s.Sink.Plays.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Mix_Loop_OwnHandlesEach_HarvestOneOnlyStopsThatHandle()
+    {
+        // Mix without SuppressIfStagePlaying: every plot already owns its own
+        // handle, so resolving one must just stop that one — no transfer needed.
+        var s = BuildSut(AlarmCollisionBehavior.Mix);
+        s.Settings.Alarms.Rules[PlotStage.Ripe].Loop = true;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].StopOnInteraction = true;
+
+        RipenPlot(s, "1", "Carrot");
+        RipenPlot(s, "2", "Onion");
+        var firstHandle = s.Sink.Plays[0].Handle;
+        var secondHandle = s.Sink.Plays[1].Handle;
+
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "1", "SummonedCarrot"));
+
+        firstHandle.IsPlaying.Should().BeFalse();
+        secondHandle.IsPlaying.Should().BeTrue();
+        s.Sink.Plays.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void LoopOff_DoesNotTransferHandle()
+    {
+        // Non-loop alarms shouldn't get promoted — the original one-shot already
+        // played, and reusing the handle for a survivor would be surprising.
+        var s = BuildSut(AlarmCollisionBehavior.Replace);
+        s.Settings.Alarms.Rules[PlotStage.Ripe].Loop = false;
+        s.Settings.Alarms.Rules[PlotStage.Ripe].StopOnInteraction = true;
+
+        RipenPlot(s, "1", "Carrot");
+        RipenPlot(s, "2", "Onion");
+        var liveHandle = s.Sink.Plays[1].Handle;
+
+        s.StateMachine.Apply(new StartInteraction(s.Time.Now.UtcDateTime, "2", "SummonedOnion"));
+
+        liveHandle.IsPlaying.Should().BeFalse();
+        s.Sink.Plays.Should().HaveCount(2);
+    }
 }


### PR DESCRIPTION
Closes #222.

## Summary

- When multiple plots share the same alarmed stage on a `Replace` / `Suppress` channel — or `Mix` + `SuppressIfStagePlaying` — only **one** sound plays even though every plot lands in `_firedAt`. Resolving the plot whose key currently owns that sound used to stop the loop entirely, leaving still-ripe siblings silent.
- `StopOwner` now looks for a surviving same-stage `_firedAt` key with no owner of its own, and **transfers** the live handle to it (rebinding `ChannelOwner.AlarmKey`) instead of stopping and restarting. The user hears the loop continue uninterrupted; it finally falls silent only when the last plot is resolved.
- Gated on `rule.Loop` so non-looping one-shot alarms aren't promoted.
- Mix-without-`SuppressIfStagePlaying` is unaffected — every plot already has its own handle, so the survivor lookup finds none unowned and falls through to the original stop-and-remove path.

## Test plan

- [x] `dotnet test Mithril.slnx` — all 1,545 tests pass.
- [x] 4 new tests (`Replace_Loop_HarvestCurrentOwner_TransfersHandleToSurvivor`, `Replace_Loop_HarvestAllSurvivors_FinallyStopsLoop`, `Suppress_Loop_HarvestCurrentOwner_TransfersHandleToSurvivor`, `Mix_SuppressIfStagePlaying_Loop_HarvestCurrentOwner_TransfersHandleToSurvivor`) fail on `main` and pass with the fix.
- [x] 2 control tests (`Mix_Loop_OwnHandlesEach_HarvestOneOnlyStopsThatHandle`, `LoopOff_DoesNotTransferHandle`) pin the unaffected paths — Mix-per-plot stays per-plot, non-loop alarms keep their one-shot semantics.
- [ ] Live smoke: run two plots into Ripe, harvest the most-recently-ripe one first, confirm the alarm loop keeps playing for the still-ripe plot without an audible glitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)