### PR TITLE
docs(silmarillion): cookbook updates after #272 + #264

### DIFF
--- a/docs/silmarillion-tab-cookbook.md
+++ b/docs/silmarillion-tab-cookbook.md
@@ -2,7 +2,7 @@
 
 > **Companion doc:** [silmarillion-roadmap.md](silmarillion-roadmap.md) — *why* each tab exists. This doc covers *how* to build one.
 
-How to add a new master-detail tab to Silmarillion, after the Items + Recipes v1 shipped (PR #236) and the navigator was refactored to a kind-target registry (#239). Every Bucket B tab follows the same scaffold; this doc is the scaffold. Per-tab handoffs in [`docs/agent-plans/`](agent-plans/) own the entity-specific decisions.
+How to add a new master-detail tab to Silmarillion, after the Items + Recipes v1 shipped (PR #236), the navigator was refactored to a kind-target registry (#239), and the tab-strip moved to MVVM `ItemsSource` binding via [`ModuleTab`](../src/Mithril.Shared.Wpf/ModuleTab.cs) (#272 / #233). Every Bucket B tab follows the same scaffold; this doc is the scaffold. Per-tab handoffs in [`docs/agent-plans/`](agent-plans/) own the entity-specific decisions.
 
 ## What's in scope vs. what your handoff still owns
 
@@ -41,9 +41,10 @@ For tab `X` (e.g. `Npcs`, `Quests`, `Areas`):
        sp.GetRequiredService<XTabViewModel>(),
        sp.GetService<IDiagnosticsSink>()));
    ```
-3. **`SilmarillionViewModel`** ([src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs](../src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs)) — add a constructor parameter `XTabViewModel x` and a public `X { get; }` property. **No changes to `OnNavigated` or `OpenInWindow`** — the registry-driven dispatch already handles new kinds automatically. Confirm `EntityKind.<X>` exists in [src/Mithril.Shared/Reference/EntityRef.cs](../src/Mithril.Shared/Reference/EntityRef.cs); it should — all 11 entity kinds were enumerated in v1, plus the synthetic `RecipeIngredientKeyword` deep-link variant added by #259 (see *Synthetic kinds*, below).
-4. **`SilmarillionView.xaml`** ([src/Silmarillion.Module/Views/SilmarillionView.xaml:46-54](../src/Silmarillion.Module/Views/SilmarillionView.xaml#L46-L54)) — add `<TabItem Header="<Label>"><local:XTabView DataContext="{Binding X}"/></TabItem>`. Tab index is implicit; the `IReferenceKindTarget.TabIndex` property is what the navigator uses to drive `SelectedTabIndex`, so keep them in sync.
+3. **`SilmarillionViewModel`** ([src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs](../src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs)) — add a constructor parameter `XTabViewModel x`, a public `X { get; }` property, and **append a `new ModuleTab("<Label>", x)` entry to the `Tabs` collection** built in the constructor. Tab index is the array position. **No changes to `OnNavigated` or `OpenInWindow`** — the registry-driven dispatch already handles new kinds automatically. Confirm `EntityKind.<X>` exists in [src/Mithril.Shared/Reference/EntityRef.cs](../src/Mithril.Shared/Reference/EntityRef.cs); it should — all 11 entity kinds were enumerated in v1, alongside three synthetic deep-link variants (`RecipeIngredientKeyword` from #259, `ItemKeyword` from #270, `RecipeIngredientItem` from #273) — see *Synthetic kinds*, below.
+4. **`SilmarillionView.xaml`** ([src/Silmarillion.Module/Views/SilmarillionView.xaml](../src/Silmarillion.Module/Views/SilmarillionView.xaml)) — **the `TabControl` itself doesn't change** (it binds `ItemsSource="{Binding Tabs}"` since the #272 / #233 refactor). Add a `<DataTemplate DataType="{x:Type vm:XTabViewModel}"><local:XTabView/></DataTemplate>` entry to `UserControl.Resources` so the TabControl's `ContentTemplate` can resolve the new VM type to its view. Header rendering and the gold IsSelected underline come from `ModuleTabHeaderTemplate` + `MithrilTabItemStyle` — already wired.
 5. **Wire `IReferenceDataService.FileUpdated`** in the tab VM constructor — subscribe to the file name your data source reads (e.g. `"npcs"`, `"quests"`). Rebuild the master list on the UI thread; preserve selection by `InternalName`. **Don't skip this** — without it, a background CDN refresh leaves WPF's ListBox bound to a stale collection and selections set via the navigator silently fall out of the list.
+6. **Expose `public static IReadOnlyList<ColumnSchema> SchemaSnapshot`** on the tab VM, reflected from your row type via `ColumnBindingHelper.BuildFromProperties(typeof(<Row>)).ToSchema()` — see [ItemsTabViewModel.cs:34](../src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs#L34) for the canonical shape. Bind it from XAML as `<wpf:MithrilQueryBox Schema="{x:Static vm:XTabViewModel.SchemaSnapshot}" .../>` (#264 / #262). Without this binding the completion popup silently never opens and column-name highlighting falls back to unknown-column red. The reflected surface must match what the row type exposes, since the same reflection drives the `QueryFilter` parser at attach time.
 
 That's it. No edits to `SilmarillionReferenceNavigator`, no `V1TabbedKinds` (it was retired in #239), no `OnNavigated` switch.
 
@@ -65,11 +66,20 @@ Use [`ItemSourceChipVm`](../src/Mithril.Shared.Wpf/EntityChipVm.cs) for source-s
 
 ## Synthetic kinds — deep-linking to a tab with a pre-filled query
 
-Not every `IReferenceKindTarget` selects an entity by name. PR #259 introduced [`RecipeIngredientKeywordKindTarget`](../src/Silmarillion.Module/Navigation/RecipeIngredientKeywordKindTarget.cs) — its `Kind` is `EntityKind.RecipeIngredientKeyword`, but `InternalName` carries a keyword tag (e.g. `"Crystal"`), and `TrySelectByInternalName` doesn't select a row — it sets `RecipesTabViewModel.QueryText` to `IngredientKeywords CONTAINS "<keyword>"`, leveraging PR #261's `IQueryStringValue` + collection-CONTAINS support. `TabIndex = 1` (same tab as Recipes); `TryOpenInWindow` returns false (nothing to open in isolation).
+Not every `IReferenceKindTarget` selects an entity by name. The `Silmarillion.Module/Navigation/` folder ships three synthetic kind targets, all following the same shape — `Kind` is a synthetic `EntityKind` value, `InternalName` carries a payload (keyword tag, item internal name, etc.), and `TrySelectByInternalName` mutates a tab VM's `QueryText` instead of selecting a row:
 
-The lesson: when a chip's natural target is *"open the right tab filtered to this concept"* rather than *"select this specific row"*, model it as a synthetic `EntityKind` + a kind target that mutates `QueryText`. Don't fan out to a list of name-keyed chips when the cardinality could be high — Massive Tourmaline's "any Crystal" expansion produced ~547 chips and was unscannable; the synthetic-keyword chip replaced it with a single chip + filtered list.
+- **[`RecipeIngredientKeywordKindTarget`](../src/Silmarillion.Module/Navigation/RecipeIngredientKeywordKindTarget.cs)** (#259) — keyword chip on item-detail's "Used as" → Recipes tab filtered to `IngredientKeywords CONTAINS "<keyword>"`.
+- **[`ItemKeywordKindTarget`](../src/Silmarillion.Module/Navigation/ItemKeywordKindTarget.cs)** (#270) — keyword chip on recipe-detail → Items tab filtered to items whose Keywords contain the chip's tag.
+- **[`RecipeIngredientItemKindTarget`](../src/Silmarillion.Module/Navigation/RecipeIngredientItemKindTarget.cs)** (#273) — overflow pill on item-detail's "Used in" → Recipes tab filtered to `Ingredients CONTAINS "<itemInternalName>"`. Used when chip cardinality exceeds `SilmarillionSettings.UsedInChipCap`.
 
-If your tab needs collection-CONTAINS filtering, the existing `IQueryStringValue` pattern in [`IngredientKeywordValue.cs`](../src/Silmarillion.Module/ViewModels/IngredientKeywordValue.cs) is the template: wrap the tag string in a tiny record exposing `QueryStringValue`, expose the field on your master-list row as `IReadOnlyList<TKeywordValue>`, and the `MithrilQueryBox` parser handles `CONTAINS` for free.
+All three set `TryOpenInWindow` → `false` (nothing to open in isolation) and `TabIndex` to the destination tab's index.
+
+**Two lessons from this pattern's evolution:**
+
+1. **When a chip's natural target is *"open the right tab filtered to this concept"* rather than *"select this specific row"*, model it as a synthetic `EntityKind` + a query-mutating kind target.** Don't fan out to a list of name-keyed chips when the cardinality could be high — Massive Tourmaline's "any Crystal" expansion produced ~547 chips and was unscannable until #259 collapsed it to a single keyword chip.
+2. **When fan-out cardinality is unbounded but the *direct* refs are still useful, cap + overflow-pill.** [`ItemsTabViewModel.BuildConsumedByChips`](../src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs) returns the first `UsedInChipCap` (default 12) chips plus a `+{N-cap} more →` pill that uses a synthetic kind target to deep-link to the filtered tab. The pill carries the source entity's icon for visual continuity. Settings live in [`SilmarillionSettings`](../src/Silmarillion.Module/SilmarillionSettings.cs); follow that file as the template if your tab needs persistent settings (`SchemaVersion` stamped from day one, `INotifyPropertyChanged`, source-gen STJ context, debounced autosave via `AddMithrilSettings<T>`).
+
+**Tooling for collection-CONTAINS filtering:** wrap the tag/value in a small record implementing `IQueryStringValue` (e.g. [`IngredientKeywordValue.cs`](../src/Silmarillion.Module/ViewModels/IngredientKeywordValue.cs), [`IngredientItemValue.cs`](../src/Silmarillion.Module/ViewModels/IngredientItemValue.cs)), expose the field on your master-list row as `IReadOnlyList<TValue>`, and the `MithrilQueryBox` parser handles `CONTAINS` for free (#261). Make sure the row type's reflected schema (step 6 above) includes the collection field — without it, autocomplete won't suggest it.
 
 ## DI cycle break — why the Func<> wrappers exist
 
@@ -104,17 +114,19 @@ Every Bucket B PR should pass these in order:
 2. `dotnet test tests/Silmarillion.Tests` — the three new test files + existing tests pass.
 3. `dotnet test Mithril.slnx` — no regressions, especially in consumers of `IReferenceDataService` (Celebrimbor, Bilbo, Elrond, Arwen).
 4. `dotnet run --project src/Mithril.Shell` — manual checks:
-   - Open Silmarillion → new tab appears in the strip.
+   - Open Silmarillion → new tab appears in the strip with the gold IsSelected underline (confirms `MithrilTabItemStyle` is being applied — only happens when the tab comes through `ItemsSource`, not direct `TabControl.Items.Add`).
    - Pick an entity → detail pane populates.
+   - Type a column name in the query box → completion popup opens, known names highlight in column-gold (confirms `SchemaSnapshot` is wired per step 6).
    - Cross-link chips render (navigable to tabbed kinds, plain text otherwise).
    - Click a chip that points to your new kind from an *existing* tab → tab switches and entity selects.
    - Open-in-window button on the header works for the new kind.
    - Background refresh check: leave the tab open, force a CDN refresh, confirm the list rebuilds without losing the current selection.
 
-## Two things that go wrong
+## Three things that go wrong
 
 1. **The tab VM is registered but the kind target isn't.** The tab renders but cross-link chips to its kind stay plain-text, and the navigator's `CanOpen` returns false for the new kind. Symptom: clicking a chip silently does nothing. Cause: missed the second `AddSingleton<IReferenceKindTarget>` line. Fix: register the target.
 2. **The tab VM lookup happens against `IReferenceDataService` instead of the bound `All<X>` collection.** Symptom: post-CDN-refresh navigation appears to succeed but the detail pane goes blank. Cause: WPF's ListBox can't match the new refData instance to its `ItemsSource`. Fix: resolve in `TrySelectByInternalName` against the tab VM's bound collection, per the `ItemsKindTarget` comment.
+3. **`MithrilQueryBox.Schema` isn't bound.** Symptom: typing in the query box never opens the completion popup, and known column names render as unknown-column red. Cause: missed the `Schema="{x:Static vm:XTabViewModel.SchemaSnapshot}"` binding (or never exposed `SchemaSnapshot`). The query *parser* still works for hand-typed expressions, so this fails silently in tests — only manual smoke catches it. Fix: per step 6 above.
 
 ## When the cookbook doesn't apply
 


### PR DESCRIPTION
## Summary

Three real shape changes since the cookbook was first committed (PR #263) needed to land:

- **TabControl is now MVVM `ItemsSource` via `ModuleTab`** (PR #272 / #233). Step 4 of the scaffold no longer involves editing the TabControl markup — the new tab is appended to `SilmarillionViewModel.Tabs` and resolved to its view via a `DataTemplate` by VM type. The cookbook's old "add a `<TabItem>` element" instruction would now produce a tab without the gold IsSelected underline (the WPF quirk #272 was filed to fix), so updating this is load-bearing.
- **`MithrilQueryBox.Schema` is required for autocomplete** (PR #264 / #262). New step 6 codifies the `static IReadOnlyList<ColumnSchema> SchemaSnapshot` pattern + the XAML binding. Without it the completion popup silently never opens.
- **Synthetic-kind precedents tripled.** The original cookbook called out `RecipeIngredientKeyword` only; we now also have `ItemKeyword` (#270) and `RecipeIngredientItem` (#273). Section rewritten as a list with a clear lesson on cap+overflow-pill (the precedent #273 set after #259's keyword-collapse win), and a pointer to `SilmarillionSettings` as the persistent-settings template.

Also: verification ladder gains an autocomplete + gold-underline manual check; "Two things that go wrong" became "Three" with the silent `Schema`-binding failure added.

No code changes. Roadmap doc untouched (its synthetic-kind footnote already says "synthetic kinds for deep-link routing exist; not part of the bucketing" — still accurate).

## Test plan

- [ ] Skim the diff against the current state of `SilmarillionView.xaml`, `SilmarillionViewModel.cs`, and the kind-target folder — verify the cookbook describes what's actually shipped.
- [ ] Confirm the `SchemaSnapshot` pattern reference at [`ItemsTabViewModel.cs:34`](src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs#L34) still matches what the doc describes.

Docs-only PR. Build / test impact: none.

---

— drafted by Claude (Opus 4.7), posted by @arthur-conde