### PR TITLE
feat(silmarillion): provenance-retaining effect→abilities index (#318 slice 1)

### DIFF
--- a/src/Mithril.Shared/Reference/EffectAbilityMatch.cs
+++ b/src/Mithril.Shared/Reference/EffectAbilityMatch.cs
@@ -1,0 +1,53 @@
+using Mithril.Reference.Models.Abilities;
+
+namespace Mithril.Shared.Reference;
+
+/// <summary>
+/// Why an ability qualified as a member of the effect-keyword → abilities index for a
+/// given tag. The effect→abilities relationship is the union of three ability fields;
+/// the index used to flatten that union to a dedup'd ability set, discarding which field
+/// matched. Retaining the reason is the invariant that lets the relationship explain
+/// itself rather than requiring a second (query-string) derivation to agree with the
+/// index (see <c>docs/agent-plans/silmarillion-1n-provenance-popups.md</c>).
+/// <para>
+/// The three reasons are not mutually exclusive: one ability can qualify for the same
+/// tag via more than one field (e.g. it both requires and is enabled by the keyword).
+/// Such a member is carried <b>once</b> with multiple reason flags set — dedup intent
+/// preserved, provenance complete. <see cref="EffectAbilityMatchReason"/> is therefore
+/// a <c>[Flags]</c> enum.
+/// </para>
+/// </summary>
+[System.Flags]
+public enum EffectAbilityMatchReason
+{
+    /// <summary>No reason. Never present on a real index member; the zero value.</summary>
+    None = 0,
+
+    /// <summary>
+    /// The tag appears in <see cref="Ability.EffectKeywordReqs"/> — the ability hard-requires
+    /// the effect's keyword to be present (a gate).
+    /// </summary>
+    Requires = 1 << 0,
+
+    /// <summary>
+    /// The tag appears in <see cref="Ability.EffectKeywordsIndicatingEnabled"/> — having the
+    /// effect's keyword enables / unlocks the ability.
+    /// </summary>
+    EnabledBy = 1 << 1,
+
+    /// <summary>
+    /// The tag equals <see cref="Ability.TargetEffectKeywordReq"/> — the ability targets
+    /// something carrying the effect's keyword.
+    /// </summary>
+    Targets = 1 << 2,
+}
+
+/// <summary>
+/// One member of the effect-keyword → abilities index for a tag: the qualifying
+/// <see cref="Ability"/> plus the <see cref="EffectAbilityMatchReason"/> flags recording
+/// which of the three unioned ability fields caused it to qualify. A member that matched
+/// via several fields is represented by a single record with several reason flags set —
+/// the index never double-counts a multi-reason ability, so a distinct-member count over
+/// these records equals the displayed "View all N".
+/// </summary>
+public sealed record EffectAbilityMatch(Ability Ability, EffectAbilityMatchReason Reason);

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -236,6 +236,9 @@ public interface IReferenceDataService
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<Ability>> EmptyAbilityIndex
         = new Dictionary<string, IReadOnlyList<Ability>>(StringComparer.Ordinal);
 
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>> EmptyEffectAbilityMatchIndex
+        = new Dictionary<string, IReadOnlyList<EffectAbilityMatch>>(StringComparer.Ordinal);
+
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<AbilitySource>> EmptyAbilitySourceIndex
         = new Dictionary<string, IReadOnlyList<AbilitySource>>(StringComparer.Ordinal);
 
@@ -377,8 +380,19 @@ public interface IReferenceDataService
     /// Built whenever <c>abilities.json</c> or <c>effects.json</c> reloads. Powers the
     /// on-detail "Required by abilities" section and the <c>EntityKind.AbilityByEffectKeyword</c>
     /// overflow-pill deep-link. Defaults to empty so test fakes don't need to opt in.
+    /// <para>
+    /// Each value member is an <see cref="EffectAbilityMatch"/> carrying the qualifying
+    /// <see cref="Ability"/> <b>and</b> the <see cref="EffectAbilityMatchReason"/> flags
+    /// recording which of the three unioned fields matched. The set is materialized
+    /// exactly once here, retaining provenance, so a reverse-lookup surface renders
+    /// membership <i>and</i> reason without a second derivation (see
+    /// <c>docs/agent-plans/silmarillion-1n-provenance-popups.md</c>). An ability
+    /// qualifying via several fields appears <b>once</b> with several reason flags set,
+    /// so a distinct-member count equals the displayed "View all N".
+    /// </para>
     /// </summary>
-    IReadOnlyDictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeyword => EmptyAbilityIndex;
+    IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>> AbilitiesByEffectKeyword
+        => EmptyEffectAbilityMatchIndex;
 
     /// <summary>
     /// Ability-keyword tag → effects whose <see cref="Effect.AbilityKeywords"/> list

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -224,8 +224,8 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
     private IReadOnlyDictionary<string, IReadOnlyList<Effect>> _effectsByStackingType =
         new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
-    private IReadOnlyDictionary<string, IReadOnlyList<Ability>> _abilitiesByEffectKeyword =
-        new Dictionary<string, IReadOnlyList<Ability>>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>> _abilitiesByEffectKeyword =
+        new Dictionary<string, IReadOnlyList<EffectAbilityMatch>>(StringComparer.Ordinal);
     private IReadOnlyDictionary<string, IReadOnlyList<Effect>> _effectsByTriggeringAbilityKeyword =
         new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _effectsSnapshot;
@@ -333,7 +333,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, Effect> EffectsByInternalName => _effectsByInternalName;
     public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByKeyword => _effectsByKeyword;
     public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByStackingType => _effectsByStackingType;
-    public IReadOnlyDictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeyword => _abilitiesByEffectKeyword;
+    public IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>> AbilitiesByEffectKeyword => _abilitiesByEffectKeyword;
     public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByTriggeringAbilityKeyword => _effectsByTriggeringAbilityKeyword;
     public IReadOnlyDictionary<string, string> Strings => _strings;
 
@@ -1176,6 +1176,14 @@ public sealed class ReferenceDataService : IReferenceDataService
     /// <see cref="ParseAndSwapEffects"/> and <see cref="ParseAndSwapAbilities"/> call this.
     /// Abilities with <see cref="Ability.InternalAbility"/> = <c>true</c> are excluded from
     /// <see cref="_abilitiesByEffectKeyword"/> per the on-detail chip-cluster contract.
+    /// <para>
+    /// <see cref="_abilitiesByEffectKeyword"/> retains <i>why</i> each ability qualified:
+    /// its members are <see cref="EffectAbilityMatch"/> records carrying
+    /// <see cref="EffectAbilityMatchReason"/> flags for the matching field(s). A
+    /// multi-field ability is carried once with its reason flags OR'd, so the index is
+    /// still dedup'd by ability (a distinct-member count equals the displayed
+    /// "View all N").
+    /// </para>
     /// </summary>
     private void BuildEffectAbilityCrossLinkIndices()
     {
@@ -1224,38 +1232,42 @@ public sealed class ReferenceDataService : IReferenceDataService
             }
         }
 
-        var byEffectKeyword = new Dictionary<string, List<Ability>>(StringComparer.Ordinal);
+        // tag → ability internal name → accumulated match reason flags. The reason is
+        // accumulated (OR'd) per (tag, ability) so an ability qualifying via several of
+        // the three unioned fields is carried ONCE with multiple reason flags set —
+        // dedup intent preserved (a distinct-member count equals the displayed
+        // "View all N"), provenance complete (the popup can section by reason).
+        var byEffectKeyword =
+            new Dictionary<string, Dictionary<string, (Ability Ability, EffectAbilityMatchReason Reason)>>(
+                StringComparer.Ordinal);
+
         foreach (var ability in _abilities.Values)
         {
             if (ability.InternalAbility == true) continue;
+            if (string.IsNullOrEmpty(ability.InternalName)) continue;
 
             // Union: EffectKeywordReqs ∪ EffectKeywordsIndicatingEnabled ∪ {TargetEffectKeywordReq}.
-            // Dedupe per ability so a tag mentioned in multiple slots doesn't double-count the
-            // ability in the index.
-            HashSet<string>? tagsForAbility = null;
-            void Mark(string? tag)
+            // Unlike the old flatten-to-HashSet<Ability>, the matching field is retained as a
+            // reason flag — this is the provenance the index used to discard.
+            void Mark(string? tag, EffectAbilityMatchReason reason)
             {
                 if (string.IsNullOrEmpty(tag)) return;
-                tagsForAbility ??= new HashSet<string>(StringComparer.Ordinal);
-                tagsForAbility.Add(tag);
+                if (!byEffectKeyword.TryGetValue(tag!, out var perAbility))
+                {
+                    perAbility = new Dictionary<string, (Ability, EffectAbilityMatchReason)>(StringComparer.Ordinal);
+                    byEffectKeyword[tag!] = perAbility;
+                }
+                if (perAbility.TryGetValue(ability.InternalName!, out var existing))
+                    perAbility[ability.InternalName!] = (existing.Ability, existing.Reason | reason);
+                else
+                    perAbility[ability.InternalName!] = (ability, reason);
             }
 
             if (ability.EffectKeywordReqs is { Count: > 0 } reqs)
-                foreach (var tag in reqs) Mark(tag);
+                foreach (var tag in reqs) Mark(tag, EffectAbilityMatchReason.Requires);
             if (ability.EffectKeywordsIndicatingEnabled is { Count: > 0 } enabled)
-                foreach (var tag in enabled) Mark(tag);
-            Mark(ability.TargetEffectKeywordReq);
-
-            if (tagsForAbility is null) continue;
-            foreach (var tag in tagsForAbility)
-            {
-                if (!byEffectKeyword.TryGetValue(tag, out var list))
-                {
-                    list = new List<Ability>();
-                    byEffectKeyword[tag] = list;
-                }
-                list.Add(ability);
-            }
+                foreach (var tag in enabled) Mark(tag, EffectAbilityMatchReason.EnabledBy);
+            Mark(ability.TargetEffectKeywordReq, EffectAbilityMatchReason.Targets);
         }
 
         _effectsByKeyword = byKeyword.ToDictionary(
@@ -1265,7 +1277,11 @@ public sealed class ReferenceDataService : IReferenceDataService
         _effectsByTriggeringAbilityKeyword = byTriggeringAbilityKeyword.ToDictionary(
             kv => kv.Key, kv => (IReadOnlyList<Effect>)kv.Value, StringComparer.Ordinal);
         _abilitiesByEffectKeyword = byEffectKeyword.ToDictionary(
-            kv => kv.Key, kv => (IReadOnlyList<Ability>)kv.Value, StringComparer.Ordinal);
+            kv => kv.Key,
+            kv => (IReadOnlyList<EffectAbilityMatch>)kv.Value.Values
+                .Select(v => new EffectAbilityMatch(v.Ability, v.Reason))
+                .ToList(),
+            StringComparer.Ordinal);
     }
 
     private void ParseAndSwapAbilitySources(IReadOnlyDictionary<string, PocoSourceEnvelope> raw, ReferenceFileMetadata meta)

--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -301,10 +301,17 @@ public sealed class EffectDetailViewModel
         foreach (var tag in effect.Keywords)
         {
             if (string.IsNullOrEmpty(tag)) continue;
-            if (!refData.AbilitiesByEffectKeyword.TryGetValue(tag, out var abilities)) continue;
+            if (!refData.AbilitiesByEffectKeyword.TryGetValue(tag, out var matches)) continue;
             shortcutKeyword ??= tag;
-            foreach (var ability in abilities)
+            foreach (var match in matches)
             {
+                // Slice 1 (#318): the index now carries provenance
+                // (EffectAbilityMatch.Reason). This reader is adapted minimally —
+                // membership and the "View all N" count are unchanged. Distinct-by-
+                // InternalName across tags is preserved here; the index is already
+                // dedup'd per tag, so the count equals distinct members. The
+                // provenance is surfaced by the popup in slice 2.
+                var ability = match.Ability;
                 if (ability.InternalName is null) continue;
                 if (!seen.Add(ability.InternalName)) continue;
                 ordered.Add(ability);

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceEffectCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceEffectCrossLinkIndexTests.cs
@@ -123,12 +123,20 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
         var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
 
         svc.AbilitiesByEffectKeyword.Should().ContainKey("FrostShard");
-        svc.AbilitiesByEffectKeyword["FrostShard"].Select(a => a.InternalName)
+        svc.AbilitiesByEffectKeyword["FrostShard"].Select(m => m.Ability.InternalName)
             .Should().BeEquivalentTo(["Req", "Enabled", "TargetReq"]);
+
+        // #318 slice 1: the index retains *which field* matched. Each single-field member
+        // carries exactly its own reason flag.
+        var byName = svc.AbilitiesByEffectKeyword["FrostShard"]
+            .ToDictionary(m => m.Ability.InternalName!, m => m.Reason);
+        byName["Req"].Should().Be(EffectAbilityMatchReason.Requires);
+        byName["Enabled"].Should().Be(EffectAbilityMatchReason.EnabledBy);
+        byName["TargetReq"].Should().Be(EffectAbilityMatchReason.Targets);
     }
 
     [Fact]
-    public void AbilitiesByEffectKeyword_DedupesWhenSameTagAppearsInMultipleFields()
+    public void AbilitiesByEffectKeyword_MultiFieldMember_CarriedOnceWithOredReasonFlags()
     {
         WriteFixture(
             effectsJson: "{ }",
@@ -145,8 +153,16 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
 
         var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
 
-        svc.AbilitiesByEffectKeyword["FrostShard"].Should().ContainSingle()
-            .Which.InternalName.Should().Be("Double");
+        // Dedup intent preserved: a single member (so a distinct-member count == the
+        // displayed "View all N"), but provenance is complete — all three reason flags
+        // are OR'd onto the one record. (No multi-reason member exists in bundled data
+        // today, so this is the synthetic guard for the OR-accumulation path.)
+        var match = svc.AbilitiesByEffectKeyword["FrostShard"].Should().ContainSingle().Which;
+        match.Ability.InternalName.Should().Be("Double");
+        match.Reason.Should().Be(
+            EffectAbilityMatchReason.Requires
+            | EffectAbilityMatchReason.EnabledBy
+            | EffectAbilityMatchReason.Targets);
     }
 
     [Fact]
@@ -164,7 +180,7 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
         var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
 
         svc.AbilitiesByEffectKeyword["FrostShard"].Should().ContainSingle()
-            .Which.InternalName.Should().Be("Player");
+            .Which.Ability.InternalName.Should().Be("Player");
     }
 
     [Fact]
@@ -204,7 +220,7 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
             """);
 
         var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
-        svc.AbilitiesByEffectKeyword["FrostShard"].Select(a => a.InternalName)
+        svc.AbilitiesByEffectKeyword["FrostShard"].Select(m => m.Ability.InternalName)
             .Should().BeEquivalentTo(["Strike"]);
 
         // Refresh abilities.json with a second ability now requiring FrostShard. The
@@ -219,7 +235,7 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
 
         // Force re-load of abilities from cache.
         var reloaded = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
-        reloaded.AbilitiesByEffectKeyword["FrostShard"].Select(a => a.InternalName)
+        reloaded.AbilitiesByEffectKeyword["FrostShard"].Select(m => m.Ability.InternalName)
             .Should().BeEquivalentTo(["Strike", "Slash"]);
         await Task.CompletedTask;
     }
@@ -254,17 +270,79 @@ public sealed class ReferenceDataServiceEffectCrossLinkIndexTests : IDisposable
         parsed.Count.Should().BeGreaterThan(10_000);
     }
 
-    private static string? LocateBundledEffects()
+    private static string? LocateBundledEffects() => LocateBundled("effects.json");
+
+    private static string? LocateBundledData()
+    {
+        var effects = LocateBundled("effects.json");
+        return effects is null ? null : Path.GetDirectoryName(effects);
+    }
+
+    private static string? LocateBundled(string file)
     {
         // Walk up from the test binary toward the repo root looking for the bundled file.
         var dir = AppContext.BaseDirectory;
         for (var i = 0; i < 10 && dir is not null; i++)
         {
-            var candidate = Path.Combine(dir, "src", "Mithril.Shared", "Reference", "BundledData", "effects.json");
+            var candidate = Path.Combine(dir, "src", "Mithril.Shared", "Reference", "BundledData", file);
             if (File.Exists(candidate)) return candidate;
             dir = Directory.GetParent(dir)?.FullName;
         }
         return null;
+    }
+
+    [Fact]
+    public void RealBundled_NonPrimaryFieldOnlyTag_RetainsProvenance_WouldHaveCaughtTheBug()
+    {
+        // #318 slice 1 — the load-bearing regression test.
+        //
+        // The original bug: the synthetic AbilityByEffectKeyword kind target re-derived the
+        // set as `EffectKeywordReqs CONTAINS "<tag>"` — one of the three fields the index
+        // unions. Quantified on bundled data: of 24 distinct effect-keyword tags,
+        // EffectKeywordReqs carries exactly 1 (GraffitiSpot); EffectKeywordsIndicatingEnabled
+        // carries 21; TargetEffectKeywordReq carries 2. So 23/24 tags deep-linked to an empty
+        // list. This test pins a concrete non-primary-field-only tag — "BloodMist", carried
+        // ONLY by EffectKeywordsIndicatingEnabled — and asserts it is present in the index
+        // *with the correct provenance reason*. Pre-#318 the value shape discarded the field;
+        // there was nowhere for this assertion to live. It now would.
+        var bundledDir = LocateBundledData();
+        if (bundledDir is null) return; // CI shapes that strip bundled data stay green.
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: bundledDir);
+
+        svc.AbilitiesByEffectKeyword.Should().ContainKey("BloodMist",
+            because: "BloodMist appears only in EffectKeywordsIndicatingEnabled, not EffectKeywordReqs — "
+                + "the field the old synthetic deep-link queried");
+
+        var members = svc.AbilitiesByEffectKeyword["BloodMist"];
+        members.Should().NotBeEmpty();
+
+        // Every BloodMist member qualified via EnabledBy and ONLY EnabledBy in bundled data.
+        members.Should().OnlyContain(
+            m => m.Reason == EffectAbilityMatchReason.EnabledBy,
+            because: "BloodMist is not in any ability's EffectKeywordReqs or TargetEffectKeywordReq");
+
+        // None carry the Requires flag — this is exactly the divergence the bug produced:
+        // a 'Requires CONTAINS BloodMist' query returns empty while the index (correctly)
+        // has 9 EnabledBy members.
+        members.Should().OnlyContain(m => !m.Reason.HasFlag(EffectAbilityMatchReason.Requires));
+
+        // The concrete ability set, pinned so a future bundled-data change that drops the
+        // relationship surfaces as a failure here rather than a silent empty popup.
+        members.Select(m => m.Ability.InternalName).Should().BeEquivalentTo(
+            ["BloodMist1", "BloodMist2", "BloodMist3", "BloodMist4", "BloodMist5",
+             "BloodMist6", "BloodMist7", "BloodMist8", "BloodMist9"]);
+
+        // And the single primary-field tag still classifies as Requires — proving the
+        // index distinguishes the fields rather than tagging everything uniformly.
+        svc.AbilitiesByEffectKeyword.Should().ContainKey("GraffitiSpot");
+        svc.AbilitiesByEffectKeyword["GraffitiSpot"].Should().OnlyContain(
+            m => m.Reason == EffectAbilityMatchReason.Requires);
+
+        // And a TargetEffectKeywordReq-only tag classifies as Targets.
+        svc.AbilitiesByEffectKeyword.Should().ContainKey("MindRevealed");
+        svc.AbilitiesByEffectKeyword["MindRevealed"].Should().OnlyContain(
+            m => m.Reason == EffectAbilityMatchReason.Targets);
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
@@ -393,7 +393,18 @@ public sealed class EffectsTabViewModelTests
         public IReadOnlyDictionary<string, PocoEffect> Effects => EffectsByKey;
         public IReadOnlyDictionary<string, PocoEffect> EffectsByInternalName => EffectsByKey;
         public IReadOnlyDictionary<string, IReadOnlyList<PocoEffect>> EffectsByStackingType => EffectsByStackingTypeMap;
-        public IReadOnlyDictionary<string, IReadOnlyList<Ability>> AbilitiesByEffectKeyword => AbilitiesByEffectKeywordMap;
+        // The stub map is keyed by Ability for test ergonomics; the interface shape now
+        // carries provenance (#318 slice 1). These ViewModel tests only assert membership
+        // / counts, so a uniform Requires reason is sufficient — the provenance regression
+        // is asserted against real bundled data in
+        // ReferenceDataServiceEffectCrossLinkIndexTests.
+        public IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>> AbilitiesByEffectKeyword =>
+            AbilitiesByEffectKeywordMap.ToDictionary(
+                kv => kv.Key,
+                kv => (IReadOnlyList<EffectAbilityMatch>)kv.Value
+                    .Select(a => new EffectAbilityMatch(a, EffectAbilityMatchReason.Requires))
+                    .ToList(),
+                StringComparer.Ordinal);
         public IReadOnlyList<AbilityDynamicDot> AbilityDynamicDots => DotRules;
         public IReadOnlyList<AbilityDynamicSpecialValue> AbilityDynamicSpecialValues => SpecialValueRules;
 


### PR DESCRIPTION
**Tracked in:** #318 (slice 1 of the Sequencing list)

## What this is

Slice 1 of the #318 1:N-provenance-popups refactor: change the **effect→abilities index value shape** so it retains *why* each member qualified, plus tests. This is the invariant from the plan — *the set is materialized exactly once, in the index, AND the index retains why each member qualified* — which is the actual fix; the popup (slice 2) is its consequence.

`BuildEffectAbilityCrossLinkIndices` used to union `EffectKeywordReqs ∪ EffectKeywordsIndicatingEnabled ∪ TargetEffectKeywordReq` and flatten to a dedup'd `HashSet<Ability>`, discarding which field matched. `AbilitiesByEffectKeyword` is now `IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>>`, each member carrying the qualifying `Ability` plus `EffectAbilityMatchReason` flags.

## Scope (explicit)

**This slice is index-shape + tests only.** No shared popup control (slice 2). No UI/XAML/ViewModel changes beyond the minimal `EffectDetailViewModel` reader adaptation needed to keep the build green and the displayed behavior (detail-pane chip cluster + "View all N" count) identical on bundled data. No synthetic-kind / kind-target deletion and no cookbook edits (slice 3). Items/Areas indices untouched.

## The two implementation calls (mine to make, documented per the handoff)

1. **Reason-enum shape:** `EffectAbilityMatchReason` is a **`[Flags]` enum** — `None=0, Requires=1, EnabledBy=2, Targets=4`. Flags (not a plain enum or a `List<reason>`) because a member can qualify via several fields and the natural representation of "qualified via Requires *and* EnabledBy" is an OR'd flag value; it also makes the multi-reason rendering decision below a single field rather than a collection.
2. **Multi-reason member rendering:** **once with multiple reason flags** (the recommended option). The index OR-accumulates reasons per `(tag, ability)` so a multi-field ability is carried as a single record with several flags set. Rationale: dedup intent is preserved (a distinct-member count equals the displayed "View all N" — no double-counting), and provenance is complete (a future popup can section by reason). I found no concrete reason for a surface to differ; bundled data currently has **zero** multi-reason members, so once-with-flags has no behavioral cost today and is the structurally honest shape for when one appears.

## Regression test (the load-bearing one)

`RealBundled_NonPrimaryFieldOnlyTag_RetainsProvenance_WouldHaveCaughtTheBug` walks real bundled `abilities.json`. Quantification confirmed against bundled data and matches the plan exactly: of **24** distinct effect-keyword tags, `EffectKeywordReqs` carries **1** (`GraffitiSpot`), `EffectKeywordsIndicatingEnabled` **21**, `TargetEffectKeywordReq` **2** (`MindRevealed`, `HasRecentlyHeardBardSong`).

The test pins **`BloodMist`** — present *only* in `EffectKeywordsIndicatingEnabled`, never `EffectKeywordReqs` (the single field the old synthetic `AbilityByEffectKeyword` deep-link queried). It asserts `BloodMist` is in the index with reason `EnabledBy`, never the `Requires` flag, and pins its 9 concrete abilities (`BloodMist1..9`). Pre-#318 the value shape discarded the field, so there was nowhere for this assertion to live — it now would have caught the original bug (23/24 tags deep-linking to an empty list). Also pins `GraffitiSpot → Requires` and `MindRevealed → Targets` to prove the index distinguishes fields rather than tagging uniformly. The synthetic `..._MultiFieldMember_CarriedOnceWithOredReasonFlags` test guards the OR-accumulation path (no bundled multi-reason member exists to exercise it).

## Verification

- `dotnet build Mithril.slnx` — Build succeeded, **0 Warning(s), 0 Error(s)** (warnings-as-errors clean).
- `dotnet test tests/Mithril.Shared.Tests` — **Passed: 919, Failed: 0, Skipped: 0**.
- `dotnet test tests/Silmarillion.Tests` — **Passed: 331, Failed: 0, Skipped: 0**.
- Full `dotnet test Mithril.slnx` — green across all projects (Celebrimbor / Bilbo / Elrond / Arwen / Legolas / etc. — all `IReferenceDataService` consumers pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)