### PR TITLE
feat(silmarillion): Effects tab — #244

### DIFF
--- a/src/Mithril.Reference/Models/Effects/Effect.cs
+++ b/src/Mithril.Reference/Models/Effects/Effect.cs
@@ -7,6 +7,14 @@ namespace Mithril.Reference.Models.Effects;
 /// </summary>
 public sealed class Effect
 {
+    /// <summary>
+    /// Lifted from the envelope key by <c>ReferenceDeserializer.ParseEffects</c>
+    /// (e.g. <c>"effect_10003"</c>). Source JSON has no human-form name field that
+    /// could play this role; the envelope key is the only stable identifier.
+    /// Mirrors the lift pattern on <c>Item.Id</c> / <c>Recipe.Key</c>.
+    /// </summary>
+    public string? InternalName { get; set; }
+
     public string? Desc { get; set; }
     public string? DisplayMode { get; set; }
     public int IconId { get; set; }

--- a/src/Mithril.Reference/Serialization/ReferenceDeserializer.cs
+++ b/src/Mithril.Reference/Serialization/ReferenceDeserializer.cs
@@ -247,6 +247,14 @@ public static class ReferenceDeserializer
         return result ?? new Dictionary<string, Ability>();
     }
 
+    /// <summary>
+    /// Deserializes the contents of <c>effects.json</c> into a dictionary of
+    /// <see cref="Effect"/> POCOs keyed by the JSON envelope's effect_id strings
+    /// (e.g. <c>"effect_10003"</c>). The envelope key is lifted onto
+    /// <see cref="Effect.InternalName"/> for every entry — there is no human-form
+    /// name in the source data, so the envelope key is the only stable identifier
+    /// and serves as the InternalName for cross-link / deep-link purposes.
+    /// </summary>
     public static IReadOnlyDictionary<string, Effect> ParseEffects(string json)
     {
         var settings = SerializerSettings.Build();
@@ -254,7 +262,12 @@ public static class ReferenceDeserializer
         settings.Converters.Add(new SingleOrArrayConverter<string>());
 
         var result = JsonConvert.DeserializeObject<Dictionary<string, Effect>>(json, settings);
-        return result ?? new Dictionary<string, Effect>();
+        if (result is null) return new Dictionary<string, Effect>();
+
+        foreach (var pair in result)
+            pair.Value.InternalName = pair.Key;
+
+        return result;
     }
 
     /// <summary>

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -48,9 +48,9 @@
                     </StackPanel>
                 </DockPanel>
 
-                <!-- Description + optional food effect -->
+                <!-- Description + optional food effect (FormattedText parses any inline <i>/<b> markup). -->
                 <StackPanel Margin="0,0,0,10">
-                    <TextBlock Text="{Binding Description}" Foreground="#CCFFFFFF"
+                    <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF"
                                FontStyle="Italic" FontSize="{DynamicResource AppFontSize}"
                                TextWrapping="Wrap" MaxWidth="460"
                                HorizontalAlignment="Left"

--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -66,6 +66,16 @@ public enum EntityKind
     /// section's overflow pill when the chip cluster exceeds the configured cap.
     /// </summary>
     AbilityByEffectKeyword,
+
+    /// <summary>
+    /// Not an entity per se — a deep-link target for "open the Effects tab filtered to
+    /// effects sharing this <see cref="Mithril.Reference.Models.Effects.Effect.StackingType"/>."
+    /// InternalName carries the StackingType value (e.g. <c>"Food"</c>, <c>"Snack"</c>).
+    /// Dispatched by EffectByStackingTypeKindTarget; powers the Effects-tab "Stacks with"
+    /// section's overflow pill — stacking groups like <c>"Food"</c> contain ~326 entries
+    /// and would render unscannably as a flat chip cluster.
+    /// </summary>
+    EffectByStackingType,
 }
 
 /// <summary>
@@ -121,6 +131,7 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef RecipeIngredientItem(string itemInternalName) => new(EntityKind.RecipeIngredientItem, itemInternalName);
     public static EntityRef EffectKeyword(string keyword) => new(EntityKind.EffectKeyword, keyword);
     public static EntityRef AbilityByEffectKeyword(string keyword) => new(EntityKind.AbilityByEffectKeyword, keyword);
+    public static EntityRef EffectByStackingType(string stackingType) => new(EntityKind.EffectByStackingType, stackingType);
 }
 
 /// <summary>

--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Mithril.Shared.Reference;
 
 /// <summary>
@@ -46,6 +48,24 @@ public enum EntityKind
     /// <see cref="RecipeIngredientKeyword"/> for the item-pivot direction.
     /// </summary>
     RecipeIngredientItem,
+
+    /// <summary>
+    /// Not an entity per se — a deep-link target for "open the Effects tab filtered to effects
+    /// whose <c>Keywords</c> list contains this tag." InternalName carries the keyword
+    /// (e.g. <c>"FrostShard"</c>, <c>"Buff"</c>). Dispatched by EffectKeywordKindTarget.
+    /// Use this — not <see cref="Effect"/> — when a chip's natural target is a keyword
+    /// filter rather than a specific effect envelope row.
+    /// </summary>
+    EffectKeyword,
+
+    /// <summary>
+    /// Not an entity per se — a deep-link target for "open the Abilities tab filtered to
+    /// abilities whose effect-keyword requirement union contains this tag." InternalName
+    /// carries the effect-keyword (e.g. <c>"FrostShard"</c>). Dispatched by
+    /// AbilityByEffectKeywordKindTarget; powers the Effects-tab "Required by abilities"
+    /// section's overflow pill when the chip cluster exceeds the configured cap.
+    /// </summary>
+    AbilityByEffectKeyword,
 }
 
 /// <summary>
@@ -60,7 +80,21 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef Item(string internalName) => new(EntityKind.Item, internalName);
     public static EntityRef Recipe(string internalName) => new(EntityKind.Recipe, internalName);
     public static EntityRef Ability(string internalName) => new(EntityKind.Ability, internalName);
-    public static EntityRef Effect(string internalName) => new(EntityKind.Effect, internalName);
+
+    /// <summary>
+    /// Effect InternalName — equal to the envelope key (e.g. <c>"effect_10003"</c>), lifted
+    /// from effects.json by the deserializer. Not a keyword tag and not the human-form
+    /// <c>Effect.Name</c> (which collides across many entries). For keyword-based filtering
+    /// of the Effects tab use <see cref="EffectKeyword"/> instead.
+    /// </summary>
+    public static EntityRef Effect(string internalName)
+    {
+        Debug.Assert(
+            internalName.StartsWith("effect_", StringComparison.Ordinal),
+            $"EntityRef.Effect expects an envelope-key InternalName like 'effect_10003', got '{internalName}'. "
+            + "If you have a keyword tag, use EntityRef.EffectKeyword(...) instead.");
+        return new(EntityKind.Effect, internalName);
+    }
     /// <summary>
     /// Construct a Npc reference, normalising any area-prefixed slug form (used by quest
     /// fields like <c>Quest.QuestNpc</c> = <c>"AreaSerbule2/NPC_DurstinTallow"</c>) to the
@@ -85,6 +119,8 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef ItemKeyword(string keyword) => new(EntityKind.ItemKeyword, keyword);
     public static EntityRef ItemKeyword(IReadOnlyList<string> itemKeys) => new(EntityKind.ItemKeyword, string.Join('+', itemKeys));
     public static EntityRef RecipeIngredientItem(string itemInternalName) => new(EntityKind.RecipeIngredientItem, itemInternalName);
+    public static EntityRef EffectKeyword(string keyword) => new(EntityKind.EffectKeyword, keyword);
+    public static EntityRef AbilityByEffectKeyword(string keyword) => new(EntityKind.AbilityByEffectKeyword, keyword);
 }
 
 /// <summary>

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -1,4 +1,5 @@
 using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Effects;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Misc;
 using Mithril.Reference.Models.Npcs;
@@ -307,6 +308,70 @@ public interface IReferenceDataService
     /// Defaults to empty so test fakes don't need to opt in.
     /// </summary>
     IReadOnlyList<AbilityDynamicSpecialValue> AbilityDynamicSpecialValues => Array.Empty<AbilityDynamicSpecialValue>();
+
+    /// <summary>
+    /// Effect envelope key (e.g. <c>"effect_10003"</c>) → <see cref="Effect"/> POCO from
+    /// <c>effects.json</c>. Carries the full effect metadata surface (description, keywords,
+    /// duration, stacking type, spew text, particle name, triggering-ability-keyword gate)
+    /// consumed by Silmarillion's Effects tab. Defaults to empty so test fakes don't need
+    /// to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, Effect> Effects => EmptyEffectMap;
+
+    /// <summary>
+    /// Effect <c>InternalName</c> → <see cref="Effect"/>. Mirrors <see cref="Effects"/> for
+    /// kinds where the envelope key and the InternalName coincide (the deserializer lifts
+    /// the envelope key onto <see cref="Effect.InternalName"/>). Same shape as
+    /// <see cref="ItemsByInternalName"/> / <see cref="AbilitiesByInternalName"/>.
+    /// </summary>
+    IReadOnlyDictionary<string, Effect> EffectsByInternalName => EmptyEffectMap;
+
+    /// <summary>
+    /// Effect <see cref="Effect.Keywords"/> tag → effects carrying that tag. Powers the
+    /// <c>EntityKind.EffectKeyword</c> synthetic deep-link target (Effects tab filtered to
+    /// <c>Keywords CONTAINS "&lt;tag&gt;"</c>) and the on-detail "Other effects with this
+    /// keyword" cross-link. Built whenever <c>effects.json</c> reloads. Defaults to empty.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByKeyword => EmptyEffectIndex;
+
+    /// <summary>
+    /// Effect <see cref="Effect.StackingType"/> → all effects sharing that stacking group.
+    /// Powers the on-detail "Stacks with" section. Built whenever <c>effects.json</c>
+    /// reloads. Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByStackingType => EmptyEffectIndex;
+
+    /// <summary>
+    /// Effect-keyword tag → abilities whose
+    /// <see cref="Ability.EffectKeywordReqs"/> ∪
+    /// <see cref="Ability.EffectKeywordsIndicatingEnabled"/> ∪
+    /// <see cref="Ability.TargetEffectKeywordReq"/> contains that tag.
+    /// <para>
+    /// <b>Excludes</b> abilities with <see cref="Ability.InternalAbility"/> = <c>true</c>
+    /// — engine-internal scaffolding (mob skills, mount transitions) with no player-facing
+    /// display name that would otherwise pollute the on-detail chip cluster.
+    /// </para>
+    /// Built whenever <c>abilities.json</c> or <c>effects.json</c> reloads. Powers the
+    /// on-detail "Required by abilities" section and the <c>EntityKind.AbilityByEffectKeyword</c>
+    /// overflow-pill deep-link. Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeyword => EmptyAbilityIndex;
+
+    /// <summary>
+    /// Ability-keyword tag → effects whose <see cref="Effect.AbilityKeywords"/> list
+    /// contains it. Powers the on-detail "Procs from abilities with keyword" section
+    /// (which abilities can trigger this effect's behaviour). Reverse of
+    /// <see cref="AbilitiesByEffectKeyword"/> — that one says "abilities that gate on
+    /// having this effect", this one says "abilities that trigger this effect's
+    /// behaviour". Built whenever <c>effects.json</c> reloads. Defaults to empty.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByTriggeringAbilityKeyword => EmptyEffectIndex;
+
+    private static readonly IReadOnlyDictionary<string, Effect> EmptyEffectMap
+        = new Dictionary<string, Effect>(StringComparer.Ordinal);
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<Effect>> EmptyEffectIndex
+        = new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
 
     /// <summary>
     /// All localizable strings from <c>strings_all.json</c>, keyed by their

--- a/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
@@ -22,6 +22,7 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         EntityKind.Npc => ResolveNpc(reference.InternalName),
         EntityKind.Quest => ResolveQuest(reference.InternalName),
         EntityKind.Ability => ResolveAbility(reference.InternalName),
+        EntityKind.Effect => ResolveEffect(reference.InternalName),
         EntityKind.Skill => ResolveSkill(reference.InternalName),
         _ => reference.InternalName,
     };
@@ -58,6 +59,17 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
     private string ResolveAbility(string internalName) =>
         _refData.AbilitiesByInternalName.TryGetValue(internalName, out var ability) && !string.IsNullOrEmpty(ability.Name)
             ? ability.Name!
+            : internalName;
+
+    /// <summary>
+    /// Effect InternalNames are the envelope keys (e.g. <c>"effect_10003"</c>, lifted by
+    /// <c>ReferenceDeserializer.ParseEffects</c>). The human-form <see cref="Effect.Name"/>
+    /// is preferred for display; the envelope key falls through when no entry is registered
+    /// or the Name field is empty (which is uncommon — effects almost always carry a Name).
+    /// </summary>
+    private string ResolveEffect(string internalName) =>
+        _refData.EffectsByInternalName.TryGetValue(internalName, out var effect) && !string.IsNullOrEmpty(effect.Name)
+            ? effect.Name!
             : internalName;
 
     /// <summary>

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -7,6 +7,7 @@ using Mithril.Reference.Serialization;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Diagnostics.Performance;
 using Ability = Mithril.Reference.Models.Abilities.Ability;
+using Effect = Mithril.Reference.Models.Effects.Effect;
 using Item = Mithril.Reference.Models.Items.Item;
 using PocoArea = Mithril.Reference.Models.Misc.Area;
 using PocoAttribute = Mithril.Reference.Models.Misc.AttributeDef;
@@ -201,6 +202,24 @@ public sealed class ReferenceDataService : IReferenceDataService
     private IReadOnlyList<AbilityDynamicSpecialValue> _abilityDynamicSpecialValues = Array.Empty<AbilityDynamicSpecialValue>();
     private ReferenceFileSnapshot _abilityDynamicSpecialValuesSnapshot;
 
+    // Effects (effects.json) — keyed by "effect_N" plus a sibling InternalName lookup
+    // (envelope key === InternalName, lifted by ParseEffects). Derived keyword and
+    // stacking indices plus the bidirectional ability×effect-keyword cross-link indices
+    // power Silmarillion's Effects tab.
+    private IReadOnlyDictionary<string, Effect> _effects =
+        new Dictionary<string, Effect>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, Effect> _effectsByInternalName =
+        new Dictionary<string, Effect>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<Effect>> _effectsByKeyword =
+        new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<Effect>> _effectsByStackingType =
+        new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<Ability>> _abilitiesByEffectKeyword =
+        new Dictionary<string, IReadOnlyList<Ability>>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<Effect>> _effectsByTriggeringAbilityKeyword =
+        new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _effectsSnapshot;
+
     public ReferenceDataService(string cacheDir, HttpClient http, IDiagnosticsSink? diag = null, string? bundledDir = null, IPerfTracer? perf = null)
     {
         _cacheDir = cacheDir;
@@ -233,6 +252,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _abilityKeywordRulesSnapshot = new ReferenceFileSnapshot("abilitykeywords", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _abilityDynamicDotsSnapshot = new ReferenceFileSnapshot("abilitydynamicdots", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _abilityDynamicSpecialValuesSnapshot = new ReferenceFileSnapshot("abilitydynamicspecialvalues", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _effectsSnapshot = new ReferenceFileSnapshot("effects", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
 
         LoadItems();
         LoadRecipes();
@@ -244,6 +264,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadItemSources();
         LoadRecipeSources();
         LoadAbilities();           // Must run before LoadAbilitySources — ParseAndSwapAbilitySources keys by Ability.InternalName.
+                                   // Also must run before LoadEffects so BuildEffectAbilityCrossLinkIndices sees both sides.
         LoadAbilitySources();
         LoadAttributes();
         LoadPowers();
@@ -253,9 +274,10 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadAbilityKeywords();
         LoadAbilityDynamicDots();
         LoadAbilityDynamicSpecialValues();
+        LoadEffects();
     }
 
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues"];
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects"];
 
     public IReadOnlyDictionary<long, Item> Items => _items;
     public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByInternalName;
@@ -293,6 +315,12 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyList<AbilityKeyword> AbilityKeywordRules => _abilityKeywordRules;
     public IReadOnlyList<AbilityDynamicDot> AbilityDynamicDots => _abilityDynamicDots;
     public IReadOnlyList<AbilityDynamicSpecialValue> AbilityDynamicSpecialValues => _abilityDynamicSpecialValues;
+    public IReadOnlyDictionary<string, Effect> Effects => _effects;
+    public IReadOnlyDictionary<string, Effect> EffectsByInternalName => _effectsByInternalName;
+    public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByKeyword => _effectsByKeyword;
+    public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByStackingType => _effectsByStackingType;
+    public IReadOnlyDictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeyword => _abilitiesByEffectKeyword;
+    public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByTriggeringAbilityKeyword => _effectsByTriggeringAbilityKeyword;
     public IReadOnlyDictionary<string, string> Strings => _strings;
 
     public ReferenceFileSnapshot GetSnapshot(string key) => key switch
@@ -316,6 +344,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "abilitykeywords" => _abilityKeywordRulesSnapshot,
         "abilitydynamicdots" => _abilityDynamicDotsSnapshot,
         "abilitydynamicspecialvalues" => _abilityDynamicSpecialValuesSnapshot,
+        "effects" => _effectsSnapshot,
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -342,6 +371,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "abilitykeywords" => RefreshFileAsync("abilitykeywords", ReferenceDeserializer.ParseAbilityKeywords, ParseAndSwapAbilityKeywords, ct),
         "abilitydynamicdots" => RefreshFileAsync("abilitydynamicdots", ReferenceDeserializer.ParseAbilityDynamicDots, ParseAndSwapAbilityDynamicDots, ct),
         "abilitydynamicspecialvalues" => RefreshFileAsync("abilitydynamicspecialvalues", ReferenceDeserializer.ParseAbilityDynamicSpecialValues, ParseAndSwapAbilityDynamicSpecialValues, ct),
+        "effects" => RefreshFileAsync("effects", ReferenceDeserializer.ParseEffects, ParseAndSwapEffects, ct),
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -366,6 +396,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         await RefreshAsync("abilitykeywords", ct).ConfigureAwait(false);
         await RefreshAsync("abilitydynamicdots", ct).ConfigureAwait(false);
         await RefreshAsync("abilitydynamicspecialvalues", ct).ConfigureAwait(false);
+        await RefreshAsync("effects", ct).ConfigureAwait(false);
     }
 
     public void BeginBackgroundRefresh()
@@ -550,6 +581,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void LoadAbilityKeywords() => LoadFile("abilitykeywords", ReferenceDeserializer.ParseAbilityKeywords, ParseAndSwapAbilityKeywords);
     private void LoadAbilityDynamicDots() => LoadFile("abilitydynamicdots", ReferenceDeserializer.ParseAbilityDynamicDots, ParseAndSwapAbilityDynamicDots);
     private void LoadAbilityDynamicSpecialValues() => LoadFile("abilitydynamicspecialvalues", ReferenceDeserializer.ParseAbilityDynamicSpecialValues, ParseAndSwapAbilityDynamicSpecialValues);
+    private void LoadEffects() => LoadFile("effects", ReferenceDeserializer.ParseEffects, ParseAndSwapEffects);
 
     // ── Per-type parse-and-swap ──────────────────────────────────────────
 
@@ -1046,6 +1078,131 @@ public sealed class ReferenceDataService : IReferenceDataService
         BuildAbilityCrossLinkIndices();
         // Re-derive AbilitiesTaughtByNpc when the ability set itself changes.
         BuildNpcCrossLinkIndices();
+        // Re-derive AbilitiesByEffectKeyword — keyed on Ability.EffectKeywordReqs ∪
+        // EffectKeywordsIndicatingEnabled ∪ TargetEffectKeywordReq, so any abilities-file
+        // refresh changes the membership of those sets.
+        BuildEffectAbilityCrossLinkIndices();
+    }
+
+    private void ParseAndSwapEffects(IReadOnlyDictionary<string, Effect> raw, ReferenceFileMetadata meta)
+    {
+        var byKey = new Dictionary<string, Effect>(raw.Count, StringComparer.Ordinal);
+        var byInternalName = new Dictionary<string, Effect>(raw.Count, StringComparer.Ordinal);
+        foreach (var (key, effect) in raw)
+        {
+            if (effect is null) continue;
+            byKey[key] = effect;
+            // ParseEffects lifts the envelope key onto effect.InternalName; the InternalName
+            // and envelope-key dictionaries therefore carry the same entries with the same
+            // keys, but the sibling lookup mirrors the shape of ItemsByInternalName /
+            // AbilitiesByInternalName so resolver and kind-target code paths don't special-case.
+            if (!string.IsNullOrEmpty(effect.InternalName))
+                byInternalName[effect.InternalName!] = effect;
+        }
+        _effects = byKey;
+        _effectsByInternalName = byInternalName;
+        _effectsSnapshot = new ReferenceFileSnapshot("effects", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
+        BuildEffectAbilityCrossLinkIndices();
+    }
+
+    /// <summary>
+    /// Builds the four effect/ability cross-link indices: <see cref="_effectsByKeyword"/>,
+    /// <see cref="_effectsByStackingType"/>, <see cref="_effectsByTriggeringAbilityKeyword"/>,
+    /// and <see cref="_abilitiesByEffectKeyword"/>. The last index reads ability fields and
+    /// must rebuild when either <c>effects.json</c> or <c>abilities.json</c> reloads — both
+    /// <see cref="ParseAndSwapEffects"/> and <see cref="ParseAndSwapAbilities"/> call this.
+    /// Abilities with <see cref="Ability.InternalAbility"/> = <c>true</c> are excluded from
+    /// <see cref="_abilitiesByEffectKeyword"/> per the on-detail chip-cluster contract.
+    /// </summary>
+    private void BuildEffectAbilityCrossLinkIndices()
+    {
+        var byKeyword = new Dictionary<string, List<Effect>>(StringComparer.Ordinal);
+        var byStacking = new Dictionary<string, List<Effect>>(StringComparer.Ordinal);
+        var byTriggeringAbilityKeyword = new Dictionary<string, List<Effect>>(StringComparer.Ordinal);
+
+        foreach (var effect in _effects.Values)
+        {
+            if (effect.Keywords is { Count: > 0 } keywords)
+            {
+                foreach (var tag in keywords)
+                {
+                    if (string.IsNullOrEmpty(tag)) continue;
+                    if (!byKeyword.TryGetValue(tag, out var list))
+                    {
+                        list = new List<Effect>();
+                        byKeyword[tag] = list;
+                    }
+                    list.Add(effect);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(effect.StackingType))
+            {
+                if (!byStacking.TryGetValue(effect.StackingType!, out var list))
+                {
+                    list = new List<Effect>();
+                    byStacking[effect.StackingType!] = list;
+                }
+                list.Add(effect);
+            }
+
+            if (effect.AbilityKeywords is { Count: > 0 } abilityKeywords)
+            {
+                foreach (var tag in abilityKeywords)
+                {
+                    if (string.IsNullOrEmpty(tag)) continue;
+                    if (!byTriggeringAbilityKeyword.TryGetValue(tag, out var list))
+                    {
+                        list = new List<Effect>();
+                        byTriggeringAbilityKeyword[tag] = list;
+                    }
+                    list.Add(effect);
+                }
+            }
+        }
+
+        var byEffectKeyword = new Dictionary<string, List<Ability>>(StringComparer.Ordinal);
+        foreach (var ability in _abilities.Values)
+        {
+            if (ability.InternalAbility == true) continue;
+
+            // Union: EffectKeywordReqs ∪ EffectKeywordsIndicatingEnabled ∪ {TargetEffectKeywordReq}.
+            // Dedupe per ability so a tag mentioned in multiple slots doesn't double-count the
+            // ability in the index.
+            HashSet<string>? tagsForAbility = null;
+            void Mark(string? tag)
+            {
+                if (string.IsNullOrEmpty(tag)) return;
+                tagsForAbility ??= new HashSet<string>(StringComparer.Ordinal);
+                tagsForAbility.Add(tag);
+            }
+
+            if (ability.EffectKeywordReqs is { Count: > 0 } reqs)
+                foreach (var tag in reqs) Mark(tag);
+            if (ability.EffectKeywordsIndicatingEnabled is { Count: > 0 } enabled)
+                foreach (var tag in enabled) Mark(tag);
+            Mark(ability.TargetEffectKeywordReq);
+
+            if (tagsForAbility is null) continue;
+            foreach (var tag in tagsForAbility)
+            {
+                if (!byEffectKeyword.TryGetValue(tag, out var list))
+                {
+                    list = new List<Ability>();
+                    byEffectKeyword[tag] = list;
+                }
+                list.Add(ability);
+            }
+        }
+
+        _effectsByKeyword = byKeyword.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<Effect>)kv.Value, StringComparer.Ordinal);
+        _effectsByStackingType = byStacking.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<Effect>)kv.Value, StringComparer.Ordinal);
+        _effectsByTriggeringAbilityKeyword = byTriggeringAbilityKeyword.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<Effect>)kv.Value, StringComparer.Ordinal);
+        _abilitiesByEffectKeyword = byEffectKeyword.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<Ability>)kv.Value, StringComparer.Ordinal);
     }
 
     private void ParseAndSwapAbilitySources(IReadOnlyDictionary<string, PocoSourceEnvelope> raw, ReferenceFileMetadata meta)

--- a/src/Silmarillion.Module/Navigation/AbilityByEffectKeywordKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/AbilityByEffectKeywordKindTarget.cs
@@ -1,0 +1,53 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> for <see cref="EntityKind.AbilityByEffectKeyword"/>.
+/// Flips to the Abilities tab and pre-populates <see cref="AbilitiesTabViewModel.QueryText"/>
+/// with <c>EffectKeywordReqs CONTAINS "&lt;tag&gt;"</c>. Powers the Effects-tab
+/// "Required by abilities" section's overflow pill when the chip cluster exceeds
+/// <c>SilmarillionSettings.RequiredByAbilitiesChipCap</c>.
+/// <para>
+/// Mirror of <see cref="EffectKeywordKindTarget"/> for the abilities-pivot direction:
+/// EffectKeyword filters Effects whose Keywords contain the tag; this one filters
+/// Abilities whose EffectKeywordReqs contain the tag. Both work because both row types
+/// surface the relevant collection field as <see cref="IngredientKeywordValue"/>
+/// wrappers for the query engine's <c>CONTAINS</c> path.
+/// </para>
+/// </summary>
+public sealed class AbilityByEffectKeywordKindTarget : IReferenceKindTarget
+{
+    private readonly AbilitiesTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public AbilityByEffectKeywordKindTarget(AbilitiesTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.AbilityByEffectKeyword;
+
+    public int TabIndex => 4; // Abilities tab
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (string.IsNullOrEmpty(internalName))
+        {
+            _diag?.Info("Silmarillion.Nav", "AbilityByEffectKeyword.TrySelect '' → empty payload, leaving Abilities tab unchanged.");
+            return false;
+        }
+
+        var escaped = internalName.Replace("\"", "\\\"");
+        var query = $"EffectKeywordReqs CONTAINS \"{escaped}\"";
+        _diag?.Info("Silmarillion.Nav", $"AbilityByEffectKeyword.TrySelect '{internalName}' → QueryText='{query}'.");
+        _vm.SelectedRow = null;
+        _vm.QueryText = query;
+        return true;
+    }
+
+    public bool TryOpenInWindow() => false;
+}

--- a/src/Silmarillion.Module/Navigation/EffectByStackingTypeKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/EffectByStackingTypeKindTarget.cs
@@ -1,0 +1,47 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> for <see cref="EntityKind.EffectByStackingType"/>.
+/// Flips to the Effects tab and pre-populates <see cref="EffectsTabViewModel.QueryText"/>
+/// with <c>StackingType = "&lt;value&gt;"</c>. Powers the Effects-tab "Stacks with"
+/// section's overflow pill — large stacking groups like <c>"Food"</c> (~326 effects)
+/// or <c>"Snack"</c> (~190 effects) collapse the long tail behind a single pill that
+/// deep-links to the filtered set.
+/// </summary>
+public sealed class EffectByStackingTypeKindTarget : IReferenceKindTarget
+{
+    private readonly EffectsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public EffectByStackingTypeKindTarget(EffectsTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.EffectByStackingType;
+
+    public int TabIndex => 5; // Effects tab
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (string.IsNullOrEmpty(internalName))
+        {
+            _diag?.Info("Silmarillion.Nav", "EffectByStackingType.TrySelect '' → empty payload, leaving Effects tab unchanged.");
+            return false;
+        }
+
+        var escaped = internalName.Replace("\"", "\\\"");
+        var query = $"StackingType = \"{escaped}\"";
+        _diag?.Info("Silmarillion.Nav", $"EffectByStackingType.TrySelect '{internalName}' → QueryText='{query}'.");
+        _vm.SelectedRow = null;
+        _vm.QueryText = query;
+        return true;
+    }
+
+    public bool TryOpenInWindow() => false;
+}

--- a/src/Silmarillion.Module/Navigation/EffectKeywordKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/EffectKeywordKindTarget.cs
@@ -1,0 +1,51 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> for <see cref="EntityKind.EffectKeyword"/>.
+/// Flips to the Effects tab and pre-populates <see cref="EffectsTabViewModel.QueryText"/>
+/// with <c>Keywords CONTAINS "&lt;tag&gt;"</c>, where the tag is the
+/// <see cref="EntityRef.InternalName"/> payload.
+/// <para>
+/// Singleton-payload only — effect-keyword references in the catalogue are always single
+/// tags (Ability.EffectKeywordReqs, AbilityConditionalKeyword.EffectKeywordMustExist,
+/// HasEffectKeywordRequirement.Keyword, etc.) so no '+'-joined composite form is needed.
+/// Mirrors the shape of <see cref="ItemKeywordKindTarget"/> for the effect-pivot direction.
+/// </para>
+/// </summary>
+public sealed class EffectKeywordKindTarget : IReferenceKindTarget
+{
+    private readonly EffectsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public EffectKeywordKindTarget(EffectsTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.EffectKeyword;
+
+    public int TabIndex => 5; // Effects tab
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        if (string.IsNullOrEmpty(internalName))
+        {
+            _diag?.Info("Silmarillion.Nav", "EffectKeyword.TrySelect '' → empty payload, leaving Effects tab unchanged.");
+            return false;
+        }
+
+        var escaped = internalName.Replace("\"", "\\\"");
+        var query = $"Keywords CONTAINS \"{escaped}\"";
+        _diag?.Info("Silmarillion.Nav", $"EffectKeyword.TrySelect '{internalName}' → QueryText='{query}'.");
+        _vm.SelectedRow = null;
+        _vm.QueryText = query;
+        return true;
+    }
+
+    public bool TryOpenInWindow() => false;
+}

--- a/src/Silmarillion.Module/Navigation/EffectsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/EffectsKindTarget.cs
@@ -1,0 +1,55 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the Effects tab. Resolves selection
+/// against the tab VM's bound <see cref="EffectsTabViewModel.AllEffects"/> collection
+/// rather than <see cref="IReferenceDataService"/> directly — same instance-identity
+/// concern as <see cref="ItemsKindTarget"/>: a background CDN refresh hands out fresh
+/// Effect POCOs but the ListBox is still bound to the old collection.
+/// <para>
+/// The <c>internalName</c> argument is the lifted envelope key (e.g. <c>"effect_10003"</c>),
+/// which equals <c>Effect.InternalName</c> after the deserializer lift.
+/// </para>
+/// </summary>
+public sealed class EffectsKindTarget : IReferenceKindTarget
+{
+    private readonly EffectsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public EffectsKindTarget(EffectsTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.Effect;
+
+    public int TabIndex => 5;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var row = _vm.AllEffects.FirstOrDefault(r => r.EnvelopeKey == internalName);
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Effects.TrySelect '{internalName}' → not found (AllEffects={_vm.AllEffects.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Effects.TrySelect '{internalName}' → found, selecting.");
+        // Clear any residual filter so the target row isn't filtered out of the visible ListBox.
+        _vm.QueryText = "";
+        _vm.SelectedRow = row;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new EffectDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -107,6 +107,9 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<IReferenceKindTarget>(sp => new AbilityByEffectKeywordKindTarget(
             sp.GetRequiredService<AbilitiesTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new EffectByStackingTypeKindTarget(
+            sp.GetRequiredService<EffectsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).
         services.AddSingleton<IDeepLinkHandler>(sp =>

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -54,6 +54,7 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<NpcsTabViewModel>();
         services.AddSingleton<QuestsTabViewModel>();
         services.AddSingleton<AbilitiesTabViewModel>();
+        services.AddSingleton<EffectsTabViewModel>();
         // Forward each concrete tab VM to ITabViewModel so SilmarillionViewModel can compose
         // its Tabs collection from IEnumerable<ITabViewModel>. Adding a future tab is a single
         // pair of registrations here — no SilmarillionViewModel ctor change (refactor #243).
@@ -62,6 +63,7 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<NpcsTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<QuestsTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<AbilitiesTabViewModel>());
+        services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<EffectsTabViewModel>());
         services.AddSingleton<SilmarillionViewModel>();
 
         // Kind targets registered after the tab VMs so DI can resolve them.
@@ -91,6 +93,15 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new RecipeIngredientItemKindTarget(
             sp.GetRequiredService<RecipesTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new EffectsKindTarget(
+            sp.GetRequiredService<EffectsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new EffectKeywordKindTarget(
+            sp.GetRequiredService<EffectsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new AbilityByEffectKeywordKindTarget(
+            sp.GetRequiredService<AbilitiesTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -54,7 +54,11 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<NpcsTabViewModel>();
         services.AddSingleton<QuestsTabViewModel>();
         services.AddSingleton<AbilitiesTabViewModel>();
-        services.AddSingleton<EffectsTabViewModel>();
+        services.AddSingleton<EffectsTabViewModel>(sp => new EffectsTabViewModel(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IReferenceNavigator>(),
+            sp.GetRequiredService<IEntityNameResolver>(),
+            sp.GetRequiredService<SilmarillionSettings>()));
         // Forward each concrete tab VM to ITabViewModel so SilmarillionViewModel can compose
         // its Tabs collection from IEnumerable<ITabViewModel>. Adding a future tab is a single
         // pair of registrations here — no SilmarillionViewModel ctor change (refactor #243).

--- a/src/Silmarillion.Module/SilmarillionSettings.cs
+++ b/src/Silmarillion.Module/SilmarillionSettings.cs
@@ -5,16 +5,15 @@ using System.Text.Json.Serialization;
 namespace Silmarillion;
 
 /// <summary>
-/// Persisted preferences for the Silmarillion module. v1 only exposes
-/// <see cref="UsedInChipCap"/>; the class exists primarily as scaffolding so future
-/// settings (default tab, hide-empty-sections, …) can land as small follow-ups.
-/// <see cref="SchemaVersion"/> is stamped from day one per the project's
-/// versioned-JSON convention — cheap forward-compat without committing to the
-/// <c>IVersionedState</c> migration path yet.
+/// Persisted preferences for the Silmarillion module. Exposes per-tab chip caps that
+/// trade off detail-pane chip density against the overflow pill's deep-link route.
+/// <see cref="SchemaVersion"/> is stamped from day one per the project's versioned-JSON
+/// convention — cheap forward-compat without committing to the <c>IVersionedState</c>
+/// migration path yet.
 /// </summary>
 public sealed class SilmarillionSettings : INotifyPropertyChanged
 {
-    /// <summary>Lowest valid cap. Zero collapses every "Used in" chip into the overflow pill.</summary>
+    /// <summary>Lowest valid cap. Zero collapses every chip into the overflow pill.</summary>
     public const int MinUsedInChipCap = 0;
 
     /// <summary>Highest valid cap. Above ~100 the section becomes unbrowsable regardless of perf.</summary>
@@ -23,8 +22,12 @@ public sealed class SilmarillionSettings : INotifyPropertyChanged
     /// <summary>Default cap: cheap case stays cheap, long tail collapses behind the overflow pill.</summary>
     public const int DefaultUsedInChipCap = 12;
 
+    /// <summary>Default cap for the Effects-tab "Required by abilities" chip cluster.</summary>
+    public const int DefaultRequiredByAbilitiesChipCap = 12;
+
     private int _schemaVersion = 1;
     private int _usedInChipCap = DefaultUsedInChipCap;
+    private int _requiredByAbilitiesChipCap = DefaultRequiredByAbilitiesChipCap;
 
     /// <summary>
     /// Persisted schema version. Always written so a future <c>IVersionedState</c> migration
@@ -45,6 +48,20 @@ public sealed class SilmarillionSettings : INotifyPropertyChanged
     {
         get => _usedInChipCap;
         set => Set(ref _usedInChipCap, Math.Clamp(value, MinUsedInChipCap, MaxUsedInChipCap));
+    }
+
+    /// <summary>
+    /// Maximum number of per-ability chips rendered in the effect-detail
+    /// "Required by abilities" section before collapsing the rest behind a
+    /// <c>+N more →</c> overflow pill. The pill deep-links to the Abilities tab
+    /// filtered by <c>EffectKeywordReqs CONTAINS "&lt;tag&gt;"</c> via the
+    /// <see cref="Mithril.Shared.Reference.EntityKind.AbilityByEffectKeyword"/>
+    /// synthetic kind. Clamped to <see cref="MinUsedInChipCap"/>..<see cref="MaxUsedInChipCap"/>.
+    /// </summary>
+    public int RequiredByAbilitiesChipCap
+    {
+        get => _requiredByAbilitiesChipCap;
+        set => Set(ref _requiredByAbilitiesChipCap, Math.Clamp(value, MinUsedInChipCap, MaxUsedInChipCap));
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/Silmarillion.Module/ViewModels/AbilitiesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/AbilitiesTabViewModel.cs
@@ -120,6 +120,13 @@ public sealed partial class AbilitiesTabViewModel : ObservableObject, ITabViewMo
             .Where(k => !string.IsNullOrEmpty(k))
             .Select(k => new IngredientKeywordValue(k))
             .ToList();
+        // Surface EffectKeywordReqs as a CONTAINS-queryable collection so the
+        // AbilityByEffectKeyword synthetic kind target can deep-link via
+        // `EffectKeywordReqs CONTAINS "<tag>"`.
+        var effectKeywordReqs = (ability.EffectKeywordReqs ?? (IReadOnlyList<string>)[])
+            .Where(k => !string.IsNullOrEmpty(k))
+            .Select(k => new IngredientKeywordValue(k))
+            .ToList();
 
         return new AbilityListRow(
             Ability: ability,
@@ -129,6 +136,7 @@ public sealed partial class AbilitiesTabViewModel : ObservableObject, ITabViewMo
             Level: ability.Level,
             Rank: ability.Rank,
             Keywords: keywords,
+            EffectKeywordReqs: effectKeywordReqs,
             ResetTimeSeconds: ability.ResetTime,
             IconID: ability.IconID);
     }

--- a/src/Silmarillion.Module/ViewModels/AbilityDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/AbilityDetailViewModel.cs
@@ -45,11 +45,12 @@ public sealed class AbilityDetailViewModel
         SharesResetTimerWithChip = BuildAbilityChip(ability.SharesResetTimerWith, nameResolver, navigator);
 
         ItemKeywordReqChips = BuildItemKeywordChips(ability.ItemKeywordReqs, navigator);
-        EffectKeywordReqs = ability.EffectKeywordReqs ?? (IReadOnlyList<string>)[];
+        EffectKeywordReqChips = BuildEffectKeywordChips(ability.EffectKeywordReqs, navigator);
+        TargetEffectKeywordReqChip = BuildSingleEffectKeywordChip(ability.TargetEffectKeywordReq, navigator);
         SpecialCasterRequirementLabels = BuildSpecialCasterRequirementLabels(ability.SpecialCasterRequirements);
 
         CostRows = BuildCostRows(ability.Costs);
-        ConditionalKeywordRows = BuildConditionalKeywordRows(ability.ConditionalKeywords);
+        ConditionalKeywordRows = BuildConditionalKeywordRows(ability.ConditionalKeywords, navigator);
         AmmoKeywordRows = BuildAmmoKeywordRows(ability.AmmoKeywords, ability.AmmoDescription, navigator);
 
         EnvironmentalFlags = BuildEnvironmentalFlags(ability);
@@ -88,9 +89,21 @@ public sealed class AbilityDetailViewModel
     public EntityChipVm? SharesResetTimerWithChip { get; }
 
     public IReadOnlyList<EntityChipVm> ItemKeywordReqChips { get; }
-    public IReadOnlyList<string> EffectKeywordReqs { get; }
-    /// <summary>Comma-joined effect-keyword requirements for the XAML <c>Run</c>.</summary>
-    public string EffectKeywordReqsDisplay => string.Join(", ", EffectKeywordReqs);
+
+    /// <summary>
+    /// Required effect-keyword chips — each chip points at the Effects tab filtered by
+    /// <c>Keywords CONTAINS "&lt;tag&gt;"</c> via <see cref="EntityRef.EffectKeyword"/>.
+    /// Empty when the ability has no <c>EffectKeywordReqs</c>.
+    /// </summary>
+    public IReadOnlyList<EntityChipVm> EffectKeywordReqChips { get; }
+
+    /// <summary>
+    /// Single chip for <see cref="Ability.TargetEffectKeywordReq"/> — the targeting-gate
+    /// keyword that the ability requires the target effect to carry. Null when unset.
+    /// Surfaced in the Special-Targeting section above the flag rows.
+    /// </summary>
+    public EntityChipVm? TargetEffectKeywordReqChip { get; }
+
     public IReadOnlyList<string> SpecialCasterRequirementLabels { get; }
 
     public IReadOnlyList<AbilityCostRow> CostRows { get; }
@@ -189,6 +202,31 @@ public sealed class AbilityDetailViewModel
         return list;
     }
 
+    private static IReadOnlyList<EntityChipVm> BuildEffectKeywordChips(
+        IReadOnlyList<string>? effectKeywordReqs,
+        IReferenceNavigator navigator)
+    {
+        if (effectKeywordReqs is null || effectKeywordReqs.Count == 0) return [];
+        var list = new List<EntityChipVm>(effectKeywordReqs.Count);
+        foreach (var kw in effectKeywordReqs)
+        {
+            var chip = BuildSingleEffectKeywordChip(kw, navigator);
+            if (chip is not null) list.Add(chip);
+        }
+        return list;
+    }
+
+    private static EntityChipVm? BuildSingleEffectKeywordChip(string? keyword, IReferenceNavigator navigator)
+    {
+        if (string.IsNullOrEmpty(keyword)) return null;
+        var reference = EntityRef.EffectKeyword(keyword!);
+        return new EntityChipVm(
+            DisplayName: keyword!,
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: navigator.CanOpen(reference));
+    }
+
     private static IReadOnlyList<string> BuildSpecialCasterRequirementLabels(
         IReadOnlyList<AbilitySpecialCasterRequirement>? requirements)
     {
@@ -257,7 +295,8 @@ public sealed class AbilityDetailViewModel
     }
 
     private static IReadOnlyList<AbilityConditionalKeywordRow> BuildConditionalKeywordRows(
-        IReadOnlyList<AbilityConditionalKeyword>? conditionals)
+        IReadOnlyList<AbilityConditionalKeyword>? conditionals,
+        IReferenceNavigator navigator)
     {
         if (conditionals is null || conditionals.Count == 0) return [];
         var list = new List<AbilityConditionalKeywordRow>(conditionals.Count);
@@ -265,17 +304,29 @@ public sealed class AbilityDetailViewModel
         {
             if (c is null) continue;
             string condition;
+            EntityChipVm? chip = null;
             if (c.Default == true)
+            {
                 condition = "Default";
+            }
             else if (!string.IsNullOrEmpty(c.EffectKeywordMustExist))
-                condition = $"When effect keyword present: {c.EffectKeywordMustExist}";
+            {
+                condition = "When effect keyword present:";
+                chip = BuildSingleEffectKeywordChip(c.EffectKeywordMustExist, navigator);
+            }
             else if (!string.IsNullOrEmpty(c.EffectKeywordMustNotExist))
-                condition = $"When effect keyword absent: {c.EffectKeywordMustNotExist}";
+            {
+                condition = "When effect keyword absent:";
+                chip = BuildSingleEffectKeywordChip(c.EffectKeywordMustNotExist, navigator);
+            }
             else
+            {
                 condition = "Always";
+            }
             list.Add(new AbilityConditionalKeywordRow(
                 Keyword: c.Keyword ?? "(none)",
-                Condition: condition));
+                Condition: condition,
+                EffectKeywordChip: chip));
         }
         return list;
     }
@@ -343,8 +394,8 @@ public sealed class AbilityDetailViewModel
     private static IReadOnlyList<AbilityFlagRow> BuildSpecialTargetingFlags(Ability ability)
     {
         var list = new List<AbilityFlagRow>();
-        if (!string.IsNullOrEmpty(ability.TargetEffectKeywordReq))
-            list.Add(new AbilityFlagRow("Target effect keyword", ability.TargetEffectKeywordReq!));
+        // TargetEffectKeywordReq is surfaced as a chip via TargetEffectKeywordReqChip above the
+        // flag rows, not in this list — the chip carries the EffectKeyword deep-link affordance.
         if (!string.IsNullOrEmpty(ability.TargetTypeTagReq))
             list.Add(new AbilityFlagRow("Target type tag", ability.TargetTypeTagReq!));
         if (ability.SpecialTargetingTypeReq is int s)
@@ -542,8 +593,15 @@ public sealed class AbilityDetailViewModel
 /// <summary>One row in <see cref="AbilityDetailViewModel.CostRows"/>.</summary>
 public sealed record AbilityCostRow(string Currency, int Price);
 
-/// <summary>One row in <see cref="AbilityDetailViewModel.ConditionalKeywordRows"/>.</summary>
-public sealed record AbilityConditionalKeywordRow(string Keyword, string Condition);
+/// <summary>
+/// One row in <see cref="AbilityDetailViewModel.ConditionalKeywordRows"/>. The
+/// <paramref name="Condition"/> string carries the human-readable trigger prefix
+/// ("When effect keyword present:", "When effect keyword absent:", "Always",
+/// "Default"); when an effect-keyword chip is appropriate it lands on
+/// <paramref name="EffectKeywordChip"/> for the XAML to render alongside the
+/// prefix. The chip is null for unconditional / default rows.
+/// </summary>
+public sealed record AbilityConditionalKeywordRow(string Keyword, string Condition, EntityChipVm? EffectKeywordChip);
 
 /// <summary>One row in <see cref="AbilityDetailViewModel.AmmoKeywordRows"/>. The chip is keyed by
 /// <see cref="EntityRef.ItemKeyword(string)"/>; clicking opens the Items tab filtered by that keyword.</summary>

--- a/src/Silmarillion.Module/ViewModels/AbilityListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/AbilityListRow.cs
@@ -24,5 +24,6 @@ public sealed record AbilityListRow(
     int Level,
     string? Rank,
     IReadOnlyList<IngredientKeywordValue> Keywords,
+    IReadOnlyList<IngredientKeywordValue> EffectKeywordReqs,
     double ResetTimeSeconds,
     int IconID);

--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -1,0 +1,44 @@
+using System.Windows.Input;
+using Mithril.Shared.Reference;
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Read-only projection of an <see cref="PocoEffect"/> for the Silmarillion Effects tab
+/// detail pane. Hostable in both the master-detail right pane and the popup
+/// <see cref="Silmarillion.Views.EffectDetailWindow"/>.
+/// <para>
+/// Slice (c) ships the skeleton: header (icon + name + envelope-key footer) and basic
+/// metadata pass-through. The richer projected sections — keyword chips, conditional-rule
+/// sub-tables (from #288/#296), stacks-with cluster, required-by-abilities cluster with
+/// the overflow pill, procs-from-abilities, and SpewText footer — land in slice (d).
+/// </para>
+/// </summary>
+public sealed class EffectDetailViewModel
+{
+    public EffectDetailViewModel(
+        PocoEffect effect,
+        string envelopeKey,
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        ICommand? openEntityCommand = null)
+    {
+        Effect = effect;
+        EnvelopeKey = envelopeKey;
+        DisplayName = string.IsNullOrEmpty(effect.Name) ? envelopeKey : effect.Name!;
+        OpenEntityCommand = openEntityCommand;
+        _ = refData;
+        _ = navigator;
+        _ = nameResolver;
+    }
+
+    public PocoEffect Effect { get; }
+    public string EnvelopeKey { get; }
+    public string DisplayName { get; }
+    public int IconId => Effect.IconId;
+    public string? Description => Effect.Desc;
+
+    public ICommand? OpenEntityCommand { get; }
+}

--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -38,13 +38,12 @@ public sealed class EffectDetailViewModel
         DisplayName = string.IsNullOrEmpty(effect.Name) ? envelopeKey : effect.Name!;
 
         DurationLabel = FormatDuration(effect.Duration);
-        StackingType = string.IsNullOrEmpty(effect.StackingType) ? null : effect.StackingType;
         DisplayMode = NormaliseDisplayMode(effect.DisplayMode);
 
         KeywordChips = BuildKeywordChips(effect.Keywords, navigator);
         ConditionalDotRows = BuildConditionalDotRows(effect, refData);
         ConditionalSpecialValueRows = BuildConditionalSpecialValueRows(effect, refData);
-        StacksWithChip = BuildStacksWithChip(effect, envelopeKey, refData, navigator);
+        StackingTypeChip = BuildStackingTypeChip(effect, envelopeKey, refData, navigator);
         var (chips, pill) = BuildRequiredByAbilityChips(effect, refData, nameResolver, navigator, settings.RequiredByAbilitiesChipCap);
         RequiredByAbilityChips = chips;
         RequiredByAbilitiesOverflowPill = pill;
@@ -63,7 +62,6 @@ public sealed class EffectDetailViewModel
 
     /// <summary>Formatted duration label or <see langword="null"/> when the duration is missing/zero.</summary>
     public string? DurationLabel { get; }
-    public string? StackingType { get; }
 
     /// <summary>
     /// <see cref="PocoEffect.DisplayMode"/> when non-default. The universal default
@@ -81,15 +79,20 @@ public sealed class EffectDetailViewModel
         ConditionalDotRows.Count > 0 || ConditionalSpecialValueRows.Count > 0;
 
     /// <summary>
-    /// Single collapsed chip representing the stacking group this effect belongs to —
-    /// label is the StackingType value with a peer-count suffix (e.g. <c>"Food (326)"</c>),
-    /// reference is <see cref="EntityRef.EffectByStackingType(string)"/>. Clicking filters
-    /// the Effects tab to <c>StackingType = "&lt;value&gt;"</c>. Null when the effect has
-    /// no StackingType or is the only entry in the group (per #259's keyword-collapse
-    /// precedent — don't fan out to per-effect chips when cardinality could be large; the
-    /// "Food" stacking group alone has hundreds of effects).
+    /// Chip for the metadata strip's <c>"Stacking type:"</c> row — label is the StackingType
+    /// value plus a peer-count suffix (e.g. <c>"Food (325)"</c>), reference is
+    /// <see cref="EntityRef.EffectByStackingType(string)"/>. Clicking filters the Effects
+    /// tab to <c>StackingType = "&lt;value&gt;"</c>. Null when the effect has no StackingType
+    /// or is the sole entry in the stacking group (no peers means no useful filter target,
+    /// per the cookbook's default-value-noise-filtering rule).
+    /// <para>
+    /// Folds what was originally a separate "Stacks with" section into the metadata strip:
+    /// the chip is the StackingType's navigation affordance directly. Per #259's
+    /// keyword-collapse precedent — don't fan out to per-effect chips when cardinality
+    /// could be large (the "Food" stacking group alone has ~326 entries).
+    /// </para>
     /// </summary>
-    public EntityChipVm? StacksWithChip { get; }
+    public EntityChipVm? StackingTypeChip { get; }
     public IReadOnlyList<EntityChipVm> RequiredByAbilityChips { get; }
 
     /// <summary>
@@ -236,14 +239,12 @@ public sealed class EffectDetailViewModel
     }
 
     /// <summary>
-    /// Build the single "Stacks with" chip. Collapses what could be hundreds of per-effect
-    /// chips (the <c>"Food"</c> stacking group alone has ~326 entries) into one chip whose
-    /// label is the StackingType value plus a peer-count suffix; clicking deep-links to
-    /// the Effects tab filtered by <c>StackingType = "&lt;value&gt;"</c>. Mirrors the
-    /// keyword-collapse pattern from #259. Returns <see langword="null"/> when the effect
-    /// has no StackingType or is the only entry in its stacking group.
+    /// Build the metadata-strip StackingType chip. Returns <see langword="null"/> when the
+    /// effect has no StackingType or is the only entry in its stacking group — the entire
+    /// "Stacking type:" row hides in those cases (the chip *is* the row's payload, so
+    /// no chip means no row).
     /// </summary>
-    private static EntityChipVm? BuildStacksWithChip(
+    private static EntityChipVm? BuildStackingTypeChip(
         PocoEffect effect,
         string envelopeKey,
         IReferenceDataService refData,

--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -1,5 +1,9 @@
+using System.Globalization;
 using System.Windows.Input;
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Misc;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
 using PocoEffect = Mithril.Reference.Models.Effects.Effect;
 
 namespace Silmarillion.ViewModels;
@@ -9,10 +13,13 @@ namespace Silmarillion.ViewModels;
 /// detail pane. Hostable in both the master-detail right pane and the popup
 /// <see cref="Silmarillion.Views.EffectDetailWindow"/>.
 /// <para>
-/// Slice (c) ships the skeleton: header (icon + name + envelope-key footer) and basic
-/// metadata pass-through. The richer projected sections — keyword chips, conditional-rule
-/// sub-tables (from #288/#296), stacks-with cluster, required-by-abilities cluster with
-/// the overflow pill, procs-from-abilities, and SpewText footer — land in slice (d).
+/// Nine sections: header, formatted description, metadata strip (duration + stacking type
+/// + display mode), keyword chips, conditional-rule sub-tables fed by
+/// <see cref="IReferenceDataService.AbilityDynamicDots"/> and
+/// <see cref="IReferenceDataService.AbilityDynamicSpecialValues"/>, stacks-with cluster
+/// (other effects sharing <see cref="PocoEffect.StackingType"/>), required-by-abilities
+/// cluster with cap + overflow pill, procs-from-abilities-with-keyword rows, and a
+/// SpewText footer.
 /// </para>
 /// </summary>
 public sealed class EffectDetailViewModel
@@ -23,15 +30,29 @@ public sealed class EffectDetailViewModel
         IReferenceDataService refData,
         IReferenceNavigator navigator,
         IEntityNameResolver nameResolver,
+        Silmarillion.SilmarillionSettings settings,
         ICommand? openEntityCommand = null)
     {
         Effect = effect;
         EnvelopeKey = envelopeKey;
         DisplayName = string.IsNullOrEmpty(effect.Name) ? envelopeKey : effect.Name!;
+
+        DurationLabel = FormatDuration(effect.Duration);
+        StackingType = string.IsNullOrEmpty(effect.StackingType) ? null : effect.StackingType;
+        DisplayMode = NormaliseDisplayMode(effect.DisplayMode);
+
+        KeywordChips = BuildKeywordChips(effect.Keywords, navigator);
+        ConditionalDotRows = BuildConditionalDotRows(effect, refData);
+        ConditionalSpecialValueRows = BuildConditionalSpecialValueRows(effect, refData);
+        StacksWithChips = BuildStacksWithChips(effect, envelopeKey, refData, nameResolver, navigator);
+        var (chips, pill) = BuildRequiredByAbilityChips(effect, refData, nameResolver, navigator, settings.RequiredByAbilitiesChipCap);
+        RequiredByAbilityChips = chips;
+        RequiredByAbilitiesOverflowPill = pill;
+        ProcsFromAbilityKeywordRows = BuildProcsFromAbilityKeywordRows(effect.AbilityKeywords);
+
+        SpewText = string.IsNullOrEmpty(effect.SpewText) ? null : effect.SpewText;
+
         OpenEntityCommand = openEntityCommand;
-        _ = refData;
-        _ = navigator;
-        _ = nameResolver;
     }
 
     public PocoEffect Effect { get; }
@@ -40,5 +61,298 @@ public sealed class EffectDetailViewModel
     public int IconId => Effect.IconId;
     public string? Description => Effect.Desc;
 
+    /// <summary>Formatted duration label or <see langword="null"/> when the duration is missing/zero.</summary>
+    public string? DurationLabel { get; }
+    public string? StackingType { get; }
+
+    /// <summary>
+    /// <see cref="PocoEffect.DisplayMode"/> when non-default. The universal default
+    /// <c>"Effect"</c> is filtered out so the chip only surfaces for entries with
+    /// information content (e.g. <c>"Cocoon"</c>, <c>"Curse"</c>).
+    /// </summary>
+    public string? DisplayMode { get; }
+
+    public IReadOnlyList<EntityChipVm> KeywordChips { get; }
+    public IReadOnlyList<EffectConditionalDotRow> ConditionalDotRows { get; }
+    public IReadOnlyList<EffectConditionalSpecialValueRow> ConditionalSpecialValueRows { get; }
+
+    /// <summary>True when at least one conditional sub-table row applies — drives the section header visibility.</summary>
+    public bool HasConditionalRuleRows =>
+        ConditionalDotRows.Count > 0 || ConditionalSpecialValueRows.Count > 0;
+
+    public IReadOnlyList<EntityChipVm> StacksWithChips { get; }
+    public IReadOnlyList<EntityChipVm> RequiredByAbilityChips { get; }
+
+    /// <summary>
+    /// Overflow pill rendered after the capped <see cref="RequiredByAbilityChips"/> when the
+    /// total exceeds <c>SilmarillionSettings.RequiredByAbilitiesChipCap</c>. Anchored on
+    /// <see cref="EntityRef.AbilityByEffectKeyword"/> so clicking opens the Abilities tab
+    /// filtered by <c>EffectKeywordReqs CONTAINS "&lt;tag&gt;"</c>.
+    /// </summary>
+    public EntityChipVm? RequiredByAbilitiesOverflowPill { get; }
+
+    public IReadOnlyList<EffectProcsFromAbilityKeywordRow> ProcsFromAbilityKeywordRows { get; }
+    public string? SpewText { get; }
+
     public ICommand? OpenEntityCommand { get; }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Render the Duration field. JSON ships either an int second count, the literal string
+    /// <c>"Permanent"</c>, or a sentinel int (<c>-1</c>, <c>-2</c>). The sentinel meanings are
+    /// best-guess labels — Elder Game doesn't publish a key and reverse-engineering from
+    /// bundled data suggests <c>-1</c> = until cleansed and <c>-2</c> = until removed (e.g.
+    /// <c>effect_10003</c> Sticky! is <c>-2</c>). If a future PG patch contradicts this,
+    /// the projection needs to change — there's no automatic drift detector.
+    /// </summary>
+    private static string? FormatDuration(string? duration)
+    {
+        if (string.IsNullOrEmpty(duration)) return null;
+        if (string.Equals(duration, "Permanent", StringComparison.Ordinal)) return "Permanent";
+        if (!int.TryParse(duration, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+            return duration;
+
+        if (seconds == 0) return null;
+        if (seconds == -1) return "Until cleansed";
+        if (seconds == -2) return "Until removed";
+        if (seconds < 0) return duration;
+        if (seconds < 60) return $"{seconds} second{(seconds == 1 ? "" : "s")}";
+        if (seconds < 3600)
+        {
+            var mins = seconds / 60;
+            var remSec = seconds % 60;
+            return remSec == 0
+                ? $"{mins} minute{(mins == 1 ? "" : "s")}"
+                : $"{mins} min {remSec} sec";
+        }
+        var hours = seconds / 3600;
+        var remMin = (seconds % 3600) / 60;
+        return remMin == 0
+            ? $"{hours} hour{(hours == 1 ? "" : "s")}"
+            : $"{hours} hr {remMin} min";
+    }
+
+    /// <summary>
+    /// Filter out <see cref="PocoEffect.DisplayMode"/>'s universal default so the chip
+    /// only renders when it carries information per the cookbook's <em>Default-value
+    /// noise filtering</em> rule. <c>"Effect"</c> dominates the bundled file (the
+    /// implicit default when JSON omits the field); rare values like <c>"Cocoon"</c>
+    /// or <c>"Curse"</c> are the player-facing variants.
+    /// </summary>
+    private static string? NormaliseDisplayMode(string? raw) =>
+        string.IsNullOrEmpty(raw) || string.Equals(raw, "Effect", StringComparison.Ordinal)
+            ? null
+            : raw;
+
+    private static IReadOnlyList<EntityChipVm> BuildKeywordChips(
+        IReadOnlyList<string>? keywords,
+        IReferenceNavigator navigator)
+    {
+        if (keywords is null || keywords.Count == 0) return [];
+        var list = new List<EntityChipVm>(keywords.Count);
+        foreach (var tag in keywords)
+        {
+            if (string.IsNullOrEmpty(tag)) continue;
+            var reference = EntityRef.EffectKeyword(tag);
+            list.Add(new EntityChipVm(
+                DisplayName: tag,
+                IconId: 0,
+                Reference: reference,
+                IsNavigable: navigator.CanOpen(reference)));
+        }
+        return list;
+    }
+
+    private static IReadOnlyList<EffectConditionalDotRow> BuildConditionalDotRows(
+        PocoEffect effect, IReferenceDataService refData)
+    {
+        var rules = refData.AbilityDynamicDots;
+        if (rules.Count == 0) return [];
+
+        var list = new List<EffectConditionalDotRow>();
+        foreach (var rule in rules)
+        {
+            if (!AbilityRulePredicate.Matches(rule.ReqEffectKeywords, effect.Keywords)) continue;
+            var display = FormatDotRule(rule);
+            list.Add(new EffectConditionalDotRow(display, rule.ReqAbilityKeywords ?? []));
+        }
+        return list;
+    }
+
+    private static string FormatDotRule(AbilityDynamicDot rule)
+    {
+        // "Deals N damage per tick × M ticks of <DamageType>" — keep the format close to the
+        // bundled-data shape so the rendered prose matches in-game tooltip expectations.
+        var damageType = string.IsNullOrEmpty(rule.DamageType) ? "(unspecified)" : rule.DamageType;
+        var body = $"{rule.DamagePerTick} damage × {rule.NumTicks} ticks of {damageType}";
+
+        var gates = new List<string>();
+        if (rule.ReqAbilityKeywords is { Count: > 0 } abKw)
+            gates.Add($"ability keywords [{string.Join(", ", abKw)}]");
+        if (!string.IsNullOrEmpty(rule.ReqActiveSkill))
+            gates.Add($"active skill {rule.ReqActiveSkill}");
+
+        return gates.Count > 0 ? $"{body}, gated by {string.Join(" + ", gates)}" : body;
+    }
+
+    private static IReadOnlyList<EffectConditionalSpecialValueRow> BuildConditionalSpecialValueRows(
+        PocoEffect effect, IReferenceDataService refData)
+    {
+        var rules = refData.AbilityDynamicSpecialValues;
+        if (rules.Count == 0) return [];
+
+        var list = new List<EffectConditionalSpecialValueRow>();
+        foreach (var rule in rules)
+        {
+            if (!AbilityRulePredicate.Matches(rule.ReqEffectKeywords, effect.Keywords)) continue;
+            if (rule.SkipIfZero == true && rule.Value == 0) continue;
+            list.Add(new EffectConditionalSpecialValueRow(
+                FormatSpecialValueRule(rule),
+                rule.ReqAbilityKeywords ?? []));
+        }
+        return list;
+    }
+
+    private static string FormatSpecialValueRule(AbilityDynamicSpecialValue rule)
+    {
+        var label = string.IsNullOrEmpty(rule.Label) ? "(value)" : rule.Label;
+        var value = rule.Value.ToString("0.##", CultureInfo.InvariantCulture);
+        var suffix = string.IsNullOrEmpty(rule.Suffix) ? "" : $" {rule.Suffix}";
+        var body = $"{label} {value}{suffix}";
+
+        if (rule.ReqAbilityKeywords is { Count: > 0 } abKw)
+            return $"{body}, gated by ability keywords [{string.Join(", ", abKw)}]";
+        return body;
+    }
+
+    private static IReadOnlyList<EntityChipVm> BuildStacksWithChips(
+        PocoEffect effect,
+        string envelopeKey,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator)
+    {
+        if (string.IsNullOrEmpty(effect.StackingType)) return [];
+        if (!refData.EffectsByStackingType.TryGetValue(effect.StackingType!, out var peers)) return [];
+        if (peers.Count <= 1) return [];
+
+        var list = new List<EntityChipVm>(peers.Count - 1);
+        foreach (var peer in peers)
+        {
+            if (peer.InternalName is null) continue;
+            if (peer.InternalName == envelopeKey) continue;
+            var reference = EntityRef.Effect(peer.InternalName);
+            list.Add(new EntityChipVm(
+                DisplayName: nameResolver.Resolve(reference),
+                IconId: peer.IconId,
+                Reference: reference,
+                IsNavigable: navigator.CanOpen(reference)));
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Build the cap-limited "Required by abilities" chip list plus an optional overflow
+    /// pill. Reads the union of <c>AbilitiesByEffectKeyword[tag]</c> across every tag in
+    /// <see cref="PocoEffect.Keywords"/> (the index excludes
+    /// <see cref="Ability.InternalAbility"/> rows already). Dedupes by InternalName and
+    /// sorts by Skill then Level so the chip cluster reads consistently.
+    /// </summary>
+    private static (IReadOnlyList<EntityChipVm> Chips, EntityChipVm? Pill) BuildRequiredByAbilityChips(
+        PocoEffect effect,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator,
+        int cap)
+    {
+        if (effect.Keywords is null || effect.Keywords.Count == 0) return ([], null);
+
+        var ordered = new List<Ability>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        // Capture the first matching keyword for the overflow-pill payload — picking
+        // *some* keyword is unavoidable, and "first" is stable and matches the order
+        // the player sees in the Keywords chip strip immediately above.
+        string? pillKeyword = null;
+
+        foreach (var tag in effect.Keywords)
+        {
+            if (string.IsNullOrEmpty(tag)) continue;
+            if (!refData.AbilitiesByEffectKeyword.TryGetValue(tag, out var abilities)) continue;
+            pillKeyword ??= tag;
+            foreach (var ability in abilities)
+            {
+                if (ability.InternalName is null) continue;
+                if (!seen.Add(ability.InternalName)) continue;
+                ordered.Add(ability);
+            }
+        }
+
+        if (ordered.Count == 0) return ([], null);
+
+        ordered.Sort(static (a, b) =>
+        {
+            var skillCmp = StringComparer.OrdinalIgnoreCase.Compare(a.Skill, b.Skill);
+            if (skillCmp != 0) return skillCmp;
+            return a.Level.CompareTo(b.Level);
+        });
+
+        var visibleCount = Math.Min(cap, ordered.Count);
+        var chips = new List<EntityChipVm>(visibleCount);
+        for (var i = 0; i < visibleCount; i++)
+        {
+            var ability = ordered[i];
+            var reference = EntityRef.Ability(ability.InternalName!);
+            chips.Add(new EntityChipVm(
+                DisplayName: nameResolver.Resolve(reference),
+                IconId: ability.IconID,
+                Reference: reference,
+                IsNavigable: navigator.CanOpen(reference)));
+        }
+
+        EntityChipVm? pill = null;
+        if (ordered.Count > cap && !string.IsNullOrEmpty(pillKeyword))
+        {
+            var overflow = ordered.Count - cap;
+            var reference = EntityRef.AbilityByEffectKeyword(pillKeyword!);
+            pill = new EntityChipVm(
+                DisplayName: $"+{overflow} more →",
+                IconId: effect.IconId,
+                Reference: reference,
+                IsNavigable: navigator.CanOpen(reference));
+        }
+
+        return (chips, pill);
+    }
+
+    private static IReadOnlyList<EffectProcsFromAbilityKeywordRow> BuildProcsFromAbilityKeywordRows(
+        IReadOnlyList<string>? abilityKeywords)
+    {
+        if (abilityKeywords is null || abilityKeywords.Count == 0) return [];
+        var list = new List<EffectProcsFromAbilityKeywordRow>(abilityKeywords.Count);
+        foreach (var tag in abilityKeywords)
+        {
+            if (string.IsNullOrEmpty(tag)) continue;
+            list.Add(new EffectProcsFromAbilityKeywordRow(tag));
+        }
+        return list;
+    }
 }
+
+/// <summary>
+/// One row in <see cref="EffectDetailViewModel.ConditionalDotRows"/>. Plain projected text
+/// (predicate rules don't deep-link to entity rows). <paramref name="GatingAbilityKeywords"/>
+/// is surfaced for tooltip / future filtering use.
+/// </summary>
+public sealed record EffectConditionalDotRow(string Display, IReadOnlyList<string> GatingAbilityKeywords);
+
+/// <summary>One row in <see cref="EffectDetailViewModel.ConditionalSpecialValueRows"/>.</summary>
+public sealed record EffectConditionalSpecialValueRow(string Display, IReadOnlyList<string> GatingAbilityKeywords);
+
+/// <summary>
+/// One row in <see cref="EffectDetailViewModel.ProcsFromAbilityKeywordRows"/>. The
+/// <paramref name="Tag"/> is rendered as plain text in v1 — no synthetic kind exists
+/// yet for the abilities-keyword pivot (<see cref="EntityKind.AbilityByEffectKeyword"/>
+/// is for a different field), so navigation deferred to a follow-up.
+/// </summary>
+public sealed record EffectProcsFromAbilityKeywordRow(string Tag);

--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -44,7 +44,7 @@ public sealed class EffectDetailViewModel
         KeywordChips = BuildKeywordChips(effect.Keywords, navigator);
         ConditionalDotRows = BuildConditionalDotRows(effect, refData);
         ConditionalSpecialValueRows = BuildConditionalSpecialValueRows(effect, refData);
-        StacksWithChips = BuildStacksWithChips(effect, envelopeKey, refData, nameResolver, navigator);
+        StacksWithChip = BuildStacksWithChip(effect, envelopeKey, refData, navigator);
         var (chips, pill) = BuildRequiredByAbilityChips(effect, refData, nameResolver, navigator, settings.RequiredByAbilitiesChipCap);
         RequiredByAbilityChips = chips;
         RequiredByAbilitiesOverflowPill = pill;
@@ -80,7 +80,16 @@ public sealed class EffectDetailViewModel
     public bool HasConditionalRuleRows =>
         ConditionalDotRows.Count > 0 || ConditionalSpecialValueRows.Count > 0;
 
-    public IReadOnlyList<EntityChipVm> StacksWithChips { get; }
+    /// <summary>
+    /// Single collapsed chip representing the stacking group this effect belongs to —
+    /// label is the StackingType value with a peer-count suffix (e.g. <c>"Food (326)"</c>),
+    /// reference is <see cref="EntityRef.EffectByStackingType(string)"/>. Clicking filters
+    /// the Effects tab to <c>StackingType = "&lt;value&gt;"</c>. Null when the effect has
+    /// no StackingType or is the only entry in the group (per #259's keyword-collapse
+    /// precedent — don't fan out to per-effect chips when cardinality could be large; the
+    /// "Food" stacking group alone has hundreds of effects).
+    /// </summary>
+    public EntityChipVm? StacksWithChip { get; }
     public IReadOnlyList<EntityChipVm> RequiredByAbilityChips { get; }
 
     /// <summary>
@@ -226,30 +235,38 @@ public sealed class EffectDetailViewModel
         return body;
     }
 
-    private static IReadOnlyList<EntityChipVm> BuildStacksWithChips(
+    /// <summary>
+    /// Build the single "Stacks with" chip. Collapses what could be hundreds of per-effect
+    /// chips (the <c>"Food"</c> stacking group alone has ~326 entries) into one chip whose
+    /// label is the StackingType value plus a peer-count suffix; clicking deep-links to
+    /// the Effects tab filtered by <c>StackingType = "&lt;value&gt;"</c>. Mirrors the
+    /// keyword-collapse pattern from #259. Returns <see langword="null"/> when the effect
+    /// has no StackingType or is the only entry in its stacking group.
+    /// </summary>
+    private static EntityChipVm? BuildStacksWithChip(
         PocoEffect effect,
         string envelopeKey,
         IReferenceDataService refData,
-        IEntityNameResolver nameResolver,
         IReferenceNavigator navigator)
     {
-        if (string.IsNullOrEmpty(effect.StackingType)) return [];
-        if (!refData.EffectsByStackingType.TryGetValue(effect.StackingType!, out var peers)) return [];
-        if (peers.Count <= 1) return [];
+        if (string.IsNullOrEmpty(effect.StackingType)) return null;
+        if (!refData.EffectsByStackingType.TryGetValue(effect.StackingType!, out var peers)) return null;
 
-        var list = new List<EntityChipVm>(peers.Count - 1);
+        var peerCount = 0;
         foreach (var peer in peers)
         {
             if (peer.InternalName is null) continue;
             if (peer.InternalName == envelopeKey) continue;
-            var reference = EntityRef.Effect(peer.InternalName);
-            list.Add(new EntityChipVm(
-                DisplayName: nameResolver.Resolve(reference),
-                IconId: peer.IconId,
-                Reference: reference,
-                IsNavigable: navigator.CanOpen(reference)));
+            peerCount++;
         }
-        return list;
+        if (peerCount == 0) return null;
+
+        var reference = EntityRef.EffectByStackingType(effect.StackingType!);
+        return new EntityChipVm(
+            DisplayName: $"{effect.StackingType} ({peerCount})",
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: navigator.CanOpen(reference));
     }
 
     /// <summary>

--- a/src/Silmarillion.Module/ViewModels/EffectKeywordValue.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectKeywordValue.cs
@@ -1,0 +1,15 @@
+using Mithril.Reference;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Lightweight wrapper that lets an effect's <c>Keywords</c> list participate in the
+/// query engine's collection-<c>CONTAINS</c> path (see <see cref="IQueryStringValue"/>,
+/// shipped in PR #261). Exposes the raw keyword <see cref="Tag"/> as the queryable string
+/// so <c>Keywords CONTAINS "Buff"</c> works on the Effects tab the same way
+/// <see cref="IngredientKeywordValue"/> handles recipe-side keyword filtering.
+/// </summary>
+public sealed record EffectKeywordValue(string Tag) : IQueryStringValue
+{
+    public string QueryStringValue => Tag;
+}

--- a/src/Silmarillion.Module/ViewModels/EffectListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectListRow.cs
@@ -1,0 +1,20 @@
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Master-list row for the Silmarillion Effects tab. Wraps the <see cref="PocoEffect"/>
+/// POCO and surfaces the fields the query box and card template need (with collection
+/// fields surfaced via <see cref="EffectKeywordValue"/> wrappers so <c>CONTAINS</c>
+/// queries work). <see cref="EnvelopeKey"/> is the selection identity — names collide
+/// across effects (multiple <c>"Riposte!"</c> entries exist), so the envelope key is
+/// what selection-preservation captures across refreshes.
+/// </summary>
+public sealed record EffectListRow(
+    PocoEffect Effect,
+    string EnvelopeKey,
+    string DisplayName,
+    int IconId,
+    string? StackingType,
+    string? Duration,
+    IReadOnlyList<EffectKeywordValue> Keywords);

--- a/src/Silmarillion.Module/ViewModels/EffectsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectsTabViewModel.cs
@@ -1,0 +1,139 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Effects master-detail view-model. Mirrors <see cref="AbilitiesTabViewModel"/>'s shape:
+/// virtualized row list on the left, effect detail on the right. On selection change
+/// builds an <see cref="EffectDetailViewModel"/> for the right pane.
+/// <para>
+/// Subscribes to <see cref="IReferenceDataService.FileUpdated"/> for <c>"effects"</c> and
+/// <c>"abilities"</c> — the first drives the master list, the second feeds the on-detail
+/// "Required by abilities" cross-link (rebuilt by
+/// <c>ReferenceDataService.BuildEffectAbilityCrossLinkIndices</c> from both refresh paths).
+/// Rebuilds <see cref="AllEffects"/> on the UI thread, preserving selection by
+/// <see cref="EffectListRow.EnvelopeKey"/> — <see cref="PocoEffect.Name"/> collides across
+/// many entries (e.g. multiple <c>"Riposte!"</c> effects), so the envelope key is the
+/// only stable identity.
+/// </para>
+/// </summary>
+public sealed partial class EffectsTabViewModel : ObservableObject, ITabViewModel
+{
+    /// <summary>
+    /// Reflected schema for <see cref="EffectListRow"/> exposed to
+    /// <c>MithrilQueryBox.Schema</c> so the query box can offer completion and highlight
+    /// known column names. <c>QueryFilter</c> on the bound ListBox reflects the same
+    /// surface from the row type at attach time, so the suggestions stay in sync.
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(EffectListRow)));
+
+    public string TabHeader => "Effects";
+    public int TabOrder => 5;
+
+    private readonly IReferenceDataService _refData;
+    private readonly IReferenceNavigator _navigator;
+    private readonly IEntityNameResolver _nameResolver;
+    private readonly RelayCommand<EntityRef?> _openEntityCommand;
+
+    public EffectsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator, IEntityNameResolver nameResolver)
+    {
+        _refData = refData;
+        _navigator = navigator;
+        _nameResolver = nameResolver;
+        _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
+        _allEffects = BuildAllEffects(refData);
+        refData.FileUpdated += OnFileUpdated;
+    }
+
+    [ObservableProperty]
+    private IReadOnlyList<EffectListRow> _allEffects;
+
+    [ObservableProperty]
+    private string _queryText = "";
+
+    [ObservableProperty]
+    private string? _queryError;
+
+    [ObservableProperty]
+    private EffectListRow? _selectedRow;
+
+    [ObservableProperty]
+    private EffectDetailViewModel? _detailViewModel;
+
+    partial void OnSelectedRowChanged(EffectListRow? value)
+    {
+        if (value is null)
+        {
+            DetailViewModel = null;
+            return;
+        }
+        DetailViewModel = BuildDetailViewModel(value);
+    }
+
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        // effects.json drives the master list. abilities.json doesn't change row identity
+        // but DOES rebuild the on-detail "Required by abilities" cross-link via the shared
+        // index — rebuild the detail VM on either refresh so chip resolution reads fresh
+        // data. npcs.json doesn't affect this tab today.
+        if (fileKey is not ("effects" or "abilities"))
+            return;
+
+        UiThread.Run(() =>
+        {
+            var captured = SelectedRow?.EnvelopeKey;
+            if (fileKey == "effects")
+            {
+                AllEffects = BuildAllEffects(_refData);
+            }
+            if (!string.IsNullOrEmpty(captured))
+            {
+                var resolved = AllEffects.FirstOrDefault(r => r.EnvelopeKey == captured);
+                // Toggle through null to force OnSelectedRowChanged to rebuild the detail VM
+                // with the fresh refData snapshot.
+                SelectedRow = null;
+                SelectedRow = resolved;
+            }
+        });
+    }
+
+    private static IReadOnlyList<EffectListRow> BuildAllEffects(IReferenceDataService refData) =>
+        refData.Effects
+            .Where(kv => kv.Value is not null)
+            .Select(kv => BuildRow(kv.Key, kv.Value))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static EffectListRow BuildRow(string envelopeKey, PocoEffect effect)
+    {
+        var name = string.IsNullOrEmpty(effect.Name) ? envelopeKey : effect.Name!;
+        var keywords = (effect.Keywords ?? (IReadOnlyList<string>)[])
+            .Where(k => !string.IsNullOrEmpty(k))
+            .Select(k => new EffectKeywordValue(k))
+            .ToList();
+
+        return new EffectListRow(
+            Effect: effect,
+            EnvelopeKey: envelopeKey,
+            DisplayName: name,
+            IconId: effect.IconId,
+            StackingType: string.IsNullOrEmpty(effect.StackingType) ? null : effect.StackingType,
+            Duration: string.IsNullOrEmpty(effect.Duration) ? null : effect.Duration,
+            Keywords: keywords);
+    }
+
+    private EffectDetailViewModel BuildDetailViewModel(EffectListRow row) =>
+        new EffectDetailViewModel(
+            row.Effect,
+            row.EnvelopeKey,
+            _refData,
+            _navigator,
+            _nameResolver,
+            _openEntityCommand);
+}

--- a/src/Silmarillion.Module/ViewModels/EffectsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectsTabViewModel.cs
@@ -39,13 +39,19 @@ public sealed partial class EffectsTabViewModel : ObservableObject, ITabViewMode
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
     private readonly IEntityNameResolver _nameResolver;
+    private readonly Silmarillion.SilmarillionSettings _settings;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;
 
-    public EffectsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator, IEntityNameResolver nameResolver)
+    public EffectsTabViewModel(
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        Silmarillion.SilmarillionSettings settings)
     {
         _refData = refData;
         _navigator = navigator;
         _nameResolver = nameResolver;
+        _settings = settings;
         _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
         _allEffects = BuildAllEffects(refData);
         refData.FileUpdated += OnFileUpdated;
@@ -135,5 +141,6 @@ public sealed partial class EffectsTabViewModel : ObservableObject, ITabViewMode
             _refData,
             _navigator,
             _nameResolver,
+            _settings,
             _openEntityCommand);
 }

--- a/src/Silmarillion.Module/ViewModels/QuestDetailProjector.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestDetailProjector.cs
@@ -251,17 +251,14 @@ public static class QuestDetailProjector
 
             case HasEffectKeywordRequirement h:
                 {
-                    // Effect keywords are tags on entries in effects.json (one keyword may be
-                    // attached to multiple effects). Build a chip stub anchored on
-                    // EntityRef.Effect(keyword); _navigator.CanOpen returns false today since
-                    // the Effects tab (#244) isn't registered, so the chip degrades to plain
-                    // text. The moment the Effects kind target ships, every HasEffectKeyword
-                    // requirement across the catalogue flips to navigable without further
-                    // changes here.
+                    // A "Has effect keyword X" requirement is a predicate over effect keywords,
+                    // not a single effect row — many effects may carry the same keyword. Anchor
+                    // the chip on EntityRef.EffectKeyword(...) so clicking it filters the Effects
+                    // tab to entries whose Keywords list contains the tag.
                     if (string.IsNullOrEmpty(h.Keyword))
                         return new QuestRequirementDisplay("Has effect: (unknown)", null, false);
                     var chipName = SplitCamelCase(h.Keyword);
-                    var reference = EntityRef.Effect(h.Keyword!);
+                    var reference = EntityRef.EffectKeyword(h.Keyword!);
                     return new QuestRequirementDisplay(
                         Text: $"Has effect: {chipName}",
                         Reference: reference,

--- a/src/Silmarillion.Module/Views/AbilityDetailView.xaml
+++ b/src/Silmarillion.Module/Views/AbilityDetailView.xaml
@@ -27,13 +27,27 @@
                 </TextBlock>
             </DataTemplate>
 
-            <!-- Conditional-keyword row (trigger + applied keyword). -->
+            <!-- Conditional-keyword row (trigger + applied keyword). The trigger half is a
+                 prefix string + an optional EffectKeyword chip (rendered when the row's
+                 EffectKeywordChip is non-null); the applied half is the keyword tag the
+                 ability adds when the condition is met. -->
             <DataTemplate DataType="{x:Type vm:AbilityConditionalKeywordRow}">
                 <Border Background="#FF1F1F1F" BorderBrush="#22FFFFFF" BorderThickness="1"
                         CornerRadius="3" Padding="6,4" Margin="0,0,0,3">
                     <StackPanel>
-                        <TextBlock Text="{Binding Condition}" Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding Condition}" Foreground="#88FFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeSmall}"
+                                       VerticalAlignment="Center"/>
+                            <ContentControl Content="{Binding EffectKeywordChip}" Margin="4,0,0,0"
+                                            VerticalAlignment="Center">
+                                <ContentControl.Resources>
+                                    <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                        <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AbilityDetailView}}}"/>
+                                    </DataTemplate>
+                                </ContentControl.Resources>
+                            </ContentControl>
+                        </StackPanel>
                         <TextBlock Foreground="#CCFFFFFF"
                                    FontSize="{DynamicResource AppFontSizeHint}"
                                    TextWrapping="Wrap" Margin="0,2,0,0">
@@ -194,7 +208,7 @@
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ─── 4. Prerequisites: Prerequisite chip + UpgradeOf chip + ItemKeywordReqs chips + EffectKeywordReqs text + SpecialCasterRequirements text ─── -->
+                <!-- ─── 4. Prerequisites: Prerequisite chip + UpgradeOf chip + ItemKeywordReqs chips + EffectKeywordReqChips + SpecialCasterRequirements text ─── -->
                 <StackPanel Margin="0,0,0,10">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
@@ -209,7 +223,7 @@
                                 <DataTrigger Binding="{Binding ItemKeywordReqChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding EffectKeywordReqs.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding EffectKeywordReqChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding SpecialCasterRequirementLabels.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
@@ -261,12 +275,19 @@
                         </ItemsControl>
                     </StackPanel>
                     <StackPanel Margin="0,0,0,3"
-                                Visibility="{Binding EffectKeywordReqs.Count, Converter={StaticResource PositiveIntToVis}}">
-                        <TextBlock Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}" TextWrapping="Wrap">
-                            <Run Text="Required effect keywords: " Foreground="#88FFFFFF"/>
-                            <Run Text="{Binding EffectKeywordReqsDisplay, Mode=OneWay}"/>
-                        </TextBlock>
+                                Visibility="{Binding EffectKeywordReqChips.Count, Converter={StaticResource PositiveIntToVis}}">
+                        <TextBlock Text="Required effect keywords:" Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,2"/>
+                        <ItemsControl ItemsSource="{Binding EffectKeywordReqChips}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AbilityDetailView}}}"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </StackPanel>
                     <StackPanel Margin="0,0,0,3"
                                 Visibility="{Binding SpecialCasterRequirementLabels.Count, Converter={StaticResource PositiveIntToVis}}">
@@ -351,11 +372,38 @@
                 </StackPanel>
 
                 <!-- ─── 9. Special targeting tags ─── -->
-                <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding SpecialTargetingFlags.Count, Converter={StaticResource PositiveIntToVis}}">
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding TargetEffectKeywordReqChip, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding SpecialTargetingFlags.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock Text="Special targeting" FontWeight="SemiBold" Foreground="#88FFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding SpecialTargetingFlags}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,3"
+                                Visibility="{Binding TargetEffectKeywordReqChip, Converter={StaticResource NullOrEmptyToVis}}">
+                        <TextBlock Text="Target effect keyword:" Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl Content="{Binding TargetEffectKeywordReqChip}"
+                                        VerticalAlignment="Center">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AbilityDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
+                    </StackPanel>
+                    <ItemsControl ItemsSource="{Binding SpecialTargetingFlags}"
+                                  Visibility="{Binding SpecialTargetingFlags.Count, Converter={StaticResource PositiveIntToVis}}"/>
                 </StackPanel>
 
                 <!-- ─── 10. Pet-related ─── -->

--- a/src/Silmarillion.Module/Views/AbilityDetailView.xaml
+++ b/src/Silmarillion.Module/Views/AbilityDetailView.xaml
@@ -377,7 +377,7 @@
                         <Style TargetType="StackPanel">
                             <Setter Property="Visibility" Value="Collapsed"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding TargetEffectKeywordReqChip, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding TargetEffectKeywordReqChip, Converter={StaticResource NullToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding SpecialTargetingFlags.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
@@ -389,7 +389,7 @@
                     <TextBlock Text="Special targeting" FontWeight="SemiBold" Foreground="#88FFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,3"
-                                Visibility="{Binding TargetEffectKeywordReqChip, Converter={StaticResource NullOrEmptyToVis}}">
+                                Visibility="{Binding TargetEffectKeywordReqChip, Converter={StaticResource NullToVis}}">
                         <TextBlock Text="Target effect keyword:" Foreground="#88FFFFFF"
                                    FontSize="{DynamicResource AppFontSizeHint}"
                                    VerticalAlignment="Center" Margin="0,0,6,0"/>

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -15,6 +15,25 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- Conditional sub-table rows (DoT layered by ability + tooltip special-value). -->
+            <DataTemplate DataType="{x:Type vm:EffectConditionalDotRow}">
+                <TextBlock Text="{Binding Display}" Foreground="#CCFFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:EffectConditionalSpecialValueRow}">
+                <TextBlock Text="{Binding Display}" Foreground="#CCFFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:EffectProcsFromAbilityKeywordRow}">
+                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
+                        CornerRadius="3" Padding="6,2" Margin="0,0,4,3">
+                    <TextBlock Text="{Binding Tag}" Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeSmall}"/>
+                </Border>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -49,6 +68,154 @@
                            FontSize="{DynamicResource AppFontSizeHint}"
                            TextWrapping="Wrap" Margin="0,0,0,10"
                            Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
+
+                <!-- ─── 3. Metadata strip: duration / stacking / display mode ─── -->
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding DurationLabel, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding StackingType, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
+                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                               Margin="0,0,0,2"
+                               Visibility="{Binding DurationLabel, Converter={StaticResource NullOrEmptyToVis}}">
+                        <Run Text="Duration: " Foreground="#88FFFFFF"/>
+                        <Run Text="{Binding DurationLabel, Mode=OneWay}"/>
+                    </TextBlock>
+                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                               Margin="0,0,0,2"
+                               Visibility="{Binding StackingType, Converter={StaticResource NullOrEmptyToVis}}">
+                        <Run Text="Stacking type: " Foreground="#88FFFFFF"/>
+                        <Run Text="{Binding StackingType, Mode=OneWay}"/>
+                    </TextBlock>
+                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
+                               Margin="0,0,0,2"
+                               Visibility="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}">
+                        <Run Text="Display mode: " Foreground="#88FFFFFF"/>
+                        <Run Text="{Binding DisplayMode, Mode=OneWay}"/>
+                    </TextBlock>
+                </StackPanel>
+
+                <!-- ─── 4. Keywords ─── -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding KeywordChips.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Keywords" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding KeywordChips}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- ─── 5. Conditional rules (DoTs + Special values) ─── -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding HasConditionalRuleRows, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="Conditional rules" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <StackPanel Margin="0,0,0,4"
+                                Visibility="{Binding ConditionalDotRows.Count, Converter={StaticResource PositiveIntToVis}}">
+                        <TextBlock Text="DoT effects layered on by abilities" Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,2"/>
+                        <ItemsControl ItemsSource="{Binding ConditionalDotRows}"/>
+                    </StackPanel>
+                    <StackPanel
+                                Visibility="{Binding ConditionalSpecialValueRows.Count, Converter={StaticResource PositiveIntToVis}}">
+                        <TextBlock Text="Tooltip values surfaced by abilities" Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,2"/>
+                        <ItemsControl ItemsSource="{Binding ConditionalSpecialValueRows}"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- ─── 6. Stacks with ─── -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding StacksWithChips.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Stacks with" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding StacksWithChips}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- ─── 7. Required by abilities ─── -->
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding RequiredByAbilityChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
+                    <TextBlock Text="Required by abilities" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding RequiredByAbilityChips}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <ContentControl Content="{Binding RequiredByAbilitiesOverflowPill}"
+                                    Margin="0,4,0,0"
+                                    Visibility="{Binding RequiredByAbilitiesOverflowPill, Converter={StaticResource NullOrEmptyToVis}}">
+                        <ContentControl.Resources>
+                            <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                            </DataTemplate>
+                        </ContentControl.Resources>
+                    </ContentControl>
+                </StackPanel>
+
+                <!-- ─── 8. Procs from abilities with keyword ─── -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding ProcsFromAbilityKeywordRows.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Procs from abilities with keyword" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ItemsControl ItemsSource="{Binding ProcsFromAbilityKeywordRows}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- ─── 9. Spew text — combat float text shown on effect application/refresh ─── -->
+                <TextBlock Margin="0,0,0,10"
+                           Foreground="#88FFFFFF" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextWrapping="Wrap"
+                           Visibility="{Binding SpewText, Converter={StaticResource NullOrEmptyToVis}}">
+                    <Run Text="Combat float text: "/>
+                    <Run Text="{Binding SpewText, Mode=OneWay}"/>
+                </TextBlock>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -69,7 +69,12 @@
                            TextWrapping="Wrap" Margin="0,0,0,10"
                            Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
-                <!-- ─── 3. Metadata strip: duration / stacking / display mode ─── -->
+                <!-- ─── 3. Metadata strip: duration / stacking-type chip / display mode.
+                       The stacking-type row carries the navigation affordance (clicking the chip
+                       filters the Effects tab to peers in the same stacking group); the chip
+                       label includes a peer-count suffix so the group's size is visible at glance
+                       time. Per the design folded in from the separate 'Stacks with' section
+                       (#259's keyword-collapse precedent). -->
                 <StackPanel Margin="0,0,0,10">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
@@ -78,7 +83,7 @@
                                 <DataTrigger Binding="{Binding DurationLabel, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding StackingType, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding StackingTypeChip, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
@@ -93,12 +98,19 @@
                         <Run Text="Duration: " Foreground="#88FFFFFF"/>
                         <Run Text="{Binding DurationLabel, Mode=OneWay}"/>
                     </TextBlock>
-                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                               Margin="0,0,0,2"
-                               Visibility="{Binding StackingType, Converter={StaticResource NullOrEmptyToVis}}">
-                        <Run Text="Stacking type: " Foreground="#88FFFFFF"/>
-                        <Run Text="{Binding StackingType, Mode=OneWay}"/>
-                    </TextBlock>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,2"
+                                Visibility="{Binding StackingTypeChip, Converter={StaticResource NullOrEmptyToVis}}">
+                        <TextBlock Text="Stacking type: " Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center"/>
+                        <ContentControl Content="{Binding StackingTypeChip}" VerticalAlignment="Center">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
+                    </StackPanel>
                     <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
                                Margin="0,0,0,2"
                                Visibility="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}">
@@ -143,21 +155,9 @@
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ─── 6. Stacks with — single chip per StackingType (collapsed). Clicking
-                       filters the Effects tab to peers in the same stacking group. The label
-                       carries the peer-count suffix so the group's size is visible upfront. -->
-                <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding StacksWithChip, Converter={StaticResource NullOrEmptyToVis}}">
-                    <TextBlock Text="Stacks with" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ContentControl Content="{Binding StacksWithChip}">
-                        <ContentControl.Resources>
-                            <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
-                            </DataTemplate>
-                        </ContentControl.Resources>
-                    </ContentControl>
-                </StackPanel>
+                <!-- ─── 6. (was 'Stacks with' — folded into Section 3's StackingType chip
+                       since the standalone section was redundant once the metadata strip's
+                       row carried the navigation affordance directly.) ─── -->
 
                 <!-- ─── 7. Required by abilities ─── -->
                 <StackPanel Margin="0,0,0,10">

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -1,0 +1,55 @@
+<UserControl x:Class="Silmarillion.Views.EffectDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:EffectDetailViewModel}"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border Padding="14,12">
+        <DockPanel>
+            <!-- Footer: envelope key (mono, bottom-right) — per the detail-view convention. -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding EnvelopeKey}"
+                       Foreground="#88FFFFFF"
+                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       Margin="0,8,0,0" HorizontalAlignment="Right"
+                       VerticalAlignment="Bottom"/>
+
+            <StackPanel>
+                <!-- ─── 1. Header: icon + name ─── -->
+                <DockPanel Margin="0,0,0,10">
+                    <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                 Width="40" Height="40" Margin="0,0,10,0"
+                                 VerticalAlignment="Top"
+                                 Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding DisplayName}"
+                                   FontFamily="{DynamicResource AppHeaderFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeXLarge}"
+                                   Foreground="#FFD4A847"/>
+                    </StackPanel>
+                </DockPanel>
+
+                <!-- ─── 2. Description ─── -->
+                <TextBlock c:FormattedText.Text="{Binding Description}"
+                           Foreground="#CCFFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           TextWrapping="Wrap" Margin="0,0,0,10"
+                           Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -143,21 +143,20 @@
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ─── 6. Stacks with ─── -->
+                <!-- ─── 6. Stacks with — single chip per StackingType (collapsed). Clicking
+                       filters the Effects tab to peers in the same stacking group. The label
+                       carries the peer-count suffix so the group's size is visible upfront. -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding StacksWithChips.Count, Converter={StaticResource PositiveIntToVis}}">
+                            Visibility="{Binding StacksWithChip, Converter={StaticResource NullOrEmptyToVis}}">
                     <TextBlock Text="Stacks with" FontWeight="SemiBold" Foreground="#88FFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding StacksWithChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
+                    <ContentControl Content="{Binding StacksWithChip}">
+                        <ContentControl.Resources>
+                            <DataTemplate DataType="{x:Type c:EntityChipVm}">
                                 <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
                             </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                        </ContentControl.Resources>
+                    </ContentControl>
                 </StackPanel>
 
                 <!-- ─── 7. Required by abilities ─── -->

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -83,7 +83,7 @@
                                 <DataTrigger Binding="{Binding DurationLabel, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding StackingTypeChip, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding StackingTypeChip, Converter={StaticResource NullToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
@@ -99,7 +99,7 @@
                         <Run Text="{Binding DurationLabel, Mode=OneWay}"/>
                     </TextBlock>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,2"
-                                Visibility="{Binding StackingTypeChip, Converter={StaticResource NullOrEmptyToVis}}">
+                                Visibility="{Binding StackingTypeChip, Converter={StaticResource NullToVis}}">
                         <TextBlock Text="Stacking type: " Foreground="#88FFFFFF"
                                    FontSize="{DynamicResource AppFontSizeHint}"
                                    VerticalAlignment="Center"/>
@@ -185,7 +185,7 @@
                     </ItemsControl>
                     <ContentControl Content="{Binding RequiredByAbilitiesOverflowPill}"
                                     Margin="0,4,0,0"
-                                    Visibility="{Binding RequiredByAbilitiesOverflowPill, Converter={StaticResource NullOrEmptyToVis}}">
+                                    Visibility="{Binding RequiredByAbilitiesOverflowPill, Converter={StaticResource NullToVis}}">
                         <ContentControl.Resources>
                             <DataTemplate DataType="{x:Type c:EntityChipVm}">
                                 <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml.cs
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class EffectDetailView : UserControl
+{
+    public EffectDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/EffectDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailWindow.xaml
@@ -1,0 +1,48 @@
+<Window x:Class="Silmarillion.Views.EffectDetailWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Silmarillion.Views"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="{Binding DisplayName}"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        FontFamily="{DynamicResource AppFontFamily}"
+        FontSize="{DynamicResource AppFontSize}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+            MinWidth="360" MaxWidth="620">
+        <DockPanel>
+            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
+                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
+                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                            ToolTip="Close" Click="CloseButton_Click">
+                        <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
+                    </Button>
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                </DockPanel>
+            </Border>
+
+            <local:EffectDetailView/>
+        </DockPanel>
+    </Border>
+</Window>

--- a/src/Silmarillion.Module/Views/EffectDetailWindow.xaml.cs
+++ b/src/Silmarillion.Module/Views/EffectDetailWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Silmarillion.Views;
+
+public partial class EffectDetailWindow : Window
+{
+    public EffectDetailWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) DragMove();
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/Silmarillion.Module/Views/EffectsTabView.xaml
+++ b/src/Silmarillion.Module/Views/EffectsTabView.xaml
@@ -1,0 +1,106 @@
+<UserControl x:Class="Silmarillion.Views.EffectsTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320" MinWidth="240"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
+            <StackPanel>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:EffectsTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. Keywords CONTAINS 'Buff' AND StackingType = 'GenericBuff'"/>
+                <TextBlock Text="{Binding QueryError}"
+                           Foreground="#FFD96A6A" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="0,4,0,0"
+                           Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </Border>
+
+        <ListBox Grid.Row="1" Grid.Column="0"
+                 ItemsSource="{Binding AllEffects}"
+                 ItemTemplate="{StaticResource EffectCardTemplate}"
+                 SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                 query:QueryFilter.QueryText="{Binding QueryText}"
+                 query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"
+                 Background="#FF1A1A1A" BorderThickness="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 VirtualizingStackPanel.IsVirtualizing="True"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
+
+        <Grid Grid.Row="1" Grid.Column="1" Background="#FF1A1A1A">
+            <ScrollViewer x:Name="DetailScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <ContentControl Content="{Binding DetailViewModel}"
+                                MinHeight="{Binding ViewportHeight, ElementName=DetailScroller}">
+                    <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type vm:EffectDetailViewModel}">
+                            <local:EffectDetailView/>
+                        </DataTemplate>
+                    </ContentControl.Resources>
+                </ContentControl>
+            </ScrollViewer>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="320">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DetailViewModel}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <icon:PackIconLucide Kind="Sparkles" Width="48" Height="48"
+                                     Foreground="#33FFFFFF"
+                                     HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                <TextBlock Text="Browse Effects"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeLarge}"
+                           Foreground="#CCFFFFFF"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Select an effect to see its description, keywords, stacking peers, and the abilities that depend on it."
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Foreground="#88FFFFFF"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Silmarillion.Module/Views/EffectsTabView.xaml.cs
+++ b/src/Silmarillion.Module/Views/EffectsTabView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class EffectsTabView : UserControl
+{
+    public EffectsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml
@@ -213,8 +213,8 @@
                     </TextBlock>
                 </StackPanel>
 
-                <!-- Description -->
-                <TextBlock Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
+                <!-- Description (FormattedText parses any inline <i>/<b> markup). -->
+                <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
                            FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
                            MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                            Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>

--- a/src/Silmarillion.Module/Views/QuestDetailView.xaml
+++ b/src/Silmarillion.Module/Views/QuestDetailView.xaml
@@ -141,7 +141,7 @@
                                 <TextBlock Text="{Binding Index}" Foreground="#FFD4A847"
                                            FontSize="{DynamicResource AppFontSizeSmall}"/>
                             </Border>
-                            <TextBlock Text="{Binding Description}" Foreground="#FFFFFFFF"
+                            <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#FFFFFFFF"
                                        FontSize="{DynamicResource AppFontSizeHint}"
                                        TextWrapping="Wrap" VerticalAlignment="Center"/>
                         </DockPanel>

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -48,8 +48,8 @@
                            FontSize="{DynamicResource AppFontSizeHint}"/>
             </Border>
 
-            <!-- Description -->
-            <TextBlock Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
+            <!-- Description (FormattedText parses any inline <i>/<b> markup). -->
+            <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
                        FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
                        MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                        Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>

--- a/src/Silmarillion.Module/Views/Resources.xaml
+++ b/src/Silmarillion.Module/Views/Resources.xaml
@@ -102,6 +102,32 @@
         </DockPanel>
     </DataTemplate>
 
+    <!-- Compact two-line row for Effects tab. Bound DataContext: Silmarillion.ViewModels.EffectListRow.
+         Effects ship icon ids in most entries; secondary line shows StackingType or Duration when
+         non-null (StackingType wins because it carries more identity, Duration falls back).
+         Primary key for selection-preservation is EnvelopeKey, not DisplayName — names collide. -->
+    <DataTemplate x:Key="EffectCardTemplate">
+        <DockPanel LastChildFill="True">
+            <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                           Width="24" Height="24" Margin="6,3,6,3" VerticalAlignment="Center"/>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis">
+                    <TextBlock.Text>
+                        <PriorityBinding>
+                            <Binding Path="StackingType"/>
+                            <Binding Path="Duration"/>
+                        </PriorityBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
+
     <!-- Compact two-line row for Recipes tab. Bound DataContext: Silmarillion.ViewModels.RecipeListRow. -->
     <DataTemplate x:Key="RecipeCardTemplate">
         <DockPanel LastChildFill="True">

--- a/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml
@@ -35,6 +35,24 @@
                 tab pre-filtered to recipes using this item. Default 12. Set to 0 to always
                 collapse; raise to 100 to show everything.
             </TextBlock>
+
+            <!-- Effect detail · 'Required by abilities' chip cap -->
+            <TextBlock Text="Effect detail · 'Required by abilities' chips" Foreground="#88FFFFFF" Margin="0,0,0,6" FontWeight="SemiBold"/>
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock DockPanel.Dock="Left" Text="Show at most" VerticalAlignment="Center" Foreground="#FFE8E8E8" Width="110"/>
+                <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" Foreground="#88FFFFFF" Width="60"
+                           Text="{Binding RequiredByAbilitiesChipCap, StringFormat={}{0} chips}"/>
+                <Slider Minimum="0" Maximum="100" TickFrequency="4" IsSnapToTickEnabled="True"
+                        Value="{Binding RequiredByAbilitiesChipCap, Mode=TwoWay}"
+                        VerticalAlignment="Center" Margin="0,0,8,0"/>
+            </DockPanel>
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource AppFontSizeHint}" Foreground="#88FFFFFF" Margin="0,0,0,24">
+                Effects with broad keywords (e.g. &quot;Buff&quot;) appear on hundreds of abilities;
+                rendering every one as a chip makes the section unscannable. Above the cap, the
+                remainder collapses into a single &quot;+N more →&quot; pill that opens the
+                Abilities tab pre-filtered to abilities requiring this effect keyword. Default
+                12. Set to 0 to always collapse; raise to 100 to show everything.
+            </TextBlock>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/Silmarillion.Module/Views/SilmarillionView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionView.xaml
@@ -31,6 +31,9 @@
             <DataTemplate DataType="{x:Type vm:AbilitiesTabViewModel}">
                 <local:AbilitiesTabView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:EffectsTabViewModel}">
+                <local:EffectsTabView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.InputBindings>

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataEntityNameResolverTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataEntityNameResolverTests.cs
@@ -221,12 +221,13 @@ public sealed class ReferenceDataEntityNameResolverTests
     [Fact]
     public void UnknownKind_ReturnsInternalNameVerbatim()
     {
-        // Kinds the resolver doesn't yet have a case for (e.g. Effect/Area/PlayerTitle —
-        // not tabbed yet) return InternalName unchanged so callers render *something*
-        // readable rather than empty.
+        // Kinds the resolver doesn't yet have a case for (e.g. Area/PlayerTitle — not tabbed
+        // yet) return InternalName unchanged so callers render *something* readable rather
+        // than empty. EffectKeyword is a synthetic payload-as-display kind (the keyword tag
+        // is itself the display string), so it falls through the same path.
         var resolver = new ReferenceDataEntityNameResolver(new ResolverStub());
 
-        resolver.Resolve(EntityRef.Effect("FrostShard")).Should().Be("FrostShard");
+        resolver.Resolve(EntityRef.EffectKeyword("FrostShard")).Should().Be("FrostShard");
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceEffectCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceEffectCrossLinkIndexTests.cs
@@ -1,0 +1,255 @@
+using System.IO;
+using System.Net.Http;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cacheDir;
+    private readonly string _bundledDir;
+
+    public ReferenceDataServiceEffectCrossLinkIndexTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-ref-effect-crosslink-tests");
+        _cacheDir = Path.Combine(_root, "cache");
+        _bundledDir = Path.Combine(_root, "bundled");
+        Directory.CreateDirectory(_cacheDir);
+        Directory.CreateDirectory(_bundledDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static HttpClient NeverCallHttp() => new(new ThrowingHandler());
+
+    private void WriteFixture(string? effectsJson = null, string? abilitiesJson = null)
+    {
+        if (effectsJson is not null)
+        {
+            File.WriteAllText(Path.Combine(_bundledDir, "effects.json"), effectsJson);
+            File.WriteAllText(Path.Combine(_bundledDir, "effects.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        }
+        if (abilitiesJson is not null)
+        {
+            File.WriteAllText(Path.Combine(_bundledDir, "abilities.json"), abilitiesJson);
+            File.WriteAllText(Path.Combine(_bundledDir, "abilities.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        }
+    }
+
+    [Fact]
+    public void EffectsByInternalName_LiftsEnvelopeKey()
+    {
+        WriteFixture(effectsJson: """
+        {
+          "effect_10003": { "Name": "Sticky!", "IconId": 1, "Keywords": ["Buff"] }
+        }
+        """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.Effects.Should().ContainKey("effect_10003");
+        svc.EffectsByInternalName.Should().ContainKey("effect_10003");
+        svc.EffectsByInternalName["effect_10003"].InternalName.Should().Be("effect_10003");
+        svc.EffectsByInternalName["effect_10003"].Name.Should().Be("Sticky!");
+    }
+
+    [Fact]
+    public void EffectsByKeyword_GroupsByEachKeywordTag()
+    {
+        WriteFixture(effectsJson: """
+        {
+          "effect_1": { "Name": "A", "IconId": 1, "Keywords": ["Buff", "OrranInv"] },
+          "effect_2": { "Name": "B", "IconId": 2, "Keywords": ["Buff"] },
+          "effect_3": { "Name": "C", "IconId": 3, "Keywords": ["Debuff"] }
+        }
+        """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.EffectsByKeyword["Buff"].Should().HaveCount(2);
+        svc.EffectsByKeyword["Buff"].Select(e => e.InternalName)
+            .Should().BeEquivalentTo(["effect_1", "effect_2"]);
+        svc.EffectsByKeyword["OrranInv"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("effect_1");
+        svc.EffectsByKeyword["Debuff"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("effect_3");
+    }
+
+    [Fact]
+    public void EffectsByStackingType_GroupsByStackingType()
+    {
+        WriteFixture(effectsJson: """
+        {
+          "effect_1": { "Name": "A", "IconId": 1, "StackingType": "WordOfPowerInventory" },
+          "effect_2": { "Name": "B", "IconId": 2, "StackingType": "WordOfPowerInventory" },
+          "effect_3": { "Name": "C", "IconId": 3, "StackingType": "ShamanicHeal" },
+          "effect_4": { "Name": "D", "IconId": 4 }
+        }
+        """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.EffectsByStackingType["WordOfPowerInventory"].Should().HaveCount(2);
+        svc.EffectsByStackingType["WordOfPowerInventory"].Select(e => e.InternalName)
+            .Should().BeEquivalentTo(["effect_1", "effect_2"]);
+        svc.EffectsByStackingType["ShamanicHeal"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("effect_3");
+        // Effects with no StackingType don't appear under any key.
+        svc.EffectsByStackingType.Should().NotContainKey("");
+    }
+
+    [Fact]
+    public void AbilitiesByEffectKeyword_IndexesUnionOfThreeFields()
+    {
+        WriteFixture(
+            effectsJson: "{ }",
+            abilitiesJson: """
+            {
+              "ability_1": { "InternalName": "Req", "Name": "Req", "Skill": "Sword", "Level": 1, "IconID": 1, "EffectKeywordReqs": ["FrostShard"] },
+              "ability_2": { "InternalName": "Enabled", "Name": "Enabled", "Skill": "Sword", "Level": 2, "IconID": 2, "EffectKeywordsIndicatingEnabled": ["FrostShard"] },
+              "ability_3": { "InternalName": "TargetReq", "Name": "TargetReq", "Skill": "Sword", "Level": 3, "IconID": 3, "TargetEffectKeywordReq": "FrostShard" },
+              "ability_4": { "InternalName": "Unrelated", "Name": "Unrelated", "Skill": "Sword", "Level": 4, "IconID": 4 }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.AbilitiesByEffectKeyword.Should().ContainKey("FrostShard");
+        svc.AbilitiesByEffectKeyword["FrostShard"].Select(a => a.InternalName)
+            .Should().BeEquivalentTo(["Req", "Enabled", "TargetReq"]);
+    }
+
+    [Fact]
+    public void AbilitiesByEffectKeyword_DedupesWhenSameTagAppearsInMultipleFields()
+    {
+        WriteFixture(
+            effectsJson: "{ }",
+            abilitiesJson: """
+            {
+              "ability_1": {
+                "InternalName": "Double", "Name": "Double", "Skill": "Sword", "Level": 1, "IconID": 1,
+                "EffectKeywordReqs": ["FrostShard"],
+                "EffectKeywordsIndicatingEnabled": ["FrostShard"],
+                "TargetEffectKeywordReq": "FrostShard"
+              }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.AbilitiesByEffectKeyword["FrostShard"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("Double");
+    }
+
+    [Fact]
+    public void AbilitiesByEffectKeyword_ExcludesInternalAbilities()
+    {
+        WriteFixture(
+            effectsJson: "{ }",
+            abilitiesJson: """
+            {
+              "ability_1": { "InternalName": "Player", "Name": "Player", "Skill": "Sword", "Level": 1, "IconID": 1, "EffectKeywordReqs": ["FrostShard"] },
+              "ability_2": { "InternalName": "Mob", "Name": "Mob", "Skill": "Internal", "Level": 1, "IconID": 2, "EffectKeywordReqs": ["FrostShard"], "InternalAbility": true }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.AbilitiesByEffectKeyword["FrostShard"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("Player");
+    }
+
+    [Fact]
+    public void EffectsByTriggeringAbilityKeyword_IndexesEffectAbilityKeywords()
+    {
+        WriteFixture(effectsJson: """
+        {
+          "effect_1": { "Name": "Augury", "IconId": 1, "AbilityKeywords": ["Attack"] },
+          "effect_2": { "Name": "OtherAttack", "IconId": 2, "AbilityKeywords": ["Attack", "Ranged"] },
+          "effect_3": { "Name": "NoTrigger", "IconId": 3 }
+        }
+        """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.EffectsByTriggeringAbilityKeyword["Attack"].Should().HaveCount(2);
+        svc.EffectsByTriggeringAbilityKeyword["Attack"].Select(e => e.InternalName)
+            .Should().BeEquivalentTo(["effect_1", "effect_2"]);
+        svc.EffectsByTriggeringAbilityKeyword["Ranged"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("effect_2");
+    }
+
+    [Fact]
+    public async Task RefreshAbilities_RebuildsAbilitiesByEffectKeyword()
+    {
+        // Initial state: one ability requiring FrostShard.
+        WriteFixture(
+            effectsJson: """
+            {
+              "effect_1": { "Name": "FrostShard", "IconId": 1, "Keywords": ["FrostShard"] }
+            }
+            """,
+            abilitiesJson: """
+            {
+              "ability_1": { "InternalName": "Strike", "Name": "Strike", "Skill": "Sword", "Level": 1, "IconID": 1, "EffectKeywordReqs": ["FrostShard"] }
+            }
+            """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+        svc.AbilitiesByEffectKeyword["FrostShard"].Select(a => a.InternalName)
+            .Should().BeEquivalentTo(["Strike"]);
+
+        // Refresh abilities.json with a second ability now requiring FrostShard. The
+        // ParseAndSwapAbilities path must rebuild the effect/ability cross-link.
+        File.WriteAllText(Path.Combine(_cacheDir, "abilities.json"), """
+        {
+          "ability_1": { "InternalName": "Strike", "Name": "Strike", "Skill": "Sword", "Level": 1, "IconID": 1, "EffectKeywordReqs": ["FrostShard"] },
+          "ability_2": { "InternalName": "Slash", "Name": "Slash", "Skill": "Sword", "Level": 2, "IconID": 2, "EffectKeywordReqs": ["FrostShard"] }
+        }
+        """);
+        File.WriteAllText(Path.Combine(_cacheDir, "abilities.meta.json"), "{\"cdnVersion\":\"v2\",\"source\":1}");
+
+        // Force re-load of abilities from cache.
+        var reloaded = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+        reloaded.AbilitiesByEffectKeyword["FrostShard"].Select(a => a.InternalName)
+            .Should().BeEquivalentTo(["Strike", "Slash"]);
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public void RefreshEffects_RebuildsEffectKeywordIndices()
+    {
+        // Single-shot construction verifies the effect-side indices rebuild when
+        // ParseAndSwapEffects runs. The constructor calls LoadEffects which feeds
+        // BuildEffectAbilityCrossLinkIndices, so a populated effect set yields a
+        // populated EffectsByKeyword / EffectsByStackingType / EffectsByTriggeringAbilityKeyword.
+        WriteFixture(effectsJson: """
+        {
+          "effect_1": {
+            "Name": "Combo", "IconId": 1,
+            "Keywords": ["Buff"], "StackingType": "GenericBuff", "AbilityKeywords": ["Attack"]
+          }
+        }
+        """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.EffectsByKeyword["Buff"].Should().ContainSingle();
+        svc.EffectsByStackingType["GenericBuff"].Should().ContainSingle();
+        svc.EffectsByTriggeringAbilityKeyword["Attack"].Should().ContainSingle();
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("HTTP must not be called in this test");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceEffectCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceEffectCrossLinkIndexTests.cs
@@ -225,6 +225,49 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
     }
 
     [Fact]
+    public void RealBundledEffects_KnownEntries_ProjectSensibly()
+    {
+        // Cookbook verification-ladder step 4: walk 2-3 real entries from the bundled JSON for
+        // the kind and confirm each projects legibly with real data. Skips when the bundled
+        // file isn't co-located (some CI shapes strip them); a real failure means a future
+        // bundled-data update broke the projection contract for these entries.
+        var bundledPath = LocateBundledEffects();
+        if (bundledPath is null) return;
+
+        var json = File.ReadAllText(bundledPath);
+        var parsed = Mithril.Reference.Serialization.ReferenceDeserializer.ParseEffects(json);
+
+        // effect_10003 is Sticky! — known canonical entry referenced in the handoff doc and
+        // featuring the -2 duration sentinel that the projector maps to "Until removed".
+        parsed.Should().ContainKey("effect_10003");
+        var sticky = parsed["effect_10003"];
+        sticky.InternalName.Should().Be("effect_10003", because: "the deserializer lifts the envelope key onto InternalName");
+        sticky.Name.Should().NotBeNullOrEmpty();
+        sticky.Name.Should().NotContain("(unknown)");
+
+        // Every effect should round-trip with a populated InternalName after the lift.
+        parsed.Values.Should().OnlyContain(e => !string.IsNullOrEmpty(e.InternalName));
+
+        // The bundled set should be large enough to be meaningful — ~23k entries per the
+        // handoff. A small sanity check below catches the case where the file shipped empty
+        // (e.g. a botched CDN refresh).
+        parsed.Count.Should().BeGreaterThan(10_000);
+    }
+
+    private static string? LocateBundledEffects()
+    {
+        // Walk up from the test binary toward the repo root looking for the bundled file.
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 10 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, "src", "Mithril.Shared", "Reference", "BundledData", "effects.json");
+            if (File.Exists(candidate)) return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        return null;
+    }
+
+    [Fact]
     public void RefreshEffects_RebuildsEffectKeywordIndices()
     {
         // Single-shot construction verifies the effect-side indices rebuild when

--- a/tests/Silmarillion.Tests/Navigation/AbilityByEffectKeywordKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/AbilityByEffectKeywordKindTargetTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class AbilityByEffectKeywordKindTargetTests
+{
+    [Fact]
+    public void Kind_IsAbilityByEffectKeyword()
+    {
+        var (target, _) = Build();
+        target.Kind.Should().Be(EntityKind.AbilityByEffectKeyword);
+    }
+
+    [Fact]
+    public void TabIndex_IsFour()
+    {
+        // Lands on the Abilities tab — pre-filtered by EffectKeywordReqs CONTAINS "<tag>".
+        var (target, _) = Build();
+        target.TabIndex.Should().Be(4);
+    }
+
+    [Fact]
+    public void TryOpenInWindow_ReturnsFalse()
+    {
+        var (target, _) = Build();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_SetsEffectKeywordReqsContainsFilter()
+    {
+        var (target, vm) = Build();
+
+        var ok = target.TrySelectByInternalName("FrostShard");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().Be("EffectKeywordReqs CONTAINS \"FrostShard\"");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_EmptyKeyword_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm) = Build();
+
+        target.TrySelectByInternalName("").Should().BeFalse();
+        vm.QueryText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsPriorSelection_SoFilteredListHasNoStaleRow()
+    {
+        var ability = new Ability { InternalName = "Strike", Name = "Strike", Skill = "Sword", Level = 1, EffectKeywordReqs = ["FrostShard"] };
+        var (target, vm) = Build(("ability_1", ability));
+        vm.SelectedRow = vm.AllAbilities.Single();
+        vm.SelectedRow.Should().NotBeNull();
+
+        target.TrySelectByInternalName("FrostShard").Should().BeTrue();
+
+        vm.SelectedRow.Should().BeNull(because: "filter-only navigation must drop any stale detail selection");
+    }
+
+    private static (AbilityByEffectKeywordKindTarget Target, AbilitiesTabViewModel Vm) Build(
+        params (string Key, Ability Ability)[] abilities)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, ability) in abilities) refData.AddAbility(key, ability);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new AbilitiesTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData));
+        return (new AbilityByEffectKeywordKindTarget(vm), vm);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, Ability> _byKey = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Ability> _byInternalName = new(StringComparer.Ordinal);
+
+        public void AddAbility(string key, Ability ability)
+        {
+            _byKey[key] = ability;
+            if (!string.IsNullOrEmpty(ability.InternalName))
+                _byInternalName[ability.InternalName!] = ability;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public IReadOnlyDictionary<string, Ability> Abilities => _byKey;
+        public IReadOnlyDictionary<string, Ability> AbilitiesByInternalName => _byInternalName;
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/EffectByStackingTypeKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/EffectByStackingTypeKindTargetTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class EffectByStackingTypeKindTargetTests
+{
+    [Fact]
+    public void Kind_IsEffectByStackingType()
+    {
+        var (target, _) = Build();
+        target.Kind.Should().Be(EntityKind.EffectByStackingType);
+    }
+
+    [Fact]
+    public void TabIndex_IsFive()
+    {
+        var (target, _) = Build();
+        target.TabIndex.Should().Be(5);
+    }
+
+    [Fact]
+    public void TryOpenInWindow_ReturnsFalse()
+    {
+        var (target, _) = Build();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_SetsStackingTypeEqualsFilter()
+    {
+        var (target, vm) = Build();
+
+        var ok = target.TrySelectByInternalName("Food");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().Be("StackingType = \"Food\"");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_EmptyValue_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm) = Build();
+
+        target.TrySelectByInternalName("").Should().BeFalse();
+        vm.QueryText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsPriorSelection_SoFilteredListHasNoStaleRow()
+    {
+        var (target, vm) = Build(
+            ("effect_1", new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, StackingType = "Food" }));
+        vm.SelectedRow = vm.AllEffects.Single();
+
+        target.TrySelectByInternalName("Food").Should().BeTrue();
+
+        vm.SelectedRow.Should().BeNull(because: "filter-only navigation must drop any stale detail selection");
+    }
+
+    private static (EffectByStackingTypeKindTarget Target, EffectsTabViewModel Vm) Build(
+        params (string Key, PocoEffect Effect)[] effects)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, eff) in effects) refData.AddEffect(key, eff);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var settings = new SilmarillionSettings();
+        var vm = new EffectsTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData), settings);
+        return (new EffectByStackingTypeKindTarget(vm), vm);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, PocoEffect> _effectsByKey = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, PocoEffect> _effectsByInternalName = new(StringComparer.Ordinal);
+
+        public void AddEffect(string key, PocoEffect effect)
+        {
+            _effectsByKey[key] = effect;
+            if (!string.IsNullOrEmpty(effect.InternalName))
+                _effectsByInternalName[effect.InternalName!] = effect;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public IReadOnlyDictionary<string, PocoEffect> Effects => _effectsByKey;
+        public IReadOnlyDictionary<string, PocoEffect> EffectsByInternalName => _effectsByInternalName;
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/EffectKeywordKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/EffectKeywordKindTargetTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class EffectKeywordKindTargetTests
+{
+    [Fact]
+    public void Kind_IsEffectKeyword()
+    {
+        var (target, _) = Build();
+        target.Kind.Should().Be(EntityKind.EffectKeyword);
+    }
+
+    [Fact]
+    public void TabIndex_IsFive()
+    {
+        var (target, _) = Build();
+        target.TabIndex.Should().Be(5);
+    }
+
+    [Fact]
+    public void TryOpenInWindow_ReturnsFalse()
+    {
+        var (target, _) = Build();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_SetsKeywordsContainsFilter()
+    {
+        var (target, vm) = Build();
+
+        var ok = target.TrySelectByInternalName("FrostShard");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().Be("Keywords CONTAINS \"FrostShard\"");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_EmptyKeyword_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm) = Build();
+
+        target.TrySelectByInternalName("").Should().BeFalse();
+        vm.QueryText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsPriorSelection_SoFilteredListHasNoStaleRow()
+    {
+        var (target, vm) = Build(
+            ("effect_1", new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["FrostShard"] }));
+        vm.SelectedRow = vm.AllEffects.Single();
+
+        target.TrySelectByInternalName("FrostShard").Should().BeTrue();
+
+        vm.SelectedRow.Should().BeNull(because: "filter-only navigation must drop any stale detail selection");
+    }
+
+    private static (EffectKeywordKindTarget Target, EffectsTabViewModel Vm) Build(
+        params (string Key, PocoEffect Effect)[] effects)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, eff) in effects) refData.AddEffect(key, eff);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var settings = new SilmarillionSettings();
+        var vm = new EffectsTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData), settings);
+        return (new EffectKeywordKindTarget(vm), vm);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, PocoEffect> _effectsByKey = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, PocoEffect> _effectsByInternalName = new(StringComparer.Ordinal);
+
+        public void AddEffect(string key, PocoEffect effect)
+        {
+            _effectsByKey[key] = effect;
+            if (!string.IsNullOrEmpty(effect.InternalName))
+                _effectsByInternalName[effect.InternalName!] = effect;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public IReadOnlyDictionary<string, PocoEffect> Effects => _effectsByKey;
+        public IReadOnlyDictionary<string, PocoEffect> EffectsByInternalName => _effectsByInternalName;
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/EffectsKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/EffectsKindTargetTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class EffectsKindTargetTests
+{
+    [Fact]
+    public void Kind_IsEffect()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Effect);
+    }
+
+    [Fact]
+    public void TabIndex_IsFive()
+    {
+        // Items=0, Recipes=1, NPCs=2, Quests=3, Abilities=4, Effects=5 — sixth tab.
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(5);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownEffect_SelectsOnTabVm_ReturnsTrue()
+    {
+        var (target, vm, _) = BuildTarget(
+            ("effect_10003", new PocoEffect { InternalName = "effect_10003", Name = "Sticky!", IconId = 42 }));
+
+        var ok = target.TrySelectByInternalName("effect_10003");
+
+        ok.Should().BeTrue();
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRow!.EnvelopeKey.Should().Be("effect_10003");
+        vm.DetailViewModel.Should().NotBeNull();
+        vm.DetailViewModel!.DisplayName.Should().Be("Sticky!");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownEffect_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        vm.SelectedRow.Should().BeNull();
+
+        target.TrySelectByInternalName("effect_99999").Should().BeFalse();
+        vm.SelectedRow.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsResidualQueryText_SoTargetRowIsVisible()
+    {
+        var (target, vm, _) = BuildTarget(
+            ("effect_1", new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["Buff"] }));
+        vm.QueryText = "Keywords CONTAINS 'Debuff'";
+
+        var ok = target.TrySelectByInternalName("effect_1");
+
+        ok.Should().BeTrue();
+        vm.QueryText.Should().BeEmpty(because: "the kind target clears any prior filter before selecting");
+        vm.SelectedRow!.EnvelopeKey.Should().Be("effect_1");
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (EffectsKindTarget Target, EffectsTabViewModel Vm, FakeReferenceData RefData) BuildTarget(
+        params (string Key, PocoEffect Effect)[] effects)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, eff) in effects) refData.AddEffect(key, eff);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var settings = new SilmarillionSettings();
+        var vm = new EffectsTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData), settings);
+        var target = new EffectsKindTarget(vm);
+        return (target, vm, refData);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, PocoEffect> _effectsByKey = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, PocoEffect> _effectsByInternalName = new(StringComparer.Ordinal);
+
+        public void AddEffect(string key, PocoEffect effect)
+        {
+            _effectsByKey[key] = effect;
+            if (!string.IsNullOrEmpty(effect.InternalName))
+                _effectsByInternalName[effect.InternalName!] = effect;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public IReadOnlyDictionary<string, PocoEffect> Effects => _effectsByKey;
+        public IReadOnlyDictionary<string, PocoEffect> EffectsByInternalName => _effectsByInternalName;
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
@@ -85,6 +85,7 @@ public sealed class SilmarillionDeepLinkHandlerTests
     [InlineData("npc/Marna", EntityKind.Npc, "Marna")]
     [InlineData("ability/Hatchet", EntityKind.Ability, "Hatchet")]
     [InlineData("quest/RuminationsOfAYoungMan", EntityKind.Quest, "RuminationsOfAYoungMan")]
+    [InlineData("effect/effect_10003", EntityKind.Effect, "effect_10003")]
     public void TryHandle_DispatchesAnyEntityKindTheNavigatorAccepts(
         string subPath, EntityKind expectedKind, string expectedName)
     {

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -348,6 +348,99 @@ public sealed class SilmarillionReferenceNavigatorTests
         recipesVm.QueryText.Should().Be("IngredientKeywords CONTAINS \"Crystal\"");
     }
 
+    [Fact]
+    public void Open_Effect_SwitchesToEffectsTab_AndSelects()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddEffect(new Mithril.Reference.Models.Effects.Effect { InternalName = "effect_10003", Name = "Sticky!", IconId = 42 });
+        var settings = new Silmarillion.SilmarillionSettings();
+        var effectsVm = new EffectsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var effectsTarget = new EffectsKindTarget(effectsVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            effectsTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(new ITabViewModel[] { effectsVm }, nav, targets);
+
+        nav.Open(EntityRef.Effect("effect_10003"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(5);
+        effectsVm.SelectedRow.Should().NotBeNull();
+        effectsVm.SelectedRow!.EnvelopeKey.Should().Be("effect_10003");
+    }
+
+    [Fact]
+    public void Open_EffectKeyword_SwitchesToEffectsTab_AndSetsQueryText()
+    {
+        var refData = new FakeReferenceData();
+        var settings = new Silmarillion.SilmarillionSettings();
+        var effectsVm = new EffectsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var keywordTarget = new EffectKeywordKindTarget(effectsVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            keywordTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(new ITabViewModel[] { effectsVm }, nav, targets);
+
+        nav.Open(EntityRef.EffectKeyword("FrostShard"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(5);
+        effectsVm.QueryText.Should().Be("Keywords CONTAINS \"FrostShard\"");
+    }
+
+    [Fact]
+    public void Open_AbilityByEffectKeyword_SwitchesToAbilitiesTab_AndSetsQueryText()
+    {
+        var refData = new FakeReferenceData();
+        var abilitiesVm = new AbilitiesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+        var pillTarget = new AbilityByEffectKeywordKindTarget(abilitiesVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            pillTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(new ITabViewModel[] { abilitiesVm }, nav, targets);
+
+        nav.Open(EntityRef.AbilityByEffectKeyword("FrostShard"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(4);
+        abilitiesVm.QueryText.Should().Be("EffectKeywordReqs CONTAINS \"FrostShard\"");
+    }
+
+    [Fact]
+    public void Constructor_DuplicateGuard_TripsForEffectAndEffectKeyword()
+    {
+        // Verifies the duplicate-registration guard still trips with the new kinds in the mix.
+        var dupEffect = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Effect),
+            new StubTarget(EntityKind.Effect),
+        };
+        Action act1 = () => new SilmarillionReferenceNavigator(dupEffect);
+        act1.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Duplicate IReferenceKindTarget*Effect*");
+
+        var dupEffectKeyword = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.EffectKeyword),
+            new StubTarget(EntityKind.EffectKeyword),
+        };
+        Action act2 = () => new SilmarillionReferenceNavigator(dupEffectKeyword);
+        act2.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Duplicate IReferenceKindTarget*EffectKeyword*");
+    }
+
     private static IEnumerable<IReferenceKindTarget> NavTargets() => new IReferenceKindTarget[]
     {
         new StubTarget(EntityKind.Item),
@@ -369,6 +462,8 @@ public sealed class SilmarillionReferenceNavigatorTests
         private readonly Dictionary<string, Recipe> _recipesByInternalName = new(StringComparer.Ordinal);
         private readonly Dictionary<long, Item> _itemsById = new();
         private readonly Dictionary<string, Item> _itemsByInternalName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Mithril.Reference.Models.Effects.Effect> _effects = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Mithril.Reference.Models.Abilities.Ability> _abilitiesByInternalName = new(StringComparer.Ordinal);
 
         public void AddRecipe(Recipe recipe)
         {
@@ -380,6 +475,16 @@ public sealed class SilmarillionReferenceNavigatorTests
         {
             _itemsById[item.Id] = item;
             if (item.InternalName is not null) _itemsByInternalName[item.InternalName] = item;
+        }
+
+        public void AddEffect(Mithril.Reference.Models.Effects.Effect effect)
+        {
+            if (effect.InternalName is not null) _effects[effect.InternalName] = effect;
+        }
+
+        public void AddAbility(Mithril.Reference.Models.Abilities.Ability ability)
+        {
+            if (ability.InternalName is not null) _abilitiesByInternalName[ability.InternalName] = ability;
         }
 
         public IReadOnlyList<string> Keys => Array.Empty<string>();
@@ -399,6 +504,9 @@ public sealed class SilmarillionReferenceNavigatorTests
         public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> Quests { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
         public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> QuestsByInternalName { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
         public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Effects.Effect> Effects => _effects;
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Effects.Effect> EffectsByInternalName => _effects;
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Abilities.Ability> AbilitiesByInternalName => _abilitiesByInternalName;
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
         public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/tests/Silmarillion.Tests/ViewModels/AbilitiesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/AbilitiesTabViewModelTests.cs
@@ -246,7 +246,7 @@ public sealed class AbilitiesTabViewModelTests
             EffectKeywordReqs = ["BattleRage"],
         };
         var refData = new StubReferenceData { AbilitiesByKey = { ["ability_1"] = ability } };
-        var vm = new AbilitiesTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword), new ReferenceDataEntityNameResolver(refData));
+        var vm = new AbilitiesTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword, EntityKind.EffectKeyword), new ReferenceDataEntityNameResolver(refData));
 
         vm.SelectedRow = vm.AllAbilities.Single();
         var detail = vm.DetailViewModel!;
@@ -256,7 +256,13 @@ public sealed class AbilitiesTabViewModelTests
         chip.DisplayName.Should().Be("Sword");
         chip.Reference.Kind.Should().Be(EntityKind.ItemKeyword);
         chip.IsNavigable.Should().BeTrue();
-        detail.EffectKeywordReqs.Should().Equal(["BattleRage"]);
+
+        detail.EffectKeywordReqChips.Should().ContainSingle();
+        var effectChip = detail.EffectKeywordReqChips[0];
+        effectChip.DisplayName.Should().Be("BattleRage");
+        effectChip.Reference.Kind.Should().Be(EntityKind.EffectKeyword);
+        effectChip.Reference.InternalName.Should().Be("BattleRage");
+        effectChip.IsNavigable.Should().BeTrue();
     }
 
     [Fact]
@@ -275,7 +281,7 @@ public sealed class AbilitiesTabViewModelTests
             },
         };
         var refData = new StubReferenceData { AbilitiesByKey = { ["ability_1"] = ability } };
-        var vm = new AbilitiesTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+        var vm = new AbilitiesTabViewModel(refData, NavFactory.WithKinds(EntityKind.EffectKeyword), new ReferenceDataEntityNameResolver(refData));
 
         vm.SelectedRow = vm.AllAbilities.Single();
         var rows = vm.DetailViewModel!.ConditionalKeywordRows;
@@ -283,8 +289,15 @@ public sealed class AbilitiesTabViewModelTests
         rows.Should().HaveCount(2);
         rows[0].Keyword.Should().Be("Melee");
         rows[0].Condition.Should().Be("Default");
+        rows[0].EffectKeywordChip.Should().BeNull();
         rows[1].Keyword.Should().Be("Burst");
-        rows[1].Condition.Should().Be("When effect keyword present: ManyCutsAoE");
+        rows[1].Condition.Should().Be("When effect keyword present:");
+        var burstChip = rows[1].EffectKeywordChip;
+        burstChip.Should().NotBeNull();
+        burstChip!.DisplayName.Should().Be("ManyCutsAoE");
+        burstChip.Reference.Kind.Should().Be(EntityKind.EffectKeyword);
+        burstChip.Reference.InternalName.Should().Be("ManyCutsAoE");
+        burstChip.IsNavigable.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
@@ -128,10 +128,11 @@ public sealed class EffectsTabViewModelTests
     }
 
     [Fact]
-    public void DetailViewModel_StacksWith_CollapsesToSingleChipPerStackingType_WithPeerCountSuffix()
+    public void DetailViewModel_StackingType_RendersAsMetadataStripChip_WithPeerCountSuffix()
     {
         // Per #259's keyword-collapse precedent: a stacking group like "Food" (~326 effects)
-        // would produce an unscannable chip wall. Render a single chip whose label includes
+        // would produce an unscannable chip wall. Render a single chip in the metadata strip
+        // (folded in from the original standalone "Stacks with" section) whose label includes
         // the peer count, and whose click filters the Effects tab.
         var sticky = new PocoEffect { InternalName = "effect_1", Name = "Sticky 1", IconId = 1, StackingType = "Sticky" };
         var sticky2 = new PocoEffect { InternalName = "effect_2", Name = "Sticky 2", IconId = 2, StackingType = "Sticky" };
@@ -156,7 +157,7 @@ public sealed class EffectsTabViewModelTests
             new SilmarillionSettings());
 
         vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_1");
-        var chip = vm.DetailViewModel!.StacksWithChip;
+        var chip = vm.DetailViewModel!.StackingTypeChip;
 
         chip.Should().NotBeNull();
         chip!.DisplayName.Should().Be("Sticky (2)", because: "the chip carries the StackingType plus a peer-count suffix");
@@ -166,7 +167,7 @@ public sealed class EffectsTabViewModelTests
     }
 
     [Fact]
-    public void DetailViewModel_StacksWith_NullWhenNoStackingType()
+    public void DetailViewModel_StackingType_NullWhenNoStackingType()
     {
         var refData = new StubReferenceData
         {
@@ -175,11 +176,11 @@ public sealed class EffectsTabViewModelTests
         var vm = BuildVm(refData);
 
         vm.SelectedRow = vm.AllEffects.Single();
-        vm.DetailViewModel!.StacksWithChip.Should().BeNull();
+        vm.DetailViewModel!.StackingTypeChip.Should().BeNull();
     }
 
     [Fact]
-    public void DetailViewModel_StacksWith_NullWhenSoleMemberOfGroup()
+    public void DetailViewModel_StackingType_NullWhenSoleMemberOfGroup()
     {
         var lone = new PocoEffect { InternalName = "effect_1", Name = "Solo", StackingType = "Unique" };
         var refData = new StubReferenceData
@@ -190,7 +191,7 @@ public sealed class EffectsTabViewModelTests
         var vm = BuildVm(refData);
 
         vm.SelectedRow = vm.AllEffects.Single();
-        vm.DetailViewModel!.StacksWithChip.Should().BeNull(because: "no peers means no useful filter target");
+        vm.DetailViewModel!.StackingTypeChip.Should().BeNull(because: "no peers means no useful filter target");
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
@@ -128,8 +128,11 @@ public sealed class EffectsTabViewModelTests
     }
 
     [Fact]
-    public void DetailViewModel_StacksWith_ListsSiblingsWithSameStackingType_ExcludingSelf()
+    public void DetailViewModel_StacksWith_CollapsesToSingleChipPerStackingType_WithPeerCountSuffix()
     {
+        // Per #259's keyword-collapse precedent: a stacking group like "Food" (~326 effects)
+        // would produce an unscannable chip wall. Render a single chip whose label includes
+        // the peer count, and whose click filters the Effects tab.
         var sticky = new PocoEffect { InternalName = "effect_1", Name = "Sticky 1", IconId = 1, StackingType = "Sticky" };
         var sticky2 = new PocoEffect { InternalName = "effect_2", Name = "Sticky 2", IconId = 2, StackingType = "Sticky" };
         var sticky3 = new PocoEffect { InternalName = "effect_3", Name = "Sticky 3", IconId = 3, StackingType = "Sticky" };
@@ -146,15 +149,48 @@ public sealed class EffectsTabViewModelTests
                 ["Sticky"] = new[] { sticky, sticky2, sticky3 },
             },
         };
-        var vm = BuildVm(refData);
+        var vm = new EffectsTabViewModel(
+            refData,
+            NavFactory.WithKinds(EntityKind.EffectByStackingType),
+            new ReferenceDataEntityNameResolver(refData),
+            new SilmarillionSettings());
 
         vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_1");
-        var chips = vm.DetailViewModel!.StacksWithChips;
+        var chip = vm.DetailViewModel!.StacksWithChip;
 
-        chips.Select(c => c.Reference.InternalName)
-            .Should().BeEquivalentTo("effect_2", "effect_3");
-        chips.Select(c => c.Reference.Kind)
-            .Should().AllBeEquivalentTo(EntityKind.Effect);
+        chip.Should().NotBeNull();
+        chip!.DisplayName.Should().Be("Sticky (2)", because: "the chip carries the StackingType plus a peer-count suffix");
+        chip.Reference.Kind.Should().Be(EntityKind.EffectByStackingType);
+        chip.Reference.InternalName.Should().Be("Sticky");
+        chip.IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetailViewModel_StacksWith_NullWhenNoStackingType()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "Loner" } },
+        };
+        var vm = BuildVm(refData);
+
+        vm.SelectedRow = vm.AllEffects.Single();
+        vm.DetailViewModel!.StacksWithChip.Should().BeNull();
+    }
+
+    [Fact]
+    public void DetailViewModel_StacksWith_NullWhenSoleMemberOfGroup()
+    {
+        var lone = new PocoEffect { InternalName = "effect_1", Name = "Solo", StackingType = "Unique" };
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_1"] = lone },
+            EffectsByStackingTypeMap = { ["Unique"] = new[] { lone } },
+        };
+        var vm = BuildVm(refData);
+
+        vm.SelectedRow = vm.AllEffects.Single();
+        vm.DetailViewModel!.StacksWithChip.Should().BeNull(because: "no peers means no useful filter target");
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
@@ -1,0 +1,368 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Misc;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using PocoEffect = Mithril.Reference.Models.Effects.Effect;
+
+namespace Silmarillion.Tests.ViewModels;
+
+file static class NavFactory
+{
+    public static SilmarillionReferenceNavigator WithKinds(params EntityKind[] kinds) =>
+        new(kinds.Select(k => (IReferenceKindTarget)new StubKindTarget(k)));
+
+    private sealed class StubKindTarget : IReferenceKindTarget
+    {
+        public StubKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+}
+
+public sealed class EffectsTabViewModelTests
+{
+    [Fact]
+    public void AllEffects_PopulatedFromReferenceData_OrderedByDisplayName()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "Bravery", IconId = 1 },
+                ["effect_2"] = new PocoEffect { InternalName = "effect_2", Name = "Aegis", IconId = 2 },
+            },
+        };
+
+        var vm = BuildVm(refData);
+
+        vm.AllEffects.Should().HaveCount(2);
+        vm.AllEffects.Select(r => r.DisplayName).Should().Equal("Aegis", "Bravery");
+    }
+
+    [Fact]
+    public void EffectListRow_NameFallsBackToEnvelopeKey_WhenPocoNameIsEmpty()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_999"] = new PocoEffect { InternalName = "effect_999", Name = "" } },
+        };
+
+        var vm = BuildVm(refData);
+
+        vm.AllEffects.Single().DisplayName.Should().Be("effect_999");
+    }
+
+    [Fact]
+    public void EffectListRow_SurfacesKeywordsAsCONTAINSQueryableValues()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "Buff", Keywords = ["Buff", "Allied"] },
+            },
+        };
+
+        var vm = BuildVm(refData);
+
+        vm.AllEffects.Single().Keywords.Select(k => k.Tag).Should().BeEquivalentTo("Buff", "Allied");
+    }
+
+    [Fact]
+    public void SchemaSnapshot_IncludesKeywordsColumn_SoQueryCompletionCanSuggestIt()
+    {
+        EffectsTabViewModel.SchemaSnapshot.Select(c => c.Name).Should().Contain("Keywords");
+    }
+
+    [Fact]
+    public void Selection_RebuildsDetailViewModel_OnRowSelect()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "Sticky!", IconId = 42, Keywords = ["Sticky"] },
+            },
+        };
+        var vm = BuildVm(refData);
+
+        vm.SelectedRow = vm.AllEffects.Single();
+
+        vm.DetailViewModel.Should().NotBeNull();
+        vm.DetailViewModel!.DisplayName.Should().Be("Sticky!");
+        vm.DetailViewModel.IconId.Should().Be(42);
+    }
+
+    [Fact]
+    public void DetailViewModel_KeywordChips_AnchorOnEffectKeywordKind_AndAreNavigableWhenTargetRegistered()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "X", Keywords = ["FrostShard"] },
+            },
+        };
+        var vm = new EffectsTabViewModel(
+            refData,
+            NavFactory.WithKinds(EntityKind.EffectKeyword),
+            new ReferenceDataEntityNameResolver(refData),
+            new SilmarillionSettings());
+
+        vm.SelectedRow = vm.AllEffects.Single();
+        var chips = vm.DetailViewModel!.KeywordChips;
+
+        chips.Should().ContainSingle();
+        chips[0].DisplayName.Should().Be("FrostShard");
+        chips[0].Reference.Kind.Should().Be(EntityKind.EffectKeyword);
+        chips[0].IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetailViewModel_StacksWith_ListsSiblingsWithSameStackingType_ExcludingSelf()
+    {
+        var sticky = new PocoEffect { InternalName = "effect_1", Name = "Sticky 1", IconId = 1, StackingType = "Sticky" };
+        var sticky2 = new PocoEffect { InternalName = "effect_2", Name = "Sticky 2", IconId = 2, StackingType = "Sticky" };
+        var sticky3 = new PocoEffect { InternalName = "effect_3", Name = "Sticky 3", IconId = 3, StackingType = "Sticky" };
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = sticky,
+                ["effect_2"] = sticky2,
+                ["effect_3"] = sticky3,
+            },
+            EffectsByStackingTypeMap =
+            {
+                ["Sticky"] = new[] { sticky, sticky2, sticky3 },
+            },
+        };
+        var vm = BuildVm(refData);
+
+        vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_1");
+        var chips = vm.DetailViewModel!.StacksWithChips;
+
+        chips.Select(c => c.Reference.InternalName)
+            .Should().BeEquivalentTo("effect_2", "effect_3");
+        chips.Select(c => c.Reference.Kind)
+            .Should().AllBeEquivalentTo(EntityKind.Effect);
+    }
+
+    [Fact]
+    public void DetailViewModel_RequiredByAbilities_BuildsChipsFromIndex_AndAddsOverflowPillBeyondCap()
+    {
+        var effect = new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["FrostShard"] };
+        var abilities = Enumerable.Range(1, 15)
+            .Select(i => new Ability { InternalName = $"Strike{i}", Name = $"Strike {i}", Skill = "Sword", Level = i, IconID = 100 + i })
+            .ToList();
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_1"] = effect },
+            AbilitiesByEffectKeywordMap = { ["FrostShard"] = abilities },
+        };
+        var settings = new SilmarillionSettings { RequiredByAbilitiesChipCap = 12 };
+        var vm = new EffectsTabViewModel(
+            refData,
+            NavFactory.WithKinds(EntityKind.Ability, EntityKind.AbilityByEffectKeyword),
+            new ReferenceDataEntityNameResolver(refData),
+            settings);
+
+        vm.SelectedRow = vm.AllEffects.Single();
+        var detail = vm.DetailViewModel!;
+
+        detail.RequiredByAbilityChips.Should().HaveCount(12);
+        detail.RequiredByAbilitiesOverflowPill.Should().NotBeNull();
+        detail.RequiredByAbilitiesOverflowPill!.DisplayName.Should().Be("+3 more →");
+        detail.RequiredByAbilitiesOverflowPill.Reference.Kind.Should().Be(EntityKind.AbilityByEffectKeyword);
+        detail.RequiredByAbilitiesOverflowPill.Reference.InternalName.Should().Be("FrostShard");
+        detail.RequiredByAbilitiesOverflowPill.IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetailViewModel_RequiredByAbilities_NoOverflowPill_WhenCountWithinCap()
+    {
+        var effect = new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["FrostShard"] };
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_1"] = effect },
+            AbilitiesByEffectKeywordMap =
+            {
+                ["FrostShard"] = new[]
+                {
+                    new Ability { InternalName = "Strike", Name = "Strike", Skill = "Sword", Level = 1 },
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+
+        vm.SelectedRow = vm.AllEffects.Single();
+        var detail = vm.DetailViewModel!;
+
+        detail.RequiredByAbilityChips.Should().ContainSingle();
+        detail.RequiredByAbilitiesOverflowPill.Should().BeNull();
+    }
+
+    [Fact]
+    public void Duration_MapsSentinels_ToFriendlyLabels()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_p"] = new PocoEffect { InternalName = "effect_p", Name = "P", Duration = "Permanent" },
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "A", Duration = "-1" },
+                ["effect_2"] = new PocoEffect { InternalName = "effect_2", Name = "B", Duration = "-2" },
+                ["effect_30"] = new PocoEffect { InternalName = "effect_30", Name = "C", Duration = "30" },
+                ["effect_180"] = new PocoEffect { InternalName = "effect_180", Name = "D", Duration = "180" },
+            },
+        };
+        var vm = BuildVm(refData);
+
+        Label(vm, "effect_p").Should().Be("Permanent");
+        Label(vm, "effect_1").Should().Be("Until cleansed");
+        Label(vm, "effect_2").Should().Be("Until removed");
+        Label(vm, "effect_30").Should().Be("30 seconds");
+        Label(vm, "effect_180").Should().Be("3 minutes");
+
+        static string? Label(EffectsTabViewModel vm, string envelopeKey)
+        {
+            vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == envelopeKey);
+            return vm.DetailViewModel!.DurationLabel;
+        }
+    }
+
+    [Fact]
+    public void DisplayMode_FiltersOutUniversalDefault()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "A", DisplayMode = "Effect" },
+                ["effect_2"] = new PocoEffect { InternalName = "effect_2", Name = "B", DisplayMode = "Cocoon" },
+            },
+        };
+        var vm = BuildVm(refData);
+
+        vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_1");
+        vm.DetailViewModel!.DisplayMode.Should().BeNull(because: "\"Effect\" is the universal default and is filtered out");
+
+        vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_2");
+        vm.DetailViewModel!.DisplayMode.Should().Be("Cocoon");
+    }
+
+    [Fact]
+    public void FileUpdated_EffectsRefresh_RebuildsListPreservingSelectionByEnvelopeKey()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "Original", IconId = 1 },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.Single();
+
+        // Mutate the underlying refData with a renamed effect at the same envelope key.
+        refData.EffectsByKey["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "Renamed", IconId = 2 };
+        refData.RaiseFileUpdated("effects");
+
+        vm.AllEffects.Single().DisplayName.Should().Be("Renamed");
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRow!.EnvelopeKey.Should().Be("effect_1");
+        vm.DetailViewModel.Should().NotBeNull();
+        vm.DetailViewModel!.DisplayName.Should().Be("Renamed");
+    }
+
+    [Fact]
+    public void FileUpdated_AbilitiesRefresh_RebuildsDetailVM_SoCrossLinkChipsRefresh()
+    {
+        var effect = new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["FrostShard"] };
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_1"] = effect },
+            AbilitiesByEffectKeywordMap = { ["FrostShard"] = new[] { new Ability { InternalName = "Strike", Name = "Strike", Skill = "Sword", Level = 1 } } },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.Single();
+        vm.DetailViewModel!.RequiredByAbilityChips.Should().ContainSingle();
+
+        refData.AbilitiesByEffectKeywordMap["FrostShard"] = new[]
+        {
+            new Ability { InternalName = "Strike", Name = "Strike", Skill = "Sword", Level = 1 },
+            new Ability { InternalName = "Slash", Name = "Slash", Skill = "Sword", Level = 2 },
+        };
+        refData.RaiseFileUpdated("abilities");
+
+        vm.DetailViewModel!.RequiredByAbilityChips.Should().HaveCount(2);
+    }
+
+    private static EffectsTabViewModel BuildVm(StubReferenceData refData) =>
+        new EffectsTabViewModel(
+            refData,
+            new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData),
+            new SilmarillionSettings());
+
+    private sealed class StubReferenceData : IReferenceDataService
+    {
+        public Dictionary<string, PocoEffect> EffectsByKey { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<PocoEffect>> EffectsByStackingTypeMap { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeywordMap { get; } = new(StringComparer.Ordinal);
+        public List<AbilityDynamicDot> DotRules { get; } = new();
+        public List<AbilityDynamicSpecialValue> SpecialValueRules { get; } = new();
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        // Surface Ability via a derived AbilitiesByInternalName so the resolver can project
+        // InternalName → Name; otherwise required-by-ability chip DisplayName falls back to
+        // raw InternalName and tests asserting DisplayName silently regress (cookbook caveat).
+        public IReadOnlyDictionary<string, Ability> Abilities { get; } = new Dictionary<string, Ability>();
+        public IReadOnlyDictionary<string, Ability> AbilitiesByInternalName =>
+            AbilitiesByEffectKeywordMap.Values
+                .SelectMany(v => v)
+                .GroupBy(a => a.InternalName!, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        public IReadOnlyDictionary<string, PocoEffect> Effects => EffectsByKey;
+        public IReadOnlyDictionary<string, PocoEffect> EffectsByInternalName => EffectsByKey;
+        public IReadOnlyDictionary<string, IReadOnlyList<PocoEffect>> EffectsByStackingType => EffectsByStackingTypeMap;
+        public IReadOnlyDictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeyword => AbilitiesByEffectKeywordMap;
+        public IReadOnlyList<AbilityDynamicDot> AbilityDynamicDots => DotRules;
+        public IReadOnlyList<AbilityDynamicSpecialValue> AbilityDynamicSpecialValues => SpecialValueRules;
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated;
+        public void RaiseFileUpdated(string fileKey) => FileUpdated?.Invoke(this, fileKey);
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/QuestDetailProjectorTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestDetailProjectorTests.cs
@@ -174,9 +174,9 @@ public sealed class QuestDetailProjectorTests
         req.Text.Should().Be("Has effect: Live Event Crafting");
         req.Prefix.Should().Be("Has effect:");
         req.ChipName.Should().Be("Live Event Crafting");
-        req.Reference!.Kind.Should().Be(EntityKind.Effect);
+        req.Reference!.Kind.Should().Be(EntityKind.EffectKeyword);
         req.Reference.InternalName.Should().Be("LiveEvent_Crafting");
-        req.IsNavigable.Should().BeFalse("the Effects kind target isn't registered until #244");
+        req.IsNavigable.Should().BeFalse("no EffectKeyword kind target is registered in this stub setup");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds the Silmarillion Effects tab (the natural rendering destination for `effects.json` and the conditional-rule plumbing landed in #288/#296). Per the [agent handoff doc](docs/agent-plans/silmarillion-244-effects-tab.md). Closes #244.

Cited:
- **#244** — this issue
- **#288 / #296** — the ability conditional-rule plumbing (`AbilityDynamicDots`, `AbilityDynamicSpecialValues`); the Effects detail pane is the natural consumer
- **#293** — Abilities tab, established the `ITabViewModel` enumerable-composition pattern that this tab plugs into without touching `SilmarillionViewModel`'s ctor
- **#203** — Reference-DB epic umbrella
- **#229** — the deep-link route handler. `mithril://silmarillion/effect/effect_NNNN` flows through it for free; the new kind picks up automatically via `Enum.TryParse<EntityKind>` + the navigator's `CanOpen` filter

## What's here

5 commit slices (a → e) on top of `main`:

1. **(a) Service-layer plumbing** — `Effect.InternalName` lift on the POCO + the `ParseEffects` deserializer (mirrors `Item.Id` / `Recipe.Key`); six new `IReferenceDataService` properties (`Effects`, `EffectsByInternalName`, `EffectsByKeyword`, `EffectsByStackingType`, `AbilitiesByEffectKeyword`, `EffectsByTriggeringAbilityKeyword`) all defaulted to empty so test fakes and other modules don't need to opt in; `BuildEffectAbilityCrossLinkIndices` called from both `ParseAndSwapEffects` and `ParseAndSwapAbilities` so a refresh of either file rebuilds the cross-link index; `AbilitiesByEffectKeyword` excludes `InternalAbility == true` rows.
2. **(b) New `EntityKind` values + audit-pass migrations** — `EntityKind.EffectKeyword` (synthetic, Effects-tab keyword filter) + `EntityKind.AbilityByEffectKeyword` (synthetic, Abilities-tab `EffectKeywordReqs CONTAINS` filter — backs the overflow pill). The existing `EntityRef.Effect` factory is locked to envelope-key payloads via `Debug.Assert` so the prior misuse pattern (passing a keyword tag) is caught at construction site. Every pre-existing chip surface that passed a keyword to `EntityRef.Effect` is migrated in this PR: `QuestDetailProjector.cs:264`, `AbilityDetailViewModel`'s `EffectKeywordReqs` strip + `TargetEffectKeywordReq` flag + `ConditionalKeyword` trigger conditions, and the resolver fall-through test.
3. **(c) Tab skeleton + three kind targets** — `EffectsTabViewModel` + `EffectListRow` + `EffectKeywordValue` (`IQueryStringValue` for `CONTAINS` filtering) + `EffectsTabView` + `EffectDetailWindow`. Three kind targets: `EffectsKindTarget` (entity row-select), `EffectKeywordKindTarget` (synthetic filter), `AbilityByEffectKeywordKindTarget` (synthetic filter on the Abilities tab — required adding an `EffectKeywordReqs` column to `AbilityListRow` so the query parser recognises the field).
4. **(d) Detail-pane sections + chip caps + FormattedText audit** — nine projected sections (header, FormattedText description, metadata strip with Duration sentinel mapping, keyword chips, conditional DoT + special-value rule sub-tables, stacks-with cluster, required-by-abilities cluster with cap + overflow pill, procs-from-abilities, SpewText footer). New `SilmarillionSettings.RequiredByAbilitiesChipCap` (default 12) backs the overflow pill; surfaced in the settings panel as a slider alongside `UsedInChipCap`. Migrated four other detail views (`RecipeDetailView`, `NpcDetailView`, `QuestDetailView` objective row, the shared `ItemDetailView` in `Mithril.Shared.Wpf`) from plain `Text="{Binding Description}"` to `c:FormattedText.Text` so inline `<i>` / `<b>` markup renders.
5. **(e) Test trio + integration sweep** — `EffectsTabViewModelTests`, `EffectsKindTargetTests`, `EffectKeywordKindTargetTests`, `AbilityByEffectKeywordKindTargetTests`; `SilmarillionReferenceNavigatorTests` extended with three open-route tests + a duplicate-registration guard for both new kinds; `SilmarillionDeepLinkHandlerTests` gains the `effect_NNNN` form; `ReferenceDataServiceEffectCrossLinkIndexTests` adds a real-bundled-data sanity walk that asserts `effect_10003` (Sticky!) projects sensibly, with a guard to no-op when the bundled file isn't co-located.

## The four wrong assumptions (and how they resolved)

The original #244 issue body predated #239's kind-target refactor and the data-shape verification. The handoff doc spelled out each in detail; for review summary:

1. **"AbilitiesApplyingEffect" reverse lookup** — abilities don't reference effects by InternalName, they reference them by *keyword*. The reverse lookup is keyword-set intersection (`AbilitiesByEffectKeyword` keyed by individual tag), rendered as the "Required by abilities" section.
2. **"ItemsApplyingEffect" reverse lookup** — items have no clean foreign-key into `effects.json`. `Item.EffectDescs` is procedural placeholder strings resolved against `attributes.json`, not effect references. Dropped from v1; documented as a hypothetical follow-up.
3. **"Reuse the Celebrimbor `ResultEffectsParser`"** — that parser handles `Recipe.ResultEffects` method-call strings, not `effects.json` entries. The "Effect" in the name is a different axis. Renderer reuse explicitly out of scope.
4. **`EntityRef.Effect` carried keyword payloads at two pre-existing call sites** — split into two kinds (`Effect` for envelope-key row-select, `EffectKeyword` for keyword filter), with a `Debug.Assert` guard on the original factory so the misuse pattern surfaces at construction. Migrated both call sites + the resolver test in this PR.

## Resolved-during-review decisions

- **Required-by-abilities overflow pill** — wired to `EntityKind.AbilityByEffectKeyword` (added in slice c) instead of staying plain text. The pill payload is the first keyword on the effect; clicking it opens the Abilities tab filtered by `EffectKeywordReqs CONTAINS "<tag>"`.
- **Duration sentinel mapping** — `-1` → "Until cleansed", `-2` → "Until removed" (best-guess labels documented in the projector; flagged for revisit if PG ships a contradicting key). `"Permanent"` literal passes through; positive int values bucket into seconds / minutes / hours.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors, XamlResourceLint OK (90 keys)
- [x] `dotnet test Mithril.slnx` — 2,132 tests pass, 0 failures
- [x] Shell boot — `boot.log` advances `creating App → resolving ShellWindow → shell shown → startup done` cleanly (DI graph healthy)
- [ ] Manual smoke (reviewer):
  - [x] Effects tab appears in the strip with the gold IsSelected underline
  - [x] Query box accepts `Keywords CONTAINS "Buff"` → list filters
  - [x] Pick an effect → description renders (italic markup preserved), keyword chips show, stacking peers / required-by-abilities sections populate
  - [x] Keyword chip click → tab stays on Effects, query box auto-populates `Keywords CONTAINS "<tag>"`
  - [x] Required-by-abilities chip → switches to Abilities tab and selects
  - [ ] `+N more →` overflow pill → switches to Abilities tab, query is `EffectKeywordReqs CONTAINS "<tag>"`
  - [x] Quest with `HasEffectKeywordRequirement` → "Has effect:" chip is now navigable
  - [x] Ability with `EffectKeywordReqs` populated → chips render clickable
  - [x] Deep-link `start mithril://silmarillion/effect/effect_10003` → Effects tab opens, Sticky! selected
  - [x] Settings panel shows the new `Required by abilities` chip cap slider

— drafted by Claude (Opus 4.7), posted by @arthur-conde