### PR TITLE
chore(templates): add silmarillion + mithril.gamestate to module dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -49,6 +49,8 @@ body:
         - smaug
         - celebrimbor
         - palantir
+        - silmarillion
+        - mithril.gamestate
         - mithril.reference
         - cross-module / unsure
     validations:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -48,6 +48,8 @@ body:
         - smaug
         - celebrimbor
         - palantir
+        - silmarillion
+        - mithril.gamestate
         - mithril.reference
         - cross-module / unsure
     validations:


### PR DESCRIPTION
## Summary

- The `module:silmarillion` and `module:mithril.gamestate` labels exist on the repo, but neither was listed in the Module dropdown in `bug.yml` / `feature.yml`. New issues for those modules couldn't auto-apply the label and had to be labeled manually.
- Adds both to both templates. Spotted while filing #308.

## Test plan

- [ ] Open the bug-report template form on GitHub and confirm `silmarillion` and `mithril.gamestate` appear in the Module dropdown.
- [ ] Same for the feature template.