### PR TITLE
feat(silmarillion): wire query-box Schema for autocomplete + highlighting (#262)

### DIFF
--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -4,6 +4,7 @@ using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
 
 namespace Silmarillion.ViewModels;
 
@@ -23,6 +24,15 @@ namespace Silmarillion.ViewModels;
 /// </summary>
 public sealed partial class ItemsTabViewModel : ObservableObject
 {
+    /// <summary>
+    /// Reflected schema for <see cref="Item"/> exposed to <c>MithrilQueryBox.Schema</c> so the
+    /// query box can offer completion and highlight known column names. <c>QueryFilter</c> on
+    /// the bound ListBox reflects the same surface from the item type at attach time, so the
+    /// suggestions stay in sync with what actually filters.
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(Item)));
+
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
 
 namespace Silmarillion.ViewModels;
 
@@ -19,6 +20,15 @@ namespace Silmarillion.ViewModels;
 /// </summary>
 public sealed partial class RecipesTabViewModel : ObservableObject
 {
+    /// <summary>
+    /// Reflected schema for <see cref="RecipeListRow"/> exposed to <c>MithrilQueryBox.Schema</c>
+    /// so the query box can offer completion and highlight known column names. <c>QueryFilter</c>
+    /// on the bound ListBox reflects the same surface from the item type at attach time, so the
+    /// suggestions stay in sync with what actually filters.
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(RecipeListRow)));
+
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;

--- a/src/Silmarillion.Module/Views/ItemsTabView.xaml
+++ b/src/Silmarillion.Module/Views/ItemsTabView.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Silmarillion.Views.ItemsTabView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
@@ -31,7 +32,8 @@
         <!-- Query box spans both columns -->
         <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
             <StackPanel>
-                <wpf:MithrilQueryBox QueryText="{Binding QueryText, Mode=TwoWay}"
+                <wpf:MithrilQueryBox Schema="{x:Static vm:ItemsTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
                                      Watermark="bare text, or e.g. Name = 'Tomato'"/>
                 <TextBlock Text="{Binding QueryError}"
                            Foreground="#FFD96A6A" FontStyle="Italic"

--- a/src/Silmarillion.Module/Views/RecipesTabView.xaml
+++ b/src/Silmarillion.Module/Views/RecipesTabView.xaml
@@ -32,8 +32,9 @@
 
         <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
             <StackPanel>
-                <wpf:MithrilQueryBox QueryText="{Binding QueryText, Mode=TwoWay}"
-                                     Watermark="bare text, or e.g. Skill = 'Cooking' AND SkillLevelReq &gt;= 30"/>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:RecipesTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. SkillDisplayName = 'Cooking' AND SkillLevelReq &gt;= 30"/>
                 <TextBlock Text="{Binding QueryError}"
                            Foreground="#FFD96A6A" FontStyle="Italic"
                            FontSize="{DynamicResource AppFontSizeHint}"


### PR DESCRIPTION
Closes #262.

## Summary

- Both Silmarillion tabs drove a `MithrilQueryBox` against a `QueryFilter`-attached `ListBox` but didn't bind the query box's `Schema` (or `Grid`). `MithrilQueryBox.RefreshCompletion` short-circuits on `!HasSchemaSource`, so the completion popup never opened, and column-name highlighting fell back to unknown-column red.
- Expose `public static IReadOnlyList<ColumnSchema> SchemaSnapshot` on `ItemsTabViewModel` (reflected from `typeof(Item)`) and on `RecipesTabViewModel` (from `typeof(RecipeListRow)`) — same `ColumnBindingHelper.BuildFromProperties` + `ToSchema` pattern as `AugmentPoolViewModel.SchemaSnapshot`. The reflected surface matches what `QueryFilter` builds at attach time, so suggestions stay in sync with what actually filters.
- Bind it via `Schema=\"{x:Static vm:…ViewModel.SchemaSnapshot}\"` in both views.
- Drive-by: fix the misleading Recipes watermark, which referenced `Skill =` but `RecipeListRow` exposes `SkillDisplayName` — the literal example would have produced an Unknown-column error.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings.
- [x] `dotnet test Mithril.slnx` — all suites green (Silmarillion: 87/87).
- [x] Launched the shell; boot.log advanced through `creating App` → `shell shown` → `=== startup done ===`. No static-init regression.
- [x] Confirmed in the running app: typing in either Silmarillion query box opens the completion popup with reflected column names, and known column names highlight in column-gold.

---

*Drafted by Claude (Opus 4.7), filed by @arthur-conde via Claude Code.*