### PR TITLE
fix(silmarillion): emit Consignment ItemTypes as keyword chips — #299

### DIFF
--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -192,10 +192,11 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
         BarterService barter when barter.AdditionalUnlocks is { Count: > 0 } =>
             BuildLabeledLines(("Unlocks at higher favor", barter.AdditionalUnlocks)),
 
+        // Consignment.ItemTypes is a raw item-keyword tuple (Equipment, CorpseTrophy, …) — same
+        // shape as Store cap-increase keywords from PR #294, so lift it into a chip strip via
+        // BuildKeywordChips. Unlocks are favor tiers and stay text-only.
         ConsignmentService consignment =>
-            BuildLabeledLines(
-                ("Items", consignment.ItemTypes),
-                ("Unlocks at higher favor", consignment.Unlocks)),
+            BuildConsignmentDetails(consignment),
 
         InstallAugmentsService install when install.LevelRange is { Count: > 0 } =>
             BuildLabeledLines(("Levels", install.LevelRange)),
@@ -229,6 +230,23 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
             if (items is null || items.Count == 0) continue;
             lines.Add(NpcServiceDetailLine.TextOnly($"{label}: {string.Join(", ", items)}"));
         }
+        return lines;
+    }
+
+    /// <summary>
+    /// Build the Consignment service detail lines. The <c>Items</c> row carries a label-only prose
+    /// (<c>"Items:"</c>) plus a per-line keyword chip strip — each chip targets the Items tab via
+    /// <see cref="EntityKind.ItemKeyword"/>, mirroring the Store cap-keyword pattern from PR #294.
+    /// Empty groups drop out so a Consignment with only <c>Unlocks</c> (or only <c>ItemTypes</c>)
+    /// still renders cleanly.
+    /// </summary>
+    private IReadOnlyList<NpcServiceDetailLine> BuildConsignmentDetails(ConsignmentService consignment)
+    {
+        var lines = new List<NpcServiceDetailLine>(2);
+        if (consignment.ItemTypes is { Count: > 0 } itemTypes)
+            lines.Add(new NpcServiceDetailLine("Items:", BuildKeywordChips(itemTypes)));
+        if (consignment.Unlocks is { Count: > 0 } unlocks)
+            lines.Add(NpcServiceDetailLine.TextOnly($"Unlocks at higher favor: {string.Join(", ", unlocks)}"));
         return lines;
     }
 

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -574,6 +574,113 @@ public sealed class NpcsTabViewModelTests
     }
 
     [Fact]
+    public void DetailViewModel_ServiceDetails_ConsignmentItemTypes_EmitChips_Navigable_WhenItemKeywordKindRegistered()
+    {
+        // Follow-up to #292 / PR #294: ConsignmentService.ItemTypes is an array of raw
+        // item-keyword tags (e.g. Equipment, CorpseTrophy, Tool) — same shape as Store cap
+        // keyword tuples. Lift them out of the comma-joined "Items:" prose into a per-line
+        // chip strip that routes the Items tab via EntityKind.ItemKeyword, matching #270.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new ConsignmentService
+                {
+                    Type = "Consignment",
+                    ItemTypes = ["Equipment", "CorpseTrophy", "AugmentationRelated"],
+                    Unlocks = ["CloseFriends", "BestFriends"],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var consignment = vm.DetailViewModel!.Services.Single();
+        consignment.Details.Should().HaveCount(2);
+
+        var itemsLine = consignment.Details[0];
+        itemsLine.Text.Should().Be("Items:", because: "the label is preserved as prose so the chip strip reads as a labeled list, matching the Store cap-increase visual rhythm");
+        itemsLine.Chips.Should().HaveCount(3);
+        itemsLine.Chips.Select(c => c.Reference).Should().Equal(
+            EntityRef.ItemKeyword("Equipment"),
+            EntityRef.ItemKeyword("CorpseTrophy"),
+            EntityRef.ItemKeyword("AugmentationRelated"));
+        itemsLine.Chips.Should().AllSatisfy(c => c.IsNavigable.Should().BeTrue(
+            because: "ItemKeyword kind is registered, so each consignment chip should route to the Items tab."));
+        // CamelCase split fallback when KeywordDisplayNames has no entry (default test stub).
+        itemsLine.Chips.Select(c => c.DisplayName).Should().Equal(
+            "Equipment", "Corpse Trophy", "Augmentation Related");
+    }
+
+    [Fact]
+    public void DetailViewModel_ServiceDetails_ConsignmentUnlocks_StaysTextOnly()
+    {
+        // Unlocks are favor tiers, not item keywords — they must stay as comma-joined prose.
+        // Only ItemTypes lifts into chips; mirrors the Store cap split where the keyword tuple
+        // becomes chips but the tier→gold prose stays text.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new ConsignmentService
+                {
+                    Type = "Consignment",
+                    ItemTypes = ["Equipment"],
+                    Unlocks = ["CloseFriends", "BestFriends", "LikeFamily"],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.ItemKeyword), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var unlocksLine = vm.DetailViewModel!.Services.Single().Details[1];
+        unlocksLine.Text.Should().Be("Unlocks at higher favor: CloseFriends, BestFriends, LikeFamily");
+        unlocksLine.Chips.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetailViewModel_ServiceDetails_ConsignmentItemTypes_NonNavigable_WhenItemKeywordKindNotRegistered()
+    {
+        // Mirror image of the Store cap non-navigable test: when the navigator has no
+        // ItemKeyword kind wired, chips still render but degrade to IsNavigable=false.
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new ConsignmentService
+                {
+                    Type = "Consignment",
+                    ItemTypes = ["Equipment", "Tool"],
+                },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = npc },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var chips = vm.DetailViewModel!.Services.Single().Details[0].Chips;
+        chips.Should().HaveCount(2);
+        chips.Should().AllSatisfy(c => c.IsNavigable.Should().BeFalse());
+    }
+
+    [Fact]
     public void DetailViewModel_Quests_PopulatedFromQuestsByGiverNpc()
     {
         var npc = new Npc { Name = "Joeh" };


### PR DESCRIPTION
## Summary

Closes #299. Direct follow-up to #292 / PR #294, applying the same keyword-chip lift to NPC **Consignment** rows.

`ConsignmentService.ItemTypes` is the same raw item-keyword tuple shape that Store cap-increase rows carry (e.g. `Equipment`, `CorpseTrophy`, `Tool`, `SkillIngredient`, `AlchemyIngredient`, `Augment`) — but the NPC detail was still rendering them as comma-joined prose:

> Items: Equipment, CorpseTrophy, AugmentationRelated

Now each tag becomes a navigable `EntityKind.ItemKeyword` chip that flips the Items tab pre-filtered, reusing the `BuildKeywordChips` helper introduced in #294. The `Items:` label is preserved as prose alongside the chip strip so the labelled-row visual rhythm matches the Store cap-increase rows.

`Consignment.Unlocks` stays text-only — favor tiers, not item keywords.

## Implementation notes

- Extracted `BuildConsignmentDetails(ConsignmentService)` so the per-group empty-drop-out semantic from `BuildLabeledLines` is preserved (NPCs with only `Unlocks`, or only `ItemTypes`, still render cleanly).
- No XAML changes — `NpcDetailView.xaml`'s per-line chip strip from #294 already renders chips on any `NpcServiceDetailLine` that carries them.
- `BarterService.AdditionalUnlocks` is intentionally out of scope — favor tiers, not item keywords.

## Test plan

- [x] `DetailViewModel_ServiceDetails_ConsignmentItemTypes_EmitChips_Navigable_WhenItemKeywordKindRegistered` — chips carry the correct `EntityRef.ItemKeyword(...)` refs, `IsNavigable=true`, with CamelCase-split display names (e.g. `AugmentationRelated` → `Augmentation Related`)
- [x] `DetailViewModel_ServiceDetails_ConsignmentUnlocks_StaysTextOnly` — Unlocks line is the comma-joined `Unlocks at higher favor: …` prose with `Chips.Empty`
- [x] `DetailViewModel_ServiceDetails_ConsignmentItemTypes_NonNavigable_WhenItemKeywordKindNotRegistered` — mirror of the Store-cap non-navigable test
- [x] Full solution build clean (0 warnings, 0 errors)
- [x] Full test suite green (Silmarillion.Tests: 238 passed; whole solution: all green)
- [ ] Manual sanity walk on a Consignment NPC (e.g. NPC_Sevyn / NPC_Joeh / NPC_Saidi) to confirm chip click flips to Items tab pre-filtered

Pattern precedents: #267 (item-detail "Used as"), #270 (recipe-detail keyword chip), #294 (Store cap-keyword chips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)