### PR TITLE
Lift tab style app-wide via MVVM ItemsSource refactor — #233

### DIFF
--- a/src/Arwen.Module/ArwenModule.cs
+++ b/src/Arwen.Module/ArwenModule.cs
@@ -89,29 +89,26 @@ public sealed class ArwenModule : IMithrilModule
         services.AddSingleton<StorageGiftsViewModel>();
         services.AddSingleton<CalibrationViewModel>();
 
-        // Holder is constructed early; .Inner is wired below once FavorView exists.
-        // VMs depend on IFavorViewNavigator (the holder) so DI doesn't loop back into FavorView.
+        // Holder is constructed early; .Inner is wired below once FavorShellViewModel exists.
+        // VMs depend on IFavorViewNavigator (the holder) so DI doesn't loop back into the shell VM.
         services.AddSingleton<FavorViewNavigatorHolder>();
         services.AddSingleton<IFavorViewNavigator>(sp => sp.GetRequiredService<FavorViewNavigatorHolder>());
 
-        services.AddSingleton<FavorView>(sp =>
+        services.AddSingleton<FavorShellViewModel>(sp =>
         {
-            var view = new FavorView();
-            view.AddTab("NPC Dashboard", new NpcDashboardTab { DataContext = sp.GetRequiredService<FavorDashboardViewModel>() });
-            view.AddTab("Favor Calculator", new FavorCalculatorTab { DataContext = sp.GetRequiredService<FavorCalculatorViewModel>() });
-            view.AddTab("Gift Scanner", new GiftScannerTab { DataContext = sp.GetRequiredService<GiftScannerViewModel>() });
-            view.AddTab("Item Lookup", new ItemLookupTab { DataContext = sp.GetRequiredService<ItemLookupViewModel>() });
-            view.AddTab("Storage Gifts", new StorageGiftsTab { DataContext = sp.GetRequiredService<StorageGiftsViewModel>() });
-            var calibrationVm = sp.GetRequiredService<CalibrationViewModel>();
-            view.AddTab("Calibration", new CalibrationTab { DataContext = calibrationVm });
-            // Editor shares the same VM — every change recomputes rates via the VM's Refresh()
-            // wired to CalibrationService.DataChanged, so both tabs stay in sync automatically.
-            // Pending observations live here too, so the PendingCount badge follows.
-            var editorTab = view.AddTab("Edit Observations", new ObservationsEditorTab { DataContext = calibrationVm });
-            editorTab.SetBinding(TabBadge.CountProperty,
-                new System.Windows.Data.Binding(nameof(CalibrationViewModel.PendingCount)) { Source = calibrationVm });
-            sp.GetRequiredService<FavorViewNavigatorHolder>().Inner = view;
-            return view;
+            var shell = new FavorShellViewModel(
+                sp.GetRequiredService<FavorDashboardViewModel>(),
+                sp.GetRequiredService<FavorCalculatorViewModel>(),
+                sp.GetRequiredService<GiftScannerViewModel>(),
+                sp.GetRequiredService<ItemLookupViewModel>(),
+                sp.GetRequiredService<StorageGiftsViewModel>(),
+                sp.GetRequiredService<CalibrationViewModel>());
+            sp.GetRequiredService<FavorViewNavigatorHolder>().Inner = shell;
+            return shell;
+        });
+        services.AddSingleton<FavorView>(sp => new FavorView
+        {
+            DataContext = sp.GetRequiredService<FavorShellViewModel>(),
         });
         services.AddSingleton<ArwenSettingsView>(sp => new ArwenSettingsView
         {

--- a/src/Arwen.Module/ViewModels/FavorShellViewModel.cs
+++ b/src/Arwen.Module/ViewModels/FavorShellViewModel.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Shared.Wpf;
+
+namespace Arwen.ViewModels;
+
+/// <summary>
+/// Composes Arwen's tabs as VM data for <c>TabControl.ItemsSource</c> binding,
+/// and serves as the cross-tab navigator (<see cref="IFavorViewNavigator"/>)
+/// so child VMs can ask the shell to switch tabs and hand off context.
+/// <para>
+/// Calibration and "Edit Observations" share <see cref="CalibrationViewModel"/>
+/// state but render through different views; the latter is wrapped in
+/// <see cref="ObservationsEditorViewModel"/> so DataTemplate-by-type can
+/// distinguish them.
+/// </para>
+/// <para>
+/// The "Edit Observations" tab's badge count mirrors
+/// <see cref="CalibrationViewModel.PendingCount"/>; updates flow via a
+/// <see cref="INotifyPropertyChanged"/> subscription wired in the constructor.
+/// </para>
+/// </summary>
+public sealed partial class FavorShellViewModel : ObservableObject, IFavorViewNavigator
+{
+    private readonly GiftScannerViewModel _giftScanner;
+
+    [ObservableProperty]
+    private object? selectedTab;
+
+    public IReadOnlyList<ModuleTab> Tabs { get; }
+
+    public FavorShellViewModel(
+        FavorDashboardViewModel dashboard,
+        FavorCalculatorViewModel calculator,
+        GiftScannerViewModel giftScanner,
+        ItemLookupViewModel itemLookup,
+        StorageGiftsViewModel storageGifts,
+        CalibrationViewModel calibration)
+    {
+        _giftScanner = giftScanner;
+
+        var editor = new ObservationsEditorViewModel(calibration);
+        var editorTab = new ModuleTab("Edit Observations", editor, badgeCount: calibration.PendingCount);
+
+        // Pending observations live on CalibrationViewModel; keep the badge
+        // count on the editor tab in sync with it.
+        calibration.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(CalibrationViewModel.PendingCount))
+                editorTab.BadgeCount = calibration.PendingCount;
+        };
+
+        Tabs = new[]
+        {
+            new ModuleTab("NPC Dashboard",     dashboard),
+            new ModuleTab("Favor Calculator",  calculator),
+            new ModuleTab("Gift Scanner",      giftScanner),
+            new ModuleTab("Item Lookup",       itemLookup),
+            new ModuleTab("Storage Gifts",     storageGifts),
+            new ModuleTab("Calibration",       calibration),
+            editorTab,
+        };
+
+        selectedTab = Tabs[0];
+    }
+
+    /// <inheritdoc/>
+    public void OpenInGiftScanner(string npcKey)
+    {
+        var tab = Tabs.FirstOrDefault(t => t.Content is GiftScannerViewModel);
+        if (tab is null) return;
+
+        SelectedTab = tab;
+
+        var entry = _giftScanner.NpcList.FirstOrDefault(e => e.NpcKey == npcKey);
+        if (entry is not null) _giftScanner.SelectedNpc = entry;
+    }
+}

--- a/src/Arwen.Module/ViewModels/ObservationsEditorViewModel.cs
+++ b/src/Arwen.Module/ViewModels/ObservationsEditorViewModel.cs
@@ -1,0 +1,13 @@
+namespace Arwen.ViewModels;
+
+/// <summary>
+/// Marker VM that wraps <see cref="CalibrationViewModel"/> so the
+/// "Edit Observations" tab can be distinguished from the "Calibration" tab
+/// by DataTemplate type even though both surfaces share the same underlying
+/// view-model state. The <c>FavorView</c>'s DataTemplate unwraps this back
+/// to the inner <see cref="Calibration"/> instance for the actual
+/// <c>ObservationsEditorTab</c> view, so existing <c>{Binding X}</c>
+/// expressions inside that view continue to resolve against
+/// <see cref="CalibrationViewModel"/> unchanged.
+/// </summary>
+public sealed record ObservationsEditorViewModel(CalibrationViewModel Calibration);

--- a/src/Arwen.Module/Views/FavorView.xaml
+++ b/src/Arwen.Module/Views/FavorView.xaml
@@ -1,10 +1,14 @@
 <UserControl x:Class="Arwen.Views.FavorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:vm="clr-namespace:Arwen.ViewModels"
+             xmlns:local="clr-namespace:Arwen.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:FavorShellViewModel}"
              Background="#FF1A1A1A">
 
     <UserControl.Resources>
@@ -12,11 +16,35 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:FavorDashboardViewModel}">
+                <local:NpcDashboardTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:FavorCalculatorViewModel}">
+                <local:FavorCalculatorTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:GiftScannerViewModel}">
+                <local:GiftScannerTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:ItemLookupViewModel}">
+                <local:ItemLookupTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:StorageGiftsViewModel}">
+                <local:StorageGiftsTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:CalibrationViewModel}">
+                <local:CalibrationTab/>
+            </DataTemplate>
+            <!-- Editor and Calibration share VM state but render different views;
+                 the wrapper distinguishes them by type. Unwrap to the inner VM
+                 so the existing ObservationsEditorTab bindings keep working. -->
+            <DataTemplate DataType="{x:Type vm:ObservationsEditorViewModel}">
+                <local:ObservationsEditorTab DataContext="{Binding Calibration}"/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
     <DockPanel Margin="12">
-        <!-- Header -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal">
                 <Image Source="pack://application:,,,/Arwen.Module;component/Resources/arwen.ico"
@@ -26,7 +54,20 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0"
-                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"/>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    SelectedItem="{Binding SelectedTab, Mode=TwoWay}"
+                    Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ItemContainerStyle>
+                <Style TargetType="TabItem" BasedOn="{StaticResource MithrilTabItemStyle}">
+                    <Setter Property="c:TabBadge.Count" Value="{Binding BadgeCount}"/>
+                </Style>
+            </TabControl.ItemContainerStyle>
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
+        </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Arwen.Module/Views/FavorView.xaml.cs
+++ b/src/Arwen.Module/Views/FavorView.xaml.cs
@@ -1,54 +1,11 @@
-using System.Windows;
 using System.Windows.Controls;
-using Arwen.ViewModels;
 
 namespace Arwen.Views;
 
-public partial class FavorView : UserControl, IFavorViewNavigator
+public partial class FavorView : UserControl
 {
     public FavorView()
     {
         InitializeComponent();
-    }
-
-    /// <summary>
-    /// Adds a tab with its DataContext already set, and returns the created
-    /// <see cref="TabItem"/> so callers can attach a notification badge via
-    /// <c>Mithril.Shared.Wpf.TabBadge.SetCount(item, n)</c> or bind it to a VM
-    /// property. Called by ArwenModule during DI registration so each tab
-    /// has its ViewModel before any bindings are evaluated.
-    /// </summary>
-    public TabItem AddTab(string header, UserControl content)
-    {
-        var tab = new TabItem
-        {
-            Header = header,
-            Content = content,
-            Margin = new System.Windows.Thickness(0, 8, 0, 0),
-        };
-        Tabs.Items.Add(tab);
-        return tab;
-    }
-
-    /// <summary>
-    /// Switches to the Gift Scanner tab and tells its VM to focus the given NPC.
-    /// Silent no-op if the tab isn't registered or the NPC isn't in the dropdown
-    /// (player hasn't met them yet).
-    /// </summary>
-    public void OpenInGiftScanner(string npcKey)
-    {
-        foreach (TabItem tab in Tabs.Items)
-        {
-            if (tab.Header is not string header || header != "Gift Scanner") continue;
-
-            Tabs.SelectedItem = tab;
-
-            if (tab.Content is FrameworkElement fe && fe.DataContext is GiftScannerViewModel vm)
-            {
-                var entry = vm.NpcList.FirstOrDefault(e => e.NpcKey == npcKey);
-                if (entry is not null) vm.SelectedNpc = entry;
-            }
-            return;
-        }
     }
 }

--- a/src/Bilbo.Module/BilboModule.cs
+++ b/src/Bilbo.Module/BilboModule.cs
@@ -4,9 +4,7 @@ using Bilbo.ViewModels;
 using Bilbo.Views;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Modules;
-using Mithril.Shared.Wpf;
 using MahApps.Metro.IconPacks;
-using Mithril.Shared.Settings;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bilbo;
@@ -14,7 +12,7 @@ namespace Bilbo;
 public sealed class BilboModule : IMithrilModule
 {
     public string Id => "bilbo";
-    public string DisplayName => "Bilbo \u00b7 Storage";
+    public string DisplayName => "Bilbo · Storage";
     public PackIconLucideKind Icon => PackIconLucideKind.Package;
     public string? IconUri => "pack://application:,,,/Bilbo.Module;component/Resources/bilbo.ico";
     public int SortOrder => 400;
@@ -30,12 +28,12 @@ public sealed class BilboModule : IMithrilModule
         services.AddMithrilSettings<BilboSettings>(settingsPath, BilboSettingsJsonContext.Default.BilboSettings);
 
         services.AddSingleton<StorageViewModel>();
-        services.AddSingleton<StorageView>(sp => new StorageView(
-            sp.GetRequiredService<BilboSettings>(),
-            sp.GetRequiredService<SettingsAutoSaver<BilboSettings>>(),
-            sp.GetRequiredService<IItemDetailPresenter>())
+        services.AddSingleton<InventoryTabViewModel>();
+        services.AddSingleton<CraftableRecipesTabViewModel>();
+        services.AddSingleton<BilboShellViewModel>();
+        services.AddSingleton<StorageView>(sp => new StorageView
         {
-            DataContext = sp.GetRequiredService<StorageViewModel>(),
+            DataContext = sp.GetRequiredService<BilboShellViewModel>(),
         });
     }
 }

--- a/src/Bilbo.Module/ViewModels/BilboShellViewModel.cs
+++ b/src/Bilbo.Module/ViewModels/BilboShellViewModel.cs
@@ -1,0 +1,35 @@
+using Mithril.Shared.Wpf;
+
+namespace Bilbo.ViewModels;
+
+/// <summary>
+/// Composes Bilbo's tabs as VM data so the View can bind
+/// <c>TabControl.ItemsSource</c> rather than hard-coding TabItems in XAML.
+/// Tab views are picked by <c>DataTemplate</c>s keyed on each tab VM's type.
+/// <para>
+/// Both tabs share the same <see cref="Storage"/> VM but render through
+/// different views; the wrapper VMs (<see cref="InventoryTabViewModel"/> /
+/// <see cref="CraftableRecipesTabViewModel"/>) exist solely so DataTemplate-
+/// by-type can distinguish them. The shell exposes <see cref="Storage"/>
+/// directly too so the surrounding chrome (refresh button, status bar) can
+/// bind to it via <c>{Binding Storage.X}</c>.
+/// </para>
+/// </summary>
+public sealed class BilboShellViewModel
+{
+    public StorageViewModel Storage { get; }
+    public IReadOnlyList<ModuleTab> Tabs { get; }
+
+    public BilboShellViewModel(
+        StorageViewModel storage,
+        InventoryTabViewModel inventory,
+        CraftableRecipesTabViewModel recipes)
+    {
+        Storage = storage;
+        Tabs = new[]
+        {
+            new ModuleTab("Inventory", inventory),
+            new ModuleTab("Craftable Recipes", recipes),
+        };
+    }
+}

--- a/src/Bilbo.Module/ViewModels/CraftableRecipesTabViewModel.cs
+++ b/src/Bilbo.Module/ViewModels/CraftableRecipesTabViewModel.cs
@@ -1,0 +1,9 @@
+namespace Bilbo.ViewModels;
+
+/// <summary>
+/// Wraps the shared <see cref="StorageViewModel"/> for the Craftable Recipes
+/// tab. Exposed as a distinct VM type so DataTemplate-by-type selects the
+/// recipes view rather than the inventory view (both share the same
+/// underlying VM).
+/// </summary>
+public sealed record CraftableRecipesTabViewModel(StorageViewModel Storage);

--- a/src/Bilbo.Module/ViewModels/InventoryTabViewModel.cs
+++ b/src/Bilbo.Module/ViewModels/InventoryTabViewModel.cs
@@ -1,0 +1,33 @@
+using Bilbo.Domain;
+using Mithril.Shared.Settings;
+using Mithril.Shared.Wpf;
+
+namespace Bilbo.ViewModels;
+
+/// <summary>
+/// Wraps the shared <see cref="StorageViewModel"/> for the Inventory tab and
+/// carries the view-side services that <c>InventoryTab</c>'s code-behind needs
+/// to wire its <c>MithrilDataGrid</c> column-state persistence and item-detail
+/// double-click handler. Exposed as a distinct VM type so the parent view's
+/// DataTemplate-by-type selector renders the Inventory view rather than the
+/// Recipes view (both tabs share <see cref="Storage"/>).
+/// </summary>
+public sealed class InventoryTabViewModel
+{
+    public StorageViewModel Storage { get; }
+    public BilboSettings Settings { get; }
+    public SettingsAutoSaver<BilboSettings> Saver { get; }
+    public IItemDetailPresenter ItemDetail { get; }
+
+    public InventoryTabViewModel(
+        StorageViewModel storage,
+        BilboSettings settings,
+        SettingsAutoSaver<BilboSettings> saver,
+        IItemDetailPresenter itemDetail)
+    {
+        Storage = storage;
+        Settings = settings;
+        Saver = saver;
+        ItemDetail = itemDetail;
+    }
+}

--- a/src/Bilbo.Module/Views/CraftableRecipesTab.xaml
+++ b/src/Bilbo.Module/Views/CraftableRecipesTab.xaml
@@ -1,0 +1,117 @@
+<UserControl x:Class="Bilbo.Views.CraftableRecipesTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Bilbo.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:CraftableRecipesTabViewModel}"
+             Background="#FF1A1A1A">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel DataContext="{Binding Storage}">
+        <DockPanel DockPanel.Dock="Top" Margin="0,8,0,8">
+            <TextBlock Text="Confidence:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <ComboBox Width="170" Margin="0,0,16,0"
+                      ItemsSource="{Binding ConfidenceOptions}"
+                      DisplayMemberPath="Label"
+                      SelectedValuePath="Value"
+                      SelectedValue="{Binding Confidence}"/>
+            <wpf:MithrilQueryBox Grid="{Binding ElementName=RecipesGrid}"
+                                QueryText="{Binding RecipeQueryText, Mode=TwoWay}"
+                                Watermark="e.g. MaxCraftable &gt; 0 AND IsKnown AND SkillLevelMet"/>
+        </DockPanel>
+        <wpf:MithrilDataGrid x:Name="RecipesGrid"
+                            ItemsSource="{Binding CraftableRecipes}"
+                            QueryText="{Binding RecipeQueryText, Mode=TwoWay}"
+                            Mode="ReadOnly">
+            <wpf:MithrilDataGrid.Columns>
+                <DataGridTemplateColumn Header="Recipe" Width="*" MinWidth="200" SortMemberPath="Name">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Skill" Binding="{Binding Skill}" SortMemberPath="Skill" Width="110"/>
+                <DataGridTextColumn Header="Req" Binding="{Binding SkillLevelReq}" SortMemberPath="SkillLevelReq" Width="45">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Char Lvl" Binding="{Binding CharacterSkillLevel, Converter={StaticResource NullDash}}" SortMemberPath="CharacterSkillLevel" Width="60">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridCheckBoxColumn Header="Met" Binding="{Binding SkillLevelMet}" SortMemberPath="SkillLevelMet" Width="45"/>
+                <DataGridCheckBoxColumn Header="Known" Binding="{Binding IsKnown}" SortMemberPath="IsKnown" Width="55"/>
+                <DataGridTextColumn Header="Done" Binding="{Binding TimesCompleted}" SortMemberPath="TimesCompleted" Width="50">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Max" Binding="{Binding MaxCraftable}" SortMemberPath="MaxCraftable" Width="60">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                            <Setter Property="FontWeight" Value="SemiBold"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Result" Binding="{Binding ResultItem}" SortMemberPath="ResultItem" Width="*" MinWidth="160"/>
+            </wpf:MithrilDataGrid.Columns>
+            <wpf:MithrilDataGrid.RowStyle>
+                <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
+                    <Setter Property="ToolTip">
+                        <Setter.Value>
+                            <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
+                                     Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <ToolTip.ContentTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
+                                                CornerRadius="4" Padding="10" MaxWidth="380">
+                                            <StackPanel>
+                                                <DockPanel Margin="0,0,0,6">
+                                                    <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                                   Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
+                                                    <TextBlock Text="{Binding Name}" FontWeight="Bold"
+                                                               Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}"
+                                                               TextWrapping="Wrap" VerticalAlignment="Center"/>
+                                                </DockPanel>
+                                                <TextBlock Text="Ingredients" Foreground="#88FFFFFF"
+                                                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,2"/>
+                                                <TextBlock Text="{Binding Ingredients}" Foreground="#FFE8E8E8"
+                                                           TextWrapping="Wrap" Margin="0,0,0,4"/>
+                                                <TextBlock Text="Missing" Foreground="#88FFFFFF"
+                                                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,2"
+                                                           Visibility="{Binding MissingIngredients, Converter={StaticResource NonEmptyToVisible}}"/>
+                                                <TextBlock Text="{Binding MissingIngredients}" Foreground="#FFE09090"
+                                                           TextWrapping="Wrap"
+                                                           Visibility="{Binding MissingIngredients, Converter={StaticResource NonEmptyToVisible}}"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ToolTip.ContentTemplate>
+                            </ToolTip>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </wpf:MithrilDataGrid.RowStyle>
+        </wpf:MithrilDataGrid>
+    </DockPanel>
+</UserControl>

--- a/src/Bilbo.Module/Views/CraftableRecipesTab.xaml.cs
+++ b/src/Bilbo.Module/Views/CraftableRecipesTab.xaml.cs
@@ -2,9 +2,9 @@ using System.Windows.Controls;
 
 namespace Bilbo.Views;
 
-public partial class StorageView : UserControl
+public partial class CraftableRecipesTab : UserControl
 {
-    public StorageView()
+    public CraftableRecipesTab()
     {
         InitializeComponent();
     }

--- a/src/Bilbo.Module/Views/InventoryTab.xaml
+++ b/src/Bilbo.Module/Views/InventoryTab.xaml
@@ -1,0 +1,115 @@
+<UserControl x:Class="Bilbo.Views.InventoryTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Bilbo.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:InventoryTabViewModel}"
+             Background="#FF1A1A1A">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <DockPanel DataContext="{Binding Storage}">
+        <DockPanel DockPanel.Dock="Top" Margin="0,8,0,8">
+            <TextBlock Text="Location:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <ComboBox Width="180" Margin="0,0,16,0"
+                      ItemsSource="{Binding AvailableLocations}"
+                      SelectedItem="{Binding SelectedLocation}"/>
+            <wpf:MithrilQueryBox Grid="{Binding ElementName=ItemsGrid}"
+                                QueryText="{Binding InventoryQueryText, Mode=TwoWay}"
+                                Watermark="bare text, or e.g. Rarity = 'Epic' AND Level &gt;= 50"/>
+        </DockPanel>
+        <wpf:MithrilDataGrid x:Name="ItemsGrid"
+                            ItemsSource="{Binding FilteredItems}"
+                            QueryText="{Binding InventoryQueryText, Mode=TwoWay}"
+                            Mode="ReadOnly"
+                            MouseDoubleClick="ItemsGrid_OnMouseDoubleClick">
+            <wpf:MithrilDataGrid.Columns>
+                <DataGridTemplateColumn Header="Name" Width="*" MinWidth="160" SortMemberPath="Name">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Location" Binding="{Binding Location}" SortMemberPath="Location" Width="160"/>
+                <DataGridTextColumn Header="Stack" Binding="{Binding StackSize}" SortMemberPath="StackSize" Width="60">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Total Value" Binding="{Binding TotalValue, Converter={StaticResource DecimalFormat}}" SortMemberPath="TotalValue" Width="85">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Rarity" Binding="{Binding Rarity, Converter={StaticResource NullDash}}" SortMemberPath="Rarity" Width="90">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                            <Setter Property="Foreground" Value="{Binding Rarity, Converter={StaticResource RarityBrush}}"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Slot" Binding="{Binding Slot, Converter={StaticResource NullDash}}" SortMemberPath="Slot" Width="90">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Lvl" Binding="{Binding Level, Converter={StaticResource NullDash}}" SortMemberPath="Level" Width="50">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="Mods" Binding="{Binding ModCount}" SortMemberPath="ModCount" Width="50">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+            </wpf:MithrilDataGrid.Columns>
+            <wpf:MithrilDataGrid.RowStyle>
+                <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
+                    <Setter Property="ToolTip">
+                        <Setter.Value>
+                            <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
+                                     Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <ToolTip.ContentTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
+                                                CornerRadius="4" Padding="10" MaxWidth="320">
+                                            <DockPanel>
+                                                <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                               Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold"
+                                                           Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"
+                                                           VerticalAlignment="Center"/>
+                                            </DockPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ToolTip.ContentTemplate>
+                            </ToolTip>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </wpf:MithrilDataGrid.RowStyle>
+        </wpf:MithrilDataGrid>
+    </DockPanel>
+</UserControl>

--- a/src/Bilbo.Module/Views/InventoryTab.xaml.cs
+++ b/src/Bilbo.Module/Views/InventoryTab.xaml.cs
@@ -1,0 +1,48 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Bilbo.Domain;
+using Bilbo.ViewModels;
+using Mithril.Shared.Wpf;
+
+namespace Bilbo.Views;
+
+public partial class InventoryTab : UserControl
+{
+    public InventoryTab()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        if (DataContext is InventoryTabViewModel vm)
+        {
+            DataGridStateBinder.Bind(ItemsGrid, vm.Settings.StorageGrid, vm.Storage.ApplyFilter, vm.Saver.Touch);
+        }
+    }
+
+    private void ItemsGrid_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        // Only fire for double-clicks that land on an actual row — header / scrollbar / empty
+        // space double-clicks bubble up here too.
+        if (e.OriginalSource is not System.Windows.DependencyObject source) return;
+        var row = FindAncestor<DataGridRow>(source);
+        if (row?.Item is not StorageItemRow item || string.IsNullOrEmpty(item.InternalName)) return;
+        if (DataContext is not InventoryTabViewModel vm) return;
+
+        vm.ItemDetail.Show(item.InternalName);
+        e.Handled = true;
+    }
+
+    private static T? FindAncestor<T>(System.Windows.DependencyObject start) where T : System.Windows.DependencyObject
+    {
+        var current = start;
+        while (current is not null)
+        {
+            if (current is T match) return match;
+            current = System.Windows.Media.VisualTreeHelper.GetParent(current);
+        }
+        return null;
+    }
+}

--- a/src/Bilbo.Module/Views/StorageView.xaml
+++ b/src/Bilbo.Module/Views/StorageView.xaml
@@ -4,8 +4,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:vm="clr-namespace:Bilbo.ViewModels"
+             xmlns:local="clr-namespace:Bilbo.Views"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:BilboShellViewModel}"
              Background="#FF1A1A1A">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -13,6 +15,13 @@
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
                 <ResourceDictionary Source="Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:InventoryTabViewModel}">
+                <local:InventoryTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:CraftableRecipesTabViewModel}">
+                <local:CraftableRecipesTab/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -30,7 +39,7 @@
         <!-- Controls bar -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10" LastChildFill="False">
             <Button DockPanel.Dock="Right" Padding="10,4"
-                    Command="{Binding RefreshCommand}"
+                    Command="{Binding Storage.RefreshCommand}"
                     ToolTip="Re-scan the Reports folder for new storage exports">
                 <StackPanel Orientation="Horizontal">
                     <icon:PackIconLucide Kind="RefreshCw" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
@@ -41,207 +50,19 @@
 
         <!-- Status bar -->
         <Border DockPanel.Dock="Bottom" Margin="0,8,0,0" Padding="4">
-            <TextBlock Text="{Binding StatusMessage}" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
+            <TextBlock Text="{Binding Storage.StatusMessage}" Foreground="#88FFFFFF" FontSize="{DynamicResource AppFontSizeHint}"/>
         </Border>
 
         <!-- Tabs: Inventory / Craftable Recipes -->
-        <TabControl Background="Transparent" BorderThickness="0" Padding="0">
-            <TabItem Header="Inventory">
-                <DockPanel>
-                    <DockPanel DockPanel.Dock="Top" Margin="0,8,0,8">
-                        <TextBlock Text="Location:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <ComboBox Width="180" Margin="0,0,16,0"
-                                  ItemsSource="{Binding AvailableLocations}"
-                                  SelectedItem="{Binding SelectedLocation}"/>
-                        <wpf:MithrilQueryBox Grid="{Binding ElementName=ItemsGrid}"
-                                            QueryText="{Binding InventoryQueryText, Mode=TwoWay}"
-                                            Watermark="bare text, or e.g. Rarity = 'Epic' AND Level &gt;= 50"/>
-                    </DockPanel>
-                    <wpf:MithrilDataGrid x:Name="ItemsGrid"
-                                        ItemsSource="{Binding FilteredItems}"
-                                        QueryText="{Binding InventoryQueryText, Mode=TwoWay}"
-                                        Mode="ReadOnly"
-                                        MouseDoubleClick="ItemsGrid_OnMouseDoubleClick">
-                    <wpf:MithrilDataGrid.Columns>
-                        <DataGridTemplateColumn Header="Name" Width="*" MinWidth="160" SortMemberPath="Name">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
-                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" SortMemberPath="Location" Width="160"/>
-                        <DataGridTextColumn Header="Stack" Binding="{Binding StackSize}" SortMemberPath="StackSize" Width="60">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Total Value" Binding="{Binding TotalValue, Converter={StaticResource DecimalFormat}}" SortMemberPath="TotalValue" Width="85">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Rarity" Binding="{Binding Rarity, Converter={StaticResource NullDash}}" SortMemberPath="Rarity" Width="90">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                    <Setter Property="Foreground" Value="{Binding Rarity, Converter={StaticResource RarityBrush}}"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Slot" Binding="{Binding Slot, Converter={StaticResource NullDash}}" SortMemberPath="Slot" Width="90">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Lvl" Binding="{Binding Level, Converter={StaticResource NullDash}}" SortMemberPath="Level" Width="50">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Header="Mods" Binding="{Binding ModCount}" SortMemberPath="ModCount" Width="50">
-                            <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                </Style>
-                            </DataGridTextColumn.ElementStyle>
-                        </DataGridTextColumn>
-                    </wpf:MithrilDataGrid.Columns>
-                    <wpf:MithrilDataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
-                            <Setter Property="ToolTip">
-                                <Setter.Value>
-                                    <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
-                                             Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                        <ToolTip.ContentTemplate>
-                                            <DataTemplate>
-                                                <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                                                        CornerRadius="4" Padding="10" MaxWidth="320">
-                                                    <DockPanel>
-                                                        <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                                       Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
-                                                        <TextBlock Text="{Binding Name}" FontWeight="Bold"
-                                                                   Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"
-                                                                   VerticalAlignment="Center"/>
-                                                    </DockPanel>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ToolTip.ContentTemplate>
-                                    </ToolTip>
-                                </Setter.Value>
-                            </Setter>
-                        </Style>
-                    </wpf:MithrilDataGrid.RowStyle>
-                    </wpf:MithrilDataGrid>
-                </DockPanel>
-            </TabItem>
-            <TabItem Header="Craftable Recipes">
-                <DockPanel>
-                    <DockPanel DockPanel.Dock="Top" Margin="0,8,0,8">
-                        <TextBlock Text="Confidence:" Foreground="#AAFFFFFF" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <ComboBox Width="170" Margin="0,0,16,0"
-                                  ItemsSource="{Binding ConfidenceOptions}"
-                                  DisplayMemberPath="Label"
-                                  SelectedValuePath="Value"
-                                  SelectedValue="{Binding Confidence}"/>
-                        <wpf:MithrilQueryBox Grid="{Binding ElementName=RecipesGrid}"
-                                            QueryText="{Binding RecipeQueryText, Mode=TwoWay}"
-                                            Watermark="e.g. MaxCraftable &gt; 0 AND IsKnown AND SkillLevelMet"/>
-                    </DockPanel>
-                    <wpf:MithrilDataGrid x:Name="RecipesGrid"
-                                        ItemsSource="{Binding CraftableRecipes}"
-                                        QueryText="{Binding RecipeQueryText, Mode=TwoWay}"
-                                        Mode="ReadOnly">
-                        <wpf:MithrilDataGrid.Columns>
-                            <DataGridTemplateColumn Header="Recipe" Width="*" MinWidth="200" SortMemberPath="Name">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <wpf:IconNameCell IconId="{Binding IconId}" DisplayName="{Binding Name}"/>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Skill" Binding="{Binding Skill}" SortMemberPath="Skill" Width="110"/>
-                            <DataGridTextColumn Header="Req" Binding="{Binding SkillLevelReq}" SortMemberPath="SkillLevelReq" Width="45">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="Char Lvl" Binding="{Binding CharacterSkillLevel, Converter={StaticResource NullDash}}" SortMemberPath="CharacterSkillLevel" Width="60">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridCheckBoxColumn Header="Met" Binding="{Binding SkillLevelMet}" SortMemberPath="SkillLevelMet" Width="45"/>
-                            <DataGridCheckBoxColumn Header="Known" Binding="{Binding IsKnown}" SortMemberPath="IsKnown" Width="55"/>
-                            <DataGridTextColumn Header="Done" Binding="{Binding TimesCompleted}" SortMemberPath="TimesCompleted" Width="50">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="Max" Binding="{Binding MaxCraftable}" SortMemberPath="MaxCraftable" Width="60">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="HorizontalAlignment" Value="Right"/>
-                                        <Setter Property="FontWeight" Value="SemiBold"/>
-                                    </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Header="Result" Binding="{Binding ResultItem}" SortMemberPath="ResultItem" Width="*" MinWidth="160"/>
-                        </wpf:MithrilDataGrid.Columns>
-                        <wpf:MithrilDataGrid.RowStyle>
-                            <Style TargetType="DataGridRow" BasedOn="{StaticResource MithrilDataGridRowStyle}">
-                                <Setter Property="ToolTip">
-                                    <Setter.Value>
-                                        <ToolTip Background="Transparent" BorderThickness="0" Padding="0"
-                                                 Content="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                            <ToolTip.ContentTemplate>
-                                                <DataTemplate>
-                                                    <Border Background="#FF2A2A2A" BorderBrush="#55FFFFFF" BorderThickness="1"
-                                                            CornerRadius="4" Padding="10" MaxWidth="380">
-                                                        <StackPanel>
-                                                            <DockPanel Margin="0,0,0,6">
-                                                                <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                                               Width="40" Height="40" Margin="0,0,10,0" VerticalAlignment="Top"/>
-                                                                <TextBlock Text="{Binding Name}" FontWeight="Bold"
-                                                                           Foreground="#FFD4A847" FontSize="{DynamicResource AppFontSizeLarge}"
-                                                                           TextWrapping="Wrap" VerticalAlignment="Center"/>
-                                                            </DockPanel>
-                                                            <TextBlock Text="Ingredients" Foreground="#88FFFFFF"
-                                                                       FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,2"/>
-                                                            <TextBlock Text="{Binding Ingredients}" Foreground="#FFE8E8E8"
-                                                                       TextWrapping="Wrap" Margin="0,0,0,4"/>
-                                                            <TextBlock Text="Missing" Foreground="#88FFFFFF"
-                                                                       FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,2"
-                                                                       Visibility="{Binding MissingIngredients, Converter={StaticResource NonEmptyToVisible}}"/>
-                                                            <TextBlock Text="{Binding MissingIngredients}" Foreground="#FFE09090"
-                                                                       TextWrapping="Wrap"
-                                                                       Visibility="{Binding MissingIngredients, Converter={StaticResource NonEmptyToVisible}}"/>
-                                                        </StackPanel>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ToolTip.ContentTemplate>
-                                        </ToolTip>
-                                    </Setter.Value>
-                                </Setter>
-                            </Style>
-                        </wpf:MithrilDataGrid.RowStyle>
-                    </wpf:MithrilDataGrid>
-                </DockPanel>
-            </TabItem>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Bilbo.Module/Views/StorageView.xaml
+++ b/src/Bilbo.Module/Views/StorageView.xaml
@@ -46,32 +46,6 @@
 
         <!-- Tabs: Inventory / Craftable Recipes -->
         <TabControl Background="Transparent" BorderThickness="0" Padding="0">
-            <TabControl.Resources>
-                <Style TargetType="TabItem">
-                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
-                    <Setter Property="Padding" Value="14,6"/>
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="TabItem">
-                                <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                        BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
-                                    <ContentPresenter ContentSource="Header"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
-                                        <Setter Property="Foreground" Value="#FFE8E8E8"/>
-                                    </Trigger>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </TabControl.Resources>
             <TabItem Header="Inventory">
                 <DockPanel>
                     <DockPanel DockPanel.Dock="Top" Margin="0,8,0,8">

--- a/src/Gandalf.Module/ViewModels/GandalfShellViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/GandalfShellViewModel.cs
@@ -1,10 +1,23 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Mithril.Shared.Wpf;
 
 namespace Gandalf.ViewModels;
 
+/// <summary>
+/// Composes Gandalf's tabs as VM data so the View can bind
+/// <c>TabControl.ItemsSource</c> rather than hard-coding TabItems in XAML.
+/// Tab views are picked by <c>DataTemplate</c>s keyed on each child VM's type.
+/// <para>
+/// <see cref="SelectedTabIndex"/> is two-way bound by the View; the dashboard's
+/// <c>NavigationRequested</c> event drives it via <see cref="OnNavigationRequested"/>
+/// so child VMs can ask the shell to switch tabs.
+/// </para>
+/// </summary>
 public sealed partial class GandalfShellViewModel : ObservableObject
 {
     [ObservableProperty] private int _selectedTabIndex;
+
+    public IReadOnlyList<ModuleTab> Tabs { get; }
 
     public GandalfShellViewModel(
         DashboardViewModel dashboardTab,
@@ -12,18 +25,16 @@ public sealed partial class GandalfShellViewModel : ObservableObject
         QuestTimersViewModel questsTab,
         LootTimersViewModel lootTab)
     {
-        DashboardTab = dashboardTab;
-        UserTab = userTab;
-        QuestsTab = questsTab;
-        LootTab = lootTab;
+        Tabs = new[]
+        {
+            new ModuleTab("Dashboard", dashboardTab),
+            new ModuleTab("User",      userTab),
+            new ModuleTab("Quests",    questsTab),
+            new ModuleTab("Loot",      lootTab),
+        };
 
-        DashboardTab.NavigationRequested += (_, n) => OnNavigationRequested(n.SourceId);
+        dashboardTab.NavigationRequested += (_, n) => OnNavigationRequested(n.SourceId);
     }
-
-    public DashboardViewModel DashboardTab { get; }
-    public TimerListViewModel UserTab { get; }
-    public QuestTimersViewModel QuestsTab { get; }
-    public LootTimersViewModel LootTab { get; }
 
     private void OnNavigationRequested(string sourceId) =>
         SelectedTabIndex = sourceId switch

--- a/src/Gandalf.Module/Views/GandalfShellView.xaml
+++ b/src/Gandalf.Module/Views/GandalfShellView.xaml
@@ -8,13 +8,15 @@
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance vm:GandalfShellViewModel}"
              Background="#FF1A1A1A">
+    <!-- Intentionally no MergedDictionary for Mithril.Shared.Wpf here: a per-UserControl
+         copy shadows Application.Resources and isn't reliably re-scaled by UiFontApplier
+         at the right moment for Eager modules, so the tab strip ends up at the unscaled
+         AppFontSizeMedium. Letting DynamicResource references fall through to App-level
+         keeps the lookup hitting the dict UiFontApplier owns. The Gandalf module
+         resources (just converters) aren't referenced from this view either; tab
+         content views pull them in at their own UserControl.Resources level. -->
     <UserControl.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
-                <ResourceDictionary Source="pack://application:,,,/Gandalf.Module;component/Views/Resources.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
-
             <DataTemplate DataType="{x:Type vm:DashboardViewModel}">
                 <views:DashboardView/>
             </DataTemplate>
@@ -45,8 +47,8 @@
         <TabControl ItemsSource="{Binding Tabs}"
                     SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}"
                     Background="Transparent" BorderThickness="0" Padding="0"
-                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
-                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+                    ItemContainerStyle="{DynamicResource MithrilTabItemStyle}"
+                    ItemTemplate="{DynamicResource ModuleTabHeaderTemplate}">
             <TabControl.ContentTemplate>
                 <DataTemplate>
                     <ContentControl Content="{Binding Content}"/>

--- a/src/Gandalf.Module/Views/GandalfShellView.xaml
+++ b/src/Gandalf.Module/Views/GandalfShellView.xaml
@@ -3,6 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Gandalf.ViewModels"
              xmlns:views="clr-namespace:Gandalf.Views"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:GandalfShellViewModel}"
              Background="#FF1A1A1A">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -11,6 +15,9 @@
                 <ResourceDictionary Source="pack://application:,,,/Gandalf.Module;component/Views/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
+            <DataTemplate DataType="{x:Type vm:DashboardViewModel}">
+                <views:DashboardView/>
+            </DataTemplate>
             <DataTemplate DataType="{x:Type vm:TimerListViewModel}">
                 <views:TimerListView/>
             </DataTemplate>
@@ -19,9 +26,6 @@
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:LootTimersViewModel}">
                 <views:LootTimersView/>
-            </DataTemplate>
-            <DataTemplate DataType="{x:Type vm:DashboardViewModel}">
-                <views:DashboardView/>
             </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -38,50 +42,16 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0"
-                    SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
-            <TabControl.Resources>
-                <Style TargetType="TabItem">
-                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
-                    <Setter Property="Padding" Value="14,6"/>
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="TabItem">
-                                <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                        BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
-                                    <ContentPresenter ContentSource="Header"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
-                                        <Setter Property="Foreground" Value="#FFE8E8E8"/>
-                                    </Trigger>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </TabControl.Resources>
-
-            <TabItem Header="Dashboard" Margin="0,8,0,0">
-                <ContentControl Content="{Binding DashboardTab}"/>
-            </TabItem>
-
-            <TabItem Header="User" Margin="0,8,0,0">
-                <ContentControl Content="{Binding UserTab}"/>
-            </TabItem>
-
-            <TabItem Header="Quests" Margin="0,8,0,0">
-                <ContentControl Content="{Binding QuestsTab}"/>
-            </TabItem>
-
-            <TabItem Header="Loot" Margin="0,8,0,0">
-                <ContentControl Content="{Binding LootTab}"/>
-            </TabItem>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}"
+                    Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Mithril.Shared.Wpf/ModuleTab.cs
+++ b/src/Mithril.Shared.Wpf/ModuleTab.cs
@@ -1,0 +1,36 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// A single tab descriptor for binding to <c>TabControl.ItemsSource</c>.
+/// <para>
+/// Use this in preference to constructing TabItems in code-behind:
+/// WPF's <c>ItemContainerStyle</c> is reliably applied to generated containers
+/// (the TabItems WPF creates from each item in <c>ItemsSource</c>) but is
+/// inconsistently applied to TabItems added directly to <c>TabControl.Items</c>.
+/// </para>
+/// <para>
+/// In the parent View, declare <c>DataTemplate</c>s keyed by each child VM type so
+/// the TabControl's <c>ContentTemplate</c> resolves <see cref="Content"/> to the
+/// right view. Use the TabControl's <c>ItemTemplate</c> to render <see cref="Header"/>.
+/// To attach a notification badge, set
+/// <c>c:TabBadge.Count="{Binding BadgeCount}"</c> on the <c>ItemContainerStyle</c>;
+/// the value is observable so a parent VM can update it as child-VM state changes.
+/// </para>
+/// </summary>
+public sealed partial class ModuleTab : ObservableObject
+{
+    public string Header { get; }
+    public object Content { get; }
+
+    [ObservableProperty]
+    private int badgeCount;
+
+    public ModuleTab(string header, object content, int badgeCount = 0)
+    {
+        Header = header;
+        Content = content;
+        this.badgeCount = badgeCount;
+    }
+}

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -597,9 +597,11 @@
          c:TabBadge.Count="<int>" on a TabItem to render a small accent pill
          next to the header; the pill is hidden when Count <= 0.
 
-         Applied implicitly app-wide via the unkeyed style below. The keyed
-         style is kept for callers that bind ItemContainerStyle explicitly
-         (Arwen/Elrond) or want to base derived styles on it. -->
+         Apply via TabControl's ItemContainerStyle when binding ItemsSource
+         to a collection of ModuleTab — generated TabItem containers honor
+         the style cleanly. (Items added directly to TabControl.Items via
+         XAML or code bypass the ItemContainerStyle pipeline; that's the
+         WPF quirk #233 was unwinding.) -->
     <Style x:Key="MithrilTabItemStyle" TargetType="TabItem">
         <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
         <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
@@ -638,19 +640,6 @@
             </Setter.Value>
         </Setter>
     </Style>
-
-    <!-- Implicit app-wide TabItem style. Merged at App.Resources via
-         Mithril.Shared.Wpf/Resources.xaml, so any TabControl in the app
-         inherits the Mithril look without per-module boilerplate. Modules
-         that want a different look can still scope a local
-         TabControl.Resources style (see IngredientSourcesWindow).
-
-         Used by Bilbo and Silmarillion which still hard-code their TabItems
-         in XAML. Modules that bind TabControl.ItemsSource to a collection of
-         ModuleTab (Samwise/Smaug/Palantir/Arwen/Gandalf) set
-         ItemContainerStyle="{StaticResource MithrilTabItemStyle}" explicitly,
-         which is the right hook for WPF-generated containers. -->
-    <Style TargetType="TabItem" BasedOn="{StaticResource MithrilTabItemStyle}"/>
 
     <!-- Default DataTemplate for ModuleTab tab-strip headers. Binds Font* and
          Foreground via RelativeSource to the ancestor TabItem so the header

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -595,13 +595,17 @@
 
     <!-- Themed TabItem with optional notification badge. Set
          c:TabBadge.Count="<int>" on a TabItem to render a small accent pill
-         next to the header; the pill is hidden when Count <= 0. Apply via
-         <TabControl.ItemContainerStyle> or per-item Style. -->
+         next to the header; the pill is hidden when Count <= 0.
+
+         Applied implicitly app-wide via the unkeyed style below. The keyed
+         style is kept for callers that bind ItemContainerStyle explicitly
+         (Arwen/Elrond) or want to base derived styles on it. -->
     <Style x:Key="MithrilTabItemStyle" TargetType="TabItem">
         <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
         <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeMedium}"/>
         <Setter Property="Padding"    Value="14,6"/>
+        <Setter Property="Margin"    Value="0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TabItem">
@@ -634,6 +638,32 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- Implicit app-wide TabItem style. Merged at App.Resources via
+         Mithril.Shared.Wpf/Resources.xaml, so any TabControl in the app
+         inherits the Mithril look without per-module boilerplate. Modules
+         that want a different look can still scope a local
+         TabControl.Resources style (see IngredientSourcesWindow).
+
+         Used by Bilbo and Silmarillion which still hard-code their TabItems
+         in XAML. Modules that bind TabControl.ItemsSource to a collection of
+         ModuleTab (Samwise/Smaug/Palantir/Arwen/Gandalf) set
+         ItemContainerStyle="{StaticResource MithrilTabItemStyle}" explicitly,
+         which is the right hook for WPF-generated containers. -->
+    <Style TargetType="TabItem" BasedOn="{StaticResource MithrilTabItemStyle}"/>
+
+    <!-- Default DataTemplate for ModuleTab tab-strip headers. Binds Font* and
+         Foreground via RelativeSource to the ancestor TabItem so the header
+         text follows MithrilTabItemStyle (and its IsSelected trigger) rather
+         than picking up the implicit TextBlock style's AppFontSize/TextPrimary,
+         which would otherwise pin every tab header to 12pt and full-bright
+         regardless of selection. -->
+    <DataTemplate x:Key="ModuleTabHeaderTemplate">
+        <TextBlock Text="{Binding Header}"
+                   FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=TabItem}}"
+                   FontFamily="{Binding FontFamily, RelativeSource={RelativeSource AncestorType=TabItem}}"
+                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=TabItem}}"/>
+    </DataTemplate>
 
     <!-- ═══════════════════ MithrilQueryBox ═══════════════════ -->
 

--- a/src/Palantir.Module/PalantirModule.cs
+++ b/src/Palantir.Module/PalantirModule.cs
@@ -22,26 +22,16 @@ public sealed class PalantirModule : IMithrilModule
     public void Register(IServiceCollection services)
     {
         services.AddSingleton<LiveInventoryViewModel>();
-        services.AddSingleton<LiveInventoryView>(sp => new LiveInventoryView
-        {
-            DataContext = sp.GetRequiredService<LiveInventoryViewModel>(),
-        });
 
         services.AddSingleton<PalantirAttentionSource>();
         services.AddSingleton<IAttentionSource>(sp => sp.GetRequiredService<PalantirAttentionSource>());
 
         services.AddSingleton<NotificationTesterViewModel>();
-        services.AddSingleton<NotificationTesterView>(sp => new NotificationTesterView
-        {
-            DataContext = sp.GetRequiredService<NotificationTesterViewModel>(),
-        });
 
-        services.AddSingleton<PalantirView>(sp =>
+        services.AddSingleton<PalantirShellViewModel>();
+        services.AddSingleton<PalantirView>(sp => new PalantirView
         {
-            var view = new PalantirView();
-            view.AddTab("Live Inventory", sp.GetRequiredService<LiveInventoryView>());
-            view.AddTab("Notification Tester", sp.GetRequiredService<NotificationTesterView>());
-            return view;
+            DataContext = sp.GetRequiredService<PalantirShellViewModel>(),
         });
     }
 }

--- a/src/Palantir.Module/ViewModels/PalantirShellViewModel.cs
+++ b/src/Palantir.Module/ViewModels/PalantirShellViewModel.cs
@@ -1,0 +1,22 @@
+using Mithril.Shared.Wpf;
+
+namespace Palantir.ViewModels;
+
+/// <summary>
+/// Composes Palantir's tabs as VM data so the View can bind
+/// <c>TabControl.ItemsSource</c> rather than constructing TabItems in code.
+/// Tab views are picked by <c>DataTemplate</c>s keyed on each child VM's type.
+/// </summary>
+public sealed class PalantirShellViewModel
+{
+    public IReadOnlyList<ModuleTab> Tabs { get; }
+
+    public PalantirShellViewModel(LiveInventoryViewModel liveInventory, NotificationTesterViewModel notificationTester)
+    {
+        Tabs = new[]
+        {
+            new ModuleTab("Live Inventory", liveInventory),
+            new ModuleTab("Notification Tester", notificationTester),
+        };
+    }
+}

--- a/src/Palantir.Module/Views/PalantirView.xaml
+++ b/src/Palantir.Module/Views/PalantirView.xaml
@@ -1,10 +1,28 @@
 <UserControl x:Class="Palantir.Views.PalantirView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Palantir.ViewModels"
+             xmlns:local="clr-namespace:Palantir.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:PalantirShellViewModel}"
              Background="#FF1A1A1A">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:LiveInventoryViewModel}">
+                <local:LiveInventoryView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:NotificationTesterViewModel}">
+                <local:NotificationTesterView/>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
     <DockPanel Margin="12">
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,12">
@@ -16,33 +34,15 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0">
-            <TabControl.Resources>
-                <Style TargetType="TabItem">
-                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
-                    <Setter Property="Padding" Value="14,6"/>
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="TabItem">
-                                <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                        BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
-                                    <ContentPresenter ContentSource="Header"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
-                                        <Setter Property="Foreground" Value="#FFE8E8E8"/>
-                                    </Trigger>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </TabControl.Resources>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Palantir.Module/Views/PalantirView.xaml.cs
+++ b/src/Palantir.Module/Views/PalantirView.xaml.cs
@@ -8,14 +8,4 @@ public partial class PalantirView : UserControl
     {
         InitializeComponent();
     }
-
-    public void AddTab(string header, UserControl content)
-    {
-        Tabs.Items.Add(new TabItem
-        {
-            Header = header,
-            Content = content,
-            Margin = new System.Windows.Thickness(0, 8, 0, 0),
-        });
-    }
 }

--- a/src/Samwise.Module/SamwiseModule.cs
+++ b/src/Samwise.Module/SamwiseModule.cs
@@ -78,12 +78,10 @@ public sealed class SamwiseModule : IMithrilModule
 
         services.AddSingleton<GardenViewModel>();
         services.AddSingleton<GrowthCalibrationViewModel>();
-        services.AddSingleton<SamwiseView>(sp =>
+        services.AddSingleton<SamwiseShellViewModel>();
+        services.AddSingleton<SamwiseView>(sp => new SamwiseView
         {
-            var view = new SamwiseView();
-            view.AddTab("Garden", new GardenView { DataContext = sp.GetRequiredService<GardenViewModel>() });
-            view.AddTab("Growth Calibration", new GrowthCalibrationTab { DataContext = sp.GetRequiredService<GrowthCalibrationViewModel>() });
-            return view;
+            DataContext = sp.GetRequiredService<SamwiseShellViewModel>(),
         });
         services.AddSingleton<SamwiseSettingsView>(sp => new SamwiseSettingsView
         {

--- a/src/Samwise.Module/ViewModels/SamwiseShellViewModel.cs
+++ b/src/Samwise.Module/ViewModels/SamwiseShellViewModel.cs
@@ -1,0 +1,22 @@
+using Mithril.Shared.Wpf;
+
+namespace Samwise.ViewModels;
+
+/// <summary>
+/// Composes Samwise's tabs as VM data so the View can bind
+/// <c>TabControl.ItemsSource</c> rather than constructing TabItems in code.
+/// Tab views are picked by <c>DataTemplate</c>s keyed on each child VM's type.
+/// </summary>
+public sealed class SamwiseShellViewModel
+{
+    public IReadOnlyList<ModuleTab> Tabs { get; }
+
+    public SamwiseShellViewModel(GardenViewModel garden, GrowthCalibrationViewModel calibration)
+    {
+        Tabs = new[]
+        {
+            new ModuleTab("Garden", garden),
+            new ModuleTab("Growth Calibration", calibration),
+        };
+    }
+}

--- a/src/Samwise.Module/Views/SamwiseView.xaml
+++ b/src/Samwise.Module/Views/SamwiseView.xaml
@@ -10,12 +10,15 @@
              d:DataContext="{d:DesignInstance vm:SamwiseShellViewModel}"
              Background="#FF1A1A1A">
 
+    <!-- Intentionally no MergedDictionary for Mithril.Shared.Wpf here: a per-UserControl
+         copy shadows Application.Resources and isn't reliably re-scaled by UiFontApplier
+         at the right moment for Eager modules, so the tab strip ends up at the unscaled
+         AppFontSizeMedium. Letting StaticResource references fall through to App-level
+         keeps the lookup hitting the dict UiFontApplier owns. The shared resources are
+         still in scope via App.xaml's MergedDictionaries — DynamicResource resolves
+         them at runtime. -->
     <UserControl.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
-
             <DataTemplate DataType="{x:Type vm:GardenViewModel}">
                 <local:GardenView/>
             </DataTemplate>
@@ -37,8 +40,8 @@
 
         <TabControl ItemsSource="{Binding Tabs}"
                     Background="Transparent" BorderThickness="0" Padding="0"
-                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
-                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+                    ItemContainerStyle="{DynamicResource MithrilTabItemStyle}"
+                    ItemTemplate="{DynamicResource ModuleTabHeaderTemplate}">
             <TabControl.ContentTemplate>
                 <DataTemplate>
                     <ContentControl Content="{Binding Content}"/>

--- a/src/Samwise.Module/Views/SamwiseView.xaml
+++ b/src/Samwise.Module/Views/SamwiseView.xaml
@@ -2,13 +2,30 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:vm="clr-namespace:Samwise.ViewModels"
+             xmlns:local="clr-namespace:Samwise.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:SamwiseShellViewModel}"
              Background="#FF1A1A1A">
 
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:GardenViewModel}">
+                <local:GardenView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:GrowthCalibrationViewModel}">
+                <local:GrowthCalibrationTab/>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
     <DockPanel Margin="12">
-        <!-- Header -->
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal">
                 <Image Source="pack://application:,,,/Samwise.Module;component/Resources/samwise.ico"
@@ -18,33 +35,15 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0">
-            <TabControl.Resources>
-                <Style TargetType="TabItem">
-                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
-                    <Setter Property="Padding" Value="14,6"/>
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="TabItem">
-                                <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                        BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
-                                    <ContentPresenter ContentSource="Header"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
-                                        <Setter Property="Foreground" Value="#FFE8E8E8"/>
-                                    </Trigger>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </TabControl.Resources>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Samwise.Module/Views/SamwiseView.xaml.cs
+++ b/src/Samwise.Module/Views/SamwiseView.xaml.cs
@@ -8,19 +8,4 @@ public partial class SamwiseView : UserControl
     {
         InitializeComponent();
     }
-
-    /// <summary>
-    /// Adds a tab with its DataContext already set.
-    /// Called by SamwiseModule during DI registration so each tab
-    /// has its ViewModel before any bindings are evaluated.
-    /// </summary>
-    public void AddTab(string header, UserControl content)
-    {
-        Tabs.Items.Add(new TabItem
-        {
-            Header = header,
-            Content = content,
-            Margin = new System.Windows.Thickness(0, 8, 0, 0),
-        });
-    }
 }

--- a/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
 
 namespace Silmarillion.ViewModels;
 
@@ -30,6 +31,11 @@ public sealed partial class SilmarillionViewModel : ObservableObject
     {
         Items = items;
         Recipes = recipes;
+        Tabs = new[]
+        {
+            new ModuleTab("Items",   items),
+            new ModuleTab("Recipes", recipes),
+        };
         _navigator = navigator;
         _diag = diag;
 
@@ -54,6 +60,9 @@ public sealed partial class SilmarillionViewModel : ObservableObject
 
     public ItemsTabViewModel Items { get; }
     public RecipesTabViewModel Recipes { get; }
+
+    /// <summary>The tab descriptors bound to <c>TabControl.ItemsSource</c>.</summary>
+    public IReadOnlyList<ModuleTab> Tabs { get; }
 
     /// <summary>0 = Items, 1 = Recipes. Two-way bound to the TabControl in the view.</summary>
     [ObservableProperty]

--- a/src/Silmarillion.Module/Views/SilmarillionView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionView.xaml
@@ -2,10 +2,12 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:SilmarillionViewModel}"
              FontFamily="{DynamicResource AppFontFamily}"
              FontSize="{DynamicResource AppFontSize}">
     <UserControl.Resources>
@@ -13,6 +15,13 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:ItemsTabViewModel}">
+                <local:ItemsTabView/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:RecipesTabViewModel}">
+                <local:RecipesTabView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.InputBindings>
@@ -43,14 +52,16 @@
         </Border>
 
         <!-- Tab strip -->
-        <TabControl SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}"
-                    Background="Transparent" BorderThickness="0">
-            <TabItem Header="Items">
-                <local:ItemsTabView DataContext="{Binding Items}"/>
-            </TabItem>
-            <TabItem Header="Recipes">
-                <local:RecipesTabView DataContext="{Binding Recipes}"/>
-            </TabItem>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}"
+                    Background="Transparent" BorderThickness="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Smaug.Module/SmaugModule.cs
+++ b/src/Smaug.Module/SmaugModule.cs
@@ -53,16 +53,10 @@ public sealed class SmaugModule : IMithrilModule
         services.AddSingleton<SellPricesViewModel>();
         services.AddSingleton<CalibrationViewModel>();
 
-        services.AddSingleton<SmaugView>(sp =>
+        services.AddSingleton<SmaugShellViewModel>();
+        services.AddSingleton<SmaugView>(sp => new SmaugView
         {
-            var view = new SmaugView();
-            view.AddTab("Vendor Shop", new VendorShopTab { DataContext = sp.GetRequiredService<VendorShopViewModel>() });
-            view.AddTab("Storage Sellback", new StorageSellbackTab { DataContext = sp.GetRequiredService<StorageSellbackViewModel>() });
-            view.AddTab("Sell Planner", new SellPlannerTab { DataContext = sp.GetRequiredService<SellPlannerViewModel>() });
-            view.AddTab("Vendor Catalog", new VendorCatalogTab { DataContext = sp.GetRequiredService<VendorCatalogViewModel>() });
-            view.AddTab("Sell Prices", new SellPricesTab { DataContext = sp.GetRequiredService<SellPricesViewModel>() });
-            view.AddTab("Calibration", new CalibrationTab { DataContext = sp.GetRequiredService<CalibrationViewModel>() });
-            return view;
+            DataContext = sp.GetRequiredService<SmaugShellViewModel>(),
         });
         services.AddSingleton<SmaugSettingsView>(sp => new SmaugSettingsView
         {

--- a/src/Smaug.Module/ViewModels/SmaugShellViewModel.cs
+++ b/src/Smaug.Module/ViewModels/SmaugShellViewModel.cs
@@ -1,0 +1,32 @@
+using Mithril.Shared.Wpf;
+
+namespace Smaug.ViewModels;
+
+/// <summary>
+/// Composes Smaug's tabs as VM data so the View can bind
+/// <c>TabControl.ItemsSource</c> rather than constructing TabItems in code.
+/// Tab views are picked by <c>DataTemplate</c>s keyed on each child VM's type.
+/// </summary>
+public sealed class SmaugShellViewModel
+{
+    public IReadOnlyList<ModuleTab> Tabs { get; }
+
+    public SmaugShellViewModel(
+        VendorShopViewModel vendorShop,
+        StorageSellbackViewModel storageSellback,
+        SellPlannerViewModel sellPlanner,
+        VendorCatalogViewModel vendorCatalog,
+        SellPricesViewModel sellPrices,
+        CalibrationViewModel calibration)
+    {
+        Tabs = new[]
+        {
+            new ModuleTab("Vendor Shop", vendorShop),
+            new ModuleTab("Storage Sellback", storageSellback),
+            new ModuleTab("Sell Planner", sellPlanner),
+            new ModuleTab("Vendor Catalog", vendorCatalog),
+            new ModuleTab("Sell Prices", sellPrices),
+            new ModuleTab("Calibration", calibration),
+        };
+    }
+}

--- a/src/Smaug.Module/Views/SmaugView.xaml
+++ b/src/Smaug.Module/Views/SmaugView.xaml
@@ -1,9 +1,12 @@
 <UserControl x:Class="Smaug.Views.SmaugView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Smaug.ViewModels"
+             xmlns:local="clr-namespace:Smaug.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:SmaugShellViewModel}"
              Background="#FF1A1A1A">
 
     <UserControl.Resources>
@@ -11,6 +14,25 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate DataType="{x:Type vm:VendorShopViewModel}">
+                <local:VendorShopTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:StorageSellbackViewModel}">
+                <local:StorageSellbackTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:SellPlannerViewModel}">
+                <local:SellPlannerTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:VendorCatalogViewModel}">
+                <local:VendorCatalogTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:SellPricesViewModel}">
+                <local:SellPricesTab/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:CalibrationViewModel}">
+                <local:CalibrationTab/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -27,33 +49,15 @@
             </StackPanel>
         </DockPanel>
 
-        <TabControl x:Name="Tabs" Background="Transparent" BorderThickness="0" Padding="0">
-            <TabControl.Resources>
-                <Style TargetType="TabItem">
-                    <Setter Property="Foreground" Value="#CCFFFFFF"/>
-                    <Setter Property="FontSize" Value="{DynamicResource AppFontSizeMedium}"/>
-                    <Setter Property="Padding" Value="14,6"/>
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="TabItem">
-                                <Border x:Name="Bd" Background="Transparent" Padding="{TemplateBinding Padding}"
-                                        BorderBrush="Transparent" BorderThickness="0,0,0,2" Margin="0,0,2,0">
-                                    <ContentPresenter ContentSource="Header"/>
-                                </Border>
-                                <ControlTemplate.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="BorderBrush" Value="#FFD4A847"/>
-                                        <Setter Property="Foreground" Value="#FFE8E8E8"/>
-                                    </Trigger>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="#18FFFFFF"/>
-                                    </Trigger>
-                                </ControlTemplate.Triggers>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </TabControl.Resources>
+        <TabControl ItemsSource="{Binding Tabs}"
+                    Background="Transparent" BorderThickness="0" Padding="0"
+                    ItemContainerStyle="{StaticResource MithrilTabItemStyle}"
+                    ItemTemplate="{StaticResource ModuleTabHeaderTemplate}">
+            <TabControl.ContentTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding Content}"/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
         </TabControl>
     </DockPanel>
 </UserControl>

--- a/src/Smaug.Module/Views/SmaugView.xaml.cs
+++ b/src/Smaug.Module/Views/SmaugView.xaml.cs
@@ -8,14 +8,4 @@ public partial class SmaugView : UserControl
     {
         InitializeComponent();
     }
-
-    public void AddTab(string header, UserControl content)
-    {
-        Tabs.Items.Add(new TabItem
-        {
-            Header = header,
-            Content = content,
-            Margin = new System.Windows.Thickness(0, 8, 0, 0),
-        });
-    }
 }


### PR DESCRIPTION
## Summary

Closes #233. Originally just "lift Bilbo's tab style into Mithril.Shared.Wpf as an implicit style" but that surfaced a deeper antipattern in how every module wired its tabs. Six of seven modules either constructed TabItems imperatively in code-behind (`Tabs.Items.Add(new TabItem(...))`) or hard-coded them in XAML — both bypass WPF's `ItemContainerStyle` pipeline, which is why the implicit-style approach kept producing inconsistent results across modules during initial debugging.

This PR rebuilds Bilbo / Silmarillion / Samwise / Smaug / Palantir / Arwen / Gandalf on the standard MVVM idiom: each module owns a `*ShellViewModel` exposing `IReadOnlyList<ModuleTab> Tabs`, the View binds `TabControl.ItemsSource` to that, child views resolve via `DataTemplate`-by-VM-type, and `ItemContainerStyle="{StaticResource MithrilTabItemStyle}"` applies cleanly to the WPF-generated containers. The implicit `Style TargetType="TabItem"` is gone — no remaining users.

## What changed

- **New shared infrastructure** in `Mithril.Shared.Wpf`:
  - `ModuleTab` — `Header` / `Content` / observable `BadgeCount` descriptor
  - `ModuleTabHeaderTemplate` — `DataTemplate` that binds tab-strip text Font/Foreground via `RelativeSource` to the ancestor TabItem (works around the implicit `TextBlock` style that would otherwise pin headers to `AppFontSize` / `TextPrimary`)
- **Per-module shell VMs**:
  - `SamwiseShellViewModel`, `PalantirShellViewModel`, `SmaugShellViewModel` (simple)
  - `FavorShellViewModel` (Arwen) — implements `IFavorViewNavigator` directly via the existing `FavorViewNavigatorHolder`; `ObservationsEditorViewModel` wraps `CalibrationViewModel` so the two tabs sharing state can be distinguished by DataTemplate type; `Edit Observations` `TabBadge.Count` flows through `ModuleTab.BadgeCount`
  - `GandalfShellViewModel` — refactored from named child-VM properties to a `Tabs` collection
  - `SilmarillionViewModel` — minor: added `Tabs`; `SelectedTabIndex` stays for `IReferenceKindTarget` routing
  - `BilboShellViewModel` + extracted `InventoryTab` / `CraftableRecipesTab` UserControls + wrapper VMs that thread the view-side dependencies (`BilboSettings` / `SettingsAutoSaver` / `IItemDetailPresenter`) into `InventoryTab`'s code-behind
- **Deleted**:
  - All four `AddTab(string, UserControl)` helpers from Samwise/Smaug/Palantir/Arwen view code-behinds
  - `FavorView`'s `IFavorViewNavigator` implementation + foreach-over-Tabs `OpenInGiftScanner`
  - The `LiveInventoryView` / `NotificationTesterView` DI singleton registrations (now resolved purely via DataTemplate)
  - The implicit `Style TargetType="TabItem"` at App.Resources

## Why this fixes the original issue cleanly

WPF reliably applies `ItemContainerStyle` to **generated** TabItem containers (`ItemsSource` → containers). Items added directly to `TabControl.Items` (the old AddTab pattern, or XAML-declared TabItems) bypass that pipeline — that's the WPF quirk that produced the pre-PR inconsistent styling. Once every module routes through `ItemsSource`, the lift-Bilbo's-style goal becomes trivial: one `ItemContainerStyle` setter per TabControl.

## Test plan

- [x] Close Mithril and Visual Studio, run `./scripts/start.ps1 -Build`
- [x] All seven modules show the gold IsSelected underline on their selected tab
- [x] Tab font size matches across all modules
- [x] Bilbo: column sort/filter persistence still works on Inventory grid; double-click a row opens the item detail window
- [x] Arwen: switching to Gift Scanner via `OpenInGiftScanner` (e.g. from Storage Gifts) still works; Edit Observations badge count still tracks `CalibrationViewModel.PendingCount`
- [ ] Gandalf: dashboard's `NavigationRequested` still switches to the right tab
- [x] Silmarillion: cross-link navigation (clicking a Recipe link from an Item detail) still routes via `IReferenceKindTarget.TabIndex`
- [ ] `dotnet test Mithril.slnx` (1,860+ tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)