### PR TITLE
feat(query): CONTAINS over collections of IQueryStringValue elements (#260)

### DIFF
--- a/docs/query-system.md
+++ b/docs/query-system.md
@@ -158,6 +158,18 @@ Bare text becomes a case-insensitive substring search across the item type's
 populates `Error`. If your VM wants bare-text behaviour, compose it
 explicitly.
 
+### `CONTAINS` over collections (string and `IQueryStringValue`)
+
+`CONTAINS` on a column whose value is `IEnumerable<string>` matches when any
+element equals the needle (case-insensitive by default — equality, not
+substring). Collection-element types in `Mithril.Reference` can opt in to
+the same behaviour by implementing
+[`IQueryStringValue`](../src/Mithril.Reference/IQueryStringValue.cs) and
+returning a string from `QueryStringValue` — this is how
+`Item.Keywords` (`IReadOnlyList<ItemKeyword>`) supports
+`Keywords CONTAINS 'Crystal'` from the Silmarillion Items tab.
+`STARTSWITH` / `ENDSWITH` remain string-column-only.
+
 ### Schema is reflected, not declared
 
 `QueryableSource<T>()` and `QueryFilter` both reflect over the item type's

--- a/src/Mithril.Reference/IQueryStringValue.cs
+++ b/src/Mithril.Reference/IQueryStringValue.cs
@@ -1,0 +1,27 @@
+namespace Mithril.Reference;
+
+/// <summary>
+/// Opt-in marker for collection-element types that should be matchable by the
+/// Mithril query engine's <c>CONTAINS</c> operator. When a column is an
+/// <c>IEnumerable&lt;T&gt;</c> whose element type implements this interface,
+/// <c>Column CONTAINS 'X'</c> returns true when any element's
+/// <see cref="QueryStringValue"/> equals <c>X</c>. The engine performs a
+/// case-insensitive comparison by default (matching its standard string
+/// semantics); pass <c>caseSensitive: true</c> at compile time to switch to
+/// ordinal equality. Equality semantics (not substring) — mirroring the
+/// existing behaviour for collections of <c>string</c>.
+/// </summary>
+/// <remarks>
+/// Lives in <c>Mithril.Reference</c> (the leaf project) so that model types
+/// declared here — e.g. <see cref="Models.Items.ItemKeyword"/> — can opt in
+/// without forcing a dependency on <c>Mithril.Shared.Wpf</c>. The query
+/// compiler picks the interface up transitively.
+/// </remarks>
+public interface IQueryStringValue
+{
+    /// <summary>
+    /// The element's string projection used by the query engine for
+    /// <c>CONTAINS</c> matching.
+    /// </summary>
+    string QueryStringValue { get; }
+}

--- a/src/Mithril.Reference/Models/Items/ItemKeyword.cs
+++ b/src/Mithril.Reference/Models/Items/ItemKeyword.cs
@@ -10,4 +10,12 @@ namespace Mithril.Reference.Models.Items;
 /// exactly" invariant — the JSON ships these as plain strings. See
 /// <c>docs/mithril-reference-shape-quirks.md</c> for the rationale.
 /// </remarks>
-public sealed record ItemKeyword(string Tag, int Quality);
+public sealed record ItemKeyword(string Tag, int Quality) : IQueryStringValue
+{
+    /// <summary>
+    /// Surfaces <see cref="Tag"/> to the Mithril query engine so
+    /// <c>Keywords CONTAINS 'X'</c> matches when any keyword's tag equals
+    /// <c>X</c> (case-insensitive by default).
+    /// </summary>
+    public string QueryStringValue => Tag;
+}

--- a/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Mithril.Reference;
 
 namespace Mithril.Shared.Wpf.Query;
 
@@ -182,10 +183,12 @@ public static class QueryCompiler
         var needle = node.Text;
         bool negated = node.Negated;
 
-        // CONTAINS over a string-collection column means "any element equals the
-        // needle". Extends naturally to lists like PowerEntry.Slots without forcing
-        // callers to expose a flattened string. STARTSWITH / ENDSWITH on a list have
-        // no obvious semantic, so they remain string-only.
+        // CONTAINS over a string-like collection column means "any element equals
+        // the needle". Extends naturally to lists like PowerEntry.Slots (string
+        // elements) and Item.Keywords (ItemKeyword elements opting in via
+        // IQueryStringValue) without forcing callers to expose a flattened string.
+        // STARTSWITH / ENDSWITH on a list have no obvious semantic, so they remain
+        // string-only.
         if (node.Kind == StringMatchKind.Contains && IsStringCollection(underlying))
         {
             var elementCmp = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
@@ -199,6 +202,11 @@ public static class QueryCompiler
                 foreach (var element in seq)
                 {
                     if (element is string s && elementCmp.Equals(s, needle))
+                    {
+                        hit = true;
+                        break;
+                    }
+                    if (element is IQueryStringValue q && elementCmp.Equals(q.QueryStringValue, needle))
                     {
                         hit = true;
                         break;
@@ -231,16 +239,23 @@ public static class QueryCompiler
         };
     }
 
+    // "String-like" here means the element type is either string itself or opts
+    // in to query-CONTAINS matching via IQueryStringValue (so e.g. ItemKeyword
+    // can be matched by tag without flattening to string at the model layer).
     private static bool IsStringCollection(Type t)
     {
         if (t == typeof(string)) return false;
         foreach (var iface in t.GetInterfaces())
         {
             if (iface.IsGenericType
-                && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                && iface.GetGenericArguments()[0] == typeof(string))
+                && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
-                return true;
+                var element = iface.GetGenericArguments()[0];
+                if (element == typeof(string)
+                    || typeof(IQueryStringValue).IsAssignableFrom(element))
+                {
+                    return true;
+                }
             }
         }
         return false;

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryCompilerTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryCompilerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using Mithril.Reference;
 using Mithril.Shared.Wpf.Query;
 using Xunit;
 
@@ -283,6 +284,96 @@ public class QueryCompilerTests
     {
         Record.Exception(() => Filter("samples CONTAINS 'x'"))
             .Should().BeOfType<QueryException>();
+    }
+
+    // ─────────────── CONTAINS over IQueryStringValue collections ───────────────
+    //
+    // Mirrors the existing string-collection behaviour: equality (not substring),
+    // case-insensitive by default. Elements opt in to query matching by
+    // implementing IQueryStringValue.
+
+    private sealed record TestTag(string Name) : IQueryStringValue
+    {
+        public string QueryStringValue => Name;
+    }
+
+    private sealed record TaggedRow(string Name, IReadOnlyList<TestTag>? Tags);
+
+    private static readonly TaggedRow[] TaggedDataset =
+    {
+        new("Sword",   new[] { new TestTag("Crystal"), new TestTag("Sharp") }),
+        new("Hammer",  new[] { new TestTag("Blunt") }),
+        new("Wand",    Array.Empty<TestTag>()),
+        new("Mystery", null),
+    };
+
+    private static readonly IReadOnlyDictionary<string, ColumnBinding> TaggedColumns = new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["name"] = new("name", typeof(string),                    r => ((TaggedRow)r).Name),
+        ["tags"] = new("tags", typeof(IReadOnlyList<TestTag>),    r => ((TaggedRow)r).Tags),
+    };
+
+    private static TaggedRow[] FilterTagged(string query, bool caseSensitive = false)
+    {
+        var predicate = QueryCompiler.Compile(query, TaggedColumns, caseSensitive);
+        if (predicate is null)
+        {
+            return TaggedDataset;
+        }
+        return TaggedDataset.Where(r => predicate(r)).ToArray();
+    }
+
+    [Fact]
+    public void Contains_matches_IQueryStringValue_element()
+    {
+        FilterTagged("tags CONTAINS 'Crystal'").Select(r => r.Name)
+            .Should().BeEquivalentTo(new[] { "Sword" });
+    }
+
+    [Fact]
+    public void Contains_returns_empty_when_no_element_matches()
+    {
+        FilterTagged("tags CONTAINS 'Missing'").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Contains_is_case_insensitive_by_default_for_IQueryStringValue()
+    {
+        FilterTagged("tags CONTAINS 'crystal'").Select(r => r.Name)
+            .Should().BeEquivalentTo(new[] { "Sword" });
+    }
+
+    [Fact]
+    public void Contains_respects_case_sensitive_flag_for_IQueryStringValue()
+    {
+        FilterTagged("tags CONTAINS 'crystal'", caseSensitive: true).Should().BeEmpty();
+        FilterTagged("tags CONTAINS 'Crystal'", caseSensitive: true).Select(r => r.Name)
+            .Should().BeEquivalentTo(new[] { "Sword" });
+    }
+
+    [Fact]
+    public void Not_Contains_negates_over_IQueryStringValue_collection()
+    {
+        // Negation includes rows whose collection is empty AND rows where the
+        // collection is null — mirroring the existing string-collection behaviour
+        // (null collection returns the negated flag from the predicate).
+        FilterTagged("tags NOT CONTAINS 'Crystal'").Select(r => r.Name)
+            .Should().BeEquivalentTo(new[] { "Hammer", "Wand", "Mystery" });
+    }
+
+    [Fact]
+    public void Contains_on_null_collection_does_not_match()
+    {
+        // "Mystery" has Tags = null; CONTAINS must not throw, must not match.
+        FilterTagged("tags CONTAINS 'anything'").Should().NotContain(r => r.Name == "Mystery");
+    }
+
+    [Fact]
+    public void Contains_uses_equality_not_substring_for_IQueryStringValue()
+    {
+        // "Crys" is a substring of "Crystal", but CONTAINS over a collection
+        // means element-wise equality. No row's tag literally equals "Crys".
+        FilterTagged("tags CONTAINS 'Crys'").Should().BeEmpty();
     }
 }
 


### PR DESCRIPTION
@
## Summary

- Resolves #260. `Keywords CONTAINS Crystal` (and similar) now works against `Item.Keywords` from the Silmarillion items tab.
- Introduces a small opt-in marker interface `IQueryStringValue` in `Mithril.Reference`. The query compilers existing string-collection `CONTAINS` path generalises so an element type can be `string` *or* implement `IQueryStringValue` (returning the string projection used for equality matching).
- `ItemKeyword` opts in by returning its `Tag`. Same path will unblock `AbilityConditionalKeyword.Keyword`, `AbilityAmmoKeyword.ItemKeyword`, etc. when those tabs ship.
- Semantics preserved: equality (not substring), case-insensitive by default, `STARTSWITH`/`ENDSWITH` over collections still unsupported.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (warnings-as-errors enforced; 0 warnings / 0 errors).
- [x] `dotnet test tests/Mithril.Shared.Tests` — 758/758 pass (+7 new tests for the opt-in path: positive match, negative match, case-insensitive default, `caseSensitive: true` flag, `NOT CONTAINS` negation, null-collection no-throw / no-match, equality-not-substring).
- [x] `dotnet test tests/Silmarillion.Tests` — 81/81 pass.
- [ ] Manual smoke: open Silmarillion → Items tab, type `Keywords CONTAINS Crystal`, verify list filters to crystal-keyword items.

## Notes

- Interface lives in `Mithril.Reference` (leaf project) so model types opt in without forcing a WPF dependency. The query compiler in `Mithril.Shared.Wpf` picks it up transitively.
- Commit split keeps the engine extension (`feat(query): … — #260`) reviewable in isolation from the model-side opt-in and the test/doc additions.
- Docs: brief note added in `docs/query-system.md` under "Behaviour details you need to know".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@