### PR TITLE
feat(silmarillion): NPCs tab (first Bucket B) — #241

### DIFF
--- a/docs/agent-plans/silmarillion-241-npcs-tab.md
+++ b/docs/agent-plans/silmarillion-241-npcs-tab.md
@@ -1,0 +1,117 @@
+# Silmarillion: NPCs tab (first Bucket B — third tab)
+
+**Tracked in:** #241. Reopened today after #258 closed it administratively without shipping the tab itself.
+
+> **Read first:** [silmarillion-tab-cookbook.md](../silmarillion-tab-cookbook.md). It owns the scaffolding (file layout, DI registration, `IReferenceKindTarget` shape, `ModuleTab` wiring, `SchemaSnapshot` for autocomplete, test trio, verification ladder). This handoff covers only NPC-specific decisions.
+
+## Context
+
+NPCs are the highest cross-link payoff in Bucket B (recipe teachers, item sources, gift preferences via Arwen, quest givers / turn-ins) but the v1 master-detail spike deferred them because the entity carries real polymorphism — `Services`, `Preferences`, `ItemGifts`. PR #258 added recipe-detail "Taught by" chips that already point at `EntityRef.Npc(...)`; those chips currently degrade to plain text. Shipping this tab makes them navigable and validates the cookbook end-to-end as the first non-v1 tab.
+
+## Service-layer decision required up front
+
+`IReferenceDataService.Npcs` is currently `IReadOnlyDictionary<string, NpcEntry>` ([IReferenceDataService.cs:90](../../src/Mithril.Shared/Reference/IReferenceDataService.cs#L90)) — a thin projection consumed by Arwen for gift preferences. The NPCs tab needs the full [`Mithril.Reference.Models.Npcs.Npc`](../../src/Mithril.Reference/Models/Npcs/Npc.cs) POCO (Services, ItemGifts, Pos, AreaFriendlyName, etc.). Two paths:
+
+1. **Add a sibling `IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; }`** on `IReferenceDataService` (or similarly-named) that exposes the full POCO. Leaves Arwen on `NpcEntry` untouched. Smallest blast radius. **Recommended for this PR.**
+2. **Migrate `Npcs` to be `IReadOnlyDictionary<string, Npc>` directly** and delete `NpcEntry`, mirroring the path Items took in #209. Cleaner long-term but touches Arwen and any other consumer + test fakes. Defer to a follow-up issue if you take this path; don't bundle into the tab PR.
+
+Either way, populate the dictionary inside `ParseAndSwapNpcs` (or equivalent) — `Mithril.Reference.Models.Npcs.Npc` is already deserialised by `ReferenceDeserializer.ParseNpcs`, so this is a projection wiring change, not parser work.
+
+## Master-list row
+
+Use a `NpcListRow` projection wrapper (mirror [`RecipeListRow`](../../src/Silmarillion.Module/ViewModels/RecipeListRow.cs)). Raw `Npc` lacks an `InternalName` field (the JSON envelope key is the internal name) and needs cross-cuts:
+
+- `InternalName` — copied from the `Npcs` dictionary key
+- `Name` — `Npc.Name ?? InternalName`
+- `AreaDisplayName` — `Npc.AreaFriendlyName ?? Npc.AreaName ?? "(unknown)"`
+- `ServiceTypes` — `IReadOnlyList<IngredientKeywordValue>`-style tag set, one per `NpcService.T` value (Store / Barter / Consignment / Training / Stables / …) for `CONTAINS` filtering
+- Optional sort key for stable row ordering (likely `Name` ASC)
+
+Expose the reflected `SchemaSnapshot` from `typeof(NpcListRow)` per cookbook step 6.
+
+## Filter facets
+
+The query box, plus any chip-style row filters, should cover at minimum:
+
+- `ServiceTypes CONTAINS "Store"` (and the other service kinds)
+- `AreaDisplayName = "Serbule"` and substring match
+- `Name CONTAINS "Joeh"` for partial-name lookup
+
+If you want a quick-filter chip strip above the list (analogous to recipe-detail's keyword chips), add it but keep it composable with the query box — chips should mutate the same `QueryText` state, not a parallel filter model.
+
+## Detail-pane reading order
+
+Per the #234 reading-order convention, lead with cross-link sections, push tail metadata to the bottom:
+
+1. **Header** — name + area chip (clickable once Areas tab ships, plain text otherwise) + position string if non-null
+2. **Services** — one block per `NpcService`, grouped by `T`. Store/Barter blocks should hint at the in-game implications (e.g. "Sells items", "Buys items at favor X+"). Subordinate `CapIncreases`, `Keywords`, `MinFavorTier` from each service render as sub-rows or chips.
+3. **Teaches recipes** — reverse lookup over `IReferenceDataService.RecipeSources` filtered to entries with `Npc == this.InternalName` and `Type == "Training"`. Recipe chips are navigable today.
+4. **Sells items** — reverse lookup over `IReferenceDataService.ItemSources` filtered the same way (`Type == "Vendor"`, `Npc == this.InternalName`). Item chips are navigable today.
+5. **Quests given / turned in** — degrades to plain text until Quests tab ships. Source: scan `IReferenceDataService.Quests` for entries whose giver / turn-in NPC matches. May or may not need a reverse-lookup primitive on the service — see plumbing section below.
+6. **Gift preferences** — render `Npc.Preferences` (sentiment-tier thresholds + gift category chips) and `Npc.ItemGifts` (the sentiment-threshold list). Cross-check Arwen's existing rendering of this data so the same vocabulary is used.
+7. **Description** — `Npc.Desc` if present, free-form text
+8. **Footer** — internal-name (mono, bottom-right) per the [detail-view internal-name footer convention](../../docs/silmarillion-tab-cookbook.md) memory item
+
+Use the detail-pane hide-when-empty convention — every section above except header collapses cleanly when the source data is null/empty. Empty NPCs (altars, pedestals with no services) should render as just header + footer with no dead zones.
+
+## Cross-link plumbing
+
+Reverse lookups needed on `IReferenceDataService` if not already present:
+
+- `IReadOnlyDictionary<string npcInternalName, IReadOnlyList<Recipe>> RecipesTaughtByNpc` — derived from `RecipeSources` during refresh; cache to avoid per-selection scans.
+- `IReadOnlyDictionary<string npcInternalName, IReadOnlyList<Item>> ItemsSoldByNpc` — derived from `ItemSources` filtered to `Type == "Vendor"`. Same cache pattern.
+- *(Optional)* `IReadOnlyDictionary<string npcInternalName, IReadOnlyList<Quest>> QuestsByNpc` — only if quest cross-links land in this PR; otherwise scan `Quests` lazily inside the detail VM and defer the index to the Quests tab handoff.
+
+Build all three in `BuildRecipeCrossLinkIndices`-adjacent code paths in `ReferenceDataService` so they get rebuilt on items / recipes / npcs / quests refresh as appropriate.
+
+## Cross-link chip kinds (degradation matrix)
+
+Per cookbook: `IsNavigable = _navigator.CanOpen(reference)` decides per-chip; you don't gate manually. State today:
+
+| Chip target | Today | Ships when |
+|---|---|---|
+| `EntityRef.Item(...)` | navigable | already shipped |
+| `EntityRef.Recipe(...)` | navigable | already shipped |
+| `EntityRef.Area(...)` | plain text | #245 |
+| `EntityRef.Quest(...)` | plain text | #242 |
+| `EntityRef.PlayerTitle(...)` | plain text | #248 |
+
+No new synthetic kinds needed for NPCs. The synthetic-kinds pattern in the cookbook is for high-cardinality or query-shaped chips; NPC cross-links are bounded enough that direct-ref chips suffice.
+
+## Test fixtures
+
+Beyond the standard test trio called out in the cookbook:
+
+- **`StubReferenceData`** in `tests/Silmarillion.Tests/` needs `NpcsByInternalName` (or whatever name the new service property gets) and the two reverse-lookup dictionaries.
+- **A representative NPC fixture** with at least one Service of each common type (Store, Barter, Training), one Preference entry, one ItemGift threshold, a non-null `Desc`. Reuse for both `NpcsTabViewModelTests` and `NpcsKindTargetTests`.
+- **An empty NPC fixture** (altar / pedestal with `Services = null`, `Preferences = null`, `ItemGifts = null`) to assert the detail VM renders header + footer only and the section-hide convention works.
+- **A reverse-lookup integration test** in `tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs` — fixture an NPC + a Recipe whose `RecipeSources` entry teaches it, assert `RecipesTaughtByNpc[npcInternalName]` returns the recipe.
+
+Use `NavFactory.WithKinds(EntityKind.Npc, EntityKind.Item, EntityKind.Recipe)` to assert chip navigability — area / quest / title chips should report `IsNavigable=false` until those tabs land.
+
+## Verification (delta from the cookbook ladder)
+
+Run the standard cookbook ladder, plus:
+
+- **End-to-end cross-link round-trip:** open a recipe with a known NPC teacher (e.g. anything from a Store-type vendor), click the "Taught by Joeh" chip → NPCs tab opens, Joeh selected, Joeh's "Teaches recipes" section lists the recipe you came from. Click that recipe chip → returns to the original recipe detail. The back/forward buttons should walk this history correctly.
+- **Empty-NPC smoke:** select an altar (e.g. anything in `Altar_*` keyspace) — confirm only header + footer render, no empty section headers.
+- **Arwen non-regression:** open Arwen's favor view, switch characters, confirm gift preferences still render. (`NpcEntry` consumers shouldn't have moved.)
+
+## Out of scope
+
+- The full `NpcEntry` → `Npc` migration in path 2 above. File a follow-up if desired.
+- An "NPC location map" pin / overlay using `Pos`. Defer until Areas tab ships and a map surface exists somewhere.
+- Faction or merchant-stock detail beyond what `npcs.json` carries directly. The "Sells items" section already pulls from `sources_items` which is the canonical answer; don't duplicate by parsing in-game vendor logs.
+- Localization of service-type / sentiment-threshold strings — out of scope per #265's deferral.
+
+## Commit / PR shape
+
+Single PR against `main`. Suggested branch: `feat/241-silmarillion-npcs-tab`. Conventional commit:
+
+```
+feat(silmarillion): NPCs tab (first Bucket B) — #241
+```
+
+Likely diff size: ~600–900 lines across service-layer plumbing (~150), tab VM + view (~300), kind target (~50), tests (~250), and possibly a bundled `npcs.json` if not already bundled.
+
+Closes #241. Does **not** close any other Bucket B issue — but does light up the navigability of NPC chips already shipping in recipe details (#235's "Taught by" section).

--- a/docs/silmarillion-tab-cookbook-feedback.md
+++ b/docs/silmarillion-tab-cookbook-feedback.md
@@ -1,0 +1,101 @@
+# Silmarillion · Tab Cookbook — Feedback from the NPCs Tab Shipment (#241)
+
+Notes from shipping the first Bucket B tab against the cookbook. Each entry is something a future agent shipping a Quests / Areas / Lorebooks tab would benefit from having spelled out before they start. Items are ordered by how much friction they caused, not where they belong in the cookbook.
+
+## 1. Audit existing chip-builders for hardcoded `IsNavigable: false`
+
+**Friction:** Two surfaces — the Item-detail "Sources" section and the Recipe-detail "Taught by" section — already produced `ItemSourceChipVm` instances anchored to `EntityRef.Npc(...)`. The recipe side correctly set `IsNavigable = _navigator.CanOpen(reference)`, so it lit up the moment the NPC kind shipped. The item side, however, hardcoded `EntityReference: null, IsNavigable: false` from before the chip-VM type even had an EntityReference field. The chip stayed plain-text post-#241 and required a follow-up to fix.
+
+**Cookbook addition:** when shipping a new `EntityKind`, grep the codebase for existing chip-builders that emit `EntityRef.<NewKind>(...)` or `ItemSourceChipVm(..., EntityReference: null, IsNavigable: false)` shapes. Any that match are stale and won't auto-flip when `CanOpen` starts returning true. Treat the audit as part of the "Cross-link chips" section.
+
+The cookbook's *Don't gate on the kind manually — let `CanOpen` decide* rule is right, but it only protects the chips that follow the rule. Pre-existing chip-builders that violated it are invisible to the new author.
+
+## 2. Cross-link chip vocabulary needs both `EntityChip` AND `ItemSourceChip`
+
+**Friction:** The cookbook's "Cross-link chips" section says to use `EntityChip` for entity references and `ItemSourceChipVm` for source-style rows where the anchor may not exist as a clickable target. It does *not* mention how `ItemSourceChipVm` gets rendered — pre-#241 it was a plain `TextBlock` in every consuming XAML, gated by a `TODO(stub:#207)` comment. The cookbook reader is left to discover that the chip control was never built.
+
+**Cookbook addition:** add a parallel paragraph about `ItemSourceChip` (the UserControl now in `Mithril.Shared.Wpf`) alongside `EntityChip`. Make explicit that source-style sections render through `ItemSourceChip` with `ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={...}}"` — same shape as `EntityChip`, the chip auto-degrades to plain text in a transparent frame when `IsNavigable=false`.
+
+## 3. Display-name resolution belongs in a single helper, written once
+
+**Friction:** `Vendor: NPC_Joeh` shipped with the raw envelope key on the chip. The Items tab uses `item.Name`, the Recipes tab uses `recipe.Name ?? r.InternalName ?? r.Key`. For NPCs there was no canonical helper, and source-chip builders on *two* other tabs (Items and Recipes) both needed one. The first patch resolved through `_refData.NpcsByInternalName[s.Npc]?.Name ?? s.Npc` inline in each VM, but the fallback ("strip `NPC_` prefix") was wanted in three places — eventually a `NpcNameResolver` static was factored.
+
+**Cookbook addition:** when shipping a new entity kind, factor a `<Kind>NameResolver.Resolve(refData, internalName)` static **before** writing the tab VM. Use it everywhere the kind's friendly name surfaces — master list, detail header, and any pre-existing chip-builder on a different tab that references this kind's internal name. The cost is one extra file and saves three rewrites later.
+
+## 4. `NpcEntry` vs `Npc` POCO split should be a cookbook decision tree, not handoff prose
+
+**Friction:** Path 1 (sibling property `NpcsByInternalName` exposing the full POCO) vs path 2 (migrate `Npcs` outright) was a real upfront decision that needed explicit framing in the handoff. Future Bucket B handoffs may face the same — `QuestEntry` vs `Quest`, `AreaEntry` vs `Area`. Today's slim projections are consumed by other modules (Arwen, Smaug); the new tab needs the full POCO.
+
+**Cookbook addition:** the "What your handoff still owns" section currently says "Which `IReferenceDataService` source dictionary to read." Strengthen this with a sub-bullet: *"If a slim `*Entry` projection already exists for that kind (check `IReferenceDataService` properties), decide explicitly whether to add a sibling `*ByInternalName` property exposing the full POCO (path 1, smallest blast radius) or migrate the existing projection (path 2, defer to a follow-up issue). Default to path 1 unless the tab is the only consumer."*
+
+## 5. Polymorphic-entity rendering needs a real-data sanity check before shipping
+
+**Friction:** The NPC POCO has six subclasses of `NpcService` (Store, Training, Barter, Storage, Consignment, InstallAugments, …). My first pass collapsed each subclass's payload via `Concat(left, right)` — e.g. `Concat(training.Skills, training.Unlocks)` — and rendered the result as one undifferentiated bullet list. Synthetic test fixtures with simple data didn't catch how confusing it reads against real game NPCs whose `Training` row showed `["Unarmed", "Lore", "Neutral", "Comfortable", "Friends", "CloseFriends", "BestFriends"]` — skill names visually indistinguishable from favor-tier unlocks.
+
+**Cookbook addition:** for polymorphic kinds, the verification ladder should include a "walk the bundled JSON for 2-3 real examples before shipping the detail VM, and confirm each polymorphic subclass renders legibly with real data, not just unit-test fixtures." Synthetic tests verify projection correctness; only real data exposes whether the *grouping* is parseable.
+
+## 6. "Default values that render as noise" — common with PG data
+
+**Friction:** Every `NpcService` in `npcs.json` carries `Favor = "Despised"` (the lowest favor tier, i.e. "anyone can access"). Rendering `Favor: Despised` on every service row was pure noise. The fix was to null it out in the VM for the default case so the XAML hides the chip.
+
+**Cookbook addition:** specific to this codebase but broadly applicable — when a chip / badge surfaces an enum-like value, identify whether one value is the *default* and treat it as null in the projection. Common offenders: `Despised` (favor), zero-valued numeric thresholds, default-empty arrays. The verification ladder could flag this: *"Confirm every persistent chip on the detail pane carries information — if it'd say the same thing for every row, fold it into the projection."*
+
+## 7. Name collisions between `Mithril.Reference.Models.*` and `Mithril.Shared.Reference.*`
+
+**Friction:** `NpcService` exists in both `Mithril.Reference.Models.Npcs` (full POCO) and `Mithril.Shared.Reference` (slim record consumed by Arwen). Same with `NpcPreference`. Required `using NpcServicePoco = Mithril.Reference.Models.Npcs.NpcService;` aliases in two files (VM + tests).
+
+**Cookbook addition:** mention this gotcha in the "Which source dictionary to read" section. Heads-up: *"For kinds with both a POCO and a slim projection (NPCs, possibly Quests/Areas in the future), expect to alias `using <Kind>Poco = Mithril.Reference.Models.<Kind>s.<Kind>;` in the tab VM and tests to disambiguate at every reference site."*
+
+## 8. Constructor changes to `SilmarillionViewModel` ripple to navigator tests
+
+**Friction:** Adding `NpcsTabViewModel npcs` to the `SilmarillionViewModel` constructor broke not only `SilmarillionViewModelTests` (5 sites of `items: null!, recipes: null!`) but also `SilmarillionReferenceNavigatorTests` (5 more sites). The cookbook's scaffolding checklist mentions "add a constructor parameter `XTabViewModel x` and a public `X { get; }` property" without flagging that this ripples into two test files and the named-argument calls there.
+
+**Cookbook addition:** in the scaffolding checklist's step 3, add a sub-bullet: *"This will ripple to `SilmarillionViewModelTests` and `SilmarillionReferenceNavigatorTests` — both currently call `new SilmarillionViewModel(items: null!, recipes: null!, ...)`. Update each `null!` site to add the new positional argument. Use named arguments throughout to keep the diff readable."*
+
+## 9. The "two things that go wrong" list missed a third
+
+**Friction:** The cookbook's "Two things that go wrong" section calls out (a) tab VM registered without kind target, and (b) lookup against `IReferenceDataService` instead of bound collection. A third snuck through this iteration:
+
+**(c) The new kind's tab ships, but pre-existing chip-builders on *other* tabs are stale.** Items tab's `BuildSourceChips` and the section XAMLs were both stale w.r.t. the new kind. The kind target was registered, the lookup was correct, and *new* chip-builders auto-degrade — but pre-existing surfaces don't get the upgrade for free.
+
+**Cookbook addition:** add this as a third entry. Symptom: clicking a chip on a tab *other* than the one being shipped doesn't navigate. Cause: a chip-builder elsewhere hardcoded `IsNavigable: false` or rendered through a plain `TextBlock` instead of `EntityChip` / `ItemSourceChip`. Fix: grep for the new EntityKind's name across all consumers; replace hardcoded falsy flags with `_navigator.CanOpen(reference)` and upgrade `TextBlock` source rows to `<c:ItemSourceChip .../>`.
+
+## 10. Build file-lock when Mithril is running for smoke
+
+**Friction:** During iterative manual-smoke + fix cycles, Mithril runs while I rebuild. MSB3026/27 cascade locks every module's copy-to-`modules/` step. This is documented in `mithril_build_file_lock_silent.md` as a memory item, but the cookbook's verification ladder doesn't mention it.
+
+**Cookbook addition:** in step 4 of the verification ladder, note: *"For iterative fix cycles during manual smoke, close Mithril between rebuilds — the post-build copy-to-`Mithril.Shell/modules/` cascades to MSB3027 file-lock errors when the running app holds the module DLL open. Symptom: a clean build of the Module fails 10× retries before erroring; the test DLL builds cleanly because tests don't copy to `modules/`."*
+
+## 11. Reverse-lookup rebuild plumbing pattern is implicit
+
+**Friction:** The cookbook talks about reverse-lookup indices as a handoff concern ("Reverse-lookup plumbing on `IReferenceDataService` if the detail pane needs new cross-links") but doesn't show the *rebuild trigger* pattern. For NPCs, the indices `RecipesTaughtByNpc` and `ItemsSoldByNpc` derive from `_recipeSources` + `_recipesByInternalName` and `_itemSources` + `_itemsByInternalName` respectively. The rebuild needs to fire on parse-and-swap of *any* of those four files. Mirror of `BuildRecipeCrossLinkIndices` which already does this for items+recipes.
+
+**Cookbook addition:** the "Cross-link plumbing" sub-section should reference `BuildRecipeCrossLinkIndices` and `BuildNpcCrossLinkIndices` as the template, and explicitly list the trigger sites: *"For each input dictionary the index depends on, call your `Build<X>CrossLinkIndices()` at the end of that file's `ParseAndSwap*` method. Files-input matrix:*
+
+| Index | Triggers rebuild from |
+| --- | --- |
+| `RecipesByProducedItem`, `RecipesByIngredientItem` | items.json, recipes.json |
+| `RecipesTaughtByNpc` | recipes.json, sources_recipes.json |
+| `ItemsSoldByNpc` | items.json, sources_items.json |
+
+## 12. Default `IReadOnlyDictionary<,>` for new `IReferenceDataService` properties
+
+**Friction:** Adding `NpcsByInternalName`, `RecipesTaughtByNpc`, `ItemsSoldByNpc` to `IReferenceDataService` would normally cascade across every test fake (Bilbo, Arwen, Smaug, Celebrimbor, ...). The cookbook's "Test scaffolding" section says *"Extend `StubReferenceData` with new source dictionaries as needed; consumer fakes in other modules use the interface default for any property they don't care about"* — this is the rule, and it worked, but the *pattern* (declaring a private static empty default + `=> EmptyXMap` on the interface declaration) deserves a one-line example.
+
+**Cookbook addition:** in the test scaffolding section, show the interface-default pattern with a one-line example: *"Default-implement every new `IReferenceDataService` property to an empty dictionary so test fakes in other modules don't need to opt in. Pattern:*
+
+```csharp
+IReadOnlyDictionary<string, Npc> NpcsByInternalName => EmptyNpcMap;
+private static readonly IReadOnlyDictionary<string, Npc> EmptyNpcMap
+    = new Dictionary<string, Npc>(StringComparer.Ordinal);
+```
+
+## Summary — proposed cookbook delta
+
+The bigger restructure suggested by this list:
+- Split "Cross-link chips" into two sub-sections: **entity-anchored** (`EntityChip` / `EntityChipVm`) and **source-anchored** (`ItemSourceChip` / `ItemSourceChipVm`).
+- Add an **"Audit existing surfaces"** sub-section to "What your handoff still owns" — a checklist of grep targets when shipping a new `EntityKind`.
+- Add a **"Real-data sanity check"** rung to the verification ladder before "manual checks", calling for a 2-3 NPC walkthrough of polymorphic shapes.
+- Promote the `<Kind>NameResolver` pattern to a first-class cookbook step alongside the master-list row projection.
+
+Items 1, 3, and 9 are the highest-friction items — addressing them in the cookbook would have saved the bulk of the post-smoke iteration cycle.

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -65,19 +65,21 @@
                     </TextBlock>
                 </StackPanel>
 
-                <!-- Sources (vendor / drop / quest reward / …); plain-text in Phase 1 -->
+                <!-- Sources (vendor / drop / quest reward / …). Renders as ItemSourceChip:
+                     navigable chip when the source resolves to a tabbed entity (e.g. NPC vendors
+                     after #241 shipped the NPCs tab), plain-text otherwise. -->
                 <StackPanel Margin="0,10,0,0"
                             Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
                     <TextBlock Text="Sources" FontWeight="SemiBold"
                                Foreground="#88FFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
                     <ItemsControl ItemsSource="{Binding Sources}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- TODO(stub:#207): replace with EntityChip in Phase 5 -->
-                                <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <c:ItemSourceChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Mithril.Shared.Wpf/ItemSourceChip.xaml
+++ b/src/Mithril.Shared.Wpf/ItemSourceChip.xaml
@@ -1,0 +1,55 @@
+<UserControl x:Class="Mithril.Shared.Wpf.ItemSourceChip"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf"
+             xmlns:local="clr-namespace:Mithril.Shared.Wpf"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Name="ChipRoot">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Converters.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Button Padding="6,2" Margin="0,1,4,1"
+            Click="OnChipClicked"
+            HorizontalAlignment="Left">
+        <Button.Style>
+            <Style TargetType="Button">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderBrush" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Foreground" Value="#CCFFFFFF"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+                <!-- IsNavigable=true: chip-style (matches EntityChip); IsNavigable=false:
+                     transparent border + plain text styling, preserving the v1 "Vendor: NPC_X"
+                     plain-text look for source kinds without a tab. -->
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsNavigable}" Value="True">
+                        <Setter Property="Background" Value="#FF1F3A5F"/>
+                        <Setter Property="BorderBrush" Value="#553398FF"/>
+                        <Setter Property="Foreground" Value="#FFFFFFFF"/>
+                        <Setter Property="Cursor" Value="Hand"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Button.Style>
+        <Button.Template>
+            <ControlTemplate TargetType="Button">
+                <Border Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="3" Padding="{TemplateBinding Padding}">
+                    <TextBlock Text="{Binding DisplayName}"
+                               Foreground="{TemplateBinding Foreground}"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               TextWrapping="Wrap"
+                               VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Button.Template>
+    </Button>
+</UserControl>

--- a/src/Mithril.Shared.Wpf/ItemSourceChip.xaml.cs
+++ b/src/Mithril.Shared.Wpf/ItemSourceChip.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Shared chip for an item / recipe source row. Binds to an <see cref="ItemSourceChipVm"/>
+/// DataContext and renders as a clickable accent-styled button when
+/// <see cref="ItemSourceChipVm.IsNavigable"/> is true, or as plain text in a transparent
+/// frame when not — preserving the legacy "Vendor: NPC_X" plain rendering for source kinds
+/// without a tab yet. Mirrors <see cref="EntityChip"/>'s shape but reads the parallel
+/// <see cref="ItemSourceChipVm"/> with its nullable <see cref="ItemSourceChipVm.EntityReference"/>.
+/// </summary>
+public partial class ItemSourceChip : UserControl
+{
+    public ItemSourceChip()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Parent-supplied navigation command. Receives the chip's
+    /// <see cref="ItemSourceChipVm.EntityReference"/> as parameter.
+    /// </summary>
+    public ICommand? ClickCommand
+    {
+        get => (ICommand?)GetValue(ClickCommandProperty);
+        set => SetValue(ClickCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty ClickCommandProperty = DependencyProperty.Register(
+        nameof(ClickCommand),
+        typeof(ICommand),
+        typeof(ItemSourceChip),
+        new PropertyMetadata(null));
+
+    private void OnChipClicked(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ItemSourceChipVm vm || !vm.IsNavigable || vm.EntityReference is null) return;
+        var cmd = ClickCommand;
+        if (cmd is null || !cmd.CanExecute(vm.EntityReference)) return;
+        cmd.Execute(vm.EntityReference);
+    }
+}

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -1,4 +1,5 @@
 using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
 using Mithril.Reference.Models.Recipes;
 
 namespace Mithril.Shared.Reference;
@@ -88,6 +89,37 @@ public interface IReferenceDataService
 
     /// <summary>NPC key (e.g. "NPC_Marna") → NpcEntry with gift preferences.</summary>
     IReadOnlyDictionary<string, NpcEntry> Npcs { get; }
+
+    /// <summary>
+    /// NPC <c>InternalName</c> (the JSON envelope key, e.g. <c>"NPC_Marna"</c>, <c>"Altar_Druid"</c>) →
+    /// the full <see cref="Npc"/> POCO from <c>npcs.json</c>. Unlike <see cref="Npcs"/>, which is a
+    /// slim projection consumed by Arwen for gift calculation, this dictionary exposes Services,
+    /// Preferences, ItemGifts, Pos, AreaFriendlyName etc. for Silmarillion's master-detail tab.
+    /// Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, Npc> NpcsByInternalName => EmptyNpcMap;
+
+    /// <summary>
+    /// Reverse index from NPC <c>InternalName</c> → recipes the NPC teaches, derived from
+    /// <see cref="RecipeSources"/> entries with <c>Type == "Training"</c>. Built whenever
+    /// recipes.json, npcs.json, or sources_recipes.json reloads. Defaults to empty so test
+    /// fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesTaughtByNpc => EmptyRecipeIndex;
+
+    /// <summary>
+    /// Reverse index from NPC <c>InternalName</c> → items the NPC sells, derived from
+    /// <see cref="ItemSources"/> entries with <c>Type == "Vendor"</c>. Built whenever items.json,
+    /// npcs.json, or sources_items.json reloads. Defaults to empty so test fakes don't need to
+    /// opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsSoldByNpc => EmptyItemIndex;
+
+    private static readonly IReadOnlyDictionary<string, Npc> EmptyNpcMap
+        = new Dictionary<string, Npc>(StringComparer.Ordinal);
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<Item>> EmptyItemIndex
+        = new Dictionary<string, IReadOnlyList<Item>>(StringComparer.Ordinal);
 
     /// <summary>
     /// Area key (e.g. <c>"AreaSerbule"</c>) → friendly display names. Pulled from

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -107,6 +107,12 @@ public sealed class ReferenceDataService : IReferenceDataService
 
     // NPCs
     private IReadOnlyDictionary<string, NpcEntry> _npcs = new Dictionary<string, NpcEntry>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, PocoNpc> _npcsByInternalName =
+        new Dictionary<string, PocoNpc>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<Recipe>> _recipesTaughtByNpc =
+        new Dictionary<string, IReadOnlyList<Recipe>>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<Item>> _itemsSoldByNpc =
+        new Dictionary<string, IReadOnlyList<Item>>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _npcsSnapshot;
 
     // Areas (areas.json) — area code → friendly display names.
@@ -206,6 +212,9 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
     public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xpTables;
     public IReadOnlyDictionary<string, NpcEntry> Npcs => _npcs;
+    public IReadOnlyDictionary<string, PocoNpc> NpcsByInternalName => _npcsByInternalName;
+    public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesTaughtByNpc => _recipesTaughtByNpc;
+    public IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsSoldByNpc => _itemsSoldByNpc;
     public IReadOnlyDictionary<string, AreaEntry> Areas => _areas;
     public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources => _itemSources;
     public IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> RecipeSources => _recipeSources;
@@ -473,6 +482,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _keywordIndex = new ItemKeywordIndex(byId);
         _itemsSnapshot = new ReferenceFileSnapshot("items", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byId.Count);
         BuildRecipeCrossLinkIndices();
+        BuildNpcCrossLinkIndices();
     }
 
     private void ParseAndSwapRecipes(IReadOnlyDictionary<string, Recipe> raw, ReferenceFileMetadata meta)
@@ -489,6 +499,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _recipesByInternalName = byName;
         _recipesSnapshot = new ReferenceFileSnapshot("recipes", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
         BuildRecipeCrossLinkIndices();
+        BuildNpcCrossLinkIndices();
     }
 
     /// <summary>
@@ -629,6 +640,59 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
     }
 
+    /// <summary>
+    /// Builds <see cref="_recipesTaughtByNpc"/> and <see cref="_itemsSoldByNpc"/> from the
+    /// current <see cref="_recipeSources"/> / <see cref="_itemSources"/> filtered to the
+    /// <c>Training</c> / <c>Vendor</c> source kinds. Powers the Silmarillion NPCs tab's
+    /// "Teaches recipes" and "Sells items" sections without per-selection scans of the
+    /// sources dictionaries. Called from every parse-and-swap whose inputs feed either
+    /// index — both source files and both entity files (items / recipes), since the
+    /// dictionary swap re-keys on InternalName.
+    /// </summary>
+    private void BuildNpcCrossLinkIndices()
+    {
+        var recipesTaught = new Dictionary<string, List<Recipe>>(StringComparer.Ordinal);
+        foreach (var (recipeInternalName, sources) in _recipeSources)
+        {
+            if (!_recipesByInternalName.TryGetValue(recipeInternalName, out var recipe)) continue;
+            foreach (var source in sources)
+            {
+                if (!string.Equals(source.Type, "Training", StringComparison.Ordinal)) continue;
+                if (string.IsNullOrEmpty(source.Npc)) continue;
+                if (!recipesTaught.TryGetValue(source.Npc, out var list))
+                {
+                    list = new List<Recipe>();
+                    recipesTaught[source.Npc] = list;
+                }
+                if (!list.Contains(recipe))
+                    list.Add(recipe);
+            }
+        }
+
+        var itemsSold = new Dictionary<string, List<Item>>(StringComparer.Ordinal);
+        foreach (var (itemInternalName, sources) in _itemSources)
+        {
+            if (!_itemsByInternalName.TryGetValue(itemInternalName, out var item)) continue;
+            foreach (var source in sources)
+            {
+                if (!string.Equals(source.Type, "Vendor", StringComparison.Ordinal)) continue;
+                if (string.IsNullOrEmpty(source.Npc)) continue;
+                if (!itemsSold.TryGetValue(source.Npc, out var list))
+                {
+                    list = new List<Item>();
+                    itemsSold[source.Npc] = list;
+                }
+                if (!list.Contains(item))
+                    list.Add(item);
+            }
+        }
+
+        _recipesTaughtByNpc = recipesTaught.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<Recipe>)kv.Value, StringComparer.Ordinal);
+        _itemsSoldByNpc = itemsSold.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<Item>)kv.Value, StringComparer.Ordinal);
+    }
+
     private void ParseAndSwapSkills(IReadOnlyDictionary<string, PocoSkill> raw, ReferenceFileMetadata meta)
     {
         var byName = new Dictionary<string, SkillEntry>(raw.Count, StringComparer.Ordinal);
@@ -682,6 +746,9 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void ParseAndSwapNpcs(IReadOnlyDictionary<string, PocoNpc> raw, ReferenceFileMetadata meta)
     {
         var byKey = new Dictionary<string, NpcEntry>(raw.Count, StringComparer.Ordinal);
+        // The raw dictionary is already keyed by the NPC envelope key (== InternalName).
+        // Copy it through with the Ordinal comparer to match the rest of the service.
+        var byInternalName = new Dictionary<string, PocoNpc>(raw.Count, StringComparer.Ordinal);
         foreach (var (key, v) in raw)
         {
             var prefs = (v.Preferences ?? (IReadOnlyList<PocoNpcPreference>)[])
@@ -711,8 +778,10 @@ public sealed class ReferenceDataService : IReferenceDataService
                 services);
 
             byKey[key] = entry;
+            byInternalName[key] = v;
         }
         _npcs = byKey;
+        _npcsByInternalName = byInternalName;
         _npcsSnapshot = new ReferenceFileSnapshot("npcs", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
     }
 
@@ -784,6 +853,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _itemSources = byInternalName;
         _itemSourcesSnapshot = new ReferenceFileSnapshot("sources_items", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
+        BuildNpcCrossLinkIndices();
     }
 
     private void ParseAndSwapRecipeSources(IReadOnlyDictionary<string, PocoSourceEnvelope> raw, ReferenceFileMetadata meta)
@@ -810,6 +880,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _recipeSources = byInternalName;
         _recipeSourcesSnapshot = new ReferenceFileSnapshot("sources_recipes", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
+        BuildNpcCrossLinkIndices();
     }
 
     private static string? ExtractNpc(SourceModels.SourceEntry s) => s switch

--- a/src/Silmarillion.Module/Navigation/NpcsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/NpcsKindTarget.cs
@@ -1,0 +1,52 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the NPCs tab.
+/// See <see cref="ItemsKindTarget"/> for the rationale on resolving against
+/// the tab VM's bound collection instead of refData directly.
+/// </summary>
+public sealed class NpcsKindTarget : IReferenceKindTarget
+{
+    private readonly NpcsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public NpcsKindTarget(NpcsTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.Npc;
+
+    public int TabIndex => 2;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        // Resolve against AllNpcs (canonical, matches WPF's ListBox ItemsSource), not against
+        // refData. See ItemsKindTarget for the post-refresh divergence that motivates this.
+        var row = _vm.AllNpcs.FirstOrDefault(r => r.InternalName == internalName);
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Npcs.TrySelect '{internalName}' → not found (AllNpcs={_vm.AllNpcs.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Npcs.TrySelect '{internalName}' → found, selecting.");
+        // Clear any residual filter so the target row isn't filtered out of the visible
+        // ListBox. See ItemsKindTarget for the symptom.
+        _vm.QueryText = "";
+        _vm.SelectedRow = row;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new NpcDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -50,6 +50,7 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetRequiredService<IReferenceNavigator>(),
             sp.GetRequiredService<SilmarillionSettings>()));
         services.AddSingleton<RecipesTabViewModel>();
+        services.AddSingleton<NpcsTabViewModel>();
         services.AddSingleton<SilmarillionViewModel>();
 
         // Kind targets registered after the tab VMs so DI can resolve them.
@@ -61,6 +62,9 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new RecipesKindTarget(
             sp.GetRequiredService<RecipesTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new NpcsKindTarget(
+            sp.GetRequiredService<NpcsTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new RecipeIngredientKeywordKindTarget(
             sp.GetRequiredService<RecipesTabViewModel>(),

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -244,16 +244,26 @@ public sealed partial class ItemsTabViewModel : ObservableObject
         {
             return null;
         }
+        // NPC-anchored source kinds (Vendor / Barter / NpcGift / HangOut / Training) carry an
+        // <see cref="EntityRef.Npc"/> so they're navigable the moment the NPCs kind target ships
+        // (#241). Other source kinds (Monster drop, Recipe, Quest, Skill, …) leave the reference
+        // null and render as plain-text in the source chip. Mirrors RecipesTabViewModel.BuildSourceChips.
         return sources
-            .Select(s => new ItemSourceChipVm(
-                DisplayName: FormatSourceDisplayName(s),
-                Detail: s.Context,
-                IconId: null,
-                EntityReference: null,
-                IsNavigable: false))
+            .Select(s =>
+            {
+                var reference = string.IsNullOrEmpty(s.Npc) ? null : EntityRef.Npc(s.Npc!);
+                return new ItemSourceChipVm(
+                    DisplayName: FormatSourceDisplayName(s),
+                    Detail: s.Context,
+                    IconId: null,
+                    EntityReference: reference,
+                    IsNavigable: reference is not null && _navigator.CanOpen(reference));
+            })
             .ToList();
     }
 
-    private static string FormatSourceDisplayName(ItemSource s) =>
-        string.IsNullOrEmpty(s.Npc) ? s.Type : $"{s.Type}: {s.Npc}";
+    private string FormatSourceDisplayName(ItemSource s) =>
+        string.IsNullOrEmpty(s.Npc)
+            ? s.Type
+            : $"{s.Type}: {NpcNameResolver.Resolve(_refData, s.Npc!)}";
 }

--- a/src/Silmarillion.Module/ViewModels/NpcDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcDetailViewModel.cs
@@ -1,0 +1,63 @@
+using System.Windows.Input;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Shared.Wpf;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Read-only projection of an <see cref="Npc"/> for the Silmarillion NPCs tab detail pane.
+/// Hostable in both the master-detail right pane and the popup <see cref="Silmarillion.Views.NpcDetailWindow"/>.
+/// Cross-link projections (taught recipes, sold items, given quests, gift preferences) are
+/// supplied by the page-level view-model, which has access to the reverse-lookup indices on
+/// <see cref="Mithril.Shared.Reference.IReferenceDataService"/> and the navigator's
+/// <c>CanOpen</c> for the <see cref="EntityChipVm.IsNavigable"/> flag.
+/// </summary>
+public sealed class NpcDetailViewModel
+{
+    public NpcDetailViewModel(
+        Npc npc,
+        string internalName,
+        IReadOnlyList<NpcServiceRow> services,
+        IReadOnlyList<EntityChipVm> taughtRecipes,
+        IReadOnlyList<EntityChipVm> soldItems,
+        IReadOnlyList<NpcQuestLink> quests,
+        IReadOnlyList<NpcPreferenceRow> preferences,
+        IReadOnlyList<string> giftSentimentTiers,
+        ICommand? openEntityCommand = null)
+    {
+        Npc = npc;
+        InternalName = internalName;
+        Services = services;
+        TaughtRecipes = taughtRecipes;
+        SoldItems = soldItems;
+        Quests = quests;
+        Preferences = preferences;
+        GiftSentimentTiers = giftSentimentTiers;
+        OpenEntityCommand = openEntityCommand;
+    }
+
+    public Npc Npc { get; }
+    public string InternalName { get; }
+    public string DisplayName =>
+        !string.IsNullOrEmpty(Npc.Name) ? Npc.Name! : NpcNameResolver.StripNpcPrefix(InternalName);
+    public string? AreaDisplayName => Npc.AreaFriendlyName ?? Npc.AreaName;
+    public string? Pos => Npc.Pos;
+    public string? Description => Npc.Desc;
+
+    public IReadOnlyList<NpcServiceRow> Services { get; }
+    public IReadOnlyList<EntityChipVm> TaughtRecipes { get; }
+    public IReadOnlyList<EntityChipVm> SoldItems { get; }
+    public IReadOnlyList<NpcQuestLink> Quests { get; }
+    public IReadOnlyList<NpcPreferenceRow> Preferences { get; }
+    public IReadOnlyList<string> GiftSentimentTiers { get; }
+
+    /// <summary>Comma-joined list of <see cref="GiftSentimentTiers"/> for the XAML <c>Run</c>.</summary>
+    public string GiftSentimentTiersDisplay => string.Join(", ", GiftSentimentTiers);
+
+    /// <summary>
+    /// Command invoked when the user clicks a cross-link chip (taught recipe / sold item).
+    /// Receives the chip's <see cref="Mithril.Shared.Reference.EntityRef"/>. Wired by
+    /// <see cref="NpcsTabViewModel"/> to the navigator.
+    /// </summary>
+    public ICommand? OpenEntityCommand { get; }
+}

--- a/src/Silmarillion.Module/ViewModels/NpcListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcListRow.cs
@@ -1,0 +1,17 @@
+using Mithril.Reference.Models.Npcs;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Lightweight projection of an <see cref="Npc"/> for the NPCs tab card list. The raw POCO
+/// has no <c>InternalName</c> field (it's the JSON envelope key), so the row carries it
+/// alongside pre-resolved display names. <see cref="ServiceTypes"/> is the flat, deduplicated
+/// set of <c>NpcService.Type</c> values across the NPC's services — queryable via the engine's
+/// collection-<c>CONTAINS</c> path (powers <c>ServiceTypes CONTAINS "Store"</c> and friends).
+/// </summary>
+public sealed record NpcListRow(
+    Npc Npc,
+    string InternalName,
+    string Name,
+    string AreaDisplayName,
+    IReadOnlyList<NpcServiceTypeValue> ServiceTypes);

--- a/src/Silmarillion.Module/ViewModels/NpcNameResolver.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcNameResolver.cs
@@ -1,0 +1,30 @@
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Resolves an NPC's friendly display name from its envelope-key InternalName, e.g.
+/// <c>"NPC_Joeh"</c> → <c>"Joeh"</c>. Used wherever an NPC appears as a label —
+/// the NPCs-tab master list, the <c>Vendor: NPC_X</c> / <c>Training: NPC_X</c> source
+/// chips on item and recipe details. Mirrors the NpcEntry projection rule already used
+/// by Arwen: prefer <see cref="Mithril.Reference.Models.Npcs.Npc.Name"/> when set,
+/// otherwise strip the leading <c>NPC_</c> prefix so the envelope key still reads
+/// reasonably even for entries that ship without a Name.
+/// </summary>
+internal static class NpcNameResolver
+{
+    public static string Resolve(IReferenceDataService refData, string internalName)
+    {
+        if (refData.NpcsByInternalName.TryGetValue(internalName, out var npc)
+            && !string.IsNullOrEmpty(npc.Name))
+        {
+            return npc.Name!;
+        }
+        return StripNpcPrefix(internalName);
+    }
+
+    public static string StripNpcPrefix(string internalName) =>
+        internalName.StartsWith("NPC_", StringComparison.Ordinal)
+            ? internalName.Substring(4)
+            : internalName;
+}

--- a/src/Silmarillion.Module/ViewModels/NpcPreferenceRow.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcPreferenceRow.cs
@@ -1,0 +1,14 @@
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Display projection of one <see cref="Mithril.Reference.Models.Npcs.NpcPreference"/> for the
+/// NPCs tab detail pane. <see cref="Desire"/> is the raw sentiment string (Love / Like /
+/// Dislike / Hate) — matches Arwen's vocabulary. <see cref="Pref"/> is the multiplier on
+/// the gift baseline (positive for Love/Like, negative for Dislike/Hate).
+/// </summary>
+public sealed record NpcPreferenceRow(
+    string Desire,
+    string DisplayName,
+    double Pref,
+    IReadOnlyList<string> Keywords,
+    string? MinFavorTier);

--- a/src/Silmarillion.Module/ViewModels/NpcQuestLink.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcQuestLink.cs
@@ -1,0 +1,12 @@
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Display projection of a quest associated with an NPC for the NPCs tab detail pane.
+/// Plain-text rendering until the Quests tab ships (#242) — at which point this is the spot
+/// to swap in an <c>EntityRef.Quest</c>-anchored chip. v1 matches only on
+/// <c>Quest.FavorNpc</c> (the giver/turn-in NPC); per-objective turn-in detection is a
+/// follow-up.
+/// </summary>
+public sealed record NpcQuestLink(
+    string DisplayName,
+    string InternalName);

--- a/src/Silmarillion.Module/ViewModels/NpcServiceRow.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcServiceRow.cs
@@ -1,0 +1,13 @@
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Display projection of one <see cref="Mithril.Reference.Models.Npcs.NpcService"/> for the
+/// NPCs tab detail pane. <see cref="Details"/> is the flattened, human-readable list of
+/// per-subclass sub-rows (CapIncreases for stores, Skills/Unlocks for trainers, etc.) — the
+/// detail view renders one bullet per entry under the service header. <see cref="MinFavorTier"/>
+/// surfaces the access threshold (Favor on the raw POCO) as its own chip.
+/// </summary>
+public sealed record NpcServiceRow(
+    string Type,
+    string? MinFavorTier,
+    IReadOnlyList<string> Details);

--- a/src/Silmarillion.Module/ViewModels/NpcServiceTypeValue.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcServiceTypeValue.cs
@@ -1,0 +1,16 @@
+using Mithril.Reference;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Lightweight wrapper that lets an NPC's flattened service-type set
+/// participate in the query engine's collection-<c>CONTAINS</c> path. Exposes the
+/// raw service <see cref="Type"/> (e.g. <c>"Store"</c>, <c>"Training"</c>,
+/// <c>"Barter"</c>) as the queryable string. Mirror of <see cref="IngredientKeywordValue"/>
+/// for the NPC service-type pivot — powers the NPCs tab's
+/// <c>ServiceTypes CONTAINS "Store"</c> query.
+/// </summary>
+public sealed record NpcServiceTypeValue(string Type) : IQueryStringValue
+{
+    public string QueryStringValue => Type;
+}

--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -1,0 +1,319 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
+// Disambiguate the POCO type from the slim Mithril.Shared.Reference.NpcService projection
+// (the latter is consumed by Arwen for gift calculation).
+using NpcServicePoco = Mithril.Reference.Models.Npcs.NpcService;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// NPCs master-detail view-model. Mirrors <see cref="ItemsTabViewModel"/> / <see cref="RecipesTabViewModel"/>'s
+/// shape: filterable row list on the left, NPC detail on the right. On selection change
+/// builds an <see cref="NpcDetailViewModel"/> with service rows, "Teaches recipes" / "Sells items"
+/// cross-link chips, "Quests" link list, and gift-preference rows resolved from
+/// <see cref="IReferenceDataService"/>.
+///
+/// Subscribes to <see cref="IReferenceDataService.FileUpdated"/> for <c>"npcs"</c>,
+/// <c>"items"</c>, <c>"recipes"</c>, <c>"sources_items"</c>, <c>"sources_recipes"</c>, and
+/// <c>"quests"</c> (any of which can change either the master list or one of the cross-link
+/// sections) and rebuilds <see cref="AllNpcs"/> on the UI thread, preserving the current
+/// selection by <see cref="NpcListRow.InternalName"/>.
+/// </summary>
+public sealed partial class NpcsTabViewModel : ObservableObject
+{
+    /// <summary>
+    /// Reflected schema for <see cref="NpcListRow"/> exposed to <c>MithrilQueryBox.Schema</c>
+    /// so the query box can offer completion and highlight known column names. <c>QueryFilter</c>
+    /// on the bound ListBox reflects the same surface from the item type at attach time, so the
+    /// suggestions stay in sync with what actually filters.
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(NpcListRow)));
+
+    private readonly IReferenceDataService _refData;
+    private readonly IReferenceNavigator _navigator;
+    private readonly RelayCommand<EntityRef?> _openEntityCommand;
+
+    public NpcsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator)
+    {
+        _refData = refData;
+        _navigator = navigator;
+        _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
+        _allNpcs = BuildAllNpcs(refData);
+        refData.FileUpdated += OnFileUpdated;
+    }
+
+    [ObservableProperty]
+    private IReadOnlyList<NpcListRow> _allNpcs;
+
+    [ObservableProperty]
+    private string _queryText = "";
+
+    [ObservableProperty]
+    private string? _queryError;
+
+    /// <summary>
+    /// ListBox-bound selection. Setting it from an <see cref="Npc"/> POCO (in tests or via the
+    /// navigator) resolves to the matching row.
+    /// </summary>
+    [ObservableProperty]
+    private NpcListRow? _selectedRow;
+
+    [ObservableProperty]
+    private NpcDetailViewModel? _detailViewModel;
+
+    partial void OnSelectedRowChanged(NpcListRow? value)
+    {
+        if (value is null)
+        {
+            DetailViewModel = null;
+            return;
+        }
+
+        DetailViewModel = BuildDetailViewModel(value);
+    }
+
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        // npcs.json drives the master list. items/recipes/sources_* affect the cross-link
+        // sections on the detail pane — rebuild on each so an open detail re-resolves chips
+        // against the fresh refData snapshot. quests.json feeds the (plain-text) Quests block.
+        if (fileKey is not ("npcs" or "items" or "recipes" or "sources_items" or "sources_recipes" or "quests"))
+            return;
+
+        UiThread.Run(() =>
+        {
+            var captured = SelectedRow?.InternalName;
+            if (fileKey == "npcs")
+            {
+                AllNpcs = BuildAllNpcs(_refData);
+            }
+            if (!string.IsNullOrEmpty(captured))
+            {
+                var resolved = AllNpcs.FirstOrDefault(r => r.InternalName == captured);
+                // Toggle through null to force OnSelectedRowChanged to rebuild the detail
+                // VM with the fresh refData snapshot (cross-link resolution uses live refData).
+                SelectedRow = null;
+                SelectedRow = resolved;
+            }
+        });
+    }
+
+    private static IReadOnlyList<NpcListRow> BuildAllNpcs(IReferenceDataService refData) =>
+        refData.NpcsByInternalName
+            .Select(kv => BuildRow(kv.Key, kv.Value))
+            .OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static NpcListRow BuildRow(string internalName, Npc npc) => new(
+        Npc: npc,
+        InternalName: internalName,
+        // Prefer the POCO's Name; fall back to the envelope key with the "NPC_" prefix stripped
+        // so unnamed entries (altars, placeholders) read as "SpiderPlaceholder" rather than
+        // "NPC_SpiderPlaceholder". Same rule applied to source-chip display names so the two
+        // surfaces stay in sync — see NpcNameResolver.
+        Name: !string.IsNullOrEmpty(npc.Name) ? npc.Name! : NpcNameResolver.StripNpcPrefix(internalName),
+        AreaDisplayName: npc.AreaFriendlyName ?? npc.AreaName ?? "(unknown)",
+        ServiceTypes: BuildServiceTypes(npc));
+
+    private static IReadOnlyList<NpcServiceTypeValue> BuildServiceTypes(Npc npc)
+    {
+        if (npc.Services is null || npc.Services.Count == 0) return [];
+        return npc.Services
+            .Where(s => !string.IsNullOrEmpty(s.Type))
+            .Select(s => s.Type)
+            .Distinct(StringComparer.Ordinal)
+            .Select(t => new NpcServiceTypeValue(t))
+            .ToList();
+    }
+
+    private NpcDetailViewModel BuildDetailViewModel(NpcListRow row)
+    {
+        var services = BuildServiceRows(row.Npc);
+        var taught = BuildTaughtRecipeChips(row.InternalName);
+        var sold = BuildSoldItemChips(row.InternalName);
+        var quests = BuildQuestLinks(row.InternalName);
+        var preferences = BuildPreferenceRows(row.Npc);
+        var giftTiers = row.Npc.ItemGifts ?? (IReadOnlyList<string>)[];
+
+        return new NpcDetailViewModel(
+            row.Npc,
+            row.InternalName,
+            services,
+            taught,
+            sold,
+            quests,
+            preferences,
+            giftTiers,
+            _openEntityCommand);
+    }
+
+    private static IReadOnlyList<NpcServiceRow> BuildServiceRows(Npc npc)
+    {
+        if (npc.Services is null || npc.Services.Count == 0) return [];
+        return npc.Services
+            .Where(s => !string.IsNullOrEmpty(s.Type))
+            .Select(s => new NpcServiceRow(
+                s.Type,
+                // "Despised" is the lowest favor tier — i.e. anyone can access the service.
+                // Showing a "Favor: Despised" badge on every row is pure noise; null it out
+                // so the XAML hides the chip and reserves the badge for meaningful gates.
+                MinFavorTier: string.Equals(s.Favor, "Despised", StringComparison.Ordinal) ? null : s.Favor,
+                BuildServiceDetails(s)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Flatten each NpcService subclass to display-relevant payload lines. Lines are pre-labeled
+    /// per sub-list (e.g. <c>"Skills: Unarmed, Lore"</c> / <c>"Unlocks at higher favor: Neutral,
+    /// Comfortable, ..."</c>) so the detail view can render them in a single linear strip and the
+    /// viewer can tell skill names apart from favor-tier unlocks. Plain strings — richer per-row
+    /// chips are a #229-style polish follow-up.
+    /// </summary>
+    private static IReadOnlyList<string> BuildServiceDetails(NpcServicePoco service) => service switch
+    {
+        // Store caps are kept one-per-row: each tier raises a distinct gold cap and the per-row
+        // keyword tuple disambiguates which category the cap applies to.
+        StoreService store when store.CapIncreases is { Count: > 0 } =>
+            store.CapIncreases.Select(FormatCapIncrease).ToList(),
+
+        BarterService barter when barter.AdditionalUnlocks is { Count: > 0 } =>
+            BuildLabeledLines(("Unlocks at higher favor", barter.AdditionalUnlocks)),
+
+        ConsignmentService consignment =>
+            BuildLabeledLines(
+                ("Items", consignment.ItemTypes),
+                ("Unlocks at higher favor", consignment.Unlocks)),
+
+        InstallAugmentsService install when install.LevelRange is { Count: > 0 } =>
+            BuildLabeledLines(("Levels", install.LevelRange)),
+
+        StorageService storage =>
+            BuildLabeledLines(
+                ("Items", storage.ItemDescs),
+                ("Space increases at", storage.SpaceIncreases)),
+
+        TrainingService training =>
+            BuildLabeledLines(
+                ("Skills", training.Skills),
+                ("Unlocks at higher favor", training.Unlocks)),
+
+        _ => [],
+    };
+
+    /// <summary>
+    /// Join each non-empty sub-list into a single labeled line so Skills and Unlocks (etc.) stay
+    /// visually distinct in the detail pane. Empty groups drop out entirely.
+    /// </summary>
+    private static IReadOnlyList<string> BuildLabeledLines(params (string Label, IReadOnlyList<string>? Items)[] groups)
+    {
+        var lines = new List<string>(groups.Length);
+        foreach (var (label, items) in groups)
+        {
+            if (items is null || items.Count == 0) continue;
+            lines.Add($"{label}: {string.Join(", ", items)}");
+        }
+        return lines;
+    }
+
+    /// <summary>
+    /// Format one Store cap-increase entry as <c>"Tier → 5,000g (Kw1, Kw2)"</c>, falling back to
+    /// the tier + gold form when no keywords are listed. Mirrors the parser shape in
+    /// <see cref="Mithril.Shared.Reference.ReferenceDataService"/> (the colon-separated raw form
+    /// is already decomposed into tier/gold/keywords by the time it reaches the slim NpcEntry,
+    /// but we're rendering off the raw POCO here, so we re-split.).
+    /// </summary>
+    private static string FormatCapIncrease(string raw)
+    {
+        // Raw line shape: "Despised:5000:Armor,Weapon,CorpseTrophy". Three colon-separated parts;
+        // last part may be empty.
+        var parts = raw.Split(':', 3);
+        if (parts.Length < 2) return raw;
+        var tier = parts[0];
+        var gold = int.TryParse(parts[1], out var g) ? g.ToString("N0") + "g" : parts[1];
+        if (parts.Length < 3 || string.IsNullOrWhiteSpace(parts[2])) return $"{tier} → {gold}";
+        var keywords = parts[2].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        return keywords.Length == 0 ? $"{tier} → {gold}" : $"{tier} → {gold} ({string.Join(", ", keywords)})";
+    }
+
+    private IReadOnlyList<EntityChipVm> BuildTaughtRecipeChips(string npcInternalName)
+    {
+        if (!_refData.RecipesTaughtByNpc.TryGetValue(npcInternalName, out var recipes) || recipes.Count == 0)
+            return [];
+        return recipes
+            .OrderBy(r => r.Name ?? r.InternalName ?? r.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(r => new EntityChipVm(
+                DisplayName: r.Name ?? r.InternalName ?? r.Key,
+                IconId: r.IconId > 0 ? r.IconId : ResolveRecipeFallbackIcon(r),
+                Reference: EntityRef.Recipe(r.InternalName ?? r.Key),
+                IsNavigable: _navigator.CanOpen(EntityRef.Recipe(r.InternalName ?? r.Key))))
+            .ToList();
+    }
+
+    private int ResolveRecipeFallbackIcon(Recipe recipe)
+    {
+        var source = (recipe.ResultItems is { Count: > 0 } ? recipe.ResultItems : recipe.ProtoResultItems)
+            ?? (IReadOnlyList<RecipeResultItem>)Array.Empty<RecipeResultItem>();
+        foreach (var result in source)
+        {
+            if (_refData.Items.TryGetValue(result.ItemCode, out var item) && item.IconId > 0)
+                return item.IconId;
+        }
+        return 0;
+    }
+
+    private IReadOnlyList<EntityChipVm> BuildSoldItemChips(string npcInternalName)
+    {
+        if (!_refData.ItemsSoldByNpc.TryGetValue(npcInternalName, out var items) || items.Count == 0)
+            return [];
+        return items
+            .OrderBy(i => i.Name ?? i.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
+            .Select(i => new EntityChipVm(
+                DisplayName: i.Name ?? i.InternalName ?? "",
+                IconId: i.IconId,
+                Reference: EntityRef.Item(i.InternalName ?? ""),
+                IsNavigable: _navigator.CanOpen(EntityRef.Item(i.InternalName ?? ""))))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Quest cross-link list. v1 matches only on <see cref="Mithril.Shared.Reference.QuestEntry.FavorNpc"/>
+    /// — that's the giver/turn-in NPC. Per-objective turn-in detection is deferred to the
+    /// Quests tab handoff (#242). Renders as plain text until that tab ships.
+    /// </summary>
+    private IReadOnlyList<NpcQuestLink> BuildQuestLinks(string npcInternalName)
+    {
+        var matches = new List<NpcQuestLink>();
+        foreach (var quest in _refData.Quests.Values)
+        {
+            if (!string.Equals(quest.FavorNpc, npcInternalName, StringComparison.Ordinal)) continue;
+            matches.Add(new NpcQuestLink(
+                DisplayName: string.IsNullOrEmpty(quest.Name) ? quest.InternalName : quest.Name,
+                InternalName: quest.InternalName));
+        }
+        matches.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
+        return matches;
+    }
+
+    private static IReadOnlyList<NpcPreferenceRow> BuildPreferenceRows(Npc npc)
+    {
+        if (npc.Preferences is null || npc.Preferences.Count == 0) return [];
+        // Sort matches Arwen's order: Love → Like → Dislike → Hate, then by descending Pref.
+        return npc.Preferences
+            .OrderBy(p => p.Desire switch { "Love" => 0, "Like" => 1, "Dislike" => 2, "Hate" => 3, _ => 4 })
+            .ThenByDescending(p => p.Pref)
+            .Select(p => new NpcPreferenceRow(
+                Desire: p.Desire ?? "",
+                DisplayName: p.Name ?? string.Join(", ", p.Keywords ?? (IReadOnlyList<string>)[]),
+                Pref: p.Pref,
+                Keywords: p.Keywords ?? (IReadOnlyList<string>)[],
+                MinFavorTier: p.Favor))
+            .ToList();
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -258,6 +258,8 @@ public sealed partial class RecipesTabViewModel : ObservableObject
             .ToList();
     }
 
-    private static string FormatSourceDisplayName(RecipeSource s) =>
-        string.IsNullOrEmpty(s.Npc) ? s.Type : $"{s.Type}: {s.Npc}";
+    private string FormatSourceDisplayName(RecipeSource s) =>
+        string.IsNullOrEmpty(s.Npc)
+            ? s.Type
+            : $"{s.Type}: {NpcNameResolver.Resolve(_refData, s.Npc!)}";
 }

--- a/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/SilmarillionViewModel.cs
@@ -25,16 +25,19 @@ public sealed partial class SilmarillionViewModel : ObservableObject
     public SilmarillionViewModel(
         ItemsTabViewModel items,
         RecipesTabViewModel recipes,
+        NpcsTabViewModel npcs,
         IReferenceNavigator navigator,
         IEnumerable<IReferenceKindTarget> targets,
         IDiagnosticsSink? diag = null)
     {
         Items = items;
         Recipes = recipes;
+        Npcs = npcs;
         Tabs = new[]
         {
             new ModuleTab("Items",   items),
             new ModuleTab("Recipes", recipes),
+            new ModuleTab("NPCs",    npcs),
         };
         _navigator = navigator;
         _diag = diag;
@@ -60,11 +63,12 @@ public sealed partial class SilmarillionViewModel : ObservableObject
 
     public ItemsTabViewModel Items { get; }
     public RecipesTabViewModel Recipes { get; }
+    public NpcsTabViewModel Npcs { get; }
 
     /// <summary>The tab descriptors bound to <c>TabControl.ItemsSource</c>.</summary>
     public IReadOnlyList<ModuleTab> Tabs { get; }
 
-    /// <summary>0 = Items, 1 = Recipes. Two-way bound to the TabControl in the view.</summary>
+    /// <summary>0 = Items, 1 = Recipes, 2 = NPCs. Two-way bound to the TabControl in the view.</summary>
     [ObservableProperty]
     private int _selectedTabIndex;
 

--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml
@@ -1,0 +1,189 @@
+<UserControl x:Class="Silmarillion.Views.NpcDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border Padding="14,12">
+        <DockPanel>
+            <!-- Footer docks to bottom; body StackPanel fills the rest. With the host
+                 ContentControl bound to ScrollViewer.ViewportHeight, this pins the footer to
+                 the bottom of the pane even for sparse NPCs (altars / pedestals). -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding InternalName}"
+                       Foreground="#88FFFFFF"
+                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       Margin="0,8,0,0" HorizontalAlignment="Right"
+                       VerticalAlignment="Bottom"/>
+            <StackPanel>
+                <!-- Header: name + area + position -->
+                <StackPanel Margin="0,0,0,10">
+                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
+                               Foreground="#FFD4A847"
+                               FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                        <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                CornerRadius="3" Padding="6,2"
+                                Visibility="{Binding AreaDisplayName, Converter={StaticResource NullOrEmptyToVis}}">
+                            <TextBlock Text="{Binding AreaDisplayName}" Foreground="#CCFFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeHint}"/>
+                        </Border>
+                        <TextBlock Text="{Binding Pos}" Foreground="#88FFFFFF"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                   VerticalAlignment="Center" Margin="8,0,0,0"
+                                   Visibility="{Binding Pos, Converter={StaticResource NullOrEmptyToVis}}"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- Services -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding Services.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Services" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding Services}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="#FF222222" BorderBrush="#22FFFFFF" BorderThickness="1"
+                                        CornerRadius="3" Padding="8,6" Margin="0,0,0,4">
+                                    <StackPanel>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Type}" FontWeight="SemiBold"
+                                                       Foreground="#FFD4A847"
+                                                       FontSize="{DynamicResource AppFontSizeHint}"/>
+                                            <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1"
+                                                    CornerRadius="3" Padding="5,1" Margin="8,0,0,0"
+                                                    Visibility="{Binding MinFavorTier, Converter={StaticResource NullOrEmptyToVis}}">
+                                                <TextBlock Foreground="#CCFFFFFF"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                                    <Run Text="Favor: "/>
+                                                    <Run Text="{Binding MinFavorTier, Mode=OneWay}"/>
+                                                </TextBlock>
+                                            </Border>
+                                        </StackPanel>
+                                        <ItemsControl ItemsSource="{Binding Details}" Margin="0,4,0,0"
+                                                      Visibility="{Binding Details.Count, Converter={StaticResource PositiveIntToVis}}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
+                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               TextWrapping="Wrap" Margin="0,0,0,1"/>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Teaches recipes -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding TaughtRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Teaches recipes" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding TaughtRecipes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Sells items -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding SoldItems.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Sells items" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding SoldItems}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Quests (plain text until #242 ships the Quests tab) -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding Quests.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Quests" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding Quests}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Gift preferences -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding Preferences.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Gift preferences" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding Preferences}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <DockPanel Margin="0,0,0,3">
+                                    <Border DockPanel.Dock="Left" Background="#FF252525" BorderBrush="#33FFFFFF"
+                                            BorderThickness="1" CornerRadius="3" Padding="5,1" Margin="0,0,6,0"
+                                            VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding Desire}" Foreground="#FFD4A847"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                    </Border>
+                                    <TextBlock Foreground="#CCFFFFFF"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               TextWrapping="Wrap" VerticalAlignment="Center">
+                                        <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                        <Run Text=" ("/><Run Text="{Binding Pref, Mode=OneWay, StringFormat={}{0:+0.#;-0.#}}"/><Run Text="×)"/>
+                                    </TextBlock>
+                                </DockPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <!-- Gift sentiment tiers (Friends, BestFriends, ...) — the thresholds at which
+                         this NPC accepts gifts. Rendered as a comma-joined plain line below the
+                         preference rows. -->
+                    <TextBlock Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeSmall}"
+                               Margin="0,4,0,0" TextWrapping="Wrap"
+                               Visibility="{Binding GiftSentimentTiers.Count, Converter={StaticResource PositiveIntToVis}}">
+                        <Run Text="Accepts gifts at: " FontStyle="Italic"/>
+                        <Run Text="{Binding GiftSentimentTiersDisplay, Mode=OneWay}"/>
+                    </TextBlock>
+                </StackPanel>
+
+                <!-- Description -->
+                <TextBlock Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
+                           MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
+                           Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml.cs
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class NpcDetailView : UserControl
+{
+    public NpcDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/NpcDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailWindow.xaml
@@ -1,0 +1,49 @@
+<Window x:Class="Silmarillion.Views.NpcDetailWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Silmarillion.Views"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="{Binding DisplayName}"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        FontFamily="{DynamicResource AppFontFamily}"
+        FontSize="{DynamicResource AppFontSize}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+            MinWidth="320" MaxWidth="520">
+        <DockPanel>
+            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
+                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
+                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                            ToolTip="Close" Click="CloseButton_Click">
+                        <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
+                    </Button>
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                </DockPanel>
+            </Border>
+
+            <!-- Body: shared UserControl. -->
+            <local:NpcDetailView/>
+        </DockPanel>
+    </Border>
+</Window>

--- a/src/Silmarillion.Module/Views/NpcDetailWindow.xaml.cs
+++ b/src/Silmarillion.Module/Views/NpcDetailWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Silmarillion.Views;
+
+public partial class NpcDetailWindow : Window
+{
+    public NpcDetailWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) DragMove();
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/Silmarillion.Module/Views/NpcsTabView.xaml
+++ b/src/Silmarillion.Module/Views/NpcsTabView.xaml
@@ -1,0 +1,109 @@
+<UserControl x:Class="Silmarillion.Views.NpcsTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320" MinWidth="240"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
+            <StackPanel>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:NpcsTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. ServiceTypes CONTAINS 'Store'"/>
+                <TextBlock Text="{Binding QueryError}"
+                           Foreground="#FFD96A6A" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="0,4,0,0"
+                           Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </Border>
+
+        <ListBox Grid.Row="1" Grid.Column="0"
+                 ItemsSource="{Binding AllNpcs}"
+                 ItemTemplate="{StaticResource NpcCardTemplate}"
+                 SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                 query:QueryFilter.QueryText="{Binding QueryText}"
+                 query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"
+                 Background="#FF1A1A1A" BorderThickness="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 VirtualizingStackPanel.IsVirtualizing="True"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
+
+        <Grid Grid.Row="1" Grid.Column="1" Background="#FF1A1A1A">
+            <ScrollViewer x:Name="DetailScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <!-- DataType-keyed template applies only when Content is a non-null VM.
+                     See ItemsTabView.xaml comment for context. MinHeight bound to viewport
+                     so the NPC detail's footer pins to the bottom of the pane. -->
+                <ContentControl Content="{Binding DetailViewModel}"
+                                MinHeight="{Binding ViewportHeight, ElementName=DetailScroller}">
+                    <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type vm:NpcDetailViewModel}">
+                            <local:NpcDetailView/>
+                        </DataTemplate>
+                    </ContentControl.Resources>
+                </ContentControl>
+            </ScrollViewer>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="320">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DetailViewModel}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <icon:PackIconLucide Kind="Users" Width="48" Height="48"
+                                     Foreground="#33FFFFFF"
+                                     HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                <TextBlock Text="Browse NPCs"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeLarge}"
+                           Foreground="#CCFFFFFF"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Select an NPC to see their services, what they teach or sell, the quests they give, and their gift preferences."
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Foreground="#88FFFFFF"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Silmarillion.Module/Views/NpcsTabView.xaml.cs
+++ b/src/Silmarillion.Module/Views/NpcsTabView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class NpcsTabView : UserControl
+{
+    public NpcsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -54,19 +54,20 @@
                        MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                        Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
-            <!-- Taught by (sources_recipes.json projection) — plain-text in v1; chips will
-                 become navigable once an NPC tab ships (#241). Mirrors the Sources block in
-                 ItemDetailView. Hidden when no sources are recorded. -->
+            <!-- Taught by (sources_recipes.json projection). Renders as ItemSourceChip:
+                 navigable chip when the source's EntityReference resolves to a tabbed kind
+                 (e.g. NPC trainers, post-#241), plain-text in a transparent frame otherwise. -->
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
                 <TextBlock Text="Taught by" FontWeight="SemiBold" Foreground="#88FFFFFF"
                            FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
                 <ItemsControl ItemsSource="{Binding Sources}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding DisplayName}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            <c:ItemSourceChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>

--- a/src/Silmarillion.Module/Views/Resources.xaml
+++ b/src/Silmarillion.Module/Views/Resources.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf">
+                    xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+                    xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks">
     <!-- Converters.xaml merged locally so {StaticResource NullOrEmptyToVis} inside the
          DataTemplates below resolves at template parse time. The outer UserControl's
          resource merge is too late for StaticResource lookups inside merged DataTemplates. -->
@@ -24,6 +25,28 @@
                            FontSize="{DynamicResource AppFontSizeSmall}"
                            TextTrimming="CharacterEllipsis"
                            Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
+
+    <!-- Compact two-line row for NPCs tab. Bound DataContext: Silmarillion.ViewModels.NpcListRow.
+         Icon-less for now (NPC entries don't ship icon ids in npcs.json); a Users icon stands in
+         to keep the row height consistent with the Items/Recipes tabs. -->
+    <DataTemplate x:Key="NpcCardTemplate">
+        <DockPanel LastChildFill="True">
+            <Border DockPanel.Dock="Left" Width="24" Height="24" Margin="6,3,6,3"
+                    VerticalAlignment="Center" Background="#FF1F1F1F" CornerRadius="3">
+                <icon:PackIconLucide Kind="User" Width="14" Height="14" Foreground="#88FFFFFF"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Text="{Binding AreaDisplayName}" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis"
+                           Visibility="{Binding AreaDisplayName, Converter={StaticResource NullOrEmptyToVis}}"/>
             </StackPanel>
         </DockPanel>
     </DataTemplate>

--- a/src/Silmarillion.Module/Views/SilmarillionView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionView.xaml
@@ -22,6 +22,9 @@
             <DataTemplate DataType="{x:Type vm:RecipesTabViewModel}">
                 <local:RecipesTabView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:NpcsTabViewModel}">
+                <local:NpcsTabView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.InputBindings>

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -653,6 +653,122 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void RecipesTaughtByNpc_indexes_Training_recipe_sources_by_npc_InternalName()
+    {
+        // Reverse index built from sources_recipes.json filtered to Type == "Training".
+        // Skill / Effect / Quest source rows are excluded; the index is the spine of the
+        // NPCs tab's "Teaches recipes" section (#241).
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.json"), """
+            {
+              "recipe_42": {
+                "Name": "Bake Bread",
+                "InternalName": "BakeBread",
+                "Skill": "Cooking",
+                "SkillLevelReq": 5
+              },
+              "recipe_43": {
+                "Name": "Make Cheese",
+                "InternalName": "MakeCheese",
+                "Skill": "Cooking",
+                "SkillLevelReq": 12
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_recipes.json"), """
+            {
+              "recipe_42": {
+                "entries": [
+                  { "npc": "NPC_Marna", "type": "Training" },
+                  { "skill": "Cooking", "type": "Skill" }
+                ]
+              },
+              "recipe_43": {
+                "entries": [
+                  { "npc": "NPC_Marna", "type": "Training" }
+                ]
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_recipes.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.RecipesTaughtByNpc.Should().ContainKey("NPC_Marna");
+        svc.RecipesTaughtByNpc["NPC_Marna"].Select(r => r.InternalName)
+            .Should().BeEquivalentTo(["BakeBread", "MakeCheese"]);
+    }
+
+    [Fact]
+    public void ItemsSoldByNpc_indexes_Vendor_item_sources_by_npc_InternalName()
+    {
+        // Reverse index built from sources_items.json filtered to Type == "Vendor".
+        // Drop / Quest / NpcGift source rows are excluded; the index drives the NPCs tab's
+        // "Sells items" section (#241).
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), """
+            {
+              "item_700": { "Name": "Apple", "InternalName": "Apple" },
+              "item_701": { "Name": "Bread", "InternalName": "Bread" }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_items.json"), """
+            {
+              "item_700": {
+                "entries": [
+                  { "npc": "NPC_Joeh", "type": "Vendor" }
+                ]
+              },
+              "item_701": {
+                "entries": [
+                  { "npc": "NPC_Joeh", "type": "Vendor" },
+                  { "type": "Monster", "monsterName": "Hippo" }
+                ]
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "sources_items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.ItemsSoldByNpc.Should().ContainKey("NPC_Joeh");
+        svc.ItemsSoldByNpc["NPC_Joeh"].Select(i => i.InternalName)
+            .Should().BeEquivalentTo(["Apple", "Bread"]);
+    }
+
+    [Fact]
+    public void NpcsByInternalName_exposes_full_Npc_POCO_keyed_by_envelope_key()
+    {
+        // Sibling to the slim NpcEntry projection (consumed by Arwen). NpcsByInternalName
+        // surfaces the raw POCO — Services, Preferences, ItemGifts, etc. — for the NPCs tab.
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "npcs.json"), """
+            {
+              "NPC_Joeh": {
+                "Name": "Joeh",
+                "AreaName": "Serbule",
+                "AreaFriendlyName": "Serbule",
+                "Pos": "100 50 200",
+                "Desc": "A friendly NPC."
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "npcs.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.NpcsByInternalName.Should().ContainKey("NPC_Joeh");
+        var joeh = svc.NpcsByInternalName["NPC_Joeh"];
+        joeh.Name.Should().Be("Joeh");
+        joeh.AreaFriendlyName.Should().Be("Serbule");
+        joeh.Pos.Should().Be("100 50 200");
+        joeh.Desc.Should().Be("A friendly NPC.");
+    }
+
+    [Fact]
     public void GetSnapshot_UnknownKey_Throws()
     {
         WriteBundled("""{}""", version: "v100");

--- a/tests/Silmarillion.Tests/Navigation/NpcsKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/NpcsKindTargetTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class NpcsKindTargetTests
+{
+    [Fact]
+    public void Kind_IsNpc()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Npc);
+    }
+
+    [Fact]
+    public void TabIndex_IsTwo()
+    {
+        // Items=0, Recipes=1, NPCs=2 — bucket B's first tab slots in after the v1 pair.
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownNpc_SelectsOnTabVm_ReturnsTrue()
+    {
+        var (target, vm, _) = BuildTarget(("NPC_Joeh", new Npc { Name = "Joeh" }));
+
+        var ok = target.TrySelectByInternalName("NPC_Joeh");
+
+        ok.Should().BeTrue();
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRow!.InternalName.Should().Be("NPC_Joeh");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownNpc_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        vm.SelectedRow.Should().BeNull(); // precondition
+
+        target.TrySelectByInternalName("NPC_DoesNotExist").Should().BeFalse();
+        vm.SelectedRow.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsResidualQueryText_SoTargetRowIsVisible()
+    {
+        var (target, vm, _) = BuildTarget(("NPC_Joeh", new Npc { Name = "Joeh" }));
+        vm.QueryText = "ServiceTypes CONTAINS 'Store'";
+
+        var ok = target.TrySelectByInternalName("NPC_Joeh");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().BeEmpty(because: "the kind target clears any prior filter before selecting");
+        vm.SelectedRow!.InternalName.Should().Be("NPC_Joeh");
+    }
+
+    private static (NpcsKindTarget Target, NpcsTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
+        params (string Key, Npc Npc)[] npcs)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, npc) in npcs)
+            refData.AddNpc(key, npc);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new NpcsTabViewModel(refData, nav);
+        var target = new NpcsKindTarget(vm);
+        return (target, vm, refData);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, Npc> _byKey = new(StringComparer.Ordinal);
+
+        public void AddNpc(string key, Npc npc) => _byKey[key] = npc;
+
+        public IReadOnlyList<string> Keys => Array.Empty<string>();
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>(StringComparer.Ordinal);
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName => _byKey;
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -228,7 +228,7 @@ public sealed class SilmarillionReferenceNavigatorTests
             keywordTarget,
         };
         var nav = new SilmarillionReferenceNavigator(targets);
-        var silmarillionVm = new SilmarillionViewModel(items: null!, recipes: recipesVm, nav, targets);
+        var silmarillionVm = new SilmarillionViewModel(items: null!, recipes: recipesVm, npcs: null!, nav, targets);
 
         // Act
         nav.Open(EntityRef.RecipeIngredientKeyword("Crystal"));
@@ -253,7 +253,7 @@ public sealed class SilmarillionReferenceNavigatorTests
             keywordTarget,
         };
         var nav = new SilmarillionReferenceNavigator(targets);
-        var silmarillionVm = new SilmarillionViewModel(items: itemsVm, recipes: null!, nav, targets);
+        var silmarillionVm = new SilmarillionViewModel(items: itemsVm, recipes: null!, npcs: null!, nav, targets);
 
         nav.Open(EntityRef.ItemKeyword("Crystal"));
 
@@ -279,7 +279,7 @@ public sealed class SilmarillionReferenceNavigatorTests
             keywordTarget,
         };
         var nav = new SilmarillionReferenceNavigator(targets);
-        _ = new SilmarillionViewModel(items: itemsVm, recipes: null!, nav, targets);
+        _ = new SilmarillionViewModel(items: itemsVm, recipes: null!, npcs: null!, nav, targets);
 
         nav.Open(EntityRef.ItemKeyword(["EquipmentSlot:MainHand", "Crystal"]));
 
@@ -308,7 +308,7 @@ public sealed class SilmarillionReferenceNavigatorTests
             keywordTarget,
         };
         var nav = new SilmarillionReferenceNavigator(targets);
-        _ = new SilmarillionViewModel(items: itemsVm, recipes: null!, nav, targets);
+        _ = new SilmarillionViewModel(items: itemsVm, recipes: null!, npcs: null!, nav, targets);
 
         nav.Open(EntityRef.ItemKeyword("Crystal"));
 
@@ -339,7 +339,7 @@ public sealed class SilmarillionReferenceNavigatorTests
             keywordTarget,
         };
         var nav = new SilmarillionReferenceNavigator(targets);
-        _ = new SilmarillionViewModel(items: null!, recipes: recipesVm, nav, targets);
+        _ = new SilmarillionViewModel(items: null!, recipes: recipesVm, npcs: null!, nav, targets);
 
         nav.Open(EntityRef.RecipeIngredientKeyword("Crystal"));
 

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -236,6 +236,136 @@ public sealed class ItemsTabViewModelTests
             .ToList();
 
     [Fact]
+    public void SourceChips_NpcVendorSource_AttachesNpcEntityRef_Navigable_WhenNpcKindRegistered()
+    {
+        // Symmetric to RecipesTabViewModel.SourceChips: an Item's NPC vendor source must carry an
+        // EntityRef.Npc(...) and be navigable once the NPCs kind target is registered (#241). Pre-fix,
+        // ItemsTabViewModel hardcoded EntityReference: null / IsNavigable: false on every source, so
+        // the chip stayed plain-text even after the NPCs tab shipped.
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["Apple"] = apple },
+            ItemSourcesByName =
+            {
+                ["Apple"] = new[]
+                {
+                    new ItemSource("Vendor", "NPC_Joeh", null),
+                },
+            },
+        };
+        // Navigator with the Npc kind registered — matches the post-#241 ship state.
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(
+            new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Npc) }));
+
+        vm.SelectedItem = apple;
+
+        vm.DetailViewModel!.Sources.Should().ContainSingle();
+        var chip = vm.DetailViewModel.Sources![0];
+        // No NPC POCO seeded → NpcNameResolver falls back to stripping the "NPC_" prefix
+        // (envelope-key heuristic), so "NPC_Joeh" reads as "Joeh" on the chip.
+        chip.DisplayName.Should().Be("Vendor: Joeh");
+        chip.EntityReference.Should().Be(EntityRef.Npc("NPC_Joeh"));
+        chip.IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SourceChips_NpcVendorSource_ResolvesNpcFriendlyName_WhenNpcPocoIsRegistered()
+    {
+        // When the NPC POCO ships a Name (the common case for the named cast — Joeh, Marna,
+        // Velkort), the chip uses Name verbatim rather than the envelope key. Mirrors what
+        // the NPCs-tab master list does.
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["Apple"] = apple },
+            ItemSourcesByName =
+            {
+                ["Apple"] = new[] { new ItemSource("Vendor", "NPC_Joeh", null) },
+            },
+            NpcsByKey =
+            {
+                ["NPC_Joeh"] = new Mithril.Reference.Models.Npcs.Npc { Name = "Joeh of Serbule" },
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(
+            new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Npc) }));
+
+        vm.SelectedItem = apple;
+
+        vm.DetailViewModel!.Sources!.Single().DisplayName.Should().Be("Vendor: Joeh of Serbule");
+    }
+
+    [Fact]
+    public void SourceChips_NonNpcSource_LeavesEntityReferenceNull_AndChipNotNavigable()
+    {
+        // Source kinds without an Npc field (Monster drop, Recipe, Quest, Skill, …) leave the
+        // chip's EntityReference null so the UI renders them as plain text in a transparent frame.
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["Apple"] = apple },
+            ItemSourcesByName =
+            {
+                ["Apple"] = new[]
+                {
+                    new ItemSource("Monster", null, "Hippo"),
+                },
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(
+            new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Npc) }));
+
+        vm.SelectedItem = apple;
+
+        var chip = vm.DetailViewModel!.Sources!.Single();
+        chip.EntityReference.Should().BeNull();
+        chip.IsNavigable.Should().BeFalse();
+    }
+
+    private sealed class StubKindTarget : IReferenceKindTarget
+    {
+        public StubKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+
+    // Slim stub with ItemSources + NpcsByInternalName support — the main StubReferenceData omits both.
+    private sealed class ItemSourceStub : IReferenceDataService
+    {
+        public Dictionary<string, Item> ItemsByName { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<ItemSource>> ItemSourcesByName { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, Mithril.Reference.Models.Npcs.Npc> NpcsByKey { get; } = new(StringComparer.Ordinal);
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items => ItemsByName.Values.ToDictionary(i => i.Id);
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName => ItemsByName;
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Npcs.Npc> NpcsByInternalName => NpcsByKey;
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources => ItemSourcesByName;
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+
+    [Fact]
     public void Keyword_chip_falls_back_to_CamelCaseSplit_when_no_friendly_display_name()
     {
         // Mirrors the GreenCrystal case: no recipe carries a friendly singleton Desc for the keyword,

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -1,0 +1,482 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Query;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+// The POCO NpcService / NpcPreference clash with the slim Mithril.Shared.Reference projections
+// of the same names — alias to keep both reachable.
+using NpcServicePoco = Mithril.Reference.Models.Npcs.NpcService;
+using NpcPreferencePoco = Mithril.Reference.Models.Npcs.NpcPreference;
+using NpcStoreServicePoco = Mithril.Reference.Models.Npcs.StoreService;
+using NpcTrainingServicePoco = Mithril.Reference.Models.Npcs.TrainingService;
+
+namespace Silmarillion.Tests.ViewModels;
+
+// Helper copied from RecipesTabViewModelTests — duplicate-free because file-scoped.
+file static class NavFactory
+{
+    public static SilmarillionReferenceNavigator WithKinds(params EntityKind[] kinds) =>
+        new(kinds.Select(k => (IReferenceKindTarget)new StubKindTarget(k)));
+
+    private sealed class StubKindTarget : IReferenceKindTarget
+    {
+        public StubKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+}
+
+public sealed class NpcsTabViewModelTests
+{
+    [Fact]
+    public void AllNpcs_PopulatedFromReferenceData_OrderedByName()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["NPC_Joeh"] = new Npc { Name = "Joeh", AreaFriendlyName = "Serbule" },
+                ["NPC_Albert"] = new Npc { Name = "Albert", AreaFriendlyName = "Eltibule" },
+            },
+        };
+
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.AllNpcs.Should().HaveCount(2);
+        vm.AllNpcs.Select(n => n.Name).Should().Equal("Albert", "Joeh");
+        vm.AllNpcs[0].InternalName.Should().Be("NPC_Albert");
+    }
+
+    [Fact]
+    public void NpcListRow_AreaDisplayName_FallsBackThroughFriendlyThenRaw_ThenUnknown()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["NPC_Friendly"] = new Npc { Name = "Friendly", AreaFriendlyName = "Friendly Area" },
+                ["NPC_Raw"] = new Npc { Name = "Raw", AreaName = "AreaRaw" },
+                ["NPC_None"] = new Npc { Name = "None" },
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.AllNpcs.Single(r => r.InternalName == "NPC_Friendly").AreaDisplayName.Should().Be("Friendly Area");
+        vm.AllNpcs.Single(r => r.InternalName == "NPC_Raw").AreaDisplayName.Should().Be("AreaRaw");
+        vm.AllNpcs.Single(r => r.InternalName == "NPC_None").AreaDisplayName.Should().Be("(unknown)");
+    }
+
+    [Fact]
+    public void NpcListRow_ServiceTypes_FlattenedDistinct_ForCollectionContainsQuery()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["NPC_Multi"] = new Npc
+                {
+                    Name = "Multi-Service",
+                    Services = new NpcServicePoco[]
+                    {
+                        new StoreService { Type = "Store" },
+                        new TrainingService { Type = "Training" },
+                        new StoreService { Type = "Store" }, // duplicate, collapses
+                    },
+                },
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        var row = vm.AllNpcs.Single();
+        row.ServiceTypes.Select(s => s.Type).Should().BeEquivalentTo(["Store", "Training"]);
+    }
+
+    [Fact]
+    public void QueryText_ServiceTypesContains_FiltersToMatchingNpcOnly()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["NPC_Vendor"] = new Npc
+                {
+                    Name = "Vendor",
+                    Services = new NpcServicePoco[] { new StoreService { Type = "Store" } },
+                },
+                ["NPC_Trainer"] = new Npc
+                {
+                    Name = "Trainer",
+                    Services = new NpcServicePoco[] { new TrainingService { Type = "Training" } },
+                },
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        const string queryString = "ServiceTypes CONTAINS \"Store\"";
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(NpcListRow));
+        var predicate = QueryCompiler.Compile(queryString, columns);
+        predicate.Should().NotBeNull();
+
+        var matches = vm.AllNpcs.Where(row => predicate!(row)).ToList();
+
+        matches.Should().ContainSingle(r => r.InternalName == "NPC_Vendor");
+        matches.Should().NotContain(r => r.InternalName == "NPC_Trainer");
+    }
+
+    [Fact]
+    public void SelectingRow_BuildsDetailViewModel()
+    {
+        var npc = new Npc { Name = "Joeh", AreaFriendlyName = "Serbule" };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel.Should().NotBeNull();
+        vm.DetailViewModel!.Npc.Should().Be(npc);
+        vm.DetailViewModel.InternalName.Should().Be("NPC_Joeh");
+    }
+
+    [Fact]
+    public void DeselectingRow_ClearsDetailViewModel()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+        vm.SelectedRow = null;
+
+        vm.DetailViewModel.Should().BeNull();
+    }
+
+    [Fact]
+    public void DetailViewModel_TaughtRecipes_ProjectsRecipesTaughtByNpc_ToChips_Navigable_WhenRecipeKindRegistered()
+    {
+        var recipe = new Recipe
+        {
+            Key = "recipe_1",
+            InternalName = "BakeBread",
+            Name = "Bake Bread",
+            IconId = 7,
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+            RecipesTaughtByNpcMap = { ["NPC_Joeh"] = new[] { recipe } },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.Recipe));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel!.TaughtRecipes.Should().HaveCount(1);
+        var chip = vm.DetailViewModel.TaughtRecipes[0];
+        chip.DisplayName.Should().Be("Bake Bread");
+        chip.IconId.Should().Be(7);
+        chip.Reference.Should().Be(EntityRef.Recipe("BakeBread"));
+        chip.IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetailViewModel_SoldItems_ProjectsItemsSoldByNpc_ToChips_Navigable_WhenItemKindRegistered()
+    {
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple", IconId = 3 };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+            ItemsSoldByNpcMap = { ["NPC_Joeh"] = new[] { apple } },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel!.SoldItems.Should().HaveCount(1);
+        var chip = vm.DetailViewModel.SoldItems[0];
+        chip.DisplayName.Should().Be("Apple");
+        chip.IconId.Should().Be(3);
+        chip.Reference.Should().Be(EntityRef.Item("Apple"));
+        chip.IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetailViewModel_EmptyNpc_ProducesEmptyCrossLinkSections_HeaderAndFooterOnly()
+    {
+        // Altars / pedestals carry no services, preferences, or gifts. The detail VM should
+        // render every section as empty/null so the section-hide convention collapses them
+        // and only the header (name/area/pos) + footer (internal name) remain.
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["Altar_Druid"] = new Npc { Name = "Druid Altar", AreaName = "AreaSerbule" },
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var detail = vm.DetailViewModel!;
+        detail.Services.Should().BeEmpty();
+        detail.TaughtRecipes.Should().BeEmpty();
+        detail.SoldItems.Should().BeEmpty();
+        detail.Quests.Should().BeEmpty();
+        detail.Preferences.Should().BeEmpty();
+        detail.GiftSentimentTiers.Should().BeEmpty();
+        detail.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public void DetailViewModel_Preferences_SortedByDesire_LoveLikeDislikeHate_ThenByPrefDescending()
+    {
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Preferences = new[]
+            {
+                new NpcPreferencePoco { Desire = "Hate", Name = "Mushrooms", Pref = -2.0, Keywords = ["Mushroom"] },
+                new NpcPreferencePoco { Desire = "Love", Name = "Magic Clubs", Pref = 3.5, Keywords = ["Club"] },
+                new NpcPreferencePoco { Desire = "Like", Name = "Fairy Wings", Pref = 1.5, Keywords = ["FairyWing"] },
+                new NpcPreferencePoco { Desire = "Love", Name = "Crystals", Pref = 4.0, Keywords = ["Crystal"] },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var prefs = vm.DetailViewModel!.Preferences;
+        prefs.Select(p => p.DisplayName).Should().Equal(
+            "Crystals",     // Love + 4.0 (highest Pref among Loves)
+            "Magic Clubs",  // Love + 3.5
+            "Fairy Wings",  // Like + 1.5
+            "Mushrooms");   // Hate
+    }
+
+    [Fact]
+    public void DetailViewModel_ServiceRow_MinFavorTier_DespisedIsHidden_AsTheDefaultAccessTier()
+    {
+        // "Despised" is the lowest favor tier — i.e. anyone can access the service. Showing
+        // a "Favor: Despised" badge on every row is pure visual noise, so the VM nulls it out
+        // and the XAML hides the chip. Non-default tiers (Neutral, Friends, …) still surface.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcStoreServicePoco { Type = "Store", Favor = "Despised" },
+                new NpcTrainingServicePoco { Type = "Training", Favor = "Neutral", Skills = ["Unarmed"] },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var rows = vm.DetailViewModel!.Services;
+        rows[0].Type.Should().Be("Store");
+        rows[0].MinFavorTier.Should().BeNull(because: "Despised is the default access tier; show no chip");
+        rows[1].Type.Should().Be("Training");
+        rows[1].MinFavorTier.Should().Be("Neutral");
+    }
+
+    [Fact]
+    public void DetailViewModel_TrainingService_LabelsSkillsAndUnlocks_AsSeparateRows()
+    {
+        // Pre-#241 review feedback: an unlabeled Concat(Skills, Unlocks) rendered as one mixed
+        // list ("Unarmed, Lore, Neutral, Comfortable, …") with no visual cue separating skill
+        // names from favor-tier unlocks. The labeled-line projection makes the grouping legible.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcTrainingServicePoco
+                {
+                    Type = "Training",
+                    Skills = ["Unarmed", "Lore"],
+                    Unlocks = ["Neutral", "Comfortable", "Friends"],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var training = vm.DetailViewModel!.Services.Single();
+        training.Details.Should().Equal(
+            "Skills: Unarmed, Lore",
+            "Unlocks at higher favor: Neutral, Comfortable, Friends");
+    }
+
+    [Fact]
+    public void DetailViewModel_TrainingService_EmptyUnlocks_OnlyEmitsSkillsRow()
+    {
+        // Empty sub-lists drop out entirely — the section doesn't render a dangling label.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcTrainingServicePoco { Type = "Training", Skills = ["Unarmed"], Unlocks = [] },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel!.Services.Single().Details
+            .Should().Equal("Skills: Unarmed");
+    }
+
+    [Fact]
+    public void DetailViewModel_ServiceDetails_StoreCapIncreases_FormattedWithTierGoldKeywords()
+    {
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcStoreServicePoco
+                {
+                    Type = "Store",
+                    Favor = "Neutral",
+                    CapIncreases =
+                    [
+                        "Despised:5000:Armor,Weapon",
+                        "Comfortable:50000:",
+                        "Friends:200000",
+                    ],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var store = vm.DetailViewModel!.Services.Single();
+        store.Type.Should().Be("Store");
+        store.MinFavorTier.Should().Be("Neutral");
+        store.Details.Should().HaveCount(3);
+        store.Details[0].Should().Be("Despised → 5,000g (Armor, Weapon)");
+        store.Details[1].Should().Be("Comfortable → 50,000g");
+        store.Details[2].Should().Be("Friends → 200,000g");
+    }
+
+    [Fact]
+    public void DetailViewModel_Quests_PopulatedFromQuestsWithMatchingFavorNpc()
+    {
+        var npc = new Npc { Name = "Joeh" };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+            QuestsByKey =
+            {
+                ["quest_1"] = new QuestEntry("quest_1", "Get Cat Eyeballs", "GetCatEyeballs", "...",
+                    DisplayedLocation: null, FavorNpc: "NPC_Joeh", Keywords: [], Objectives: [],
+                    Requirements: [], RequirementsToSustain: null, SkillRewards: [], ItemRewards: [],
+                    FavorReward: 0, RewardEffects: [], RewardLootProfile: null,
+                    ReuseMinutes: null, ReuseHours: null, ReuseDays: null,
+                    PrefaceText: null, SuccessText: null),
+                ["quest_2"] = new QuestEntry("quest_2", "Other Quest", "OtherQuest", "...",
+                    DisplayedLocation: null, FavorNpc: "NPC_Other", Keywords: [], Objectives: [],
+                    Requirements: [], RequirementsToSustain: null, SkillRewards: [], ItemRewards: [],
+                    FavorReward: 0, RewardEffects: [], RewardLootProfile: null,
+                    ReuseMinutes: null, ReuseHours: null, ReuseDays: null,
+                    PrefaceText: null, SuccessText: null),
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel!.Quests.Should().ContainSingle();
+        vm.DetailViewModel.Quests[0].InternalName.Should().Be("GetCatEyeballs");
+        vm.DetailViewModel.Quests[0].DisplayName.Should().Be("Get Cat Eyeballs");
+    }
+
+    [Fact]
+    public void FileUpdated_NpcsRefresh_RebuildsAllNpcs_PreservingSelectionByInternalName()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()));
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        // Swap in a fresh Npc instance for the same key — refData hands out the new instance.
+        refData.NpcsByKey["NPC_Joeh"] = new Npc { Name = "Joeh", Desc = "Fresh after refresh." };
+        refData.RaiseFileUpdated("npcs");
+
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRow!.InternalName.Should().Be("NPC_Joeh");
+        vm.DetailViewModel!.Description.Should().Be("Fresh after refresh.");
+    }
+
+    private sealed class StubReferenceData : IReferenceDataService
+    {
+        public Dictionary<string, Npc> NpcsByKey { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<Recipe>> RecipesTaughtByNpcMap { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<Item>> ItemsSoldByNpcMap { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, QuestEntry> QuestsByKey { get; } = new(StringComparer.Ordinal);
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>(StringComparer.Ordinal);
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName => NpcsByKey;
+        public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesTaughtByNpc => RecipesTaughtByNpcMap;
+        public IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsSoldByNpc => ItemsSoldByNpcMap;
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> RecipeSources { get; } = new Dictionary<string, IReadOnlyList<RecipeSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, QuestEntry> Quests => QuestsByKey;
+        public IReadOnlyDictionary<string, QuestEntry> QuestsByInternalName { get; } = new Dictionary<string, QuestEntry>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated;
+
+        public void RaiseFileUpdated(string fileKey) => FileUpdated?.Invoke(this, fileKey);
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
@@ -368,7 +368,8 @@ public sealed class RecipesTabViewModelTests
         vm.DetailViewModel!.Sources.Should().NotBeNull();
         vm.DetailViewModel.Sources!.Should().ContainSingle();
         var chip = vm.DetailViewModel.Sources![0];
-        chip.DisplayName.Should().Be("Training: NPC_Marna");
+        // No NPC POCO seeded → NpcNameResolver strips the "NPC_" prefix.
+        chip.DisplayName.Should().Be("Training: Marna");
         chip.EntityReference.Should().Be(EntityRef.Npc("NPC_Marna"));
         chip.IsNavigable.Should().BeFalse();
     }
@@ -409,7 +410,7 @@ public sealed class RecipesTabViewModelTests
         var sources = vm.DetailViewModel!.Sources!;
         sources.Should().HaveCount(3);
 
-        sources[0].DisplayName.Should().Be("Training: NPC_Fritz");
+        sources[0].DisplayName.Should().Be("Training: Fritz");
         sources[0].EntityReference.Should().Be(EntityRef.Npc("NPC_Fritz"));
         sources[0].IsNavigable.Should().BeFalse();
 

--- a/tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/SilmarillionViewModelTests.cs
@@ -43,10 +43,29 @@ public sealed class SilmarillionViewModelTests
         var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget });
 
         vm.SelectedTabIndex = 0;
-        nav.Open(new EntityRef(EntityKind.Npc, "NPC_Marna"));
+        nav.Open(new EntityRef(EntityKind.Quest, "FutureQuest"));
 
         vm.SelectedTabIndex.Should().Be(0);  // unchanged
         itemsTarget.LastSelectedInternalName.Should().BeNull();
+    }
+
+    [Fact]
+    public void OnNavigated_NpcKind_SwitchesTabAndCallsTarget()
+    {
+        // NPCs tab ships at index 2 (#241) — opening an Npc EntityRef should now switch the
+        // tab strip and dispatch the select call to the NPCs target rather than silently
+        // landing on the Items tab.
+        var itemsTarget = new RecordingTarget(EntityKind.Item, tabIndex: 0);
+        var recipesTarget = new RecordingTarget(EntityKind.Recipe, tabIndex: 1);
+        var npcsTarget = new RecordingTarget(EntityKind.Npc, tabIndex: 2);
+        var (vm, nav) = BuildVm(new IReferenceKindTarget[] { itemsTarget, recipesTarget, npcsTarget });
+
+        nav.Open(EntityRef.Npc("NPC_Marna"));
+
+        vm.SelectedTabIndex.Should().Be(2);
+        npcsTarget.LastSelectedInternalName.Should().Be("NPC_Marna");
+        itemsTarget.LastSelectedInternalName.Should().BeNull();
+        recipesTarget.LastSelectedInternalName.Should().BeNull();
     }
 
     [Fact]
@@ -85,7 +104,7 @@ public sealed class SilmarillionViewModelTests
             new RecordingTarget(EntityKind.Recipe, tabIndex: 1),
         });
 
-        var act = () => new SilmarillionViewModel(items: null!, recipes: null!, nav, targets);
+        var act = () => new SilmarillionViewModel(items: null!, recipes: null!, npcs: null!, nav, targets);
 
         act.Should().Throw<InvalidOperationException>()
            .WithMessage("*Duplicate IReferenceKindTarget*Item*");
@@ -97,8 +116,8 @@ public sealed class SilmarillionViewModelTests
         var nav = new SilmarillionReferenceNavigator(targets);
         // Empty/null tab VMs are fine — the tests only exercise the dispatch path,
         // not the tab VMs themselves (those are tested separately).
-        // Pass null-forgiving stubs; SilmarillionViewModel never reads .Items / .Recipes here.
-        var vm = new SilmarillionViewModel(items: null!, recipes: null!, nav, targets);
+        // Pass null-forgiving stubs; SilmarillionViewModel never reads .Items / .Recipes / .Npcs here.
+        var vm = new SilmarillionViewModel(items: null!, recipes: null!, npcs: null!, nav, targets);
         return (vm, nav);
     }
 


### PR DESCRIPTION
## Summary

- First non-v1 Silmarillion tab. NPCs master-detail with filterable list (incl. `ServiceTypes CONTAINS "Store"`), detail pane covering services / taught recipes / sold items / quests / gift preferences, hide-when-empty for altars and pedestals.
- Service-layer (path 1 from the handoff): sibling `NpcsByInternalName` exposing the full POCO + reverse-lookup indices `RecipesTaughtByNpc` / `ItemsSoldByNpc` rebuilt whenever items / recipes / sources_* change. Arwen's slim `NpcEntry` projection is untouched — smallest blast radius.
- NPC chips on **other** tabs now navigate: ItemsTabVM was hardcoding `EntityReference: null` from before the chip VM carried that field; new `ItemSourceChip` UserControl in Mithril.Shared.Wpf renders `ItemSourceChipVm` as the same accent-blue button as recipe / item chips when `IsNavigable`, plain text otherwise. Wired into item-detail "Sources" and recipe-detail "Taught by". `NpcNameResolver` resolves `NPC_Joeh` → `Joeh` (POCO Name with `NPC_`-prefix strip fallback) at every surface so chips read the same way as the NPCs-tab master list.

Closes #241. Lights up the navigability of NPC chips already shipping in recipe-detail "Taught by" (#235) and item-detail "Sources" sections — no other Bucket B issue closes.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — all green; 155 Silmarillion (15 new NPCsTabVM cases + 6 NpcsKindTarget + 2 Items-side source-chip regression + 3 NPC reverse-lookup integration tests in Mithril.Shared.Tests + 1 new NPC-dispatch test in SilmarillionViewModelTests); 775 Mithril.Shared.Tests; every other project unchanged
- [x] Manual smoke: open Silmarillion → NPCs tab, browse a Store NPC, confirm services / taught recipes / sold items / quests / gift preferences render. Verified: cross-link round-trip recipe → "Taught by Joeh" chip → NPCs tab Joeh selected → click "Teaches recipes" chip → back at recipe detail; Alt+Left/Right walks history. Empty NPC (altar) renders header + footer only. Arwen favor view unaffected (slim NpcEntry untouched).
- [x] Polish round from review: `Favor: Despised` chip noise hidden, Skills / Unlocks labeled separately so they're visually distinguishable, item-source chips now resolve to `Vendor: Joeh` rather than `Vendor: NPC_Joeh`.

A cookbook-feedback doc is bundled in [`docs/silmarillion-tab-cookbook-feedback.md`](docs/silmarillion-tab-cookbook-feedback.md) with 12 concrete improvements for the next Bucket B tab — call out stale chip-builders on other tabs, factor a `<Kind>NameResolver` before the tab VM, real-data sanity check for polymorphic kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)