### PR TITLE
feat(silmarillion): cap 'Used in' chip count + settings scaffold — #273

### DIFF
--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -41,6 +41,13 @@ public sealed class PositiveIntToVisibilityConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
 }
 
+public sealed class NullToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is null ? Visibility.Collapsed : Visibility.Visible;
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+
 public sealed class InverseBoolConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Mithril.Shared.Wpf/Converters.xaml
+++ b/src/Mithril.Shared.Wpf/Converters.xaml
@@ -7,5 +7,6 @@
     <c:NullOrEmptyToVisibilityConverter x:Key="NullOrEmptyToVis"/>
     <c:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
     <c:PositiveIntToVisibilityConverter x:Key="PositiveIntToVis"/>
+    <c:NullToVisibilityConverter x:Key="NullToVis"/>
     <c:CamelCaseSplitConverter x:Key="CamelCaseSplit"/>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/ItemDetailContext.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailContext.cs
@@ -28,7 +28,12 @@ public sealed record ItemDetailContext(
     IReadOnlyList<EntityChipVm>? ProducedByRecipes = null,
     IReadOnlyList<EntityChipVm>? ConsumedByRecipes = null,
     IReadOnlyList<EntityChipVm>? ConsumedAsKeywordIn = null,
-    IReadOnlyList<ItemSourceChipVm>? Sources = null)
+    IReadOnlyList<ItemSourceChipVm>? Sources = null,
+    // Overflow pill for "Used in" when ConsumedByRecipes is already capped.
+    // Non-null only when the underlying recipe count exceeds the cap; renders as a
+    // RecipeIngredientItem-kind chip that deep-links to the Recipes tab filtered to
+    // "Ingredients CONTAINS <itemInternalName>". DisplayName carries the "+N more →" label.
+    EntityChipVm? MoreRecipesChip = null)
 {
     public static ItemDetailContext Empty { get; } = new();
 }

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -101,14 +101,29 @@
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Used in recipes — cross-link to recipes that consume this item -->
-                <StackPanel Margin="0,10,0,0"
-                            Visibility="{Binding ConsumedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
+                <!-- Used in recipes — cross-link to recipes that consume this item. Capped at
+                     SilmarillionSettings.UsedInChipCap to keep selection-change cheap (long-tail
+                     items like MetalSlab1 ship 60+ recipes). The trailing pill collapses the
+                     overflow into a single chip that deep-links to the Recipes tab filtered to
+                     Ingredients CONTAINS "<itemInternalName>" — same total reach, one paint. -->
+                <StackPanel Margin="0,10,0,0">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ConsumedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding MoreRecipesChip, Converter={StaticResource NullToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock FontWeight="SemiBold"
                                Foreground="#88FFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4">
                         <Run Text="Used in" />
-                        <Run Text="{Binding ConsumedByRecipes.Count, StringFormat=' ({0})', Mode=OneWay}" />
                     </TextBlock>
                     <ItemsControl ItemsSource="{Binding ConsumedByRecipes}">
                         <ItemsControl.ItemsPanel>
@@ -120,6 +135,10 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+                    <c:EntityChip DataContext="{Binding MoreRecipesChip}"
+                                  ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"
+                                  Visibility="{Binding Converter={StaticResource NullToVis}}"
+                                  HorizontalAlignment="Left"/>
                 </StackPanel>
 
                 <!-- Used as: keyword chips — items that satisfy keyword-based slots in recipes -->

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -57,6 +57,7 @@ public sealed partial class ItemDetailViewModel
         UnpreviewableExtractions = context.UnpreviewableExtractions ?? [];
         ProducedByRecipes = context.ProducedByRecipes ?? [];
         ConsumedByRecipes = context.ConsumedByRecipes ?? [];
+        MoreRecipesChip = context.MoreRecipesChip;
         ConsumedAsKeywordIn = context.ConsumedAsKeywordIn ?? [];
         Sources = context.Sources ?? [];
         _poolPresenter = poolPresenter;
@@ -96,9 +97,19 @@ public sealed partial class ItemDetailViewModel
 
     /// <summary>
     /// Recipes that consume this item as an ingredient. Same lifecycle as
-    /// <see cref="ProducedByRecipes"/>.
+    /// <see cref="ProducedByRecipes"/>. Capped at
+    /// <c>SilmarillionSettings.UsedInChipCap</c>; the overflow lives on
+    /// <see cref="MoreRecipesChip"/>.
     /// </summary>
     public IReadOnlyList<EntityChipVm> ConsumedByRecipes { get; }
+
+    /// <summary>
+    /// Overflow pill for the "Used in" section. Non-null only when the underlying recipe
+    /// count exceeds the cap; clicking deep-links to the Recipes tab pre-filtered via
+    /// <c>QueryText = Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>. Bound visibility
+    /// on the XAML side hides the pill when this is null.
+    /// </summary>
+    public EntityChipVm? MoreRecipesChip { get; }
 
     /// <summary>
     /// Per-keyword chips for the item-detail "Used as" section. One chip per keyword the

--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -31,6 +31,14 @@ public enum EntityKind
     /// Dispatched by ItemKeywordKindTarget.
     /// </summary>
     ItemKeyword,
+
+    /// <summary>
+    /// Not an entity per se — a deep-link target for "open the Recipes tab filtered to recipes
+    /// that consume this item as a direct ingredient." InternalName carries the item's
+    /// InternalName. Dispatched by RecipeIngredientItemKindTarget. Mirror of
+    /// <see cref="RecipeIngredientKeyword"/> for the item-pivot direction.
+    /// </summary>
+    RecipeIngredientItem,
 }
 
 /// <summary>
@@ -56,6 +64,7 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef RecipeIngredientKeyword(string keyword) => new(EntityKind.RecipeIngredientKeyword, keyword);
     public static EntityRef ItemKeyword(string keyword) => new(EntityKind.ItemKeyword, keyword);
     public static EntityRef ItemKeyword(IReadOnlyList<string> itemKeys) => new(EntityKind.ItemKeyword, string.Join('+', itemKeys));
+    public static EntityRef RecipeIngredientItem(string itemInternalName) => new(EntityKind.RecipeIngredientItem, itemInternalName);
 }
 
 /// <summary>

--- a/src/Silmarillion.Module/Navigation/RecipeIngredientItemKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/RecipeIngredientItemKindTarget.cs
@@ -1,0 +1,40 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> for <see cref="EntityKind.RecipeIngredientItem"/>.
+/// Flips to the Recipes tab and pre-populates <see cref="RecipesTabViewModel.QueryText"/>
+/// with <c>Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>. Mirror of
+/// <see cref="RecipeIngredientKeywordKindTarget"/> for the item-pivot direction — powers
+/// the item-detail "Used in" overflow pill (<c>+N more →</c>) when the per-recipe chip
+/// count exceeds <c>SilmarillionSettings.UsedInChipCap</c>.
+/// </summary>
+public sealed class RecipeIngredientItemKindTarget : IReferenceKindTarget
+{
+    private readonly RecipesTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public RecipeIngredientItemKindTarget(RecipesTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.RecipeIngredientItem;
+
+    public int TabIndex => 1;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var query = $"Ingredients CONTAINS \"{internalName}\"";
+        _diag?.Info("Silmarillion.Nav", $"RecipeIngredientItem.TrySelect '{internalName}' → setting QueryText.");
+        _vm.SelectedRow = null;
+        _vm.QueryText = query;
+        return true;
+    }
+
+    public bool TryOpenInWindow() => false;
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -1,5 +1,7 @@
+using System.IO;
 using MahApps.Metro.IconPacks;
 using Microsoft.Extensions.DependencyInjection;
+using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
@@ -23,10 +25,15 @@ public sealed class SilmarillionModule : IMithrilModule
     public int SortOrder => 950;
     public ActivationMode DefaultActivation => ActivationMode.Lazy;
     public Type ViewType => typeof(SilmarillionView);
-    public Type? SettingsViewType => null;
+    public Type? SettingsViewType => typeof(SilmarillionSettingsView);
 
     public void Register(IServiceCollection services)
     {
+        var localApp = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var silmarillionDir = Path.Combine(localApp, "Mithril", "Silmarillion");
+        var settingsPath = Path.Combine(silmarillionDir, "settings.json");
+        services.AddMithrilSettings<SilmarillionSettings>(settingsPath, SilmarillionSettingsJsonContext.Default.SilmarillionSettings);
+
         // Replace the shell-registered NoOpReferenceNavigator. Last AddSingleton<T> wins
         // for non-keyed singleton resolution, and module Register() runs after shell DI
         // setup. The navigator pulls all IReferenceKindTarget registrations via DI;
@@ -38,7 +45,10 @@ public sealed class SilmarillionModule : IMithrilModule
             () => sp.GetService<IModuleActivator>(),
             sp.GetService<IDiagnosticsSink>()));
 
-        services.AddSingleton<ItemsTabViewModel>();
+        services.AddSingleton<ItemsTabViewModel>(sp => new ItemsTabViewModel(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IReferenceNavigator>(),
+            sp.GetRequiredService<SilmarillionSettings>()));
         services.AddSingleton<RecipesTabViewModel>();
         services.AddSingleton<SilmarillionViewModel>();
 
@@ -58,6 +68,9 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<IReferenceKindTarget>(sp => new ItemKeywordKindTarget(
             sp.GetRequiredService<ItemsTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new RecipeIngredientItemKindTarget(
+            sp.GetRequiredService<RecipesTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
         services.AddSingleton<IDeepLinkHandler>(sp =>
@@ -66,6 +79,10 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<SilmarillionView>(sp => new SilmarillionView
         {
             DataContext = sp.GetRequiredService<SilmarillionViewModel>(),
+        });
+        services.AddSingleton<SilmarillionSettingsView>(sp => new SilmarillionSettingsView
+        {
+            DataContext = sp.GetRequiredService<SilmarillionSettings>(),
         });
     }
 }

--- a/src/Silmarillion.Module/SilmarillionSettings.cs
+++ b/src/Silmarillion.Module/SilmarillionSettings.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+
+namespace Silmarillion;
+
+/// <summary>
+/// Persisted preferences for the Silmarillion module. v1 only exposes
+/// <see cref="UsedInChipCap"/>; the class exists primarily as scaffolding so future
+/// settings (default tab, hide-empty-sections, …) can land as small follow-ups.
+/// <see cref="SchemaVersion"/> is stamped from day one per the project's
+/// versioned-JSON convention — cheap forward-compat without committing to the
+/// <c>IVersionedState</c> migration path yet.
+/// </summary>
+public sealed class SilmarillionSettings : INotifyPropertyChanged
+{
+    /// <summary>Lowest valid cap. Zero collapses every "Used in" chip into the overflow pill.</summary>
+    public const int MinUsedInChipCap = 0;
+
+    /// <summary>Highest valid cap. Above ~100 the section becomes unbrowsable regardless of perf.</summary>
+    public const int MaxUsedInChipCap = 100;
+
+    /// <summary>Default cap: cheap case stays cheap, long tail collapses behind the overflow pill.</summary>
+    public const int DefaultUsedInChipCap = 12;
+
+    private int _schemaVersion = 1;
+    private int _usedInChipCap = DefaultUsedInChipCap;
+
+    /// <summary>
+    /// Persisted schema version. Always written so a future <c>IVersionedState</c> migration
+    /// switch can branch on the stored value instead of guessing.
+    /// </summary>
+    public int SchemaVersion
+    {
+        get => _schemaVersion;
+        set => Set(ref _schemaVersion, value);
+    }
+
+    /// <summary>
+    /// Maximum number of per-recipe chips rendered in the item-detail "Used in" section
+    /// before collapsing the rest behind a <c>+N more →</c> overflow pill. Clamped to
+    /// <see cref="MinUsedInChipCap"/>..<see cref="MaxUsedInChipCap"/>.
+    /// </summary>
+    public int UsedInChipCap
+    {
+        get => _usedInChipCap;
+        set => Set(ref _usedInChipCap, Math.Clamp(value, MinUsedInChipCap, MaxUsedInChipCap));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(SilmarillionSettings))]
+public partial class SilmarillionSettingsJsonContext : JsonSerializerContext { }

--- a/src/Silmarillion.Module/ViewModels/IngredientItemValue.cs
+++ b/src/Silmarillion.Module/ViewModels/IngredientItemValue.cs
@@ -1,0 +1,16 @@
+using Mithril.Reference;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Lightweight wrapper that lets a recipe's flattened ingredient-item set
+/// participate in the query engine's collection-<c>CONTAINS</c> path. Exposes the
+/// item's <c>InternalName</c> as the queryable string. Mirror of
+/// <see cref="IngredientKeywordValue"/> for the item-pivot direction — powers
+/// the item-detail "Used in" overflow pill deep-link
+/// (<c>Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>).
+/// </summary>
+public sealed record IngredientItemValue(string InternalName) : IQueryStringValue
+{
+    public string QueryStringValue => InternalName;
+}

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Items;
@@ -35,15 +36,25 @@ public sealed partial class ItemsTabViewModel : ObservableObject
 
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
+    private readonly SilmarillionSettings _settings;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;
 
     public ItemsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator)
+        : this(refData, navigator, settings: null)
+    {
+    }
+
+    public ItemsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator, SilmarillionSettings? settings)
     {
         _refData = refData;
         _navigator = navigator;
+        // null → owned default instance keeps non-DI callers (tests) working without forcing
+        // every fixture to construct one. The DI path always passes the live singleton.
+        _settings = settings ?? new SilmarillionSettings();
         _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
         _allItems = BuildAllItems(refData);
         refData.FileUpdated += OnFileUpdated;
+        _settings.PropertyChanged += OnSettingsChanged;
     }
 
     [ObservableProperty]
@@ -108,17 +119,63 @@ public sealed partial class ItemsTabViewModel : ObservableObject
             .OrderBy(i => i.Name ?? i.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
             .ToList();
 
+    private void OnSettingsChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // UsedInChipCap controls the "Used in" overflow pill threshold; rebuild the live
+        // detail VM when it changes so the slider feels immediate. Toggle through null to
+        // sidestep [ObservableProperty]'s reference-equality check.
+        if (e.PropertyName != nameof(SilmarillionSettings.UsedInChipCap)) return;
+        var captured = SelectedItem;
+        if (captured is null) return;
+        UiThread.Run(() =>
+        {
+            SelectedItem = null;
+            SelectedItem = captured;
+        });
+    }
+
     private ItemDetailContext BuildCrossLinkContext(Item item)
     {
         if (string.IsNullOrEmpty(item.InternalName))
         {
             return ItemDetailContext.Empty;
         }
+        var (consumed, more) = BuildConsumedByChips(_refData.RecipesByIngredientItem, item);
         return new ItemDetailContext(
             ProducedByRecipes: BuildRecipeChips(_refData.RecipesByProducedItem, item.InternalName!),
-            ConsumedByRecipes: BuildRecipeChips(_refData.RecipesByIngredientItem, item.InternalName!),
+            ConsumedByRecipes: consumed,
             ConsumedAsKeywordIn: BuildKeywordChips(item),
-            Sources: BuildSourceChips(item.InternalName!));
+            Sources: BuildSourceChips(item.InternalName!),
+            MoreRecipesChip: more);
+    }
+
+    /// <summary>
+    /// Apply <see cref="SilmarillionSettings.UsedInChipCap"/> to the "Used in" chip list.
+    /// When the underlying recipe count exceeds the cap, returns the first N chips plus a
+    /// pill chip pointing to the symmetric recipe-tab filter
+    /// (<c>Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>). Pill carries the item's own
+    /// icon for visual continuity with the detail header.
+    /// </summary>
+    private (IReadOnlyList<EntityChipVm>? Chips, EntityChipVm? More) BuildConsumedByChips(
+        IReadOnlyDictionary<string, IReadOnlyList<Recipe>> index,
+        Item item)
+    {
+        var itemName = item.InternalName!;
+        var all = BuildRecipeChips(index, itemName);
+        if (all is null) return (null, null);
+
+        var cap = _settings.UsedInChipCap;
+        if (all.Count <= cap) return (all, null);
+
+        var capped = cap == 0 ? (IReadOnlyList<EntityChipVm>)Array.Empty<EntityChipVm>() : all.Take(cap).ToList();
+        var overflow = all.Count - cap;
+        var reference = EntityRef.RecipeIngredientItem(itemName);
+        var pill = new EntityChipVm(
+            DisplayName: $"+{overflow} more →",
+            IconId: item.IconId,
+            Reference: reference,
+            IsNavigable: _navigator.CanOpen(reference));
+        return (capped, pill);
     }
 
     private IReadOnlyList<EntityChipVm>? BuildKeywordChips(Item item)

--- a/src/Silmarillion.Module/ViewModels/RecipeListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeListRow.cs
@@ -10,7 +10,10 @@ namespace Silmarillion.ViewModels;
 /// binds directly to these projected fields. <see cref="IngredientKeywords"/> is the flat,
 /// deduplicated list of every keyword string across the recipe's <see cref="RecipeKeywordIngredient"/>
 /// slots — queryable via the engine's collection-<c>CONTAINS</c> path (powers the item-detail
-/// "Used as" chip deep-link).
+/// "Used as" chip deep-link). <see cref="Ingredients"/> mirrors that for the item-pivot direction:
+/// the flat, deduplicated list of every <c>InternalName</c> consumed via a direct
+/// <see cref="RecipeItemIngredient"/> — powers the item-detail "Used in" overflow pill deep-link
+/// (<c>Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>).
 /// </summary>
 public sealed record RecipeListRow(
     Recipe Recipe,
@@ -18,4 +21,5 @@ public sealed record RecipeListRow(
     int IconId,
     string? SkillDisplayName,
     int SkillLevelReq,
-    IReadOnlyList<IngredientKeywordValue> IngredientKeywords);
+    IReadOnlyList<IngredientKeywordValue> IngredientKeywords,
+    IReadOnlyList<IngredientItemValue> Ingredients);

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -126,7 +126,8 @@ public sealed partial class RecipesTabViewModel : ObservableObject
                 IconId: r.IconId > 0 ? r.IconId : ResolveResultIcon(r),
                 SkillDisplayName: ResolveSkillDisplayName(r.Skill),
                 SkillLevelReq: r.SkillLevelReq,
-                IngredientKeywords: BuildIngredientKeywords(r)))
+                IngredientKeywords: BuildIngredientKeywords(r),
+                Ingredients: BuildIngredientItems(r, refData)))
             .OrderBy(row => row.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
@@ -138,6 +139,19 @@ public sealed partial class RecipesTabViewModel : ObservableObject
             .SelectMany(slot => slot.ItemKeys)
             .Distinct(StringComparer.Ordinal)
             .Select(tag => new IngredientKeywordValue(tag))
+            .ToList();
+    }
+
+    private static IReadOnlyList<IngredientItemValue> BuildIngredientItems(Recipe recipe, IReferenceDataService refData)
+    {
+        if (recipe.Ingredients is null) return [];
+        return recipe.Ingredients
+            .OfType<RecipeItemIngredient>()
+            .Select(slot => refData.Items.TryGetValue(slot.ItemCode, out var item) ? item.InternalName : null)
+            .Where(name => !string.IsNullOrEmpty(name))
+            .Select(name => name!)
+            .Distinct(StringComparer.Ordinal)
+            .Select(name => new IngredientItemValue(name))
             .ToList();
     }
 

--- a/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml
@@ -1,0 +1,40 @@
+<UserControl x:Class="Silmarillion.Views.SilmarillionSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="#FF1A1A1A"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+    </UserControl.Resources>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="24,16" MaxWidth="720" HorizontalAlignment="Left">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,20">
+                <Image Source="pack://application:,,,/Silmarillion.Module;component/Resources/silmarillion.ico"
+                       Width="28" Height="28" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBlock Text="Silmarillion · Reference Settings"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeHero}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- "Used in" chip cap -->
+            <TextBlock Text="Item detail · 'Used in' chips" Foreground="#88FFFFFF" Margin="0,0,0,6" FontWeight="SemiBold"/>
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock DockPanel.Dock="Left" Text="Show at most" VerticalAlignment="Center" Foreground="#FFE8E8E8" Width="110"/>
+                <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" Foreground="#88FFFFFF" Width="60"
+                           Text="{Binding UsedInChipCap, StringFormat={}{0} chips}"/>
+                <Slider Minimum="0" Maximum="100" TickFrequency="4" IsSnapToTickEnabled="True"
+                        Value="{Binding UsedInChipCap, Mode=TwoWay}"
+                        VerticalAlignment="Center" Margin="0,0,8,0"/>
+            </DockPanel>
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource AppFontSizeHint}" Foreground="#88FFFFFF" Margin="0,0,0,24">
+                Items with many recipes (e.g. metal slabs, leather hides) take longer to render
+                when every consuming recipe gets its own chip. Above the cap, the remaining
+                recipes collapse into a single &quot;+N more →&quot; pill that opens the Recipes
+                tab pre-filtered to recipes using this item. Default 12. Set to 0 to always
+                collapse; raise to 100 to show everything.
+            </TextBlock>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml.cs
+++ b/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml.cs
@@ -1,0 +1,6 @@
+namespace Silmarillion.Views;
+
+public partial class SilmarillionSettingsView : System.Windows.Controls.UserControl
+{
+    public SilmarillionSettingsView() { InitializeComponent(); }
+}

--- a/tests/Mithril.Shared.Tests/Reference/EntityRefTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/EntityRefTests.cs
@@ -43,4 +43,13 @@ public class EntityRefTests
         // InternalName, so callers can construct either way without ambiguity.
         EntityRef.ItemKeyword(["Crystal"]).Should().Be(EntityRef.ItemKeyword("Crystal"));
     }
+
+    [Fact]
+    public void RecipeIngredientItem_factory_produces_expected_kind_and_internalname()
+    {
+        var reference = EntityRef.RecipeIngredientItem("MetalSlab1");
+
+        reference.Kind.Should().Be(EntityKind.RecipeIngredientItem);
+        reference.InternalName.Should().Be("MetalSlab1");
+    }
 }

--- a/tests/Silmarillion.Tests/Navigation/RecipeIngredientItemKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/RecipeIngredientItemKindTargetTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class RecipeIngredientItemKindTargetTests
+{
+    [Fact]
+    public void Kind_IsRecipeIngredientItem()
+    {
+        var (target, _) = Build();
+        target.Kind.Should().Be(EntityKind.RecipeIngredientItem);
+    }
+
+    [Fact]
+    public void TabIndex_IsOne()
+    {
+        var (target, _) = Build();
+        target.TabIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryOpenInWindow_ReturnsFalse()
+    {
+        var (target, _) = Build();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_SetsIngredientsContainsFilter()
+    {
+        var (target, vm) = Build();
+
+        var ok = target.TrySelectByInternalName("MetalSlab1");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().Be("Ingredients CONTAINS \"MetalSlab1\"");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsPriorSelection_SoFilteredListHasNoStaleRow()
+    {
+        var recipe = new Recipe { Key = "recipe_1", InternalName = "MakeSlab", Name = "Make Slab", Ingredients = [] };
+        var (target, vm) = Build(recipe);
+        vm.SelectedRow = vm.AllRecipes.Single();
+        vm.SelectedRow.Should().NotBeNull();
+
+        target.TrySelectByInternalName("MetalSlab1").Should().BeTrue();
+
+        vm.SelectedRow.Should().BeNull(because: "filter-only navigation must drop any stale detail selection");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_QuotesItemName_SoInternalNamesWithSpecialCharsParse()
+    {
+        // InternalNames in PG are ASCII identifiers, but quoting is the safe default — mirrors
+        // RecipeIngredientKeywordKindTarget's behaviour so future schema oddities don't break it.
+        var (target, vm) = Build();
+
+        target.TrySelectByInternalName("Item With Spaces").Should().BeTrue();
+
+        vm.QueryText.Should().Be("Ingredients CONTAINS \"Item With Spaces\"");
+    }
+
+    private static (RecipeIngredientItemKindTarget Target, RecipesTabViewModel Vm) Build(params Recipe[] recipes)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var recipe in recipes)
+            refData.AddRecipe(recipe);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new RecipesTabViewModel(refData, nav);
+        return (new RecipeIngredientItemKindTarget(vm), vm);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
+
+        public void AddRecipe(Recipe recipe) => _recipes[recipe.Key] = recipe;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/SilmarillionSettingsTests.cs
+++ b/tests/Silmarillion.Tests/SilmarillionSettingsTests.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Xunit;
+
+namespace Silmarillion.Tests;
+
+public sealed class SilmarillionSettingsTests
+{
+    [Fact]
+    public void Defaults_StampSchemaVersion1_AndCap12()
+    {
+        var s = new SilmarillionSettings();
+        s.SchemaVersion.Should().Be(1);
+        s.UsedInChipCap.Should().Be(SilmarillionSettings.DefaultUsedInChipCap);
+        SilmarillionSettings.DefaultUsedInChipCap.Should().Be(12);
+    }
+
+    [Fact]
+    public void UsedInChipCap_ClampsBelowZero_ToZero()
+    {
+        var s = new SilmarillionSettings { UsedInChipCap = -5 };
+        s.UsedInChipCap.Should().Be(0);
+    }
+
+    [Fact]
+    public void UsedInChipCap_ClampsAboveMax_ToMax()
+    {
+        var s = new SilmarillionSettings { UsedInChipCap = 9999 };
+        s.UsedInChipCap.Should().Be(SilmarillionSettings.MaxUsedInChipCap);
+    }
+
+    [Fact]
+    public void UsedInChipCap_AcceptsZero_AsAllCollapsed()
+    {
+        var s = new SilmarillionSettings { UsedInChipCap = 0 };
+        s.UsedInChipCap.Should().Be(0);
+    }
+
+    [Fact]
+    public void UsedInChipCap_RaisesPropertyChanged_OnChange()
+    {
+        var s = new SilmarillionSettings();
+        var fired = new List<string?>();
+        s.PropertyChanged += (_, e) => fired.Add(e.PropertyName);
+
+        s.UsedInChipCap = 24;
+
+        fired.Should().Contain(nameof(SilmarillionSettings.UsedInChipCap));
+    }
+
+    [Fact]
+    public void UsedInChipCap_DoesNotRaise_WhenValueUnchanged()
+    {
+        var s = new SilmarillionSettings { UsedInChipCap = 24 };
+        var fired = new List<string?>();
+        s.PropertyChanged += (_, e) => fired.Add(e.PropertyName);
+
+        s.UsedInChipCap = 24;
+
+        fired.Should().BeEmpty();
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/IngredientItemValueTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/IngredientItemValueTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Mithril.Reference;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public class IngredientItemValueTests
+{
+    [Fact]
+    public void QueryStringValue_returns_InternalName()
+    {
+        var value = new IngredientItemValue("MetalSlab1");
+
+        value.QueryStringValue.Should().Be("MetalSlab1");
+    }
+
+    [Fact]
+    public void Implements_IQueryStringValue()
+    {
+        IQueryStringValue value = new IngredientItemValue("MetalSlab1");
+
+        value.QueryStringValue.Should().Be("MetalSlab1");
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -116,6 +116,126 @@ public sealed class ItemsTabViewModelTests
     }
 
     [Fact]
+    public void UsedIn_belowCap_emitsAllChips_andNoMoreRecipesChip()
+    {
+        var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["MetalSlab1"] = item },
+            RecipesByIngredient =
+            {
+                ["MetalSlab1"] = MakeRecipeList(count: 5),
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new SilmarillionSettings { UsedInChipCap = 12 });
+
+        vm.SelectedItem = item;
+
+        vm.DetailViewModel!.ConsumedByRecipes.Should().HaveCount(5);
+        vm.DetailViewModel.MoreRecipesChip.Should().BeNull();
+    }
+
+    [Fact]
+    public void UsedIn_aboveCap_capsChips_andEmitsMoreRecipesPill()
+    {
+        var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab", IconId = 4242 };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["MetalSlab1"] = item },
+            RecipesByIngredient =
+            {
+                // The MetalSlab1 case from the issue (~69 recipes).
+                ["MetalSlab1"] = MakeRecipeList(count: 69),
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new SilmarillionSettings { UsedInChipCap = 12 });
+
+        vm.SelectedItem = item;
+
+        vm.DetailViewModel!.ConsumedByRecipes.Should().HaveCount(12,
+            because: "cap 12 means the first dozen show as chips and the rest collapse behind the pill");
+
+        var pill = vm.DetailViewModel.MoreRecipesChip;
+        pill.Should().NotBeNull();
+        pill!.DisplayName.Should().Be("+57 more →");
+        pill.IconId.Should().Be(4242, because: "pill carries the item's own icon for visual continuity");
+        pill.Reference.Should().Be(EntityRef.RecipeIngredientItem("MetalSlab1"));
+    }
+
+    [Fact]
+    public void UsedIn_capZero_collapsesEverythingIntoPill()
+    {
+        var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["MetalSlab1"] = item },
+            RecipesByIngredient = { ["MetalSlab1"] = MakeRecipeList(count: 3) },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new SilmarillionSettings { UsedInChipCap = 0 });
+
+        vm.SelectedItem = item;
+
+        vm.DetailViewModel!.ConsumedByRecipes.Should().BeEmpty();
+        vm.DetailViewModel.MoreRecipesChip.Should().NotBeNull();
+        vm.DetailViewModel.MoreRecipesChip!.DisplayName.Should().Be("+3 more →");
+    }
+
+    [Fact]
+    public void UsedIn_capExactlyMatchesCount_noOverflowPill()
+    {
+        var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["MetalSlab1"] = item },
+            RecipesByIngredient = { ["MetalSlab1"] = MakeRecipeList(count: 12) },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new SilmarillionSettings { UsedInChipCap = 12 });
+
+        vm.SelectedItem = item;
+
+        vm.DetailViewModel!.ConsumedByRecipes.Should().HaveCount(12);
+        vm.DetailViewModel.MoreRecipesChip.Should().BeNull(
+            because: "the pill appears only when count exceeds the cap, not when they're equal");
+    }
+
+    [Fact]
+    public void UsedInChipCap_change_liveRebuilds_DetailViewModel()
+    {
+        // The user drags the slider; the open detail view should re-cap on the spot. We
+        // verify by changing the cap and checking that ConsumedByRecipes / MoreRecipesChip
+        // reflect the new value.
+        var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
+        var refData = new StubReferenceData
+        {
+            ItemsByName = { ["MetalSlab1"] = item },
+            RecipesByIngredient = { ["MetalSlab1"] = MakeRecipeList(count: 20) },
+        };
+        var settings = new SilmarillionSettings { UsedInChipCap = 12 };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), settings);
+        vm.SelectedItem = item;
+
+        var before = vm.DetailViewModel!;
+        before.ConsumedByRecipes.Should().HaveCount(12);
+        before.MoreRecipesChip.Should().NotBeNull();
+
+        settings.UsedInChipCap = 25;
+
+        var after = vm.DetailViewModel!;
+        after.Should().NotBeSameAs(before, because: "live-update rebuilds the detail VM on slider drag");
+        after.ConsumedByRecipes.Should().HaveCount(20);
+        after.MoreRecipesChip.Should().BeNull();
+    }
+
+    private static IReadOnlyList<Recipe> MakeRecipeList(int count) =>
+        Enumerable.Range(1, count)
+            .Select(i => new Recipe { Key = $"recipe_{i:D3}", InternalName = $"Recipe{i:D3}", Name = $"Recipe {i:D3}" })
+            .ToList();
+
+    [Fact]
     public void Keyword_chip_falls_back_to_CamelCaseSplit_when_no_friendly_display_name()
     {
         // Mirrors the GreenCrystal case: no recipe carries a friendly singleton Desc for the keyword,
@@ -145,12 +265,14 @@ public sealed class ItemsTabViewModelTests
     private sealed class StubReferenceData : IReferenceDataService
     {
         public Dictionary<string, Item> ItemsByName { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<Recipe>> RecipesByIngredient { get; } = new(StringComparer.Ordinal);
         public IReadOnlyCollection<string> KeywordsInRecipeSlots { get; init; } = [];
         public IReadOnlyDictionary<string, string> KeywordDisplays { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items => ItemsByName.Values.ToDictionary(i => i.Id);
         public IReadOnlyDictionary<string, Item> ItemsByInternalName => ItemsByName;
+        public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesByIngredientItem => RecipesByIngredient;
         public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
         public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
         public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();

--- a/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
@@ -469,6 +469,75 @@ public sealed class RecipesTabViewModelTests
     }
 
     [Fact]
+    public void RecipeListRow_Ingredients_flattens_RecipeItemIngredient_InternalNames_distinctly()
+    {
+        // Two direct-item slots referencing the same item code, plus a keyword slot
+        // (which must be ignored — keywords go into IngredientKeywords, not Ingredients).
+        var slab = new Item { Id = 42, InternalName = "MetalSlab1", Name = "Metal Slab" };
+        var oil = new Item { Id = 7, InternalName = "OilTier1", Name = "Tier 1 Oil" };
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "ForgeSlab",
+            Name = "Forge Slab",
+            Skill = "Blacksmithing",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeItemIngredient { ItemCode = 42, StackSize = 1 },
+                new RecipeItemIngredient { ItemCode = 42, StackSize = 2 }, // dup → collapses
+                new RecipeItemIngredient { ItemCode = 7, StackSize = 1 },
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], StackSize = 1 }, // ignored
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            ItemsByCode = { [42] = slab, [7] = oil },
+            RecipesByKey = { ["r1"] = recipe },
+        };
+
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        var row = vm.AllRecipes.Should().ContainSingle().Subject;
+        row.Ingredients.Select(i => i.InternalName)
+            .Should().BeEquivalentTo(["MetalSlab1", "OilTier1"]);
+    }
+
+    [Fact]
+    public void QueryText_IngredientsContains_FiltersToMatchingRecipeOnly()
+    {
+        // Symmetric counterpart to the IngredientKeywords query test — verifies the same
+        // query path works for the item-pivot direction (powers the "Used in" overflow pill).
+        var slab = new Item { Id = 42, InternalName = "MetalSlab1", Name = "Metal Slab" };
+        var hide = new Item { Id = 88, InternalName = "LeatherHide", Name = "Leather Hide" };
+        var recipeA = new Recipe
+        {
+            Key = "rA", InternalName = "ForgeSlab", Name = "Forge Slab", Skill = "Blacksmithing",
+            Ingredients = new RecipeIngredient[] { new RecipeItemIngredient { ItemCode = 42, StackSize = 1 } },
+        };
+        var recipeB = new Recipe
+        {
+            Key = "rB", InternalName = "TanHide", Name = "Tan Hide", Skill = "Tanning",
+            Ingredients = new RecipeIngredient[] { new RecipeItemIngredient { ItemCode = 88, StackSize = 1 } },
+        };
+        var refData = new StubReferenceData
+        {
+            ItemsByCode = { [42] = slab, [88] = hide },
+            RecipesByKey = { ["rA"] = recipeA, ["rB"] = recipeB },
+        };
+        var vm = new RecipesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        const string queryString = "Ingredients CONTAINS \"MetalSlab1\"";
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(RecipeListRow));
+        var predicate = QueryCompiler.Compile(queryString, columns);
+        predicate.Should().NotBeNull();
+
+        var matches = vm.AllRecipes.Where(row => predicate!(row)).ToList();
+
+        matches.Should().ContainSingle(r => r.Recipe.InternalName == "ForgeSlab");
+        matches.Should().NotContain(r => r.Recipe.InternalName == "TanHide");
+    }
+
+    [Fact]
     public void ProducedItemChips_PreferResultItems_FallBackToProtoResultItems()
     {
         var sauce = new Item { Id = 101, InternalName = "TomatoSauce", Name = "Tomato Sauce", IconId = 2 };


### PR DESCRIPTION
## Summary

Resolves #273. Two changes shipped together:

**Part 1 — capped "Used in" + overflow pill.** Long-tail items like MetalSlab1 (69 consuming recipes) made every item-detail selection pay icon-load + WrapPanel measure for every chip. New `EntityKind.RecipeIngredientItem` + `RecipeIngredientItemKindTarget` + `RecipeListRow.Ingredients` mirror the PR #267 pattern for the item-pivot direction. When the recipe count exceeds the cap, `ItemsTabViewModel.BuildConsumedByChips` returns the first N chips plus a `+{N-cap} more →` pill that deep-links to the Recipes tab pre-filtered to `Ingredients CONTAINS "<itemInternalName>"`. Pill carries the item's own icon for visual continuity (per the issue's recommendation).

**Part 2 — Silmarillion settings scaffold.** Silmarillion had `SettingsViewType => null`. New `SilmarillionSettings` class:
- `INotifyPropertyChanged` + source-generated STJ context per the CLAUDE.md convention
- `SchemaVersion = 1` stamped from day one (per the versioned-JSON memory)
- `UsedInChipCap` clamped 0..100, default 12
- `AddMithrilSettings<SilmarillionSettings>` wired with debounced autosave
- `SilmarillionSettingsView` slider UI; live-rebuilds the open detail VM on drag

## Files

| Area | Change |
|---|---|
| `Mithril.Shared` | `EntityKind.RecipeIngredientItem` (last position, ordinals preserved) + factory |
| `Mithril.Shared.Wpf` | `ItemDetailContext.MoreRecipesChip`; `ItemDetailViewModel.MoreRecipesChip` passthrough; `NullToVisibilityConverter`; XAML overflow pill |
| `Silmarillion.Module` | `IngredientItemValue : IQueryStringValue`; `RecipeListRow.Ingredients`; `RecipeIngredientItemKindTarget`; `SilmarillionSettings` + JSON ctx + DI; `SilmarillionSettingsView` |
| `tests` | `RecipeIngredientItemKindTargetTests`, `SilmarillionSettingsTests`, `IngredientItemValueTests`, cap/overflow/live-rebuild cases in `ItemsTabViewModelTests`, `Ingredients`-flatten + query-parse cases in `RecipesTabViewModelTests`, `EntityRef.RecipeIngredientItem` factory case |

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Mithril.slnx` — all suites green; Silmarillion went 108 → 129 tests
- [ ] Manual: open Silmarillion, select MetalSlab1, confirm 12 chips + "+57 more →" pill appears
- [ ] Manual: click the pill — Recipes tab opens with `Ingredients CONTAINS "MetalSlab1"`, no stale selection
- [ ] Manual: open Silmarillion settings, drag slider — open detail view re-caps live; value persists across restart at `%LocalAppData%/Mithril/Silmarillion/settings.json`
- [ ] Manual: shell boot smoke — watch `boot.log` advance past `creating App` (DI cycle paranoia: new `SilmarillionSettings` singleton is leaf-shaped, but verify per the auto-memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)