### PR TITLE
feat(silmarillion): keyword chip display names via singleton-slot Descs + strings_all — #266

### DIFF
--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -59,8 +59,16 @@ public sealed class CamelCaseSplitConverter : IValueConverter
 {
     private static readonly Regex SplitPattern = new("(?<=[a-z0-9])(?=[A-Z])", RegexOptions.Compiled);
 
+    /// <summary>
+    /// Splits a PascalCase / camelCase token into space-separated words.
+    /// Exposed for non-XAML callers (VMs, services) that want the same heuristic
+    /// without going through the converter pipeline.
+    /// </summary>
+    public static string Split(string value) =>
+        string.IsNullOrEmpty(value) ? value : SplitPattern.Replace(value, " ");
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is string s && !string.IsNullOrEmpty(s) ? SplitPattern.Replace(s, " ") : (value ?? "");
+        => value is string s ? Split(s) : (value ?? "");
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
 }

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -59,6 +59,22 @@ public interface IReferenceDataService
     /// </summary>
     IReadOnlyCollection<string> KeywordsUsedInRecipeSlots => Array.Empty<string>();
 
+    /// <summary>
+    /// Friendly display names for keyword tags, sourced from singleton-slot Descs in recipes
+    /// (looked up via <c>strings_all["recipe_&lt;id&gt;_Ingredients_&lt;idx&gt;_Desc"]</c>, falling
+    /// back to <see cref="RecipeKeywordIngredient.Desc"/> from recipes.json). Only singleton slots
+    /// — those whose <see cref="RecipeKeywordIngredient.ItemKeys"/> has exactly one entry — are
+    /// considered, because composite-tuple Descs describe the AND-matched composite, not any one
+    /// keyword. Keywords whose only friendly Desc is identical to the raw tag are omitted (callers
+    /// should treat "missing" as "use the raw tag, optionally split by camel-case"). First match
+    /// wins (recipe-id iteration order is stable). Built whenever recipes.json or strings_all.json
+    /// reloads. Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, string> KeywordDisplayNames => EmptyStringMap;
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyStringMap
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<Recipe>> EmptyRecipeIndex
         = new Dictionary<string, IReadOnlyList<Recipe>>(StringComparer.Ordinal);
 

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -68,6 +68,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private IReadOnlyDictionary<string, IReadOnlyList<Recipe>> _recipesByIngredientItem =
         new Dictionary<string, IReadOnlyList<Recipe>>(StringComparer.Ordinal);
     private IReadOnlyCollection<string> _keywordsUsedInRecipeSlots = Array.Empty<string>();
+    private IReadOnlyDictionary<string, string> _keywordDisplayNames = new Dictionary<string, string>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _recipesSnapshot;
 
     // Skills
@@ -175,6 +176,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesByProducedItem => _recipesByProducedItem;
     public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesByIngredientItem => _recipesByIngredientItem;
     public IReadOnlyCollection<string> KeywordsUsedInRecipeSlots => _keywordsUsedInRecipeSlots;
+    public IReadOnlyDictionary<string, string> KeywordDisplayNames => _keywordDisplayNames;
     public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
     public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xpTables;
     public IReadOnlyDictionary<string, NpcEntry> Npcs => _npcs;
@@ -465,19 +467,23 @@ public sealed class ReferenceDataService : IReferenceDataService
 
     /// <summary>
     /// Builds <see cref="_recipesByProducedItem"/>, <see cref="_recipesByIngredientItem"/>,
-    /// and <see cref="_keywordsUsedInRecipeSlots"/> from the current <see cref="_recipes"/> +
-    /// <see cref="_items"/>. Items lacking InternalName or item codes that don't resolve to a
-    /// known item are silently skipped (they can't be cross-linked to a browsable entity anyway).
+    /// <see cref="_keywordsUsedInRecipeSlots"/>, and <see cref="_keywordDisplayNames"/>
+    /// from the current <see cref="_recipes"/> + <see cref="_items"/>. Items lacking
+    /// InternalName or item codes that don't resolve to a known item are silently skipped
+    /// (they can't be cross-linked to a browsable entity anyway).
     /// <see cref="_keywordsUsedInRecipeSlots"/> accumulates the union of every
     /// <see cref="Mithril.Reference.Models.Recipes.RecipeKeywordIngredient.ItemKeys"/> entry
-    /// across all recipes. Called from both ParseAndSwapItems and ParseAndSwapRecipes so a
-    /// refresh of either file rebuilds the indices.
+    /// across all recipes. <see cref="_keywordDisplayNames"/> records friendly per-keyword
+    /// display strings sourced from singleton-slot Descs (strings_all-resolved with the raw
+    /// Desc field as fallback). Called from both ParseAndSwapItems and ParseAndSwapRecipes so
+    /// a refresh of either file rebuilds the indices.
     /// </summary>
     private void BuildRecipeCrossLinkIndices()
     {
         var produced = new Dictionary<string, List<Recipe>>(StringComparer.Ordinal);
         var ingredient = new Dictionary<string, List<Recipe>>(StringComparer.Ordinal);
         var keywordSet = new HashSet<string>(StringComparer.Ordinal);
+        var displayNames = new Dictionary<string, string>(StringComparer.Ordinal);
 
         foreach (var recipe in _recipes.Values)
         {
@@ -499,8 +505,9 @@ public sealed class ReferenceDataService : IReferenceDataService
             // recipe.Ingredients is annotated non-nullable but JSON deserialization with a missing
             // field yields null at runtime — guard rather than crash.
             var ingredients = recipe.Ingredients ?? (IReadOnlyList<Mithril.Reference.Models.Recipes.RecipeIngredient>)Array.Empty<Mithril.Reference.Models.Recipes.RecipeIngredient>();
-            foreach (var ing in ingredients)
+            for (var slotIndex = 0; slotIndex < ingredients.Count; slotIndex++)
             {
+                var ing = ingredients[slotIndex];
                 switch (ing)
                 {
                     case Mithril.Reference.Models.Recipes.RecipeItemIngredient itemIng:
@@ -511,6 +518,19 @@ public sealed class ReferenceDataService : IReferenceDataService
                     case Mithril.Reference.Models.Recipes.RecipeKeywordIngredient kwIng:
                         foreach (var key in kwIng.ItemKeys)
                             keywordSet.Add(key);
+                        // Singleton slots are the only unambiguous source for a per-keyword display
+                        // name. Composite tuples like ["EquipmentSlot:MainHand","MinTSysPrereq:0"]
+                        // carry Descs that describe the AND-matched composite, not any one tag.
+                        if (kwIng.ItemKeys.Count == 1)
+                        {
+                            var tag = kwIng.ItemKeys[0];
+                            if (!displayNames.ContainsKey(tag))
+                            {
+                                var resolved = ResolveSlotDesc(recipe.Key, slotIndex, kwIng.Desc);
+                                if (!string.IsNullOrEmpty(resolved) && !string.Equals(resolved, tag, StringComparison.Ordinal))
+                                    displayNames[tag] = resolved;
+                            }
+                        }
                         break;
                 }
             }
@@ -519,6 +539,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _recipesByProducedItem = produced.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<Recipe>)kv.Value, StringComparer.Ordinal);
         _recipesByIngredientItem = ingredient.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<Recipe>)kv.Value, StringComparer.Ordinal);
         _keywordsUsedInRecipeSlots = keywordSet;
+        _keywordDisplayNames = displayNames;
 
         static void AddIngredientRecipe(Dictionary<string, List<Recipe>> map, string internalName, Recipe recipe)
         {
@@ -529,6 +550,14 @@ public sealed class ReferenceDataService : IReferenceDataService
             }
             if (!list.Contains(recipe))
                 list.Add(recipe);
+        }
+
+        string? ResolveSlotDesc(string recipeKey, int slotIndex, string? fallback)
+        {
+            var stringsKey = $"{recipeKey}_Ingredients_{slotIndex}_Desc";
+            return _strings.TryGetValue(stringsKey, out var s) && !string.IsNullOrEmpty(s)
+                ? s
+                : fallback;
         }
     }
 
@@ -639,6 +668,10 @@ public sealed class ReferenceDataService : IReferenceDataService
         // dictionary conventions and freeze it as IReadOnlyDictionary.
         _strings = new Dictionary<string, string>(raw, StringComparer.Ordinal);
         _stringsSnapshot = new ReferenceFileSnapshot("strings_all", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, _strings.Count);
+        // Rebuild cross-link indices: _keywordDisplayNames consults _strings, so a refresh of
+        // strings_all changes the answer. The other two indices are unaffected but rebuilding
+        // them is cheap (single recipe walk).
+        BuildRecipeCrossLinkIndices();
     }
 
     /// <summary>Parses <c>"Despised:5000:Armor,Weapon,CorpseTrophy"</c> strings.</summary>

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -69,6 +69,32 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, IReadOnlyList<Recipe>>(StringComparer.Ordinal);
     private IReadOnlyCollection<string> _keywordsUsedInRecipeSlots = Array.Empty<string>();
     private IReadOnlyDictionary<string, string> _keywordDisplayNames = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Hardcoded overrides for the slot-walk that builds <see cref="_keywordDisplayNames"/>.
+    /// Each entry forces the display name for a keyword tag regardless of what singleton-slot
+    /// Descs say. Two semantics:
+    /// <list type="bullet">
+    ///   <item>Non-null value: use the value as the display name.</item>
+    ///   <item><c>null</c> value: suppress the slot-walk entirely for that keyword, so the
+    ///   consumer's fallback (typically CamelCase splitting) takes over.</item>
+    /// </list>
+    /// Seeded with keywords whose singleton-slot Descs encode slot ROLE rather than describing
+    /// the keyword itself — e.g. <c>Crystal</c> slots are labelled "Primary Crystal" or
+    /// "Auxiliary Crystal" by the recipe author, neither of which is a faithful per-keyword
+    /// label. Grow as we discover more cases (small enough to stay hardcoded for now).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string?> KeywordDisplayOverrides
+        = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            // Crystal slots are labelled by their slot role (Primary/Auxiliary) in singleton
+            // Descs, not by what a Crystal is. Force fallback.
+            ["Crystal"] = null,
+            ["MassiveCrystal"] = null,
+            // The sole non-tag singleton Desc for Equipment is "Item to Copy Appearance From"
+            // (recipe_30105) — recipe-specific, misleading as a generic chip label.
+            ["Equipment"] = null,
+        };
     private ReferenceFileSnapshot _recipesSnapshot;
 
     // Skills
@@ -474,16 +500,21 @@ public sealed class ReferenceDataService : IReferenceDataService
     /// <see cref="_keywordsUsedInRecipeSlots"/> accumulates the union of every
     /// <see cref="Mithril.Reference.Models.Recipes.RecipeKeywordIngredient.ItemKeys"/> entry
     /// across all recipes. <see cref="_keywordDisplayNames"/> records friendly per-keyword
-    /// display strings sourced from singleton-slot Descs (strings_all-resolved with the raw
-    /// Desc field as fallback). Called from both ParseAndSwapItems and ParseAndSwapRecipes so
-    /// a refresh of either file rebuilds the indices.
+    /// display strings — checked against <see cref="KeywordDisplayOverrides"/> first, then
+    /// resolved by picking the most-common Desc across all singleton slots that reference
+    /// the keyword (with <c>strings_all</c> consulted before <see cref="RecipeKeywordIngredient.Desc"/>).
+    /// Called from both ParseAndSwapItems and ParseAndSwapRecipes so a refresh of either file
+    /// rebuilds the indices.
     /// </summary>
     private void BuildRecipeCrossLinkIndices()
     {
         var produced = new Dictionary<string, List<Recipe>>(StringComparer.Ordinal);
         var ingredient = new Dictionary<string, List<Recipe>>(StringComparer.Ordinal);
         var keywordSet = new HashSet<string>(StringComparer.Ordinal);
-        var displayNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        // tag → Desc → occurrence count. Used after the walk to pick the most-common Desc
+        // for each keyword. Most-common-wins handles cases where one Desc dominates across
+        // recipes; ties broken by first-encountered (dictionary insertion order is stable).
+        var descCounts = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
 
         foreach (var recipe in _recipes.Values)
         {
@@ -518,22 +549,59 @@ public sealed class ReferenceDataService : IReferenceDataService
                     case Mithril.Reference.Models.Recipes.RecipeKeywordIngredient kwIng:
                         foreach (var key in kwIng.ItemKeys)
                             keywordSet.Add(key);
-                        // Singleton slots are the only unambiguous source for a per-keyword display
-                        // name. Composite tuples like ["EquipmentSlot:MainHand","MinTSysPrereq:0"]
-                        // carry Descs that describe the AND-matched composite, not any one tag.
+                        // Only singleton slots feed display-name resolution. Composite tuples
+                        // (e.g. ["EquipmentSlot:MainHand","MinTSysPrereq:0"]) carry Descs that
+                        // describe the AND-matched composite, not any one tag.
                         if (kwIng.ItemKeys.Count == 1)
                         {
                             var tag = kwIng.ItemKeys[0];
-                            if (!displayNames.ContainsKey(tag))
+                            var resolved = ResolveSlotDesc(recipe.Key, slotIndex, kwIng.Desc);
+                            if (!string.IsNullOrEmpty(resolved) && !string.Equals(resolved, tag, StringComparison.Ordinal))
                             {
-                                var resolved = ResolveSlotDesc(recipe.Key, slotIndex, kwIng.Desc);
-                                if (!string.IsNullOrEmpty(resolved) && !string.Equals(resolved, tag, StringComparison.Ordinal))
-                                    displayNames[tag] = resolved;
+                                if (!descCounts.TryGetValue(tag, out var perDesc))
+                                {
+                                    perDesc = new Dictionary<string, int>(StringComparer.Ordinal);
+                                    descCounts[tag] = perDesc;
+                                }
+                                perDesc[resolved] = perDesc.TryGetValue(resolved, out var c) ? c + 1 : 1;
                             }
                         }
                         break;
                 }
             }
+        }
+
+        // Resolve final display names: overrides win first, then most-common-Desc from the walk.
+        var displayNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (tag, perDesc) in descCounts)
+        {
+            if (KeywordDisplayOverrides.TryGetValue(tag, out var overrideValue))
+            {
+                if (!string.IsNullOrEmpty(overrideValue))
+                    displayNames[tag] = overrideValue;
+                // null override → suppress; let the consumer's fallback take over
+                continue;
+            }
+            // Pick the Desc with the highest occurrence count. Dictionary iteration order is
+            // insertion order, so ties resolve to the first-encountered Desc deterministically.
+            string? best = null;
+            var bestCount = 0;
+            foreach (var (desc, count) in perDesc)
+            {
+                if (count > bestCount)
+                {
+                    best = desc;
+                    bestCount = count;
+                }
+            }
+            if (best is not null)
+                displayNames[tag] = best;
+        }
+        // Apply non-null overrides for tags that didn't appear in any singleton slot at all.
+        foreach (var (tag, overrideValue) in KeywordDisplayOverrides)
+        {
+            if (!string.IsNullOrEmpty(overrideValue) && !displayNames.ContainsKey(tag))
+                displayNames[tag] = overrideValue;
         }
 
         _recipesByProducedItem = produced.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<Recipe>)kv.Value, StringComparer.Ordinal);

--- a/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/ItemsKindTarget.cs
@@ -44,6 +44,11 @@ public sealed class ItemsKindTarget : IReferenceKindTarget
             return false;
         }
         _diag?.Info("Silmarillion.Nav", $"Items.TrySelect '{internalName}' → found, selecting.");
+        // Clear any residual filter so the target item isn't filtered out of the visible
+        // ListBox — without this, a deep-link arriving while the user (or a previous
+        // navigation) had a query in the box would set SelectedItem to a row that's
+        // hidden by the filter, and the selection wouldn't be visible.
+        _vm.QueryText = "";
         _vm.SelectedItem = item;
         return true;
     }

--- a/src/Silmarillion.Module/Navigation/RecipeIngredientKeywordKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/RecipeIngredientKeywordKindTarget.cs
@@ -32,6 +32,10 @@ public sealed class RecipeIngredientKeywordKindTarget : IReferenceKindTarget
         // doesn't break the query parser.
         var query = $"IngredientKeywords CONTAINS \"{internalName}\"";
         _diag?.Info("Silmarillion.Nav", $"RecipeIngredientKeyword.TrySelect '{internalName}' → setting QueryText.");
+        // Clear any prior row selection: this navigation expresses a *filter*, not a
+        // specific recipe pick. A residual SelectedRow from earlier in-tab navigation
+        // would otherwise linger as a stale selection on top of the new filtered list.
+        _vm.SelectedRow = null;
         _vm.QueryText = query;
         return true;
     }

--- a/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/RecipesKindTarget.cs
@@ -36,6 +36,11 @@ public sealed class RecipesKindTarget : IReferenceKindTarget
             return false;
         }
         _diag?.Info("Silmarillion.Nav", $"Recipes.TrySelect '{internalName}' → found, selecting.");
+        // Clear any residual filter so the target row isn't filtered out of the visible
+        // ListBox. See ItemsKindTarget for the symptom — particularly relevant now that
+        // the item-detail "Used as" keyword chip leaves an IngredientKeywords filter in
+        // the box; a subsequent recipe-link navigation needs to land cleanly.
+        _vm.QueryText = "";
         _vm.SelectedRow = row;
         return true;
     }

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -127,13 +127,17 @@ public sealed partial class ItemsTabViewModel : ObservableObject
             return null;
         var used = _refData.KeywordsUsedInRecipeSlots;
         if (used.Count == 0) return null;
+        var displayNames = _refData.KeywordDisplayNames;
         var chips = item.Keywords
             .Where(k => used.Contains(k.Tag))
             .Select(k =>
             {
                 var reference = EntityRef.RecipeIngredientKeyword(k.Tag);
+                var display = displayNames.TryGetValue(k.Tag, out var friendly)
+                    ? friendly
+                    : CamelCaseSplitConverter.Split(k.Tag);
                 return new EntityChipVm(
-                    DisplayName: k.Tag,
+                    DisplayName: display,
                     IconId: 0,
                     Reference: reference,
                     IsNavigable: _navigator.CanOpen(reference));

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -4,6 +4,7 @@ using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
 
 namespace Silmarillion.ViewModels;
 
@@ -23,6 +24,15 @@ namespace Silmarillion.ViewModels;
 /// </summary>
 public sealed partial class ItemsTabViewModel : ObservableObject
 {
+    /// <summary>
+    /// Reflected schema for <see cref="Item"/> exposed to <c>MithrilQueryBox.Schema</c> so the
+    /// query box can offer completion and highlight known column names. <c>QueryFilter</c> on
+    /// the bound ListBox reflects the same surface from the item type at attach time, so the
+    /// suggestions stay in sync with what actually filters.
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(Item)));
+
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
 
 namespace Silmarillion.ViewModels;
 
@@ -19,6 +20,15 @@ namespace Silmarillion.ViewModels;
 /// </summary>
 public sealed partial class RecipesTabViewModel : ObservableObject
 {
+    /// <summary>
+    /// Reflected schema for <see cref="RecipeListRow"/> exposed to <c>MithrilQueryBox.Schema</c>
+    /// so the query box can offer completion and highlight known column names. <c>QueryFilter</c>
+    /// on the bound ListBox reflects the same surface from the item type at attach time, so the
+    /// suggestions stay in sync with what actually filters.
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(RecipeListRow)));
+
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;

--- a/src/Silmarillion.Module/Views/ItemsTabView.xaml
+++ b/src/Silmarillion.Module/Views/ItemsTabView.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Silmarillion.Views.ItemsTabView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
@@ -31,7 +32,8 @@
         <!-- Query box spans both columns -->
         <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
             <StackPanel>
-                <wpf:MithrilQueryBox QueryText="{Binding QueryText, Mode=TwoWay}"
+                <wpf:MithrilQueryBox Schema="{x:Static vm:ItemsTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
                                      Watermark="bare text, or e.g. Name = 'Tomato'"/>
                 <TextBlock Text="{Binding QueryError}"
                            Foreground="#FFD96A6A" FontStyle="Italic"

--- a/src/Silmarillion.Module/Views/RecipesTabView.xaml
+++ b/src/Silmarillion.Module/Views/RecipesTabView.xaml
@@ -32,8 +32,9 @@
 
         <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
             <StackPanel>
-                <wpf:MithrilQueryBox QueryText="{Binding QueryText, Mode=TwoWay}"
-                                     Watermark="bare text, or e.g. Skill = 'Cooking' AND SkillLevelReq &gt;= 30"/>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:RecipesTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. SkillDisplayName = 'Cooking' AND SkillLevelReq &gt;= 30"/>
                 <TextBlock Text="{Binding QueryError}"
                            Foreground="#FFD96A6A" FontStyle="Italic"
                            FontSize="{DynamicResource AppFontSizeHint}"

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceRecipeCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceRecipeCrossLinkIndexTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
@@ -315,26 +316,31 @@ public sealed class ReferenceDataServiceRecipeCrossLinkIndexTests : IDisposable
     }
 
     [Fact]
-    public void KeywordDisplayNames_first_match_wins_when_a_keyword_has_multiple_singleton_slots()
+    public void KeywordDisplayNames_most_common_Desc_wins_across_singleton_slots()
     {
-        // Two recipes both use Crystal as a singleton slot; the first one (recipe_100) sets a
-        // friendly Desc, the second (recipe_200) sets the raw tag. First-match-wins should land
-        // on the friendly Desc (recipe iteration order is dictionary order, which is stable enough
-        // for the test fixture's controlled inputs).
+        // Three recipes use CheapMeat as a singleton slot with two distinct friendly Descs.
+        // The dominant Desc ("Cheap Meat", 2 occurrences) should be picked over the variant
+        // ("Cheap Meat (stack of 25)", 1 occurrence) — mirroring the bundled-data shape.
         WriteFixture(
             itemsJson: """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""",
             recipesJson: """
             {
               "recipe_100": {
-                "Name": "R1", "InternalName": "R1", "Skill": "Smithing",
+                "Name": "R1", "InternalName": "R1", "Skill": "Cooking",
                 "Ingredients": [
-                  { "Desc": "Sparkly Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                  { "Desc": "Cheap Meat (stack of 25)", "ItemKeys": ["CheapMeat"], "StackSize": 25 }
                 ]
               },
               "recipe_200": {
-                "Name": "R2", "InternalName": "R2", "Skill": "Smithing",
+                "Name": "R2", "InternalName": "R2", "Skill": "Cooking",
                 "Ingredients": [
-                  { "Desc": "Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                  { "Desc": "Cheap Meat", "ItemKeys": ["CheapMeat"], "StackSize": 1 }
+                ]
+              },
+              "recipe_300": {
+                "Name": "R3", "InternalName": "R3", "Skill": "Cooking",
+                "Ingredients": [
+                  { "Desc": "Cheap Meat", "ItemKeys": ["CheapMeat"], "StackSize": 1 }
                 ]
               }
             }
@@ -342,9 +348,117 @@ public sealed class ReferenceDataServiceRecipeCrossLinkIndexTests : IDisposable
 
         var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
 
-        svc.KeywordDisplayNames.Should().ContainKey("Crystal")
-            .WhoseValue.Should().Be("Sparkly Crystal",
-                because: "first slot encountered with a friendly Desc claims the display name");
+        svc.KeywordDisplayNames.Should().ContainKey("CheapMeat")
+            .WhoseValue.Should().Be("Cheap Meat",
+                because: "the most-common Desc across singleton slots wins (2 vs 1)");
+    }
+
+    [Fact]
+    public void KeywordDisplayNames_override_suppresses_lookup_to_force_consumer_fallback()
+    {
+        // The Crystal keyword's singleton slots are labelled by their slot ROLE ("Primary Crystal",
+        // "Auxiliary Crystal") rather than describing what a Crystal is. The override table maps
+        // Crystal to null, which suppresses the slot-walk for this tag — the consumer's
+        // CamelCaseSplit fallback then yields the raw "Crystal" instead of a misleading slot label.
+        WriteFixture(
+            itemsJson: """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""",
+            recipesJson: """
+            {
+              "recipe_100": {
+                "Name": "R1", "InternalName": "R1", "Skill": "Smithing",
+                "Ingredients": [
+                  { "Desc": "Primary Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                ]
+              },
+              "recipe_200": {
+                "Name": "R2", "InternalName": "R2", "Skill": "Smithing",
+                "Ingredients": [
+                  { "Desc": "Auxiliary Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.KeywordDisplayNames.Should().NotContainKey("Crystal",
+            because: "Crystal is in the suppression override — let the consumer's fallback handle it");
+    }
+
+    [Fact]
+    public void KeywordDisplayNames_real_bundled_data_no_unreviewed_divergent_display_names()
+    {
+        // Drift detector. Walks the picked display names for the real bundled recipes.json +
+        // strings_all.json and verifies each shares at least one length-≥3 token with the
+        // camel-case-split keyword tag. When this fails, the slot-Desc resolution has produced
+        // a label that's recipe-context-specific (the "Item to Copy Appearance From" pattern that
+        // bit us on the Equipment keyword). Each new failure means either:
+        //   - The keyword belongs in ReferenceDataService.KeywordDisplayOverrides (null to
+        //     suppress, or a friendly value to pin).
+        //   - The divergence is acceptable game-side wording (e.g. "Trophy Skin or Hide" for
+        //     FlawlessSkin), in which case allowlist it below.
+        var realBundled = Path.Combine(AppContext.BaseDirectory, "Reference", "BundledData");
+        if (!File.Exists(Path.Combine(realBundled, "recipes.json"))) return;
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: realBundled);
+
+        // Allowlist for cases where the divergent name is the right in-game wording. Audited
+        // 2026-05-14. Re-audit any time this list grows.
+        var allowlistExact = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "FlawlessSkin",     // → "Trophy Skin or Hide" — the dominant in-game labelling.
+            "MainHandAugment",  // → "Weapon Augment" — dominant in-game labelling.
+            "EnergyBow",        // → "Faebow" — two recipes deliberately label by the weapon class.
+            "Edible",           // → "Food or Drink" — both edible-keyword recipes label it this way.
+            "VendorTrash",      // → "Miscellaneous Junk" — natural in-game term.
+            "NecroFuel",        // → "Any Decent-Sized Bone" — natural enumeration.
+        };
+        // Pattern allowlist. Brewing*<Level> tags (e.g. BrewingGarnishA2, BrewingFlowersW6) are
+        // opaque shorthand for kind-keyed slots; the slot Descs enumerate the actual accepted
+        // items ("Beet, Squash, Broccoli, or Carrot") which is the right in-game wording.
+        bool IsAllowed(string tag) =>
+            allowlistExact.Contains(tag) || tag.StartsWith("Brewing", StringComparison.Ordinal);
+
+        // Audit scope: only keywords that could actually surface as a chip — i.e. those present
+        // in some raw item.Keywords list. Synthesized/virtual keywords (e.g. EquipmentSlot:Hands)
+        // appear in recipe slots but never on items directly, so a divergent display name there
+        // doesn't reach the UI.
+        var chipSurfacingKeywords = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in svc.Items.Values)
+        {
+            if (item.Keywords is null) continue;
+            foreach (var kw in item.Keywords)
+                chipSurfacingKeywords.Add(kw.Tag);
+        }
+
+        var tokenSplitter = new Regex("[A-Z][a-z0-9]*|[a-z0-9]+", RegexOptions.Compiled);
+        var failures = new List<string>();
+        foreach (var (tag, display) in svc.KeywordDisplayNames)
+        {
+            if (!chipSurfacingKeywords.Contains(tag)) continue;
+            if (IsAllowed(tag)) continue;
+
+            HashSet<string> Tokens(string s) =>
+                tokenSplitter.Matches(s).Select(m => m.Value.ToLowerInvariant())
+                    .Where(t => t.Length >= 3)
+                    .ToHashSet(StringComparer.Ordinal);
+
+            var tagTokens = Tokens(tag);
+            var displayTokens = Tokens(display);
+            if (tagTokens.Count == 0 || displayTokens.Count == 0) continue;
+            if (!tagTokens.Overlaps(displayTokens))
+                failures.Add($"'{tag}' → '{display}' (no shared length-≥3 token)");
+        }
+
+        if (failures.Count > 0)
+        {
+            var lines = string.Join(Environment.NewLine, failures.Select(f => "  • " + f));
+            throw new Xunit.Sdk.XunitException(
+                $"Keyword display names diverge from their tags without a corresponding override:{Environment.NewLine}{lines}{Environment.NewLine}" +
+                "Each entry is a chip-surfacing keyword whose resolved Desc shares no length-≥3 token with the camel-case-split tag. " +
+                "Add to ReferenceDataService.KeywordDisplayOverrides (null to suppress, or pin a value), " +
+                "or extend this test's allowlist if the wording is intentional.");
+        }
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceRecipeCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceRecipeCrossLinkIndexTests.cs
@@ -213,6 +213,141 @@ public sealed class ReferenceDataServiceRecipeCrossLinkIndexTests : IDisposable
     }
 
     [Fact]
+    public void KeywordDisplayNames_uses_recipes_json_Desc_when_strings_all_absent()
+    {
+        WriteFixture(
+            itemsJson: """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""",
+            recipesJson: """
+            {
+              "recipe_777": {
+                "Name": "R", "InternalName": "R", "Skill": "Smithing",
+                "Ingredients": [
+                  { "Desc": "Metal Armor", "ItemKeys": ["MetalArmor"], "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.KeywordDisplayNames.Should().ContainKey("MetalArmor")
+            .WhoseValue.Should().Be("Metal Armor",
+                because: "the slot is a singleton and its recipes.json Desc is a friendly form of the raw tag");
+    }
+
+    [Fact]
+    public void KeywordDisplayNames_prefers_strings_all_over_recipes_json_Desc()
+    {
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"),
+            """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.json"),
+            """
+            {
+              "recipe_888": {
+                "Name": "R", "InternalName": "R", "Skill": "Smithing",
+                "Ingredients": [
+                  { "Desc": "Main-Hand Weapon", "ItemKeys": ["MainHandWeapon"], "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "strings_all.json"),
+            """{ "recipe_888_Ingredients_0_Desc": "Main-Hand Item" }""");
+        File.WriteAllText(Path.Combine(_bundledDir, "strings_all.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.KeywordDisplayNames.Should().ContainKey("MainHandWeapon")
+            .WhoseValue.Should().Be("Main-Hand Item",
+                because: "strings_all takes precedence over recipes.json's Desc — it's the in-game wording");
+    }
+
+    [Fact]
+    public void KeywordDisplayNames_omits_keywords_whose_Desc_is_the_raw_tag()
+    {
+        // recipe_9008's GreenCrystal slot has Desc = "GreenCrystal" — same as the raw tag.
+        // The map should NOT contain GreenCrystal so the caller knows to apply a CamelCaseSplit fallback.
+        WriteFixture(
+            itemsJson: """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""",
+            recipesJson: """
+            {
+              "recipe_9008": {
+                "Name": "R", "InternalName": "R", "Skill": "Teleportation",
+                "Ingredients": [
+                  { "Desc": "GreenCrystal", "ItemKeys": ["GreenCrystal"], "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.KeywordsUsedInRecipeSlots.Should().Contain("GreenCrystal");
+        svc.KeywordDisplayNames.Should().NotContainKey("GreenCrystal",
+            because: "a Desc identical to the raw tag adds no value over a CamelCase-split fallback");
+    }
+
+    [Fact]
+    public void KeywordDisplayNames_ignores_composite_tuple_slots()
+    {
+        // Composite slots like ["EquipmentSlot:MainHand", "MinTSysPrereq:0"] have Descs that
+        // describe the AND-matched composite ("Main-Hand Item"), not any single keyword tag.
+        // Surfacing the composite's Desc for either tag would be misleading.
+        WriteFixture(
+            itemsJson: """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""",
+            recipesJson: """
+            {
+              "recipe_555": {
+                "Name": "R", "InternalName": "R", "Skill": "Augmentation",
+                "Ingredients": [
+                  { "Desc": "Main-Hand Item", "ItemKeys": ["EquipmentSlot:MainHand", "MinTSysPrereq:0"], "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.KeywordDisplayNames.Should().NotContainKey("EquipmentSlot:MainHand");
+        svc.KeywordDisplayNames.Should().NotContainKey("MinTSysPrereq:0");
+    }
+
+    [Fact]
+    public void KeywordDisplayNames_first_match_wins_when_a_keyword_has_multiple_singleton_slots()
+    {
+        // Two recipes both use Crystal as a singleton slot; the first one (recipe_100) sets a
+        // friendly Desc, the second (recipe_200) sets the raw tag. First-match-wins should land
+        // on the friendly Desc (recipe iteration order is dictionary order, which is stable enough
+        // for the test fixture's controlled inputs).
+        WriteFixture(
+            itemsJson: """{ "item_100": { "Name": "Boots", "InternalName": "Boots" } }""",
+            recipesJson: """
+            {
+              "recipe_100": {
+                "Name": "R1", "InternalName": "R1", "Skill": "Smithing",
+                "Ingredients": [
+                  { "Desc": "Sparkly Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                ]
+              },
+              "recipe_200": {
+                "Name": "R2", "InternalName": "R2", "Skill": "Smithing",
+                "Ingredients": [
+                  { "Desc": "Crystal", "ItemKeys": ["Crystal"], "StackSize": 1 }
+                ]
+              }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.KeywordDisplayNames.Should().ContainKey("Crystal")
+            .WhoseValue.Should().Be("Sparkly Crystal",
+                because: "first slot encountered with a friendly Desc claims the display name");
+    }
+
+    [Fact]
     public void Indices_SkipItemsThatLackInternalName()
     {
         // Some items in the bundled file lack InternalName; cross-link indices key on

--- a/tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/ItemsKindTargetTests.cs
@@ -54,6 +54,23 @@ public sealed class ItemsKindTargetTests
         target.TryOpenInWindow().Should().BeFalse();
     }
 
+    [Fact]
+    public void TrySelectByInternalName_ClearsResidualQueryText_SoTargetItemIsVisible()
+    {
+        // Direct link to an item must clear any leftover filter — otherwise the target
+        // row might be filtered out of the visible ListBox and the selection would land
+        // on an invisible row.
+        var item = new Item { Id = 5010, InternalName = "Tomato", Name = "Tomato" };
+        var (target, vm, _) = BuildTarget(item);
+        vm.QueryText = "Name STARTSWITH 'XYZ'";
+
+        var ok = target.TrySelectByInternalName("Tomato");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().BeEmpty(because: "the kind target clears any prior filter before selecting");
+        vm.SelectedItem.Should().Be(item);
+    }
+
     private static (ItemsKindTarget Target, ItemsTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
         params Item[] items)
     {

--- a/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/RecipesKindTargetTests.cs
@@ -52,6 +52,23 @@ public sealed class RecipesKindTargetTests
     }
 
     [Fact]
+    public void TrySelectByInternalName_ClearsResidualQueryText_SoTargetRowIsVisible()
+    {
+        // Direct link to a recipe must clear any leftover filter — otherwise the target
+        // row might be filtered out of the visible list and the selection would land
+        // on an invisible row. Reproduces the keyword-chip → direct-recipe-link sequence.
+        var recipe = new Recipe { Key = "recipe_123", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] };
+        var (target, vm, _) = BuildTarget(recipe);
+        vm.QueryText = "IngredientKeywords CONTAINS \"Crystal\"";
+
+        var ok = target.TrySelectByInternalName("MakeSalsa");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().BeEmpty(because: "the kind target clears any prior filter before selecting");
+        vm.SelectedRecipe.Should().Be(recipe);
+    }
+
+    [Fact]
     public void TrySelectByInternalName_AfterRefresh_ResolvesFreshInstance()
     {
         // Simulates a background reference-data refresh: refData hands out a NEW

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -238,6 +238,37 @@ public sealed class SilmarillionReferenceNavigatorTests
         silmarillionVm.Recipes.QueryText.Should().Be("IngredientKeywords CONTAINS \"Crystal\"");
     }
 
+    [Fact]
+    public void Open_RecipeIngredientKeyword_ClearsResidualSelectedRow()
+    {
+        // Keyword-chip navigation expresses a *filter*, not a specific recipe pick. Any
+        // SelectedRow lingering from earlier in-tab navigation must be cleared so the
+        // new filtered list doesn't render with a stale (and possibly filter-excluded)
+        // selection.
+        var refData = new FakeReferenceData();
+        // Seed a recipe so SelectedRow has something to point at before navigation.
+        refData.AddRecipe(new Recipe { Key = "recipe_1", InternalName = "MakeSalsa", Name = "Make Salsa", Ingredients = [] });
+        var recipesVm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+        recipesVm.SelectedRow = recipesVm.AllRecipes.Single();
+        recipesVm.SelectedRow.Should().NotBeNull(); // precondition
+
+        var keywordTarget = new RecipeIngredientKeywordKindTarget(recipesVm);
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            keywordTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        _ = new SilmarillionViewModel(items: null!, recipes: recipesVm, nav, targets);
+
+        nav.Open(EntityRef.RecipeIngredientKeyword("Crystal"));
+
+        recipesVm.SelectedRow.Should().BeNull(
+            because: "keyword-chip navigation is a filter action; prior row selection must clear");
+        recipesVm.QueryText.Should().Be("IngredientKeywords CONTAINS \"Crystal\"");
+    }
+
     private static IEnumerable<IReferenceKindTarget> NavTargets() => new IReferenceKindTarget[]
     {
         new StubTarget(EntityKind.Item),
@@ -255,12 +286,21 @@ public sealed class SilmarillionReferenceNavigatorTests
 
     private sealed class FakeReferenceData : IReferenceDataService
     {
+        private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Recipe> _recipesByInternalName = new(StringComparer.Ordinal);
+
+        public void AddRecipe(Recipe recipe)
+        {
+            _recipes[recipe.Key] = recipe;
+            if (recipe.InternalName is not null) _recipesByInternalName[recipe.InternalName] = recipe;
+        }
+
         public IReadOnlyList<string> Keys => Array.Empty<string>();
         public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
         public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
         public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
-        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
-        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _recipesByInternalName;
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -88,10 +88,65 @@ public sealed class ItemsTabViewModelTests
         chips.Single().Reference.Should().Be(EntityRef.RecipeIngredientKeyword("Crystal"));
     }
 
+    [Fact]
+    public void Keyword_chip_uses_KeywordDisplayNames_when_present()
+    {
+        var item = new Item
+        {
+            Id = 99,
+            InternalName = "ShinyArmor",
+            Name = "Shiny Armor",
+            Keywords = [new ItemKeyword("MetalArmor", 0)],
+        };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["ShinyArmor"] = item },
+            KeywordsInRecipeSlots = new HashSet<string>(StringComparer.Ordinal) { "MetalArmor" },
+            KeywordDisplays = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["MetalArmor"] = "Metal Armor",  // friendly form sourced from a recipe slot
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedItem = item;
+
+        vm.DetailViewModel!.ConsumedAsKeywordIn.Single().DisplayName
+            .Should().Be("Metal Armor", because: "KeywordDisplayNames lookup wins over the raw tag");
+    }
+
+    [Fact]
+    public void Keyword_chip_falls_back_to_CamelCaseSplit_when_no_friendly_display_name()
+    {
+        // Mirrors the GreenCrystal case: no recipe carries a friendly singleton Desc for the keyword,
+        // so the map has no entry. CamelCaseSplit on the raw tag is the visible result.
+        var item = new Item
+        {
+            Id = 99,
+            InternalName = "Tourmaline",
+            Name = "Tourmaline",
+            Keywords = [new ItemKeyword("GreenCrystal", 0)],
+        };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["Tourmaline"] = item },
+            KeywordsInRecipeSlots = new HashSet<string>(StringComparer.Ordinal) { "GreenCrystal" },
+            // KeywordDisplays intentionally empty — no friendly display name available.
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedItem = item;
+
+        vm.DetailViewModel!.ConsumedAsKeywordIn.Single().DisplayName
+            .Should().Be("Green Crystal",
+                because: "CamelCaseSplit splits PascalCase tokens at the camel-hump");
+    }
+
     private sealed class StubReferenceData : IReferenceDataService
     {
         public Dictionary<string, Item> ItemsByName { get; } = new(StringComparer.Ordinal);
         public IReadOnlyCollection<string> KeywordsInRecipeSlots { get; init; } = [];
+        public IReadOnlyDictionary<string, string> KeywordDisplays { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items => ItemsByName.Values.ToDictionary(i => i.Id);
@@ -112,6 +167,7 @@ public sealed class ItemsTabViewModelTests
         public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
 
         public IReadOnlyCollection<string> KeywordsUsedInRecipeSlots => KeywordsInRecipeSlots;
+        public IReadOnlyDictionary<string, string> KeywordDisplayNames => KeywordDisplays;
 
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

PR #259's "Used as" chips on the item-detail view rendered the raw PascalCase keyword tag (`MetalArmor`, `GreenCrystal`, `EquipmentSlot:MainHand`). This PR resolves them to friendlier display strings:

1. **Service-layer index.** `IReferenceDataService.KeywordDisplayNames` (new) is built during `BuildRecipeCrossLinkIndices`. For each `RecipeKeywordIngredient` slot:
   - Only **singleton** slots (`ItemKeys.Count == 1`) — composite tuples have Descs that describe the AND-matched composite, not any one tag.
   - Resolve the slot's display string via `_strings["recipe_<id>_Ingredients_<idx>_Desc"]` first, fall back to `slot.Desc` from recipes.json.
   - If the resolved value is non-empty AND differs from the raw tag, record it. First match wins.
2. **`ParseAndSwapStrings` rebuilds cross-link indices.** strings_all loads after recipes.json in the bundled-load path, so without this the index would be built against an empty strings map. Refresh-safe.
3. **`CamelCaseSplitConverter.Split` exposed as a static method** for non-XAML callers — the converter delegates to it.
4. **`ItemsTabViewModel.BuildKeywordChips`** consults `KeywordDisplayNames[tag]` first; misses fall back to `CamelCaseSplitConverter.Split(tag)`.

## Visible result

| Keyword | Before | After |
|---|---|---|
| `Crystal` | `Crystal` | `Crystal` (unchanged — no internal boundary) |
| `MetalArmor` | `MetalArmor` | `Metal Armor` (singleton slot Desc) |
| `GreenCrystal` | `GreenCrystal` | `Green Crystal` (CamelCaseSplit fallback — no friendly singleton Desc) |
| `Tourmaline` | `Tourmaline` | `Tourmaline` (unchanged) |

## Test plan

- [x] `dotnet build Mithril.slnx` clean.
- [x] `dotnet test Mithril.slnx` — full suite (~1959) green.
- [x] Service tests: 5 new in `ReferenceDataServiceRecipeCrossLinkIndexTests` covering `recipes.json` Desc, strings_all override, raw-tag-Desc omission, composite-slot ignore, first-match-wins.
- [x] VM tests: 2 new in `ItemsTabViewModelTests` covering lookup hit and CamelCaseSplit fallback.
- [x] Manual: Silmarillion → Items → any item carrying `MetalArmor` → "Used as" chip reads "Metal Armor", not "MetalArmor". Massive Tourmaline → `Crystal` chip unchanged.

## Related

- Closes #266.
- Adjacent forward-looking pattern (typed `StringRef` across POCOs) tracked in #265.