### PR TITLE
fix(silmarillion): NPC Training skill display names + Store cap-keyword chips — #292

### DIFF
--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -18,6 +18,13 @@ public enum EntityKind
     PlayerTitle,
     StorageVault,
     /// <summary>
+    /// A player skill (e.g. <c>"NonfictionWriting"</c>, <c>"Carpentry"</c>). InternalName carries
+    /// the skill key from <c>skills.json</c>; the resolver maps it to <see cref="SkillEntry.DisplayName"/>
+    /// (e.g. <c>"Non-Fiction Writing"</c>). No browsable Silmarillion skill tab today, so the
+    /// resolver covers the rendering case while leaving navigation as a follow-up.
+    /// </summary>
+    Skill,
+    /// <summary>
     /// Not an entity per se — a deep-link target for "open the Recipes tab filtered to recipes
     /// whose ingredient list mentions this keyword tag." InternalName carries the keyword
     /// (e.g. "Crystal"). Dispatched by RecipeIngredientKeywordKindTarget.
@@ -73,6 +80,7 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef Area(string internalName) => new(EntityKind.Area, internalName);
     public static EntityRef PlayerTitle(string internalName) => new(EntityKind.PlayerTitle, internalName);
     public static EntityRef StorageVault(string internalName) => new(EntityKind.StorageVault, internalName);
+    public static EntityRef Skill(string skillKey) => new(EntityKind.Skill, skillKey);
     public static EntityRef RecipeIngredientKeyword(string keyword) => new(EntityKind.RecipeIngredientKeyword, keyword);
     public static EntityRef ItemKeyword(string keyword) => new(EntityKind.ItemKeyword, keyword);
     public static EntityRef ItemKeyword(IReadOnlyList<string> itemKeys) => new(EntityKind.ItemKeyword, string.Join('+', itemKeys));

--- a/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
@@ -22,6 +22,7 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         EntityKind.Npc => ResolveNpc(reference.InternalName),
         EntityKind.Quest => ResolveQuest(reference.InternalName),
         EntityKind.Ability => ResolveAbility(reference.InternalName),
+        EntityKind.Skill => ResolveSkill(reference.InternalName),
         _ => reference.InternalName,
     };
 
@@ -58,6 +59,18 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         _refData.AbilitiesByInternalName.TryGetValue(internalName, out var ability) && !string.IsNullOrEmpty(ability.Name)
             ? ability.Name!
             : internalName;
+
+    /// <summary>
+    /// Skill keys are ASCII identifier-safe (matches <c>[A-Za-z0-9_]+</c>) and frequently
+    /// PascalCase (<c>"NonfictionWriting"</c>, <c>"BattleChemistry"</c>). The slim
+    /// <see cref="SkillEntry"/> projection carries the human-readable
+    /// <see cref="SkillEntry.DisplayName"/>; fall back to the raw key when no entry is
+    /// registered (defensive — every PG skill ships with a name).
+    /// </summary>
+    private string ResolveSkill(string skillKey) =>
+        _refData.Skills.TryGetValue(skillKey, out var skill) && !string.IsNullOrEmpty(skill.DisplayName)
+            ? skill.DisplayName
+            : skillKey;
 
     private static string StripNpcPrefix(string internalName) =>
         internalName.StartsWith("NPC_", StringComparison.Ordinal)

--- a/src/Silmarillion.Module/ViewModels/NpcServiceRow.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcServiceRow.cs
@@ -1,3 +1,5 @@
+using Mithril.Shared.Wpf;
+
 namespace Silmarillion.ViewModels;
 
 /// <summary>
@@ -10,4 +12,16 @@ namespace Silmarillion.ViewModels;
 public sealed record NpcServiceRow(
     string Type,
     string? MinFavorTier,
-    IReadOnlyList<string> Details);
+    IReadOnlyList<NpcServiceDetailLine> Details);
+
+/// <summary>
+/// One line in a service row's detail strip. <see cref="Text"/> carries the prose ("Despised → 5,000g",
+/// "Skills: Toolcrafting, Non-Fiction Writing") and is always rendered. <see cref="Chips"/> is an
+/// optional trailing chip strip — Store cap-increase rows surface their per-tier keyword tuple as
+/// navigable <see cref="EntityChipVm"/>s targeting the Items tab via <see cref="Mithril.Shared.Reference.EntityKind.ItemKeyword"/>.
+/// Empty for non-Store rows; the XAML hides the strip when the list is empty.
+/// </summary>
+public sealed record NpcServiceDetailLine(string Text, IReadOnlyList<EntityChipVm> Chips)
+{
+    public static NpcServiceDetailLine TextOnly(string text) => new(text, []);
+}

--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -159,7 +159,7 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
             _openEntityCommand);
     }
 
-    private static IReadOnlyList<NpcServiceRow> BuildServiceRows(Npc npc)
+    private IReadOnlyList<NpcServiceRow> BuildServiceRows(Npc npc)
     {
         if (npc.Services is null || npc.Services.Count == 0) return [];
         return npc.Services
@@ -178,13 +178,14 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     /// Flatten each NpcService subclass to display-relevant payload lines. Lines are pre-labeled
     /// per sub-list (e.g. <c>"Skills: Unarmed, Lore"</c> / <c>"Unlocks at higher favor: Neutral,
     /// Comfortable, ..."</c>) so the detail view can render them in a single linear strip and the
-    /// viewer can tell skill names apart from favor-tier unlocks. Plain strings — richer per-row
-    /// chips are a #229-style polish follow-up.
+    /// viewer can tell skill names apart from favor-tier unlocks. Store cap-increase rows carry
+    /// a chip strip on top of the prose (per-tier keyword tuple as <see cref="EntityKind.ItemKeyword"/>
+    /// chips); other rows are text-only.
     /// </summary>
-    private static IReadOnlyList<string> BuildServiceDetails(NpcServicePoco service) => service switch
+    private IReadOnlyList<NpcServiceDetailLine> BuildServiceDetails(NpcServicePoco service) => service switch
     {
         // Store caps are kept one-per-row: each tier raises a distinct gold cap and the per-row
-        // keyword tuple disambiguates which category the cap applies to.
+        // keyword tuple is surfaced as a chip strip that flips to the Items tab pre-filtered.
         StoreService store when store.CapIncreases is { Count: > 0 } =>
             store.CapIncreases.Select(FormatCapIncrease).ToList(),
 
@@ -204,9 +205,13 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
                 ("Items", storage.ItemDescs),
                 ("Space increases at", storage.SpaceIncreases)),
 
+        // Skills are raw skills.json keys (e.g. "NonfictionWriting"); resolve through the
+        // entity-name resolver so PascalCase keys render with their friendly DisplayName
+        // ("Non-Fiction Writing"). Single-word keys ("Toolcrafting", "Carpentry") pass through
+        // unchanged because their key matches their display name.
         TrainingService training =>
             BuildLabeledLines(
-                ("Skills", training.Skills),
+                ("Skills", training.Skills?.Select(s => _nameResolver.Resolve(EntityRef.Skill(s))).ToList()),
                 ("Unlocks at higher favor", training.Unlocks)),
 
         _ => [],
@@ -216,35 +221,64 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     /// Join each non-empty sub-list into a single labeled line so Skills and Unlocks (etc.) stay
     /// visually distinct in the detail pane. Empty groups drop out entirely.
     /// </summary>
-    private static IReadOnlyList<string> BuildLabeledLines(params (string Label, IReadOnlyList<string>? Items)[] groups)
+    private static IReadOnlyList<NpcServiceDetailLine> BuildLabeledLines(params (string Label, IReadOnlyList<string>? Items)[] groups)
     {
-        var lines = new List<string>(groups.Length);
+        var lines = new List<NpcServiceDetailLine>(groups.Length);
         foreach (var (label, items) in groups)
         {
             if (items is null || items.Count == 0) continue;
-            lines.Add($"{label}: {string.Join(", ", items)}");
+            lines.Add(NpcServiceDetailLine.TextOnly($"{label}: {string.Join(", ", items)}"));
         }
         return lines;
     }
 
     /// <summary>
-    /// Format one Store cap-increase entry as <c>"Tier → 5,000g (Kw1, Kw2)"</c>, falling back to
-    /// the tier + gold form when no keywords are listed. Mirrors the parser shape in
-    /// <see cref="Mithril.Shared.Reference.ReferenceDataService"/> (the colon-separated raw form
-    /// is already decomposed into tier/gold/keywords by the time it reaches the slim NpcEntry,
-    /// but we're rendering off the raw POCO here, so we re-split.).
+    /// Format one Store cap-increase entry. Prose is <c>"Tier → 5,000g"</c>; the keyword tuple
+    /// (when present) becomes the per-line chip strip — each chip targets the Items tab via
+    /// <see cref="EntityKind.ItemKeyword"/>, mirroring the recipe-detail "Used as" pattern from
+    /// PR #267 / #270. Mirrors the colon-separated parser shape in
+    /// <see cref="Mithril.Shared.Reference.ReferenceDataService"/>.
     /// </summary>
-    private static string FormatCapIncrease(string raw)
+    private NpcServiceDetailLine FormatCapIncrease(string raw)
     {
         // Raw line shape: "Despised:5000:Armor,Weapon,CorpseTrophy". Three colon-separated parts;
         // last part may be empty.
         var parts = raw.Split(':', 3);
-        if (parts.Length < 2) return raw;
+        if (parts.Length < 2) return NpcServiceDetailLine.TextOnly(raw);
         var tier = parts[0];
         var gold = int.TryParse(parts[1], out var g) ? g.ToString("N0") + "g" : parts[1];
-        if (parts.Length < 3 || string.IsNullOrWhiteSpace(parts[2])) return $"{tier} → {gold}";
+        var prose = $"{tier} → {gold}";
+        if (parts.Length < 3 || string.IsNullOrWhiteSpace(parts[2]))
+            return NpcServiceDetailLine.TextOnly(prose);
         var keywords = parts[2].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        return keywords.Length == 0 ? $"{tier} → {gold}" : $"{tier} → {gold} ({string.Join(", ", keywords)})";
+        if (keywords.Length == 0) return NpcServiceDetailLine.TextOnly(prose);
+        var chips = BuildKeywordChips(keywords);
+        return new NpcServiceDetailLine(prose, chips);
+    }
+
+    /// <summary>
+    /// Wrap each Store-cap keyword tag as a navigable chip targeting the Items tab via
+    /// <see cref="EntityKind.ItemKeyword"/>. Friendly chip labels come from
+    /// <see cref="IReferenceDataService.KeywordDisplayNames"/>; unmapped tags fall back to a
+    /// CamelCase split (matching the item-detail "Used as" chip behavior from PR #267).
+    /// </summary>
+    private IReadOnlyList<EntityChipVm> BuildKeywordChips(IReadOnlyList<string> keywordTags)
+    {
+        var displayNames = _refData.KeywordDisplayNames;
+        var chips = new List<EntityChipVm>(keywordTags.Count);
+        foreach (var tag in keywordTags)
+        {
+            var reference = EntityRef.ItemKeyword(tag);
+            var display = displayNames.TryGetValue(tag, out var friendly)
+                ? friendly
+                : CamelCaseSplitConverter.Split(tag);
+            chips.Add(new EntityChipVm(
+                DisplayName: display,
+                IconId: 0,
+                Reference: reference,
+                IsNavigable: _navigator.CanOpen(reference)));
+        }
+        return chips;
     }
 
     private IReadOnlyList<EntityChipVm> BuildTaughtRecipeChips(string npcInternalName)

--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml
@@ -78,9 +78,25 @@
                                                       Visibility="{Binding Details.Count, Converter={StaticResource PositiveIntToVis}}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                                               FontSize="{DynamicResource AppFontSizeHint}"
-                                                               TextWrapping="Wrap" Margin="0,0,0,1"/>
+                                                    <StackPanel Margin="0,0,0,1">
+                                                        <TextBlock Text="{Binding Text}" Foreground="#CCFFFFFF"
+                                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                                   TextWrapping="Wrap"/>
+                                                        <!-- Per-line chip strip — Store cap rows surface their keyword tuple
+                                                             as ItemKeyword chips (filter the Items tab on click). Hidden when
+                                                             the line carries no chips (every non-Store row). -->
+                                                        <ItemsControl ItemsSource="{Binding Chips}" Margin="0,2,0,0"
+                                                                      Visibility="{Binding Chips.Count, Converter={StaticResource PositiveIntToVis}}">
+                                                            <ItemsControl.ItemsPanel>
+                                                                <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                                                            </ItemsControl.ItemsPanel>
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate>
+                                                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </StackPanel>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataEntityNameResolverTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataEntityNameResolverTests.cs
@@ -229,6 +229,51 @@ public sealed class ReferenceDataEntityNameResolverTests
         resolver.Resolve(EntityRef.Effect("FrostShard")).Should().Be("FrostShard");
     }
 
+    [Fact]
+    public void Skill_ResolvesDisplayName_WhenSkillEntryPresent()
+    {
+        // skills.json keys are PascalCase identifiers ("NonfictionWriting"); the SkillEntry
+        // carries the human-readable form ("Non-Fiction Writing") that the NPC trainer view
+        // and other surfaces need.
+        var refData = new ResolverStub
+        {
+            SkillsByKey =
+            {
+                ["NonfictionWriting"] = MakeSkill("NonfictionWriting", "Non-Fiction Writing"),
+            },
+        };
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+
+        resolver.Resolve(EntityRef.Skill("NonfictionWriting")).Should().Be("Non-Fiction Writing");
+    }
+
+    [Fact]
+    public void Skill_FallsBackToKey_WhenSkillEntryAbsent()
+    {
+        var resolver = new ReferenceDataEntityNameResolver(new ResolverStub());
+
+        resolver.Resolve(EntityRef.Skill("UnknownSkill")).Should().Be("UnknownSkill");
+    }
+
+    [Fact]
+    public void Skill_FallsBackToKey_WhenDisplayNameIsEmpty()
+    {
+        var refData = new ResolverStub
+        {
+            SkillsByKey =
+            {
+                ["Nameless"] = MakeSkill("Nameless", ""),
+            },
+        };
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+
+        resolver.Resolve(EntityRef.Skill("Nameless")).Should().Be("Nameless");
+    }
+
+    private static SkillEntry MakeSkill(string key, string displayName) =>
+        new(key, displayName, Id: 0, Combat: false, XpTable: "", MaxBonusLevels: 0,
+            Parents: Array.Empty<string>(), Rewards: new Dictionary<string, SkillRewardEntry>());
+
     private sealed class ResolverStub : IReferenceDataService
     {
         public Dictionary<string, Item> ItemsByInternalNameMap { get; } = new(StringComparer.Ordinal);
@@ -236,6 +281,7 @@ public sealed class ReferenceDataEntityNameResolverTests
         public Dictionary<string, Npc> NpcsByInternalNameMap { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, Quest> QuestsByInternalNameMap { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, Ability> AbilitiesByInternalNameMap { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, SkillEntry> SkillsByKey { get; } = new(StringComparer.Ordinal);
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
@@ -243,7 +289,7 @@ public sealed class ReferenceDataEntityNameResolverTests
         public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
         public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
         public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => RecipesByInternalNameMap;
-        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills => SkillsByKey;
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
         public IReadOnlyDictionary<string, Npc> NpcsByInternalName => NpcsByInternalNameMap;

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -354,9 +354,11 @@ public sealed class NpcsTabViewModelTests
         vm.SelectedRow = vm.AllNpcs.Single();
 
         var training = vm.DetailViewModel!.Services.Single();
-        training.Details.Should().Equal(
+        training.Details.Select(d => d.Text).Should().Equal(
             "Skills: Unarmed, Lore",
             "Unlocks at higher favor: Neutral, Comfortable, Friends");
+        training.Details.Should().AllSatisfy(d => d.Chips.Should().BeEmpty(
+            because: "Training rows are text-only; only Store cap-increase rows surface chips."));
     }
 
     [Fact]
@@ -380,12 +382,81 @@ public sealed class NpcsTabViewModelTests
         vm.SelectedRow = vm.AllNpcs.Single();
 
         vm.DetailViewModel!.Services.Single().Details
-            .Should().Equal("Skills: Unarmed");
+            .Select(d => d.Text).Should().Equal("Skills: Unarmed");
     }
+
+    [Fact]
+    public void DetailViewModel_TrainingService_SkillsResolveToFriendlyDisplayName_FromSkillsJson()
+    {
+        // Bug from #292: training.Skills carries raw skills.json keys ("NonfictionWriting"),
+        // which were being passed straight to string.Join. The resolver should map PascalCase
+        // keys to their SkillEntry.DisplayName ("Non-Fiction Writing"). Skills whose key already
+        // matches their display name (Toolcrafting, Carpentry) round-trip unchanged.
+        var npc = new Npc
+        {
+            Name = "Hulon",
+            Services = new NpcServicePoco[]
+            {
+                new NpcTrainingServicePoco
+                {
+                    Type = "Training",
+                    Skills = ["Toolcrafting", "NonfictionWriting", "Carpentry"],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Hulon"] = npc },
+            SkillsByKey =
+            {
+                ["Toolcrafting"] = MakeSkill("Toolcrafting", "Toolcrafting"),
+                ["NonfictionWriting"] = MakeSkill("NonfictionWriting", "Non-Fiction Writing"),
+                ["Carpentry"] = MakeSkill("Carpentry", "Carpentry"),
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel!.Services.Single().Details
+            .Select(d => d.Text).Should().Equal("Skills: Toolcrafting, Non-Fiction Writing, Carpentry");
+    }
+
+    [Fact]
+    public void DetailViewModel_TrainingService_UnknownSkillKey_FallsThroughToRawKey()
+    {
+        // Defensive — if a Training service references a skill that isn't in skills.json
+        // (stale or out-of-sync data), surface the raw key rather than crash or render blank.
+        var npc = new Npc
+        {
+            Name = "Trainer",
+            Services = new NpcServicePoco[]
+            {
+                new NpcTrainingServicePoco { Type = "Training", Skills = ["UnknownSkillFromTheFuture"] },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Trainer"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        vm.DetailViewModel!.Services.Single().Details
+            .Select(d => d.Text).Should().Equal("Skills: UnknownSkillFromTheFuture");
+    }
+
+    private static SkillEntry MakeSkill(string key, string displayName) =>
+        new(key, displayName, Id: 0, Combat: false, XpTable: "", MaxBonusLevels: 0,
+            Parents: Array.Empty<string>(), Rewards: new Dictionary<string, SkillRewardEntry>());
 
     [Fact]
     public void DetailViewModel_ServiceDetails_StoreCapIncreases_FormattedWithTierGoldKeywords()
     {
+        // Prose stays the tier+gold form; keywords move to a per-line chip strip (covered by
+        // the dedicated chip test below). The parenthesised "(Armor, Weapon)" tail is gone now
+        // that chips replace it.
         var npc = new Npc
         {
             Name = "Joeh",
@@ -416,9 +487,90 @@ public sealed class NpcsTabViewModelTests
         store.Type.Should().Be("Store");
         store.MinFavorTier.Should().Be("Neutral");
         store.Details.Should().HaveCount(3);
-        store.Details[0].Should().Be("Despised → 5,000g (Armor, Weapon)");
-        store.Details[1].Should().Be("Comfortable → 50,000g");
-        store.Details[2].Should().Be("Friends → 200,000g");
+        store.Details[0].Text.Should().Be("Despised → 5,000g");
+        store.Details[1].Text.Should().Be("Comfortable → 50,000g");
+        store.Details[2].Text.Should().Be("Friends → 200,000g");
+    }
+
+    [Fact]
+    public void DetailViewModel_ServiceDetails_StoreCapKeywords_EmitChips_Navigable_WhenItemKeywordKindRegistered()
+    {
+        // Bug from #292: the per-tier keyword tuple should be navigable chips that flip to the
+        // Items tab pre-filtered, mirroring the recipe-detail "Used as" pattern from #270.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcStoreServicePoco
+                {
+                    Type = "Store",
+                    CapIncreases =
+                    [
+                        "Despised:10000:Food,CookingIngredient,AlchemyIngredient,Potion",
+                        "Comfortable:50000:",
+                    ],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var store = vm.DetailViewModel!.Services.Single();
+        store.Details.Should().HaveCount(2);
+
+        var firstLine = store.Details[0];
+        firstLine.Chips.Should().HaveCount(4);
+        firstLine.Chips.Select(c => c.Reference).Should().Equal(
+            EntityRef.ItemKeyword("Food"),
+            EntityRef.ItemKeyword("CookingIngredient"),
+            EntityRef.ItemKeyword("AlchemyIngredient"),
+            EntityRef.ItemKeyword("Potion"));
+        firstLine.Chips.Should().AllSatisfy(c => c.IsNavigable.Should().BeTrue(
+            because: "ItemKeyword kind is registered, so each cap-keyword chip should route to the Items tab."));
+        // Friendly chip labels fall back to a CamelCase split when KeywordDisplayNames has no
+        // entry — mirrors the existing item-detail "Used as" chip behaviour from PR #267.
+        firstLine.Chips.Select(c => c.DisplayName).Should().Equal(
+            "Food", "Cooking Ingredient", "Alchemy Ingredient", "Potion");
+
+        // The empty-keyword row has no chips.
+        store.Details[1].Chips.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetailViewModel_ServiceDetails_StoreCapKeywords_NonNavigable_WhenItemKeywordKindNotRegistered()
+    {
+        // Mirror image: in a context where ItemKeyword routing isn't wired (e.g. tests, or a
+        // future host that swaps out the navigator), chips should still render but degrade to
+        // plain-text via IsNavigable=false. Validates EntityChipVm's graceful-degradation contract.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcStoreServicePoco
+                {
+                    Type = "Store",
+                    CapIncreases = ["Despised:10000:Food,Potion"],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var chips = vm.DetailViewModel!.Services.Single().Details[0].Chips;
+        chips.Should().HaveCount(2);
+        chips.Should().AllSatisfy(c => c.IsNavigable.Should().BeFalse());
     }
 
     [Fact]
@@ -472,6 +624,7 @@ public sealed class NpcsTabViewModelTests
         public Dictionary<string, IReadOnlyList<Ability>> AbilitiesTaughtByNpcMap { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, Mithril.Reference.Models.Quests.Quest> QuestsByKey { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, IReadOnlyList<Mithril.Reference.Models.Quests.Quest>> QuestsByGiverNpcMap { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, SkillEntry> SkillsByKey { get; } = new(StringComparer.Ordinal);
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
@@ -479,7 +632,7 @@ public sealed class NpcsTabViewModelTests
         public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
         public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
         public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
-        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills => SkillsByKey;
         public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
         public IReadOnlyDictionary<string, Npc> NpcsByInternalName => NpcsByKey;


### PR DESCRIPTION
Closes #292.

## Summary

- Training row now resolves `training.Skills` raw keys through `IEntityNameResolver` so `NonfictionWriting` reads as `Non-Fiction Writing`. Adds `EntityKind.Skill` to the resolver switch (same shape as #282's NPC wiring).
- Store cap-increase rows surface the per-tier keyword tuple as a chip strip targeting the Items tab via `EntityKind.ItemKeyword` (reuses `ItemKeywordKindTarget` from PR #270). Friendly labels via `KeywordDisplayNames` with a CamelCase-split fallback — matches the item-detail "Used as" chip behaviour from PR #267.
- Reshapes `NpcServiceRow.Details` from `IReadOnlyList<string>` to `IReadOnlyList<NpcServiceDetailLine(Text, Chips)>` so chips live per-line (cap rows can in principle differ per tier).
- Three existing tests updated to compare against `.Text`; four new tests cover: skill display-name resolution, unknown-skill fallback, store keyword chips navigability (positive + degradation), plus three resolver-level tests for the new `EntityKind.Skill` case.

## Out of scope

- The chip-label-vs-query-token UX wrinkle from #268 still applies — the chip would say "Cooking Ingredient" but the query lands on `Keywords CONTAINS "CookingIngredient"`. Consistent with the rest of the surface; left to #268 to resolve broadly.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings
- [x] `dotnet test Mithril.slnx` — all 2,189 passing (one Smaug parallel-execution flake `SplitMigration_LegacySingleFile_LiftsObservationsAndWritesBackup` that passes in isolation on both this branch and `main` — pre-existing, not introduced here)
- [x] Shell launch: `dotnet run --project src/Mithril.Shell` — boot.log advances past `=== startup done ===` cleanly; no DI cycle, no XAML parse error
- [ ] Visual: open NPCs tab, select a trainer (e.g. Hulon for Non-Fiction Writing) and a shopkeeper with cap increases (e.g. Joeh) to confirm skill names render correctly and Store keyword chips render + click through to the Items tab pre-filtered. **I couldn't take the screenshot myself — please spot-check on your end before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)