### PR TITLE
feat(silmarillion): recipe-detail keyword chip filters Items tab — #270

### DIFF
--- a/docs/agent-plans/silmarillion-recipe-keyword-chip-to-items-filter.md
+++ b/docs/agent-plans/silmarillion-recipe-keyword-chip-to-items-filter.md
@@ -1,0 +1,123 @@
+# Silmarillion: recipe-detail keyword chip → Items tab keyword filter
+
+**Tracked in:** #270
+
+**Companion to:** PR #267 / #266 (merged 2026-05-14, recipe-side keyword chip display names + reverse direction). Closes the *forward* symmetry — the inverse direction is already shipped: clicking a keyword chip on an item-detail's "Used as" section filters the Recipes tab by `IngredientKeywords CONTAINS "<keyword>"`.
+
+## Context
+
+The Silmarillion item-detail "Used as" section now has navigable keyword chips. Clicking a chip on Massive Tourmaline's detail page (e.g. "Crystal") flips to the Recipes tab and pre-populates `QueryText = IngredientKeywords CONTAINS "Crystal"`, leveraging #260/#261's collection-`CONTAINS`-via-`IQueryStringValue` plumbing.
+
+The **forward direction is still asymmetric**: when a user opens a recipe's detail page and sees a keyword ingredient chip (e.g. the "Crystal" slot on an enchanting recipe), the chip is rendered but **not clickable** — it carries a sentinel `EntityRef` and `IsNavigable: false`. From [src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs:184-188](../../src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs#L184-L188):
+
+```csharp
+private static EntityChipVm BuildKeywordChip(RecipeKeywordIngredient kwIng)
+{
+    var label = kwIng.Desc ?? $"any {ItemKeywordIndex.Humanise(kwIng.ItemKeys)}";
+    return new EntityChipVm(label, IconId: 0, Reference: KeywordSentinelRef, IsNavigable: false);
+}
+```
+
+The comment that gates this — *"keyword-set ingredients don't point at a single entity, so the chip is non-navigable"* — was correct at the time (pre-#260/#261) but is now obsolete. The collection-CONTAINS path lets a keyword chip mean *"filter the Items tab to items carrying this keyword"* without having to point at a single item.
+
+This plan closes that gap.
+
+## Approach
+
+Mirror the existing keyword-chip → filtered-tab pattern (the one PR #267 introduced for the reverse direction), applied to the inverse:
+
+1. New `EntityKind.ItemKeyword` variant on `EntityRef` (alongside the existing `RecipeIngredientKeyword`). Carries the slot's `ItemKeys` list `+`-joined into `InternalName` (no `ItemKey` value contains `+`, verified against bundled `recipes.json`). Two factories: `EntityRef.ItemKeyword(string)` for singleton callers, `EntityRef.ItemKeyword(IReadOnlyList<string>)` for the composite case.
+2. New `ItemKeywordQueryMapper` static helper. **All-or-nothing translation**: takes the slot's `ItemKeys`, returns a query fragment iff *every* key can be mapped to an Items-tab query clause. Mapping rules for v1:
+   - Bare tag (no `:`) → `Keywords CONTAINS "<tag>"`
+   - `EquipmentSlot:X` → `EquipSlot = "X"` (lossless — `Item.EquipSlot` is a direct queryable string property)
+   - Anything else (`MinTSysPrereq:*`, `MaxTSysPrereq:*`, `SkillPrereq:*`, …) → fail the whole slot; chip stays non-navigable
+   - Multiple mapped fragments joined with ` AND `
+3. New `ItemKeywordKindTarget` (sibling of `RecipeIngredientKeywordKindTarget`). Dispatches to the Items tab (`TabIndex = 0`); calls the mapper, sets `ItemsTabViewModel.QueryText`; clears `SelectedItem` (the navigation expresses a filter, not a row pick). Returns `false` from `TrySelectByInternalName` if the mapper fails (kept as a defensive belt — the chip-builder is the gate).
+4. Update `RecipesTabViewModel.BuildKeywordChip` to call the mapper to determine `IsNavigable`, then emit `EntityRef.ItemKeyword(itemKeys)`. Display label preserved (`kwIng.Desc ?? $"any {ItemKeywordIndex.Humanise(kwIng.ItemKeys)}"`).
+5. Register the new kind target in `SilmarillionModule.cs` DI.
+
+The end state:
+- "Crystal" slot chip → clickable → Items tab with `Keywords CONTAINS "Crystal"`.
+- "Main-Hand Item" slot chip (`[EquipmentSlot:MainHand, MinTSysPrereq:0]`) → **non-navigable** (because `MinTSysPrereq:0` has no item-side mapping). Honest UX: if a chip can't faithfully express its slot constraint, it stays inert. Future expansion can promote it as item-side analogues land.
+- Hypothetical singleton `[EquipmentSlot:MainHand]` chip (no prereq) → clickable → `EquipSlot = "MainHand"`. Not present in today's catalog but supported by the mapping.
+
+## Why this works under PR #267's plumbing
+
+- `Item.Keywords` is `IReadOnlyList<ItemKeyword>`, and `ItemKeyword(string Tag, int Quality)` already implements `IQueryStringValue` via `Tag` (per `Mithril.Reference/Models/Items/ItemKeyword.cs`). The query engine's collection-CONTAINS path (`QueryCompiler` in `Mithril.Shared.Wpf.Query`) picks this up automatically.
+- The kind-target pattern is well-established. `RecipeIngredientKeywordKindTarget` ([src/Silmarillion.Module/Navigation/RecipeIngredientKeywordKindTarget.cs](../../src/Silmarillion.Module/Navigation/RecipeIngredientKeywordKindTarget.cs)) is the template — copy and invert.
+- `ItemsKindTarget` already exists for the entity (specific item) direction. The new target is its filter-action sibling.
+
+## Files to touch
+
+| Path | Change |
+|---|---|
+| `src/Mithril.Shared/Reference/EntityRef.cs` | Add `EntityKind.ItemKeyword` (append to the end of the enum to preserve ordinals). Two factories: `ItemKeyword(string)` and `ItemKeyword(IReadOnlyList<string>)` (`+`-joins for the latter). |
+| `src/Silmarillion.Module/Navigation/ItemKeywordQueryMapper.cs` (new) | Static helper. `TryBuildQuery(IReadOnlyList<string> itemKeys, out string? query)`. All-or-nothing semantics described above. |
+| `src/Silmarillion.Module/Navigation/ItemKeywordKindTarget.cs` (new) | Sibling of `RecipeIngredientKeywordKindTarget`. `Kind => EntityKind.ItemKeyword`, `TabIndex => 0`. `TrySelectByInternalName` splits the `+`-encoded `internalName`, calls the mapper; on success sets `_vm.SelectedItem = null` then `_vm.QueryText = <query>`; returns false otherwise. `TryOpenInWindow() => false`. |
+| `src/Silmarillion.Module/SilmarillionModule.cs` | Register the new target alongside the existing `IReferenceKindTarget` registrations (mirror the `RecipeIngredientKeywordKindTarget` factory-lambda style). |
+| `src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs` | `BuildKeywordChip` becomes instance method (needs the mapper + navigator to compute `IsNavigable`). Always emits `EntityRef.ItemKeyword(ItemKeys)`; `IsNavigable` = mapper succeeded AND `_navigator.CanOpen(ref)`. Display label preserved as today (`kwIng.Desc ?? $"any {ItemKeywordIndex.Humanise(kwIng.ItemKeys)}"`). |
+| `tests/Mithril.Shared.Tests/Reference/EntityRefTests.cs` | Test both `EntityRef.ItemKeyword` overloads (singleton + list). |
+| `tests/Silmarillion.Tests/Navigation/ItemKeywordQueryMapperTests.cs` (new) | Mapper coverage: bare-tag, EquipmentSlot map, unmappable token → fail whole slot, multi-key AND-join, empty slot. |
+| `tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs` | Tests mirroring the existing `Open_RecipeIngredientKeyword_*` pair: `Open_ItemKeyword_SwitchesToItemsTab_AndSetsQueryText` (singleton), `Open_ItemKeyword_ClearsResidualSelectedItem`, plus `Open_ItemKeyword_CompositeSlotWithEquipmentSlot_SetsAndJoinedQuery`. |
+| `tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs` | Cover: (a) singleton keyword slot produces a navigable chip with `EntityRef.ItemKeyword(tag)`; (b) composite slot of all-mappable keys produces a navigable chip; (c) composite tuple containing an unmappable key (`MinTSysPrereq:*`) stays non-navigable; (d) chip display label unchanged from pre-existing behaviour. |
+
+## Resolved design question — composite-tuple slots
+
+**Decision (2026-05-14, during plan refinement):** v1 *does* navigate composite slots when every key is translatable. The plan's original "out of scope" stance was overcautious — it assumed virtual keys couldn't be expressed in the Items query, but `Item.EquipSlot` is a direct queryable string property, so `EquipmentSlot:X` maps cleanly onto `EquipSlot = "X"`.
+
+The all-or-nothing rule (any unmappable key → entire chip non-navigable) keeps the UX honest:
+
+| Slot pattern | Result |
+|---|---|
+| `["Crystal"]` (singleton bare tag) | navigable → `Keywords CONTAINS "Crystal"` |
+| `["EquipmentSlot:MainHand"]` (hypothetical singleton) | navigable → `EquipSlot = "MainHand"` |
+| `["Crystal", "Tier3"]` (composite all-bare, hypothetical) | navigable → `Keywords CONTAINS "Crystal" AND Keywords CONTAINS "Tier3"` |
+| `["EquipmentSlot:MainHand", "MinTSysPrereq:0"]` (real catalog) | **non-navigable** — `MinTSysPrereq:N` has no item-side analogue |
+
+`MinTSysPrereq` / `MaxTSysPrereq` are item-level concepts (per-item TSys tier prereq) but **not currently exposed on `Item`**. When/if they're surfaced, the mapper can be extended; chips that are inert today will quietly become clickable with no chip-builder change.
+
+`SkillPrereq:X` is also unmappable for v1 (`Item.SkillReqs` is a dictionary, no simple equality clause). Treated the same way: chip stays inert.
+
+## Test plan
+
+1. Build clean: `dotnet build Mithril.slnx` (warnings-as-errors on).
+2. Targeted tests: `dotnet test tests/Silmarillion.Tests`.
+3. Full suite: `dotnet test Mithril.slnx`.
+4. Manual:
+   - `dotnet run --project src/Mithril.Shell`.
+   - Silmarillion → Recipes tab → open an enchanting recipe (e.g. "Enchant Boots" or any `*E`/`*Max` recipe).
+   - The "Crystal" ingredient chip should now render as clickable (hover highlight, hand cursor).
+   - Click it → Items tab opens, query box reads `Keywords CONTAINS "Crystal"`, filtered list shows every Crystal item.
+   - Refine query (`AND Skill = "..."` etc.) — composes naturally.
+   - Clear query box → full Items list returns.
+   - Verify composite slots that include unmappable tokens (e.g. the "Main-Hand Item" slot on `Decompose Main-Hand Weapon` / `recipe_10501`, ItemKeys `[EquipmentSlot:MainHand, MinTSysPrereq:0]`) stay non-clickable — `MinTSysPrereq:0` blocks the mapper. The chip still renders its `Desc` ("Main-Hand Item") as text.
+
+## Workflow
+
+1. **File the issue first** (`gh issue create`) with `type:feature` + `module:silmarillion` + `area:ui` labels. Title suggestion: `Silmarillion recipe-detail keyword chip should filter Items tab (symmetric to PR #267)`. Body summarises the asymmetry, links to PR #267 and this plan.
+2. Branch from main: `feat/<issue-number>-recipe-keyword-chip-to-items-filter`. Branch policy forbids direct commits to main — always PR.
+3. TDD as the existing kind-target tests do: write the failing test first, then implement, then run.
+4. Land as a single PR. Reasonable size (~150 LoC across new files + edits).
+
+## Related memories and references
+
+- Branch policy: `~/.claude/projects/i--src-project-gorgon/memory/branch_policy_no_direct_commits.md`
+- Collaboration style (frequent commits, present trade-offs before building): `collaboration_style.md`
+- WPF gotchas worth remembering: `wpf_run_text_default_twoway.md`, `wpf_virtualizing_wrap_panel.md`, `wpf_combobox_displaymember_quirk.md`
+- Query system three surfaces: `query_system_overview.md` (pointer to `docs/query-system.md`)
+
+## Out of scope
+
+- Mapping additional virtual-key prefixes (`SkillPrereq:*`, `MinValue:*`, `MinRarity:*`, `MinTSysPrereq:*`, `MaxTSysPrereq:*`). The mapper's `EquipmentSlot:` mapping is the only one with a clean item-side analogue today. The others would need either new `Item` columns or schema-level synthesized-keyword exposure — separate feature.
+- The "chip display name vs query token" UX wrinkle is tracked separately in **#268** (the chip might show "Crystal" but the query box would read `Keywords CONTAINS "Crystal"`; for keywords like "MetalArmor" the chip says "Metal Armor" but the query has the raw `MetalArmor` — same issue as #268 for the inverse direction). Don't address here.
+- Typed `StringRef` pattern (broader infra, low urgency) — tracked in **#265**.
+
+## What got us here
+
+This session (2026-05-13 → 2026-05-14):
+
+- PR #259 (merged) — shipped the "Used as" keyword-chip section on the item-detail view. Used singleton-slot Descs + strings_all + CamelCaseSplit fallback for display names.
+- PR #267 (merged) — built on #259 with: hardcoded `KeywordDisplayOverrides` table for cases where slot Descs are misleading (`Crystal` → "Auxiliary Crystal" is a slot role, not a keyword name); most-common-Desc-wins resolution; drift-detector unit test against real bundled data; kind-target navigation-state clearance so direct links don't land selection on filtered-out rows.
+- Issues filed: #265 (typed StringRef pattern, low urgency), #266 (closed by #267), #268 (chip display vs query token wrinkle, low urgency).
+
+This plan closes the natural symmetry that emerged at the end of PR #267's review.

--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -23,6 +23,14 @@ public enum EntityKind
     /// (e.g. "Crystal"). Dispatched by RecipeIngredientKeywordKindTarget.
     /// </summary>
     RecipeIngredientKeyword,
+
+    /// <summary>
+    /// Not an entity per se — a deep-link target for "open the Items tab filtered to items
+    /// that satisfy this recipe-slot's keyword constraint." InternalName carries the slot's
+    /// <c>ItemKeys</c> list, '+'-joined (singleton slots collapse to a single token).
+    /// Dispatched by ItemKeywordKindTarget.
+    /// </summary>
+    ItemKeyword,
 }
 
 /// <summary>
@@ -46,6 +54,8 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef PlayerTitle(string internalName) => new(EntityKind.PlayerTitle, internalName);
     public static EntityRef StorageVault(string internalName) => new(EntityKind.StorageVault, internalName);
     public static EntityRef RecipeIngredientKeyword(string keyword) => new(EntityKind.RecipeIngredientKeyword, keyword);
+    public static EntityRef ItemKeyword(string keyword) => new(EntityKind.ItemKeyword, keyword);
+    public static EntityRef ItemKeyword(IReadOnlyList<string> itemKeys) => new(EntityKind.ItemKeyword, string.Join('+', itemKeys));
 }
 
 /// <summary>

--- a/src/Silmarillion.Module/Navigation/ItemKeywordKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/ItemKeywordKindTarget.cs
@@ -1,0 +1,53 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> for <see cref="EntityKind.ItemKeyword"/>.
+/// Flips to the Items tab and pre-populates <see cref="ItemsTabViewModel.QueryText"/>
+/// with an AND-joined query derived from the recipe slot's <c>ItemKeys</c> list.
+/// <see cref="EntityRef.InternalName"/> carries the slot's keys '+'-joined; this
+/// target splits, runs <see cref="ItemKeywordQueryMapper"/>, and on success applies
+/// the resulting filter (clearing any prior <see cref="ItemsTabViewModel.SelectedItem"/>
+/// so the filtered list doesn't render with a stale selection).
+///
+/// Closes the symmetry started by <see cref="RecipeIngredientKeywordKindTarget"/>
+/// for the reverse direction (item-detail "Used as" chips).
+/// </summary>
+public sealed class ItemKeywordKindTarget : IReferenceKindTarget
+{
+    private readonly ItemsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public ItemKeywordKindTarget(ItemsTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.ItemKeyword;
+
+    public int TabIndex => 0; // Items tab
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var itemKeys = internalName.Split('+');
+        if (!ItemKeywordQueryMapper.TryBuildQuery(itemKeys, out var query))
+        {
+            // Defensive: the chip-builder is the gate (it doesn't emit a navigable chip
+            // when the mapper fails), so we only reach here if a deep-link or hand-built
+            // EntityRef snuck through with an unmappable slot.
+            _diag?.Info("Silmarillion.Nav", $"ItemKeyword.TrySelect '{internalName}' → unmappable, leaving Items tab unchanged.");
+            return false;
+        }
+
+        _diag?.Info("Silmarillion.Nav", $"ItemKeyword.TrySelect '{internalName}' → QueryText='{query}'.");
+        _vm.SelectedItem = null;
+        _vm.QueryText = query;
+        return true;
+    }
+
+    public bool TryOpenInWindow() => false;
+}

--- a/src/Silmarillion.Module/Navigation/ItemKeywordQueryMapper.cs
+++ b/src/Silmarillion.Module/Navigation/ItemKeywordQueryMapper.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// Translates a recipe slot's <c>ItemKeys</c> list into an Items-tab query fragment, when
+/// every key can be expressed against the existing <c>Item</c> query schema. All-or-nothing:
+/// if any key is unmappable, the whole slot fails so the chip stays non-navigable rather
+/// than emit a lossy filter.
+/// </summary>
+/// <remarks>
+/// v1 mapping rules:
+/// <list type="bullet">
+///   <item>Bare tag (no <c>:</c>) → <c>Keywords CONTAINS "tag"</c>.</item>
+///   <item><c>EquipmentSlot:X</c> → <c>EquipSlot = "X"</c> (lossless; <c>Item.EquipSlot</c> is queryable).</item>
+///   <item>Anything else with a <c>:</c> prefix (<c>MinTSysPrereq:N</c>, <c>MaxTSysPrereq:N</c>,
+///         <c>SkillPrereq:X</c>, <c>MinValue:N</c>, <c>MinRarity:X</c>) → fail. The synthesized
+///         keyword index from <c>ItemKeywordSynthesis.Enrich</c> isn't exposed to the Items query
+///         engine, and no direct <c>Item</c> property captures these prereq constraints today.</item>
+/// </list>
+/// </remarks>
+public static class ItemKeywordQueryMapper
+{
+    public static bool TryBuildQuery(IReadOnlyList<string> itemKeys, [NotNullWhen(true)] out string? query)
+    {
+        if (itemKeys.Count == 0)
+        {
+            query = null;
+            return false;
+        }
+
+        var fragments = new string[itemKeys.Count];
+        for (var i = 0; i < itemKeys.Count; i++)
+        {
+            if (!TryMapOne(itemKeys[i], out var fragment))
+            {
+                query = null;
+                return false;
+            }
+            fragments[i] = fragment;
+        }
+
+        query = string.Join(" AND ", fragments);
+        return true;
+    }
+
+    private static bool TryMapOne(string key, [NotNullWhen(true)] out string? fragment)
+    {
+        var colon = key.IndexOf(':');
+        if (colon < 0)
+        {
+            fragment = $"Keywords CONTAINS \"{key}\"";
+            return true;
+        }
+
+        var prefix = key.AsSpan(0, colon);
+        var value = key.AsSpan(colon + 1);
+        if (prefix.SequenceEqual("EquipmentSlot"))
+        {
+            fragment = $"EquipSlot = \"{value}\"";
+            return true;
+        }
+
+        fragment = null;
+        return false;
+    }
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -55,6 +55,9 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<IReferenceKindTarget>(sp => new RecipeIngredientKeywordKindTarget(
             sp.GetRequiredService<RecipesTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new ItemKeywordKindTarget(
+            sp.GetRequiredService<ItemsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
         services.AddSingleton<IDeepLinkHandler>(sp =>

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -4,6 +4,7 @@ using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
 using Mithril.Shared.Wpf.Query;
+using Silmarillion.Navigation;
 
 namespace Silmarillion.ViewModels;
 
@@ -176,15 +177,18 @@ public sealed partial class RecipesTabViewModel : ObservableObject
         _ => null,
     };
 
-    // Keyword-set ingredients ({"ItemKeys":[…]}) don't point at a single entity, so the chip is
-    // non-navigable. EntityChipVm.Reference is non-nullable; a sentinel EntityRef is safe because
-    // EntityChip only dereferences Reference inside its click handler, which is gated on IsNavigable.
-    private static readonly EntityRef KeywordSentinelRef = EntityRef.Item(string.Empty);
-
-    private static EntityChipVm BuildKeywordChip(RecipeKeywordIngredient kwIng)
+    // The chip's Reference is always the slot's keys encoded as EntityRef.ItemKeyword; IsNavigable
+    // gates two ways: (a) the kind target is registered with the navigator, AND (b) every slot key
+    // is mappable to a query clause via ItemKeywordQueryMapper. Either failing → inert chip, but the
+    // reference is still well-formed so a future mapping/registration expansion flips the chip live
+    // with no chip-builder change.
+    private EntityChipVm BuildKeywordChip(RecipeKeywordIngredient kwIng)
     {
         var label = kwIng.Desc ?? $"any {ItemKeywordIndex.Humanise(kwIng.ItemKeys)}";
-        return new EntityChipVm(label, IconId: 0, Reference: KeywordSentinelRef, IsNavigable: false);
+        var reference = EntityRef.ItemKeyword(kwIng.ItemKeys);
+        var canMap = ItemKeywordQueryMapper.TryBuildQuery(kwIng.ItemKeys, out _);
+        var isNavigable = canMap && _navigator.CanOpen(reference);
+        return new EntityChipVm(label, IconId: 0, Reference: reference, IsNavigable: isNavigable);
     }
 
     private IReadOnlyList<EntityChipVm> BuildProducedChips(Recipe recipe)

--- a/tests/Mithril.Shared.Tests/Reference/EntityRefTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/EntityRefTests.cs
@@ -14,4 +14,33 @@ public class EntityRefTests
         reference.Kind.Should().Be(EntityKind.RecipeIngredientKeyword);
         reference.InternalName.Should().Be("Crystal");
     }
+
+    [Fact]
+    public void ItemKeyword_singleton_factory_produces_kind_and_internalname()
+    {
+        var reference = EntityRef.ItemKeyword("Crystal");
+
+        reference.Kind.Should().Be(EntityKind.ItemKeyword);
+        reference.InternalName.Should().Be("Crystal");
+    }
+
+    [Fact]
+    public void ItemKeyword_list_factory_joins_keys_with_plus()
+    {
+        // The slot's ItemKeys are encoded into EntityRef.InternalName as a "+"-joined
+        // string so a single EntityKind can carry both singleton and composite slots.
+        // '+' is safe because no ItemKeys value in recipes.json contains '+'.
+        var reference = EntityRef.ItemKeyword(["EquipmentSlot:MainHand", "MinTSysPrereq:0"]);
+
+        reference.Kind.Should().Be(EntityKind.ItemKeyword);
+        reference.InternalName.Should().Be("EquipmentSlot:MainHand+MinTSysPrereq:0");
+    }
+
+    [Fact]
+    public void ItemKeyword_list_factory_with_single_key_round_trips_to_singleton_form()
+    {
+        // A one-element list and the singleton overload should produce the same
+        // InternalName, so callers can construct either way without ambiguity.
+        EntityRef.ItemKeyword(["Crystal"]).Should().Be(EntityRef.ItemKeyword("Crystal"));
+    }
 }

--- a/tests/Silmarillion.Tests/Navigation/ItemKeywordQueryMapperTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/ItemKeywordQueryMapperTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Silmarillion.Navigation;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class ItemKeywordQueryMapperTests
+{
+    [Fact]
+    public void Singleton_bare_tag_maps_to_keywords_contains()
+    {
+        var success = ItemKeywordQueryMapper.TryBuildQuery(["Crystal"], out var query);
+
+        success.Should().BeTrue();
+        query.Should().Be("Keywords CONTAINS \"Crystal\"");
+    }
+
+    [Fact]
+    public void Singleton_EquipmentSlot_token_maps_to_EquipSlot_equality()
+    {
+        // EquipmentSlot:X is a synthesized matcher key (see ItemKeywordSynthesis.Enrich),
+        // but Item.EquipSlot is a direct string property — so the chip click can produce
+        // a clean equality query against the existing schema.
+        var success = ItemKeywordQueryMapper.TryBuildQuery(["EquipmentSlot:MainHand"], out var query);
+
+        success.Should().BeTrue();
+        query.Should().Be("EquipSlot = \"MainHand\"");
+    }
+
+    [Fact]
+    public void Composite_of_mappable_tokens_AND_joins_fragments()
+    {
+        var success = ItemKeywordQueryMapper.TryBuildQuery(
+            ["EquipmentSlot:MainHand", "Crystal"],
+            out var query);
+
+        success.Should().BeTrue();
+        query.Should().Be("EquipSlot = \"MainHand\" AND Keywords CONTAINS \"Crystal\"");
+    }
+
+    [Fact]
+    public void Unmappable_token_fails_the_whole_slot()
+    {
+        // All-or-nothing: if any key in the slot can't be translated to a query clause,
+        // the chip stays non-navigable rather than emit a lossy filter. MinTSysPrereq:N
+        // has no item-side analogue today, so this real catalog pattern stays inert.
+        var success = ItemKeywordQueryMapper.TryBuildQuery(
+            ["EquipmentSlot:MainHand", "MinTSysPrereq:0"],
+            out var query);
+
+        success.Should().BeFalse();
+        query.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("MinTSysPrereq:0")]
+    [InlineData("MaxTSysPrereq:60")]
+    [InlineData("SkillPrereq:Archery")]
+    [InlineData("MinValue:1000")]
+    [InlineData("MinRarity:Rare")]
+    public void Known_unmappable_prefixes_fail(string token)
+    {
+        var success = ItemKeywordQueryMapper.TryBuildQuery([token], out var query);
+
+        success.Should().BeFalse();
+        query.Should().BeNull();
+    }
+
+    [Fact]
+    public void Empty_slot_fails()
+    {
+        // Defensive: a slot with no keys can't produce a meaningful filter.
+        var success = ItemKeywordQueryMapper.TryBuildQuery([], out var query);
+
+        success.Should().BeFalse();
+        query.Should().BeNull();
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -239,6 +239,85 @@ public sealed class SilmarillionReferenceNavigatorTests
     }
 
     [Fact]
+    public void Open_ItemKeyword_SwitchesToItemsTab_AndSetsQueryText()
+    {
+        var refData = new FakeReferenceData();
+        var navStub = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var itemsVm = new ItemsTabViewModel(refData, navStub);
+        var keywordTarget = new ItemKeywordKindTarget(itemsVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            keywordTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(items: itemsVm, recipes: null!, nav, targets);
+
+        nav.Open(EntityRef.ItemKeyword("Crystal"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(0);
+        itemsVm.QueryText.Should().Be("Keywords CONTAINS \"Crystal\"");
+    }
+
+    [Fact]
+    public void Open_ItemKeyword_CompositeSlotWithEquipmentSlot_SetsAndJoinedQuery()
+    {
+        // Composite slot every key of which is mappable → AND-joined fragments.
+        // Validates the EntityRef.ItemKeyword(IReadOnlyList<string>) overload encodes
+        // the slot as '+'-joined InternalName and the kind target reconstitutes it.
+        var refData = new FakeReferenceData();
+        var navStub = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var itemsVm = new ItemsTabViewModel(refData, navStub);
+        var keywordTarget = new ItemKeywordKindTarget(itemsVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            keywordTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        _ = new SilmarillionViewModel(items: itemsVm, recipes: null!, nav, targets);
+
+        nav.Open(EntityRef.ItemKeyword(["EquipmentSlot:MainHand", "Crystal"]));
+
+        itemsVm.QueryText.Should().Be("EquipSlot = \"MainHand\" AND Keywords CONTAINS \"Crystal\"");
+    }
+
+    [Fact]
+    public void Open_ItemKeyword_ClearsResidualSelectedItem()
+    {
+        // Keyword-chip navigation expresses a *filter*, not a specific item pick. Any
+        // SelectedItem lingering from earlier in-tab navigation must clear so the new
+        // filtered list doesn't render with a stale (and possibly filter-excluded)
+        // selection.
+        var refData = new FakeReferenceData();
+        refData.AddItem(new Item { Id = 100, InternalName = "RawCrystal", Name = "Raw Crystal" });
+        var navStub = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var itemsVm = new ItemsTabViewModel(refData, navStub);
+        itemsVm.SelectedItem = itemsVm.AllItems.Single();
+        itemsVm.SelectedItem.Should().NotBeNull(); // precondition
+
+        var keywordTarget = new ItemKeywordKindTarget(itemsVm);
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            keywordTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        _ = new SilmarillionViewModel(items: itemsVm, recipes: null!, nav, targets);
+
+        nav.Open(EntityRef.ItemKeyword("Crystal"));
+
+        itemsVm.SelectedItem.Should().BeNull(
+            because: "keyword-chip navigation is a filter action; prior item selection must clear");
+        itemsVm.QueryText.Should().Be("Keywords CONTAINS \"Crystal\"");
+    }
+
+    [Fact]
     public void Open_RecipeIngredientKeyword_ClearsResidualSelectedRow()
     {
         // Keyword-chip navigation expresses a *filter*, not a specific recipe pick. Any
@@ -288,6 +367,8 @@ public sealed class SilmarillionReferenceNavigatorTests
     {
         private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
         private readonly Dictionary<string, Recipe> _recipesByInternalName = new(StringComparer.Ordinal);
+        private readonly Dictionary<long, Item> _itemsById = new();
+        private readonly Dictionary<string, Item> _itemsByInternalName = new(StringComparer.Ordinal);
 
         public void AddRecipe(Recipe recipe)
         {
@@ -295,10 +376,16 @@ public sealed class SilmarillionReferenceNavigatorTests
             if (recipe.InternalName is not null) _recipesByInternalName[recipe.InternalName] = recipe;
         }
 
+        public void AddItem(Item item)
+        {
+            _itemsById[item.Id] = item;
+            if (item.InternalName is not null) _itemsByInternalName[item.InternalName] = item;
+        }
+
         public IReadOnlyList<string> Keys => Array.Empty<string>();
-        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
-        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
-        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<long, Item> Items => _itemsById;
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByInternalName;
+        public ItemKeywordIndex KeywordIndex => new(_itemsById);
         public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
         public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _recipesByInternalName;
         public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();

--- a/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
@@ -196,6 +196,94 @@ public sealed class RecipesTabViewModelTests
     }
 
     [Fact]
+    public void IngredientChips_SingletonKeywordSlot_WithItemKeywordKindRegistered_IsNavigable()
+    {
+        // Symmetric to the item-detail "Used as" chip → recipe-tab filter direction
+        // (PR #267): a recipe's singleton keyword slot now navigates back to the Items
+        // tab filtered by that keyword. Chip stays inert (existing test above) when
+        // the ItemKeyword kind isn't registered with the navigator.
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "EnchantCrystal",
+            Name = "Enchant Crystal",
+            Skill = "Enchanting",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], Desc = "Auxiliary Crystal", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData { RecipesByKey = { ["r1"] = recipe } };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword));
+
+        vm.SelectedRecipe = recipe;
+
+        var chip = vm.DetailViewModel!.Ingredients.Single();
+        chip.IsNavigable.Should().BeTrue();
+        chip.Reference.Should().Be(EntityRef.ItemKeyword("Crystal"));
+        chip.DisplayName.Should().Be("Auxiliary Crystal");
+    }
+
+    [Fact]
+    public void IngredientChips_CompositeKeywordSlot_AllMappable_IsNavigable()
+    {
+        // Composite slot every key of which is translatable (bare tag + EquipmentSlot:)
+        // → mapper succeeds → AND-joined query, chip is navigable. Today's catalogue
+        // doesn't ship a slot of this exact shape but the mapping covers any future one.
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "Hypothetical",
+            Name = "Hypothetical",
+            Skill = "Augmentation",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["EquipmentSlot:MainHand", "Crystal"], Desc = "Crystal Main-Hand", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData { RecipesByKey = { ["r1"] = recipe } };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword));
+
+        vm.SelectedRecipe = recipe;
+
+        var chip = vm.DetailViewModel!.Ingredients.Single();
+        chip.IsNavigable.Should().BeTrue();
+        chip.Reference.Should().Be(EntityRef.ItemKeyword(["EquipmentSlot:MainHand", "Crystal"]));
+        chip.DisplayName.Should().Be("Crystal Main-Hand");
+    }
+
+    [Fact]
+    public void IngredientChips_CompositeKeywordSlot_WithUnmappableKey_StaysNonNavigable()
+    {
+        // Real catalogue pattern: Decompose Main-Hand Weapon's slot is
+        // ["EquipmentSlot:MainHand", "MinTSysPrereq:0"]. MinTSysPrereq:N has no item-side
+        // analogue today, so the mapper fails and the chip stays inert even with the
+        // ItemKeyword kind target registered. The Reference is still emitted so a future
+        // mapping expansion (e.g. item-side TSys prereq exposure) flips the chip live
+        // with no chip-builder change.
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "DecomposeMainHand",
+            Name = "Decompose Main-Hand Weapon",
+            Skill = "WeaponAugmentBrewing",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["EquipmentSlot:MainHand", "MinTSysPrereq:0"], Desc = "Main-Hand Item", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData { RecipesByKey = { ["r1"] = recipe } };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword));
+
+        vm.SelectedRecipe = recipe;
+
+        var chip = vm.DetailViewModel!.Ingredients.Single();
+        chip.IsNavigable.Should().BeFalse(because: "MinTSysPrereq:0 has no item-side mapping");
+        chip.Reference.Should().Be(EntityRef.ItemKeyword(["EquipmentSlot:MainHand", "MinTSysPrereq:0"]));
+        chip.DisplayName.Should().Be("Main-Hand Item");
+    }
+
+    [Fact]
     public void IngredientChips_KeywordIngredient_WithoutDesc_FallsBackToHumanisedItemKeys()
     {
         var recipe = new Recipe


### PR DESCRIPTION
Closes #270.

## Summary

Closes the forward symmetry started by PR #267 / #259. A recipe's keyword ingredient slot now renders as a navigable chip when every key in the slot is translatable to an Items-tab query clause. Clicking the "Crystal" slot on an enchanting recipe flips to the Items tab with `Keywords CONTAINS "Crystal"` pre-filled.

## What changed

- **New `EntityKind.ItemKeyword`** (and `EntityRef.ItemKeyword(string)` / `EntityRef.ItemKeyword(IReadOnlyList<string>)` factories). Encodes the slot's `ItemKeys` as `+`-joined into `InternalName` — `+` is safe (no `ItemKeys` value in `recipes.json` contains it).
- **New `ItemKeywordQueryMapper`** — all-or-nothing slot-to-query translation:
  - bare tag (no `:`) → `Keywords CONTAINS "tag"`
  - `EquipmentSlot:X` → `EquipSlot = "X"` (lossless; `Item.EquipSlot` is a direct queryable property)
  - anything else → fail; chip stays inert
- **New `ItemKeywordKindTarget`** — Items-tab dispatch sibling of `RecipeIngredientKeywordKindTarget`. Clears `SelectedItem` then sets `QueryText`.
- **`RecipesTabViewModel.BuildKeywordChip`** is now an instance method that emits the real `EntityRef.ItemKeyword(ItemKeys)`; `IsNavigable` is the AND of mapper-succeeds and `navigator.CanOpen`. No more sentinel ref.

## Composite-tuple slots

Real catalogue composite slots like `[EquipmentSlot:MainHand, MinTSysPrereq:0]` (the augmentation / decompose family) stay non-navigable because `MinTSysPrereq:*` has no item-side analogue today. The `EntityRef.ItemKeyword(...)` is still well-formed on the chip, so a future mapping expansion can promote them with no chip-builder change.

The plan's original Open Question called for keeping all composite slots non-navigable; during refinement we resolved this to *"navigate iff every key is mappable"*, which is a strict superset (covers any future composite of bare tags + `EquipmentSlot:`) and stays honest about today's catalogue (no silent lossy filters).

## Test Plan

- [x] `dotnet build Mithril.slnx` — 0 errors, 0 warnings (warnings-as-errors enforced)
- [x] `dotnet test Mithril.slnx` — 1983/1983 passing
  - 6 new `ItemKeywordQueryMapper` tests (bare-tag, `EquipmentSlot:` map, AND-join, all-unmappable-prefix theory cases, empty slot)
  - 3 new navigator `Open_ItemKeyword_*` tests (tab switch + query, AND-joined composite, residual `SelectedItem` clear)
  - 3 new `RecipesTabViewModel` chip tests (singleton navigable, composite all-mappable navigable, composite-with-`MinTSysPrereq` stays inert)
  - 3 new `EntityRefTests` (singleton factory, list-factory `+`-join, singleton/list round-trip equality)
- [ ] Manual smoke test in `dotnet run --project src/Mithril.Shell`:
  - Open an enchanting recipe (e.g. any `*E` / `*Max` recipe) → "Crystal" chip should be clickable (hover highlight, hand cursor)
  - Click → Items tab opens, query box reads `Keywords CONTAINS "Crystal"`, filtered list shows every Crystal
  - Compose with `AND Skill = "..."` etc.
  - Open `Decompose Main-Hand Weapon` (recipe_10501) → "Main-Hand Item" chip stays text-only (non-clickable) because `MinTSysPrereq:0` is unmappable

## Plan

[`docs/agent-plans/silmarillion-recipe-keyword-chip-to-items-filter.md`](../blob/feat/270-recipe-keyword-chip-to-items-filter/docs/agent-plans/silmarillion-recipe-keyword-chip-to-items-filter.md)

— drafted by Claude (Opus 4.7), posted by @arthur-conde