### PR TITLE
refactor: centralize deep-link internal-name regex in DeepLinkPayload

### DIFF
--- a/src/Mithril.Shared.Wpf/Modules/DeepLinkPayload.cs
+++ b/src/Mithril.Shared.Wpf/Modules/DeepLinkPayload.cs
@@ -1,0 +1,20 @@
+using System.Text.RegularExpressions;
+
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Shared validation helpers for <c>mithril://</c> deep-link payloads. Centralises
+/// the rules so they stay in sync as more handlers ship.
+/// </summary>
+public static class DeepLinkPayload
+{
+    private static readonly Regex InternalNamePattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="name"/> matches the reference-data
+    /// internal-name grammar: 1–128 ASCII characters from <c>[A-Za-z0-9_]</c>. The cap
+    /// guards downstream lookups against unbounded inputs; the alphabet refuses anything
+    /// that could smuggle URI separators or whitespace.
+    /// </summary>
+    public static bool IsValidInternalName(string name) => InternalNamePattern.IsMatch(name);
+}

--- a/src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs
+++ b/src/Mithril.Shared.Wpf/Modules/ItemDeepLinkHandler.cs
@@ -1,18 +1,14 @@
-using System.Text.RegularExpressions;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 
 namespace Mithril.Shared.Modules;
 
 /// <summary>
-/// Handles <c>mithril://item/&lt;internalName&gt;</c>. Internal names in the reference
-/// data are ASCII identifiers; the regex refuses anything that could confuse downstream
-/// lookups or smuggle separators.
+/// Handles <c>mithril://item/&lt;internalName&gt;</c>. Validation lives in
+/// <see cref="DeepLinkPayload.IsValidInternalName"/>.
 /// </summary>
 public sealed class ItemDeepLinkHandler : IDeepLinkHandler
 {
-    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
-
     private readonly IReferenceNavigator _navigator;
 
     public ItemDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
@@ -21,7 +17,7 @@ public sealed class ItemDeepLinkHandler : IDeepLinkHandler
 
     public bool TryHandle(string subPath, IDiagnosticsSink? diag)
     {
-        if (!PayloadPattern.IsMatch(subPath))
+        if (!DeepLinkPayload.IsValidInternalName(subPath))
         {
             diag?.Info("DeepLink", $"Rejected: item payload '{subPath}' failed validation.");
             return false;

--- a/src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs
+++ b/src/Mithril.Shared.Wpf/Modules/RecipeDeepLinkHandler.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 
@@ -7,8 +6,6 @@ namespace Mithril.Shared.Modules;
 /// <summary>Handles <c>mithril://recipe/&lt;internalName&gt;</c>. See <see cref="ItemDeepLinkHandler"/>.</summary>
 public sealed class RecipeDeepLinkHandler : IDeepLinkHandler
 {
-    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
-
     private readonly IReferenceNavigator _navigator;
 
     public RecipeDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
@@ -17,7 +14,7 @@ public sealed class RecipeDeepLinkHandler : IDeepLinkHandler
 
     public bool TryHandle(string subPath, IDiagnosticsSink? diag)
     {
-        if (!PayloadPattern.IsMatch(subPath))
+        if (!DeepLinkPayload.IsValidInternalName(subPath))
         {
             diag?.Info("DeepLink", $"Rejected: recipe payload '{subPath}' failed validation.");
             return false;

--- a/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
@@ -19,8 +18,6 @@ namespace Silmarillion.Navigation;
 /// </summary>
 public sealed class SilmarillionDeepLinkHandler : IDeepLinkHandler
 {
-    private static readonly Regex PayloadPattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
-
     private readonly IReferenceNavigator _navigator;
 
     public SilmarillionDeepLinkHandler(IReferenceNavigator navigator) => _navigator = navigator;
@@ -47,7 +44,7 @@ public sealed class SilmarillionDeepLinkHandler : IDeepLinkHandler
         var kind = parts[0];
         var name = parts[1];
 
-        if (!PayloadPattern.IsMatch(name))
+        if (!DeepLinkPayload.IsValidInternalName(name))
         {
             diag?.Info("DeepLink", $"Rejected: silmarillion name '{name}' failed validation.");
             return false;

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkPayloadTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkPayloadTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Mithril.Shared.Modules;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Modules;
+
+public class DeepLinkPayloadTests
+{
+    [Theory]
+    [InlineData("CraftedLeatherBoots5")]
+    [InlineData("Bread")]
+    [InlineData("MakeTomatoSauce")]
+    [InlineData("A")]                            // 1-char lower bound
+    [InlineData("snake_case_name")]              // underscore allowed
+    [InlineData("123Numeric")]                   // leading digit allowed
+    public void IsValidInternalName_Accepts_TypicalInternalNames(string name)
+    {
+        DeepLinkPayload.IsValidInternalName(name).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidInternalName_Accepts_128CharBoundary()
+    {
+        DeepLinkPayload.IsValidInternalName(new string('A', 128)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]                             // empty
+    [InlineData("has space")]                    // whitespace
+    [InlineData("has-hyphen")]                   // hyphen not in alphabet
+    [InlineData("has.dot")]                      // dot not in alphabet
+    [InlineData("has/slash")]                    // slash not in alphabet
+    [InlineData("has\ttab")]                     // tab
+    public void IsValidInternalName_Rejects_NamesWithIllegalChars(string name)
+    {
+        DeepLinkPayload.IsValidInternalName(name).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidInternalName_Rejects_OverLengthCap()
+    {
+        DeepLinkPayload.IsValidInternalName(new string('A', 129)).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #250.

The `^[A-Za-z0-9_]{1,128}$` payload regex was compiled three times across `ItemDeepLinkHandler`, `RecipeDeepLinkHandler`, and `SilmarillionDeepLinkHandler`. Extracts it into `Mithril.Shared.Modules.DeepLinkPayload.IsValidInternalName` so the length cap (128) and the alphabet decision (no hyphens, no whitespace) live in one place. Future internal-name handlers (NPCs, Quests, …) reuse the same helper.

Visibility note: the originating issue draft suggested `internal static`, but `SilmarillionDeepLinkHandler` lives in a separate assembly (`Silmarillion.Module`) so the helper must be `public static`. Lives in the same `Mithril.Shared.Modules` namespace as the existing `IDeepLinkHandler` types.

## Diff shape

- New: `src/Mithril.Shared.Wpf/Modules/DeepLinkPayload.cs` (~20 lines)
- New: `tests/Mithril.Shared.Tests/Modules/DeepLinkPayloadTests.cs` (14 cases — typical names, 128-char boundary, illegal chars, empty, 129-char over-cap)
- Modified: three handler files — drop the local `PayloadPattern` const + `System.Text.RegularExpressions` using, replace `PayloadPattern.IsMatch(...)` with `DeepLinkPayload.IsValidInternalName(...)`. Net -16 lines across the handlers.

## Test plan

Automated:
- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — full suite green, 0 failures
- [x] `dotnet test tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj --filter DeepLinkPayloadTests` — 14 / 14
- [x] `dotnet test tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj --filter DeepLinkRouterTests` — 50 / 50 (handler validation exercised transitively)
- [x] `dotnet test tests/Silmarillion.Tests/Silmarillion.Tests.csproj` — 75 / 75

No behavior change is expected; the migration is purely an extraction of duplicated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)