### PR TITLE
fix(query): gate MithrilQueryBox completion popup on editor focus

### DIFF
--- a/src/Mithril.Shared.Wpf/MithrilQueryBox.cs
+++ b/src/Mithril.Shared.Wpf/MithrilQueryBox.cs
@@ -286,6 +286,16 @@ public class MithrilQueryBox : Control
             if (_popup is not null) ClosePopup();
             return;
         }
+        // Completion is a typing affordance: only surface it when the user actually has
+        // focus on the editor (or on the popup list — mouse-accept hands focus there briefly).
+        // Without this gate, programmatic writes to QueryText — chip-click navigation that
+        // pre-populates a filter, or the initial OnApplyTemplate text sync — would pop the
+        // list unbidden the moment the tab is shown.
+        if (!_editor.IsKeyboardFocused && !_list.IsKeyboardFocusWithin)
+        {
+            ClosePopup();
+            return;
+        }
         var text = _editor.Text ?? string.Empty;
         int caret = _editor.CaretIndex;
         var schema = EffectiveSchema();


### PR DESCRIPTION
Regression follow-up to #264.

## Summary

Programmatic writes to `MithrilQueryBox.QueryText` — Silmarillion's keyword-chip navigation pre-populating `IngredientKeywords CONTAINS \"…\"` on the Recipes tab, or the initial `OnApplyTemplate` text sync — propagate through the DP binding into `_editor.Text`, fire `TextChanged`, and call `RefreshCompletion`. Pre-#264 this was harmless because `RefreshCompletion` short-circuited on `!HasSchemaSource`; now that Silmarillion's boxes have a `Schema`, the same path pops the completion list unbidden the moment a chip-driven tab switch lands.

Gate the body of `RefreshCompletion` on `_editor.IsKeyboardFocused || _list.IsKeyboardFocusWithin`. Completion is a typing affordance — if no user is at the keyboard, no popup.

## Why the existing user-driven paths still work

- **Typing** — `OnEditorTextChanged` fires while the user is keyed into the editor → `IsKeyboardFocused` is `true` → popup shows.
- **Ctrl+Space** — handler is on `OnEditorPreviewKeyDown`, only fires when the editor has focus.
- **Tab/Enter accept** — same handler; editor has focus.
- **Mouse-click accept on a list item** — `OnListClicked` runs `AcceptCompletion` which calls `RefreshCompletion`; the popup list briefly owns focus, so `_list.IsKeyboardFocusWithin` keeps the chain alive for the follow-up suggestion.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean.
- [x] `dotnet test Mithril.slnx` — all suites green.
- [x] Shell boot smoke (`boot.log` advances through `=== startup done ===`).
- [x] Interactive verify: clicking an item-detail keyword chip switches to the Recipes tab with the `IngredientKeywords CONTAINS \"…\"` filter applied **and no popup**. Clicking into the box and typing still surfaces the completion popup as before.

---

*Drafted by Claude (Opus 4.7), filed by @arthur-conde via Claude Code.*