### PR TITLE
feat(silmarillion): recipe sources — Taught by section + sources_recipes plumbing (#235)

### DIFF
--- a/src/Mithril.Shared/Reference/BundledData/sources_recipes.meta.json
+++ b/src/Mithril.Shared/Reference/BundledData/sources_recipes.meta.json
@@ -1,0 +1,5 @@
+{
+  "cdnVersion": "v470",
+  "fetchedAtUtc": "2026-04-23T20:43:00+00:00",
+  "source": 0
+}

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -78,6 +78,17 @@ public interface IReferenceDataService
     IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; }
 
     /// <summary>
+    /// Recipe InternalName → sources describing how the recipe is acquired
+    /// (Training / Skill / Effect / Quest / NpcGift / …). Pulled from
+    /// <c>sources_recipes.json</c>. Mirrors <see cref="ItemSources"/>. Defaults
+    /// to an empty dictionary so existing test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> RecipeSources => EmptyRecipeSourceIndex;
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> EmptyRecipeSourceIndex
+        = new Dictionary<string, IReadOnlyList<RecipeSource>>(StringComparer.Ordinal);
+
+    /// <summary>
     /// Placeholder token (e.g. <c>"MAX_ARMOR"</c>) → <see cref="AttributeEntry"/> with the
     /// human-readable label and formatting hints used to render <see cref="Item.EffectDescs"/>.
     /// Pulled from <c>attributes.json</c>.

--- a/src/Mithril.Shared/Reference/RecipeSource.cs
+++ b/src/Mithril.Shared/Reference/RecipeSource.cs
@@ -1,0 +1,9 @@
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// One entry from <c>sources_recipes.json</c> — identifies how a recipe is acquired
+/// (taught by an NPC, granted by a scroll/effect, awarded by a quest, …). Mirrors
+/// <see cref="ItemSource"/>; the two are parallel records rather than a shared base
+/// so <see cref="IReferenceDataService"/> stays self-documenting.
+/// </summary>
+public sealed record RecipeSource(string Type, string? Npc, string? Context);

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -90,6 +90,11 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, IReadOnlyList<ItemSource>>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _itemSourcesSnapshot;
 
+    // Recipe sources (sources_recipes.json)
+    private IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> _recipeSources =
+        new Dictionary<string, IReadOnlyList<RecipeSource>>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _recipeSourcesSnapshot;
+
     // Attributes (attributes.json) — resolves EffectDescs placeholder tokens.
     private IReadOnlyDictionary<string, AttributeEntry> _attributes =
         new Dictionary<string, AttributeEntry>(StringComparer.Ordinal);
@@ -137,6 +142,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _npcsSnapshot = new ReferenceFileSnapshot("npcs", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _areasSnapshot = new ReferenceFileSnapshot("areas", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _itemSourcesSnapshot = new ReferenceFileSnapshot("sources_items", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _recipeSourcesSnapshot = new ReferenceFileSnapshot("sources_recipes", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _attributesSnapshot = new ReferenceFileSnapshot("attributes", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _powersSnapshot = new ReferenceFileSnapshot("tsysclientinfo", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _profilesSnapshot = new ReferenceFileSnapshot("tsysprofiles", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
@@ -149,15 +155,16 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadXpTables();
         LoadNpcs();
         LoadAreas();
-        LoadQuests();              // Must run before LoadItemSources — ResolveSourceContext reads _quests.
+        LoadQuests();              // Must run before LoadItemSources / LoadRecipeSources — ResolveSourceContext reads _quests.
         LoadItemSources();
+        LoadRecipeSources();
         LoadAttributes();
         LoadPowers();
         LoadProfiles();
         LoadStrings();
     }
 
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all"];
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "sources_recipes", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all"];
 
     public IReadOnlyDictionary<long, Item> Items => _items;
     public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByInternalName;
@@ -171,6 +178,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, NpcEntry> Npcs => _npcs;
     public IReadOnlyDictionary<string, AreaEntry> Areas => _areas;
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources => _itemSources;
+    public IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> RecipeSources => _recipeSources;
     public IReadOnlyDictionary<string, AttributeEntry> Attributes => _attributes;
     public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
@@ -187,6 +195,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "npcs" => _npcsSnapshot,
         "areas" => _areasSnapshot,
         "sources_items" => _itemSourcesSnapshot,
+        "sources_recipes" => _recipeSourcesSnapshot,
         "attributes" => _attributesSnapshot,
         "tsysclientinfo" => _powersSnapshot,
         "tsysprofiles" => _profilesSnapshot,
@@ -206,6 +215,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "npcs" => RefreshFileAsync("npcs", ReferenceDeserializer.ParseNpcs, ParseAndSwapNpcs, ct),
         "areas" => RefreshFileAsync("areas", ReferenceDeserializer.ParseAreas, ParseAndSwapAreas, ct),
         "sources_items" => RefreshFileAsync("sources_items", ReferenceDeserializer.ParseSources, ParseAndSwapItemSources, ct),
+        "sources_recipes" => RefreshFileAsync("sources_recipes", ReferenceDeserializer.ParseSources, ParseAndSwapRecipeSources, ct),
         "attributes" => RefreshFileAsync("attributes", ReferenceDeserializer.ParseAttributes, ParseAndSwapAttributes, ct),
         "tsysclientinfo" => RefreshFileAsync("tsysclientinfo", ReferenceDeserializer.ParseTsysClientInfo, ParseAndSwapPowers, ct),
         "tsysprofiles" => RefreshFileAsync("tsysprofiles", ReferenceDeserializer.ParseTsysProfiles, ParseAndSwapProfiles, ct),
@@ -223,6 +233,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         await RefreshAsync("npcs", ct).ConfigureAwait(false);
         await RefreshAsync("areas", ct).ConfigureAwait(false);
         await RefreshAsync("sources_items", ct).ConfigureAwait(false);
+        await RefreshAsync("sources_recipes", ct).ConfigureAwait(false);
         await RefreshAsync("attributes", ct).ConfigureAwait(false);
         await RefreshAsync("tsysclientinfo", ct).ConfigureAwait(false);
         await RefreshAsync("tsysprofiles", ct).ConfigureAwait(false);
@@ -400,6 +411,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void LoadNpcs() => LoadFile("npcs", ReferenceDeserializer.ParseNpcs, ParseAndSwapNpcs);
     private void LoadAreas() => LoadFile("areas", ReferenceDeserializer.ParseAreas, ParseAndSwapAreas);
     private void LoadItemSources() => LoadFile("sources_items", ReferenceDeserializer.ParseSources, ParseAndSwapItemSources);
+    private void LoadRecipeSources() => LoadFile("sources_recipes", ReferenceDeserializer.ParseSources, ParseAndSwapRecipeSources);
     private void LoadAttributes() => LoadFile("attributes", ReferenceDeserializer.ParseAttributes, ParseAndSwapAttributes);
     private void LoadPowers() => LoadFile("tsysclientinfo", ReferenceDeserializer.ParseTsysClientInfo, ParseAndSwapPowers);
     private void LoadProfiles() => LoadFile("tsysprofiles", ReferenceDeserializer.ParseTsysProfiles, ParseAndSwapProfiles);
@@ -650,6 +662,32 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _itemSources = byInternalName;
         _itemSourcesSnapshot = new ReferenceFileSnapshot("sources_items", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
+    }
+
+    private void ParseAndSwapRecipeSources(IReadOnlyDictionary<string, PocoSourceEnvelope> raw, ReferenceFileMetadata meta)
+    {
+        // sources_recipes.json shape: { "recipe_N": { "entries": [ { type, npc, ... }, ... ] } }
+        // Mirrors ParseAndSwapItemSources; differs only in envelope-key prefix and the
+        // dictionary it resolves against. ResolveSourceContext is shared between both
+        // because Recipe / Quest sources resolve the same way regardless of which
+        // sources_*.json file they were found in.
+        var byInternalName = new Dictionary<string, IReadOnlyList<RecipeSource>>(raw.Count, StringComparer.Ordinal);
+        foreach (var (key, envelope) in raw)
+        {
+            if (!_recipes.TryGetValue(key, out var recipe) || string.IsNullOrEmpty(recipe.InternalName)) continue;
+            if (envelope.entries is null || envelope.entries.Count == 0) continue;
+
+            var projected = new List<RecipeSource>(envelope.entries.Count);
+            foreach (var r in envelope.entries)
+            {
+                if (string.IsNullOrEmpty(r.type)) continue;
+                projected.Add(new RecipeSource(r.type, ExtractNpc(r), ResolveSourceContext(r)));
+            }
+            if (projected.Count > 0)
+                byInternalName[recipe.InternalName!] = projected;
+        }
+        _recipeSources = byInternalName;
+        _recipeSourcesSnapshot = new ReferenceFileSnapshot("sources_recipes", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
     }
 
     private static string? ExtractNpc(SourceModels.SourceEntry s) => s switch

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -20,7 +20,8 @@ public sealed class RecipeDetailViewModel
         IReadOnlyList<EntityChipVm> producedItems,
         IReadOnlyList<string> resultEffectsText,
         ICommand? openEntityCommand = null,
-        string? skillDisplayName = null)
+        string? skillDisplayName = null,
+        IReadOnlyList<ItemSourceChipVm>? sources = null)
     {
         Recipe = recipe;
         Ingredients = ingredients;
@@ -28,6 +29,7 @@ public sealed class RecipeDetailViewModel
         ResultEffectsText = resultEffectsText;
         OpenEntityCommand = openEntityCommand;
         SkillDisplayName = skillDisplayName ?? recipe.Skill;
+        Sources = sources;
     }
 
     /// <summary>
@@ -67,4 +69,12 @@ public sealed class RecipeDetailViewModel
     /// <see cref="EntityRef"/>. Wired by <see cref="RecipesTabViewModel"/> to the navigator.
     /// </summary>
     public ICommand? OpenEntityCommand { get; }
+
+    /// <summary>
+    /// Where this recipe comes from (NPC trainer, scroll/effect, quest reward, …). Pulled
+    /// from <c>IReferenceDataService.RecipeSources</c>. Null when no sources are known —
+    /// drives the empty-section hide in <see cref="Views.RecipeDetailView"/>. Mirrors the
+    /// <c>Sources</c> shape used by <see cref="ItemDetailViewModel"/>.
+    /// </summary>
+    public IReadOnlyList<ItemSourceChipVm>? Sources { get; }
 }

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -78,8 +78,9 @@ public sealed partial class RecipesTabViewModel : ObservableObject
         var ingredients = BuildIngredientChips(recipe);
         var produced = BuildProducedChips(recipe);
         var effects = recipe.ResultEffects ?? Array.Empty<string>();
+        var sources = BuildSourceChips(recipe);
         DetailViewModel = new RecipeDetailViewModel(
-            recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName);
+            recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName, sources);
     }
 
     private void OnFileUpdated(object? sender, string fileKey)
@@ -189,4 +190,34 @@ public sealed partial class RecipesTabViewModel : ObservableObject
         var reference = EntityRef.Item(item.InternalName!);
         return new EntityChipVm(displayName, item.IconId, reference, _navigator.CanOpen(reference));
     }
+
+    /// <summary>
+    /// Project the recipe's <c>sources_recipes.json</c> entries to display chips. NPC chips
+    /// carry an <see cref="EntityRef.Npc"/> reference so they'll become clickable the moment
+    /// an NPCs tab ships (#241); other source kinds (Skill, Effect, Quest, …) render as plain
+    /// text with the <c>Context</c> resolved by <see cref="ReferenceDataService.ResolveSourceContext"/>.
+    /// Returns null when no sources are recorded — drives the empty-section hide in XAML.
+    /// </summary>
+    private IReadOnlyList<ItemSourceChipVm>? BuildSourceChips(Recipe recipe)
+    {
+        if (string.IsNullOrEmpty(recipe.InternalName)) return null;
+        if (!_refData.RecipeSources.TryGetValue(recipe.InternalName!, out var sources) || sources.Count == 0)
+            return null;
+
+        return sources
+            .Select(s =>
+            {
+                var reference = string.IsNullOrEmpty(s.Npc) ? null : EntityRef.Npc(s.Npc!);
+                return new ItemSourceChipVm(
+                    DisplayName: FormatSourceDisplayName(s),
+                    Detail: s.Context,
+                    IconId: null,
+                    EntityReference: reference,
+                    IsNavigable: reference is not null && _navigator.CanOpen(reference));
+            })
+            .ToList();
+    }
+
+    private static string FormatSourceDisplayName(RecipeSource s) =>
+        string.IsNullOrEmpty(s.Npc) ? s.Type : $"{s.Type}: {s.Npc}";
 }

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -54,6 +54,24 @@
                        MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                        Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
+            <!-- Taught by (sources_recipes.json projection) — plain-text in v1; chips will
+                 become navigable once an NPC tab ships (#241). Mirrors the Sources block in
+                 ItemDetailView. Hidden when no sources are recorded. -->
+            <StackPanel Margin="0,0,0,10"
+                        Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
+                <TextBlock Text="Taught by" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                <ItemsControl ItemsSource="{Binding Sources}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
             <!-- Ingredients -->
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding Ingredients.Count, Converter={StaticResource PositiveIntToVis}}">

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -275,6 +275,89 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void Recipe_sources_project_envelope_to_RecipeSource_records_keyed_by_recipe_InternalName()
+    {
+        // sources_recipes.json envelope is keyed by "recipe_N". The parser resolves
+        // those against the recipes dictionary and emits projected RecipeSource records
+        // keyed by recipe.InternalName, mirroring how ItemSources is keyed by InternalName.
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.json"), """
+            {
+              "recipe_42": {
+                "Name": "Bake Bread",
+                "InternalName": "BakeBread",
+                "Skill": "Cooking",
+                "SkillLevelReq": 5
+              },
+              "recipe_43": {
+                "Name": "Make Cheese",
+                "InternalName": "MakeCheese",
+                "Skill": "Cooking",
+                "SkillLevelReq": 12
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_recipes.json"), """
+            {
+              "recipe_42": {
+                "entries": [
+                  { "npc": "NPC_Marna", "type": "Training" },
+                  { "skill": "Cooking", "type": "Skill" }
+                ]
+              },
+              "recipe_43": {
+                "entries": [
+                  { "type": "Effect" }
+                ]
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.RecipeSources.Should().ContainKey("BakeBread");
+        var bakeBread = svc.RecipeSources["BakeBread"];
+        bakeBread.Should().HaveCount(2);
+        bakeBread[0].Type.Should().Be("Training");
+        bakeBread[0].Npc.Should().Be("NPC_Marna");
+        bakeBread[1].Type.Should().Be("Skill");
+        bakeBread[1].Context.Should().Be("Cooking");
+
+        svc.RecipeSources.Should().ContainKey("MakeCheese");
+        svc.RecipeSources["MakeCheese"].Should().ContainSingle()
+            .Which.Type.Should().Be("Effect");
+
+        svc.GetSnapshot("sources_recipes").EntryCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void RealBundled_sources_recipes_LoadsAndKeysByInternalName()
+    {
+        // Smoke test against the real bundled file shipped with the app — confirms the
+        // production payload parses cleanly and the consumer-facing dictionary is keyed
+        // by recipe InternalName (not "recipe_N"). Skipped in environments where the
+        // bundled file isn't reachable (e.g. CI without binplacing).
+        var realBundled = Path.Combine(AppContext.BaseDirectory, "Reference", "BundledData");
+        if (!File.Exists(Path.Combine(realBundled, "sources_recipes.json"))) return;
+        if (!File.Exists(Path.Combine(realBundled, "recipes.json"))) return;
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: realBundled);
+
+        svc.RecipeSources.Count.Should().BeGreaterThan(1000);
+        // recipe_1 is taught by NPC_Braigon per the bundled file — resolve via InternalName.
+        var braigonRecipe = svc.Recipes["recipe_1"];
+        if (!string.IsNullOrEmpty(braigonRecipe.InternalName))
+        {
+            svc.RecipeSources.Should().ContainKey(braigonRecipe.InternalName!);
+            svc.RecipeSources[braigonRecipe.InternalName!]
+                .Should().Contain(s => s.Type == "Training" && s.Npc == "NPC_Braigon");
+        }
+    }
+
+    [Fact]
     public void Quest_requirements_with_polymorphic_T_discriminator_project_correctly()
     {
         // Verifies the polymorphic discriminator dispatch in Mithril.Reference's

--- a/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
@@ -246,6 +246,111 @@ public sealed class RecipesTabViewModelTests
     }
 
     [Fact]
+    public void SourceChips_NpcTrainerSource_NotNavigable_UntilNpcKindShips()
+    {
+        // Recipe taught by a single NPC trainer → one ItemSourceChipVm chip with the NPC
+        // EntityRef attached but IsNavigable=false because the NPCs tab hasn't shipped yet.
+        // The moment a kind target for Npc is registered (#241), the same chip flips to
+        // clickable with no code change here.
+        var recipe = new Recipe
+        {
+            Key = "recipe_1",
+            InternalName = "MakeTomatoSauce",
+            Name = "Make Tomato Sauce",
+            Skill = "Cooking",
+            Ingredients = [],
+        };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["recipe_1"] = recipe },
+            RecipeSourcesByName =
+            {
+                ["MakeTomatoSauce"] = new[]
+                {
+                    new RecipeSource("Training", "NPC_Marna", null),
+                },
+            },
+        };
+        // Navigator has Recipe + Item kinds, but NOT Npc — matches v1 ship state.
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item, EntityKind.Recipe));
+
+        vm.SelectedRecipe = recipe;
+
+        vm.DetailViewModel!.Sources.Should().NotBeNull();
+        vm.DetailViewModel.Sources!.Should().ContainSingle();
+        var chip = vm.DetailViewModel.Sources![0];
+        chip.DisplayName.Should().Be("Training: NPC_Marna");
+        chip.EntityReference.Should().Be(EntityRef.Npc("NPC_Marna"));
+        chip.IsNavigable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SourceChips_MixedKinds_ProjectInOrder_WithCorrectShapePerKind()
+    {
+        // Recipe with three source kinds:
+        //   1. Training (NPC chip) — NPC ref attached, non-navigable in v1.
+        //   2. Skill — no NPC, Context carries the skill name as Detail.
+        //   3. Effect — no NPC, no Context (scroll-derived recipes don't carry it
+        //      yet; reverse-resolve is #252-style follow-up). Plain-text chip.
+        var recipe = new Recipe
+        {
+            Key = "recipe_99",
+            InternalName = "ScrollOfFireball",
+            Name = "Scroll of Fireball",
+            Skill = "Mentalism",
+            Ingredients = [],
+        };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["recipe_99"] = recipe },
+            RecipeSourcesByName =
+            {
+                ["ScrollOfFireball"] = new[]
+                {
+                    new RecipeSource("Training", "NPC_Fritz", null),
+                    new RecipeSource("Skill", null, "Mentalism"),
+                    new RecipeSource("Effect", null, null),
+                },
+            },
+        };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Recipe));
+
+        vm.SelectedRecipe = recipe;
+
+        var sources = vm.DetailViewModel!.Sources!;
+        sources.Should().HaveCount(3);
+
+        sources[0].DisplayName.Should().Be("Training: NPC_Fritz");
+        sources[0].EntityReference.Should().Be(EntityRef.Npc("NPC_Fritz"));
+        sources[0].IsNavigable.Should().BeFalse();
+
+        sources[1].DisplayName.Should().Be("Skill");
+        sources[1].EntityReference.Should().BeNull();
+        sources[1].Detail.Should().Be("Mentalism");
+
+        sources[2].DisplayName.Should().Be("Effect");
+        sources[2].EntityReference.Should().BeNull();
+        sources[2].Detail.Should().BeNull();
+    }
+
+    [Fact]
+    public void SourceChips_RecipeWithNoSources_LeavesSourcesNull_ForXamlHide()
+    {
+        // The XAML uses PositiveIntToVis on Sources.Count to collapse the section;
+        // a null Sources list therefore disappears the "Taught by" header entirely.
+        var recipe = new Recipe { Key = "recipe_42", InternalName = "Untaught", Name = "Untaught", Ingredients = [] };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["recipe_42"] = recipe },
+        };
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRecipe = recipe;
+
+        vm.DetailViewModel!.Sources.Should().BeNull();
+    }
+
+    [Fact]
     public void ProducedItemChips_PreferResultItems_FallBackToProtoResultItems()
     {
         var sauce = new Item { Id = 101, InternalName = "TomatoSauce", Name = "Tomato Sauce", IconId = 2 };
@@ -276,6 +381,7 @@ public sealed class RecipesTabViewModelTests
         public Dictionary<long, Item> ItemsByCode { get; } = new();
         public Dictionary<string, Recipe> RecipesByKey { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, SkillEntry> SkillsByKey { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<RecipeSource>> RecipeSourcesByName { get; } = new(StringComparer.Ordinal);
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items => ItemsByCode;
@@ -289,6 +395,7 @@ public sealed class RecipesTabViewModelTests
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
         public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> RecipeSources => RecipeSourcesByName;
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();


### PR DESCRIPTION
## Summary

- Mirrors the item-sources pipeline for recipes, end-to-end: new `RecipeSource` projection, `IReferenceDataService.RecipeSources` surface, `LoadRecipeSources` / `ParseAndSwapRecipeSources` sequenced after `LoadQuests`, and `sources_recipes` wired into `Keys` / `GetSnapshot` / `RefreshAsync` / `RefreshAllAsync`.
- Adds a "Taught by" section to `RecipeDetailView` (between Description and Ingredients, hidden when empty). NPC chips carry `EntityRef.Npc(...)` so they'll auto-become clickable when #241 ships an NPCs tab — no code change needed here when it lands. Other source kinds (Skill, Effect, Quest, …) render as plain text via the shared `ResolveSourceContext`.
- `sources_recipes.json` was already bundled; this PR adds the missing `sources_recipes.meta.json` for symmetry with `sources_items`.
- Tests: service-layer round-trip + real-bundled smoke in `ReferenceDataServiceTests`; three new chip-projection cases in `RecipesTabViewModelTests` (NPC non-navigability in v1, mixed kinds, null-sources hide path). Full suite (1,936 tests) passes.
- Closes #235. Does not close #241.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (warnings-as-errors on)
- [x] `dotnet test Mithril.slnx` — 1,936 passed, 0 failed
- [x] Shell boots past `=== startup done ===` (DI graph healthy; new `LoadRecipeSources()` init step runs without crashing)
- [x] Manual UI smoke: confirmed "Taught by" section renders with non-navigable chips (NPC tab not yet shipped — #241 will flip them clickable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
