### PR TITLE
chore(ci): bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/cdn-drift-check.yml
+++ b/.github/workflows/cdn-drift-check.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Nerdbank.GitVersioning (wired in via Directory.Build.targets) needs
           # full history to compute build height; default fetch-depth: 1 fails
           # the build. Same reason release.yml does this.
           fetch-depth: 0
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       # Don't `dotnet build Mithril.slnx` — it contains net10.0-windows projects

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Nerdbank.GitVersioning needs full history to compute height/SemVer.
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
           "DisableScriptScanning     = $($p.DisableScriptScanning)"
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -168,7 +168,7 @@ jobs:
           --outputDir releases
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           # Quoted because the value has a literal `: ` (colon-space), which is the YAML


### PR DESCRIPTION
## Summary

Three actions warned about Node.js 20 deprecation on the test-org1 release run (deadline **2026-06-02**, runner forces Node.js 24 by default after that). Bumping each to its current major:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-dotnet` | v4 | v5 |
| `softprops/action-gh-release` | v2 | v3 |

Touches both [release.yml](.github/workflows/release.yml) (3 sites) and [cdn-drift-check.yml](.github/workflows/cdn-drift-check.yml) (2 sites).

## Why these majors are safe for us

All three major bumps are pure Node.js 24 modernization with no API breaks for our usage:

- **checkout v6**: minor internal change (cred persistence to separate file). Our single \`fetch-depth: 0\` checkout is the most basic case.
- **setup-dotnet v5**: \"Removed older .NET versions\" — doesn't apply, we're on .NET 10.
- **action-gh-release v3**: changelog explicitly says \"no API changes, only Node 24 runtime bump.\"

## Test plan

- [x] Pre-bump v2 release pipeline verified end-to-end on moumantai-gg/mithril via v0.0.1-test-org1 (5m30s, all 8 Velopack artifacts uploaded). That release has been deleted after verification.
- [ ] After merge: cut another low-stakes test tag (e.g. v0.0.1-test-node24-1) and confirm the bumped workflow still passes end-to-end. Delete the test release afterward.