### PR TITLE
Silmarillion polish v1 (#229/#231/#234) + DeepLink + Navigator registries (#239)

### DIFF
--- a/docs/agent-plans/2026-05-13-silmarillion-polish-v1-plan.md
+++ b/docs/agent-plans/2026-05-13-silmarillion-polish-v1-plan.md
@@ -1,0 +1,2141 @@
+# Silmarillion polish v1 + registry refactors — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle three #207-followup polish issues (#229 module-scoped deep-link routes, #231 compact row layout, #234 item-detail reading-order rework) with two parallel "switch-as-registry" refactors (DeepLinkRouter and IReferenceNavigator), into a single PR on branch `feat/silmarillion-polish-v1`.
+
+**Architecture:** Refactor the existing `DeepLinkRouter` (a `switch (action)` with six near-identical cases) into a DI-registered `IDeepLinkHandler` registry. Each module's handler lives alongside its existing import-target implementation. Apply the same pattern to `IReferenceNavigator` (HashSet + two switches → `IReferenceKindTarget` registry) so the upcoming NPCs tab (the immediate next PR) is purely additive. Two XAML changes: compact two-line row templates for the master-detail left pane, and DockPanel-based restructure of `ItemDetailView` that lets cross-link sections move to the top.
+
+**Tech Stack:** .NET 10, C# latest, WPF (`net10.0-windows`), CommunityToolkit.Mvvm, xunit + FluentAssertions. Build via `dotnet build Mithril.slnx`; test via `dotnet test`.
+
+**Design spec:** [docs/agent-plans/silmarillion-polish-v1.md](silmarillion-polish-v1.md) — every task references its spec section number.
+
+**Tracked issues:** #229, #231, #234, #239 (bundled).
+
+---
+
+## File Structure
+
+### Created files
+
+| Path | Responsibility | Task |
+|---|---|---|
+| `src/Mithril.Shared.Wpf/Modules/IDeepLinkHandler.cs` | Handler interface (action + TryHandle) | T1 |
+| `src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs` | `mithril://item/<name>` handler | T2 |
+| `src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs` | `mithril://recipe/<name>` handler | T2 |
+| `src/Celebrimbor.Module/Services/CraftListDeepLinkHandler.cs` | `mithril://list/<base64>` handler | T5 |
+| `src/Pippin.Module/Sharing/PippinDeepLinkHandler.cs` | `mithril://pippin/<base64>` handler | T6 |
+| `src/Legolas.Module/Sharing/LegolasDeepLinkHandler.cs` | `mithril://legolas/<base64>` handler | T7 |
+| `src/Elrond.Module/Services/ElrondDeepLinkHandler.cs` | `mithril://elrond/<skill>` handler | T8 |
+| `src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs` | `mithril://silmarillion/<kind>/<name>` handler | T10 |
+| `src/Mithril.Shared/Reference/IReferenceKindTarget.cs` | Kind-target interface | T13 |
+| `src/Silmarillion.Module/Navigation/ItemsKindTarget.cs` | Items adapter for the registry | T14 |
+| `src/Silmarillion.Module/Navigation/RecipesKindTarget.cs` | Recipes adapter for the registry | T15 |
+| `tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs` | Handler-level tests (#229) | T9 |
+| `tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs` | Items adapter tests (#239) | T14 |
+| `tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs` | Recipes adapter tests (#239) | T15 |
+| `tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs` | Top-level VM tests for OnNavigated / OpenInWindow (#239) | T17 |
+
+### Modified files
+
+| Path | Change | Task |
+|---|---|---|
+| `src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs` | Rewrite ~170 → ~40 lines as registry dispatcher | T3 |
+| `src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs` | Register Item/Recipe handlers from shell DI; rewire DeepLinkRouter ctor | T3 |
+| `tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs` | Re-wire to register handlers via DI; add silmarillion integration test in T9 | T4, T9 |
+| `src/Celebrimbor.Module/CelebrimborModule.cs` | Register `CraftListDeepLinkHandler` | T5 |
+| `src/Pippin.Module/PippinModule.cs` | Register `PippinDeepLinkHandler` | T6 |
+| `src/Legolas.Module/LegolasModule.cs` | Register `LegolasDeepLinkHandler` | T7 |
+| `src/Elrond.Module/ElrondModule.cs` | Register `ElrondDeepLinkHandler` | T8 |
+| `src/Silmarillion.Module/SilmarillionModule.cs` | Register `SilmarillionDeepLinkHandler` + 2 kind targets | T10, T16 |
+| `src/Silmarillion.Module/Views/Resources.xaml` | Replace card templates with compact rows | T11 |
+| `src/Mithril.Shared.Wpf/ItemDetailView.xaml` | DockPanel + StackPanel + cross-link reorder | T12 |
+| `src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs` | `V1TabbedKinds` deleted; ctor takes `IEnumerable<IReferenceKindTarget>` | T16 |
+| `src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs` | Switches → registry lookups | T17 |
+| `tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs` | Re-wire `CanOpen` tests to register targets; add duplicate-kind test | T16 |
+| `src/Mithril.Shell/Views/AboutSettingsView.xaml` | Update example URI to module-scoped form | T18 |
+| `[project-gorgon.wiki]/Deep-Linking.md` (or equivalent) | Document preferred form; legacy noted | T18 |
+
+---
+
+## Commit map
+
+| Commit | Tasks | Description |
+|---|---|---|
+| 1 | T1–T8 | DeepLink router → handler-registry refactor (no new URI behavior) |
+| 2 | T9–T10 | Silmarillion deep-link handler + tests (#229) |
+| 3 | T11 | Compact row templates (#231) |
+| 4 | T12 | ItemDetailView restructure (#234) |
+| 5 | T13–T17 | Navigator → kind-target registry refactor (#239) |
+| 6 | T18 | Wiki update + AboutSettingsView example string |
+
+The branch `feat/silmarillion-polish-v1` already exists with two prior commits (spec + spec correction). Push and open PR via `gh pr create` after T18.
+
+---
+
+## Task 1: Define `IDeepLinkHandler` interface
+
+**Files:**
+- Create: `src/Mithril.Shared.Wpf/Modules/IDeepLinkHandler.cs`
+
+Spec §1.
+
+- [ ] **Step 1: Create the interface file**
+
+```csharp
+using Mithril.Shared.Diagnostics;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// A single mithril:// scheme dispatch handler. The <see cref="DeepLinkRouter"/>
+/// looks handlers up by <see cref="Action"/> (the URI host segment) and delegates
+/// payload parsing and dispatch to each implementation.
+///
+/// Replaces the per-action <c>switch</c> the router used pre-#229. Each handler
+/// owns its payload grammar (regex, length cap, segment-splitting), its dependency
+/// null-checks, and its diagnostic messages.
+/// </summary>
+public interface IDeepLinkHandler
+{
+    /// <summary>The first path segment after <c>mithril://</c>. Must be lowercase ASCII.</summary>
+    string Action { get; }
+
+    /// <summary>
+    /// Handle the remainder of the URI path (everything after the host segment,
+    /// with the leading '/' stripped). Implementations own their payload grammar
+    /// and any per-handler diagnostic messages. Return false for validation
+    /// failure or missing dependency; true on successful dispatch.
+    /// </summary>
+    bool TryHandle(string subPath, IDiagnosticsSink? diag);
+}
+```
+
+- [ ] **Step 2: Build to verify the file compiles**
+
+Run: `dotnet build src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj`
+Expected: build succeeds (interface alone introduces no consumer).
+
+---
+
+## Task 2: Extract Item + Recipe handlers
+
+**Files:**
+- Create: `src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs`
+- Create: `src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs`
+
+Spec §2. Both handlers depend only on `IReferenceNavigator` so they stay in the shared layer and degrade gracefully when Silmarillion isn't loaded (`NoOpReferenceNavigator` accepts the call).
+
+- [ ] **Step 1: Create `ItemDeepLinkHandler.cs`**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Handles <c>mithril://item/&lt;internalName&gt;</c>. Internal names in the reference
+/// data are ASCII identifiers; the regex refuses anything that could confuse downstream
+/// lookups or smuggle separators.
+/// </summary>
+public sealed class ItemDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IReferenceNavigator _navigator;
+
+    public ItemDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
+
+    public string Action => "item";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: item payload '{subPath}' failed validation.");
+            return false;
+        }
+        _navigator.Open(EntityRef.Item(subPath));
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Create `RecipeDeepLinkHandler.cs` (same shape)**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>Handles <c>mithril://recipe/&lt;internalName&gt;</c>. See <see cref="ItemDeepLinkHandler"/>.</summary>
+public sealed class RecipeDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IReferenceNavigator _navigator;
+
+    public RecipeDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
+
+    public string Action => "recipe";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: recipe payload '{subPath}' failed validation.");
+            return false;
+        }
+        _navigator.Open(EntityRef.Recipe(subPath));
+        return true;
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj`
+Expected: build succeeds.
+
+---
+
+## Task 3: Rewrite `DeepLinkRouter` + shell DI
+
+**Files:**
+- Modify: `src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs`
+- Modify: `src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs:84-90`
+
+Spec §3.
+
+- [ ] **Step 1: Replace `DeepLinkRouter.cs` body**
+
+Replace the entire file content with:
+
+```csharp
+using Mithril.Shared.Diagnostics;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Default <see cref="IDeepLinkRouter"/>. Builds a per-action lookup from injected
+/// <see cref="IDeepLinkHandler"/>s and delegates payload parsing + dispatch to the
+/// matching handler. Each handler owns its payload grammar; the router only
+/// validates the scheme and finds the right handler.
+/// </summary>
+public sealed class DeepLinkRouter : IDeepLinkRouter
+{
+    private const string Scheme = "mithril";
+
+    private readonly IReadOnlyDictionary<string, IDeepLinkHandler> _handlers;
+    private readonly IDiagnosticsSink? _diag;
+
+    public DeepLinkRouter(IEnumerable<IDeepLinkHandler> handlers, IDiagnosticsSink? diag = null)
+    {
+        // Fail-loud on duplicate Action registrations — that's a DI ordering bug,
+        // not graceful-degradation territory.
+        var byAction = new Dictionary<string, IDeepLinkHandler>(StringComparer.Ordinal);
+        foreach (var h in handlers)
+        {
+            var key = h.Action.ToLowerInvariant();
+            if (byAction.ContainsKey(key))
+                throw new InvalidOperationException(
+                    $"Duplicate IDeepLinkHandler registration for action '{key}': " +
+                    $"{byAction[key].GetType().FullName} and {h.GetType().FullName}.");
+            byAction[key] = h;
+        }
+        _handlers = byAction;
+        _diag = diag;
+    }
+
+    public bool Handle(string? uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri)) return false;
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsed))
+        {
+            _diag?.Info("DeepLink", $"Rejected: not a well-formed URI: '{uri}'.");
+            return false;
+        }
+        if (!string.Equals(parsed.Scheme, Scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            _diag?.Info("DeepLink", $"Rejected: scheme '{parsed.Scheme}' is not 'mithril'.");
+            return false;
+        }
+
+        var action = parsed.Host.ToLowerInvariant();
+        var subPath = parsed.AbsolutePath.TrimStart('/');
+
+        if (!_handlers.TryGetValue(action, out var handler))
+        {
+            _diag?.Info("DeepLink", $"Rejected: unknown action '{action}'.");
+            return false;
+        }
+        return handler.TryHandle(subPath, _diag);
+    }
+}
+```
+
+- [ ] **Step 2: Update `ShellServiceCollectionExtensions.AddMithrilItemDetail`**
+
+Find the existing block in `src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs` (around lines 77–90) and replace the `DeepLinkRouter` registration. The new shape — pasted in full so the executor doesn't have to diff:
+
+```csharp
+    public static IServiceCollection AddMithrilItemDetail(this IServiceCollection services) =>
+        services
+            .AddSingleton<IItemDetailPresenter, ItemDetailPresenter>()
+            .AddSingleton<IModuleActivator, ShellModuleActivator>()
+            // Shell-side deep-link handlers: depend only on IReferenceNavigator
+            // (NoOp when Silmarillion isn't loaded), so they belong here, not in
+            // a module's Register(). Modules register their own action handlers.
+            .AddSingleton<IDeepLinkHandler, ItemDeepLinkHandler>()
+            .AddSingleton<IDeepLinkHandler, RecipeDeepLinkHandler>()
+            // Router pulls every registered IDeepLinkHandler. Module-side handlers
+            // register from their own IMithrilModule.Register() implementations.
+            .AddSingleton<IDeepLinkRouter>(sp => new DeepLinkRouter(
+                sp.GetServices<IDeepLinkHandler>(),
+                sp.GetService<IDiagnosticsSink>()));
+```
+
+Drop the old `using` for `ICraftListImportTarget` etc. if it's now unused. Drop the comment line about "factory form so module-side import targets and IDiagnosticsSink stay optional" — it's no longer accurate.
+
+- [ ] **Step 3: Build the whole solution**
+
+Run: `dotnet build Mithril.slnx`
+Expected: build succeeds. Tests don't compile yet (DeepLinkRouterTests still calls the old constructor) — that's Task 4.
+
+---
+
+## Task 4: Re-wire `DeepLinkRouterTests` to use handlers
+
+**Files:**
+- Modify: `tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs`
+
+Spec §"Router refactor (commit 1)" testing. Existing test cases all stay; the test factory shape changes.
+
+- [ ] **Step 1: Add a test-side handler-builder helper**
+
+At the bottom of the test class (inside the same `DeepLinkRouterTests` class but above the private `Recording*` types), add a private factory:
+
+```csharp
+    private static DeepLinkRouter BuildRouter(
+        IReferenceNavigator nav,
+        ICraftListImportTarget? listTarget = null,
+        IPippinShareImportTarget? pippinTarget = null,
+        ILegolasShareImportTarget? legolasTarget = null,
+        IElrondSkillImportTarget? elrondTarget = null)
+    {
+        var handlers = new List<IDeepLinkHandler>
+        {
+            new ItemDeepLinkHandler(nav),
+            new RecipeDeepLinkHandler(nav),
+        };
+        if (listTarget is not null)
+            handlers.Add(new Celebrimbor.Services.CraftListDeepLinkHandler(listTarget));
+        if (pippinTarget is not null)
+            handlers.Add(new Pippin.Sharing.PippinDeepLinkHandler(pippinTarget));
+        if (legolasTarget is not null)
+            handlers.Add(new Legolas.Sharing.LegolasDeepLinkHandler(legolasTarget));
+        if (elrondTarget is not null)
+            handlers.Add(new Elrond.Services.ElrondDeepLinkHandler(elrondTarget));
+        return new DeepLinkRouter(handlers);
+    }
+```
+
+This won't compile yet — the module-side handlers don't exist. Tasks 5–8 add them and add the needed project references. Add a `// TODO(T4): finalise project refs once T5-T8 land` comment above the helper and proceed; the test project gains those refs in Tasks 5–8.
+
+- [ ] **Step 2: Replace each `new DeepLinkRouter(...)` call site**
+
+Search for `new DeepLinkRouter` in the file. Replace each construction with a `BuildRouter(...)` call passing the matching targets. Example diff for one site:
+
+```csharp
+// Before:
+var router = new DeepLinkRouter(nav, listImport: null, pippinImport: pippinTarget);
+
+// After:
+var router = BuildRouter(nav, pippinTarget: pippinTarget);
+```
+
+Every old call site has a structurally-identical replacement; the helper's named parameters map 1:1 to the old constructor's optional arguments.
+
+- [ ] **Step 3: Add a new test for duplicate-action registration**
+
+Append to `DeepLinkRouterTests`:
+
+```csharp
+    [Fact]
+    public void Constructor_DuplicateAction_Throws()
+    {
+        var nav = new RecordingNavigator();
+        var handlers = new IDeepLinkHandler[]
+        {
+            new ItemDeepLinkHandler(nav),
+            new ItemDeepLinkHandler(nav),  // duplicate
+        };
+        var act = () => new DeepLinkRouter(handlers);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Duplicate IDeepLinkHandler*item*");
+    }
+```
+
+- [ ] **Step 4: Build (will fail until T5–T8)**
+
+Run: `dotnet build tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj`
+Expected: compile errors for the module-side handler types referenced in `BuildRouter`. Acceptable — Tasks 5–8 add them.
+
+---
+
+## Task 5: Celebrimbor `CraftListDeepLinkHandler`
+
+**Files:**
+- Create: `src/Celebrimbor.Module/Services/CraftListDeepLinkHandler.cs`
+- Modify: `src/Celebrimbor.Module/CelebrimborModule.cs` (register handler)
+- Modify: `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` (add ProjectReference to Celebrimbor.Module)
+
+Spec §2.
+
+- [ ] **Step 1: Create the handler**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Celebrimbor.Services;
+
+/// <summary>Handles <c>mithril://list/&lt;base64url&gt;</c> craft-list imports.</summary>
+public sealed class CraftListDeepLinkHandler : IDeepLinkHandler
+{
+    // base64url alphabet = [A-Za-z0-9_-]. Length cap matches the pre-registry behaviour.
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
+
+    private readonly ICraftListImportTarget _target;
+
+    public CraftListDeepLinkHandler(ICraftListImportTarget target) => _target = target;
+
+    public string Action => "list";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: list payload (len={subPath.Length}) failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Register in `CelebrimborModule.Register`**
+
+Find `services.AddSingleton<ICraftListImportTarget, CraftListImportTarget>();` (around line 36) and add immediately after:
+
+```csharp
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new CraftListDeepLinkHandler(sp.GetRequiredService<ICraftListImportTarget>()));
+```
+
+Add the `using Mithril.Shared.Modules;` import at the top if it isn't already there.
+
+- [ ] **Step 3: Add ProjectReference from test project**
+
+In `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj`, ensure there's a `<ProjectReference Include="..\..\src\Celebrimbor.Module\Celebrimbor.Module.csproj" />` entry. If not, add it inside the existing `<ItemGroup>` of project references.
+
+- [ ] **Step 4: Build solution**
+
+Run: `dotnet build Mithril.slnx`
+Expected: build succeeds for Celebrimbor.Module and the test project (other handlers still missing — those tests fail to compile until T6/T7/T8).
+
+---
+
+## Task 6: Pippin `PippinDeepLinkHandler`
+
+**Files:**
+- Create: `src/Pippin.Module/Sharing/PippinDeepLinkHandler.cs`
+- Modify: `src/Pippin.Module/PippinModule.cs`
+- Modify: `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` (ProjectReference to Pippin.Module — likely already present via existing share-target tests; verify)
+
+Spec §2.
+
+- [ ] **Step 1: Create the handler**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Pippin.Sharing;
+
+/// <summary>Handles <c>mithril://pippin/&lt;base64url&gt;</c> shared-progress imports.</summary>
+public sealed class PippinDeepLinkHandler : IDeepLinkHandler
+{
+    // Pippin payloads are larger than list because they encode the full-catalogue progress dump.
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_-]{1,16384}$", RegexOptions.Compiled);
+
+    private readonly IPippinShareImportTarget _target;
+
+    public PippinDeepLinkHandler(IPippinShareImportTarget target) => _target = target;
+
+    public string Action => "pippin";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: pippin payload (len={subPath.Length}) failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Register in `PippinModule.Register`**
+
+Find the existing `services.AddSingleton<IPippinShareImportTarget>(...)` block (around line 71) and add immediately after:
+
+```csharp
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new PippinDeepLinkHandler(sp.GetRequiredService<IPippinShareImportTarget>()));
+```
+
+Add `using Mithril.Shared.Modules;` at the top if missing.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Mithril.slnx`
+Expected: build succeeds for Pippin.Module; test project still fails until T7/T8.
+
+---
+
+## Task 7: Legolas `LegolasDeepLinkHandler`
+
+**Files:**
+- Create: `src/Legolas.Module/Sharing/LegolasDeepLinkHandler.cs`
+- Modify: `src/Legolas.Module/LegolasModule.cs`
+- Modify: `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` (verify ProjectReference)
+
+Spec §2.
+
+- [ ] **Step 1: Create the handler**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Legolas.Sharing;
+
+/// <summary>Handles <c>mithril://legolas/&lt;base64url&gt;</c> survey-report imports.</summary>
+public sealed class LegolasDeepLinkHandler : IDeepLinkHandler
+{
+    // Legolas payloads are bounded by a single survey run (≤ a couple dozen items + timestamps).
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
+
+    private readonly ILegolasShareImportTarget _target;
+
+    public LegolasDeepLinkHandler(ILegolasShareImportTarget target) => _target = target;
+
+    public string Action => "legolas";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: legolas payload (len={subPath.Length}) failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Register in `LegolasModule.Register`**
+
+Find the `services.AddSingleton<ILegolasShareImportTarget>(...)` block and add immediately after:
+
+```csharp
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new LegolasDeepLinkHandler(sp.GetRequiredService<ILegolasShareImportTarget>()));
+```
+
+Add `using Mithril.Shared.Modules;` at the top if missing.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Mithril.slnx`
+Expected: build succeeds for Legolas.Module.
+
+---
+
+## Task 8: Elrond `ElrondDeepLinkHandler` + close commit 1
+
+**Files:**
+- Create: `src/Elrond.Module/Services/ElrondDeepLinkHandler.cs`
+- Modify: `src/Elrond.Module/ElrondModule.cs`
+- Modify: `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` (verify ProjectReference)
+
+Spec §2.
+
+- [ ] **Step 1: Create the handler**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Elrond.Services;
+
+/// <summary>
+/// Handles <c>mithril://elrond/&lt;skillKey&gt;</c>. Skill keys are id-shaped
+/// (matches <c>SkillEntry.Key</c>); reuse the strict item-style pattern. Hyphens
+/// and spaces are explicitly NOT permitted — the human-readable display name is
+/// never on the wire.
+/// </summary>
+public sealed class ElrondDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IElrondSkillImportTarget _target;
+
+    public ElrondDeepLinkHandler(IElrondSkillImportTarget target) => _target = target;
+
+    public string Action => "elrond";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: elrond payload '{subPath}' failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Register in `ElrondModule.Register`**
+
+Find the `services.AddSingleton<IElrondSkillImportTarget>(...)` block (around line 42) and add immediately after:
+
+```csharp
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new ElrondDeepLinkHandler(sp.GetRequiredService<IElrondSkillImportTarget>()));
+```
+
+Add `using Mithril.Shared.Modules;` at the top if missing.
+
+- [ ] **Step 3: Remove the TODO marker in DeepLinkRouterTests**
+
+Open `tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs` and delete the `// TODO(T4): finalise project refs once T5-T8 land` comment added in T4 — the project refs now resolve.
+
+- [ ] **Step 4: Build + run all DeepLinkRouter tests**
+
+Run:
+```
+dotnet build Mithril.slnx
+dotnet test tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj --filter "FullyQualifiedName~DeepLinkRouterTests" -v normal
+```
+Expected: all DeepLinkRouter tests pass (including the new `Constructor_DuplicateAction_Throws`). Coverage parity with pre-refactor.
+
+- [ ] **Step 5: Commit (commit 1)**
+
+```
+git add src/Mithril.Shared.Wpf/Modules/IDeepLinkHandler.cs \
+        src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs \
+        src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs \
+        src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs \
+        src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs \
+        src/Celebrimbor.Module/Services/CraftListDeepLinkHandler.cs \
+        src/Celebrimbor.Module/CelebrimborModule.cs \
+        src/Pippin.Module/Sharing/PippinDeepLinkHandler.cs \
+        src/Pippin.Module/PippinModule.cs \
+        src/Legolas.Module/Sharing/LegolasDeepLinkHandler.cs \
+        src/Legolas.Module/LegolasModule.cs \
+        src/Elrond.Module/Services/ElrondDeepLinkHandler.cs \
+        src/Elrond.Module/ElrondModule.cs \
+        tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs \
+        tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
+```
+
+Commit message:
+```
+refactor(deep-link): IDeepLinkRouter switch → IDeepLinkHandler registry
+
+The DeepLinkRouter's switch (action) had grown to six structurally-identical
+cases (validate payload, null-check optional import target, dispatch, log).
+Extract each branch into an IDeepLinkHandler implementation; the router
+becomes a registry lookup keyed by Action.
+
+Per-module handlers register from each IMithrilModule.Register(). Item +
+Recipe stay in Mithril.Shared.Wpf since they depend only on
+IReferenceNavigator (NoOp-friendly when Silmarillion isn't loaded).
+
+No new URI behavior. All existing DeepLinkRouter tests pass.
+
+Precursor to #229 (silmarillion-scoped routes).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Task 9: SilmarillionDeepLinkHandler — failing tests
+
+**Files:**
+- Create: `tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs`
+
+Spec §4 + "Silmarillion handler (commit 2)" testing.
+
+- [ ] **Step 1: Create the test file**
+
+```csharp
+using FluentAssertions;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class SilmarillionDeepLinkHandlerTests
+{
+    [Fact]
+    public void TryHandle_ItemKind_OpensItem()
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        var handled = handler.TryHandle("item/CraftedLeatherBoots5", diag: null);
+
+        handled.Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Item("CraftedLeatherBoots5"));
+    }
+
+    [Fact]
+    public void TryHandle_RecipeKind_OpensRecipe()
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        var handled = handler.TryHandle("recipe/MakeTomatoSauce", diag: null);
+
+        handled.Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Recipe("MakeTomatoSauce"));
+    }
+
+    [Theory]
+    [InlineData("npc/Marna")]            // unknown kind segment
+    [InlineData("ability/Hatchet")]
+    [InlineData("")]                     // empty subPath
+    [InlineData("item")]                 // no second segment
+    [InlineData("item/")]                // empty payload after slash
+    [InlineData("item/has space")]       // illegal payload char
+    [InlineData("item/has-hyphen")]      // hyphen rejected by EntityPayloadPattern
+    [InlineData("item/extra/segment")]   // extra path segments forbidden
+    public void TryHandle_Malformed_ReturnsFalse_AndDoesNotDispatch(string subPath)
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        handler.TryHandle(subPath, diag: null).Should().BeFalse();
+        nav.LastOpened.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryHandle_PayloadOverLengthCap_IsRejected()
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        var tooLong = new string('A', 129);
+        handler.TryHandle($"item/{tooLong}", diag: null).Should().BeFalse();
+        nav.LastOpened.Should().BeNull();
+    }
+
+    [Fact]
+    public void Action_IsSilmarillion()
+    {
+        var nav = new RecordingNavigator();
+        new SilmarillionDeepLinkHandler(nav).Action.Should().Be("silmarillion");
+    }
+
+    private sealed class RecordingNavigator : IReferenceNavigator
+    {
+        public EntityRef? LastOpened { get; private set; }
+        public EntityRef? Current => LastOpened;
+        public bool CanGoBack => false;
+        public bool CanGoForward => false;
+        public bool CanOpen(EntityRef reference) => true;
+        public void Open(EntityRef reference) => LastOpened = reference;
+        public void Back() { }
+        public void Forward() { }
+        public event EventHandler<NavigatedEventArgs>? Navigated { add { } remove { } }
+    }
+}
+```
+
+- [ ] **Step 2: Verify the tests fail (handler doesn't exist yet)**
+
+Run: `dotnet build tests/Silmarillion.Tests/Silmarillion.Tests.csproj`
+Expected: build fails — `SilmarillionDeepLinkHandler` type not found. Acceptable; Task 10 creates it.
+
+---
+
+## Task 10: SilmarillionDeepLinkHandler — implementation + commit 2
+
+**Files:**
+- Create: `src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs`
+- Modify: `src/Silmarillion.Module/SilmarillionModule.cs`
+- Modify: `tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs` (add integration test)
+- Modify: `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` (ProjectReference to Silmarillion.Module if absent)
+
+Spec §4.
+
+- [ ] **Step 1: Create the handler**
+
+```csharp
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// Handles <c>mithril://silmarillion/&lt;kind&gt;/&lt;internalName&gt;</c> — the
+/// module-scoped form (issue #229). Symmetric with <c>mithril://pippin/...</c>,
+/// <c>mithril://legolas/...</c>, etc. The legacy single-kind forms
+/// (<c>mithril://item/...</c> / <c>mithril://recipe/...</c>) remain supported
+/// via <see cref="ItemDeepLinkHandler"/> / <see cref="RecipeDeepLinkHandler"/>.
+/// </summary>
+public sealed class SilmarillionDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex NamePattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IReferenceNavigator _navigator;
+
+    public SilmarillionDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
+
+    public string Action => "silmarillion";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (string.IsNullOrEmpty(subPath))
+        {
+            diag?.Info("DeepLink", "Rejected: silmarillion payload is empty.");
+            return false;
+        }
+
+        // Strictly two segments: kind/name. Extra segments are rejected so the
+        // grammar stays unambiguous when future kinds ship.
+        var slash = subPath.IndexOf('/');
+        if (slash < 0 || slash == subPath.Length - 1)
+        {
+            diag?.Info("DeepLink", $"Rejected: silmarillion payload '{subPath}' missing kind or name segment.");
+            return false;
+        }
+        var kind = subPath.AsSpan(0, slash).ToString().ToLowerInvariant();
+        var name = subPath[(slash + 1)..];
+        if (name.Contains('/'))
+        {
+            diag?.Info("DeepLink", $"Rejected: silmarillion payload '{subPath}' has extra segments.");
+            return false;
+        }
+        if (!NamePattern.IsMatch(name))
+        {
+            diag?.Info("DeepLink", $"Rejected: silmarillion name '{name}' failed validation.");
+            return false;
+        }
+
+        switch (kind)
+        {
+            case "item":
+                _navigator.Open(EntityRef.Item(name));
+                return true;
+            case "recipe":
+                _navigator.Open(EntityRef.Recipe(name));
+                return true;
+            default:
+                diag?.Info("DeepLink", $"Rejected: silmarillion kind '{kind}' is not yet routable.");
+                return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register in `SilmarillionModule.Register`**
+
+Open `src/Silmarillion.Module/SilmarillionModule.cs`. Find the existing `Register(IServiceCollection)`. Add immediately after the `services.AddSingleton<IReferenceNavigator, SilmarillionReferenceNavigator>();` line:
+
+```csharp
+        // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
+        // Legacy mithril://item/<name> / mithril://recipe/<name> remain wired in
+        // Mithril.Shared.Wpf.
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new SilmarillionDeepLinkHandler(sp.GetRequiredService<IReferenceNavigator>()));
+```
+
+Add `using Mithril.Shared.Modules;` and `using Silmarillion.Navigation;` at the top if missing.
+
+- [ ] **Step 3: Run handler tests**
+
+Run: `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj --filter "FullyQualifiedName~SilmarillionDeepLinkHandlerTests" -v normal`
+Expected: all tests from Task 9 pass.
+
+- [ ] **Step 4: Add router-level integration test**
+
+In `tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs`, append:
+
+```csharp
+    [Fact]
+    public void SilmarillionRoute_DispatchedToReferenceNavigator()
+    {
+        var nav = new RecordingNavigator();
+        var router = new DeepLinkRouter(new IDeepLinkHandler[]
+        {
+            new ItemDeepLinkHandler(nav),
+            new RecipeDeepLinkHandler(nav),
+            new Silmarillion.Navigation.SilmarillionDeepLinkHandler(nav),
+        });
+
+        router.Handle("mithril://silmarillion/item/CraftedLeatherBoots5").Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Item("CraftedLeatherBoots5"));
+
+        router.Handle("mithril://silmarillion/recipe/MakeTomatoSauce").Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Recipe("MakeTomatoSauce"));
+    }
+```
+
+If `tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj` doesn't already reference `Silmarillion.Module.csproj`, add the `<ProjectReference>` entry to the existing references `<ItemGroup>`.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `dotnet test Mithril.slnx --filter "FullyQualifiedName~DeepLinkRouter|FullyQualifiedName~SilmarillionDeepLinkHandler"`
+Expected: all pass.
+
+- [ ] **Step 6: Commit (commit 2)**
+
+```
+git add src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs \
+        src/Silmarillion.Module/SilmarillionModule.cs \
+        tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs \
+        tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs \
+        tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
+```
+
+Commit message:
+```
+feat(silmarillion): mithril://silmarillion/<kind>/<name> deep-link route (#229)
+
+Module-scoped form symmetric with mithril://pippin/..., mithril://legolas/...,
+etc. Strictly two-segment grammar (kind + name); unknown kinds rejected for
+forward-compat as Bucket-B tabs ship.
+
+Legacy mithril://item/<name> and mithril://recipe/<name> remain supported.
+The about-settings panel and wiki Deep-Linking page are updated to point at
+the preferred form in commit 6.
+
+Closes #229.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Task 11: Compact row templates (commit 3)
+
+**Files:**
+- Modify: `src/Silmarillion.Module/Views/Resources.xaml`
+
+Spec §5.
+
+- [ ] **Step 1: Replace both DataTemplates**
+
+Open the file. Replace the entire `ItemCardTemplate` and `RecipeCardTemplate` blocks (current content shown for context, around lines 11–52). New content:
+
+```xml
+    <!-- Compact two-line row for Items tab. Bound DataContext: Mithril.Reference.Models.Items.Item.
+         Replaces the card layout in #231; ~36px per row, ~40+ visible. Key name kept as
+         "*CardTemplate" to avoid rippling into both tab views — names are wallpaper. -->
+    <DataTemplate x:Key="ItemCardTemplate">
+        <DockPanel LastChildFill="True">
+            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                           Width="24" Height="24" Margin="6,3,6,3" VerticalAlignment="Center"/>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
+                           Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis"
+                           Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
+
+    <!-- Compact two-line row for Recipes tab. Bound DataContext: Silmarillion.ViewModels.RecipeListRow. -->
+    <DataTemplate x:Key="RecipeCardTemplate">
+        <DockPanel LastChildFill="True">
+            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                           Width="24" Height="24" Margin="6,3,6,3" VerticalAlignment="Center"/>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis"
+                           Visibility="{Binding SkillDisplayName, Converter={StaticResource NullOrEmptyToVis}}">
+                    <Run Text="{Binding SkillDisplayName, Mode=OneWay}"/>
+                    <Run Text=" "/>
+                    <Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
+                </TextBlock>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Mithril.slnx`
+Expected: build succeeds (XAML compiles).
+
+- [ ] **Step 3: Manual visual verification**
+
+Launch: `dotnet run --project src/Mithril.Shell`
+
+Navigate to Silmarillion module. Confirm on both tabs (Items + Recipes):
+- Rows are ~36px tall (24px icon + tight padding).
+- Two-line layout: name on line 1 in gold/semibold; subtitle on line 2 in dim grey/small.
+- Subtitle hides for items without an equip slot (e.g. consumables).
+- Long names truncate with `…` ellipsis rather than wrapping.
+- Hover and selection accent still work.
+- ~40+ rows fit in the visible area (vs ~17 before).
+- Scroll smoothness unchanged (virtualization still on).
+
+Close the app.
+
+- [ ] **Step 4: Commit (commit 3)**
+
+```
+git add src/Silmarillion.Module/Views/Resources.xaml
+git commit -m "$(cat <<'EOF'
+feat(silmarillion): compact two-line row layout for browse lists (#231)
+
+Replace card-shaped DataTemplates with row-shaped compact layout: 24px
+icon + name (line 1) + dim subtitle (line 2, equip-slot for items /
+skill+level for recipes). Row height drops from ~80px to ~36px; visible
+row count rises from ~17 to ~40+.
+
+Card layout was inherited from Celebrimbor's RecipeCard, but Celebrimbor
+uses cards as inspect-popups while Silmarillion uses them for browsable
+catalogue navigation — density beats card-shape for the browse use case.
+
+Closes #231.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: ItemDetailView restructure (commit 4)
+
+**Files:**
+- Modify: `src/Mithril.Shared.Wpf/ItemDetailView.xaml`
+
+Spec §6.
+
+- [ ] **Step 1: Replace the top-level structure**
+
+The current file uses `<Border>` → `<Grid>` with 23 `<RowDefinition>`s and one `<TextBlock Grid.Row="22" VerticalAlignment="Bottom">` for the footer. Replace with `<Border>` → `<DockPanel>` → footer-docked-bottom + body `<StackPanel>`.
+
+Apply this targeted edit (preserve every existing child element's content; only their containers change, and the cross-link sections move):
+
+Replace:
+```xml
+    <Border Padding="14,12">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <!-- ...20 more RowDefinitions... -->
+            </Grid.RowDefinitions>
+            <!-- existing children with Grid.Row="N" -->
+```
+
+With:
+```xml
+    <Border Padding="14,12">
+        <DockPanel>
+            <!-- Internal-name footer pins to the bottom of the DockPanel. With the
+                 host ContentControl bound to ScrollViewer.ViewportHeight, the
+                 DockPanel stretches to viewport and the footer pins to the bottom
+                 of the right pane even for sparse items. Matches the pattern
+                 already used by RecipeDetailView. -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding InternalName}"
+                       Foreground="#88FFFFFF"
+                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       Margin="0,8,0,0" HorizontalAlignment="Right"/>
+            <StackPanel>
+                <!-- children below, reordered: cross-links float up to right
+                     after Description (was rows 19-21, now rows 2-4). -->
+```
+
+Strip every `Grid.Row="N"` attribute from the child `<DockPanel>` / `<StackPanel>` blocks. Remove the old footer `<TextBlock Grid.Row="22">` block (replaced by the docked footer above).
+
+Re-order the body children to this sequence (each becomes a direct child of the new `<StackPanel>`):
+
+1. Header `<DockPanel>` (was Row 0)
+2. Description `<StackPanel>` (was Row 1)
+3. **Sources `<StackPanel>`** (was Row 19 — moved up)
+4. **Produced by `<StackPanel>`** (was Row 20 — moved up)
+5. **Used in `<StackPanel>`** (was Row 21 — moved up)
+6. Skill requirements `<StackPanel>` (was Row 2)
+7. Effects `<StackPanel>` (was Row 3 — drop the `<ScrollViewer MaxHeight="480">` wrapper? **No** — keep it as-is; it caps the inline effects panel's height inside the parent scroll. The outer ItemsTabView ScrollViewer is the one with the host MinHeight binding.)
+8. Augmentation (was Row 4)
+9. Applied augment waxes (was Row 5)
+10. Infusions (was Row 6)
+11. Treasure Effects (was Row 7)
+12. Teaches recipe (was Row 8)
+13. Additional effects (was Row 9)
+14. Progresses research (was Row 10)
+15. Grants XP (was Row 11)
+16. Reveals words of power (was Row 12)
+17. Teaches ability (was Row 13)
+18. Produces (was Row 14)
+19. Bonuses while equipped (was Row 15)
+20. Modifies crafted item (was Row 16)
+21. Cooldown adjustments (was Row 17)
+22. Extraction (was Row 18)
+
+Each `<StackPanel>`'s existing `Visibility="{Binding ...Count, Converter={StaticResource PositiveIntToVis}}"` binding is preserved verbatim — that's still how empty sections hide.
+
+For the Effects section specifically: drop the `Height="*"` semantics (was on `Grid.Row="3"`'s `RowDefinition`); the section becomes a plain `<StackPanel>` like the others. The inner `<ScrollViewer MaxHeight="480">` stays.
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Mithril.slnx`
+Expected: build succeeds. If there are XAML compile errors, the most likely cause is a leftover `Grid.Row="N"` attribute on a child — search the file for `Grid.Row` and remove every occurrence.
+
+- [ ] **Step 3: Manual visual verification**
+
+Launch: `dotnet run --project src/Mithril.Shell`
+
+Navigate to Silmarillion → Items. Verify:
+
+**Sparse item** (e.g., Lorebook 1, candle wick, or any material with no equip slot and no effects): Sources / Produced by / Used in sections render immediately below the description. Internal-name footer is at the bottom of the right pane regardless of scroll position. No empty band between description and cross-links.
+
+**Effect-heavy item** (e.g., any crafted weapon at tier 5+ with Treasure Effects): all sections render in the new order. The "Effects" section's internal `MaxHeight="480"` scroller still works for very long effect lists. Scrolling the outer pane works. No visual regressions.
+
+**Popup window**: right-click an item (or use the OpenInWindow command path) to open `ItemDetailWindow`. The popup sizes to content so the footer-pin behavior is irrelevant; verify the new section order looks reasonable.
+
+Close the app.
+
+- [ ] **Step 4: Commit (commit 4)**
+
+```
+git add src/Mithril.Shared.Wpf/ItemDetailView.xaml
+git commit -m "$(cat <<'EOF'
+feat(silmarillion): ItemDetailView reading-order rework for sparse items (#234)
+
+Replace the Grid+Height="*" slack-absorber pattern with a DockPanel
+wrapping a StackPanel body; internal-name footer is DockPanel.Dock=Bottom.
+Move cross-link sections (Sources / Produced by / Used in) from rows
+19-21 to immediately after Description — sparse items no longer force the
+eye past a dead zone of empty effects-region to reach the recipes that
+produce/consume them.
+
+Mirrors the structure already used by RecipeDetailView; the two detail
+views are now structurally consistent.
+
+Closes #234.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: `IReferenceKindTarget` interface
+
+**Files:**
+- Create: `src/Mithril.Shared/Reference/IReferenceKindTarget.cs`
+
+Spec §7.
+
+- [ ] **Step 1: Create the interface**
+
+```csharp
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// A single entity-kind dispatch target registered with the Silmarillion
+/// reference navigator. Each tab module registers one implementation; the
+/// navigator and the host VM enumerate registered targets instead of
+/// enumerating <c>switch (EntityKind)</c> cases (issue #239).
+///
+/// Replaces the hardcoded <c>V1TabbedKinds</c> HashSet and the two switches
+/// in <c>SilmarillionViewModel</c>. As Bucket-B tabs ship (NPCs → Quests →
+/// Areas+Landmarks → Lorebooks → Abilities → Effects → PlayerTitles →
+/// StorageVaults) each adds one more target — no touches to the navigator
+/// or the host VM.
+/// </summary>
+public interface IReferenceKindTarget
+{
+    /// <summary>The entity kind this target is responsible for. One target per kind.</summary>
+    EntityKind Kind { get; }
+
+    /// <summary>The TabControl index this target's UI lives at.</summary>
+    int TabIndex { get; }
+
+    /// <summary>
+    /// Look the entity up by internal name and select it in the tab's
+    /// master-detail. Returns false if the entity isn't in the reference data
+    /// (e.g. a stale deep link).
+    /// </summary>
+    bool TrySelectByInternalName(string internalName);
+
+    /// <summary>
+    /// Open the current detail in a popup window. Returns false if the tab
+    /// has no current detail (nothing selected).
+    /// </summary>
+    bool TryOpenInWindow();
+}
+```
+
+Lives in `Mithril.Shared` (not `Mithril.Shared.Wpf`) — `EntityKind` is here, and the contract stays presentation-agnostic. The concrete implementations are presentation-coupled and live in `Silmarillion.Module`.
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build src/Mithril.Shared/Mithril.Shared.csproj`
+Expected: build succeeds.
+
+---
+
+## Task 14: `ItemsKindTarget` + tests
+
+**Files:**
+- Create: `src/Silmarillion.Module/Navigation/ItemsKindTarget.cs`
+- Create: `tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs`
+
+Spec §8.
+
+- [ ] **Step 1: Create the failing test**
+
+```csharp
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class ItemsKindTargetTests
+{
+    [Fact]
+    public void Kind_IsItem()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Item);
+    }
+
+    [Fact]
+    public void TabIndex_IsZero()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownItem_SelectsOnTabVm_ReturnsTrue()
+    {
+        var (target, vm, refData) = BuildTarget();
+        var item = new Item { Id = 5010, InternalName = "Tomato", Name = "Tomato" };
+        refData.AddItem(item);
+        vm.RehydrateAllItems();
+
+        var ok = target.TrySelectByInternalName("Tomato");
+
+        ok.Should().BeTrue();
+        vm.SelectedItem.Should().Be(item);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownItem_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        vm.SelectedItem.Should().BeNull();  // precondition
+
+        target.TrySelectByInternalName("DoesNotExist").Should().BeFalse();
+        vm.SelectedItem.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (ItemsKindTarget Target, ItemsTabViewModel Vm, FakeReferenceData RefData) BuildTarget()
+    {
+        var refData = new FakeReferenceData();
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new ItemsTabViewModel(refData, nav);
+        var target = new ItemsKindTarget(vm, refData);
+        return (target, vm, refData);
+    }
+}
+```
+
+This test depends on a `FakeReferenceData` helper. If `tests/TestSupport/FakeReferenceData.cs` doesn't already expose `AddItem` + a settable `ItemsByInternalName`, reuse what's there or extend it minimally. If extending breaks other consumers, copy the minimal surface into a private inner class:
+
+```csharp
+    private sealed class FakeReferenceData : Mithril.Shared.Reference.IReferenceDataService
+    {
+        private readonly Dictionary<long, Item> _items = new();
+        private readonly Dictionary<string, Item> _byName = new(StringComparer.Ordinal);
+        public void AddItem(Item item) { _items[item.Id] = item; if (item.InternalName is not null) _byName[item.InternalName] = item; }
+        public IReadOnlyList<string> Keys => Array.Empty<string>();
+        public IReadOnlyDictionary<long, Item> Items => _items;
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName => _byName;
+        // ...all other members throw NotImplementedException — tests don't use them.
+        // For brevity, executor should copy the minimal stub used by existing
+        // Silmarillion test fixtures (see tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs).
+    }
+```
+
+**Executor note:** Don't reinvent the wheel. Open [tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs](../../tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs) first to see the fake-data shape that test already uses and copy that pattern.
+
+- [ ] **Step 2: Verify the test fails (type doesn't exist)**
+
+Run: `dotnet build tests/Silmarillion.Tests/Silmarillion.Tests.csproj`
+Expected: `ItemsKindTarget` not found.
+
+- [ ] **Step 3: Create the implementation**
+
+```csharp
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the Items tab. Lives next to
+/// the navigator so the registry is owned by the same module that hosts the
+/// tabs. Wires the navigator's "select this entity" call into the tab VM's
+/// existing master-detail selection, and the "open in window" call into the
+/// existing <see cref="ItemDetailWindow"/> popup.
+/// </summary>
+public sealed class ItemsKindTarget : IReferenceKindTarget
+{
+    private readonly ItemsTabViewModel _vm;
+    private readonly IReferenceDataService _refData;
+
+    public ItemsKindTarget(ItemsTabViewModel vm, IReferenceDataService refData)
+    {
+        _vm = vm;
+        _refData = refData;
+    }
+
+    public EntityKind Kind => EntityKind.Item;
+
+    public int TabIndex => 0;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (!_refData.ItemsByInternalName.TryGetValue(internalName, out var item))
+            return false;
+        _vm.SelectedItem = item;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new ItemDetailWindow(_vm.DetailViewModel).Show();
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj --filter "FullyQualifiedName~ItemsKindTargetTests" -v normal`
+Expected: all four pass.
+
+---
+
+## Task 15: `RecipesKindTarget` + tests
+
+**Files:**
+- Create: `src/Silmarillion.Module/Navigation/RecipesKindTarget.cs`
+- Create: `tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs`
+
+Spec §8.
+
+- [ ] **Step 1: Create the failing test**
+
+```csharp
+using FluentAssertions;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class RecipesKindTargetTests
+{
+    [Fact]
+    public void Kind_IsRecipe()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Recipe);
+    }
+
+    [Fact]
+    public void TabIndex_IsOne()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownRecipe_SelectsOnTabVm_ReturnsTrue()
+    {
+        var (target, vm, refData) = BuildTarget();
+        var recipe = new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa" };
+        refData.AddRecipe(recipe);
+        vm.RehydrateAllRecipes();
+
+        var ok = target.TrySelectByInternalName("MakeSalsa");
+
+        ok.Should().BeTrue();
+        vm.SelectedRecipe.Should().Be(recipe);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownRecipe_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        target.TrySelectByInternalName("DoesNotExist").Should().BeFalse();
+        vm.SelectedRecipe.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (RecipesKindTarget Target, RecipesTabViewModel Vm, FakeReferenceData RefData) BuildTarget()
+    {
+        // Use the same FakeReferenceData pattern as ItemsKindTargetTests; if the
+        // shared TestSupport version supports recipes, prefer that; otherwise use
+        // a local inner-class fake matching the shape used by RecipesTabViewModelTests.
+        var refData = new FakeReferenceData();
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new RecipesTabViewModel(refData, nav);
+        var target = new RecipesKindTarget(vm, refData);
+        return (target, vm, refData);
+    }
+}
+```
+
+**Executor note:** Same as T14 — read `tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs` first for the existing fake-data convention before writing the inner class.
+
+- [ ] **Step 2: Verify failing**
+
+Run: `dotnet build tests/Silmarillion.Tests/Silmarillion.Tests.csproj`
+Expected: `RecipesKindTarget` not found.
+
+- [ ] **Step 3: Create the implementation**
+
+```csharp
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary><see cref="IReferenceKindTarget"/> adapter for the Recipes tab.
+/// See <see cref="ItemsKindTarget"/>.</summary>
+public sealed class RecipesKindTarget : IReferenceKindTarget
+{
+    private readonly RecipesTabViewModel _vm;
+    private readonly IReferenceDataService _refData;
+
+    public RecipesKindTarget(RecipesTabViewModel vm, IReferenceDataService refData)
+    {
+        _vm = vm;
+        _refData = refData;
+    }
+
+    public EntityKind Kind => EntityKind.Recipe;
+
+    public int TabIndex => 1;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (!_refData.RecipesByInternalName.TryGetValue(internalName, out var recipe))
+            return false;
+        _vm.SelectedRecipe = recipe;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new RecipeDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj --filter "FullyQualifiedName~RecipesKindTargetTests" -v normal`
+Expected: all five pass.
+
+---
+
+## Task 16: Navigator → registry + update existing tests
+
+**Files:**
+- Modify: `src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs`
+- Modify: `src/Silmarillion.Module/SilmarillionModule.cs` (register kind targets)
+- Modify: `tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs`
+
+Spec §9.
+
+- [ ] **Step 1: Rewrite the navigator**
+
+Replace the entire body of `SilmarillionReferenceNavigator.cs` with:
+
+```csharp
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// Live implementation of <see cref="IReferenceNavigator"/>. Maintains unbounded
+/// back/forward stacks of <see cref="EntityRef"/>. Registered by
+/// <see cref="SilmarillionModule"/> and overrides the shell's
+/// <c>NoOpReferenceNavigator</c> via last-singleton-wins DI semantics.
+///
+/// <see cref="CanOpen"/> is registry-driven: a kind is navigable iff an
+/// <see cref="IReferenceKindTarget"/> has been registered for it. As Bucket-B
+/// tabs ship (NPCs → Quests → …), each one adds a target and chip
+/// clickability for that kind flips on automatically.
+/// </summary>
+public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
+{
+    private readonly IReadOnlyDictionary<EntityKind, IReferenceKindTarget> _targets;
+
+    private readonly Stack<EntityRef> _back = new();
+    private readonly Stack<EntityRef> _forward = new();
+
+    public SilmarillionReferenceNavigator(IEnumerable<IReferenceKindTarget> targets)
+    {
+        // Fail-loud on duplicate Kind registrations — same shape as DeepLinkRouter.
+        var byKind = new Dictionary<EntityKind, IReferenceKindTarget>();
+        foreach (var t in targets)
+        {
+            if (byKind.ContainsKey(t.Kind))
+                throw new InvalidOperationException(
+                    $"Duplicate IReferenceKindTarget registration for kind '{t.Kind}': " +
+                    $"{byKind[t.Kind].GetType().FullName} and {t.GetType().FullName}.");
+            byKind[t.Kind] = t;
+        }
+        _targets = byKind;
+    }
+
+    public EntityRef? Current { get; private set; }
+    public bool CanGoBack => _back.Count > 0;
+    public bool CanGoForward => _forward.Count > 0;
+    public event EventHandler<NavigatedEventArgs>? Navigated;
+
+    public bool CanOpen(EntityRef reference) => _targets.ContainsKey(reference.Kind);
+
+    public void Open(EntityRef reference)
+    {
+        var previous = Current;
+        if (previous is not null) _back.Push(previous);
+        _forward.Clear();
+        Current = reference;
+        Navigated?.Invoke(this, new NavigatedEventArgs(previous, Current, NavigationKind.Open));
+    }
+
+    public void Back()
+    {
+        if (_back.Count == 0) return;
+        var previous = Current;
+        if (previous is not null) _forward.Push(previous);
+        Current = _back.Pop();
+        Navigated?.Invoke(this, new NavigatedEventArgs(previous, Current, NavigationKind.Back));
+    }
+
+    public void Forward()
+    {
+        if (_forward.Count == 0) return;
+        var previous = Current;
+        if (previous is not null) _back.Push(previous);
+        Current = _forward.Pop();
+        Navigated?.Invoke(this, new NavigatedEventArgs(previous, Current, NavigationKind.Forward));
+    }
+}
+```
+
+- [ ] **Step 2: Update `SilmarillionReferenceNavigatorTests.cs`**
+
+Every existing test that constructs `new SilmarillionReferenceNavigator()` needs an empty-or-stub `IEnumerable<IReferenceKindTarget>` parameter. Replace all `new SilmarillionReferenceNavigator()` calls in the test file with `new SilmarillionReferenceNavigator(NavTargets())` where:
+
+```csharp
+    private static IEnumerable<IReferenceKindTarget> NavTargets() => new IReferenceKindTarget[]
+    {
+        new StubTarget(EntityKind.Item),
+        new StubTarget(EntityKind.Recipe),
+    };
+
+    private sealed class StubTarget : IReferenceKindTarget
+    {
+        public StubTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+```
+
+Add the helper + private class near the other private helpers at the bottom of `SilmarillionReferenceNavigatorTests`.
+
+Replace the existing `CanOpen_TrueForV1TabbedKinds_FalseOtherwise` `[Theory]` (lines 138–154 of the existing file) with three new tests:
+
+```csharp
+    [Fact]
+    public void CanOpen_RegisteredKind_ReturnsTrue()
+    {
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
+
+        nav.CanOpen(EntityRef.Item("anything")).Should().BeTrue();
+        nav.CanOpen(EntityRef.Recipe("anything")).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(EntityKind.Ability)]
+    [InlineData(EntityKind.Npc)]
+    [InlineData(EntityKind.Quest)]
+    [InlineData(EntityKind.Lorebook)]
+    [InlineData(EntityKind.Landmark)]
+    [InlineData(EntityKind.Area)]
+    [InlineData(EntityKind.PlayerTitle)]
+    [InlineData(EntityKind.StorageVault)]
+    [InlineData(EntityKind.Effect)]
+    public void CanOpen_UnregisteredKind_ReturnsFalse(EntityKind kind)
+    {
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
+
+        nav.CanOpen(new EntityRef(kind, "anything")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_DuplicateKind_Throws()
+    {
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Item),
+        };
+        var act = () => new SilmarillionReferenceNavigator(targets);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Duplicate IReferenceKindTarget*Item*");
+    }
+```
+
+- [ ] **Step 3: Register kind targets in `SilmarillionModule.Register`**
+
+Open `src/Silmarillion.Module/SilmarillionModule.cs`. Replace the body of `Register(IServiceCollection)` so the navigator + tab VMs + kind targets register in the right order. The whole method becomes:
+
+```csharp
+    public void Register(IServiceCollection services)
+    {
+        // Replace the shell-registered NoOpReferenceNavigator. Last AddSingleton<T> wins
+        // for non-keyed singleton resolution, and module Register() runs after shell DI
+        // setup. The navigator pulls all IReferenceKindTarget registrations via DI.
+        services.AddSingleton<IReferenceNavigator>(sp => new SilmarillionReferenceNavigator(
+            sp.GetServices<IReferenceKindTarget>()));
+
+        services.AddSingleton<ItemsTabViewModel>();
+        services.AddSingleton<RecipesTabViewModel>();
+        services.AddSingleton<SilmarillionViewModel>();
+
+        // Kind targets registered after the tab VMs so DI can resolve them.
+        services.AddSingleton<IReferenceKindTarget>(sp => new ItemsKindTarget(
+            sp.GetRequiredService<ItemsTabViewModel>(),
+            sp.GetRequiredService<IReferenceDataService>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new RecipesKindTarget(
+            sp.GetRequiredService<RecipesTabViewModel>(),
+            sp.GetRequiredService<IReferenceDataService>()));
+
+        // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new SilmarillionDeepLinkHandler(sp.GetRequiredService<IReferenceNavigator>()));
+
+        services.AddSingleton<SilmarillionView>(sp => new SilmarillionView
+        {
+            DataContext = sp.GetRequiredService<SilmarillionViewModel>(),
+        });
+    }
+```
+
+Update the using imports at the top of the file to include `Silmarillion.Navigation;` if not already there.
+
+- [ ] **Step 4: Run the navigator tests**
+
+Run: `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj --filter "FullyQualifiedName~SilmarillionReferenceNavigatorTests" -v normal`
+Expected: all tests pass (existing back/forward tests untouched + new registry tests pass).
+
+---
+
+## Task 17: `SilmarillionViewModel` → registry + tests
+
+**Files:**
+- Modify: `src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs`
+- Create: `tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs`
+
+Spec §10.
+
+- [ ] **Step 1: Replace `SilmarillionViewModel.cs` body**
+
+Replace the entire file with:
+
+```csharp
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Top-level view-model for the Silmarillion reference-data browser. Hosts the
+/// per-tab view-models and the navigation commands surfaced in the header chrome
+/// (Back / Forward / Open-in-window). Subscribes to <see cref="IReferenceNavigator.Navigated"/>
+/// to drive automatic tab-switching when an entity of a different kind is opened
+/// (e.g. clicking a Recipe cross-link from an Item detail).
+///
+/// OnNavigated and OpenInWindow dispatch via the <see cref="IReferenceKindTarget"/>
+/// registry; per-kind switches were retired in #239.
+/// </summary>
+public sealed partial class SilmarillionViewModel : ObservableObject
+{
+    private readonly IReferenceNavigator _navigator;
+    private readonly IReadOnlyDictionary<EntityKind, IReferenceKindTarget> _targets;
+
+    public SilmarillionViewModel(
+        ItemsTabViewModel items,
+        RecipesTabViewModel recipes,
+        IReferenceNavigator navigator,
+        IEnumerable<IReferenceKindTarget> targets)
+    {
+        Items = items;
+        Recipes = recipes;
+        _navigator = navigator;
+
+        var byKind = new Dictionary<EntityKind, IReferenceKindTarget>();
+        foreach (var t in targets) byKind[t.Kind] = t;
+        _targets = byKind;
+
+        BackCommand = new RelayCommand(() => _navigator.Back(), () => _navigator.CanGoBack);
+        ForwardCommand = new RelayCommand(() => _navigator.Forward(), () => _navigator.CanGoForward);
+
+        _navigator.Navigated += OnNavigated;
+    }
+
+    public ItemsTabViewModel Items { get; }
+    public RecipesTabViewModel Recipes { get; }
+
+    /// <summary>0 = Items, 1 = Recipes. Two-way bound to the TabControl in the view.</summary>
+    [ObservableProperty]
+    private int _selectedTabIndex;
+
+    public IRelayCommand BackCommand { get; }
+    public IRelayCommand ForwardCommand { get; }
+
+    [RelayCommand(CanExecute = nameof(CanOpenInWindow))]
+    private void OpenInWindow()
+    {
+        if (_navigator.Current is { } current
+            && _targets.TryGetValue(current.Kind, out var target))
+        {
+            target.TryOpenInWindow();
+        }
+    }
+
+    private bool CanOpenInWindow() => _navigator.Current is not null;
+
+    private void OnNavigated(object? sender, NavigatedEventArgs e)
+    {
+        BackCommand.NotifyCanExecuteChanged();
+        ForwardCommand.NotifyCanExecuteChanged();
+        OpenInWindowCommand.NotifyCanExecuteChanged();
+
+        if (e.Current is null) return;
+        if (!_targets.TryGetValue(e.Current.Kind, out var target)) return;
+
+        SelectedTabIndex = target.TabIndex;
+        target.TrySelectByInternalName(e.Current.InternalName);
+    }
+}
+```
+
+The constructor's `IReferenceDataService` parameter is now gone — the targets carry the ref-data dependency themselves. Drop the corresponding `using Silmarillion.Views;` if it was only there for the popup `new …Window(...)` calls (now removed since `TryOpenInWindow` lives on the targets).
+
+- [ ] **Step 2: Create the failing test**
+
+```csharp
+using CommunityToolkit.Mvvm.Input;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class SilmarillionViewModelTests
+{
+    [Fact]
+    public void OnNavigated_ItemKind_SwitchesTabAndCallsTarget()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var recipesTarget = new RecordingTarget(EntityKind.Recipe, tabIndex: 1);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget, recipesTarget });
+
+        nav.Open(EntityRef.Item("Tomato"));
+
+        vm.SelectedTabIndex.Should().Be(0);
+        itemsTarget.LastSelectedInternalName.Should().Be("Tomato");
+        recipesTarget.LastSelectedInternalName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OnNavigated_RecipeKind_SwitchesTabAndCallsTarget()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var recipesTarget = new RecordingTarget(EntityKind.Recipe, tabIndex: 1);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget, recipesTarget });
+
+        nav.Open(EntityRef.Recipe("MakeSalsa"));
+
+        vm.SelectedTabIndex.Should().Be(1);
+        recipesTarget.LastSelectedInternalName.Should().Be("MakeSalsa");
+    }
+
+    [Fact]
+    public void OnNavigated_UnregisteredKind_DoesNotChangeTab()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
+
+        vm.SelectedTabIndex = 0;
+        nav.Open(new EntityRef(EntityKind.Npc, "NPC_Marna"));
+
+        vm.SelectedTabIndex.Should().Be(0);  // unchanged
+        itemsTarget.LastSelectedInternalName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OpenInWindow_NoCurrent_NoOp()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var (vm, _) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
+
+        // CanExecute should be false; explicit call is a no-op (TryOpenInWindow not invoked).
+        vm.OpenInWindowCommand.CanExecute(null).Should().BeFalse();
+        itemsTarget.OpenInWindowCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void OpenInWindow_CurrentItem_CallsTarget()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
+
+        nav.Open(EntityRef.Item("Tomato"));
+        vm.OpenInWindowCommand.Execute(null);
+
+        itemsTarget.OpenInWindowCallCount.Should().Be(1);
+    }
+
+    private static (SilmarillionViewModel Vm, SilmarillionReferenceNavigator Nav) BuildVm(
+        IReferenceKindTarget[] targets)
+    {
+        var nav = new SilmarillionReferenceNavigator(targets);
+        // Empty/null tab VMs are fine — the tests only exercise the dispatch path,
+        // not the tab VMs themselves (those are tested separately).
+        // Pass null-forgiving stubs; SilmarillionViewModel never reads .Items / .Recipes here.
+        var vm = new SilmarillionViewModel(items: null!, recipes: null!, nav, targets);
+        return (vm, nav);
+    }
+
+    private sealed class RecordingTarget : IReferenceKindTarget
+    {
+        public RecordingTarget(EntityKind kind, int tabIndex) { Kind = kind; TabIndex = tabIndex; }
+        public EntityKind Kind { get; }
+        public int TabIndex { get; }
+        public string? LastSelectedInternalName { get; private set; }
+        public int OpenInWindowCallCount { get; private set; }
+        public bool TrySelectByInternalName(string internalName)
+        {
+            LastSelectedInternalName = internalName;
+            return true;
+        }
+        public bool TryOpenInWindow()
+        {
+            OpenInWindowCallCount++;
+            return true;
+        }
+    }
+}
+```
+
+**Executor caveat:** the `items: null!, recipes: null!` shape works ONLY because the existing `SilmarillionViewModel` only assigns these to `Items` / `Recipes` properties without dereferencing them in the navigation path. If a constructor null-check is added later, the test will need a real or stubbed `ItemsTabViewModel` / `RecipesTabViewModel`. The current constructor (after Task 17 step 1) doesn't null-check.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj --filter "FullyQualifiedName~SilmarillionViewModelTests" -v normal`
+Expected: all five pass.
+
+- [ ] **Step 4: Run the full Silmarillion test suite to catch regressions**
+
+Run: `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj`
+Expected: every test passes.
+
+- [ ] **Step 5: Commit (commit 5)**
+
+```
+git add src/Mithril.Shared/Reference/IReferenceKindTarget.cs \
+        src/Silmarillion.Module/Navigation/ItemsKindTarget.cs \
+        src/Silmarillion.Module/Navigation/RecipesKindTarget.cs \
+        src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs \
+        src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs \
+        src/Silmarillion.Module/SilmarillionModule.cs \
+        tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs \
+        tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs \
+        tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs \
+        tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs
+```
+
+Commit message:
+```
+refactor(silmarillion): IReferenceNavigator → IReferenceKindTarget registry (#239)
+
+Parallel pattern to commit 1's DeepLinkRouter refactor. The
+V1TabbedKinds HashSet and the two switches in SilmarillionViewModel
+(OnNavigated, OpenInWindow) all enumerated the same two-kind list and
+all needed to grow as Bucket-B tabs ship.
+
+Each tab module now registers an IReferenceKindTarget; the navigator
+exposes CanOpen as a registry lookup; the top-level VM dispatches via
+the same registry. As NPCs / Quests / Areas / etc. ship, each adds one
+more target — zero touches to the navigator or top-level VM.
+
+No user-visible behavior change. CanOpen still returns true for Item +
+Recipe and false for everything else. Tab-switching on cross-link
+navigation still works.
+
+Closes #239.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Task 18: Wiki + about-settings example + commit 6
+
+**Files:**
+- Modify: `src/Mithril.Shell/Views/AboutSettingsView.xaml`
+- Modify: project-gorgon.wiki Deep-Linking page (separate checkout at `i:\src\project-gorgon.wiki`)
+
+Spec §11.
+
+- [ ] **Step 1: Update the example URI in AboutSettingsView**
+
+Open `src/Mithril.Shell/Views/AboutSettingsView.xaml`. Find line 146 (the existing `Text="Register a mithril:// URL handler so other apps can open Mithril directly at a specific item. Example: mithril://item/CraftedLeatherBoots5."`). Replace the example URI in that string with the module-scoped form:
+
+```xml
+                       Text="Register a mithril:// URL handler so other apps can open Mithril directly at a specific item. Example: mithril://silmarillion/item/CraftedLeatherBoots5. Stored in your user registry (HKCU); no admin rights required."/>
+```
+
+The legacy form keeps working but the surfaced example points at the preferred form.
+
+- [ ] **Step 2: Build the shell**
+
+Run: `dotnet build src/Mithril.Shell/Mithril.Shell.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Update the wiki Deep-Linking page**
+
+Switch into the wiki checkout:
+```bash
+cd ../project-gorgon.wiki
+```
+
+Find the deep-linking page. Common candidate file names: `Deep-Linking.md`, `Deep‐Linking.md` (en-dash), `URI-Scheme.md`. If none exists, search for `mithril://item` in the wiki and edit whichever page mentions it:
+
+```bash
+git grep "mithril://item"
+```
+
+Update that page to:
+
+1. Show `mithril://silmarillion/item/<internalName>` and `mithril://silmarillion/recipe/<internalName>` as the **preferred** forms (with one or two concrete examples).
+2. Note `mithril://item/<internalName>` / `mithril://recipe/<internalName>` as **legacy but still supported** for backwards compat with existing links.
+3. Add `mithril://silmarillion/...` to whatever table or list enumerates the supported schemes.
+
+Commit on the wiki repo:
+```bash
+git add <the-edited-page>.md
+git commit -m "$(cat <<'EOF'
+Deep-Linking: document mithril://silmarillion/<kind>/<name> as preferred
+
+The legacy mithril://item/ and mithril://recipe/ forms continue to work,
+but the module-scoped form is now preferred for parity with the other
+modules' deep-link schemes (pippin, legolas, elrond).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push origin master
+```
+
+(The wiki repo's default branch is `master`, not `main` — distinct from this repo.)
+
+- [ ] **Step 4: Commit AboutSettingsView change (commit 6 on this repo)**
+
+Back in the main repo (`cd ../project gorgon`):
+
+```
+git add src/Mithril.Shell/Views/AboutSettingsView.xaml
+git commit -m "$(cat <<'EOF'
+docs: point about-settings deep-link example at module-scoped form
+
+Surface the preferred mithril://silmarillion/item/... form in the
+example string. Legacy forms keep working.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: End-to-end manual verification + open PR
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `dotnet test Mithril.slnx`
+Expected: every test passes.
+
+- [ ] **Step 2: Launch the app and verify the polish trio + URI dispatch**
+
+Run: `dotnet run --project src/Mithril.Shell`
+
+Verify in-app:
+1. **Silmarillion → Items**: compact rows render, two-line layout, ~40+ rows visible.
+2. **Silmarillion → Recipes**: same density, skill+level on line 2.
+3. **Click an item with no effects** (e.g. a Lorebook, a candle wick): the right pane shows Sources / Produced by / Used in immediately after Description, internal-name footer pinned to bottom.
+4. **Click an effect-heavy item** (e.g. any rare crafted weapon): all sections render in the new order with no regressions.
+5. **Click a cross-link chip** (e.g. a recipe chip on an item detail): the Recipes tab opens and selects the right recipe. Back-button (mouse XButton1) navigates back to the item.
+6. **OpenInWindow** (Ctrl+O or the toolbar button if present): popup window shows the current detail.
+
+Then test URI dispatch via OS-level activation:
+```bash
+# Legacy form:
+Start-Process "mithril://item/CraftedLeatherBoots5"
+# Should open Silmarillion → Items → CraftedLeatherBoots5.
+
+# Module-scoped form:
+Start-Process "mithril://silmarillion/item/CraftedLeatherBoots5"
+# Should open the same item.
+
+# Recipe form:
+Start-Process "mithril://silmarillion/recipe/MakeTomatoSauce"
+# Should open Silmarillion → Recipes → MakeTomatoSauce.
+```
+
+Close the app.
+
+- [ ] **Step 3: Push and open PR**
+
+```
+git push -u origin feat/silmarillion-polish-v1
+gh pr create --title "Silmarillion polish v1 (#229/#231/#234) + DeepLink + Navigator registries (#239)" --body "$(cat <<'EOF'
+## Summary
+
+Bundles three #207-followup polish issues with two parallel "switch-as-registry" refactors. Spec: [docs/agent-plans/silmarillion-polish-v1.md](docs/agent-plans/silmarillion-polish-v1.md). Plan: [docs/agent-plans/2026-05-13-silmarillion-polish-v1-plan.md](docs/agent-plans/2026-05-13-silmarillion-polish-v1-plan.md).
+
+- **#229** — `mithril://silmarillion/<kind>/<name>` module-scoped routes alongside legacy `mithril://item/...` / `mithril://recipe/...`.
+- **#231** — Compact two-line row layout in the master-detail left pane (~36px rows vs ~80px cards).
+- **#234** — Cross-link sections (Sources / Produced by / Used in) move to immediately after Description in `ItemDetailView`.
+- **DeepLink registry refactor** — Precursor for #229. Six structurally-identical `switch (action)` cases become `IDeepLinkHandler` implementations registered per module.
+- **#239** — Same pattern for `IReferenceNavigator`: the `V1TabbedKinds` HashSet and the two switches in `SilmarillionViewModel` become an `IReferenceKindTarget` registry. The next PR (NPCs tab) is now purely additive.
+
+#235 (recipe-sources section) is intentionally out of scope — needs new reference-data plumbing and will land as a separate PR.
+
+## Test plan
+
+- [x] `dotnet build Mithril.slnx` — succeeds
+- [x] `dotnet test Mithril.slnx` — all pass
+- [x] DeepLinkRouter tests cover legacy + module-scoped routes
+- [x] SilmarillionDeepLinkHandlerTests cover the new grammar
+- [x] SilmarillionReferenceNavigatorTests cover registry-driven CanOpen + duplicate-kind throw
+- [x] ItemsKindTargetTests + RecipesKindTargetTests cover the adapter shape
+- [x] SilmarillionViewModelTests cover OnNavigated + OpenInWindow dispatch
+- [x] Visual: compact rows render at expected density on both tabs
+- [x] Visual: sparse items show cross-links above the fold
+- [x] Visual: effect-heavy items render with no regressions
+- [x] URI: `Start-Process mithril://silmarillion/item/<name>` opens the item
+- [x] URI: legacy `Start-Process mithril://item/<name>` still works
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** Every spec section maps to a task — §1 (T1), §2 (T2, T5–T8), §3 (T3), §4 (T9, T10), §5 (T11), §6 (T12), §7 (T13), §8 (T14, T15), §9 (T16), §10 (T17), §11 (T18).
+
+**Type consistency:** `IDeepLinkHandler.TryHandle(string subPath, IDiagnosticsSink? diag)` signature is used identically across T1, T2, T5–T8, T10. `IReferenceKindTarget` has the same `Kind` / `TabIndex` / `TrySelectByInternalName` / `TryOpenInWindow` shape across T13, T14, T15, T16, T17. `SilmarillionReferenceNavigator(IEnumerable<IReferenceKindTarget>)` constructor signature is consistent between T16's implementation and T17's tests.
+
+**Placeholders:** None.
+
+**Out-of-band note for executor:** When a step says "search for X" or "find the existing block around line N," line numbers may have drifted by the time the executor reads the file. Use the surrounding code context shown in the task as the actual locator, not the line number.

--- a/docs/agent-plans/silmarillion-polish-v1.md
+++ b/docs/agent-plans/silmarillion-polish-v1.md
@@ -60,12 +60,12 @@ New files under `src/Mithril.Shared.Wpf/Modules/`:
 
 The two regex constants `EntityPayloadPattern`, `ListPayloadPattern`, `PippinPayloadPattern`, `LegolasPayloadPattern` move with their owning handler. Keep them `private static readonly` on each handler class — they're not shared across handlers.
 
-New files in each owning module project (`src/<Module>.Module/Navigation/<Module>DeepLinkHandler.cs`):
+New files in each owning module project, alongside the existing import-target implementation (so navigation lives co-located with its analogue):
 
-- `Celebrimbor.Module/Navigation/CraftListDeepLinkHandler.cs` — `Action = "list"`, calls `ICraftListImportTarget.ImportFromLinkPayload`. Project already references `Mithril.Shared.Wpf`.
-- `Pippin.Module/Navigation/PippinDeepLinkHandler.cs` — `Action = "pippin"`.
-- `Legolas.Module/Navigation/LegolasDeepLinkHandler.cs` — `Action = "legolas"`.
-- `Elrond.Module/Navigation/ElrondDeepLinkHandler.cs` — `Action = "elrond"`.
+- `Celebrimbor.Module/Services/CraftListDeepLinkHandler.cs` — `Action = "list"`, calls `ICraftListImportTarget.ImportFromLinkPayload`. Sits next to `CraftListImportTarget.cs`. Project already references `Mithril.Shared.Wpf`.
+- `Pippin.Module/Sharing/PippinDeepLinkHandler.cs` — `Action = "pippin"`. Sits next to `PippinShareImportTarget.cs`.
+- `Legolas.Module/Sharing/LegolasDeepLinkHandler.cs` — `Action = "legolas"`. Sits next to `LegolasShareImportTarget.cs`.
+- `Elrond.Module/Services/ElrondDeepLinkHandler.cs` — `Action = "elrond"`. Sits next to `ElrondSkillImportTarget.cs`.
 
 Each module's `Register(IServiceCollection)` adds `services.AddSingleton<IDeepLinkHandler, FooDeepLinkHandler>()`. Item and Recipe handlers register from shell DI ([ServiceCollectionExtensions.cs](../../src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs)) since they live in the shared layer.
 

--- a/docs/agent-plans/silmarillion-polish-v1.md
+++ b/docs/agent-plans/silmarillion-polish-v1.md
@@ -1,16 +1,19 @@
-# Silmarillion polish v1 + DeepLink registry refactor
+# Silmarillion polish v1 + DeepLink + Navigator registry refactors
 
-**Tracked in:** #229, #231, #234 (bundled); precursor refactor unfiled.
+**Tracked in:** #229, #231, #234, #239 (bundled).
 
 ## Context
 
-Three #207 follow-up polish issues for the Silmarillion reference browser, bundled with a precursor refactor of [DeepLinkRouter.cs](../../src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs):
+Three #207 follow-up polish issues for the Silmarillion reference browser, bundled with two parallel refactors of the same shape (switch/hardcoded-set converted to a DI-registered handler registry):
 
 - **#229** — add `mithril://silmarillion/item/<name>` and `mithril://silmarillion/recipe/<name>` module-scoped routes alongside the existing `mithril://item/` / `mithril://recipe/` schemes.
 - **#231** — replace the master-detail card layout (~80px per row, ~17 visible) with a compact two-line row layout (~36px per row, ~40+ visible).
 - **#234** — move the cross-link sections (Sources / Produced by / Used in) from the bottom of [ItemDetailView.xaml](../../src/Mithril.Shared.Wpf/ItemDetailView.xaml) to immediately after Description, so sparse items don't force the user's eye past a dead zone of empty Effects-region to reach the recipes that produce/consume them.
+- **#239** — convert `IReferenceNavigator`'s three hardcoded `EntityKind` dispatches (the `V1TabbedKinds` HashSet and two switches in `SilmarillionViewModel`) into a `IReferenceKindTarget` registry. Forcing function: the next Silmarillion PR adds the **NPCs tab** (third kind), and per the upcoming-tabs research note, seven more Bucket-B tabs follow it. Refactoring now means each subsequent tab PR is purely additive (register one more target).
 
-The bundled refactor: `DeepLinkRouter`'s big `switch (action)` has grown to six structurally-identical cases (validate payload regex → null-check optional import target → call one method on it → log a diagnostic), and #229 is the first multi-segment route that doesn't fit the existing shape. Adding case #7 inline would mean a nested switch; extracting to a handler registry is the natural home for the new route. Bundled here rather than deferred because the registry is *what makes #229 clean*.
+The DeepLinkRouter refactor: `Handle`'s big `switch (action)` has grown to six structurally-identical cases (validate payload regex → null-check optional import target → call one method on it → log a diagnostic), and #229 is the first multi-segment route that doesn't fit the existing shape. Adding case #7 inline would mean a nested switch; extracting to a handler registry is the natural home for the new route. Bundled here rather than deferred because the registry is *what makes #229 clean*.
+
+The navigator refactor (#239) is the parallel pattern, motivated by Bucket-B rather than #229. Bundled alongside the DeepLinkRouter refactor because (a) both refactors are the same shape and review more clearly when read together, and (b) the next PR after this one adds the NPCs tab and benefits from landing on top of the registry.
 
 #235 (recipe Sources section + `IReferenceDataService.RecipeSources` plumbing) is intentionally **out of scope** for this PR — it's the only follow-up that needs new reference-data infrastructure and benefits from being a separate review.
 
@@ -23,6 +26,8 @@ The bundled refactor: `DeepLinkRouter`'s big `switch (action)` has grown to six 
 **Card-shaped rows become row-shaped rows.** The card template chosen for #207 was modelled after Celebrimbor's RecipeCard, but Celebrimbor uses cards as inspect-popups; Silmarillion uses them for browsable catalogue navigation, which needs density. Two-line compact (24px icon + name on line 1, dim subtitle on line 2) was chosen over single-line+tail because the subtitle (equip slot / skill+level) is genuinely useful at scan time and the second line costs ~8px versus the four-line card it replaces.
 
 **ItemDetailView's reading order is restructured by dropping the `Height="*"` slack-absorber.** The outer `Grid` with 23 explicit `RowDefinition`s becomes a `DockPanel` with the internal-name footer `Dock="Bottom"` and a `StackPanel` body. With the footer pinned by `DockPanel`, no body row needs to absorb slack, so the cross-link sections move from rows 19–21 to immediately after Description — the structural change *enables* the reorder. This mirrors the pattern already used by [RecipeDetailView.xaml](../../src/Silmarillion.Module/Views/RecipeDetailView.xaml), making the two detail views structurally consistent.
+
+**The navigator becomes a kind-target registry.** Each tab module registers an `IReferenceKindTarget` that knows its `EntityKind`, how to select an entity by internal name, and how to open the current detail in a popup window. `SilmarillionReferenceNavigator` takes `IEnumerable<IReferenceKindTarget>` and exposes `CanOpen` as a registry membership check; `SilmarillionViewModel`'s `OnNavigated` and `OpenInWindow` look up the target for the current kind and delegate. The interface lives in `Mithril.Shared` so future tabs can register from their own modules if ownership ever splits — every v1+v2 implementer is in Silmarillion today. Tab-index ordering stays simple: each target carries the index it expects.
 
 ## Files to modify
 
@@ -146,7 +151,60 @@ All sections become `StackPanel` children; their `Visibility` bindings already h
 
 Cross-link section internal ordering preserved (Sources → Produced by → Used in), matching the issue's recommended layout.
 
-### 7. Wiki — Deep-Linking page
+### 7. `IReferenceKindTarget` — new interface (issue #239)
+
+New file `src/Mithril.Shared/Reference/IReferenceKindTarget.cs`:
+
+```csharp
+public interface IReferenceKindTarget
+{
+    /// <summary>The entity kind this target is responsible for. One target per kind.</summary>
+    EntityKind Kind { get; }
+
+    /// <summary>The TabControl index this target's UI lives at. Used by the
+    /// host VM when an entity of this kind is navigated to.</summary>
+    int TabIndex { get; }
+
+    /// <summary>Look the entity up by internal name and select it in the tab's
+    /// master-detail. Returns false if the entity isn't in the reference data.</summary>
+    bool TrySelectByInternalName(string internalName);
+
+    /// <summary>Open the current detail in a popup window. Returns false if
+    /// the tab has no current detail (nothing selected).</summary>
+    bool TryOpenInWindow();
+}
+```
+
+Interface lives in `Mithril.Shared` (not `Mithril.Shared.Wpf`) because `EntityKind` already does — keeps the navigation contract layered above the WPF presentation layer. The two adapter classes that implement it are presentation-layer-concrete and live in `Silmarillion.Module/Navigation/`.
+
+### 8. `ItemsKindTarget` and `RecipesKindTarget` — adapters (issue #239)
+
+New files in `src/Silmarillion.Module/Navigation/`:
+
+- `ItemsKindTarget.cs` — `Kind = EntityKind.Item`, `TabIndex = 0`. Constructor takes `ItemsTabViewModel` and `IReferenceDataService`. `TrySelectByInternalName` does `_refData.ItemsByInternalName.TryGetValue(...)` and sets `_vm.SelectedItem`. `TryOpenInWindow` reads `_vm.DetailViewModel` and instantiates [ItemDetailWindow](../../src/Mithril.Shared.Wpf/ItemDetailWindow.xaml).
+- `RecipesKindTarget.cs` — `Kind = EntityKind.Recipe`, `TabIndex = 1`. Same shape; uses `_refData.RecipesByInternalName` and `_vm.SelectedRecipe` / [RecipeDetailWindow](../../src/Silmarillion.Module/Views/RecipeDetailWindow.xaml).
+
+Both registered in [SilmarillionModule.Register](../../src/Silmarillion.Module/SilmarillionModule.cs) via `services.AddSingleton<IReferenceKindTarget, ItemsKindTarget>()` / `RecipesKindTarget`.
+
+### 9. `SilmarillionReferenceNavigator` — registry-driven `CanOpen` (issue #239)
+
+[SilmarillionReferenceNavigator.cs](../../src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs):
+
+- Constructor takes `IEnumerable<IReferenceKindTarget> targets`. Build `Dictionary<EntityKind, IReferenceKindTarget>`; duplicate `Kind` registrations throw at construction time (same fail-loud as DeepLinkRouter).
+- `V1TabbedKinds` field deleted.
+- `CanOpen(reference)` becomes `_targets.ContainsKey(reference.Kind)`.
+- `Open`, `Back`, `Forward`, the back/forward stacks, and the `Navigated` event are unchanged.
+
+### 10. `SilmarillionViewModel` — registry lookups replace switches (issue #239)
+
+[SilmarillionViewModel.cs](../../src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs):
+
+- Constructor takes `IEnumerable<IReferenceKindTarget> targets` and stores the same `Dictionary<EntityKind, IReferenceKindTarget>` (or reuses the navigator's via a small accessor — either way is fine; the dictionary is small).
+- `OnNavigated`: replace the `switch (e.Current.Kind) { case Item: ...; case Recipe: ... }` block with `if (_targets.TryGetValue(e.Current.Kind, out var target)) { SelectedTabIndex = target.TabIndex; target.TrySelectByInternalName(e.Current.InternalName); }`. Unknown kind silently no-ops (matches today's degradation).
+- `OpenInWindow`: replace the `switch (_navigator.Current?.Kind) { case Item: ...; case Recipe: ... }` block with `if (_navigator.Current is { } current && _targets.TryGetValue(current.Kind, out var target)) target.TryOpenInWindow();`.
+- `CanOpenInWindow` remains `_navigator.Current is not null` (could tighten to "and a target exists" — same outcome since the navigator only accepts navigable kinds, but the tighter check is more honest).
+
+### 11. Wiki — Deep-Linking page
 
 [Mithril wiki](https://github.com/moumantai-gg/mithril/wiki) — update the Deep-Linking page (or equivalent reference) to:
 
@@ -154,7 +212,7 @@ Cross-link section internal ordering preserved (Sources → Produced by → Used
 - Mark `mithril://item/<internalName>` / `mithril://recipe/<internalName>` as **legacy but still supported**.
 - Update the example in [AboutSettingsView.xaml:146](../../src/Mithril.Shell/Views/AboutSettingsView.xaml#L146) to use the module-scoped form.
 
-Wiki commit goes in [project-gorgon.wiki](../../../project-gorgon.wiki) (master branch — see memory `workspace_repo_map.md`).
+Wiki commit goes in the [project-gorgon.wiki](../../../project-gorgon.wiki) checkout (note: that repo's default branch is `master`, not `main` — distinct from this repo).
 
 ## Testing
 
@@ -193,17 +251,41 @@ Manual verification only — XAML restructure with no behavioral change. Confirm
 - Effect-heavy item (e.g. a weapon or armor piece): all sections render in the new order; scrolling works; no visual regressions.
 - Popup [ItemDetailWindow.xaml](../../src/Mithril.Shared.Wpf/ItemDetailWindow.xaml) (which hosts the same view) still renders correctly. The popup sizes to content so the footer-pin behavior is irrelevant there; verify the new section order looks reasonable.
 
+### Navigator kind-target registry (commit 5)
+
+[tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs](../../tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs) — update existing `CanOpen` tests to register fake targets via DI rather than rely on the deleted `V1TabbedKinds` constant. Add:
+
+- `CanOpen_KnownKind_ReturnsTrue` — registered target for Item → `CanOpen(EntityRef.Item(...))` returns true.
+- `CanOpen_UnknownKind_ReturnsFalse` — no target registered for Npc → `CanOpen(EntityRef.Npc(...))` returns false.
+- `Constructor_DuplicateKinds_Throws` — two targets with `Kind == Item` → constructor throws.
+
+New tests for the adapters:
+
+- `tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs`:
+  - `TrySelectByInternalName_KnownItem_SelectsAndReturnsTrue`.
+  - `TrySelectByInternalName_UnknownItem_ReturnsFalse_VmUnchanged`.
+  - `TryOpenInWindow_NoDetail_ReturnsFalse`.
+- `tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs` — same three shapes.
+
+`tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs` (new or extended):
+- `OnNavigated_ItemKind_SwitchesTabAndSelects` — registered Items target with a populated fake ref-data → navigator fires `Navigated(Item)` → `SelectedTabIndex == 0` and `Items.SelectedItem` is set.
+- `OnNavigated_UnknownKind_NoChange` — Navigated event with an unregistered kind → no state mutation.
+- `OpenInWindow_NoCurrent_NoOp` — `_navigator.Current is null` → no window shown (cannot directly assert "no window"; verify the target's `TryOpenInWindow` is not called via a spy).
+
 ## Out of scope
 
 - **#235 (recipe Sources section + `IReferenceDataService.RecipeSources` plumbing)** — separate PR; needs new parser plumbing and is the largest of the four follow-ups. Will land independently.
 - **Renaming `*CardTemplate` → `*RowTemplate`** in `Resources.xaml`. Names are wallpaper; rename would ripple into both tab views without changing behavior.
 - **Removing legacy `mithril://item/` and `mithril://recipe/` schemes.** Issue calls for soft-deprecation (keep working, document the preferred form). No removal scheduled.
 - **Per-handler unit tests for the extracted Item/Recipe/CraftList/Pippin/Legolas/Elrond handlers.** Coverage is preserved through the existing router tests; per-handler tests are a follow-up nicety, not a blocker.
+- **Data-driven `TabControl` markup.** XAML tab declarations stay hand-written; targets map to their tabs by carrying a `TabIndex` int. When more than ~4 tabs ship, revisit a list-driven approach — not now.
+- **Splitting tab ownership across modules** (NPCs in its own module, etc.). `IReferenceKindTarget` lives in `Mithril.Shared` so this is possible later; every v1+v2 implementer lives in Silmarillion.Module today.
 
 ## Commit sequence
 
-1. **Router → handler-registry refactor** (`IDeepLinkHandler`, extract six handlers, rewrite router, re-wire tests, register each module's handler in its `Register(IServiceCollection)`). No new URI behavior; existing tests pass.
+1. **DeepLink router → handler-registry refactor** (`IDeepLinkHandler`, extract six handlers, rewrite router, re-wire tests, register each module's handler in its `Register(IServiceCollection)`). No new URI behavior; existing tests pass.
 2. **Add Silmarillion deep-link handler** + tests + register in `SilmarillionModule.Register`. New URI behavior added; legacy URIs unchanged.
 3. **Compact row templates** in `Resources.xaml`. Manual visual verification.
 4. **ItemDetailView restructure**. Manual visual verification on both sparse and effect-heavy items.
-5. **Wiki update** + `AboutSettingsView.xaml` example string.
+5. **Navigator → kind-target registry refactor** (`IReferenceKindTarget`, `ItemsKindTarget`, `RecipesKindTarget`; navigator's `V1TabbedKinds` deleted; `SilmarillionViewModel`'s two switches replaced with dictionary lookups; tests). No new user-visible behavior; existing chip-clickability and tab-switch behavior preserved.
+6. **Wiki update** + `AboutSettingsView.xaml` example string.

--- a/docs/agent-plans/silmarillion-polish-v1.md
+++ b/docs/agent-plans/silmarillion-polish-v1.md
@@ -1,0 +1,209 @@
+# Silmarillion polish v1 + DeepLink registry refactor
+
+**Tracked in:** #229, #231, #234 (bundled); precursor refactor unfiled.
+
+## Context
+
+Three #207 follow-up polish issues for the Silmarillion reference browser, bundled with a precursor refactor of [DeepLinkRouter.cs](../../src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs):
+
+- **#229** — add `mithril://silmarillion/item/<name>` and `mithril://silmarillion/recipe/<name>` module-scoped routes alongside the existing `mithril://item/` / `mithril://recipe/` schemes.
+- **#231** — replace the master-detail card layout (~80px per row, ~17 visible) with a compact two-line row layout (~36px per row, ~40+ visible).
+- **#234** — move the cross-link sections (Sources / Produced by / Used in) from the bottom of [ItemDetailView.xaml](../../src/Mithril.Shared.Wpf/ItemDetailView.xaml) to immediately after Description, so sparse items don't force the user's eye past a dead zone of empty Effects-region to reach the recipes that produce/consume them.
+
+The bundled refactor: `DeepLinkRouter`'s big `switch (action)` has grown to six structurally-identical cases (validate payload regex → null-check optional import target → call one method on it → log a diagnostic), and #229 is the first multi-segment route that doesn't fit the existing shape. Adding case #7 inline would mean a nested switch; extracting to a handler registry is the natural home for the new route. Bundled here rather than deferred because the registry is *what makes #229 clean*.
+
+#235 (recipe Sources section + `IReferenceDataService.RecipeSources` plumbing) is intentionally **out of scope** for this PR — it's the only follow-up that needs new reference-data infrastructure and benefits from being a separate review.
+
+## Approach
+
+**The router becomes a dispatcher.** `IDeepLinkHandler` defines `Action` (the URI host segment) and `TryHandle(string subPath, IDiagnosticsSink? diag)`. Each existing branch becomes a handler class owning its payload grammar; the router takes `IEnumerable<IDeepLinkHandler>` via DI and dispatches by host. Adding the silmarillion route is then just registering one more handler that internally parses its two-segment sub-path.
+
+**Item/Recipe handlers stay in the shared layer.** They depend only on `IReferenceNavigator`, which is shell-registered as `NoOpReferenceNavigator` and overridden by Silmarillion via last-singleton-wins DI. Keeping these two handlers in `Mithril.Shared.Wpf` preserves the existing degradation path (Silmarillion uninstalled → URIs are accepted but no-op). The silmarillion handler lives in Silmarillion.Module since it's the module's own scheme.
+
+**Card-shaped rows become row-shaped rows.** The card template chosen for #207 was modelled after Celebrimbor's RecipeCard, but Celebrimbor uses cards as inspect-popups; Silmarillion uses them for browsable catalogue navigation, which needs density. Two-line compact (24px icon + name on line 1, dim subtitle on line 2) was chosen over single-line+tail because the subtitle (equip slot / skill+level) is genuinely useful at scan time and the second line costs ~8px versus the four-line card it replaces.
+
+**ItemDetailView's reading order is restructured by dropping the `Height="*"` slack-absorber.** The outer `Grid` with 23 explicit `RowDefinition`s becomes a `DockPanel` with the internal-name footer `Dock="Bottom"` and a `StackPanel` body. With the footer pinned by `DockPanel`, no body row needs to absorb slack, so the cross-link sections move from rows 19–21 to immediately after Description — the structural change *enables* the reorder. This mirrors the pattern already used by [RecipeDetailView.xaml](../../src/Silmarillion.Module/Views/RecipeDetailView.xaml), making the two detail views structurally consistent.
+
+## Files to modify
+
+### 1. `IDeepLinkHandler` — new interface
+
+New file `src/Mithril.Shared.Wpf/Modules/IDeepLinkHandler.cs`:
+
+```csharp
+public interface IDeepLinkHandler
+{
+    /// <summary>The first path segment after mithril://. Must be lowercase ASCII.</summary>
+    string Action { get; }
+
+    /// <summary>
+    /// Handle the remainder of the URI path (everything after the host segment,
+    /// with the leading '/' stripped). Implementations own their payload grammar
+    /// and any per-handler diagnostic messages. Return false for validation
+    /// failure or missing dependency; true on successful dispatch.
+    /// </summary>
+    bool TryHandle(string subPath, IDiagnosticsSink? diag);
+}
+```
+
+### 2. Extract per-action handlers
+
+New files under `src/Mithril.Shared.Wpf/Modules/`:
+
+- `ItemDeepLinkHandler.cs` — `Action = "item"`. Validates against `EntityPayloadPattern` (the existing regex `^[A-Za-z0-9_]{1,128}$`). Calls `_navigator.Open(EntityRef.Item(payload))`. Takes `IReferenceNavigator` via constructor.
+- `RecipeDeepLinkHandler.cs` — same shape, `EntityRef.Recipe(payload)`.
+
+The two regex constants `EntityPayloadPattern`, `ListPayloadPattern`, `PippinPayloadPattern`, `LegolasPayloadPattern` move with their owning handler. Keep them `private static readonly` on each handler class — they're not shared across handlers.
+
+New files in each owning module project (`src/<Module>.Module/Navigation/<Module>DeepLinkHandler.cs`):
+
+- `Celebrimbor.Module/Navigation/CraftListDeepLinkHandler.cs` — `Action = "list"`, calls `ICraftListImportTarget.ImportFromLinkPayload`. Project already references `Mithril.Shared.Wpf`.
+- `Pippin.Module/Navigation/PippinDeepLinkHandler.cs` — `Action = "pippin"`.
+- `Legolas.Module/Navigation/LegolasDeepLinkHandler.cs` — `Action = "legolas"`.
+- `Elrond.Module/Navigation/ElrondDeepLinkHandler.cs` — `Action = "elrond"`.
+
+Each module's `Register(IServiceCollection)` adds `services.AddSingleton<IDeepLinkHandler, FooDeepLinkHandler>()`. Item and Recipe handlers register from shell DI ([ServiceCollectionExtensions.cs](../../src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs)) since they live in the shared layer.
+
+### 3. `DeepLinkRouter` — rewrite as dispatcher
+
+[DeepLinkRouter.cs](../../src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs):
+
+- Constructor takes `IEnumerable<IDeepLinkHandler> handlers` and `IDiagnosticsSink? diag`. Builds `Dictionary<string, IDeepLinkHandler>` keyed by `Action.ToLowerInvariant()`. Duplicate `Action` registrations throw at construction time (DI ordering bug — fail loud).
+- `Handle(string uri)` becomes: validate well-formed URI, check scheme is `mithril`, look up handler by host, call `handler.TryHandle(parsed.AbsolutePath.TrimStart('/'), _diag)`. Unknown host → diag info + return false (existing behavior).
+- File shrinks from ~170 lines to ~40.
+
+### 4. `SilmarillionDeepLinkHandler` — new module-scoped route
+
+New file `src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs`:
+
+- `Action = "silmarillion"`. Takes `IReferenceNavigator` via constructor.
+- `TryHandle` splits `subPath` on first `/` → `(kind, name)`. Validates `name` against `EntityPayloadPattern`. Unknown `kind` → diag info + return false. Dispatch:
+  - `kind == "item"` → `_navigator.Open(EntityRef.Item(name))`
+  - `kind == "recipe"` → `_navigator.Open(EntityRef.Recipe(name))`
+- Register from [SilmarillionModule.Register](../../src/Silmarillion.Module/SilmarillionModule.cs).
+
+### 5. Compact row templates
+
+[src/Silmarillion.Module/Views/Resources.xaml](../../src/Silmarillion.Module/Views/Resources.xaml) — rewrite both DataTemplates. Border removed; row is a `DockPanel` with `IconImage` on the left and a `StackPanel` body.
+
+```xml
+<DataTemplate x:Key="ItemCardTemplate">
+    <DockPanel Margin="0" LastChildFill="True">
+        <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                       Width="24" Height="24" Margin="6,3,6,3" VerticalAlignment="Center"/>
+        <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+            <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                       Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                       FontSize="{DynamicResource AppFontSizeHint}"/>
+            <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
+                       Foreground="#88FFFFFF"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       TextTrimming="CharacterEllipsis"
+                       Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
+        </StackPanel>
+    </DockPanel>
+</DataTemplate>
+```
+
+The recipe template mirrors this shape, replacing the subtitle binding with `SkillDisplayName` + level (hidden when `SkillDisplayName` is empty via `NullOrEmptyToVis`).
+
+Key keeps `*CardTemplate` despite no longer being cards — renaming would ripple into both Silmarillion tab views and isn't worth the diff. Names are wallpaper.
+
+`TextTrimming="CharacterEllipsis"` on both lines preserves the 320px-wide listbox constraint without wrap-jumping row heights.
+
+### 6. ItemDetailView restructure
+
+[ItemDetailView.xaml](../../src/Mithril.Shared.Wpf/ItemDetailView.xaml) — rewrite the top-level structure:
+
+```xml
+<Border Padding="14,12">
+    <DockPanel>
+        <TextBlock DockPanel.Dock="Bottom" Text="{Binding InternalName}"
+                   Foreground="#88FFFFFF"
+                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                   FontSize="{DynamicResource AppFontSizeSmall}"
+                   Margin="0,8,0,0" HorizontalAlignment="Right"/>
+        <StackPanel>
+            <!-- Header -->
+            <!-- Description -->
+            <!-- Sources (was row 19) -->
+            <!-- Produced by (was row 20) -->
+            <!-- Used in (was row 21) -->
+            <!-- Skill requirements (was row 2) -->
+            <!-- Effects (was row 3; Height="*" gone) -->
+            <!-- Augmentation, WaxAugments, WaxItems, AugmentPools, TaughtRecipes,
+                 EffectTags, ResearchProgress, XpGrants, WordsOfPower,
+                 LearnedAbilities, ProducedItems, EquipBonuses,
+                 CraftingEnhancements, RecipeCooldowns,
+                 UnpreviewableExtractions (rest of optional sections,
+                 same relative order as today) -->
+        </StackPanel>
+    </DockPanel>
+</Border>
+```
+
+All sections become `StackPanel` children; their `Visibility` bindings already hide them when empty. The host `ContentControl` keeps its `MinHeight="{Binding ViewportHeight, ElementName=DetailScroller}"` binding (set in [ItemsTabView.xaml:78-85](../../src/Silmarillion.Module/Views/ItemsTabView.xaml#L78-L85)), so the DockPanel stretches to viewport and the footer pins to the bottom of the viewport for short content.
+
+Cross-link section internal ordering preserved (Sources → Produced by → Used in), matching the issue's recommended layout.
+
+### 7. Wiki — Deep-Linking page
+
+[Mithril wiki](https://github.com/moumantai-gg/mithril/wiki) — update the Deep-Linking page (or equivalent reference) to:
+
+- Document `mithril://silmarillion/item/<internalName>` and `mithril://silmarillion/recipe/<internalName>` as the **preferred** forms.
+- Mark `mithril://item/<internalName>` / `mithril://recipe/<internalName>` as **legacy but still supported**.
+- Update the example in [AboutSettingsView.xaml:146](../../src/Mithril.Shell/Views/AboutSettingsView.xaml#L146) to use the module-scoped form.
+
+Wiki commit goes in [project-gorgon.wiki](../../../project-gorgon.wiki) (master branch — see memory `workspace_repo_map.md`).
+
+## Testing
+
+### Router refactor (commit 1)
+
+[tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs](../../tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs) — existing test cases stay; refactor the test setup to register handlers via DI rather than passing import targets to the router constructor. Per-handler unit tests can live alongside each handler later — not blocking, since coverage is preserved end-to-end through the router tests.
+
+### Silmarillion handler (commit 2)
+
+New file `tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs`:
+
+- `TryHandle_ItemKind_OpensItem` — `silmarillion/item/CraftedLeatherBoots5` → navigator opens `EntityRef.Item("CraftedLeatherBoots5")`.
+- `TryHandle_RecipeKind_OpensRecipe` — `silmarillion/recipe/SkinSheep` → navigator opens `EntityRef.Recipe("SkinSheep")`.
+- `TryHandle_UnknownKind_ReturnsFalse` — `silmarillion/npc/Marna` → false, navigator not invoked, diag breadcrumb logged.
+- `TryHandle_InvalidPayload_ReturnsFalse` — `silmarillion/item/<garbage with separators>` → false.
+- `TryHandle_NoSecondSegment_ReturnsFalse` — `silmarillion/item` (no name) → false.
+- `TryHandle_EmptySubPath_ReturnsFalse` — `silmarillion/` or `silmarillion` → false.
+
+Add one router-level integration test (`Handle_SilmarillionRoute_DispatchesToHandler`) to confirm DI registration works end-to-end.
+
+### Compact rows (commit 3)
+
+Manual verification only — XAML template change with no behavioral path to unit-test. Launch `dotnet run --project src/Mithril.Shell`, open Silmarillion's Items tab, confirm:
+
+- Rows are visually compact (24px icon, two-line text).
+- Subtitle hides when empty (e.g. for items with no equip slot).
+- Hover/selection accent still works.
+- Scroll performance unchanged (virtualization still on).
+- Both tabs work (Items + Recipes).
+
+### ItemDetailView restructure (commit 4)
+
+Manual verification only — XAML restructure with no behavioral change. Confirm:
+
+- Sparse item (e.g. a lorebook or candle-wick material): cross-link sections (Sources / Produced by / Used in) appear immediately after description; internal-name footer pins to the bottom of the right pane.
+- Effect-heavy item (e.g. a weapon or armor piece): all sections render in the new order; scrolling works; no visual regressions.
+- Popup [ItemDetailWindow.xaml](../../src/Mithril.Shared.Wpf/ItemDetailWindow.xaml) (which hosts the same view) still renders correctly. The popup sizes to content so the footer-pin behavior is irrelevant there; verify the new section order looks reasonable.
+
+## Out of scope
+
+- **#235 (recipe Sources section + `IReferenceDataService.RecipeSources` plumbing)** — separate PR; needs new parser plumbing and is the largest of the four follow-ups. Will land independently.
+- **Renaming `*CardTemplate` → `*RowTemplate`** in `Resources.xaml`. Names are wallpaper; rename would ripple into both tab views without changing behavior.
+- **Removing legacy `mithril://item/` and `mithril://recipe/` schemes.** Issue calls for soft-deprecation (keep working, document the preferred form). No removal scheduled.
+- **Per-handler unit tests for the extracted Item/Recipe/CraftList/Pippin/Legolas/Elrond handlers.** Coverage is preserved through the existing router tests; per-handler tests are a follow-up nicety, not a blocker.
+
+## Commit sequence
+
+1. **Router → handler-registry refactor** (`IDeepLinkHandler`, extract six handlers, rewrite router, re-wire tests, register each module's handler in its `Register(IServiceCollection)`). No new URI behavior; existing tests pass.
+2. **Add Silmarillion deep-link handler** + tests + register in `SilmarillionModule.Register`. New URI behavior added; legacy URIs unchanged.
+3. **Compact row templates** in `Resources.xaml`. Manual visual verification.
+4. **ItemDetailView restructure**. Manual visual verification on both sparse and effect-heavy items.
+5. **Wiki update** + `AboutSettingsView.xaml` example string.

--- a/src/Celebrimbor.Module/CelebrimborModule.cs
+++ b/src/Celebrimbor.Module/CelebrimborModule.cs
@@ -34,6 +34,8 @@ public sealed class CelebrimborModule : IMithrilModule
         services.AddSingleton<RecipeSearchIndex>();
         services.AddSingleton<OnHandInventoryQuery>();
         services.AddSingleton<ICraftListImportTarget, CraftListImportTarget>();
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new CraftListDeepLinkHandler(sp.GetRequiredService<ICraftListImportTarget>()));
         services.AddSingleton<IAugmentPoolPresenter, CelebrimborAugmentPoolPresenter>();
 
         services.AddSingleton<RecipePickerViewModel>();

--- a/src/Celebrimbor.Module/Services/CraftListDeepLinkHandler.cs
+++ b/src/Celebrimbor.Module/Services/CraftListDeepLinkHandler.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Celebrimbor.Services;
+
+/// <summary>Handles <c>mithril://list/&lt;base64url&gt;</c> craft-list imports.</summary>
+public sealed class CraftListDeepLinkHandler : IDeepLinkHandler
+{
+    // base64url alphabet = [A-Za-z0-9_-]. Length cap matches the pre-registry behaviour.
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
+
+    private readonly ICraftListImportTarget _target;
+
+    public CraftListDeepLinkHandler(ICraftListImportTarget target) => _target = target;
+
+    public string Action => "list";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: list payload (len={subPath.Length}) failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -43,6 +43,8 @@ public sealed class ElrondModule : IMithrilModule
             sp.GetRequiredService<SkillAdvisorViewModel>(),
             sp.GetService<IModuleActivator>(),
             sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new ElrondDeepLinkHandler(sp.GetRequiredService<IElrondSkillImportTarget>()));
         services.AddSingleton<SkillAdvisorView>(sp => new SkillAdvisorView
         {
             DataContext = sp.GetRequiredService<SkillAdvisorViewModel>(),

--- a/src/Elrond.Module/Services/ElrondDeepLinkHandler.cs
+++ b/src/Elrond.Module/Services/ElrondDeepLinkHandler.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Elrond.Services;
+
+/// <summary>
+/// Handles <c>mithril://elrond/&lt;skillKey&gt;</c>. Skill keys are id-shaped
+/// (matches <c>SkillEntry.Key</c>); reuse the strict item-style pattern. Hyphens
+/// and spaces are explicitly NOT permitted — the human-readable display name is
+/// never on the wire.
+/// </summary>
+public sealed class ElrondDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IElrondSkillImportTarget _target;
+
+    public ElrondDeepLinkHandler(IElrondSkillImportTarget target) => _target = target;
+
+    public string Action => "elrond";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: elrond payload '{subPath}' failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -109,6 +109,8 @@ public sealed class LegolasModule : IMithrilModule
             sp.GetService<IReferenceDataService>(),
             sp.GetService<IModuleActivator>(),
             sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new LegolasDeepLinkHandler(sp.GetRequiredService<ILegolasShareImportTarget>()));
 
         services.AddSingleton<LegolasWizardViewModel>();
         services.AddSingleton<LegolasSettingsViewModel>();

--- a/src/Legolas.Module/Sharing/LegolasDeepLinkHandler.cs
+++ b/src/Legolas.Module/Sharing/LegolasDeepLinkHandler.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Legolas.Sharing;
+
+/// <summary>Handles <c>mithril://legolas/&lt;base64url&gt;</c> survey-report imports.</summary>
+public sealed class LegolasDeepLinkHandler : IDeepLinkHandler
+{
+    // Legolas payloads are bounded by a single survey run (≤ a couple dozen items + timestamps).
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
+
+    private readonly ILegolasShareImportTarget _target;
+
+    public LegolasDeepLinkHandler(ILegolasShareImportTarget target) => _target = target;
+
+    public string Action => "legolas";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: legolas payload (len={subPath.Length}) failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -18,502 +18,481 @@
     </UserControl.Resources>
 
     <Border Padding="14,12">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <!-- Phase 1 cross-link sections — Sources, Produced by, Used in. -->
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
+        <DockPanel>
+            <!-- Internal-name footer pins to the bottom of the DockPanel. With the
+                 host ContentControl bound to ScrollViewer.ViewportHeight, the
+                 DockPanel stretches to viewport and the footer pins to the bottom
+                 of the right pane even for sparse items. Matches the pattern
+                 already used by RecipeDetailView. -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding InternalName}"
+                       Foreground="#88FFFFFF"
+                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       Margin="0,8,0,0" HorizontalAlignment="Right"/>
+            <StackPanel>
+                <!-- children below, reordered: cross-links float up to right
+                     after Description (was rows 19-21, now rows 2-4). -->
 
-            <!-- Header: icon + equip slot -->
-            <DockPanel Grid.Row="0" Margin="0,0,0,10">
-                <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                             Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
-                <StackPanel VerticalAlignment="Center">
-                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
-                               Foreground="#FFD4A847"
-                               FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"
-                               Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
-                </StackPanel>
-            </DockPanel>
+                <!-- Header: icon + equip slot -->
+                <DockPanel Margin="0,0,0,10">
+                    <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                 Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
+                                   Foreground="#FFD4A847"
+                                   FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
+                                   Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"
+                                   Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
+                    </StackPanel>
+                </DockPanel>
 
-            <!-- Description + optional food effect -->
-            <StackPanel Grid.Row="1" Margin="0,0,0,10">
-                <TextBlock Text="{Binding Description}" Foreground="#CCFFFFFF"
-                           FontStyle="Italic" FontSize="{DynamicResource AppFontSize}"
-                           TextWrapping="Wrap" MaxWidth="460"
-                           HorizontalAlignment="Left"
-                           Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
-                <TextBlock Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}"
-                           TextWrapping="Wrap" MaxWidth="460" Margin="0,4,0,0"
-                           HorizontalAlignment="Left"
-                           Visibility="{Binding FoodDesc, Converter={StaticResource NullOrEmptyToVis}}">
-                    <Run Text="Food effect: " FontWeight="SemiBold"/>
-                    <Run Text="{Binding FoodDesc, Mode=OneWay}"/>
-                </TextBlock>
-            </StackPanel>
-
-            <!-- Skill requirements (hidden when empty) -->
-            <StackPanel Grid.Row="2" Margin="0,0,0,10"
-                        Visibility="{Binding SkillReqChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Skill requirements" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding SkillReqChips}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Border Background="#FF252525" BorderBrush="#33FFFFFF"
-                                    BorderThickness="1" CornerRadius="3"
-                                    Padding="6,2" Margin="0,0,4,4">
-                                <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"/>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Effects -->
-            <StackPanel Grid.Row="3">
-                <TextBlock Text="Effects" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"
-                           Visibility="{Binding EffectLines.Count, Converter={StaticResource PositiveIntToVis}}"/>
-                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
-                              MaxHeight="480">
-                    <ItemsControl ItemsSource="{Binding EffectLines}"
-                                  ItemTemplate="{StaticResource EffectLineTemplate}"/>
-                </ScrollViewer>
-            </StackPanel>
-
-            <!-- Augmentation (hidden when empty) -->
-            <StackPanel Grid.Row="4" Margin="0,10,0,0"
-                        Visibility="{Binding Augments.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Augmentation" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding Augments}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="0,0,0,6">
-                                <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
-                                           Foreground="#FFD4A847"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           Margin="0,0,0,2"/>
-                                <ItemsControl ItemsSource="{Binding EffectLines}"
-                                              ItemTemplate="{StaticResource EffectLineTemplate}"
-                                              Margin="10,0,0,0"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Applied augment waxes -->
-            <StackPanel Grid.Row="5" Margin="0,10,0,0"
-                        Visibility="{Binding WaxAugments.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Applied augment waxes" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding WaxAugments}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="0,0,0,6">
-                                <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
-                                           Foreground="#FFD4A847"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           Margin="0,0,0,2"/>
-                                <ItemsControl ItemsSource="{Binding EffectLines}"
-                                              ItemTemplate="{StaticResource EffectLineTemplate}"
-                                              Margin="10,0,0,0"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Infusions -->
-            <StackPanel Grid.Row="6" Margin="0,10,0,0"
-                        Visibility="{Binding WaxItems.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Infusions" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding WaxItems}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="0,0,0,6">
-                                <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
-                                           Foreground="#FFD4A847"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           Margin="0,0,0,2"/>
-                                <ItemsControl ItemsSource="{Binding EffectLines}"
-                                              ItemTemplate="{StaticResource EffectLineTemplate}"
-                                              Margin="10,0,0,0"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Treasure effects -->
-            <StackPanel Grid.Row="7" Margin="0,10,0,0"
-                        Visibility="{Binding AugmentPools.Count, Converter={StaticResource PositiveIntToVis}}">
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                    <TextBlock Text="Treasure Effects" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
+                <!-- Description + optional food effect -->
+                <StackPanel Margin="0,0,0,10">
+                    <TextBlock Text="{Binding Description}" Foreground="#CCFFFFFF"
+                               FontStyle="Italic" FontSize="{DynamicResource AppFontSize}"
+                               TextWrapping="Wrap" MaxWidth="460"
+                               HorizontalAlignment="Left"
+                               Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
+                    <TextBlock Foreground="#88FFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}"
-                               VerticalAlignment="Center"/>
-                    <Border Background="Transparent" Cursor="Help"
-                            VerticalAlignment="Center" Margin="5,0,0,0">
-                        <Border.ToolTip>
-                            <ToolTip MaxWidth="320">
-                                <TextBlock TextWrapping="Wrap"
-                                           Text="Project Gorgon rolls a treasure effect from a named pool when you craft this item. The pool's level rules and skill prereqs determine which effects can appear. Click &quot;Browse pool&quot; to see every option."/>
-                            </ToolTip>
-                        </Border.ToolTip>
-                        <icon:PackIconLucide Kind="CircleQuestionMark" Width="12" Height="12"
-                                             Foreground="#88FFFFFF"/>
-                    </Border>
+                               TextWrapping="Wrap" MaxWidth="460" Margin="0,4,0,0"
+                               HorizontalAlignment="Left"
+                               Visibility="{Binding FoodDesc, Converter={StaticResource NullOrEmptyToVis}}">
+                        <Run Text="Food effect: " FontWeight="SemiBold"/>
+                        <Run Text="{Binding FoodDesc, Mode=OneWay}"/>
+                    </TextBlock>
                 </StackPanel>
-                <ItemsControl ItemsSource="{Binding AugmentPools}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Border Background="#FF252525" BorderBrush="#33FFFFFF"
-                                    BorderThickness="1" CornerRadius="3"
-                                    Padding="8,6" Margin="0,0,0,6">
-                                <DockPanel>
-                                    <Button DockPanel.Dock="Right" VerticalAlignment="Center"
-                                            Margin="8,0,0,0" Padding="8,3"
-                                            Content="Browse pool"
-                                            Cursor="Hand"
-                                            Command="{Binding DataContext.BrowsePoolCommand,
-                                                      RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"
-                                            CommandParameter="{Binding}"
-                                            Visibility="{Binding DataContext.HasPoolPresenter,
-                                                         RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}},
-                                                         Converter={StaticResource BoolToVis}}"/>
+
+                <!-- Sources (vendor / drop / quest reward / …); plain-text in Phase 1 -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Sources" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding Sources}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <!-- TODO(stub:#207): replace with EntityChip in Phase 5 -->
+                                <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Produced by recipes — cross-link to recipes whose result is this item -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding ProducedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Produced by" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding ProducedByRecipes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Used in recipes — cross-link to recipes that consume this item -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding ConsumedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Used in" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding ConsumedByRecipes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Skill requirements (hidden when empty) -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding SkillReqChips.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Skill requirements" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding SkillReqChips}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="#FF252525" BorderBrush="#33FFFFFF"
+                                        BorderThickness="1" CornerRadius="3"
+                                        Padding="6,2" Margin="0,0,4,4">
+                                    <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
+                                               FontSize="{DynamicResource AppFontSizeHint}"/>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Effects -->
+                <StackPanel>
+                    <TextBlock Text="Effects" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"
+                               Visibility="{Binding EffectLines.Count, Converter={StaticResource PositiveIntToVis}}"/>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                                  MaxHeight="480">
+                        <ItemsControl ItemsSource="{Binding EffectLines}"
+                                      ItemTemplate="{StaticResource EffectLineTemplate}"/>
+                    </ScrollViewer>
+                </StackPanel>
+
+                <!-- Augmentation (hidden when empty) -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding Augments.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Augmentation" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding Augments}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,6">
+                                    <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
+                                               Foreground="#FFD4A847"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               Margin="0,0,0,2"/>
+                                    <ItemsControl ItemsSource="{Binding EffectLines}"
+                                                  ItemTemplate="{StaticResource EffectLineTemplate}"
+                                                  Margin="10,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Applied augment waxes -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding WaxAugments.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Applied augment waxes" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding WaxAugments}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,6">
+                                    <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
+                                               Foreground="#FFD4A847"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               Margin="0,0,0,2"/>
+                                    <ItemsControl ItemsSource="{Binding EffectLines}"
+                                                  ItemTemplate="{StaticResource EffectLineTemplate}"
+                                                  Margin="10,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Infusions -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding WaxItems.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Infusions" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding WaxItems}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,6">
+                                    <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
+                                               Foreground="#FFD4A847"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               Margin="0,0,0,2"/>
+                                    <ItemsControl ItemsSource="{Binding EffectLines}"
+                                                  ItemTemplate="{StaticResource EffectLineTemplate}"
+                                                  Margin="10,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Treasure effects -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding AugmentPools.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                        <TextBlock Text="Treasure Effects" FontWeight="SemiBold"
+                                   Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center"/>
+                        <Border Background="Transparent" Cursor="Help"
+                                VerticalAlignment="Center" Margin="5,0,0,0">
+                            <Border.ToolTip>
+                                <ToolTip MaxWidth="320">
+                                    <TextBlock TextWrapping="Wrap"
+                                               Text="Project Gorgon rolls a treasure effect from a named pool when you craft this item. The pool's level rules and skill prereqs determine which effects can appear. Click &quot;Browse pool&quot; to see every option."/>
+                                </ToolTip>
+                            </Border.ToolTip>
+                            <icon:PackIconLucide Kind="CircleQuestionMark" Width="12" Height="12"
+                                                 Foreground="#88FFFFFF"/>
+                        </Border>
+                    </StackPanel>
+                    <ItemsControl ItemsSource="{Binding AugmentPools}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="#FF252525" BorderBrush="#33FFFFFF"
+                                        BorderThickness="1" CornerRadius="3"
+                                        Padding="8,6" Margin="0,0,0,6">
+                                    <DockPanel>
+                                        <Button DockPanel.Dock="Right" VerticalAlignment="Center"
+                                                Margin="8,0,0,0" Padding="8,3"
+                                                Content="Browse pool"
+                                                Cursor="Hand"
+                                                Command="{Binding DataContext.BrowsePoolCommand,
+                                                          RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"
+                                                CommandParameter="{Binding}"
+                                                Visibility="{Binding DataContext.HasPoolPresenter,
+                                                             RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}},
+                                                             Converter={StaticResource BoolToVis}}"/>
+                                        <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   VerticalAlignment="Center"
+                                                   TextWrapping="Wrap"/>
+                                    </DockPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Teaches recipe -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding TaughtRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Teaches recipe" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding TaughtRecipes}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,6">
+                                    <TextBlock FontWeight="SemiBold" Foreground="#FFD4A847"
+                                               FontSize="{DynamicResource AppFontSizeHint}">
+                                        <Run Text="Teaches: "/>
+                                        <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                    </TextBlock>
+                                    <TextBlock Foreground="#88FFFFFF"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               Margin="10,1,0,0">
+                                        <Run Text="{Binding Skill, Mode=OneWay}"/>
+                                        <Run Text=" "/>
+                                        <Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Additional effects -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding EffectTags.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Additional effects" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding EffectTags}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayText}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Research progress -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding ResearchProgress.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Progresses research" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding ResearchProgress}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- XP grants -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding XpGrants.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Grants XP" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding XpGrants}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Words of Power -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding WordsOfPower.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Reveals words of power" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding WordsOfPower}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Learned abilities -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding LearnedAbilities.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Teaches ability" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding LearnedAbilities}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Produces -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding ProducedItems.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Produces" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding ProducedItems}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <DockPanel Margin="0,0,0,4">
+                                    <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                 Width="20" Height="20" Margin="0,0,8,0"
+                                                 VerticalAlignment="Center"
+                                                 Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
                                     <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
                                                FontSize="{DynamicResource AppFontSizeHint}"
                                                VerticalAlignment="Center"
                                                TextWrapping="Wrap"/>
                                 </DockPanel>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
 
-            <!-- Teaches recipe -->
-            <StackPanel Grid.Row="8" Margin="0,10,0,0"
-                        Visibility="{Binding TaughtRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Teaches recipe" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding TaughtRecipes}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Margin="0,0,0,6">
-                                <TextBlock FontWeight="SemiBold" Foreground="#FFD4A847"
-                                           FontSize="{DynamicResource AppFontSizeHint}">
-                                    <Run Text="Teaches: "/>
-                                    <Run Text="{Binding DisplayName, Mode=OneWay}"/>
-                                </TextBlock>
-                                <TextBlock Foreground="#88FFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           Margin="10,1,0,0">
-                                    <Run Text="{Binding Skill, Mode=OneWay}"/>
-                                    <Run Text=" "/>
-                                    <Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
-                                </TextBlock>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Additional effects -->
-            <StackPanel Grid.Row="9" Margin="0,10,0,0"
-                        Visibility="{Binding EffectTags.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Additional effects" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding EffectTags}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayText}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Research progress -->
-            <StackPanel Grid.Row="10" Margin="0,10,0,0"
-                        Visibility="{Binding ResearchProgress.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Progresses research" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding ResearchProgress}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- XP grants -->
-            <StackPanel Grid.Row="11" Margin="0,10,0,0"
-                        Visibility="{Binding XpGrants.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Grants XP" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding XpGrants}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Words of Power -->
-            <StackPanel Grid.Row="12" Margin="0,10,0,0"
-                        Visibility="{Binding WordsOfPower.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Reveals words of power" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding WordsOfPower}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Learned abilities -->
-            <StackPanel Grid.Row="13" Margin="0,10,0,0"
-                        Visibility="{Binding LearnedAbilities.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Teaches ability" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding LearnedAbilities}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Produces -->
-            <StackPanel Grid.Row="14" Margin="0,10,0,0"
-                        Visibility="{Binding ProducedItems.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Produces" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding ProducedItems}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <DockPanel Margin="0,0,0,4">
-                                <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                             Width="20" Height="20" Margin="0,0,8,0"
-                                             VerticalAlignment="Center"
-                                             Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
+                <!-- Equip bonuses -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding EquipBonuses.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Bonuses while equipped" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding EquipBonuses}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
                                 <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
                                            FontSize="{DynamicResource AppFontSizeHint}"
-                                           VerticalAlignment="Center"
-                                           TextWrapping="Wrap"/>
-                            </DockPanel>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
 
-            <!-- Equip bonuses -->
-            <StackPanel Grid.Row="15" Margin="0,10,0,0"
-                        Visibility="{Binding EquipBonuses.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Bonuses while equipped" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding EquipBonuses}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+                <!-- Crafting enhancements -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding CraftingEnhancements.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Modifies crafted item" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding CraftingEnhancements}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
 
-            <!-- Crafting enhancements -->
-            <StackPanel Grid.Row="16" Margin="0,10,0,0"
-                        Visibility="{Binding CraftingEnhancements.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Modifies crafted item" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding CraftingEnhancements}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+                <!-- Recipe cooldowns -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding RecipeCooldowns.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Cooldown adjustments" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding RecipeCooldowns}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayText}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
 
-            <!-- Recipe cooldowns -->
-            <StackPanel Grid.Row="17" Margin="0,10,0,0"
-                        Visibility="{Binding RecipeCooldowns.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Cooldown adjustments" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding RecipeCooldowns}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding DisplayText}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+                <!-- Unpreviewable extractions -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding UnpreviewableExtractions.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Extraction" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding UnpreviewableExtractions}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="#FF252525" BorderBrush="#33FFFFFF"
+                                        BorderThickness="1" CornerRadius="3"
+                                        Padding="8,6" Margin="0,0,0,6">
+                                    <DockPanel>
+                                        <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                     Width="20" Height="20" Margin="0,0,8,0"
+                                                     VerticalAlignment="Center"
+                                                     Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
+                                        <TextBlock Text="{Binding DisplayLine}"
+                                                   Foreground="#AAFFFFFF"
+                                                   FontStyle="Italic"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   VerticalAlignment="Center"
+                                                   TextWrapping="Wrap"/>
+                                    </DockPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
 
-            <!-- Unpreviewable extractions -->
-            <StackPanel Grid.Row="18" Margin="0,10,0,0"
-                        Visibility="{Binding UnpreviewableExtractions.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Extraction" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding UnpreviewableExtractions}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Border Background="#FF252525" BorderBrush="#33FFFFFF"
-                                    BorderThickness="1" CornerRadius="3"
-                                    Padding="8,6" Margin="0,0,0,6">
-                                <DockPanel>
-                                    <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                 Width="20" Height="20" Margin="0,0,8,0"
-                                                 VerticalAlignment="Center"
-                                                 Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
-                                    <TextBlock Text="{Binding DisplayLine}"
-                                               Foreground="#AAFFFFFF"
-                                               FontStyle="Italic"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
-                                               VerticalAlignment="Center"
-                                               TextWrapping="Wrap"/>
-                                </DockPanel>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
             </StackPanel>
-
-            <!-- Sources (vendor / drop / quest reward / …); plain-text in Phase 1 -->
-            <StackPanel Grid.Row="19" Margin="0,10,0,0"
-                        Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Sources" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding Sources}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <!-- TODO(stub:#207): replace with EntityChip in Phase 5 -->
-                            <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Produced by recipes — cross-link to recipes whose result is this item -->
-            <StackPanel Grid.Row="20" Margin="0,10,0,0"
-                        Visibility="{Binding ProducedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Produced by" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding ProducedByRecipes}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Used in recipes — cross-link to recipes that consume this item -->
-            <StackPanel Grid.Row="21" Margin="0,10,0,0"
-                        Visibility="{Binding ConsumedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Used in" FontWeight="SemiBold"
-                           Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding ConsumedByRecipes}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-
-            <!-- Internal-name footer. Pins to the bottom of the right pane when the host
-                 ContentControl has MinHeight = ScrollViewer.ViewportHeight (Grid.Row="3"
-                 Effects section uses Height="*" to absorb the slack). -->
-            <TextBlock Grid.Row="22" Text="{Binding InternalName}"
-                       Foreground="#88FFFFFF"
-                       FontFamily="{DynamicResource AppMonoFontFamily}"
-                       FontSize="{DynamicResource AppFontSizeSmall}"
-                       Margin="0,8,0,0" HorizontalAlignment="Right"
-                       VerticalAlignment="Bottom"/>
-        </Grid>
+        </DockPanel>
     </Border>
 </UserControl>

--- a/src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs
+++ b/src/Mithril.Shared.Wpf/Modules/DeepLinkRouter.cs
@@ -1,66 +1,35 @@
-using System.Text.RegularExpressions;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Reference;
 
 namespace Mithril.Shared.Modules;
 
 /// <summary>
-/// Default <see cref="IDeepLinkRouter"/> implementation. Current actions:
-/// <list type="bullet">
-///   <item><c>mithril://item/&lt;internalName&gt;</c> — opens the item via
-///         <see cref="IReferenceNavigator.Open"/> (Silmarillion's master-detail; popup
-///         <see cref="IItemDetailPresenter"/> is no longer involved).</item>
-///   <item><c>mithril://recipe/&lt;internalName&gt;</c> — opens the recipe via
-///         <see cref="IReferenceNavigator.Open"/>.</item>
-///   <item><c>mithril://list/&lt;base64url&gt;</c> — hands the payload to
-///         <see cref="ICraftListImportTarget"/> (Celebrimbor).</item>
-///   <item><c>mithril://pippin/&lt;base64url&gt;</c> — hands the payload to
-///         <see cref="IPippinShareImportTarget"/> (Pippin shared progress).</item>
-///   <item><c>mithril://legolas/&lt;base64url&gt;</c> — hands the payload to
-///         <see cref="ILegolasShareImportTarget"/> (Legolas survey report).</item>
-///   <item><c>mithril://elrond/&lt;skillKey&gt;</c> — hands the payload to
-///         <see cref="IElrondSkillImportTarget"/> (Elrond skill advisor).</item>
-/// </list>
-/// Each action defines its own payload grammar so item names stay strict while the craft-list
-/// payload can hold a much longer base64url blob. Unknown actions are logged and dropped.
+/// Default <see cref="IDeepLinkRouter"/>. Builds a per-action lookup from injected
+/// <see cref="IDeepLinkHandler"/>s and delegates payload parsing + dispatch to the
+/// matching handler. Each handler owns its payload grammar; the router only
+/// validates the scheme and finds the right handler.
 /// </summary>
 public sealed class DeepLinkRouter : IDeepLinkRouter
 {
     private const string Scheme = "mithril";
 
-    // Item/Recipe internal names in the reference data are ASCII identifiers; tighten the grammar
-    // so we refuse anything that could confuse downstream lookups or smuggle separators.
-    private static readonly Regex EntityPayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
-
-    // mithril://list, pippin, and legolas all carry a base64url-encoded gzip payload.
-    // Base64url uses [A-Za-z0-9_-]; cap length well above any plausible compressed payload
-    // so we fail fast on anything pathological rather than handing it to the decoder.
-    private static readonly Regex ListPayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
-    private static readonly Regex PippinPayloadPattern = new("^[A-Za-z0-9_-]{1,16384}$", RegexOptions.Compiled);
-    // Legolas payloads are smaller than Pippin's full-catalog progress dumps — a survey
-    // run is at most a couple dozen items + timestamps. 8192 is plenty.
-    private static readonly Regex LegolasPayloadPattern = new("^[A-Za-z0-9_-]{1,8192}$", RegexOptions.Compiled);
-
-    private readonly IReferenceNavigator _navigator;
-    private readonly ICraftListImportTarget? _listImport;
-    private readonly IPippinShareImportTarget? _pippinImport;
-    private readonly ILegolasShareImportTarget? _legolasImport;
-    private readonly IElrondSkillImportTarget? _elrondImport;
+    private readonly IReadOnlyDictionary<string, IDeepLinkHandler> _handlers;
     private readonly IDiagnosticsSink? _diag;
 
-    public DeepLinkRouter(
-        IReferenceNavigator navigator,
-        ICraftListImportTarget? listImport = null,
-        IPippinShareImportTarget? pippinImport = null,
-        ILegolasShareImportTarget? legolasImport = null,
-        IElrondSkillImportTarget? elrondImport = null,
-        IDiagnosticsSink? diag = null)
+    public DeepLinkRouter(IEnumerable<IDeepLinkHandler> handlers, IDiagnosticsSink? diag = null)
     {
-        _navigator = navigator;
-        _listImport = listImport;
-        _pippinImport = pippinImport;
-        _legolasImport = legolasImport;
-        _elrondImport = elrondImport;
+        // Fail-loud on duplicate Action registrations — that's a DI ordering bug,
+        // not graceful-degradation territory.
+        var byAction = new Dictionary<string, IDeepLinkHandler>(StringComparer.Ordinal);
+        foreach (var h in handlers)
+        {
+            var key = h.Action.ToLowerInvariant();
+            if (byAction.ContainsKey(key))
+                throw new InvalidOperationException(
+                    $"Duplicate IDeepLinkHandler registration for action '{key}': " +
+                    $"{byAction[key].GetType().FullName} and {h.GetType().FullName}.");
+            byAction[key] = h;
+        }
+        _handlers = byAction;
         _diag = diag;
     }
 
@@ -78,92 +47,14 @@ public sealed class DeepLinkRouter : IDeepLinkRouter
             return false;
         }
 
-        // mithril://item/CraftedLeatherBoots5 → Host="item", AbsolutePath="/CraftedLeatherBoots5"
         var action = parsed.Host.ToLowerInvariant();
-        var payload = parsed.AbsolutePath.TrimStart('/');
+        var subPath = parsed.AbsolutePath.TrimStart('/');
 
-        switch (action)
+        if (!_handlers.TryGetValue(action, out var handler))
         {
-            case "item":
-                if (!EntityPayloadPattern.IsMatch(payload))
-                {
-                    _diag?.Info("DeepLink", $"Rejected: item payload '{payload}' failed validation.");
-                    return false;
-                }
-                _navigator.Open(EntityRef.Item(payload));
-                return true;
-
-            case "recipe":
-                if (!EntityPayloadPattern.IsMatch(payload))
-                {
-                    _diag?.Info("DeepLink", $"Rejected: recipe payload '{payload}' failed validation.");
-                    return false;
-                }
-                _navigator.Open(EntityRef.Recipe(payload));
-                return true;
-
-            case "list":
-                if (!ListPayloadPattern.IsMatch(payload))
-                {
-                    _diag?.Info("DeepLink", $"Rejected: list payload (len={payload.Length}) failed validation.");
-                    return false;
-                }
-                if (_listImport is null)
-                {
-                    _diag?.Info("DeepLink", "Rejected: no craft-list import target registered.");
-                    return false;
-                }
-                _listImport.ImportFromLinkPayload(payload);
-                return true;
-
-            case "pippin":
-                if (!PippinPayloadPattern.IsMatch(payload))
-                {
-                    _diag?.Info("DeepLink", $"Rejected: pippin payload (len={payload.Length}) failed validation.");
-                    return false;
-                }
-                if (_pippinImport is null)
-                {
-                    _diag?.Info("DeepLink", "Rejected: no pippin import target registered.");
-                    return false;
-                }
-                _pippinImport.ImportFromLinkPayload(payload);
-                return true;
-
-            case "legolas":
-                if (!LegolasPayloadPattern.IsMatch(payload))
-                {
-                    _diag?.Info("DeepLink", $"Rejected: legolas payload (len={payload.Length}) failed validation.");
-                    return false;
-                }
-                if (_legolasImport is null)
-                {
-                    _diag?.Info("DeepLink", "Rejected: no legolas import target registered.");
-                    return false;
-                }
-                _legolasImport.ImportFromLinkPayload(payload);
-                return true;
-
-            case "elrond":
-                // Skill keys are id-shaped (matches SkillEntry.Key, recipes' RewardSkill);
-                // reuse the strict item pattern. Hyphens/spaces are NOT permitted — the
-                // human-readable display name is never on the wire.
-                if (!EntityPayloadPattern.IsMatch(payload))
-                {
-                    _diag?.Info("DeepLink", $"Rejected: elrond payload '{payload}' failed validation.");
-                    return false;
-                }
-                if (_elrondImport is null)
-                {
-                    _diag?.Info("DeepLink", "Rejected: no elrond import target registered.");
-                    return false;
-                }
-                _elrondImport.ImportFromLinkPayload(payload);
-                return true;
-
-            default:
-                _diag?.Info("DeepLink", $"Rejected: unknown action '{action}'.");
-                return false;
+            _diag?.Info("DeepLink", $"Rejected: unknown action '{action}'.");
+            return false;
         }
+        return handler.TryHandle(subPath, _diag);
     }
 }

--- a/src/Mithril.Shared.Wpf/Modules/IDeepLinkHandler.cs
+++ b/src/Mithril.Shared.Wpf/Modules/IDeepLinkHandler.cs
@@ -1,0 +1,26 @@
+using Mithril.Shared.Diagnostics;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// A single mithril:// scheme dispatch handler. The <see cref="DeepLinkRouter"/>
+/// looks handlers up by <see cref="Action"/> (the URI host segment) and delegates
+/// payload parsing and dispatch to each implementation.
+///
+/// Replaces the per-action <c>switch</c> the router used pre-#229. Each handler
+/// owns its payload grammar (regex, length cap, segment-splitting), its dependency
+/// null-checks, and its diagnostic messages.
+/// </summary>
+public interface IDeepLinkHandler
+{
+    /// <summary>The first path segment after <c>mithril://</c>. Must be lowercase ASCII.</summary>
+    string Action { get; }
+
+    /// <summary>
+    /// Handle the remainder of the URI path (everything after the host segment,
+    /// with the leading '/' stripped). Implementations own their payload grammar
+    /// and any per-handler diagnostic messages. Return false for validation
+    /// failure or missing dependency; true on successful dispatch.
+    /// </summary>
+    bool TryHandle(string subPath, IDiagnosticsSink? diag);
+}

--- a/src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs
+++ b/src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Handles <c>mithril://item/&lt;internalName&gt;</c>. Internal names in the reference
+/// data are ASCII identifiers; the regex refuses anything that could confuse downstream
+/// lookups or smuggle separators.
+/// </summary>
+public sealed class ItemDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IReferenceNavigator _navigator;
+
+    public ItemDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
+
+    public string Action => "item";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: item payload '{subPath}' failed validation.");
+            return false;
+        }
+        _navigator.Open(EntityRef.Item(subPath));
+        return true;
+    }
+}

--- a/src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs
+++ b/src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>Handles <c>mithril://recipe/&lt;internalName&gt;</c>. See <see cref="ItemDeepLinkHandler"/>.</summary>
+public sealed class RecipeDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IReferenceNavigator _navigator;
+
+    public RecipeDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
+
+    public string Action => "recipe";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: recipe payload '{subPath}' failed validation.");
+            return false;
+        }
+        _navigator.Open(EntityRef.Recipe(subPath));
+        return true;
+    }
+}

--- a/src/Mithril.Shared/Reference/IReferenceKindTarget.cs
+++ b/src/Mithril.Shared/Reference/IReferenceKindTarget.cs
@@ -1,0 +1,35 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// A single entity-kind dispatch target registered with the Silmarillion
+/// reference navigator. Each tab module registers one implementation; the
+/// navigator and the host VM enumerate registered targets instead of
+/// enumerating <c>switch (EntityKind)</c> cases (issue #239).
+///
+/// Replaces the hardcoded <c>V1TabbedKinds</c> HashSet and the two switches
+/// in <c>SilmarillionViewModel</c>. As Bucket-B tabs ship (NPCs → Quests →
+/// Areas+Landmarks → Lorebooks → Abilities → Effects → PlayerTitles →
+/// StorageVaults) each adds one more target — no touches to the navigator
+/// or the host VM.
+/// </summary>
+public interface IReferenceKindTarget
+{
+    /// <summary>The entity kind this target is responsible for. One target per kind.</summary>
+    EntityKind Kind { get; }
+
+    /// <summary>The TabControl index this target's UI lives at.</summary>
+    int TabIndex { get; }
+
+    /// <summary>
+    /// Look the entity up by internal name and select it in the tab's
+    /// master-detail. Returns false if the entity isn't in the reference data
+    /// (e.g. a stale deep link).
+    /// </summary>
+    bool TrySelectByInternalName(string internalName);
+
+    /// <summary>
+    /// Open the current detail in a popup window. Returns false if the tab
+    /// has no current detail (nothing selected).
+    /// </summary>
+    bool TryOpenInWindow();
+}

--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -78,15 +78,15 @@ public static class ShellServiceCollectionExtensions
         services
             .AddSingleton<IItemDetailPresenter, ItemDetailPresenter>()
             .AddSingleton<IModuleActivator, ShellModuleActivator>()
-            // Factory form so module-side import targets and IDiagnosticsSink stay optional —
-            // modules register them at their discretion, and the router degrades gracefully
-            // (deep links to absent handlers are logged + dropped, never thrown).
+            // Shell-side deep-link handlers: depend only on IReferenceNavigator
+            // (NoOp when Silmarillion isn't loaded), so they belong here, not in
+            // a module's Register(). Modules register their own action handlers.
+            .AddSingleton<IDeepLinkHandler, ItemDeepLinkHandler>()
+            .AddSingleton<IDeepLinkHandler, RecipeDeepLinkHandler>()
+            // Router pulls every registered IDeepLinkHandler. Module-side handlers
+            // register from their own IMithrilModule.Register() implementations.
             .AddSingleton<IDeepLinkRouter>(sp => new DeepLinkRouter(
-                sp.GetRequiredService<Mithril.Shared.Reference.IReferenceNavigator>(),
-                sp.GetService<ICraftListImportTarget>(),
-                sp.GetService<IPippinShareImportTarget>(),
-                sp.GetService<ILegolasShareImportTarget>(),
-                sp.GetService<IElrondSkillImportTarget>(),
+                sp.GetServices<IDeepLinkHandler>(),
                 sp.GetService<IDiagnosticsSink>()));
 
     public static IServiceCollection AddMithrilIngredientSources(this IServiceCollection services) =>

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -131,6 +131,20 @@ public static class Program
 
             var builder = Host.CreateApplicationBuilder(args);
 
+            // Validate the DI graph at host-build time. Catches singleton-vs-singleton
+            // cycles and missing dependencies as a clear exception at builder.Build()
+            // instead of letting them manifest later as a hung App.OnStartup. Cost is
+            // one eager singleton-resolution pass; upside is fail-fast with a precise
+            // error trace instead of "stuck at 'creating App'".
+            //
+            // HostApplicationBuilder routes this through ConfigureContainer rather
+            // than the older HostBuilder.UseDefaultServiceProvider extension.
+            builder.ConfigureContainer(new DefaultServiceProviderFactory(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true,
+            }));
+
             // Cross-cutting user preferences (12/24h clock, future display
             // toggles). Lives in Mithril.Shared so modules can read it
             // without depending on Mithril.Shell. Persisted to

--- a/src/Mithril.Shell/Views/AboutSettingsView.xaml
+++ b/src/Mithril.Shell/Views/AboutSettingsView.xaml
@@ -143,7 +143,7 @@
 
             <TextBlock Text="Deep linking" Foreground="#88FFFFFF" Margin="0,28,0,4" FontWeight="SemiBold"/>
             <TextBlock TextWrapping="Wrap" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,6"
-                       Text="Register a mithril:// URL handler so other apps can open Mithril directly at a specific item. Example: mithril://item/CraftedLeatherBoots5. Stored in your user registry (HKCU); no admin rights required."/>
+                       Text="Register a mithril:// URL handler so other apps can open Mithril directly at a specific item. Example: mithril://silmarillion/item/CraftedLeatherBoots5. Stored in your user registry (HKCU); no admin rights required."/>
             <TextBlock Text="{Binding LinkSchemeStatus}" Foreground="#CCFFFFFF"
                        FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,6"/>
             <Button Padding="12,6" HorizontalAlignment="Left"

--- a/src/Pippin.Module/PippinModule.cs
+++ b/src/Pippin.Module/PippinModule.cs
@@ -72,6 +72,8 @@ public sealed class PippinModule : IMithrilModule
             sp.GetRequiredService<FoodCatalog>(),
             sp.GetService<IModuleActivator>(),
             sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>()));
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new PippinDeepLinkHandler(sp.GetRequiredService<IPippinShareImportTarget>()));
 
         // Sharing — image export renderer (round 3)
         services.AddSingleton<PippinShareCardRenderer>(sp => new PippinShareCardRenderer(

--- a/src/Pippin.Module/Sharing/PippinDeepLinkHandler.cs
+++ b/src/Pippin.Module/Sharing/PippinDeepLinkHandler.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Pippin.Sharing;
+
+/// <summary>Handles <c>mithril://pippin/&lt;base64url&gt;</c> shared-progress imports.</summary>
+public sealed class PippinDeepLinkHandler : IDeepLinkHandler
+{
+    // Pippin payloads are larger than list because they encode the full-catalogue progress dump.
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_-]{1,16384}$", RegexOptions.Compiled);
+
+    private readonly IPippinShareImportTarget _target;
+
+    public PippinDeepLinkHandler(IPippinShareImportTarget target) => _target = target;
+
+    public string Action => "pippin";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (!PayloadPattern.IsMatch(subPath))
+        {
+            diag?.Info("DeepLink", $"Rejected: pippin payload (len={subPath.Length}) failed validation.");
+            return false;
+        }
+        _target.ImportFromLinkPayload(subPath);
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
@@ -1,3 +1,4 @@
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
 using Silmarillion.ViewModels;
@@ -15,10 +16,12 @@ namespace Silmarillion.Navigation;
 public sealed class ItemsKindTarget : IReferenceKindTarget
 {
     private readonly ItemsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
 
-    public ItemsKindTarget(ItemsTabViewModel vm)
+    public ItemsKindTarget(ItemsTabViewModel vm, IDiagnosticsSink? diag = null)
     {
         _vm = vm;
+        _diag = diag;
     }
 
     public EntityKind Kind => EntityKind.Item;
@@ -35,7 +38,12 @@ public sealed class ItemsKindTarget : IReferenceKindTarget
         // Looking up in AllItems guarantees we pick the canonical instance the
         // ListBox already knows.
         var item = _vm.AllItems.FirstOrDefault(i => i.InternalName == internalName);
-        if (item is null) return false;
+        if (item is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Items.TrySelect '{internalName}' → not found (AllItems={_vm.AllItems.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Items.TrySelect '{internalName}' → found, selecting.");
         _vm.SelectedItem = item;
         return true;
     }

--- a/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
@@ -1,0 +1,44 @@
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the Items tab. Lives next to
+/// the navigator so the registry is owned by the same module that hosts the
+/// tabs. Wires the navigator's "select this entity" call into the tab VM's
+/// existing master-detail selection, and the "open in window" call into the
+/// existing <see cref="ItemDetailWindow"/> popup.
+/// </summary>
+public sealed class ItemsKindTarget : IReferenceKindTarget
+{
+    private readonly ItemsTabViewModel _vm;
+    private readonly IReferenceDataService _refData;
+
+    public ItemsKindTarget(ItemsTabViewModel vm, IReferenceDataService refData)
+    {
+        _vm = vm;
+        _refData = refData;
+    }
+
+    public EntityKind Kind => EntityKind.Item;
+
+    public int TabIndex => 0;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (!_refData.ItemsByInternalName.TryGetValue(internalName, out var item))
+            return false;
+        _vm.SelectedItem = item;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new ItemDetailWindow(_vm.DetailViewModel).Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
@@ -15,12 +15,10 @@ namespace Silmarillion.Navigation;
 public sealed class ItemsKindTarget : IReferenceKindTarget
 {
     private readonly ItemsTabViewModel _vm;
-    private readonly IReferenceDataService _refData;
 
-    public ItemsKindTarget(ItemsTabViewModel vm, IReferenceDataService refData)
+    public ItemsKindTarget(ItemsTabViewModel vm)
     {
         _vm = vm;
-        _refData = refData;
     }
 
     public EntityKind Kind => EntityKind.Item;
@@ -29,8 +27,15 @@ public sealed class ItemsKindTarget : IReferenceKindTarget
 
     public bool TrySelectByInternalName(string internalName)
     {
-        if (!_refData.ItemsByInternalName.TryGetValue(internalName, out var item))
-            return false;
+        // Resolve against the tab VM's AllItems (the bound ListBox ItemsSource),
+        // not against refData directly. If a background reference-data refresh swaps
+        // the underlying dictionary, refData hands us a new Item instance while
+        // AllItems still holds the old reference — WPF's ListBox can't find a match
+        // by Equals and silently clears the selection, leaving the detail empty.
+        // Looking up in AllItems guarantees we pick the canonical instance the
+        // ListBox already knows.
+        var item = _vm.AllItems.FirstOrDefault(i => i.InternalName == internalName);
+        if (item is null) return false;
         _vm.SelectedItem = item;
         return true;
     }

--- a/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
@@ -1,0 +1,38 @@
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary><see cref="IReferenceKindTarget"/> adapter for the Recipes tab.
+/// See <see cref="ItemsKindTarget"/>.</summary>
+public sealed class RecipesKindTarget : IReferenceKindTarget
+{
+    private readonly RecipesTabViewModel _vm;
+    private readonly IReferenceDataService _refData;
+
+    public RecipesKindTarget(RecipesTabViewModel vm, IReferenceDataService refData)
+    {
+        _vm = vm;
+        _refData = refData;
+    }
+
+    public EntityKind Kind => EntityKind.Recipe;
+
+    public int TabIndex => 1;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (!_refData.RecipesByInternalName.TryGetValue(internalName, out var recipe))
+            return false;
+        _vm.SelectedRecipe = recipe;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new RecipeDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
@@ -1,3 +1,4 @@
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Silmarillion.ViewModels;
 using Silmarillion.Views;
@@ -12,10 +13,12 @@ namespace Silmarillion.Navigation;
 public sealed class RecipesKindTarget : IReferenceKindTarget
 {
     private readonly RecipesTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
 
-    public RecipesKindTarget(RecipesTabViewModel vm)
+    public RecipesKindTarget(RecipesTabViewModel vm, IDiagnosticsSink? diag = null)
     {
         _vm = vm;
+        _diag = diag;
     }
 
     public EntityKind Kind => EntityKind.Recipe;
@@ -25,11 +28,14 @@ public sealed class RecipesKindTarget : IReferenceKindTarget
     public bool TrySelectByInternalName(string internalName)
     {
         // Resolve against AllRecipes (canonical, matches WPF's ListBox ItemsSource),
-        // not against refData. See ItemsKindTarget for context. The pre-existing
-        // SelectedRecipe setter also uses ReferenceEquals, which fails post-refresh
-        // when references diverge — going through SelectedRow directly avoids it.
+        // not against refData. See ItemsKindTarget for context.
         var row = _vm.AllRecipes.FirstOrDefault(r => r.Recipe.InternalName == internalName);
-        if (row is null) return false;
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Recipes.TrySelect '{internalName}' → not found (AllRecipes={_vm.AllRecipes.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Recipes.TrySelect '{internalName}' → found, selecting.");
         _vm.SelectedRow = row;
         return true;
     }

--- a/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
@@ -4,17 +4,18 @@ using Silmarillion.Views;
 
 namespace Silmarillion.Navigation;
 
-/// <summary><see cref="IReferenceKindTarget"/> adapter for the Recipes tab.
-/// See <see cref="ItemsKindTarget"/>.</summary>
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the Recipes tab.
+/// See <see cref="ItemsKindTarget"/> for the rationale on resolving against
+/// the tab VM's bound collection instead of refData directly.
+/// </summary>
 public sealed class RecipesKindTarget : IReferenceKindTarget
 {
     private readonly RecipesTabViewModel _vm;
-    private readonly IReferenceDataService _refData;
 
-    public RecipesKindTarget(RecipesTabViewModel vm, IReferenceDataService refData)
+    public RecipesKindTarget(RecipesTabViewModel vm)
     {
         _vm = vm;
-        _refData = refData;
     }
 
     public EntityKind Kind => EntityKind.Recipe;
@@ -23,9 +24,13 @@ public sealed class RecipesKindTarget : IReferenceKindTarget
 
     public bool TrySelectByInternalName(string internalName)
     {
-        if (!_refData.RecipesByInternalName.TryGetValue(internalName, out var recipe))
-            return false;
-        _vm.SelectedRecipe = recipe;
+        // Resolve against AllRecipes (canonical, matches WPF's ListBox ItemsSource),
+        // not against refData. See ItemsKindTarget for context. The pre-existing
+        // SelectedRecipe setter also uses ReferenceEquals, which fails post-refresh
+        // when references diverge — going through SelectedRow directly avoids it.
+        var row = _vm.AllRecipes.FirstOrDefault(r => r.Recipe.InternalName == internalName);
+        if (row is null) return false;
+        _vm.SelectedRow = row;
         return true;
     }
 

--- a/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// Handles <c>mithril://silmarillion/&lt;kind&gt;/&lt;internalName&gt;</c> — the
+/// module-scoped form (issue #229). Symmetric with <c>mithril://pippin/...</c>,
+/// <c>mithril://legolas/...</c>, etc. The legacy single-kind forms
+/// (<c>mithril://item/...</c> / <c>mithril://recipe/...</c>) remain supported
+/// via <see cref="ItemDeepLinkHandler"/> / <see cref="RecipeDeepLinkHandler"/>.
+/// </summary>
+public sealed class SilmarillionDeepLinkHandler : IDeepLinkHandler
+{
+    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    private readonly IReferenceNavigator _navigator;
+
+    public SilmarillionDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
+
+    public string Action => "silmarillion";
+
+    public bool TryHandle(string subPath, IDiagnosticsSink? diag)
+    {
+        if (string.IsNullOrEmpty(subPath))
+        {
+            diag?.Info("DeepLink", "Rejected: silmarillion payload is empty.");
+            return false;
+        }
+
+        // Strictly two segments: kind/name. Extra segments are rejected so the
+        // grammar stays unambiguous when future kinds ship.
+        var slash = subPath.IndexOf('/');
+        if (slash < 0 || slash == subPath.Length - 1)
+        {
+            diag?.Info("DeepLink", $"Rejected: silmarillion payload '{subPath}' missing kind or name segment.");
+            return false;
+        }
+        var kind = subPath.AsSpan(0, slash).ToString().ToLowerInvariant();
+        var name = subPath[(slash + 1)..];
+        if (name.Contains('/'))
+        {
+            diag?.Info("DeepLink", $"Rejected: silmarillion payload '{subPath}' has extra segments.");
+            return false;
+        }
+        if (!PayloadPattern.IsMatch(name))
+        {
+            diag?.Info("DeepLink", $"Rejected: silmarillion name '{name}' failed validation.");
+            return false;
+        }
+
+        switch (kind)
+        {
+            case "item":
+                _navigator.Open(EntityRef.Item(name));
+                return true;
+            case "recipe":
+                _navigator.Open(EntityRef.Recipe(name));
+                return true;
+            default:
+                diag?.Info("DeepLink", $"Rejected: silmarillion kind '{kind}' is not yet routable.");
+                return false;
+        }
+    }
+}

--- a/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
@@ -54,9 +54,11 @@ public sealed class SilmarillionDeepLinkHandler : IDeepLinkHandler
         switch (kind)
         {
             case "item":
+                diag?.Info("DeepLink", $"Silmarillion handler dispatching item '{name}'.");
                 _navigator.Open(EntityRef.Item(name));
                 return true;
             case "recipe":
+                diag?.Info("DeepLink", $"Silmarillion handler dispatching recipe '{name}'.");
                 _navigator.Open(EntityRef.Recipe(name));
                 return true;
             default:

--- a/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
@@ -12,15 +12,44 @@ namespace Silmarillion.Navigation;
 /// <see cref="IReferenceKindTarget"/> has been registered for it. As Bucket-B
 /// tabs ship (NPCs → Quests → …), each one adds a target and chip
 /// clickability for that kind flips on automatically.
+///
+/// Two constructors exist: an eager one (validates at construction; used by tests
+/// that build a navigator from a fixed array) and a lazy one (validates on first
+/// <see cref="CanOpen"/> call; used by DI to break the construction cycle, since
+/// kind targets depend on tab view-models and tab view-models depend on this
+/// navigator). The lazy path's factory closure isn't invoked until first
+/// <see cref="CanOpen"/>, by which time this navigator is already cached in the
+/// container.
 /// </summary>
 public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
 {
-    private readonly IReadOnlyDictionary<EntityKind, IReferenceKindTarget> _targets;
+    private readonly Func<IEnumerable<IReferenceKindTarget>>? _targetsFactory;
+    private IReadOnlyDictionary<EntityKind, IReferenceKindTarget>? _targets;
 
     private readonly Stack<EntityRef> _back = new();
     private readonly Stack<EntityRef> _forward = new();
 
+    /// <summary>Eager construction: validates immediately. Used in tests.</summary>
     public SilmarillionReferenceNavigator(IEnumerable<IReferenceKindTarget> targets)
+    {
+        _targets = BuildRegistry(targets);
+    }
+
+    /// <summary>
+    /// Lazy construction: defers validation and target enumeration to the first
+    /// <see cref="CanOpen"/> call. Used by DI to break the cycle between this
+    /// navigator and the kind targets' tab-VM dependencies.
+    /// </summary>
+    public SilmarillionReferenceNavigator(Func<IEnumerable<IReferenceKindTarget>> targetsFactory)
+    {
+        _targetsFactory = targetsFactory;
+    }
+
+    private IReadOnlyDictionary<EntityKind, IReferenceKindTarget> Targets =>
+        _targets ??= BuildRegistry(_targetsFactory!());
+
+    private static IReadOnlyDictionary<EntityKind, IReferenceKindTarget> BuildRegistry(
+        IEnumerable<IReferenceKindTarget> targets)
     {
         // Fail-loud on duplicate Kind registrations — same shape as DeepLinkRouter.
         var byKind = new Dictionary<EntityKind, IReferenceKindTarget>();
@@ -32,7 +61,7 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
                     $"{byKind[t.Kind].GetType().FullName} and {t.GetType().FullName}.");
             byKind[t.Kind] = t;
         }
-        _targets = byKind;
+        return byKind;
     }
 
     public EntityRef? Current { get; private set; }
@@ -40,7 +69,7 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
     public bool CanGoForward => _forward.Count > 0;
     public event EventHandler<NavigatedEventArgs>? Navigated;
 
-    public bool CanOpen(EntityRef reference) => _targets.ContainsKey(reference.Kind);
+    public bool CanOpen(EntityRef reference) => Targets.ContainsKey(reference.Kind);
 
     public void Open(EntityRef reference)
     {

--- a/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
@@ -3,44 +3,49 @@ using Mithril.Shared.Reference;
 namespace Silmarillion.Navigation;
 
 /// <summary>
-/// Live implementation of <see cref="IReferenceNavigator"/>. Maintains unbounded back/forward
-/// stacks of <see cref="EntityRef"/>. Registered by <see cref="SilmarillionModule"/> and
-/// overrides the shell's <c>NoOpReferenceNavigator</c> via last-singleton-wins DI semantics.
+/// Live implementation of <see cref="IReferenceNavigator"/>. Maintains unbounded
+/// back/forward stacks of <see cref="EntityRef"/>. Registered by
+/// <see cref="SilmarillionModule"/> and overrides the shell's
+/// <c>NoOpReferenceNavigator</c> via last-singleton-wins DI semantics.
+///
+/// <see cref="CanOpen"/> is registry-driven: a kind is navigable iff an
+/// <see cref="IReferenceKindTarget"/> has been registered for it. As Bucket-B
+/// tabs ship (NPCs → Quests → …), each one adds a target and chip
+/// clickability for that kind flips on automatically.
 /// </summary>
 public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
 {
-    /// <summary>
-    /// EntityKinds for which a v1 tab exists. <see cref="CanOpen"/> drives the
-    /// clickable-vs-plain-text rendering of cross-link chips: kinds not in this set
-    /// degrade to plain text, and the same chip becomes clickable automatically when
-    /// a future tab widens this set.
-    /// </summary>
-    private static readonly HashSet<EntityKind> V1TabbedKinds = new()
-    {
-        EntityKind.Item,
-        EntityKind.Recipe,
-    };
+    private readonly IReadOnlyDictionary<EntityKind, IReferenceKindTarget> _targets;
 
     private readonly Stack<EntityRef> _back = new();
     private readonly Stack<EntityRef> _forward = new();
 
+    public SilmarillionReferenceNavigator(IEnumerable<IReferenceKindTarget> targets)
+    {
+        // Fail-loud on duplicate Kind registrations — same shape as DeepLinkRouter.
+        var byKind = new Dictionary<EntityKind, IReferenceKindTarget>();
+        foreach (var t in targets)
+        {
+            if (byKind.ContainsKey(t.Kind))
+                throw new InvalidOperationException(
+                    $"Duplicate IReferenceKindTarget registration for kind '{t.Kind}': " +
+                    $"{byKind[t.Kind].GetType().FullName} and {t.GetType().FullName}.");
+            byKind[t.Kind] = t;
+        }
+        _targets = byKind;
+    }
+
     public EntityRef? Current { get; private set; }
-
     public bool CanGoBack => _back.Count > 0;
-
     public bool CanGoForward => _forward.Count > 0;
-
     public event EventHandler<NavigatedEventArgs>? Navigated;
 
-    public bool CanOpen(EntityRef reference) => V1TabbedKinds.Contains(reference.Kind);
+    public bool CanOpen(EntityRef reference) => _targets.ContainsKey(reference.Kind);
 
     public void Open(EntityRef reference)
     {
         var previous = Current;
-        if (previous is not null)
-        {
-            _back.Push(previous);
-        }
+        if (previous is not null) _back.Push(previous);
         _forward.Clear();
         Current = reference;
         Navigated?.Invoke(this, new NavigatedEventArgs(previous, Current, NavigationKind.Open));
@@ -50,10 +55,7 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
     {
         if (_back.Count == 0) return;
         var previous = Current;
-        if (previous is not null)
-        {
-            _forward.Push(previous);
-        }
+        if (previous is not null) _forward.Push(previous);
         Current = _back.Pop();
         Navigated?.Invoke(this, new NavigatedEventArgs(previous, Current, NavigationKind.Back));
     }
@@ -62,10 +64,7 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
     {
         if (_forward.Count == 0) return;
         var previous = Current;
-        if (previous is not null)
-        {
-            _back.Push(previous);
-        }
+        if (previous is not null) _back.Push(previous);
         Current = _forward.Pop();
         Navigated?.Invoke(this, new NavigatedEventArgs(previous, Current, NavigationKind.Forward));
     }

--- a/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
@@ -1,3 +1,5 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 
 namespace Silmarillion.Navigation;
@@ -25,6 +27,8 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
 {
     private readonly Func<IEnumerable<IReferenceKindTarget>>? _targetsFactory;
     private IReadOnlyDictionary<EntityKind, IReferenceKindTarget>? _targets;
+    private readonly IModuleActivator? _activator;
+    private readonly IDiagnosticsSink? _diag;
 
     private readonly Stack<EntityRef> _back = new();
     private readonly Stack<EntityRef> _forward = new();
@@ -38,11 +42,21 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
     /// <summary>
     /// Lazy construction: defers validation and target enumeration to the first
     /// <see cref="CanOpen"/> call. Used by DI to break the cycle between this
-    /// navigator and the kind targets' tab-VM dependencies.
+    /// navigator and the kind targets' tab-VM dependencies. <paramref name="activator"/>
+    /// is optional — when wired, <see cref="Open"/> brings the Silmarillion tab to
+    /// the foreground first so that <c>SilmarillionViewModel</c> (which subscribes
+    /// to <see cref="Navigated"/> in its constructor) exists by the time the event
+    /// fires. Critical for deep links that arrive before the lazy module has been
+    /// activated by a tab click.
     /// </summary>
-    public SilmarillionReferenceNavigator(Func<IEnumerable<IReferenceKindTarget>> targetsFactory)
+    public SilmarillionReferenceNavigator(
+        Func<IEnumerable<IReferenceKindTarget>> targetsFactory,
+        IModuleActivator? activator = null,
+        IDiagnosticsSink? diag = null)
     {
         _targetsFactory = targetsFactory;
+        _activator = activator;
+        _diag = diag;
     }
 
     private IReadOnlyDictionary<EntityKind, IReferenceKindTarget> Targets =>
@@ -73,6 +87,15 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
 
     public void Open(EntityRef reference)
     {
+        _diag?.Info("Silmarillion.Nav", $"Open kind={reference.Kind} name='{reference.InternalName}'.");
+
+        // Activate the host module BEFORE firing Navigated so SilmarillionViewModel
+        // exists and is subscribed by the time the event reaches it. Without this,
+        // a deep link that arrives while the user is on a different tab silently
+        // updates Current but no UI responds — the navigator's state is correct
+        // but invisible.
+        _activator?.Activate("silmarillion");
+
         var previous = Current;
         if (previous is not null) _back.Push(previous);
         _forward.Clear();

--- a/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionReferenceNavigator.cs
@@ -27,7 +27,7 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
 {
     private readonly Func<IEnumerable<IReferenceKindTarget>>? _targetsFactory;
     private IReadOnlyDictionary<EntityKind, IReferenceKindTarget>? _targets;
-    private readonly IModuleActivator? _activator;
+    private readonly Func<IModuleActivator?>? _activatorFactory;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly Stack<EntityRef> _back = new();
@@ -51,11 +51,11 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
     /// </summary>
     public SilmarillionReferenceNavigator(
         Func<IEnumerable<IReferenceKindTarget>> targetsFactory,
-        IModuleActivator? activator = null,
+        Func<IModuleActivator?>? activatorFactory = null,
         IDiagnosticsSink? diag = null)
     {
         _targetsFactory = targetsFactory;
-        _activator = activator;
+        _activatorFactory = activatorFactory;
         _diag = diag;
     }
 
@@ -94,7 +94,16 @@ public sealed class SilmarillionReferenceNavigator : IReferenceNavigator
         // a deep link that arrives while the user is on a different tab silently
         // updates Current but no UI responds — the navigator's state is correct
         // but invisible.
-        _activator?.Activate("silmarillion");
+        //
+        // Activator resolution is deferred via Func<> because eagerly resolving
+        // IModuleActivator at navigator-construction time would drag ShellViewModel
+        // and its entire dependency closure into the DI chain that builds
+        // IDeepLinkRouter → SilmarillionDeepLinkHandler → IReferenceNavigator. That
+        // is a startup-time chain; ShellViewModel is built later and depending on
+        // it from here either cycles or blocks. The Func keeps the navigator
+        // construction-time deps minimal; Activate fires on the user-action path
+        // where ShellViewModel is already constructed.
+        _activatorFactory?.Invoke()?.Activate("silmarillion");
 
         var previous = Current;
         if (previous is not null) _back.Push(previous);

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -26,19 +26,28 @@ public sealed class SilmarillionModule : IMithrilModule
 
     public void Register(IServiceCollection services)
     {
-        // Replace the shell-registered NoOpReferenceNavigator. Last AddSingleton<T> wins for
-        // non-keyed singleton resolution, and module Register() runs after shell DI setup.
-        services.AddSingleton<IReferenceNavigator, SilmarillionReferenceNavigator>();
-
-        // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
-        // Legacy mithril://item/<name> / mithril://recipe/<name> remain wired in
-        // Mithril.Shared.Wpf.
-        services.AddSingleton<IDeepLinkHandler>(sp =>
-            new SilmarillionDeepLinkHandler(sp.GetRequiredService<IReferenceNavigator>()));
+        // Replace the shell-registered NoOpReferenceNavigator. Last AddSingleton<T> wins
+        // for non-keyed singleton resolution, and module Register() runs after shell DI
+        // setup. The navigator pulls all IReferenceKindTarget registrations via DI.
+        services.AddSingleton<IReferenceNavigator>(sp => new SilmarillionReferenceNavigator(
+            sp.GetServices<IReferenceKindTarget>()));
 
         services.AddSingleton<ItemsTabViewModel>();
         services.AddSingleton<RecipesTabViewModel>();
         services.AddSingleton<SilmarillionViewModel>();
+
+        // Kind targets registered after the tab VMs so DI can resolve them.
+        services.AddSingleton<IReferenceKindTarget>(sp => new ItemsKindTarget(
+            sp.GetRequiredService<ItemsTabViewModel>(),
+            sp.GetRequiredService<IReferenceDataService>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new RecipesKindTarget(
+            sp.GetRequiredService<RecipesTabViewModel>(),
+            sp.GetRequiredService<IReferenceDataService>()));
+
+        // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new SilmarillionDeepLinkHandler(sp.GetRequiredService<IReferenceNavigator>()));
+
         services.AddSingleton<SilmarillionView>(sp => new SilmarillionView
         {
             DataContext = sp.GetRequiredService<SilmarillionViewModel>(),

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -1,5 +1,6 @@
 using MahApps.Metro.IconPacks;
 using Microsoft.Extensions.DependencyInjection;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 using Silmarillion.Navigation;
@@ -33,7 +34,9 @@ public sealed class SilmarillionModule : IMithrilModule
         // CanOpen invocation, which is what breaks the construction cycle (kind targets
         // depend on tab VMs, tab VMs depend on this navigator).
         services.AddSingleton<IReferenceNavigator>(sp => new SilmarillionReferenceNavigator(
-            () => sp.GetServices<IReferenceKindTarget>()));
+            () => sp.GetServices<IReferenceKindTarget>(),
+            sp.GetService<IModuleActivator>(),
+            sp.GetService<IDiagnosticsSink>()));
 
         services.AddSingleton<ItemsTabViewModel>();
         services.AddSingleton<RecipesTabViewModel>();
@@ -44,9 +47,11 @@ public sealed class SilmarillionModule : IMithrilModule
         // than refData — see ItemsKindTarget for the post-refresh divergence
         // that motivates this.
         services.AddSingleton<IReferenceKindTarget>(sp => new ItemsKindTarget(
-            sp.GetRequiredService<ItemsTabViewModel>()));
+            sp.GetRequiredService<ItemsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new RecipesKindTarget(
-            sp.GetRequiredService<RecipesTabViewModel>()));
+            sp.GetRequiredService<RecipesTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
         services.AddSingleton<IDeepLinkHandler>(sp =>

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -35,7 +35,7 @@ public sealed class SilmarillionModule : IMithrilModule
         // depend on tab VMs, tab VMs depend on this navigator).
         services.AddSingleton<IReferenceNavigator>(sp => new SilmarillionReferenceNavigator(
             () => sp.GetServices<IReferenceKindTarget>(),
-            sp.GetService<IModuleActivator>(),
+            () => sp.GetService<IModuleActivator>(),
             sp.GetService<IDiagnosticsSink>()));
 
         services.AddSingleton<ItemsTabViewModel>();

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -40,12 +40,13 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<SilmarillionViewModel>();
 
         // Kind targets registered after the tab VMs so DI can resolve them.
+        // They resolve entities against the tab VMs' bound collections rather
+        // than refData — see ItemsKindTarget for the post-refresh divergence
+        // that motivates this.
         services.AddSingleton<IReferenceKindTarget>(sp => new ItemsKindTarget(
-            sp.GetRequiredService<ItemsTabViewModel>(),
-            sp.GetRequiredService<IReferenceDataService>()));
+            sp.GetRequiredService<ItemsTabViewModel>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new RecipesKindTarget(
-            sp.GetRequiredService<RecipesTabViewModel>(),
-            sp.GetRequiredService<IReferenceDataService>()));
+            sp.GetRequiredService<RecipesTabViewModel>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
         services.AddSingleton<IDeepLinkHandler>(sp =>

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -28,9 +28,12 @@ public sealed class SilmarillionModule : IMithrilModule
     {
         // Replace the shell-registered NoOpReferenceNavigator. Last AddSingleton<T> wins
         // for non-keyed singleton resolution, and module Register() runs after shell DI
-        // setup. The navigator pulls all IReferenceKindTarget registrations via DI.
+        // setup. The navigator pulls all IReferenceKindTarget registrations via DI;
+        // the Func<> wrapper defers the GetServices call until the navigator's first
+        // CanOpen invocation, which is what breaks the construction cycle (kind targets
+        // depend on tab VMs, tab VMs depend on this navigator).
         services.AddSingleton<IReferenceNavigator>(sp => new SilmarillionReferenceNavigator(
-            sp.GetServices<IReferenceKindTarget>()));
+            () => sp.GetServices<IReferenceKindTarget>()));
 
         services.AddSingleton<ItemsTabViewModel>();
         services.AddSingleton<RecipesTabViewModel>();

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -30,6 +30,12 @@ public sealed class SilmarillionModule : IMithrilModule
         // non-keyed singleton resolution, and module Register() runs after shell DI setup.
         services.AddSingleton<IReferenceNavigator, SilmarillionReferenceNavigator>();
 
+        // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
+        // Legacy mithril://item/<name> / mithril://recipe/<name> remain wired in
+        // Mithril.Shared.Wpf.
+        services.AddSingleton<IDeepLinkHandler>(sp =>
+            new SilmarillionDeepLinkHandler(sp.GetRequiredService<IReferenceNavigator>()));
+
         services.AddSingleton<ItemsTabViewModel>();
         services.AddSingleton<RecipesTabViewModel>();
         services.AddSingleton<SilmarillionViewModel>();

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -13,6 +13,13 @@ namespace Silmarillion.ViewModels;
 /// <see cref="SelectedItem"/>, built lazily on selection change with cross-link sections
 /// populated from <c>IReferenceDataService.RecipesByProducedItem</c> /
 /// <c>RecipesByIngredientItem</c> / <c>ItemSources</c>.
+///
+/// Subscribes to <see cref="IReferenceDataService.FileUpdated"/> for <c>"items"</c> and
+/// rebuilds <see cref="AllItems"/> on the UI thread, preserving the current selection by
+/// <see cref="Item.InternalName"/>. Without this, a background CDN refresh after the tab
+/// is loaded would leave WPF's ListBox bound to a stale Item collection while refData
+/// hands out new instances — selections set via the navigator would silently fall out of
+/// the list.
 /// </summary>
 public sealed partial class ItemsTabViewModel : ObservableObject
 {
@@ -25,12 +32,12 @@ public sealed partial class ItemsTabViewModel : ObservableObject
         _refData = refData;
         _navigator = navigator;
         _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
-        AllItems = refData.ItemsByInternalName.Values
-            .OrderBy(i => i.Name ?? i.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        _allItems = BuildAllItems(refData);
+        refData.FileUpdated += OnFileUpdated;
     }
 
-    public IReadOnlyList<Item> AllItems { get; }
+    [ObservableProperty]
+    private IReadOnlyList<Item> _allItems;
 
     [ObservableProperty]
     private string _queryText = "";
@@ -55,6 +62,41 @@ public sealed partial class ItemsTabViewModel : ObservableObject
         DetailViewModel = new ItemDetailViewModel(
             value, _refData, context, poolPresenter: null, openEntityCommand: _openEntityCommand);
     }
+
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        // Items.json is the primary trigger. Recipes.json updates also rebuild
+        // refData's cross-link indices (BuildRecipeCrossLinkIndices runs on both),
+        // which means an open ItemDetailView's "Produced by" / "Used in" chips can
+        // go stale even when items.json itself didn't change. Re-resolve on both.
+        if (fileKey != "items" && fileKey != "recipes") return;
+
+        UiThread.Run(() =>
+        {
+            var captured = SelectedItem?.InternalName;
+            // items.json refresh rebuilds the bound list. recipes.json refresh
+            // only changes the cross-link side; AllItems doesn't need rebuilding.
+            if (fileKey == "items")
+            {
+                AllItems = BuildAllItems(_refData);
+            }
+            if (!string.IsNullOrEmpty(captured))
+            {
+                var resolved = AllItems.FirstOrDefault(i => i.InternalName == captured);
+                // Force a SelectedItem change so OnSelectedItemChanged rebuilds the
+                // detail VM with the fresh refData snapshot. Toggling through null is
+                // necessary because [ObservableProperty]'s equality check would
+                // suppress a same-reference reassignment.
+                SelectedItem = null;
+                SelectedItem = resolved;
+            }
+        });
+    }
+
+    private static IReadOnlyList<Item> BuildAllItems(IReferenceDataService refData) =>
+        refData.ItemsByInternalName.Values
+            .OrderBy(i => i.Name ?? i.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
     private ItemDetailContext BuildCrossLinkContext(Item item)
     {

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -11,6 +11,11 @@ namespace Silmarillion.ViewModels;
 /// filterable row list on the left, recipe detail on the right. On selection change
 /// builds a <see cref="RecipeDetailViewModel"/> with ingredient/produced chips
 /// resolved from <c>IReferenceDataService</c>.
+///
+/// Subscribes to <see cref="IReferenceDataService.FileUpdated"/> for <c>"recipes"</c>
+/// and <c>"items"</c> (the latter rebuilds chip resolution) and rebuilds
+/// <see cref="AllRecipes"/> on the UI thread, preserving the current selection by
+/// <see cref="Recipe.InternalName"/>.
 /// </summary>
 public sealed partial class RecipesTabViewModel : ObservableObject
 {
@@ -23,18 +28,12 @@ public sealed partial class RecipesTabViewModel : ObservableObject
         _refData = refData;
         _navigator = navigator;
         _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
-        AllRecipes = refData.Recipes.Values
-            .Select(r => new RecipeListRow(
-                Recipe: r,
-                Name: r.Name ?? r.InternalName ?? r.Key,
-                IconId: r.IconId > 0 ? r.IconId : ResolveResultIcon(r),
-                SkillDisplayName: ResolveSkillDisplayName(r.Skill),
-                SkillLevelReq: r.SkillLevelReq))
-            .OrderBy(row => row.Name, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        _allRecipes = BuildAllRecipes(refData);
+        refData.FileUpdated += OnFileUpdated;
     }
 
-    public IReadOnlyList<RecipeListRow> AllRecipes { get; }
+    [ObservableProperty]
+    private IReadOnlyList<RecipeListRow> _allRecipes;
 
     [ObservableProperty]
     private string _queryText = "";
@@ -51,15 +50,16 @@ public sealed partial class RecipesTabViewModel : ObservableObject
 
     /// <summary>
     /// Convenience accessor — the actual <see cref="Recipe"/> behind the selected row.
-    /// Setter resolves the recipe to its row in <see cref="AllRecipes"/>. Tests and the
-    /// navigator's OnNavigated handler write through this property.
+    /// Setter resolves the recipe to its row in <see cref="AllRecipes"/> by InternalName
+    /// (not reference equality, since refresh swaps can hand out a different instance for
+    /// the same name).
     /// </summary>
     public Recipe? SelectedRecipe
     {
         get => SelectedRow?.Recipe;
         set => SelectedRow = value is null
             ? null
-            : AllRecipes.FirstOrDefault(row => ReferenceEquals(row.Recipe, value));
+            : AllRecipes.FirstOrDefault(row => row.Recipe.InternalName == value.InternalName);
     }
 
     [ObservableProperty]
@@ -82,6 +82,46 @@ public sealed partial class RecipesTabViewModel : ObservableObject
             recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName);
     }
 
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        // recipes.json updates rebuild the bound list. items.json updates only refresh
+        // the ingredient/produced chip resolution; AllRecipes doesn't change.
+        if (fileKey != "recipes" && fileKey != "items") return;
+
+        UiThread.Run(() =>
+        {
+            var captured = SelectedRow?.Recipe.InternalName;
+            if (fileKey == "recipes")
+            {
+                AllRecipes = BuildAllRecipes(_refData);
+            }
+            if (!string.IsNullOrEmpty(captured))
+            {
+                var resolved = AllRecipes.FirstOrDefault(r => r.Recipe.InternalName == captured);
+                // Toggle through null to force OnSelectedRowChanged to rebuild the detail
+                // VM with the fresh refData snapshot (chip resolution uses live refData).
+                SelectedRow = null;
+                SelectedRow = resolved;
+            }
+        });
+    }
+
+    private IReadOnlyList<RecipeListRow> BuildAllRecipes(IReferenceDataService refData) =>
+        refData.Recipes.Values
+            .Select(r => new RecipeListRow(
+                Recipe: r,
+                Name: r.Name ?? r.InternalName ?? r.Key,
+                IconId: r.IconId > 0 ? r.IconId : ResolveResultIcon(r),
+                SkillDisplayName: ResolveSkillDisplayName(r.Skill),
+                SkillLevelReq: r.SkillLevelReq))
+            .OrderBy(row => row.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    /// <summary>
+    /// Convenience accessor — the actual <see cref="Recipe"/> behind the selected row.
+    /// Setter resolves the recipe to its row in <see cref="AllRecipes"/>. Tests and the
+    /// navigator's OnNavigated handler write through this property.
+    /// </summary>
     private string? ResolveSkillDisplayName(string? skillKey) =>
         !string.IsNullOrEmpty(skillKey) && _refData.Skills.TryGetValue(skillKey, out var s)
             ? s.DisplayName

--- a/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Reference;
-using Silmarillion.Views;
 
 namespace Silmarillion.ViewModels;
 
@@ -11,22 +10,37 @@ namespace Silmarillion.ViewModels;
 /// (Back / Forward / Open-in-window). Subscribes to <see cref="IReferenceNavigator.Navigated"/>
 /// to drive automatic tab-switching when an entity of a different kind is opened
 /// (e.g. clicking a Recipe cross-link from an Item detail).
+///
+/// OnNavigated and OpenInWindow dispatch via the <see cref="IReferenceKindTarget"/>
+/// registry; per-kind switches were retired in #239.
 /// </summary>
 public sealed partial class SilmarillionViewModel : ObservableObject
 {
     private readonly IReferenceNavigator _navigator;
-    private readonly IReferenceDataService _refData;
+    private readonly IReadOnlyDictionary<EntityKind, IReferenceKindTarget> _targets;
 
     public SilmarillionViewModel(
         ItemsTabViewModel items,
         RecipesTabViewModel recipes,
         IReferenceNavigator navigator,
-        IReferenceDataService refData)
+        IEnumerable<IReferenceKindTarget> targets)
     {
         Items = items;
         Recipes = recipes;
         _navigator = navigator;
-        _refData = refData;
+
+        // Same fail-loud-on-duplicate shape as SilmarillionReferenceNavigator —
+        // mis-wired DI should crash startup, not silently last-wins.
+        var byKind = new Dictionary<EntityKind, IReferenceKindTarget>();
+        foreach (var t in targets)
+        {
+            if (byKind.ContainsKey(t.Kind))
+                throw new InvalidOperationException(
+                    $"Duplicate IReferenceKindTarget registration for kind '{t.Kind}': " +
+                    $"{byKind[t.Kind].GetType().FullName} and {t.GetType().FullName}.");
+            byKind[t.Kind] = t;
+        }
+        _targets = byKind;
 
         BackCommand = new RelayCommand(() => _navigator.Back(), () => _navigator.CanGoBack);
         ForwardCommand = new RelayCommand(() => _navigator.Forward(), () => _navigator.CanGoForward);
@@ -47,14 +61,10 @@ public sealed partial class SilmarillionViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanOpenInWindow))]
     private void OpenInWindow()
     {
-        switch (_navigator.Current?.Kind)
+        if (_navigator.Current is { } current
+            && _targets.TryGetValue(current.Kind, out var target))
         {
-            case EntityKind.Item when Items.DetailViewModel is not null:
-                new Mithril.Shared.Wpf.ItemDetailWindow(Items.DetailViewModel).Show();
-                break;
-            case EntityKind.Recipe when Recipes.DetailViewModel is not null:
-                new RecipeDetailWindow { DataContext = Recipes.DetailViewModel }.Show();
-                break;
+            target.TryOpenInWindow();
         }
     }
 
@@ -67,24 +77,9 @@ public sealed partial class SilmarillionViewModel : ObservableObject
         OpenInWindowCommand.NotifyCanExecuteChanged();
 
         if (e.Current is null) return;
+        if (!_targets.TryGetValue(e.Current.Kind, out var target)) return;
 
-        switch (e.Current.Kind)
-        {
-            case EntityKind.Item:
-                if (_refData.ItemsByInternalName.TryGetValue(e.Current.InternalName, out var item))
-                {
-                    SelectedTabIndex = 0;
-                    Items.SelectedItem = item;
-                }
-                break;
-            case EntityKind.Recipe:
-                if (_refData.RecipesByInternalName.TryGetValue(e.Current.InternalName, out var recipe))
-                {
-                    SelectedTabIndex = 1;
-                    Recipes.SelectedRecipe = recipe;
-                }
-                break;
-        }
+        SelectedTabIndex = target.TabIndex;
+        target.TrySelectByInternalName(e.Current.InternalName);
     }
 }
-

--- a/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 
 namespace Silmarillion.ViewModels;
@@ -18,16 +19,19 @@ public sealed partial class SilmarillionViewModel : ObservableObject
 {
     private readonly IReferenceNavigator _navigator;
     private readonly IReadOnlyDictionary<EntityKind, IReferenceKindTarget> _targets;
+    private readonly IDiagnosticsSink? _diag;
 
     public SilmarillionViewModel(
         ItemsTabViewModel items,
         RecipesTabViewModel recipes,
         IReferenceNavigator navigator,
-        IEnumerable<IReferenceKindTarget> targets)
+        IEnumerable<IReferenceKindTarget> targets,
+        IDiagnosticsSink? diag = null)
     {
         Items = items;
         Recipes = recipes;
         _navigator = navigator;
+        _diag = diag;
 
         // Same fail-loud-on-duplicate shape as SilmarillionReferenceNavigator —
         // mis-wired DI should crash startup, not silently last-wins.
@@ -76,9 +80,18 @@ public sealed partial class SilmarillionViewModel : ObservableObject
         ForwardCommand.NotifyCanExecuteChanged();
         OpenInWindowCommand.NotifyCanExecuteChanged();
 
-        if (e.Current is null) return;
-        if (!_targets.TryGetValue(e.Current.Kind, out var target)) return;
+        if (e.Current is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"OnNavigated kind=null ({e.Kind}) — no-op.");
+            return;
+        }
+        if (!_targets.TryGetValue(e.Current.Kind, out var target))
+        {
+            _diag?.Info("Silmarillion.Nav", $"OnNavigated kind={e.Current.Kind} name='{e.Current.InternalName}' — no target registered.");
+            return;
+        }
 
+        _diag?.Info("Silmarillion.Nav", $"OnNavigated kind={e.Current.Kind} name='{e.Current.InternalName}' tabIndex={target.TabIndex}.");
         SelectedTabIndex = target.TabIndex;
         target.TrySelectByInternalName(e.Current.InternalName);
     }

--- a/src/Silmarillion.Module/ViewModels/UiThread.cs
+++ b/src/Silmarillion.Module/ViewModels/UiThread.cs
@@ -1,0 +1,22 @@
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Marshals a callback to the WPF UI thread when one is available, or invokes it
+/// inline when no <see cref="System.Windows.Application"/> is hosted (tests). Used
+/// by the tab view-models to handle <see cref="Mithril.Shared.Reference.IReferenceDataService.FileUpdated"/>
+/// events, which fire from the background refresh task and must apply collection
+/// mutations on the UI thread.
+/// </summary>
+internal static class UiThread
+{
+    public static void Run(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+        dispatcher.BeginInvoke(action);
+    }
+}

--- a/src/Silmarillion.Module/Views/Resources.xaml
+++ b/src/Silmarillion.Module/Views/Resources.xaml
@@ -8,47 +8,45 @@
         <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Converters.xaml"/>
     </ResourceDictionary.MergedDictionaries>
 
-    <!-- Card template for Items tab. Bound DataContext: Mithril.Reference.Models.Items.Item. -->
+    <!-- Compact two-line row for Items tab. Bound DataContext: Mithril.Reference.Models.Items.Item.
+         Replaces the card layout in #231; ~36px per row, ~40+ visible. Key name kept as
+         "*CardTemplate" to avoid rippling into both tab views — names are wallpaper. -->
     <DataTemplate x:Key="ItemCardTemplate">
-        <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                CornerRadius="4" Padding="8" Margin="4" Width="240">
-            <DockPanel>
-                <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                               Width="36" Height="36" Margin="0,0,8,0" VerticalAlignment="Top"/>
-                <StackPanel>
-                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
-                               Foreground="#FFD4A847" TextWrapping="Wrap"
-                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                    <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeSmall}" Margin="0,1,0,0"
-                               Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
+        <DockPanel LastChildFill="True">
+            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                           Width="24" Height="24" Margin="6,3,6,3" VerticalAlignment="Center"/>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
+                           Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis"
+                           Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </DockPanel>
     </DataTemplate>
 
-    <!-- Card template for Recipes tab. Bound DataContext: Silmarillion.ViewModels.RecipeListRow. -->
+    <!-- Compact two-line row for Recipes tab. Bound DataContext: Silmarillion.ViewModels.RecipeListRow. -->
     <DataTemplate x:Key="RecipeCardTemplate">
-        <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                CornerRadius="4" Padding="8" Margin="4" Width="240">
-            <DockPanel>
-                <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                               Width="36" Height="36" Margin="0,0,8,0" VerticalAlignment="Top"/>
-                <StackPanel>
-                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
-                               Foreground="#FFD4A847" TextWrapping="Wrap"
-                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                    <TextBlock Foreground="#88FFFFFF" Margin="0,1,0,0"
-                               FontSize="{DynamicResource AppFontSizeSmall}"
-                               Visibility="{Binding SkillDisplayName, Converter={StaticResource NullOrEmptyToVis}}">
-                        <Run Text="{Binding SkillDisplayName, Mode=OneWay}"/>
-                        <Run Text=" "/>
-                        <Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
-                    </TextBlock>
-                </StackPanel>
-            </DockPanel>
-        </Border>
+        <DockPanel LastChildFill="True">
+            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                           Width="24" Height="24" Margin="6,3,6,3" VerticalAlignment="Center"/>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis"
+                           Visibility="{Binding SkillDisplayName, Converter={StaticResource NullOrEmptyToVis}}">
+                    <Run Text="{Binding SkillDisplayName, Mode=OneWay}"/>
+                    <Run Text=" "/>
+                    <Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
+                </TextBlock>
+            </StackPanel>
+        </DockPanel>
     </DataTemplate>
 
 </ResourceDictionary>

--- a/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
+++ b/tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj
@@ -29,5 +29,6 @@
     <ProjectReference Include="..\..\src\Celebrimbor.Module\Celebrimbor.Module.csproj" />
     <ProjectReference Include="..\..\src\Elrond.Module\Elrond.Module.csproj" />
     <ProjectReference Include="..\..\src\Gandalf.Module\Gandalf.Module.csproj" />
+    <ProjectReference Include="..\..\src\Silmarillion.Module\Silmarillion.Module.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
@@ -359,4 +359,22 @@ public class DeepLinkRouterTests
         act.Should().Throw<InvalidOperationException>()
            .WithMessage("*Duplicate IDeepLinkHandler*item*");
     }
+
+    [Fact]
+    public void SilmarillionRoute_DispatchedToReferenceNavigator()
+    {
+        var nav = new RecordingNavigator();
+        var router = new DeepLinkRouter(new IDeepLinkHandler[]
+        {
+            new ItemDeepLinkHandler(nav),
+            new RecipeDeepLinkHandler(nav),
+            new Silmarillion.Navigation.SilmarillionDeepLinkHandler(nav),
+        });
+
+        router.Handle("mithril://silmarillion/item/CraftedLeatherBoots5").Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Item("CraftedLeatherBoots5"));
+
+        router.Handle("mithril://silmarillion/recipe/MakeTomatoSauce").Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Recipe("MakeTomatoSauce"));
+    }
 }

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
@@ -11,7 +11,7 @@ public class DeepLinkRouterTests
     public void ItemUri_DispatchedTo_ReferenceNavigator_AsItemKind()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav);
+        var router = BuildRouter(nav);
 
         var handled = router.Handle("mithril://item/CraftedLeatherBoots5");
 
@@ -23,7 +23,7 @@ public class DeepLinkRouterTests
     public void RecipeUri_DispatchedTo_ReferenceNavigator_AsRecipeKind()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav);
+        var router = BuildRouter(nav);
 
         var handled = router.Handle("mithril://recipe/MakeTomatoSauce");
 
@@ -35,7 +35,7 @@ public class DeepLinkRouterTests
     public void SchemeIsCaseInsensitive()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav);
+        var router = BuildRouter(nav);
 
         router.Handle("MITHRIL://item/CraftedLeatherBoots5").Should().BeTrue();
         nav.LastOpened.Should().Be(EntityRef.Item("CraftedLeatherBoots5"));
@@ -55,7 +55,7 @@ public class DeepLinkRouterTests
     public void RejectedInputs_ReturnFalse_AndDontDispatch(string? uri)
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav);
+        var router = BuildRouter(nav);
 
         router.Handle(uri).Should().BeFalse();
         nav.LastOpened.Should().BeNull();
@@ -65,7 +65,7 @@ public class DeepLinkRouterTests
     public void Payload_OverLengthCap_IsRejected()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav);
+        var router = BuildRouter(nav);
 
         var tooLong = new string('A', 129);
         router.Handle($"mithril://item/{tooLong}").Should().BeFalse();
@@ -76,7 +76,7 @@ public class DeepLinkRouterTests
     public void Payload_AtLengthCap_IsAccepted()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav);
+        var router = BuildRouter(nav);
 
         var cap = new string('A', 128);
         router.Handle($"mithril://item/{cap}").Should().BeTrue();
@@ -90,7 +90,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var listTarget = new RecordingListTarget();
-        var router = new DeepLinkRouter(nav, listTarget);
+        var router = BuildRouter(nav, listTarget: listTarget);
 
         // Base64url alphabet includes '-' and '_', which the item validator rejects — this
         // also confirms per-action validation routes here instead of the stricter item rule.
@@ -101,10 +101,10 @@ public class DeepLinkRouterTests
     }
 
     [Fact]
-    public void ListUri_WithoutRegisteredTarget_IsDropped()
+    public void ListUri_HandlerNotRegistered_IsDropped()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav, listImport: null);
+        var router = BuildRouter(nav, listTarget: null);
 
         router.Handle("mithril://list/AB-_abcXYZ123").Should().BeFalse();
     }
@@ -117,7 +117,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var listTarget = new RecordingListTarget();
-        var router = new DeepLinkRouter(nav, listTarget);
+        var router = BuildRouter(nav, listTarget: listTarget);
 
         router.Handle(uri).Should().BeFalse();
         listTarget.LastPayload.Should().BeNull();
@@ -128,7 +128,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var listTarget = new RecordingListTarget();
-        var router = new DeepLinkRouter(nav, listTarget);
+        var router = BuildRouter(nav, listTarget: listTarget);
 
         var tooLong = new string('A', 8193);
         router.Handle($"mithril://list/{tooLong}").Should().BeFalse();
@@ -142,7 +142,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var pippinTarget = new RecordingPippinTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: pippinTarget);
+        var router = BuildRouter(nav, pippinTarget: pippinTarget);
 
         var handled = router.Handle("mithril://pippin/AB-_abcXYZ123");
 
@@ -151,10 +151,10 @@ public class DeepLinkRouterTests
     }
 
     [Fact]
-    public void PippinUri_WithoutRegisteredTarget_IsDropped()
+    public void PippinUri_HandlerNotRegistered_IsDropped()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null);
+        var router = BuildRouter(nav, pippinTarget: null);
 
         router.Handle("mithril://pippin/AB-_abcXYZ123").Should().BeFalse();
     }
@@ -167,7 +167,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var pippinTarget = new RecordingPippinTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: pippinTarget);
+        var router = BuildRouter(nav, pippinTarget: pippinTarget);
 
         router.Handle(uri).Should().BeFalse();
         pippinTarget.LastPayload.Should().BeNull();
@@ -178,7 +178,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var pippinTarget = new RecordingPippinTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: pippinTarget);
+        var router = BuildRouter(nav, pippinTarget: pippinTarget);
 
         var tooLong = new string('A', 16_385);
         router.Handle($"mithril://pippin/{tooLong}").Should().BeFalse();
@@ -217,7 +217,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var legolasTarget = new RecordingLegolasTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null, legolasImport: legolasTarget);
+        var router = BuildRouter(nav, legolasTarget: legolasTarget);
 
         var handled = router.Handle("mithril://legolas/AB-_abcXYZ123");
 
@@ -226,10 +226,10 @@ public class DeepLinkRouterTests
     }
 
     [Fact]
-    public void LegolasUri_WithoutRegisteredTarget_IsDropped()
+    public void LegolasUri_HandlerNotRegistered_IsDropped()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null, legolasImport: null);
+        var router = BuildRouter(nav, legolasTarget: null);
 
         router.Handle("mithril://legolas/AB-_abcXYZ123").Should().BeFalse();
     }
@@ -242,7 +242,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var legolasTarget = new RecordingLegolasTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null, legolasImport: legolasTarget);
+        var router = BuildRouter(nav, legolasTarget: legolasTarget);
 
         router.Handle(uri).Should().BeFalse();
         legolasTarget.LastPayload.Should().BeNull();
@@ -253,7 +253,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var legolasTarget = new RecordingLegolasTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null, legolasImport: legolasTarget);
+        var router = BuildRouter(nav, legolasTarget: legolasTarget);
 
         var tooLong = new string('A', 8193);
         router.Handle($"mithril://legolas/{tooLong}").Should().BeFalse();
@@ -273,8 +273,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var elrondTarget = new RecordingElrondTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null,
-            legolasImport: null, elrondImport: elrondTarget);
+        var router = BuildRouter(nav, elrondTarget: elrondTarget);
 
         var handled = router.Handle("mithril://elrond/ArmorAugmentBrewing");
 
@@ -283,11 +282,10 @@ public class DeepLinkRouterTests
     }
 
     [Fact]
-    public void ElrondUri_WithoutRegisteredTarget_IsDropped()
+    public void ElrondUri_HandlerNotRegistered_IsDropped()
     {
         var nav = new RecordingNavigator();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null,
-            legolasImport: null, elrondImport: null);
+        var router = BuildRouter(nav, elrondTarget: null);
 
         router.Handle("mithril://elrond/Cooking").Should().BeFalse();
     }
@@ -301,8 +299,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var elrondTarget = new RecordingElrondTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null,
-            legolasImport: null, elrondImport: elrondTarget);
+        var router = BuildRouter(nav, elrondTarget: elrondTarget);
 
         router.Handle(uri).Should().BeFalse();
         elrondTarget.LastPayload.Should().BeNull();
@@ -313,8 +310,7 @@ public class DeepLinkRouterTests
     {
         var nav = new RecordingNavigator();
         var elrondTarget = new RecordingElrondTarget();
-        var router = new DeepLinkRouter(nav, listImport: null, pippinImport: null,
-            legolasImport: null, elrondImport: elrondTarget);
+        var router = BuildRouter(nav, elrondTarget: elrondTarget);
 
         var tooLong = new string('A', 129);
         router.Handle($"mithril://elrond/{tooLong}").Should().BeFalse();
@@ -325,5 +321,42 @@ public class DeepLinkRouterTests
     {
         public string? LastPayload { get; private set; }
         public void ImportFromLinkPayload(string skillKey) => LastPayload = skillKey;
+    }
+
+    private static DeepLinkRouter BuildRouter(
+        IReferenceNavigator nav,
+        ICraftListImportTarget? listTarget = null,
+        IPippinShareImportTarget? pippinTarget = null,
+        ILegolasShareImportTarget? legolasTarget = null,
+        IElrondSkillImportTarget? elrondTarget = null)
+    {
+        var handlers = new List<IDeepLinkHandler>
+        {
+            new ItemDeepLinkHandler(nav),
+            new RecipeDeepLinkHandler(nav),
+        };
+        if (listTarget is not null)
+            handlers.Add(new Celebrimbor.Services.CraftListDeepLinkHandler(listTarget));
+        if (pippinTarget is not null)
+            handlers.Add(new Pippin.Sharing.PippinDeepLinkHandler(pippinTarget));
+        if (legolasTarget is not null)
+            handlers.Add(new Legolas.Sharing.LegolasDeepLinkHandler(legolasTarget));
+        if (elrondTarget is not null)
+            handlers.Add(new Elrond.Services.ElrondDeepLinkHandler(elrondTarget));
+        return new DeepLinkRouter(handlers);
+    }
+
+    [Fact]
+    public void Constructor_DuplicateAction_Throws()
+    {
+        var nav = new RecordingNavigator();
+        var handlers = new IDeepLinkHandler[]
+        {
+            new ItemDeepLinkHandler(nav),
+            new ItemDeepLinkHandler(nav),  // duplicate
+        };
+        var act = () => new DeepLinkRouter(handlers);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Duplicate IDeepLinkHandler*item*");
     }
 }

--- a/tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs
@@ -2,71 +2,84 @@ using FluentAssertions;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
 using Silmarillion.Navigation;
 using Silmarillion.ViewModels;
 using Xunit;
 
-namespace Silmarillion.Tests.ViewModels;
+namespace Silmarillion.Tests.Navigation;
 
-public sealed class ItemsTabViewModelTests
+public sealed class ItemsKindTargetTests
 {
     [Fact]
-    public void AllItems_PopulatedFromReferenceData_OrderedByName()
+    public void Kind_IsItem()
     {
-        var refData = new StubReferenceData
-        {
-            ItemsByName =
-            {
-                ["Tomato"] = new Item { Id = 1, InternalName = "Tomato", Name = "Tomato", IconId = 1 },
-                ["Apple"] = new Item { Id = 2, InternalName = "Apple", Name = "Apple", IconId = 2 },
-            },
-        };
-
-        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
-
-        vm.AllItems.Should().HaveCount(2);
-        vm.AllItems.Select(i => i.Name).Should().Equal("Apple", "Tomato");
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Item);
     }
 
     [Fact]
-    public void SelectingItem_BuildsDetailViewModel()
+    public void TabIndex_IsZero()
     {
-        var item = new Item { Id = 1, InternalName = "Tomato", Name = "Tomato", IconId = 1 };
-        var refData = new StubReferenceData
-        {
-            ItemsByName = { ["Tomato"] = item },
-        };
-        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
-
-        vm.SelectedItem = item;
-
-        vm.DetailViewModel.Should().NotBeNull();
-        vm.DetailViewModel!.Item.Should().Be(item);
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(0);
     }
 
     [Fact]
-    public void DeselectingItem_ClearsDetailViewModel()
+    public void TrySelectByInternalName_KnownItem_SelectsOnTabVm_ReturnsTrue()
     {
-        var item = new Item { Id = 1, InternalName = "Tomato", Name = "Tomato" };
-        var refData = new StubReferenceData
-        {
-            ItemsByName = { ["Tomato"] = item },
-        };
-        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+        var item = new Item { Id = 5010, InternalName = "Tomato", Name = "Tomato" };
+        var (target, vm, _) = BuildTarget(item);
 
-        vm.SelectedItem = item;
-        vm.SelectedItem = null;
+        var ok = target.TrySelectByInternalName("Tomato");
 
-        vm.DetailViewModel.Should().BeNull();
+        ok.Should().BeTrue();
+        vm.SelectedItem.Should().Be(item);
     }
 
-    private sealed class StubReferenceData : IReferenceDataService
+    [Fact]
+    public void TrySelectByInternalName_UnknownItem_ReturnsFalse_VmUnchanged()
     {
-        public Dictionary<string, Item> ItemsByName { get; } = new(StringComparer.Ordinal);
+        var (target, vm, _) = BuildTarget();
+        vm.SelectedItem.Should().BeNull();  // precondition
 
-        public IReadOnlyList<string> Keys { get; } = [];
-        public IReadOnlyDictionary<long, Item> Items => ItemsByName.Values.ToDictionary(i => i.Id);
-        public IReadOnlyDictionary<string, Item> ItemsByInternalName => ItemsByName;
+        target.TrySelectByInternalName("DoesNotExist").Should().BeFalse();
+        vm.SelectedItem.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (ItemsKindTarget Target, ItemsTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
+        params Item[] items)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var item in items)
+            refData.AddItem(item);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new ItemsTabViewModel(refData, nav);
+        var target = new ItemsKindTarget(vm, refData);
+        return (target, vm, refData);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<long, Item> _items = new();
+        private readonly Dictionary<string, Item> _byName = new(StringComparer.Ordinal);
+
+        public void AddItem(Item item)
+        {
+            _items[item.Id] = item;
+            if (item.InternalName is not null) _byName[item.InternalName] = item;
+        }
+
+        public IReadOnlyList<string> Keys => Array.Empty<string>();
+        public IReadOnlyDictionary<long, Item> Items => _items;
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName => _byName;
         public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
         public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
         public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();

--- a/tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs
@@ -62,7 +62,7 @@ public sealed class ItemsKindTargetTests
             refData.AddItem(item);
         var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
         var vm = new ItemsTabViewModel(refData, nav);
-        var target = new ItemsKindTarget(vm, refData);
+        var target = new ItemsKindTarget(vm);
         return (target, vm, refData);
     }
 

--- a/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
@@ -51,6 +51,30 @@ public sealed class RecipesKindTargetTests
         target.TryOpenInWindow().Should().BeFalse();
     }
 
+    [Fact]
+    public void TrySelectByInternalName_ResolvesFromAllRecipes_NotRefData()
+    {
+        // Simulates a background reference-data refresh that swaps in a NEW
+        // Recipe instance with the same InternalName. The tab VM's AllRecipes
+        // still holds the OLD reference (captured at construction). Resolving
+        // via AllRecipes (not refData) keeps the WPF ListBox selection working
+        // when references diverge.
+        var originalRecipe = new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] };
+        var refData = new FakeReferenceData();
+        refData.AddRecipe(originalRecipe);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new RecipesTabViewModel(refData, nav);
+        var target = new RecipesKindTarget(vm);
+
+        // Simulate a refresh: refData now hands out a DIFFERENT Recipe instance
+        // for the same internal name. AllRecipes still references the original.
+        refData.AddRecipe(new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] });
+
+        target.TrySelectByInternalName("MakeSalsa").Should().BeTrue();
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRecipe.Should().BeSameAs(originalRecipe);
+    }
+
     private static (RecipesKindTarget Target, RecipesTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
         params Recipe[] recipes)
     {
@@ -59,7 +83,7 @@ public sealed class RecipesKindTargetTests
             refData.AddRecipe(recipe);
         var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
         var vm = new RecipesTabViewModel(refData, nav);
-        var target = new RecipesKindTarget(vm, refData);
+        var target = new RecipesKindTarget(vm);
         return (target, vm, refData);
     }
 

--- a/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
@@ -52,13 +52,13 @@ public sealed class RecipesKindTargetTests
     }
 
     [Fact]
-    public void TrySelectByInternalName_ResolvesFromAllRecipes_NotRefData()
+    public void TrySelectByInternalName_AfterRefresh_ResolvesFreshInstance()
     {
-        // Simulates a background reference-data refresh that swaps in a NEW
-        // Recipe instance with the same InternalName. The tab VM's AllRecipes
-        // still holds the OLD reference (captured at construction). Resolving
-        // via AllRecipes (not refData) keeps the WPF ListBox selection working
-        // when references diverge.
+        // Simulates a background reference-data refresh: refData hands out a NEW
+        // Recipe instance with the same InternalName, AND FileUpdated fires for
+        // "recipes". The tab VM rebuilds AllRecipes via UiThread.Run (inline here
+        // since Application.Current is null in tests) and the selection setter
+        // resolves to the fresh instance — not the stale one captured at construction.
         var originalRecipe = new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] };
         var refData = new FakeReferenceData();
         refData.AddRecipe(originalRecipe);
@@ -66,13 +66,36 @@ public sealed class RecipesKindTargetTests
         var vm = new RecipesTabViewModel(refData, nav);
         var target = new RecipesKindTarget(vm);
 
-        // Simulate a refresh: refData now hands out a DIFFERENT Recipe instance
-        // for the same internal name. AllRecipes still references the original.
-        refData.AddRecipe(new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] });
+        // Refresh: swap in a new Recipe instance.
+        var refreshedRecipe = new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] };
+        refData.AddRecipe(refreshedRecipe);
+        refData.RaiseFileUpdated("recipes");
 
         target.TrySelectByInternalName("MakeSalsa").Should().BeTrue();
         vm.SelectedRow.Should().NotBeNull();
-        vm.SelectedRecipe.Should().BeSameAs(originalRecipe);
+        vm.SelectedRecipe.Should().BeSameAs(refreshedRecipe);
+    }
+
+    [Fact]
+    public void FileUpdated_PreservesCurrentSelectionByInternalName()
+    {
+        // VM has a selection. Refresh fires. New instance for the same name.
+        // After refresh, selection is preserved (re-resolved to the new instance)
+        // and detail VM is rebuilt with fresh data.
+        var original = new Recipe { Key = "recipe_1", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] };
+        var refData = new FakeReferenceData();
+        refData.AddRecipe(original);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new RecipesTabViewModel(refData, nav);
+        vm.SelectedRow = vm.AllRecipes.Single();
+        vm.SelectedRecipe.Should().BeSameAs(original);
+
+        var refreshed = new Recipe { Key = "recipe_1", InternalName = "MakeSalsa", Name = "Make Salsa (v2)", Ingredients = [] };
+        refData.AddRecipe(refreshed);
+        refData.RaiseFileUpdated("recipes");
+
+        vm.SelectedRecipe.Should().BeSameAs(refreshed);
+        vm.DetailViewModel.Should().NotBeNull();
     }
 
     private static (RecipesKindTarget Target, RecipesTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
@@ -120,6 +143,7 @@ public sealed class RecipesKindTargetTests
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
         public void BeginBackgroundRefresh() { }
-        public event EventHandler<string>? FileUpdated { add { } remove { } }
+        public event EventHandler<string>? FileUpdated;
+        public void RaiseFileUpdated(string fileKey) => FileUpdated?.Invoke(this, fileKey);
     }
 }

--- a/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class RecipesKindTargetTests
+{
+    [Fact]
+    public void Kind_IsRecipe()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Recipe);
+    }
+
+    [Fact]
+    public void TabIndex_IsOne()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownRecipe_SelectsOnTabVm_ReturnsTrue()
+    {
+        var recipe = new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] };
+        var (target, vm, _) = BuildTarget(recipe);
+
+        var ok = target.TrySelectByInternalName("MakeSalsa");
+
+        ok.Should().BeTrue();
+        vm.SelectedRecipe.Should().Be(recipe);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownRecipe_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        target.TrySelectByInternalName("DoesNotExist").Should().BeFalse();
+        vm.SelectedRecipe.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (RecipesKindTarget Target, RecipesTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
+        params Recipe[] recipes)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var recipe in recipes)
+            refData.AddRecipe(recipe);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new RecipesTabViewModel(refData, nav);
+        var target = new RecipesKindTarget(vm, refData);
+        return (target, vm, refData);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Recipe> _byInternalName = new(StringComparer.Ordinal);
+
+        public void AddRecipe(Recipe recipe)
+        {
+            _recipes[recipe.Key] = recipe;
+            if (recipe.InternalName is not null) _byInternalName[recipe.InternalName] = recipe;
+        }
+
+        public IReadOnlyList<string> Keys => Array.Empty<string>();
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _byInternalName;
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class SilmarillionDeepLinkHandlerTests
+{
+    [Fact]
+    public void TryHandle_ItemKind_OpensItem()
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        var handled = handler.TryHandle("item/CraftedLeatherBoots5", diag: null);
+
+        handled.Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Item("CraftedLeatherBoots5"));
+    }
+
+    [Fact]
+    public void TryHandle_RecipeKind_OpensRecipe()
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        var handled = handler.TryHandle("recipe/MakeTomatoSauce", diag: null);
+
+        handled.Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Recipe("MakeTomatoSauce"));
+    }
+
+    [Theory]
+    [InlineData("npc/Marna")]            // unknown kind segment
+    [InlineData("ability/Hatchet")]
+    [InlineData("")]                     // empty subPath
+    [InlineData("item")]                 // no second segment
+    [InlineData("item/")]                // empty payload after slash
+    [InlineData("item/has space")]       // illegal payload char
+    [InlineData("item/has-hyphen")]      // hyphen rejected by EntityPayloadPattern
+    [InlineData("item/extra/segment")]   // extra path segments forbidden
+    public void TryHandle_Malformed_ReturnsFalse_AndDoesNotDispatch(string subPath)
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        handler.TryHandle(subPath, diag: null).Should().BeFalse();
+        nav.LastOpened.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryHandle_PayloadOverLengthCap_IsRejected()
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        var tooLong = new string('A', 129);
+        handler.TryHandle($"item/{tooLong}", diag: null).Should().BeFalse();
+        nav.LastOpened.Should().BeNull();
+    }
+
+    [Fact]
+    public void Action_IsSilmarillion()
+    {
+        var nav = new RecordingNavigator();
+        new SilmarillionDeepLinkHandler(nav).Action.Should().Be("silmarillion");
+    }
+
+    [Theory]
+    [InlineData("ITEM/CraftedLeatherBoots5")]
+    [InlineData("Item/CraftedLeatherBoots5")]
+    [InlineData("iTeM/CraftedLeatherBoots5")]
+    public void TryHandle_KindIsCaseInsensitive(string subPath)
+    {
+        var nav = new RecordingNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        handler.TryHandle(subPath, diag: null).Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.Item("CraftedLeatherBoots5"));
+    }
+
+    private sealed class RecordingNavigator : IReferenceNavigator
+    {
+        public EntityRef? LastOpened { get; private set; }
+        public EntityRef? Current => LastOpened;
+        public bool CanGoBack => false;
+        public bool CanGoForward => false;
+        public bool CanOpen(EntityRef reference) => true;
+        public void Open(EntityRef reference) => LastOpened = reference;
+        public void Back() { }
+        public void Forward() { }
+        public event EventHandler<NavigatedEventArgs>? Navigated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -10,7 +10,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Initial_CurrentIsNull_AndStacksEmpty()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
 
         nav.Current.Should().BeNull();
         nav.CanGoBack.Should().BeFalse();
@@ -20,7 +20,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Open_SetsCurrent_AndFiresNavigatedWithOpenKind()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         NavigatedEventArgs? captured = null;
         nav.Navigated += (_, e) => captured = e;
 
@@ -36,7 +36,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Open_AfterFirstOpen_PushesPreviousToBackStack()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("Tomato"));
         nav.Open(EntityRef.Recipe("MakeSalsa"));
 
@@ -48,7 +48,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Open_ClearsForwardStack()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         nav.Open(EntityRef.Item("B"));
         nav.Back();
@@ -62,7 +62,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Back_PopsBackStack_PushesForward_FiresNavigatedWithBackKind()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         nav.Open(EntityRef.Item("B"));
         NavigatedEventArgs? captured = null;
@@ -82,7 +82,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Forward_PopsForwardStack_PushesBack_FiresNavigatedWithForwardKind()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         nav.Open(EntityRef.Item("B"));
         nav.Back();
@@ -101,7 +101,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Back_WhenStackEmpty_IsNoOp_AndDoesNotFireNavigated()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         var fired = false;
         nav.Navigated += (_, _) => fired = true;
 
@@ -114,7 +114,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Forward_WhenStackEmpty_IsNoOp_AndDoesNotFireNavigated()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         var fired = false;
         nav.Navigated += (_, _) => fired = true;
@@ -128,35 +128,56 @@ public sealed class SilmarillionReferenceNavigatorTests
     public void OpenSameEntityTwice_StillPushesToBackStack()
     {
         // "Open same item again" is still a history step. User can hit Back to undo.
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         nav.Open(EntityRef.Item("A"));
 
         nav.CanGoBack.Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData(EntityKind.Item, true)]
-    [InlineData(EntityKind.Recipe, true)]
-    [InlineData(EntityKind.Ability, false)]
-    [InlineData(EntityKind.Npc, false)]
-    [InlineData(EntityKind.Quest, false)]
-    [InlineData(EntityKind.Lorebook, false)]
-    [InlineData(EntityKind.Landmark, false)]
-    [InlineData(EntityKind.Area, false)]
-    [InlineData(EntityKind.PlayerTitle, false)]
-    [InlineData(EntityKind.StorageVault, false)]
-    [InlineData(EntityKind.Effect, false)]
-    public void CanOpen_TrueForV1TabbedKinds_FalseOtherwise(EntityKind kind, bool expected)
+    [Fact]
+    public void CanOpen_RegisteredKind_ReturnsTrue()
     {
-        var nav = new SilmarillionReferenceNavigator();
-        nav.CanOpen(new EntityRef(kind, "anything")).Should().Be(expected);
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
+
+        nav.CanOpen(EntityRef.Item("anything")).Should().BeTrue();
+        nav.CanOpen(EntityRef.Recipe("anything")).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(EntityKind.Ability)]
+    [InlineData(EntityKind.Npc)]
+    [InlineData(EntityKind.Quest)]
+    [InlineData(EntityKind.Lorebook)]
+    [InlineData(EntityKind.Landmark)]
+    [InlineData(EntityKind.Area)]
+    [InlineData(EntityKind.PlayerTitle)]
+    [InlineData(EntityKind.StorageVault)]
+    [InlineData(EntityKind.Effect)]
+    public void CanOpen_UnregisteredKind_ReturnsFalse(EntityKind kind)
+    {
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
+
+        nav.CanOpen(new EntityRef(kind, "anything")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_DuplicateKind_Throws()
+    {
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Item),
+        };
+        var act = () => new SilmarillionReferenceNavigator(targets);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Duplicate IReferenceKindTarget*Item*");
     }
 
     [Fact]
     public void Back_PreservesDeepHistory_WhenMultipleEntitiesOnStack()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         nav.Open(EntityRef.Recipe("B"));
         nav.Open(EntityRef.Item("C"));
@@ -174,7 +195,7 @@ public sealed class SilmarillionReferenceNavigatorTests
     [Fact]
     public void Forward_AfterMultipleBacks_RestoresIntermediateState()
     {
-        var nav = new SilmarillionReferenceNavigator();
+        var nav = new SilmarillionReferenceNavigator(NavTargets());
         nav.Open(EntityRef.Item("A"));
         nav.Open(EntityRef.Item("B"));
         nav.Open(EntityRef.Item("C"));
@@ -186,5 +207,20 @@ public sealed class SilmarillionReferenceNavigatorTests
         nav.Current.Should().Be(EntityRef.Item("B"));
         nav.CanGoBack.Should().BeTrue();
         nav.CanGoForward.Should().BeTrue();
+    }
+
+    private static IEnumerable<IReferenceKindTarget> NavTargets() => new IReferenceKindTarget[]
+    {
+        new StubTarget(EntityKind.Item),
+        new StubTarget(EntityKind.Recipe),
+    };
+
+    private sealed class StubTarget : IReferenceKindTarget
+    {
+        public StubTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
     }
 }

--- a/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
@@ -8,6 +8,23 @@ using Xunit;
 
 namespace Silmarillion.Tests.ViewModels;
 
+// Helper to build a navigator with specific kinds registered (needed for IsNavigable assertions).
+file static class NavFactory
+{
+    /// <summary>Creates a navigator with stub targets for the given entity kinds.</summary>
+    public static SilmarillionReferenceNavigator WithKinds(params EntityKind[] kinds) =>
+        new SilmarillionReferenceNavigator(kinds.Select(k => (IReferenceKindTarget)new StubKindTarget(k)));
+
+    private sealed class StubKindTarget : IReferenceKindTarget
+    {
+        public StubKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+}
+
 public sealed class RecipesTabViewModelTests
 {
     [Fact]
@@ -22,7 +39,7 @@ public sealed class RecipesTabViewModelTests
             },
         };
 
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
 
         vm.AllRecipes.Should().HaveCount(2);
         vm.AllRecipes.Select(r => r.Name).Should().Equal("Apple Sauce", "Bake Bread");
@@ -51,7 +68,7 @@ public sealed class RecipesTabViewModelTests
             },
         };
 
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
 
         vm.AllRecipes.Should().ContainSingle()
             .Which.SkillDisplayName.Should().Be("Armor Augment Brewing");
@@ -65,7 +82,7 @@ public sealed class RecipesTabViewModelTests
             RecipesByKey = { ["r1"] = new Recipe { Key = "r1", Name = "A", Skill = "UnknownSkill", SkillLevelReq = 1, Ingredients = [] } },
         };
 
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
 
         vm.AllRecipes.Should().ContainSingle()
             .Which.SkillDisplayName.Should().Be("UnknownSkill");
@@ -87,7 +104,7 @@ public sealed class RecipesTabViewModelTests
         {
             RecipesByKey = { ["r1"] = recipe },
         };
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
 
         vm.SelectedRecipe = recipe;
 
@@ -103,7 +120,7 @@ public sealed class RecipesTabViewModelTests
         {
             RecipesByKey = { ["r1"] = recipe },
         };
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
 
         vm.SelectedRecipe = recipe;
         vm.SelectedRecipe = null;
@@ -131,7 +148,8 @@ public sealed class RecipesTabViewModelTests
             ItemsByCode = { [100] = tomato },
             RecipesByKey = { ["r1"] = recipe },
         };
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        // Use a navigator that has Item kind registered so CanOpen returns true for items.
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item));
 
         vm.SelectedRecipe = recipe;
 
@@ -161,7 +179,7 @@ public sealed class RecipesTabViewModelTests
             ItemsByCode = { [101] = sauce },
             RecipesByKey = { ["r1"] = protoRecipe },
         };
-        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator());
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
 
         vm.SelectedRecipe = protoRecipe;
 

--- a/tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs
@@ -1,0 +1,123 @@
+using CommunityToolkit.Mvvm.Input;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class SilmarillionViewModelTests
+{
+    [Fact]
+    public void OnNavigated_ItemKind_SwitchesTabAndCallsTarget()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var recipesTarget = new RecordingTarget(EntityKind.Recipe, tabIndex: 1);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget, recipesTarget });
+
+        nav.Open(EntityRef.Item("Tomato"));
+
+        vm.SelectedTabIndex.Should().Be(0);
+        itemsTarget.LastSelectedInternalName.Should().Be("Tomato");
+        recipesTarget.LastSelectedInternalName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OnNavigated_RecipeKind_SwitchesTabAndCallsTarget()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var recipesTarget = new RecordingTarget(EntityKind.Recipe, tabIndex: 1);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget, recipesTarget });
+
+        nav.Open(EntityRef.Recipe("MakeSalsa"));
+
+        vm.SelectedTabIndex.Should().Be(1);
+        recipesTarget.LastSelectedInternalName.Should().Be("MakeSalsa");
+    }
+
+    [Fact]
+    public void OnNavigated_UnregisteredKind_DoesNotChangeTab()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
+
+        vm.SelectedTabIndex = 0;
+        nav.Open(new EntityRef(EntityKind.Npc, "NPC_Marna"));
+
+        vm.SelectedTabIndex.Should().Be(0);  // unchanged
+        itemsTarget.LastSelectedInternalName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OpenInWindow_NoCurrent_NoOp()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var (vm, _) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
+
+        // CanExecute should be false; explicit call is a no-op (TryOpenInWindow not invoked).
+        vm.OpenInWindowCommand.CanExecute(null).Should().BeFalse();
+        itemsTarget.OpenInWindowCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void OpenInWindow_CurrentItem_CallsTarget()
+    {
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
+
+        nav.Open(EntityRef.Item("Tomato"));
+        vm.OpenInWindowCommand.Execute(null);
+
+        itemsTarget.OpenInWindowCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Constructor_DuplicateKind_Throws()
+    {
+        var targets = new IReferenceKindTarget[]
+        {
+            new RecordingTarget(EntityKind.Item, tabIndex: 0),
+            new RecordingTarget(EntityKind.Item, tabIndex: 0),
+        };
+        var nav = new SilmarillionReferenceNavigator(new IReferenceKindTarget[]
+        {
+            new RecordingTarget(EntityKind.Recipe, tabIndex: 1),
+        });
+
+        var act = () => new SilmarillionViewModel(items: null!, recipes: null!, nav, targets);
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Duplicate IReferenceKindTarget*Item*");
+    }
+
+    private static (SilmarillionViewModel Vm, SilmarillionReferenceNavigator Nav) BuildVm(
+        IReferenceKindTarget[] targets)
+    {
+        var nav = new SilmarillionReferenceNavigator(targets);
+        // Empty/null tab VMs are fine — the tests only exercise the dispatch path,
+        // not the tab VMs themselves (those are tested separately).
+        // Pass null-forgiving stubs; SilmarillionViewModel never reads .Items / .Recipes here.
+        var vm = new SilmarillionViewModel(items: null!, recipes: null!, nav, targets);
+        return (vm, nav);
+    }
+
+    private sealed class RecordingTarget : IReferenceKindTarget
+    {
+        public RecordingTarget(EntityKind kind, int tabIndex) { Kind = kind; TabIndex = tabIndex; }
+        public EntityKind Kind { get; }
+        public int TabIndex { get; }
+        public string? LastSelectedInternalName { get; private set; }
+        public int OpenInWindowCallCount { get; private set; }
+        public bool TrySelectByInternalName(string internalName)
+        {
+            LastSelectedInternalName = internalName;
+            return true;
+        }
+        public bool TryOpenInWindow()
+        {
+            OpenInWindowCallCount++;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Bundles three #207-followup polish issues with two parallel switch-as-registry refactors. Design spec: [docs/agent-plans/silmarillion-polish-v1.md](docs/agent-plans/silmarillion-polish-v1.md). Implementation plan: [docs/agent-plans/2026-05-13-silmarillion-polish-v1-plan.md](docs/agent-plans/2026-05-13-silmarillion-polish-v1-plan.md).

- **C1** — Refactor `DeepLinkRouter` from a hardcoded switch to a registry of `IDeepLinkHandler` singletons, making module-side deep-link routes purely additive.
- **C2 / #229** — Add `mithril://silmarillion/<kind>/<name>` module-scoped route, symmetric with `mithril://elrond/...`, `mithril://legolas/...`. Legacy `mithril://item/...` and `mithril://recipe/...` keep working.
- **C3 / #231** — Replace card-shaped browse rows with compact two-line rows: row height drops ~80→~36 px, density rises ~17→~40+ rows visible.
- **C4 / #234** — Restructure `ItemDetailView` reading order: cross-link sections (Sources / Produced by / Used in) move to immediately after Description, so sparse items no longer bury their recipe links below an empty effects region.
- **C5 / #239** — Refactor `IReferenceNavigator` to dispatch through an `IReferenceKindTarget` registry: `V1TabbedKinds` set and two `switch` blocks gone. Each future Bucket-B tab (NPCs, Quests, ...) becomes a one-file additive change.
- **C6** — Update the About-settings deep-link example to the preferred module-scoped form. Wiki [Deep-Linking](https://github.com/moumantai-gg/mithril/wiki/Deep-Linking) page created with the full URI scheme reference.

#235 (recipe sources section) is intentionally out of scope — needs new reference-data plumbing and will land as a separate PR.

## Test plan

Automated:
- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — 1,901 tests passing, 0 failures across 16 test projects
- [x] Silmarillion.Tests — 70 passing (26 new for the navigator/kind-target/handler refactors)
- [x] DeepLinkRouterTests — covers legacy + module-scoped routes, registry dispatch, duplicate-action throw
- [x] SilmarillionReferenceNavigatorTests — registry-driven `CanOpen`, duplicate-kind throw

Manual (deferred — needs running build):
- [x] Compact browse rows render at ~36px on both Items and Recipes tabs (~40+ rows visible)
- [x] Sparse item (e.g. lorebook, raw material): cross-links appear immediately after Description; internal-name footer pins to bottom of pane
- [ ] Effect-heavy item: all sections render in new order; no regressions
- [x] `Start-Process "mithril://silmarillion/item/CraftedLeatherBoots5"` opens the right item
- [x] `Start-Process "mithril://silmarillion/recipe/MakeTomatoSauce"` opens the right recipe
- [ ] Legacy `mithril://item/...` and `mithril://recipe/...` still dispatch correctly
- [x] About-settings → Deep linking section shows the new example URI
- [x] Back / Forward navigation after a cross-link click

🤖 Generated with [Claude Code](https://claude.com/claude-code)