### PR TITLE
fix(mithril.reference): chance-bonus tokens render as additive percent — #278

### DIFF
--- a/src/Mithril.Shared/Reference/EffectDescsRenderer.cs
+++ b/src/Mithril.Shared/Reference/EffectDescsRenderer.cs
@@ -68,8 +68,15 @@ public static class EffectDescsRenderer
 
         if (!ShouldRender(attr, value)) return false;
 
-        var formatted = FormatValue(attr.DisplayType, value);
-        var text = ComposeLine(attr.DisplayType, attr.Label, formatted);
+        // AsBuffMod expects DefaultValue=1; combined with DefaultValue=0 it's an upstream-data
+        // anomaly — 39 tokens in attributes.json (all "Chance to..." probability bonuses).
+        // Treat as additive AsPercent. See issue #278.
+        var effectiveDisplayType = attr.DisplayType == "AsBuffMod" && attr.DefaultValue is double dv && dv == 0
+            ? "AsPercent"
+            : attr.DisplayType;
+
+        var formatted = FormatValue(effectiveDisplayType, value);
+        var text = ComposeLine(effectiveDisplayType, attr.Label, formatted);
         var icon = attr.IconIds.Count > 0 ? attr.IconIds[0] : 0;
         line = new EffectLine(icon, text);
         return true;

--- a/tests/Mithril.Shared.Tests/Reference/EffectDescsRendererTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/EffectDescsRendererTests.cs
@@ -68,6 +68,44 @@ public class EffectDescsRendererTests
     }
 
     [Fact]
+    public void AsBuffMod_WithDefaultZero_TreatedAsAdditivePercent_Issue278()
+    {
+        // Mirrors LOOT_CHANCE_EXTRA_SEEDS shape — 39 "Chance to..." tokens in attributes.json
+        // are mis-tagged AsBuffMod with DefaultValue:0. Renderer must treat them as AsPercent
+        // so +0.15 prints as "15%", not "-85%".
+        var registry = Registry(
+            new AttributeEntry("LOOT_CHANCE_EXTRA_SEEDS", "Chance to Forage Extra Herbs/Seeds %", "AsBuffMod", "IfNotDefault", 0, [108]));
+
+        var lines = EffectDescsRenderer.Render(["{LOOT_CHANCE_EXTRA_SEEDS}{0.15}"], registry);
+
+        lines.Should().ContainSingle().Which.Text.Should().Be("15% Chance to Forage Extra Herbs/Seeds %");
+    }
+
+    [Fact]
+    public void AsBuffMod_WithDefaultZero_ZeroValue_StillSuppressedByIfNotDefault_Issue278()
+    {
+        var registry = Registry(
+            new AttributeEntry("LOOT_CHANCE_EXTRA_SEEDS", "Chance to Forage Extra Herbs/Seeds %", "AsBuffMod", "IfNotDefault", 0, [108]));
+
+        var lines = EffectDescsRenderer.Render(["{LOOT_CHANCE_EXTRA_SEEDS}{0}"], registry);
+
+        lines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AsBuffMod_WithDefaultOne_StillUsesMultiplierSemantics_Issue278()
+    {
+        // Negative control: a true AsBuffMod entry (DefaultValue:1) must keep multiplier math
+        // so the data-anomaly heuristic doesn't misfire on legitimate AsBuffMod tokens.
+        var registry = Registry(
+            new AttributeEntry("MOD_SKILL_ALL_KNIFE", "Knife Damage %", "AsBuffMod", "IfNotDefault", 1, [108]));
+
+        var lines = EffectDescsRenderer.Render(["{MOD_SKILL_ALL_KNIFE}{1.08}"], registry);
+
+        lines.Should().ContainSingle().Which.Text.Should().Be("+8% Knife Damage %");
+    }
+
+    [Fact]
     public void IfNotZero_SuppressesZeroValues()
     {
         var registry = Registry(


### PR DESCRIPTION
## Summary

- `EffectDescsRenderer.TryRender` now detects the upstream-data anomaly where 39 "Chance to..." tokens in `attributes.json` are tagged `AsBuffMod` with `DefaultValue: 0` (mathematically meaningless under multiplier semantics) and renders them as `AsPercent` instead.
- Advanced Scavenger's Ring (`item_49082`) and similar items now show `+15% Chance to Forage Extra Herbs/Seeds` instead of `-85%`.
- Self-defending against CDN refresh — the bundled JSON is untouched, so a future `ReferenceDataService` refetch can't reintroduce the regression.

## Test plan

- [x] New tests in `EffectDescsRendererTests`:
  - `AsBuffMod_WithDefaultZero_TreatedAsAdditivePercent_Issue278` — bug-case, mirrors `LOOT_CHANCE_EXTRA_SEEDS` shape; +0.15 → `"15% Chance to Forage Extra Herbs/Seeds %"`.
  - `AsBuffMod_WithDefaultZero_ZeroValue_StillSuppressedByIfNotDefault_Issue278` — boundary; `IfNotDefault` still suppresses the 0 case under the new code path.
  - `AsBuffMod_WithDefaultOne_StillUsesMultiplierSemantics_Issue278` — negative control; legitimate `AsBuffMod` (DefaultValue:1) still renders `1.08 → +8%`.
- [x] Existing `AsBuffMod_InterpretsMultiplierAsSignedPercent` continues to pass unchanged.
- [x] `dotnet test Mithril.slnx` — full suite green (0 failures).

Fixes #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)