### PR TITLE
docs(silmarillion): retarget ability sub-tables to Effects tab

### DIFF
--- a/docs/silmarillion-roadmap.md
+++ b/docs/silmarillion-roadmap.md
@@ -57,7 +57,7 @@ Totals: 2 + 9 + 10 + 8 = 29, and Bucket A + Bucket B covers every `EntityKind` v
 
 **Why deferred together:** Abilities (8.7 MB) and Effects (6.5 MB) are paired — items and abilities already reference effect strings, so neither tab is complete without the other. Both are large enough that the master-detail spike needs a real design pass, not a copy-paste from Recipes.
 
-**Likely approach:** Sequence Abilities first (so Effects' cross-link chips have destinations on both ends), then Effects. Sub-tables (`abilitykeywords`, `abilitydynamicdots`, `abilitydynamicspecialvalues`) fold into the Abilities tab as filter facets and detail sections.
+**Likely approach:** Sequence Abilities first (so Effects' cross-link chips have destinations on both ends), then Effects. The three conditional-rule sub-tables (`abilitykeywords`, `abilitydynamicdots`, `abilitydynamicspecialvalues`) fold into the **Effects tab**, not Abilities — they're predicate-shaped rules engines (`ReqAbilityKeywords` / `ReqEffectKeywords` / `ReqActiveSkill` → attribute deltas / DoTs / tooltip values), more naturally consumed effect-side than ability-side. Plumbing tracked separately as #288.
 
 ### Areas and Landmarks
 
@@ -89,9 +89,9 @@ Totals: 2 + 9 + 10 + 8 = 29, and Bucket A + Bucket B covers every `EntityKind` v
 | `itemuses` | Items tab | "Where is this consumed" reverse-lookup section |
 | `lorebookinfo` | Lorebooks tab (when shipped) | Title / category metadata sidecar |
 | `directedgoals` | Quests tab (when shipped) | Filter chip alongside regular quests |
-| `abilitykeywords` | Abilities tab (when shipped) | Filter facets and detail sections |
-| `abilitydynamicdots` | Abilities tab (when shipped) | Sub-table in ability detail |
-| `abilitydynamicspecialvalues` | Abilities tab (when shipped) | Sub-table in ability detail |
+| `abilitykeywords` | Effects tab (when shipped) | Conditional attribute-delta rules predicated on `MustHaveAbilityKeywords` — effect-side, not ability-side. Tracked: #288 |
+| `abilitydynamicdots` | Effects tab (when shipped) | Conditional DoT rules predicated on `ReqAbilityKeywords` + `ReqActiveSkill` + `ReqEffectKeywords`. Tracked: #288 |
+| `abilitydynamicspecialvalues` | Effects tab (when shipped) | Conditional ability-tooltip values predicated on `ReqAbilityKeywords` + `ReqEffectKeywords`. Tracked: #288 |
 | `skills` | Recipes + Abilities tabs | Filter chips and skill-level metadata; small enough (~30 skills) that a dedicated tab adds little |
 
 These would each require their own master-detail just to render a row count and a few fields — better as enrichment of a parent entity.
@@ -115,3 +115,4 @@ These would each require their own master-detail just to render a row count and 
 
 - **2026-05-13** — v1 shipped (PR #236, Items + Recipes tabs, cross-link navigator, master-detail scaffold). Bucketing rationale captured in this doc; per-tab follow-ups filed against `module:silmarillion` on the [Roadmap Project](https://github.com/users/arthur-conde/projects/3/views/1?filterQuery=module%3A%22Silmarillion%22).
 - **2026-05-13** — `EntityKind` grew the synthetic `RecipeIngredientKeyword` variant via PR #259 (keyword-collapse design for the item-detail "Used as" section, replacing a naive fan-out widening of `RecipesByIngredientItem`). Sets the precedent for "deep-link to a tab with pre-filled query" as a kind-target shape distinct from "select a row by name."
+- **2026-05-14** — Bucket C reclassification: `abilitykeywords`, `abilitydynamicdots`, `abilitydynamicspecialvalues` move from "folds into Abilities tab" to "folds into Effects tab" (#288). Data-shape verification during the #243 Abilities handoff drafting showed these are predicate-keyed conditional rules engines, not per-ability metadata; their natural rendering destination is effect-side, not ability-side. Bucket math unchanged (still 10 entries in C, 29 total).


### PR DESCRIPTION
## Summary

The roadmap's Bucket C listed three files folding into the Abilities tab:

- `abilitykeywords.json` — "filter facets and detail sections"
- `abilitydynamicdots.json` — "sub-table in ability detail"
- `abilitydynamicspecialvalues.json` — "sub-table in ability detail"

While drafting the #243 Abilities handoff, the cookbook's data-shape verification discipline caught that the JSON shape doesn't match the framing. All three are **arrays of predicate-keyed conditional rules**, not per-ability metadata:

- `abilitykeywords.json` — `{ MustHaveAbilityKeywords: [...], AttributesThatDelta*: [...] }` rules: "if an ability has keyword X, these attribute deltas apply."
- `abilitydynamicdots.json` — `{ ReqAbilityKeywords, ReqActiveSkill, ReqEffectKeywords, DamagePerTick, Duration, ... }` rules: "when an ability with these keywords is used by a character with this skill and these effect keywords, apply this DoT."
- `abilitydynamicspecialvalues.json` — `{ ReqAbilityKeywords, ReqEffectKeywords, Label, Value, Suffix }` rules: tooltip lines like "Restores 5 Body Heat in cold environments."

These are rules engines consumed at runtime to compute what abilities + effects do in context. Their natural rendering destination is the **Effects tab** (#244), not the Abilities tab — an effect's detail pane can show "conditional behaviors triggered by this effect" by filtering the rule lists on `ReqEffectKeywords`. Filing them under Abilities would be a category error: `Ability.Keywords` is already the right source for "what keywords does ability X have."

## Changes

- **Bucket C table** — three rows retargeted from "Abilities tab (when shipped)" → "Effects tab (when shipped)", with the predicate-shape made explicit in the description.
- **"Abilities and Effects" deferred-tab narrative** — last sentence updated to reflect the new target.
- **History entry** added for 2026-05-14 documenting the reclassification, with bucket-math reassurance (C stays at 10, total still 29).

## What didn't change

- Bucket B (the tab list) is unaffected — Abilities and Effects are still both Bucket B.
- Bucket sizes are unchanged: A=2, B=9, C=10, D=8 → 29.
- The recommended sequencing (Abilities before Effects) stays correct.

## Adjacent

- Plumbing for the three sub-tables tracked as #288 (filed separately).
- #243 (Abilities tab) handoff is unaffected — it already defers these three to #288.
- #244 (Effects tab) handoff, when drafted, should account for consuming #288's plumbing.

## Test plan

- [ ] Read the diff against the actual bundled JSON shapes — verify the new descriptions match what the files contain.
- [ ] Confirm bucket math at the bottom of the doc still sums to 29.

Docs-only PR. Build / test impact: none.

---

— drafted by Claude (Opus 4.7), posted by @arthur-conde