### PR TITLE
fix(silmarillion): bump NPC service-detail rows to AppFontSizeHint — #290

### DIFF
--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml
@@ -79,7 +79,7 @@
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
                                                     <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               FontSize="{DynamicResource AppFontSizeHint}"
                                                                TextWrapping="Wrap" Margin="0,0,0,1"/>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary

- Bumps the per-service Detail bullet rows in the NPC detail view from `AppFontSizeSmall` (10) to `AppFontSizeHint` (11), aligning with the cross-tab convention shared by `ItemDetailView`, `RecipeDetailView`, and `QuestDetailView`.
- One-line XAML change: [src/Silmarillion.Module/Views/NpcDetailView.xaml#L82](https://github.com/moumantai-gg/mithril/blob/main/src/Silmarillion.Module/Views/NpcDetailView.xaml#L82).

Closes #290.

## Test plan

- [ ] `dotnet build src/Silmarillion.Module/Silmarillion.Module.csproj` — clean (verified)
- [ ] Launch Mithril → Silmarillion → NPCs → pick a vendor / trainer with multiple Services entries; confirm the Detail bullets now match the visual weight of body rows on the Items / Recipes / Quests tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)