### PR TITLE
chore(silmarillion): migrate overflow-pill surfaces to navigable summary chip (#313)

### DIFF
--- a/src/Mithril.Shared.Wpf/ItemDetailContext.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailContext.cs
@@ -30,11 +30,12 @@ public sealed record ItemDetailContext(
     IReadOnlyList<EntityChipVm>? ConsumedAsKeywordIn = null,
     IReadOnlyList<EntityChipVm>? AwardedByQuests = null,
     IReadOnlyList<ItemSourceChipVm>? Sources = null,
-    // Overflow pill for "Used in" when ConsumedByRecipes is already capped.
-    // Non-null only when the underlying recipe count exceeds the cap; renders as a
-    // RecipeIngredientItem-kind chip that deep-links to the Recipes tab filtered to
-    // "Ingredients CONTAINS <itemInternalName>". DisplayName carries the "+N more →" label.
-    EntityChipVm? MoreRecipesChip = null)
+    // Always-visible navigable summary chip for the "Used in" section. Non-null whenever
+    // the item is consumed by any recipe (independent of the chip cap); renders as a
+    // RecipeIngredientItem-kind ActionChip that deep-links to the Recipes tab filtered to
+    // "Ingredients CONTAINS <itemInternalName>". DisplayName carries the
+    // "View all N in Recipes tab →" label.
+    EntityChipVm? RecipesTabShortcut = null)
 {
     public static ItemDetailContext Empty { get; } = new();
 }

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -125,9 +125,10 @@
 
                 <!-- Used in recipes — cross-link to recipes that consume this item. Capped at
                      SilmarillionSettings.UsedInChipCap to keep selection-change cheap (long-tail
-                     items like MetalSlab1 ship 60+ recipes). The trailing pill collapses the
-                     overflow into a single chip that deep-links to the Recipes tab filtered to
-                     Ingredients CONTAINS "<itemInternalName>" — same total reach, one paint. -->
+                     items like MetalSlab1 ship 60+ recipes). The trailing always-visible
+                     ActionChip summary chip deep-links to the Recipes tab filtered to
+                     Ingredients CONTAINS "<itemInternalName>" — full reach in one paint,
+                     and a jump to the sortable Recipes view even when nothing overflowed. -->
                 <StackPanel Margin="0,10,0,0">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
@@ -136,7 +137,7 @@
                                 <DataTrigger Binding="{Binding ConsumedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding MoreRecipesChip, Converter={StaticResource NullToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding RecipesTabShortcut, Converter={StaticResource NullToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                             </Style.Triggers>
@@ -157,10 +158,16 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <c:EntityChip DataContext="{Binding MoreRecipesChip}"
-                                  ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"
-                                  Visibility="{Binding Converter={StaticResource NullToVis}}"
-                                  HorizontalAlignment="Left"/>
+                    <ContentControl Content="{Binding RecipesTabShortcut}"
+                                    Margin="0,4,0,0"
+                                    HorizontalAlignment="Left"
+                                    Visibility="{Binding RecipesTabShortcut, Converter={StaticResource NullToVis}}">
+                        <ContentControl.Resources>
+                            <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                <c:ActionChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                            </DataTemplate>
+                        </ContentControl.Resources>
+                    </ContentControl>
                 </StackPanel>
 
                 <!-- Used as: keyword chips — items that satisfy keyword-based slots in recipes -->

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -57,7 +57,7 @@ public sealed partial class ItemDetailViewModel
         UnpreviewableExtractions = context.UnpreviewableExtractions ?? [];
         ProducedByRecipes = context.ProducedByRecipes ?? [];
         ConsumedByRecipes = context.ConsumedByRecipes ?? [];
-        MoreRecipesChip = context.MoreRecipesChip;
+        RecipesTabShortcut = context.RecipesTabShortcut;
         ConsumedAsKeywordIn = context.ConsumedAsKeywordIn ?? [];
         AwardedByQuests = context.AwardedByQuests ?? [];
         Sources = context.Sources ?? [];
@@ -99,18 +99,19 @@ public sealed partial class ItemDetailViewModel
     /// <summary>
     /// Recipes that consume this item as an ingredient. Same lifecycle as
     /// <see cref="ProducedByRecipes"/>. Capped at
-    /// <c>SilmarillionSettings.UsedInChipCap</c>; the overflow lives on
-    /// <see cref="MoreRecipesChip"/>.
+    /// <c>SilmarillionSettings.UsedInChipCap</c>; the full set is always reachable via
+    /// <see cref="RecipesTabShortcut"/>.
     /// </summary>
     public IReadOnlyList<EntityChipVm> ConsumedByRecipes { get; }
 
     /// <summary>
-    /// Overflow pill for the "Used in" section. Non-null only when the underlying recipe
-    /// count exceeds the cap; clicking deep-links to the Recipes tab pre-filtered via
+    /// Always-visible navigable summary chip for the "Used in" section. Non-null whenever
+    /// the item is consumed by any recipe (independent of the cap); clicking deep-links to
+    /// the Recipes tab pre-filtered via
     /// <c>QueryText = Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>. Bound visibility
-    /// on the XAML side hides the pill when this is null.
+    /// on the XAML side hides it when this is null (item used in no recipe).
     /// </summary>
-    public EntityChipVm? MoreRecipesChip { get; }
+    public EntityChipVm? RecipesTabShortcut { get; }
 
     /// <summary>
     /// Per-keyword chips for the item-detail "Used as" section. One chip per keyword the

--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -44,9 +44,9 @@ public sealed class EffectDetailViewModel
         ConditionalDotRows = BuildConditionalDotRows(effect, refData);
         ConditionalSpecialValueRows = BuildConditionalSpecialValueRows(effect, refData);
         StackingTypeChip = BuildStackingTypeChip(effect, envelopeKey, refData, navigator);
-        var (chips, pill) = BuildRequiredByAbilityChips(effect, refData, nameResolver, navigator, settings.RequiredByAbilitiesChipCap);
+        var (chips, shortcut) = BuildRequiredByAbilityChips(effect, refData, nameResolver, navigator, settings.RequiredByAbilitiesChipCap);
         RequiredByAbilityChips = chips;
-        RequiredByAbilitiesOverflowPill = pill;
+        RequiredByAbilitiesTabShortcut = shortcut;
         ProcsFromAbilityKeywordRows = BuildProcsFromAbilityKeywordRows(effect.AbilityKeywords);
 
         SpewText = string.IsNullOrEmpty(effect.SpewText) ? null : effect.SpewText;
@@ -96,12 +96,14 @@ public sealed class EffectDetailViewModel
     public IReadOnlyList<EntityChipVm> RequiredByAbilityChips { get; }
 
     /// <summary>
-    /// Overflow pill rendered after the capped <see cref="RequiredByAbilityChips"/> when the
-    /// total exceeds <c>SilmarillionSettings.RequiredByAbilitiesChipCap</c>. Anchored on
-    /// <see cref="EntityRef.AbilityByEffectKeyword"/> so clicking opens the Abilities tab
-    /// filtered by <c>EffectKeywordReqs CONTAINS "&lt;tag&gt;"</c>.
+    /// Always-visible navigable summary chip rendered after the capped
+    /// <see cref="RequiredByAbilityChips"/>. Non-null whenever the effect is required by
+    /// any ability (independent of <c>SilmarillionSettings.RequiredByAbilitiesChipCap</c>).
+    /// Anchored on <see cref="EntityRef.AbilityByEffectKeyword"/> so clicking opens the
+    /// Abilities tab filtered by <c>EffectKeywordReqs CONTAINS "&lt;tag&gt;"</c>; rendered
+    /// as <c>ActionChip</c>.
     /// </summary>
-    public EntityChipVm? RequiredByAbilitiesOverflowPill { get; }
+    public EntityChipVm? RequiredByAbilitiesTabShortcut { get; }
 
     public IReadOnlyList<EffectProcsFromAbilityKeywordRow> ProcsFromAbilityKeywordRows { get; }
     public string? SpewText { get; }
@@ -271,13 +273,16 @@ public sealed class EffectDetailViewModel
     }
 
     /// <summary>
-    /// Build the cap-limited "Required by abilities" chip list plus an optional overflow
-    /// pill. Reads the union of <c>AbilitiesByEffectKeyword[tag]</c> across every tag in
+    /// Build the cap-limited "Required by abilities" chip list plus an always-visible
+    /// navigable summary chip (the shortcut into the filtered Abilities tab). Reads the
+    /// union of <c>AbilitiesByEffectKeyword[tag]</c> across every tag in
     /// <see cref="PocoEffect.Keywords"/> (the index excludes
     /// <see cref="Ability.InternalAbility"/> rows already). Dedupes by InternalName and
-    /// sorts by Skill then Level so the chip cluster reads consistently.
+    /// sorts by Skill then Level so the chip cluster reads consistently. The shortcut is
+    /// emitted whenever any ability requires the effect — even within the cap it offers a
+    /// jump to the sortable/filterable Abilities-tab view.
     /// </summary>
-    private static (IReadOnlyList<EntityChipVm> Chips, EntityChipVm? Pill) BuildRequiredByAbilityChips(
+    private static (IReadOnlyList<EntityChipVm> Chips, EntityChipVm? Shortcut) BuildRequiredByAbilityChips(
         PocoEffect effect,
         IReferenceDataService refData,
         IEntityNameResolver nameResolver,
@@ -288,16 +293,16 @@ public sealed class EffectDetailViewModel
 
         var ordered = new List<Ability>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        // Capture the first matching keyword for the overflow-pill payload — picking
+        // Capture the first matching keyword for the shortcut payload — picking
         // *some* keyword is unavoidable, and "first" is stable and matches the order
         // the player sees in the Keywords chip strip immediately above.
-        string? pillKeyword = null;
+        string? shortcutKeyword = null;
 
         foreach (var tag in effect.Keywords)
         {
             if (string.IsNullOrEmpty(tag)) continue;
             if (!refData.AbilitiesByEffectKeyword.TryGetValue(tag, out var abilities)) continue;
-            pillKeyword ??= tag;
+            shortcutKeyword ??= tag;
             foreach (var ability in abilities)
             {
                 if (ability.InternalName is null) continue;
@@ -328,19 +333,16 @@ public sealed class EffectDetailViewModel
                 IsNavigable: navigator.CanOpen(reference)));
         }
 
-        EntityChipVm? pill = null;
-        if (ordered.Count > cap && !string.IsNullOrEmpty(pillKeyword))
-        {
-            var overflow = ordered.Count - cap;
-            var reference = EntityRef.AbilityByEffectKeyword(pillKeyword!);
-            pill = new EntityChipVm(
-                DisplayName: $"+{overflow} more →",
-                IconId: effect.IconId,
-                Reference: reference,
-                IsNavigable: navigator.CanOpen(reference));
-        }
+        // shortcutKeyword is guaranteed non-null here: ordered.Count > 0 implies at least
+        // one keyword matched and set it before its abilities were appended.
+        var shortcutReference = EntityRef.AbilityByEffectKeyword(shortcutKeyword!);
+        var shortcut = new EntityChipVm(
+            DisplayName: $"View all {ordered.Count} in Abilities tab →",
+            IconId: 0,
+            Reference: shortcutReference,
+            IsNavigable: navigator.CanOpen(shortcutReference));
 
-        return (chips, pill);
+        return (chips, shortcut);
     }
 
     private static IReadOnlyList<EffectProcsFromAbilityKeywordRow> BuildProcsFromAbilityKeywordRows(

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -146,14 +146,14 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
         {
             return ItemDetailContext.Empty;
         }
-        var (consumed, more) = BuildConsumedByChips(_refData.RecipesByIngredientItem, item);
+        var (consumed, shortcut) = BuildConsumedByChips(_refData.RecipesByIngredientItem, item);
         return new ItemDetailContext(
             ProducedByRecipes: BuildRecipeChips(_refData.RecipesByProducedItem, item.InternalName!),
             ConsumedByRecipes: consumed,
             ConsumedAsKeywordIn: BuildKeywordChips(item),
             AwardedByQuests: BuildAwardedByQuestChips(item.InternalName!),
             Sources: BuildSourceChips(item.InternalName!),
-            MoreRecipesChip: more);
+            RecipesTabShortcut: shortcut);
     }
 
     private IReadOnlyList<EntityChipVm>? BuildAwardedByQuestChips(string itemInternalName)
@@ -177,12 +177,15 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
 
     /// <summary>
     /// Apply <see cref="SilmarillionSettings.UsedInChipCap"/> to the "Used in" chip list.
-    /// When the underlying recipe count exceeds the cap, returns the first N chips plus a
-    /// pill chip pointing to the symmetric recipe-tab filter
-    /// (<c>Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>). Pill carries the item's own
-    /// icon for visual continuity with the detail header.
+    /// Returns the first N chips plus an always-visible navigable summary chip that
+    /// deep-links to the symmetric recipe-tab filter
+    /// (<c>Ingredients CONTAINS "&lt;itemInternalName&gt;"</c>). The summary chip is
+    /// emitted whenever the item is consumed by any recipe — at counts within the cap it
+    /// still offers a jump to the sortable/filterable Recipes-tab view (the navigable
+    /// summary chip pattern; rendered as <c>ActionChip</c>). Returns
+    /// <c>(null, null)</c> only when no recipe consumes the item.
     /// </summary>
-    private (IReadOnlyList<EntityChipVm>? Chips, EntityChipVm? More) BuildConsumedByChips(
+    private (IReadOnlyList<EntityChipVm>? Chips, EntityChipVm? Shortcut) BuildConsumedByChips(
         IReadOnlyDictionary<string, IReadOnlyList<Recipe>> index,
         Item item)
     {
@@ -191,17 +194,14 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
         if (all is null) return (null, null);
 
         var cap = _settings.UsedInChipCap;
-        if (all.Count <= cap) return (all, null);
-
         var capped = cap == 0 ? (IReadOnlyList<EntityChipVm>)Array.Empty<EntityChipVm>() : all.Take(cap).ToList();
-        var overflow = all.Count - cap;
         var reference = EntityRef.RecipeIngredientItem(itemName);
-        var pill = new EntityChipVm(
-            DisplayName: $"+{overflow} more →",
-            IconId: item.IconId,
+        var shortcut = new EntityChipVm(
+            DisplayName: $"View all {all.Count} in Recipes tab →",
+            IconId: 0,
             Reference: reference,
             IsNavigable: _navigator.CanOpen(reference));
-        return (capped, pill);
+        return (capped, shortcut);
     }
 
     private IReadOnlyList<EntityChipVm>? BuildKeywordChips(Item item)

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -183,12 +183,12 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <ContentControl Content="{Binding RequiredByAbilitiesOverflowPill}"
+                    <ContentControl Content="{Binding RequiredByAbilitiesTabShortcut}"
                                     Margin="0,4,0,0"
-                                    Visibility="{Binding RequiredByAbilitiesOverflowPill, Converter={StaticResource NullToVis}}">
+                                    Visibility="{Binding RequiredByAbilitiesTabShortcut, Converter={StaticResource NullToVis}}">
                         <ContentControl.Resources>
                             <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                                <c:ActionChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
                             </DataTemplate>
                         </ContentControl.Resources>
                     </ContentControl>

--- a/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
@@ -195,7 +195,7 @@ public sealed class EffectsTabViewModelTests
     }
 
     [Fact]
-    public void DetailViewModel_RequiredByAbilities_BuildsChipsFromIndex_AndAddsOverflowPillBeyondCap()
+    public void DetailViewModel_RequiredByAbilities_BuildsChipsFromIndex_AndAddsAbilitiesTabShortcut()
     {
         var effect = new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["FrostShard"] };
         var abilities = Enumerable.Range(1, 15)
@@ -217,15 +217,15 @@ public sealed class EffectsTabViewModelTests
         var detail = vm.DetailViewModel!;
 
         detail.RequiredByAbilityChips.Should().HaveCount(12);
-        detail.RequiredByAbilitiesOverflowPill.Should().NotBeNull();
-        detail.RequiredByAbilitiesOverflowPill!.DisplayName.Should().Be("+3 more →");
-        detail.RequiredByAbilitiesOverflowPill.Reference.Kind.Should().Be(EntityKind.AbilityByEffectKeyword);
-        detail.RequiredByAbilitiesOverflowPill.Reference.InternalName.Should().Be("FrostShard");
-        detail.RequiredByAbilitiesOverflowPill.IsNavigable.Should().BeTrue();
+        detail.RequiredByAbilitiesTabShortcut.Should().NotBeNull();
+        detail.RequiredByAbilitiesTabShortcut!.DisplayName.Should().Be("View all 15 in Abilities tab →");
+        detail.RequiredByAbilitiesTabShortcut.Reference.Kind.Should().Be(EntityKind.AbilityByEffectKeyword);
+        detail.RequiredByAbilitiesTabShortcut.Reference.InternalName.Should().Be("FrostShard");
+        detail.RequiredByAbilitiesTabShortcut.IsNavigable.Should().BeTrue();
     }
 
     [Fact]
-    public void DetailViewModel_RequiredByAbilities_NoOverflowPill_WhenCountWithinCap()
+    public void DetailViewModel_RequiredByAbilities_StillEmitsShortcut_WhenCountWithinCap()
     {
         var effect = new PocoEffect { InternalName = "effect_1", Name = "X", IconId = 1, Keywords = ["FrostShard"] };
         var refData = new StubReferenceData
@@ -245,7 +245,9 @@ public sealed class EffectsTabViewModelTests
         var detail = vm.DetailViewModel!;
 
         detail.RequiredByAbilityChips.Should().ContainSingle();
-        detail.RequiredByAbilitiesOverflowPill.Should().BeNull();
+        detail.RequiredByAbilitiesTabShortcut.Should().NotBeNull(
+            because: "the navigable summary chip is always shown, even when every ability fits as a chip");
+        detail.RequiredByAbilitiesTabShortcut!.DisplayName.Should().Be("View all 1 in Abilities tab →");
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -117,7 +117,7 @@ public sealed class ItemsTabViewModelTests
     }
 
     [Fact]
-    public void UsedIn_belowCap_emitsAllChips_andNoMoreRecipesChip()
+    public void UsedIn_belowCap_emitsAllChips_andRecipesTabShortcut()
     {
         var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
         var refData = new StubReferenceData
@@ -134,11 +134,14 @@ public sealed class ItemsTabViewModelTests
         vm.SelectedItem = item;
 
         vm.DetailViewModel!.ConsumedByRecipes.Should().HaveCount(5);
-        vm.DetailViewModel.MoreRecipesChip.Should().BeNull();
+        var shortcut = vm.DetailViewModel.RecipesTabShortcut;
+        shortcut.Should().NotBeNull(because: "the navigable summary chip is always shown, even at counts within the cap");
+        shortcut!.DisplayName.Should().Be("View all 5 in Recipes tab →");
+        shortcut.Reference.Should().Be(EntityRef.RecipeIngredientItem("MetalSlab1"));
     }
 
     [Fact]
-    public void UsedIn_aboveCap_capsChips_andEmitsMoreRecipesPill()
+    public void UsedIn_aboveCap_capsChips_andEmitsRecipesTabShortcut()
     {
         var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab", IconId = 4242 };
         var refData = new StubReferenceData
@@ -156,17 +159,17 @@ public sealed class ItemsTabViewModelTests
         vm.SelectedItem = item;
 
         vm.DetailViewModel!.ConsumedByRecipes.Should().HaveCount(12,
-            because: "cap 12 means the first dozen show as chips and the rest collapse behind the pill");
+            because: "cap 12 means the first dozen show as chips and the rest are reachable via the summary chip");
 
-        var pill = vm.DetailViewModel.MoreRecipesChip;
-        pill.Should().NotBeNull();
-        pill!.DisplayName.Should().Be("+57 more →");
-        pill.IconId.Should().Be(4242, because: "pill carries the item's own icon for visual continuity");
-        pill.Reference.Should().Be(EntityRef.RecipeIngredientItem("MetalSlab1"));
+        var shortcut = vm.DetailViewModel.RecipesTabShortcut;
+        shortcut.Should().NotBeNull();
+        shortcut!.DisplayName.Should().Be("View all 69 in Recipes tab →");
+        shortcut.IconId.Should().Be(0, because: "the ActionChip renders its own ListFilter glyph, not the item icon");
+        shortcut.Reference.Should().Be(EntityRef.RecipeIngredientItem("MetalSlab1"));
     }
 
     [Fact]
-    public void UsedIn_capZero_collapsesEverythingIntoPill()
+    public void UsedIn_capZero_collapsesEverythingIntoShortcut()
     {
         var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
         var refData = new StubReferenceData
@@ -180,12 +183,12 @@ public sealed class ItemsTabViewModelTests
         vm.SelectedItem = item;
 
         vm.DetailViewModel!.ConsumedByRecipes.Should().BeEmpty();
-        vm.DetailViewModel.MoreRecipesChip.Should().NotBeNull();
-        vm.DetailViewModel.MoreRecipesChip!.DisplayName.Should().Be("+3 more →");
+        vm.DetailViewModel.RecipesTabShortcut.Should().NotBeNull();
+        vm.DetailViewModel.RecipesTabShortcut!.DisplayName.Should().Be("View all 3 in Recipes tab →");
     }
 
     [Fact]
-    public void UsedIn_capExactlyMatchesCount_noOverflowPill()
+    public void UsedIn_capExactlyMatchesCount_stillEmitsShortcut()
     {
         var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
         var refData = new StubReferenceData
@@ -199,16 +202,17 @@ public sealed class ItemsTabViewModelTests
         vm.SelectedItem = item;
 
         vm.DetailViewModel!.ConsumedByRecipes.Should().HaveCount(12);
-        vm.DetailViewModel.MoreRecipesChip.Should().BeNull(
-            because: "the pill appears only when count exceeds the cap, not when they're equal");
+        vm.DetailViewModel.RecipesTabShortcut.Should().NotBeNull(
+            because: "the navigable summary chip is always shown regardless of count vs cap");
+        vm.DetailViewModel.RecipesTabShortcut!.DisplayName.Should().Be("View all 12 in Recipes tab →");
     }
 
     [Fact]
     public void UsedInChipCap_change_liveRebuilds_DetailViewModel()
     {
         // The user drags the slider; the open detail view should re-cap on the spot. We
-        // verify by changing the cap and checking that ConsumedByRecipes / MoreRecipesChip
-        // reflect the new value.
+        // verify by changing the cap and checking that ConsumedByRecipes reflects the new
+        // value. The summary chip stays present throughout (always-visible by design).
         var item = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Metal Slab" };
         var refData = new StubReferenceData
         {
@@ -221,14 +225,17 @@ public sealed class ItemsTabViewModelTests
 
         var before = vm.DetailViewModel!;
         before.ConsumedByRecipes.Should().HaveCount(12);
-        before.MoreRecipesChip.Should().NotBeNull();
+        before.RecipesTabShortcut.Should().NotBeNull();
+        before.RecipesTabShortcut!.DisplayName.Should().Be("View all 20 in Recipes tab →");
 
         settings.UsedInChipCap = 25;
 
         var after = vm.DetailViewModel!;
         after.Should().NotBeSameAs(before, because: "live-update rebuilds the detail VM on slider drag");
         after.ConsumedByRecipes.Should().HaveCount(20);
-        after.MoreRecipesChip.Should().BeNull();
+        after.RecipesTabShortcut.Should().NotBeNull(
+            because: "the summary chip is always present even when every recipe now fits as a chip");
+        after.RecipesTabShortcut!.DisplayName.Should().Be("View all 20 in Recipes tab →");
     }
 
     private static IReadOnlyList<Recipe> MakeRecipeList(int count) =>


### PR DESCRIPTION
Closes #313.

Consolidates Silmarillion's two coexisting "more peers than the chip strip shows" patterns onto **Pattern B** (always-visible navigable summary chip rendered as `ActionChip`), retiring Pattern A's conditional `+N more →` overflow pill.

## Surfaces migrated

| Surface | Builder | Origin |
|---|---|---|
| Items detail "Used in" | `ItemsTabViewModel.BuildConsumedByChips` | #273 |
| Effects detail "Required by abilities" | `EffectDetailViewModel.BuildRequiredByAbilityChips` | #298 |

Each now **always** emits an `ActionChip` summary chip when peers exist (`View all {N} in <Tab> →`), independent of the chip cap — same `EntityChipVm` shape, `ClickCommand` contract, and synthetic-kind deep-link target as before. Purely the conditional-render → always-render flip, plus `EntityChip` → `ActionChip` in the two render sites (now mirroring the Areas `ContentControl`/`DataTemplate` shell from #310).

## Rename for vocabulary consistency

Matches Areas' `NpcsTabShortcut` (#310):

- `ItemDetailContext` / `ItemDetailViewModel.MoreRecipesChip` → `RecipesTabShortcut`
- `EffectDetailViewModel.RequiredByAbilitiesOverflowPill` → `RequiredByAbilitiesTabShortcut`

`MoreRecipesChip` had exactly 3 consumers; all migrated. No stale references remain (grep-verified across `*.cs`/`*.xaml`).

## Unchanged

`SilmarillionSettings.UsedInChipCap` / `RequiredByAbilitiesChipCap` still bound the visible chip count.

## Out of scope

- Cookbook dual-pattern retirement → separate pair PR (the issue's "Cookbook follow-up").
- Areas "NPCs" (already B), Lorebooks #247, any net-new reverse-lookup surfaces.

## Verification

- Existing Pattern A tests updated to assert the summary chip is present at counts ≤ cap **and** > cap (label + reference + `IconId: 0`).
- `dotnet build Mithril.slnx` — clean, **0 warnings** (warnings-as-errors), XamlResourceLint OK.
- `dotnet test tests/Silmarillion.Tests` — **331 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)