### PR TITLE
feat(silmarillion): Lorebooks tab — #247

### DIFF
--- a/src/Mithril.Shared.Wpf/FormattedTextRenderer.cs
+++ b/src/Mithril.Shared.Wpf/FormattedTextRenderer.cs
@@ -6,18 +6,39 @@ using System.Windows.Documents;
 namespace Mithril.Shared.Wpf;
 
 /// <summary>
-/// Attached property + parser that renders Project Gorgon's tiny inline-markup vocabulary
-/// (<c>&lt;i&gt;…&lt;/i&gt;</c>, <c>&lt;b&gt;…&lt;/b&gt;</c>) into a <see cref="TextBlock"/>'s
+/// Attached property + parser that renders Project Gorgon's inline-markup vocabulary
+/// (<c>&lt;i&gt;…&lt;/i&gt;</c>, <c>&lt;b&gt;…&lt;/b&gt;</c>, <c>&lt;h1&gt;…&lt;/h1&gt;</c>,
+/// <c>&lt;hr&gt;</c>, <c>&lt;br&gt;</c>) into a <see cref="TextBlock"/>'s
 /// <see cref="TextBlock.Inlines"/> collection. Quest descriptions, lorebook bodies and item
-/// flavor text all use this two-tag subset — most commonly as a speaker prefix
-/// (<c>&lt;i&gt;Joeh:&lt;/i&gt; Hello adventurer.</c>). A plain <c>TextBlock.Text</c> binding
-/// renders the tags literally; this property parses them into italic / bold runs so the chip
-/// reads as intended.
+/// flavor text all use this subset — most commonly as a speaker prefix
+/// (<c>&lt;i&gt;Joeh:&lt;/i&gt; Hello adventurer.</c>) or, for lorebooks, an opening
+/// <c>&lt;h1&gt;</c> title plus the occasional <c>&lt;hr&gt;</c> scene break. A plain
+/// <c>TextBlock.Text</c> binding renders the tags literally; this property parses them so the
+/// block reads as intended.
+/// <para>
+/// <b>Tag vocabulary (#247 — Option A).</b> The original two-tag subset (<c>&lt;i&gt;</c> /
+/// <c>&lt;b&gt;</c>) was extended with the three structural tags lorebook bodies use:
+/// <list type="bullet">
+/// <item><c>&lt;br&gt;</c> / <c>&lt;br/&gt;</c> → a single <see cref="LineBreak"/>.</item>
+/// <item><c>&lt;hr&gt;</c> / <c>&lt;hr/&gt;</c> → a scene-break: blank line, a row of
+/// em-dashes on its own line, blank line. (<c>TextBlock.Inlines</c> has no
+/// <c>Border</c>/<c>Separator</c> inline; the em-dash row is the lightweight idiom — see the
+/// #247 handoff's Critical → Option A note.)</item>
+/// <item><c>&lt;h1&gt;…&lt;/h1&gt;</c> → a leading line break, the heading text rendered
+/// <b>bold + larger</b>, then a trailing double line break (it opens the book; the body
+/// follows). Bold/italic state from enclosing tags is preserved.</item>
+/// </list>
+/// Extending the shared renderer (rather than pre-stripping in one VM) is deliberate: the
+/// existing call sites (quest descriptions, item flavor text) start parsing these tags too,
+/// which is the desired behaviour — those fields previously rendered literal <c>&lt;br&gt;</c>
+/// etc. on the rare entry that carried one. No consumer relied on literal pass-through (the
+/// only producers of these tags are long-form text fields that <i>want</i> them rendered).
+/// </para>
 /// <para>
 /// The parser handles nesting (<c>&lt;b&gt;&lt;i&gt;X&lt;/i&gt;&lt;/b&gt;</c>) via formatting
-/// counts; unbalanced or interleaved tags close the appropriate counter without throwing, so
-/// data drift can't crash the renderer. Bare <c>&lt;</c> characters not followed by one of the
-/// four supported tags pass through as literal text.
+/// counts; unbalanced or interleaved tags clamp at zero without throwing, so data drift can't
+/// crash the renderer. A bare <c>&lt;</c> not followed by one of the supported tags (including
+/// a malformed <c>&lt;h1</c> with no <c>&gt;</c>) passes through as literal text.
 /// </para>
 /// <para>
 /// Usage:
@@ -31,6 +52,9 @@ namespace Mithril.Shared.Wpf;
 /// </summary>
 public static class FormattedText
 {
+    /// <summary>The em-dash separator row emitted for <c>&lt;hr&gt;</c>.</summary>
+    private const string HorizontalRuleGlyph = "— — — — — — —";
+
     public static readonly DependencyProperty TextProperty =
         DependencyProperty.RegisterAttached(
             "Text",
@@ -52,9 +76,9 @@ public static class FormattedText
     }
 
     /// <summary>
-    /// Tokenise <paramref name="text"/> and yield the WPF <see cref="Inline"/> runs that
-    /// would render it with the embedded italic / bold spans applied. Pure function — usable
-    /// from tests without instantiating a TextBlock.
+    /// Tokenise <paramref name="text"/> and yield the WPF <see cref="Inline"/> runs (and
+    /// <see cref="LineBreak"/>s) that would render it with the embedded markup applied. Pure
+    /// function — usable from tests without instantiating a TextBlock.
     /// </summary>
     public static IReadOnlyList<Inline> BuildInlines(string text)
     {
@@ -63,71 +87,121 @@ public static class FormattedText
 
         // Counts rather than a stack so unbalanced/interleaved data drift can't crash —
         // each </tag> decrements (clamped at 0), each <tag> increments. A run inherits the
-        // current italic/bold state at emission time.
+        // current italic/bold/heading state at emission time.
         var italicDepth = 0;
         var boldDepth = 0;
+        var headingDepth = 0;
         var pos = 0;
+
+        void EmitText(string segment)
+        {
+            if (segment.Length == 0) return;
+            result.Add(MakeRun(segment, italicDepth, boldDepth, headingDepth));
+        }
 
         while (pos < text.Length)
         {
-            var (tagPos, tagLength, italicDelta, boldDelta) = FindNextTag(text, pos);
+            var tag = FindNextTag(text, pos);
 
-            if (tagPos < 0)
+            if (tag.Pos < 0)
             {
-                var tail = text.Substring(pos);
-                if (tail.Length > 0) result.Add(MakeRun(tail, italicDepth, boldDepth));
+                EmitText(text.Substring(pos));
                 break;
             }
 
-            if (tagPos > pos)
+            if (tag.Pos > pos)
+                EmitText(text.Substring(pos, tag.Pos - pos));
+
+            switch (tag.Kind)
             {
-                var segment = text.Substring(pos, tagPos - pos);
-                result.Add(MakeRun(segment, italicDepth, boldDepth));
+                case TagKind.Italic:
+                    italicDepth = System.Math.Max(0, italicDepth + tag.Delta);
+                    break;
+                case TagKind.Bold:
+                    boldDepth = System.Math.Max(0, boldDepth + tag.Delta);
+                    break;
+                case TagKind.Heading:
+                    if (tag.Delta > 0)
+                    {
+                        // Opening <h1>: break onto a fresh line, then bold+large text.
+                        result.Add(new LineBreak());
+                        headingDepth = headingDepth + 1;
+                    }
+                    else
+                    {
+                        // Closing </h1>: end the heading, double-break before the body.
+                        headingDepth = System.Math.Max(0, headingDepth - 1);
+                        result.Add(new LineBreak());
+                        result.Add(new LineBreak());
+                    }
+                    break;
+                case TagKind.LineBreak:
+                    result.Add(new LineBreak());
+                    break;
+                case TagKind.HorizontalRule:
+                    // Scene break: blank line, em-dash row, blank line. No inline Border in
+                    // TextBlock.Inlines, so the glyph row is the lightweight separator idiom.
+                    result.Add(new LineBreak());
+                    result.Add(new Run(HorizontalRuleGlyph) { Foreground = SystemColors.GrayTextBrush });
+                    result.Add(new LineBreak());
+                    result.Add(new LineBreak());
+                    break;
             }
 
-            italicDepth = System.Math.Max(0, italicDepth + italicDelta);
-            boldDepth = System.Math.Max(0, boldDepth + boldDelta);
-            pos = tagPos + tagLength;
+            pos = tag.Pos + tag.Length;
         }
 
         return result;
     }
 
+    private enum TagKind { Italic, Bold, Heading, LineBreak, HorizontalRule }
+
+    private readonly record struct TagMatch(int Pos, int Length, TagKind Kind, int Delta);
+
     /// <summary>
-    /// Linear scan from <paramref name="from"/> for the next occurrence of any of the four
-    /// supported tag literals. Returns -1 in <c>Pos</c> when none is found.
+    /// Linear scan from <paramref name="from"/> for the next occurrence of any supported tag
+    /// literal. <c>&lt;br&gt;</c> / <c>&lt;hr&gt;</c> also match their XML self-closing forms.
+    /// Returns <c>Pos = -1</c> when none is found.
     /// </summary>
-    private static (int Pos, int Length, int ItalicDelta, int BoldDelta) FindNextTag(string text, int from)
+    private static TagMatch FindNextTag(string text, int from)
     {
-        var bestPos = -1;
-        var bestLen = 0;
-        var bestItalic = 0;
-        var bestBold = 0;
+        var best = new TagMatch(-1, 0, TagKind.Italic, 0);
 
-        TryTag("<i>", italicDelta: +1, boldDelta: 0);
-        TryTag("</i>", italicDelta: -1, boldDelta: 0);
-        TryTag("<b>", italicDelta: 0, boldDelta: +1);
-        TryTag("</b>", italicDelta: 0, boldDelta: -1);
-
-        return (bestPos, bestLen, bestItalic, bestBold);
-
-        void TryTag(string tag, int italicDelta, int boldDelta)
+        void TryTag(string tag, TagKind kind, int delta)
         {
-            var idx = text.IndexOf(tag, from, System.StringComparison.Ordinal);
+            var idx = text.IndexOf(tag, from, System.StringComparison.OrdinalIgnoreCase);
             if (idx < 0) return;
-            if (bestPos >= 0 && idx >= bestPos) return;
-            bestPos = idx;
-            bestLen = tag.Length;
-            bestItalic = italicDelta;
-            bestBold = boldDelta;
+            // Earliest wins; on a tie the longer literal wins so "<br/>" isn't shadowed by
+            // a hypothetical shorter prefix match.
+            if (best.Pos >= 0 && (idx > best.Pos || (idx == best.Pos && tag.Length <= best.Length)))
+                return;
+            best = new TagMatch(idx, tag.Length, kind, delta);
         }
+
+        TryTag("<i>", TagKind.Italic, +1);
+        TryTag("</i>", TagKind.Italic, -1);
+        TryTag("<b>", TagKind.Bold, +1);
+        TryTag("</b>", TagKind.Bold, -1);
+        TryTag("<h1>", TagKind.Heading, +1);
+        TryTag("</h1>", TagKind.Heading, -1);
+        TryTag("<br/>", TagKind.LineBreak, 0);
+        TryTag("<br>", TagKind.LineBreak, 0);
+        TryTag("<hr/>", TagKind.HorizontalRule, 0);
+        TryTag("<hr>", TagKind.HorizontalRule, 0);
+
+        return best;
     }
 
-    private static Run MakeRun(string text, int italicDepth, int boldDepth)
+    private static Run MakeRun(string text, int italicDepth, int boldDepth, int headingDepth)
     {
         var run = new Run(text);
         if (italicDepth > 0) run.FontStyle = FontStyles.Italic;
-        if (boldDepth > 0) run.FontWeight = FontWeights.Bold;
+        if (boldDepth > 0 || headingDepth > 0) run.FontWeight = FontWeights.Bold;
+        if (headingDepth > 0)
+            // Larger reading-comfort size for the book title. Absolute (not inherited-relative
+            // — TextBlock.Inlines runs can't express a relative size) but scales off the OS
+            // message-font baseline so it tracks the user's system text-size preference.
+            run.FontSize = SystemFonts.MessageFontSize * 1.45;
         return run;
     }
 }

--- a/src/Mithril.Shared.Wpf/ItemDetailContext.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailContext.cs
@@ -29,6 +29,10 @@ public sealed record ItemDetailContext(
     IReadOnlyList<EntityChipVm>? ConsumedByRecipes = null,
     IReadOnlyList<EntityChipVm>? ConsumedAsKeywordIn = null,
     IReadOnlyList<EntityChipVm>? AwardedByQuests = null,
+    // Inbound 1:1 cross-link (#247): the lorebook this item bestows on use, resolved from
+    // Item.BestowLoreBook (int? → numeric Book id) via LorebooksById. Null when the item
+    // doesn't bestow a book, or the id doesn't resolve. A single navigable EntityChip.
+    EntityChipVm? BestowsLorebook = null,
     IReadOnlyList<ItemSourceChipVm>? Sources = null,
     // Always-visible navigable summary chip for the "Used in" section. Non-null whenever
     // the item is consumed by any recipe (independent of the chip cap); renders as a

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -123,6 +123,24 @@
                     </ItemsControl>
                 </StackPanel>
 
+                <!-- Bestows lorebook — inbound 1:1 cross-link (#247). Item.BestowLoreBook
+                     resolved to the lorebook via LorebooksById; a single navigable chip
+                     (becomes clickable once the Lorebooks kind target is registered, plain
+                     text otherwise). Hidden when the item bestows no book. -->
+                <StackPanel Margin="0,10,0,0"
+                            Visibility="{Binding BestowsLorebook, Converter={StaticResource NullToVis}}">
+                    <TextBlock Text="Bestows lorebook" FontWeight="SemiBold"
+                               Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <ContentControl Content="{Binding BestowsLorebook}" HorizontalAlignment="Left">
+                        <ContentControl.Resources>
+                            <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                            </DataTemplate>
+                        </ContentControl.Resources>
+                    </ContentControl>
+                </StackPanel>
+
                 <!-- Used in recipes — cross-link to recipes that consume this item. Capped at
                      SilmarillionSettings.UsedInChipCap to keep selection-change cheap (long-tail
                      items like MetalSlab1 ship 60+ recipes). The trailing always-visible

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -60,6 +60,7 @@ public sealed partial class ItemDetailViewModel
         RecipesTabShortcut = context.RecipesTabShortcut;
         ConsumedAsKeywordIn = context.ConsumedAsKeywordIn ?? [];
         AwardedByQuests = context.AwardedByQuests ?? [];
+        BestowsLorebook = context.BestowsLorebook;
         Sources = context.Sources ?? [];
         _poolPresenter = poolPresenter;
     }
@@ -126,6 +127,15 @@ public sealed partial class ItemDetailViewModel
     /// flow; quest chips become navigable when the Quests tab is registered (#242).
     /// </summary>
     public IReadOnlyList<EntityChipVm> AwardedByQuests { get; }
+
+    /// <summary>
+    /// The lorebook this item bestows on use (<see cref="Item.BestowLoreBook"/> resolved via
+    /// <c>LorebooksById</c>), or null when the item bestows no book. A single navigable
+    /// <see cref="EntityChip"/> — the inbound 1:1 cross-link that's the natural payoff of
+    /// the Lorebooks tab shipping (#247). Becomes clickable once the Lorebooks kind target
+    /// is registered; degrades to plain text otherwise.
+    /// </summary>
+    public EntityChipVm? BestowsLorebook { get; }
 
     /// <summary>
     /// Item sources (NPC vendors, monster drops, quest rewards, …) — rendered as a list of

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -411,6 +411,59 @@ public interface IReferenceDataService
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<Effect>> EmptyEffectIndex
         = new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
 
+    // ── Lorebooks (#247) ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lorebook envelope key (e.g. <c>"Book_101"</c>) → <see cref="Lorebook"/> POCO from
+    /// <c>lorebooks.json</c>. The envelope key and <see cref="Lorebook.InternalName"/> are
+    /// <i>different</i> identifiers (same divergence as Recipe's <c>recipe_NNNN</c> vs
+    /// human-form InternalName). Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, Lorebook> Lorebooks => EmptyLorebookMap;
+
+    /// <summary>
+    /// Lorebook <see cref="Lorebook.InternalName"/> (e.g. <c>"TheWastedWishes"</c>) →
+    /// <see cref="Lorebook"/>. The kind target's selection contract follows the cookbook
+    /// InternalName convention and matches the existing <see cref="EntityRef.Lorebook(string)"/>
+    /// factory. Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, Lorebook> LorebooksByInternalName => EmptyLorebookMap;
+
+    /// <summary>
+    /// Numeric Book id (101, 102, …) → <see cref="Lorebook"/>. The id is lifted from the
+    /// numeric suffix of the envelope key (<c>"Book_101"</c> → <c>101</c>). Powers the
+    /// inbound reverse lookup from <see cref="Item.BestowLoreBook"/> (an <c>int?</c>) on
+    /// Item detail. Defaults to empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<int, Lorebook> LorebooksById => EmptyLorebookByIdMap;
+
+    /// <summary>
+    /// Lorebook <see cref="Lorebook.InternalName"/> → items whose
+    /// <see cref="Item.BestowLoreBook"/> matches this book's numeric id. The single
+    /// materialization for the #318 popup-from-index "Items that bestow this book" surface
+    /// (single-reason — an item qualifies exactly one way). Built whenever
+    /// <c>lorebooks.json</c> or <c>items.json</c> reloads. Defaults to empty so test fakes
+    /// don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsBestowingLorebook => EmptyItemIndex;
+
+    /// <summary>
+    /// Sidecar metadata from <c>lorebookinfo.json</c>: category key (e.g. <c>"Gods"</c>) →
+    /// display info (Title / SubTitle / SortTitle). Drives the master-list group headers
+    /// and category facet. Built whenever <c>lorebookinfo.json</c> reloads. Defaults to
+    /// empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, LorebookCategoryInfo> LorebookCategories => EmptyLorebookCategoryMap;
+
+    private static readonly IReadOnlyDictionary<string, Lorebook> EmptyLorebookMap
+        = new Dictionary<string, Lorebook>(StringComparer.Ordinal);
+
+    private static readonly IReadOnlyDictionary<int, Lorebook> EmptyLorebookByIdMap
+        = new Dictionary<int, Lorebook>();
+
+    private static readonly IReadOnlyDictionary<string, LorebookCategoryInfo> EmptyLorebookCategoryMap
+        = new Dictionary<string, LorebookCategoryInfo>(StringComparer.Ordinal);
+
     /// <summary>
     /// All localizable strings from <c>strings_all.json</c>, keyed by their
     /// dotted/slashed string ID. Primary use today is friendly-name resolution

--- a/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
@@ -24,6 +24,7 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         EntityKind.Ability => ResolveAbility(reference.InternalName),
         EntityKind.Effect => ResolveEffect(reference.InternalName),
         EntityKind.Skill => ResolveSkill(reference.InternalName),
+        EntityKind.Lorebook => ResolveLorebook(reference.InternalName),
         _ => reference.InternalName,
     };
 
@@ -83,6 +84,17 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         _refData.Skills.TryGetValue(skillKey, out var skill) && !string.IsNullOrEmpty(skill.DisplayName)
             ? skill.DisplayName
             : skillKey;
+
+    /// <summary>
+    /// Lorebook InternalNames are the bare PascalCase form (e.g. <c>"TheWastedWishes"</c>,
+    /// matching <see cref="EntityRef.Lorebook(string)"/>); the human title lives on
+    /// <see cref="Mithril.Reference.Models.Misc.Lorebook.Title"/>. Prefer the title; fall
+    /// through to the InternalName when no entry is registered or Title is empty.
+    /// </summary>
+    private string ResolveLorebook(string internalName) =>
+        _refData.LorebooksByInternalName.TryGetValue(internalName, out var book) && !string.IsNullOrEmpty(book.Title)
+            ? book.Title!
+            : internalName;
 
     private static string StripNpcPrefix(string internalName) =>
         internalName.StartsWith("NPC_", StringComparison.Ordinal)

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -12,6 +12,9 @@ using Item = Mithril.Reference.Models.Items.Item;
 using PocoArea = Mithril.Reference.Models.Misc.Area;
 using PocoAttribute = Mithril.Reference.Models.Misc.AttributeDef;
 using PocoLandmark = Mithril.Reference.Models.Misc.Landmark;
+using Lorebook = Mithril.Reference.Models.Misc.Lorebook;
+using LorebookInfo = Mithril.Reference.Models.Misc.LorebookInfo;
+using LorebookCategoryInfo = Mithril.Reference.Models.Misc.LorebookCategoryInfo;
 using PocoNpc = Mithril.Reference.Models.Npcs.Npc;
 using PocoNpcPreference = Mithril.Reference.Models.Npcs.NpcPreference;
 using PocoNpcService = Mithril.Reference.Models.Npcs.NpcService;
@@ -230,6 +233,23 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, IReadOnlyList<Effect>>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _effectsSnapshot;
 
+    // Lorebooks (lorebooks.json) — keyed by "Book_N" envelope key, plus InternalName and
+    // numeric-id secondary lookups. lorebookinfo.json is a separate sidecar carrying the
+    // 7 category display-metadata entries. ItemsBestowingLorebook is the #318 popup-from-
+    // index source for the "Items that bestow this book" surface (#247).
+    private IReadOnlyDictionary<string, Lorebook> _lorebooks =
+        new Dictionary<string, Lorebook>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, Lorebook> _lorebooksByInternalName =
+        new Dictionary<string, Lorebook>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<int, Lorebook> _lorebooksById =
+        new Dictionary<int, Lorebook>();
+    private IReadOnlyDictionary<string, IReadOnlyList<Item>> _itemsBestowingLorebook =
+        new Dictionary<string, IReadOnlyList<Item>>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _lorebooksSnapshot;
+    private IReadOnlyDictionary<string, LorebookCategoryInfo> _lorebookCategories =
+        new Dictionary<string, LorebookCategoryInfo>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _lorebookInfoSnapshot;
+
     public ReferenceDataService(string cacheDir, HttpClient http, IDiagnosticsSink? diag = null, string? bundledDir = null, IPerfTracer? perf = null)
     {
         _cacheDir = cacheDir;
@@ -264,6 +284,8 @@ public sealed class ReferenceDataService : IReferenceDataService
         _abilityDynamicDotsSnapshot = new ReferenceFileSnapshot("abilitydynamicdots", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _abilityDynamicSpecialValuesSnapshot = new ReferenceFileSnapshot("abilitydynamicspecialvalues", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _effectsSnapshot = new ReferenceFileSnapshot("effects", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _lorebooksSnapshot = new ReferenceFileSnapshot("lorebooks", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _lorebookInfoSnapshot = new ReferenceFileSnapshot("lorebookinfo", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
 
         LoadItems();
         LoadRecipes();
@@ -287,9 +309,14 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadAbilityDynamicDots();
         LoadAbilityDynamicSpecialValues();
         LoadEffects();
+        LoadLorebookInfo();        // Sidecar; independent of lorebooks.json. Load before
+                                   // LoadLorebooks is not required (categories aren't a parse
+                                   // dependency) but keeps the lorebook pair adjacent.
+        LoadLorebooks();           // After LoadItems so BuildLorebookItemCrossLinkIndex sees
+                                   // the final item set on first build.
     }
 
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects"];
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects", "lorebooks", "lorebookinfo"];
 
     public IReadOnlyDictionary<long, Item> Items => _items;
     public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByInternalName;
@@ -335,6 +362,11 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByStackingType => _effectsByStackingType;
     public IReadOnlyDictionary<string, IReadOnlyList<EffectAbilityMatch>> AbilitiesByEffectKeyword => _abilitiesByEffectKeyword;
     public IReadOnlyDictionary<string, IReadOnlyList<Effect>> EffectsByTriggeringAbilityKeyword => _effectsByTriggeringAbilityKeyword;
+    public IReadOnlyDictionary<string, Lorebook> Lorebooks => _lorebooks;
+    public IReadOnlyDictionary<string, Lorebook> LorebooksByInternalName => _lorebooksByInternalName;
+    public IReadOnlyDictionary<int, Lorebook> LorebooksById => _lorebooksById;
+    public IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsBestowingLorebook => _itemsBestowingLorebook;
+    public IReadOnlyDictionary<string, LorebookCategoryInfo> LorebookCategories => _lorebookCategories;
     public IReadOnlyDictionary<string, string> Strings => _strings;
 
     public ReferenceFileSnapshot GetSnapshot(string key) => key switch
@@ -360,6 +392,8 @@ public sealed class ReferenceDataService : IReferenceDataService
         "abilitydynamicdots" => _abilityDynamicDotsSnapshot,
         "abilitydynamicspecialvalues" => _abilityDynamicSpecialValuesSnapshot,
         "effects" => _effectsSnapshot,
+        "lorebooks" => _lorebooksSnapshot,
+        "lorebookinfo" => _lorebookInfoSnapshot,
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -388,6 +422,8 @@ public sealed class ReferenceDataService : IReferenceDataService
         "abilitydynamicdots" => RefreshFileAsync("abilitydynamicdots", ReferenceDeserializer.ParseAbilityDynamicDots, ParseAndSwapAbilityDynamicDots, ct),
         "abilitydynamicspecialvalues" => RefreshFileAsync("abilitydynamicspecialvalues", ReferenceDeserializer.ParseAbilityDynamicSpecialValues, ParseAndSwapAbilityDynamicSpecialValues, ct),
         "effects" => RefreshFileAsync("effects", ReferenceDeserializer.ParseEffects, ParseAndSwapEffects, ct),
+        "lorebooks" => RefreshFileAsync("lorebooks", ReferenceDeserializer.ParseLorebooks, ParseAndSwapLorebooks, ct),
+        "lorebookinfo" => RefreshFileAsync("lorebookinfo", ReferenceDeserializer.ParseLorebookInfo, ParseAndSwapLorebookInfo, ct),
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -414,6 +450,8 @@ public sealed class ReferenceDataService : IReferenceDataService
         await RefreshAsync("abilitydynamicdots", ct).ConfigureAwait(false);
         await RefreshAsync("abilitydynamicspecialvalues", ct).ConfigureAwait(false);
         await RefreshAsync("effects", ct).ConfigureAwait(false);
+        await RefreshAsync("lorebookinfo", ct).ConfigureAwait(false);
+        await RefreshAsync("lorebooks", ct).ConfigureAwait(false);
     }
 
     public void BeginBackgroundRefresh()
@@ -600,6 +638,8 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void LoadAbilityDynamicDots() => LoadFile("abilitydynamicdots", ReferenceDeserializer.ParseAbilityDynamicDots, ParseAndSwapAbilityDynamicDots);
     private void LoadAbilityDynamicSpecialValues() => LoadFile("abilitydynamicspecialvalues", ReferenceDeserializer.ParseAbilityDynamicSpecialValues, ParseAndSwapAbilityDynamicSpecialValues);
     private void LoadEffects() => LoadFile("effects", ReferenceDeserializer.ParseEffects, ParseAndSwapEffects);
+    private void LoadLorebooks() => LoadFile("lorebooks", ReferenceDeserializer.ParseLorebooks, ParseAndSwapLorebooks);
+    private void LoadLorebookInfo() => LoadFile("lorebookinfo", ReferenceDeserializer.ParseLorebookInfo, ParseAndSwapLorebookInfo);
 
     // ── Per-type parse-and-swap ──────────────────────────────────────────
 
@@ -628,6 +668,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         BuildRecipeCrossLinkIndices();
         BuildNpcCrossLinkIndices();
         BuildQuestCrossLinkIndices();
+        BuildLorebookItemCrossLinkIndex();
     }
 
     private void ParseAndSwapRecipes(IReadOnlyDictionary<string, Recipe> raw, ReferenceFileMetadata meta)
@@ -1007,6 +1048,100 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _npcsByArea = byArea.ToDictionary(
             kv => kv.Key, kv => (IReadOnlyList<NpcEntry>)kv.Value, StringComparer.Ordinal);
+    }
+
+    private void ParseAndSwapLorebooks(IReadOnlyDictionary<string, Lorebook> raw, ReferenceFileMetadata meta)
+    {
+        var byKey = new Dictionary<string, Lorebook>(raw.Count, StringComparer.Ordinal);
+        var byInternalName = new Dictionary<string, Lorebook>(raw.Count, StringComparer.Ordinal);
+        var byId = new Dictionary<int, Lorebook>(raw.Count);
+        foreach (var (key, v) in raw)
+        {
+            byKey[key] = v;
+            if (!string.IsNullOrEmpty(v.InternalName))
+                byInternalName[v.InternalName!] = v;
+            // Envelope key is "Book_<N>"; lift the numeric suffix so Item.BestowLoreBook
+            // (an int? matching <N>) can reverse-resolve to the book. Skip keys that don't
+            // fit the convention rather than throwing — defensive against drift.
+            if (TryLiftLorebookId(key, out var id))
+                byId[id] = v;
+        }
+        _lorebooks = byKey;
+        _lorebooksByInternalName = byInternalName;
+        _lorebooksById = byId;
+        _lorebooksSnapshot = new ReferenceFileSnapshot("lorebooks", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
+        BuildLorebookItemCrossLinkIndex();
+    }
+
+    private void ParseAndSwapLorebookInfo(LorebookInfo raw, ReferenceFileMetadata meta)
+    {
+        var byCategory = raw.Categories is null
+            ? new Dictionary<string, LorebookCategoryInfo>(StringComparer.Ordinal)
+            : new Dictionary<string, LorebookCategoryInfo>(raw.Categories, StringComparer.Ordinal);
+        _lorebookCategories = byCategory;
+        _lorebookInfoSnapshot = new ReferenceFileSnapshot("lorebookinfo", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byCategory.Count);
+    }
+
+    /// <summary>
+    /// Lifts the numeric id from a <c>"Book_&lt;N&gt;"</c> envelope key. Returns false for
+    /// keys that don't match the convention (defensive against a future PG key-shape change).
+    /// </summary>
+    private static bool TryLiftLorebookId(string envelopeKey, out int id)
+    {
+        id = 0;
+        var underscore = envelopeKey.LastIndexOf('_');
+        if (underscore < 0 || underscore == envelopeKey.Length - 1) return false;
+        return int.TryParse(
+            envelopeKey.AsSpan(underscore + 1),
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out id);
+    }
+
+    /// <summary>
+    /// Builds <see cref="_itemsBestowingLorebook"/>: lorebook InternalName → items whose
+    /// <see cref="Item.BestowLoreBook"/> equals the book's numeric id. The single
+    /// materialization for the #318 popup-from-index "Items that bestow this book" surface
+    /// (single-reason — an item qualifies exactly one way). Called from
+    /// <see cref="ParseAndSwapLorebooks"/> (book set / id mapping changed) and
+    /// <see cref="ParseAndSwapItems"/> (the BestowLoreBook side changed) so a refresh of
+    /// either file rebuilds the index against fresh POCO instances. The per-book list is
+    /// dedup'd by item InternalName so the popup count equals distinct membership.
+    /// </summary>
+    private void BuildLorebookItemCrossLinkIndex()
+    {
+        if (_lorebooksById.Count == 0 || _itemsByInternalName.Count == 0)
+        {
+            _itemsBestowingLorebook = new Dictionary<string, IReadOnlyList<Item>>(StringComparer.Ordinal);
+            return;
+        }
+
+        var acc = new Dictionary<string, List<Item>>(StringComparer.Ordinal);
+        var seen = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var item in _itemsByInternalName.Values)
+        {
+            if (item.BestowLoreBook is not { } bookId) continue;
+            if (!_lorebooksById.TryGetValue(bookId, out var book)) continue;
+            if (string.IsNullOrEmpty(book.InternalName)) continue;
+            var bookName = book.InternalName!;
+
+            if (!acc.TryGetValue(bookName, out var list))
+            {
+                list = new List<Item>();
+                acc[bookName] = list;
+                seen[bookName] = new HashSet<string>(StringComparer.Ordinal);
+            }
+            var itemKey = item.InternalName ?? string.Empty;
+            if (!seen[bookName].Add(itemKey)) continue;
+            list.Add(item);
+        }
+
+        _itemsBestowingLorebook = acc.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlyList<Item>)kv.Value
+                .OrderBy(i => i.Name ?? i.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            StringComparer.Ordinal);
     }
 
     private void ParseAndSwapDirectedGoals(IReadOnlyList<DirectedGoal> raw, ReferenceFileMetadata meta)

--- a/src/Silmarillion.Module/Navigation/LorebooksKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/LorebooksKindTarget.cs
@@ -1,0 +1,56 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the Lorebooks tab. Resolves selection
+/// against the tab VM's bound <see cref="LorebooksTabViewModel.AllLorebooks"/> collection
+/// rather than <see cref="IReferenceDataService"/> directly — same instance-identity
+/// concern as the other Silmarillion tabs (cookbook *Pattern walkthrough → ItemsKindTarget*).
+/// <para>
+/// The <c>internalName</c> argument is the lorebook <see cref="LorebookListRow.InternalName"/>
+/// (e.g. <c>"TheWastedWishes"</c>) — the bare PascalCase form, NOT the <c>"Book_N"</c>
+/// envelope key (matches the existing <see cref="EntityRef.Lorebook(string)"/> factory and
+/// every existing call site, e.g. <c>QuestDetailProjector</c>'s lorebook reward chip).
+/// </para>
+/// </summary>
+public sealed class LorebooksKindTarget : IReferenceKindTarget
+{
+    private readonly LorebooksTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public LorebooksKindTarget(LorebooksTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.Lorebook;
+
+    public int TabIndex => 7;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var row = _vm.AllLorebooks.FirstOrDefault(b => b.InternalName == internalName);
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Lorebooks.TrySelect '{internalName}' → not found (AllLorebooks={_vm.AllLorebooks.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Lorebooks.TrySelect '{internalName}' → found, selecting.");
+        // Clear any residual filter so the target row isn't filtered out of the visible list.
+        _vm.QueryText = "";
+        _vm.SelectedLorebook = row;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new LorebookDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -64,6 +64,11 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetRequiredService<IReferenceNavigator>(),
             sp.GetRequiredService<IEntityNameResolver>(),
             sp.GetRequiredService<SilmarillionSettings>()));
+        services.AddSingleton<LorebooksTabViewModel>(sp => new LorebooksTabViewModel(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IReferenceNavigator>(),
+            sp.GetRequiredService<IEntityNameResolver>(),
+            sp.GetRequiredService<SilmarillionSettings>()));
         // Forward each concrete tab VM to ITabViewModel so SilmarillionViewModel can compose
         // its Tabs collection from IEnumerable<ITabViewModel>. Adding a future tab is a single
         // pair of registrations here — no SilmarillionViewModel ctor change (refactor #243).
@@ -74,6 +79,7 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<AbilitiesTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<EffectsTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<AreasTabViewModel>());
+        services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<LorebooksTabViewModel>());
         services.AddSingleton<SilmarillionViewModel>();
 
         // Kind targets registered after the tab VMs so DI can resolve them.
@@ -118,6 +124,9 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new NpcByAreaKindTarget(
             sp.GetRequiredService<NpcsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new LorebooksKindTarget(
+            sp.GetRequiredService<LorebooksTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -152,8 +152,28 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
             ConsumedByRecipes: consumed,
             ConsumedAsKeywordIn: BuildKeywordChips(item),
             AwardedByQuests: BuildAwardedByQuestChips(item.InternalName!),
+            BestowsLorebook: BuildBestowsLorebookChip(item),
             Sources: BuildSourceChips(item.InternalName!),
             RecipesTabShortcut: shortcut);
+    }
+
+    /// <summary>
+    /// Inbound 1:1 cross-link (#247): resolve <see cref="Item.BestowLoreBook"/> (an
+    /// <c>int?</c> = numeric Book id) to the lorebook via <c>LorebooksById</c> and surface
+    /// it as a single navigable chip. Null when the item bestows no book or the id doesn't
+    /// resolve (defensive — a dangling id shouldn't render a dead chip).
+    /// </summary>
+    private EntityChipVm? BuildBestowsLorebookChip(Item item)
+    {
+        if (item.BestowLoreBook is not { } bookId) return null;
+        if (!_refData.LorebooksById.TryGetValue(bookId, out var book)) return null;
+        if (string.IsNullOrEmpty(book.InternalName)) return null;
+        var reference = EntityRef.Lorebook(book.InternalName!);
+        return new EntityChipVm(
+            DisplayName: _nameResolver.Resolve(reference),
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: _navigator.CanOpen(reference));
     }
 
     private IReadOnlyList<EntityChipVm>? BuildAwardedByQuestChips(string itemInternalName)

--- a/src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs
@@ -1,0 +1,241 @@
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using LorebookPoco = Mithril.Reference.Models.Misc.Lorebook;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Lorebook detail-pane view-model. Sections top-down:
+/// <list type="number">
+/// <item><b>Header</b> — Title (large), category subtitle (<c>"from The Gods"</c>),
+/// internal-name footer (<c>Book_101 / TheWastedWishes</c>, per the detail-view footer
+/// convention).</item>
+/// <item><b>Metadata strip</b> — <c>LocationHint</c> (italic flavor) and a folded-in
+/// <c>Found in: [Area chip]</c> row. <see cref="LorebookPoco.IsClientLocal"/> is hidden
+/// (universal-default noise — true on every bundled entry); <see cref="LorebookPoco.Visibility"/>
+/// is hidden by default (found-state mechanic irrelevant to the reference page — cookbook
+/// *Default-value noise filtering*; revisit if the smoke-walk says otherwise).</item>
+/// <item><b>Body</b> — <see cref="LorebookPoco.Text"/> through the extended
+/// <c>FormattedText</c> renderer (#247 Option A: <c>&lt;h1&gt;</c>/<c>&lt;hr&gt;</c>/
+/// <c>&lt;br&gt;</c>). 12 of 64 books have null Text (GuideProgram entries point at
+/// external volunteer guides) → an italic placeholder.</item>
+/// <item><b>Items that bestow this book</b> — a 1:N reverse-lookup rendered as the #318
+/// <see cref="ProvenancePopupViewModel"/> popup-from-index. See <see cref="BestowingItemsPopup"/>.</item>
+/// </list>
+/// <para>
+/// <b>#318 — bestowing-items is a popup-from-index, single flat section.</b> The set is
+/// materialized exactly once in <see cref="IReferenceDataService.ItemsBestowingLorebook"/>
+/// (rebuilt on items.json / lorebooks.json); the popup is a view over that object. This is
+/// a <i>single-reason</i> relationship — an item qualifies exactly one way (its
+/// <c>BestowLoreBook</c> id == this book's id) — so the popup is passed a <b>single flat
+/// section, no provenance sub-sectioning</b> (a lone trivial reason is noise; #318
+/// Discipline). There is no synthetic <c>EntityKind</c>, no cap/overflow chip, no Items-tab
+/// deep-link. Opening the popup pushes no navigator history (it's a
+/// <c>Window.Show()</c> — same non-navigating contract as
+/// <c>IReferenceKindTarget.TryOpenInWindow</c>, #229). <see cref="ProvenancePopupViewModel.ToQueryCommand"/>
+/// is left null for this surface (consistent with the slice-2 effect→abilities deferral).
+/// </para>
+/// </summary>
+public sealed class LorebookDetailViewModel
+{
+    /// <summary>
+    /// Host-supplied opener for the bestowing-items provenance popup. Defaults to
+    /// <see cref="ShowProvenancePopupWindow"/> (creates + <c>Show()</c>s a
+    /// <see cref="ProvenancePopupWindow"/>). Tests swap in a capturing delegate so the VM is
+    /// fully assertable without spawning a window. Opening the popup this way never calls
+    /// <c>IReferenceNavigator</c>, so it pushes no back/forward history.
+    /// </summary>
+    public static Action<ProvenancePopupViewModel, ICommand?> ProvenancePopupOpener { get; set; }
+        = ShowProvenancePopupWindow;
+
+    public LorebookDetailViewModel(
+        LorebookListRow row,
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        Silmarillion.SilmarillionSettings settings,
+        ICommand? openEntityCommand = null)
+    {
+        Row = row;
+        var book = row.Book;
+        DisplayName = row.Title;
+        InternalName = row.InternalName;
+        EnvelopeKey = ResolveEnvelopeKey(refData, book, row.InternalName);
+        CategorySubtitle = string.IsNullOrEmpty(row.CategoryDisplayTitle)
+            ? null
+            : $"from {row.CategoryDisplayTitle}";
+
+        LocationHint = row.LocationHint;
+
+        AreaChip = BuildAreaChip(row.AreaKey, refData, nameResolver, navigator);
+
+        // Null Text → GuideProgram entries point at an external volunteer guide.
+        BodyText = string.IsNullOrEmpty(book.Text) ? null : book.Text;
+        HasBody = BodyText is not null;
+
+        var (popup, total) = BuildBestowingItemsPopup(row.InternalName, refData, nameResolver, navigator);
+        BestowingItemsPopup = popup;
+        BestowingItemsTotal = total;
+
+        OpenEntityCommand = openEntityCommand;
+        ShowBestowingItemsPopupCommand = new RelayCommand(
+            () => ProvenancePopupOpener(BestowingItemsPopup!, OpenEntityCommand),
+            () => BestowingItemsPopup is not null);
+    }
+
+    private static void ShowProvenancePopupWindow(ProvenancePopupViewModel vm, ICommand? chipClick) =>
+        new ProvenancePopupWindow { DataContext = vm, ChipClickCommand = chipClick }.Show();
+
+    public LorebookListRow Row { get; }
+    public string DisplayName { get; }
+
+    /// <summary>Bare PascalCase InternalName (e.g. <c>"TheWastedWishes"</c>).</summary>
+    public string InternalName { get; }
+
+    /// <summary>
+    /// Envelope key (e.g. <c>"Book_101"</c>). Rendered in the footer as
+    /// <c>Book_101 / TheWastedWishes</c> — both identifiers, since they diverge.
+    /// </summary>
+    public string EnvelopeKey { get; }
+
+    /// <summary>Footer text: <c>"&lt;EnvelopeKey&gt; / &lt;InternalName&gt;"</c>.</summary>
+    public string FooterText =>
+        string.Equals(EnvelopeKey, InternalName, StringComparison.Ordinal)
+            ? InternalName
+            : $"{EnvelopeKey} / {InternalName}";
+
+    /// <summary><c>"from &lt;category display title&gt;"</c> or null when uncategorized.</summary>
+    public string? CategorySubtitle { get; }
+
+    public string? LocationHint { get; }
+    public bool HasLocationHint => !string.IsNullOrEmpty(LocationHint);
+
+    /// <summary>Single area chip folded into the metadata strip (<c>Found in: [chip]</c>).</summary>
+    public EntityChipVm? AreaChip { get; }
+    public bool HasArea => AreaChip is not null;
+
+    /// <summary>Body prose, or null for the 12 external-guide books (placeholder shown instead).</summary>
+    public string? BodyText { get; }
+    public bool HasBody { get; }
+
+    /// <summary>
+    /// Distinct count of items that bestow this book (==
+    /// <see cref="IReferenceDataService.ItemsBestowingLorebook"/><c>[InternalName].Count</c>,
+    /// the index is already dedup'd by item). Drives the <c>"Bestowed by {N} item(s)"</c>
+    /// affordance label. 0 ⇒ no affordance rendered.
+    /// </summary>
+    public int BestowingItemsTotal { get; }
+
+    public bool HasBestowingItems => BestowingItemsPopup is not null;
+
+    /// <summary>
+    /// The #318 provenance popup VM for "Items that bestow this book", or null when no item
+    /// bestows it. A <b>single flat section</b> fed
+    /// <see cref="IReferenceDataService.ItemsBestowingLorebook"/> directly (single-reason —
+    /// no provenance sub-sectioning). No second query derivation, so the displayed set
+    /// cannot diverge from the index.
+    /// </summary>
+    public ProvenancePopupViewModel? BestowingItemsPopup { get; }
+
+    /// <summary>
+    /// Opens <see cref="BestowingItemsPopup"/> via <see cref="ProvenancePopupOpener"/>.
+    /// Bound to the <c>"Bestowed by N item(s)"</c> affordance. Opening pushes no navigator
+    /// history (#229 contract).
+    /// </summary>
+    public ICommand ShowBestowingItemsPopupCommand { get; }
+
+    public ICommand? OpenEntityCommand { get; }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reverse-resolves the <c>"Book_N"</c> envelope key for <paramref name="book"/>. The
+    /// POCO doesn't carry it; scan <see cref="IReferenceDataService.Lorebooks"/> for the
+    /// entry whose value is this instance (small corpus — 64 entries). Falls back to the
+    /// InternalName if not found (defensive — should always resolve).
+    /// </summary>
+    private static string ResolveEnvelopeKey(
+        IReferenceDataService refData, LorebookPoco book, string internalName)
+    {
+        foreach (var (key, value) in refData.Lorebooks)
+        {
+            if (ReferenceEquals(value, book)) return key;
+        }
+        // Fall back to a same-InternalName match (handles a refreshed snapshot where the
+        // row's POCO instance predates the swap).
+        foreach (var (key, value) in refData.Lorebooks)
+        {
+            if (string.Equals(value.InternalName, internalName, StringComparison.Ordinal))
+                return key;
+        }
+        return internalName;
+    }
+
+    private static EntityChipVm? BuildAreaChip(
+        string? areaKey,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator)
+    {
+        if (string.IsNullOrEmpty(areaKey)) return null;
+        var reference = EntityRef.Area(areaKey);
+        var displayName = refData.Areas.TryGetValue(areaKey, out var area)
+            ? area.FriendlyName
+            : nameResolver.Resolve(reference);
+        return new EntityChipVm(
+            DisplayName: displayName,
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: navigator.CanOpen(reference));
+    }
+
+    /// <summary>
+    /// Build the #318 popup-from-index for "Items that bestow this book". Reads
+    /// <see cref="IReferenceDataService.ItemsBestowingLorebook"/><c>[internalName]</c>
+    /// directly — the single materialization (rebuilt on items.json / lorebooks.json). This
+    /// is a single-reason relationship, so the popup gets <b>one flat section</b> (no
+    /// provenance sub-sectioning — <see cref="ProvenancePopupViewModel.IsFlat"/> collapses
+    /// the section chrome). The count is the index's distinct membership; the popup renders
+    /// exactly those members — never a re-derived query result. Returns
+    /// <c>(null, 0)</c> when nothing bestows the book (no affordance).
+    /// </summary>
+    private static (ProvenancePopupViewModel? Popup, int Total) BuildBestowingItemsPopup(
+        string internalName,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator)
+    {
+        if (!refData.ItemsBestowingLorebook.TryGetValue(internalName, out var items)
+            || items.Count == 0)
+        {
+            return (null, 0);
+        }
+
+        var chips = items
+            .Select(item =>
+            {
+                var reference = EntityRef.Item(item.InternalName ?? "");
+                return new EntityChipVm(
+                    DisplayName: nameResolver.Resolve(reference),
+                    IconId: item.IconId,
+                    Reference: reference,
+                    IsNavigable: navigator.CanOpen(reference));
+            })
+            .ToList();
+
+        // Single flat section — one trivial reason is noise (#318 Discipline). The popup's
+        // IsFlat path renders these chips with no section header. ToQueryCommand left null
+        // (consistent with the slice-2 effect→abilities deferral) — there is no query
+        // derivation for this surface by design.
+        var section = new ProvenancePopupSection(
+            Label: "Bestowed by",
+            Chips: chips);
+        var popup = new ProvenancePopupViewModel(
+            title: $"Items that bestow {internalName}",
+            sections: new[] { section });
+
+        return (popup, chips.Count);
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/LorebookListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/LorebookListRow.cs
@@ -1,0 +1,26 @@
+using LorebookPoco = Mithril.Reference.Models.Misc.Lorebook;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Master-list row projection for the Lorebooks tab. Raw <see cref="LorebookPoco"/> doesn't
+/// carry the resolved category display title (that lives in the
+/// <c>lorebookinfo.json</c> sidecar) nor the derived "has body" flag, so — like Recipes —
+/// the tab projects a row record rather than binding the POCO directly.
+/// <para>
+/// <see cref="InternalName"/> is the selection key (matches the
+/// <see cref="Mithril.Shared.Reference.EntityRef.Lorebook(string)"/> factory and the
+/// <c>LorebooksByInternalName</c> service contract). The <c>MithrilQueryBox</c> schema is
+/// reflected from this record, so every queryable facet (category key, area key, has-body)
+/// must be a public property here.
+/// </para>
+/// </summary>
+public sealed record LorebookListRow(
+    LorebookPoco Book,
+    string InternalName,
+    string Title,
+    string CategoryDisplayTitle,
+    string CategoryKey,
+    string? AreaKey,
+    bool HasText,
+    string? LocationHint);

--- a/src/Silmarillion.Module/ViewModels/LorebooksTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/LorebooksTabViewModel.cs
@@ -1,0 +1,180 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
+using LorebookPoco = Mithril.Reference.Models.Misc.Lorebook;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Lorebooks master-detail view-model. 64 books across 7 categories (tiny corpus — no
+/// virtualization concern). Row type is <see cref="LorebookListRow"/> (resolved category
+/// display title + has-body flag aren't on the raw POCO). Books are presented grouped by
+/// category — the in-game lorebook UX precedent is grouped, and at this scale grouping
+/// aids navigation rather than overwhelming. The query box still filters within the flat
+/// <see cref="AllLorebooks"/> binding; the grouped view is a parallel projection over the
+/// same rows (empty groups self-omit).
+/// <para>
+/// Subscribes to <see cref="IReferenceDataService.FileUpdated"/> for <c>"lorebooks"</c>
+/// (master list), <c>"lorebookinfo"</c> (category display titles) and <c>"items"</c>
+/// (rebuilds the detail-side #318 "Items that bestow this book" popup). Selection preserved
+/// by <see cref="LorebookListRow.InternalName"/>.
+/// </para>
+/// </summary>
+public sealed partial class LorebooksTabViewModel : ObservableObject, ITabViewModel
+{
+    /// <summary>
+    /// Reflected schema for <see cref="LorebookListRow"/> exposed to
+    /// <c>MithrilQueryBox.Schema</c> so the query box offers completion / highlights known
+    /// columns (Title / CategoryKey / CategoryDisplayTitle / AreaKey / HasText / …).
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(LorebookListRow)));
+
+    public string TabHeader => "Lorebooks";
+    public int TabOrder => 7;
+
+    private readonly IReferenceDataService _refData;
+    private readonly IReferenceNavigator _navigator;
+    private readonly IEntityNameResolver _nameResolver;
+    private readonly Silmarillion.SilmarillionSettings _settings;
+    private readonly RelayCommand<EntityRef?> _openEntityCommand;
+
+    public LorebooksTabViewModel(
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        Silmarillion.SilmarillionSettings settings)
+    {
+        _refData = refData;
+        _navigator = navigator;
+        _nameResolver = nameResolver;
+        _settings = settings;
+        _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
+        _allLorebooks = BuildAllLorebooks(refData);
+        _categoryGroups = BuildCategoryGroups(_allLorebooks);
+        refData.FileUpdated += OnFileUpdated;
+    }
+
+    [ObservableProperty]
+    private IReadOnlyList<LorebookListRow> _allLorebooks;
+
+    [ObservableProperty]
+    private IReadOnlyList<LorebookCategoryGroup> _categoryGroups;
+
+    [ObservableProperty]
+    private string _queryText = "";
+
+    [ObservableProperty]
+    private string? _queryError;
+
+    [ObservableProperty]
+    private LorebookListRow? _selectedLorebook;
+
+    [ObservableProperty]
+    private LorebookDetailViewModel? _detailViewModel;
+
+    partial void OnSelectedLorebookChanged(LorebookListRow? value)
+    {
+        DetailViewModel = value is null ? null : BuildDetailViewModel(value);
+    }
+
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        // lorebooks.json → master list. lorebookinfo.json → resolved CategoryDisplayTitle.
+        // items.json → the detail-side ItemsBestowingLorebook popup membership.
+        if (fileKey is not ("lorebooks" or "lorebookinfo" or "items"))
+            return;
+
+        UiThread.Run(() =>
+        {
+            var capturedName = SelectedLorebook?.InternalName;
+            if (fileKey is "lorebooks" or "lorebookinfo")
+            {
+                AllLorebooks = BuildAllLorebooks(_refData);
+                CategoryGroups = BuildCategoryGroups(AllLorebooks);
+            }
+            if (!string.IsNullOrEmpty(capturedName))
+            {
+                var resolved = AllLorebooks.FirstOrDefault(b => b.InternalName == capturedName);
+                // Toggle through null so OnSelectedLorebookChanged rebuilds the detail VM
+                // against the fresh refData snapshot ([ObservableProperty] suppresses a
+                // same-reference reassignment).
+                SelectedLorebook = null;
+                SelectedLorebook = resolved;
+            }
+        });
+    }
+
+    private static IReadOnlyList<LorebookListRow> BuildAllLorebooks(IReferenceDataService refData)
+    {
+        var categories = refData.LorebookCategories;
+        return refData.Lorebooks.Values
+            .Where(b => !string.IsNullOrEmpty(b.InternalName))
+            .Select(b => ProjectRow(b, categories))
+            .OrderBy(r => r.CategoryDisplayTitle, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(r => r.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static LorebookListRow ProjectRow(
+        LorebookPoco book,
+        IReadOnlyDictionary<string, Mithril.Reference.Models.Misc.LorebookCategoryInfo> categories)
+    {
+        var categoryKey = book.Category ?? "";
+        var displayTitle = !string.IsNullOrEmpty(categoryKey)
+                           && categories.TryGetValue(categoryKey, out var info)
+                           && !string.IsNullOrEmpty(info.Title)
+            ? info.Title!
+            : (string.IsNullOrEmpty(categoryKey) ? "Uncategorized" : categoryKey);
+
+        // First keyword that resolves to a known area key is the cross-link anchor; the
+        // bundled corpus carries exactly one area key per book that has any.
+        var areaKey = book.Keywords?
+            .FirstOrDefault(k => !string.IsNullOrEmpty(k));
+
+        return new LorebookListRow(
+            Book: book,
+            InternalName: book.InternalName!,
+            Title: string.IsNullOrEmpty(book.Title) ? book.InternalName! : book.Title!,
+            CategoryDisplayTitle: displayTitle,
+            CategoryKey: categoryKey,
+            AreaKey: areaKey,
+            HasText: !string.IsNullOrEmpty(book.Text),
+            LocationHint: string.IsNullOrEmpty(book.LocationHint) ? null : book.LocationHint);
+    }
+
+    private static IReadOnlyList<LorebookCategoryGroup> BuildCategoryGroups(
+        IReadOnlyList<LorebookListRow> rows)
+    {
+        return rows
+            .GroupBy(r => r.CategoryDisplayTitle, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new LorebookCategoryGroup(
+                g.Key,
+                $"{g.Key} ({g.Count()})",
+                g.OrderBy(r => r.Title, StringComparer.OrdinalIgnoreCase).ToList()))
+            .ToList();
+    }
+
+    private LorebookDetailViewModel BuildDetailViewModel(LorebookListRow row) =>
+        new LorebookDetailViewModel(
+            row,
+            _refData,
+            _navigator,
+            _nameResolver,
+            _settings,
+            _openEntityCommand);
+}
+
+/// <summary>
+/// One category group on the Lorebooks master list. <paramref name="CategoryDisplayTitle"/>
+/// is the resolved title (e.g. <c>"The Gods"</c>); <paramref name="Heading"/> is the
+/// pre-formatted small-caps header (<c>"The Gods (22)"</c>); <paramref name="Rows"/> are
+/// the books in that category, alpha by title.
+/// </summary>
+public sealed record LorebookCategoryGroup(
+    string CategoryDisplayTitle,
+    string Heading,
+    IReadOnlyList<LorebookListRow> Rows);

--- a/src/Silmarillion.Module/Views/LorebookDetailView.xaml
+++ b/src/Silmarillion.Module/Views/LorebookDetailView.xaml
@@ -1,0 +1,140 @@
+<UserControl x:Class="Silmarillion.Views.LorebookDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:LorebookDetailViewModel}"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border Padding="14,12">
+        <DockPanel>
+            <!-- Footer: "Book_101 / TheWastedWishes" — mono, bottom-right, per the
+                 detail-view internal-name footer convention. -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding FooterText}"
+                       Foreground="#88FFFFFF"
+                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       Margin="0,12,0,0" HorizontalAlignment="Right"
+                       VerticalAlignment="Bottom"/>
+
+            <StackPanel>
+                <!-- ─── Header: title + category subtitle ─── -->
+                <StackPanel Margin="0,0,0,10">
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding CategorySubtitle}"
+                               Foreground="#88FFFFFF" FontStyle="Italic"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Margin="0,2,0,0"
+                               Visibility="{Binding CategorySubtitle, Converter={StaticResource NullOrEmptyToVis}}"/>
+                </StackPanel>
+
+                <!-- ─── Metadata strip: location hint + folded-in area chip ─── -->
+                <StackPanel Margin="0,0,0,10">
+                    <TextBlock Text="{Binding LocationHint}"
+                               Foreground="#CCFFFFFF" FontStyle="Italic"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               TextWrapping="Wrap" Margin="0,0,0,4"
+                               Visibility="{Binding HasLocationHint, Converter={StaticResource BoolToVis}}"/>
+                    <StackPanel Orientation="Horizontal"
+                                Visibility="{Binding HasArea, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="Found in: " Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <ContentControl Content="{Binding AreaChip}">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:LorebookDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- ─── Body ─── -->
+                <Border Margin="0,0,0,10">
+                    <Grid>
+                        <TextBlock wpf:FormattedText.Text="{Binding BodyText}"
+                                   Foreground="#EEFFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeLarge}"
+                                   TextWrapping="Wrap" LineHeight="22"
+                                   Visibility="{Binding HasBody, Converter={StaticResource BoolToVis}}"/>
+                        <TextBlock Text="This book points to an external resource — see the in-game Volunteer Guide."
+                                   Foreground="#88FFFFFF" FontStyle="Italic"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   TextWrapping="Wrap">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasBody}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Grid>
+                </Border>
+
+                <!-- ─── Items that bestow this book (#318 popup-from-index) ───
+                     Single-reason 1:N. A one-line affordance opens the shared
+                     ProvenancePopupWindow fed ItemsBestowingLorebook[InternalName]
+                     directly (single flat section, no synthetic kind, no deep-link,
+                     no navigator history). Hidden entirely when nothing bestows it. -->
+                <Button HorizontalAlignment="Left" Cursor="Hand" Padding="6,2"
+                        Command="{Binding ShowBestowingItemsPopupCommand}"
+                        Visibility="{Binding HasBestowingItems, Converter={StaticResource BoolToVis}}">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Background" Value="Transparent"/>
+                            <Setter Property="BorderBrush" Value="#66D4A847"/>
+                            <Setter Property="BorderThickness" Value="1"/>
+                            <Setter Property="Foreground" Value="#FFD4A847"/>
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="#22D4A847"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="3" Padding="{TemplateBinding Padding}">
+                                <StackPanel Orientation="Horizontal">
+                                    <icon:PackIconLucide Kind="BookMarked" Width="12" Height="12"
+                                                         Foreground="{TemplateBinding Foreground}"
+                                                         Margin="0,0,4,0" VerticalAlignment="Center"/>
+                                    <TextBlock Foreground="{TemplateBinding Foreground}"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               VerticalAlignment="Center">
+                                        <Run Text="Bestowed by "/><Run Text="{Binding BestowingItemsTotal, Mode=OneWay}"/><Run Text=" item(s) →"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Border>
+                        </ControlTemplate>
+                    </Button.Template>
+                </Button>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/Silmarillion.Module/Views/LorebookDetailView.xaml.cs
+++ b/src/Silmarillion.Module/Views/LorebookDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class LorebookDetailView : UserControl
+{
+    public LorebookDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/LorebookDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/LorebookDetailWindow.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="Silmarillion.Views.LorebookDetailWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Silmarillion.Views"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="{Binding DisplayName}"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        FontFamily="{DynamicResource AppFontFamily}"
+        FontSize="{DynamicResource AppFontSize}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+            MinWidth="420" MaxWidth="680" MaxHeight="760">
+        <DockPanel>
+            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
+                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
+                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                            ToolTip="Close" Click="CloseButton_Click">
+                        <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
+                    </Button>
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                </DockPanel>
+            </Border>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          MaxHeight="700">
+                <local:LorebookDetailView/>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</Window>

--- a/src/Silmarillion.Module/Views/LorebookDetailWindow.xaml.cs
+++ b/src/Silmarillion.Module/Views/LorebookDetailWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Silmarillion.Views;
+
+public partial class LorebookDetailWindow : Window
+{
+    public LorebookDetailWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) DragMove();
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/Silmarillion.Module/Views/LorebooksTabView.xaml
+++ b/src/Silmarillion.Module/Views/LorebooksTabView.xaml
@@ -1,0 +1,132 @@
+<UserControl x:Class="Silmarillion.Views.LorebooksTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
+             xmlns:scm="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Grouped view over the flat AllLorebooks binding. Grouping on the resolved
+                 category display title gives the in-game-lorebook-UX grouped presentation
+                 while QueryFilter still filters the underlying rows (empty groups self-hide).
+                 64 entries / 7 categories — no virtualization concern. -->
+            <CollectionViewSource x:Key="GroupedLorebooks"
+                                  Source="{Binding AllLorebooks}">
+                <CollectionViewSource.GroupDescriptions>
+                    <PropertyGroupDescription PropertyName="CategoryDisplayTitle"/>
+                </CollectionViewSource.GroupDescriptions>
+            </CollectionViewSource>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320" MinWidth="240"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
+            <StackPanel>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:LorebooksTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. CategoryKey = 'Gods'"/>
+                <TextBlock Text="{Binding QueryError}"
+                           Foreground="#FFD96A6A" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="0,4,0,0"
+                           Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </Border>
+
+        <ListBox Grid.Row="1" Grid.Column="0"
+                 ItemsSource="{Binding Source={StaticResource GroupedLorebooks}}"
+                 ItemTemplate="{StaticResource LorebookCardTemplate}"
+                 SelectedItem="{Binding SelectedLorebook, Mode=TwoWay}"
+                 query:QueryFilter.QueryText="{Binding QueryText}"
+                 query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"
+                 Background="#FF1A1A1A" BorderThickness="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 VirtualizingStackPanel.IsVirtualizing="True"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <Border Background="#FF202020" Padding="8,4" Margin="0,2,0,2">
+                                <TextBlock FontWeight="SemiBold" Foreground="#FFD4A847"
+                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                    <Run Text="{Binding Name, Mode=OneWay}"/><Run Text=" ("/><Run Text="{Binding ItemCount, Mode=OneWay}"/><Run Text=")"/>
+                                </TextBlock>
+                            </Border>
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListBox.GroupStyle>
+        </ListBox>
+
+        <Grid Grid.Row="1" Grid.Column="1" Background="#FF1A1A1A">
+            <ScrollViewer x:Name="DetailScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <ContentControl Content="{Binding DetailViewModel}"
+                                MinHeight="{Binding ViewportHeight, ElementName=DetailScroller}">
+                    <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type vm:LorebookDetailViewModel}">
+                            <local:LorebookDetailView/>
+                        </DataTemplate>
+                    </ContentControl.Resources>
+                </ContentControl>
+            </ScrollViewer>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="320">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DetailViewModel}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <icon:PackIconLucide Kind="BookOpen" Width="48" Height="48"
+                                     Foreground="#33FFFFFF"
+                                     HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                <TextBlock Text="Browse Lorebooks"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeLarge}"
+                           Foreground="#CCFFFFFF"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Select a book to read its text and see where it's found."
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Foreground="#88FFFFFF"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Silmarillion.Module/Views/Resources.xaml
+++ b/src/Silmarillion.Module/Views/Resources.xaml
@@ -169,4 +169,27 @@
         </DockPanel>
     </DataTemplate>
 
+    <!-- Compact two-line row for Lorebooks tab. Bound DataContext:
+         Silmarillion.ViewModels.LorebookListRow. Secondary line is the plain
+         '<title> <location-hint-or-internal-name>' shape per the cookbook card
+         secondary-line convention (no unit prefixes / parentheticals). -->
+    <DataTemplate x:Key="LorebookCardTemplate">
+        <DockPanel LastChildFill="True">
+            <Border DockPanel.Dock="Left" Width="24" Height="24" Margin="6,3,6,3"
+                    VerticalAlignment="Center" Background="#FF1F1F1F" CornerRadius="3">
+                <icon:PackIconLucide Kind="BookOpen" Width="14" Height="14" Foreground="#88FFFFFF"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Text="{Binding InternalName}" Foreground="#88FFFFFF"
+                           FontFamily="{DynamicResource AppMonoFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis"/>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
+
 </ResourceDictionary>

--- a/src/Silmarillion.Module/Views/SilmarillionView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionView.xaml
@@ -37,6 +37,9 @@
             <DataTemplate DataType="{x:Type vm:AreasTabViewModel}">
                 <local:AreasTabView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:LorebooksTabViewModel}">
+                <local:LorebooksTabView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.InputBindings>

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceLorebookCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceLorebookCrossLinkIndexTests.cs
@@ -1,0 +1,198 @@
+using System.IO;
+using System.Net.Http;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+/// <summary>
+/// Synthetic-fixture round-trip for the #247 lorebook service plumbing: the three lorebook
+/// lookups (envelope / InternalName / numeric id), the LorebookInfo sidecar, and the #318
+/// popup-from-index source <c>ItemsBestowingLorebook</c> with its cross-trigger matrix.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class ReferenceDataServiceLorebookCrossLinkIndexTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cacheDir;
+    private readonly string _bundledDir;
+
+    public ReferenceDataServiceLorebookCrossLinkIndexTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-ref-lorebook-tests");
+        _cacheDir = Path.Combine(_root, "cache");
+        _bundledDir = Path.Combine(_root, "bundled");
+        Directory.CreateDirectory(_cacheDir);
+        Directory.CreateDirectory(_bundledDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static HttpClient NeverCallHttp() =>
+        new(new ThrowingHandler("HTTP must not be called in this test"));
+
+    private void WriteFixture(string itemsJson, string lorebooksJson, string lorebookInfoJson)
+    {
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), itemsJson);
+        File.WriteAllText(Path.Combine(_bundledDir, "lorebooks.json"), lorebooksJson);
+        File.WriteAllText(Path.Combine(_bundledDir, "lorebookinfo.json"), lorebookInfoJson);
+    }
+
+    private const string Items = """
+        {
+          "item_14036": { "Name": "The Gods of Knowledge Vol 1", "InternalName": "TheGodsOfKnowledgeVol1", "BestowLoreBook": 101 },
+          "item_99999": { "Name": "Unrelated Trinket", "InternalName": "Trinket" }
+        }
+        """;
+
+    private const string Lorebooks = """
+        {
+          "Book_101": {
+            "Category": "Stories",
+            "InternalName": "TheWastedWishes",
+            "IsClientLocal": true,
+            "Keywords": [ "AreaSerbule" ],
+            "Title": "The Wasted Wishes",
+            "Visibility": "GhostedUntilFound",
+            "Text": "<h1>The Wasted Wishes</h1>Once upon a time...",
+            "LocationHint": "Found in a house in Serbule"
+          },
+          "Book_103": {
+            "Category": "Gods",
+            "InternalName": "TheChaliceSagaVol1",
+            "Title": "The Chalice Saga Vol 1",
+            "Text": "<h1>The Chalice Saga</h1>..."
+          }
+        }
+        """;
+
+    private const string LorebookInfo = """
+        {
+          "Categories": {
+            "Gods":    { "Title": "The Gods", "SubTitle": "Gods, Myths, and Legends", "SortTitle": "Gods" },
+            "Stories": { "Title": "Stories", "SubTitle": "With Debatable Real-World Accuracy" },
+            "Misc":    { "Title": "Miscellaneous", "SortTitle": "zzzMiscellaneous" }
+          }
+        }
+        """;
+
+    [Fact]
+    public void LorebooksByInternalName_KeyedOnInternalNameNotEnvelope()
+    {
+        WriteFixture(Items, Lorebooks, LorebookInfo);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.LorebooksByInternalName.Should().ContainKey("TheWastedWishes");
+        svc.LorebooksByInternalName.Should().NotContainKey("Book_101");
+        svc.Lorebooks.Should().ContainKey("Book_101");
+        svc.Lorebooks.Should().NotContainKey("TheWastedWishes");
+        // Same POCO behind both keys, two different identifiers.
+        svc.LorebooksByInternalName["TheWastedWishes"].Should()
+            .BeSameAs(svc.Lorebooks["Book_101"]);
+    }
+
+    [Fact]
+    public void LorebooksById_LiftsNumericIdFromEnvelopeKey()
+    {
+        WriteFixture(Items, Lorebooks, LorebookInfo);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.LorebooksById.Should().ContainKey(101);
+        svc.LorebooksById[101].InternalName.Should().Be("TheWastedWishes");
+        svc.LorebooksById.Should().ContainKey(103);
+    }
+
+    [Fact]
+    public void ItemsBestowingLorebook_IndexesByItemBestowLoreBook()
+    {
+        WriteFixture(Items, Lorebooks, LorebookInfo);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        // item_14036 has BestowLoreBook=101 → resolves to Book_101 → "TheWastedWishes".
+        svc.ItemsBestowingLorebook.Should().ContainKey("TheWastedWishes");
+        svc.ItemsBestowingLorebook["TheWastedWishes"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("TheGodsOfKnowledgeVol1");
+        // The book nobody bestows is absent (no empty-list noise).
+        svc.ItemsBestowingLorebook.Should().NotContainKey("TheChaliceSagaVol1");
+    }
+
+    [Fact]
+    public void ItemsBestowingLorebook_IsDedupedByItemInternalName()
+    {
+        // Two item entries with the same InternalName + same BestowLoreBook must collapse
+        // to one member so the popup count equals distinct membership (#318 invariant).
+        WriteFixture(
+            itemsJson: """
+            {
+              "item_1": { "Name": "Book Item", "InternalName": "BookItem", "BestowLoreBook": 101 },
+              "item_1_dup": { "Name": "Book Item", "InternalName": "BookItem", "BestowLoreBook": 101 }
+            }
+            """,
+            Lorebooks, LorebookInfo);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.ItemsBestowingLorebook["TheWastedWishes"].Should().ContainSingle();
+    }
+
+    [Fact]
+    public void RefreshItemsOrLorebooks_RebuildsItemsBestowingLorebook()
+    {
+        // Trigger-matrix proof via the established cache-reconstruction pattern (mirrors
+        // ReferenceDataServiceAreaCrossLinkIndexTests): a fresh service over a rewritten
+        // cache file exercises the same ParseAndSwap* → Build…CrossLinkIndex path a live
+        // RefreshAsync would, without an HTTP round-trip.
+        WriteFixture(
+            itemsJson: """{ "item_x": { "Name": "Nothing", "InternalName": "Nothing" } }""",
+            Lorebooks, LorebookInfo);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+        svc.ItemsBestowingLorebook.Should().BeEmpty(
+            "no item bestows a lorebook in the initial fixture");
+
+        // Trigger 1 (items.json side): a cached items.json carrying a bestowing item.
+        // ParseAndSwapItems must call BuildLorebookItemCrossLinkIndex.
+        File.WriteAllText(Path.Combine(_cacheDir, "items.json"), Items);
+        File.WriteAllText(Path.Combine(_cacheDir, "items.meta.json"), "{\"cdnVersion\":\"v2\",\"source\":1}");
+        var afterItems = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+        afterItems.ItemsBestowingLorebook.Should().ContainKey("TheWastedWishes");
+
+        // Trigger 2 (lorebooks.json side): a cached lorebooks.json that re-maps id 101 to a
+        // *different* InternalName. ParseAndSwapLorebooks must rebuild the index against the
+        // current item set so the membership re-keys to the new book name.
+        File.WriteAllText(Path.Combine(_cacheDir, "lorebooks.json"), """
+        {
+          "Book_101": { "Category": "Stories", "InternalName": "RenamedBook", "Text": "x" }
+        }
+        """);
+        File.WriteAllText(Path.Combine(_cacheDir, "lorebooks.meta.json"), "{\"cdnVersion\":\"v2\",\"source\":1}");
+        var afterLorebooks = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+        afterLorebooks.ItemsBestowingLorebook.Should().ContainKey("RenamedBook",
+            "a lorebooks-only refresh must rebuild the index so the item re-keys to the new InternalName");
+        afterLorebooks.ItemsBestowingLorebook.Should().NotContainKey("TheWastedWishes");
+        afterLorebooks.ItemsBestowingLorebook["RenamedBook"].Should().ContainSingle();
+    }
+
+    [Fact]
+    public void LorebookCategories_ParseFromSidecar()
+    {
+        WriteFixture(Items, Lorebooks, LorebookInfo);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.LorebookCategories.Should().ContainKey("Gods");
+        svc.LorebookCategories["Gods"].Title.Should().Be("The Gods");
+        svc.LorebookCategories["Gods"].SubTitle.Should().Be("Gods, Myths, and Legends");
+        svc.LorebookCategories["Misc"].SortTitle.Should().Be("zzzMiscellaneous");
+        svc.LorebookCategories.Should().HaveCount(3);
+    }
+
+    private sealed class ThrowingHandler(string message) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException(message);
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/FormattedTextRendererTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/FormattedTextRendererTests.cs
@@ -119,4 +119,125 @@ public sealed class FormattedTextRendererTests
         inlines[2].As<Run>().Text.Should().Be("B");
         inlines[2].As<Run>().FontStyle.Should().Be(FontStyles.Italic);
     }
+
+    // ── #247: <h1> / <hr> / <br> structural-tag extension (Option A) ──
+
+    [Fact]
+    public void Heading_RendersBoldLargerRun_BetweenLineBreaks()
+    {
+        // The dominant lorebook-body pattern: <h1>Title</h1>\n\nbody...
+        var inlines = FormattedText.BuildInlines("<h1>The Wasted Wishes</h1>Body text.");
+
+        // LineBreak, heading Run, LineBreak, LineBreak, body Run.
+        inlines.Should().HaveCount(5);
+        inlines[0].Should().BeOfType<LineBreak>();
+        var heading = inlines[1].Should().BeOfType<Run>().Subject;
+        heading.Text.Should().Be("The Wasted Wishes");
+        heading.FontWeight.Should().Be(FontWeights.Bold);
+        heading.FontSize.Should().BeGreaterThan(SystemFonts.MessageFontSize);
+        inlines[2].Should().BeOfType<LineBreak>();
+        inlines[3].Should().BeOfType<LineBreak>();
+        var body = inlines[4].Should().BeOfType<Run>().Subject;
+        body.Text.Should().Be("Body text.");
+        body.FontWeight.Should().Be(FontWeights.Normal);
+    }
+
+    [Fact]
+    public void Heading_Unclosed_FallsBackGracefully_AppliesToEnd()
+    {
+        // Defensive: a stray <h1> with no </h1> shouldn't crash; the heading style just
+        // extends to the end of the input (mirrors the unbalanced-<i> contract).
+        var inlines = FormattedText.BuildInlines("intro <h1>title to end");
+
+        var combined = string.Concat(inlines.OfType<Run>().Select(r => r.Text));
+        combined.Should().Be("intro title to end");
+        var last = inlines.OfType<Run>().Last();
+        last.Text.Should().Be("title to end");
+        last.FontWeight.Should().Be(FontWeights.Bold);
+    }
+
+    [Fact]
+    public void MalformedHeading_NoCloseAngle_PassesThroughAsLiteral()
+    {
+        // "<h1" without a '>' is not a recognised tag literal — passes through verbatim,
+        // same contract as a bare '<' in "5 < 10".
+        var inlines = FormattedText.BuildInlines("a <h1 b");
+
+        inlines.Should().ContainSingle();
+        inlines[0].As<Run>().Text.Should().Be("a <h1 b");
+    }
+
+    [Fact]
+    public void Break_RendersLineBreak()
+    {
+        var inlines = FormattedText.BuildInlines("line one<br>line two");
+
+        inlines.Should().HaveCount(3);
+        inlines[0].As<Run>().Text.Should().Be("line one");
+        inlines[1].Should().BeOfType<LineBreak>();
+        inlines[2].As<Run>().Text.Should().Be("line two");
+    }
+
+    [Fact]
+    public void Break_SelfClosingForm_AlsoRendersLineBreak()
+    {
+        var inlines = FormattedText.BuildInlines("a<br/>b");
+
+        inlines.Should().HaveCount(3);
+        inlines[0].As<Run>().Text.Should().Be("a");
+        inlines[1].Should().BeOfType<LineBreak>();
+        inlines[2].As<Run>().Text.Should().Be("b");
+    }
+
+    [Fact]
+    public void HorizontalRule_RendersSeparatorRow_BetweenLineBreaks()
+    {
+        var inlines = FormattedText.BuildInlines("before<hr>after");
+
+        // Run "before", LineBreak, em-dash Run, LineBreak, LineBreak, Run "after".
+        inlines.Should().HaveCount(6);
+        inlines[0].As<Run>().Text.Should().Be("before");
+        inlines[1].Should().BeOfType<LineBreak>();
+        var rule = inlines[2].Should().BeOfType<Run>().Subject;
+        rule.Text.Should().Contain("—");
+        inlines[3].Should().BeOfType<LineBreak>();
+        inlines[4].Should().BeOfType<LineBreak>();
+        inlines[5].As<Run>().Text.Should().Be("after");
+    }
+
+    [Fact]
+    public void HorizontalRule_SelfClosingForm_AlsoRenders()
+    {
+        var inlines = FormattedText.BuildInlines("x<hr/>y");
+
+        inlines.OfType<Run>().Should().Contain(r => r.Text.Contains("—"));
+        inlines.OfType<LineBreak>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void HeadingWithNestedBold_KeepsBoldAndHeadingStyling()
+    {
+        // <h1><b>X</b></h1> — the inner span is bold (from both the heading and the explicit
+        // <b>); the heading run is also enlarged.
+        var inlines = FormattedText.BuildInlines("<h1><b>Chalice Saga</b></h1>");
+
+        var heading = inlines.OfType<Run>().Single();
+        heading.Text.Should().Be("Chalice Saga");
+        heading.FontWeight.Should().Be(FontWeights.Bold);
+        heading.FontSize.Should().BeGreaterThan(SystemFonts.MessageFontSize);
+    }
+
+    [Fact]
+    public void HeadingPlusBodyWithItalicSpeaker_RealLorebookShape()
+    {
+        // Realistic lorebook body: heading, then prose carrying an inline <i> span.
+        var inlines = FormattedText.BuildInlines(
+            "<h1>Notes</h1>The sign reads: <i>Beware the gorgon.</i>");
+
+        var runs = inlines.OfType<Run>().ToList();
+        runs.Should().Contain(r => r.Text == "Notes" && r.FontWeight == FontWeights.Bold);
+        runs.Should().Contain(r => r.Text == "Beware the gorgon." && r.FontStyle == FontStyles.Italic);
+        // No literal tag noise survived.
+        string.Concat(runs.Select(r => r.Text)).Should().NotContain("<");
+    }
 }

--- a/tests/Silmarillion.Tests/Navigation/LorebooksKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/LorebooksKindTargetTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using LorebookPoco = Mithril.Reference.Models.Misc.Lorebook;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class LorebooksKindTargetTests
+{
+    [Fact]
+    public void Kind_IsLorebook()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.Lorebook);
+    }
+
+    [Fact]
+    public void TabIndex_IsSeven()
+    {
+        // Items=0 … Areas=6, Lorebooks=7 — eighth tab. Must match TabOrder.
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(7);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownBook_SelectsOnTabVm_ReturnsTrue()
+    {
+        var (target, vm, _) = BuildTarget(
+            ("Book_101", "TheWastedWishes", "The Wasted Wishes"));
+
+        var ok = target.TrySelectByInternalName("TheWastedWishes");
+
+        ok.Should().BeTrue();
+        vm.SelectedLorebook.Should().NotBeNull();
+        vm.SelectedLorebook!.InternalName.Should().Be("TheWastedWishes");
+        vm.DetailViewModel.Should().NotBeNull();
+        vm.DetailViewModel!.DisplayName.Should().Be("The Wasted Wishes");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_EnvelopeKey_DoesNotMatch_ReturnsFalse()
+    {
+        // The selection contract is the bare InternalName, NOT the "Book_N" envelope key.
+        var (target, vm, _) = BuildTarget(
+            ("Book_101", "TheWastedWishes", "The Wasted Wishes"));
+
+        target.TrySelectByInternalName("Book_101").Should().BeFalse();
+        vm.SelectedLorebook.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownBook_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        vm.SelectedLorebook.Should().BeNull();
+
+        target.TrySelectByInternalName("DoesNotExist").Should().BeFalse();
+        vm.SelectedLorebook.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsResidualQueryText()
+    {
+        var (target, vm, _) = BuildTarget(
+            ("Book_101", "TheWastedWishes", "The Wasted Wishes"));
+        vm.QueryText = "CategoryKey = 'Gods'";
+
+        target.TrySelectByInternalName("TheWastedWishes").Should().BeTrue();
+
+        vm.QueryText.Should().BeEmpty(because: "the kind target clears any prior filter before selecting");
+        vm.SelectedLorebook!.InternalName.Should().Be("TheWastedWishes");
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (LorebooksKindTarget Target, LorebooksTabViewModel Vm, FakeReferenceData RefData)
+        BuildTarget(params (string EnvelopeKey, string InternalName, string Title)[] books)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, name, title) in books)
+            refData.AddLorebook(key, new LorebookPoco
+            {
+                Category = "Stories",
+                InternalName = name,
+                Title = title,
+                Text = "<h1>" + title + "</h1>body",
+            });
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var settings = new SilmarillionSettings();
+        var vm = new LorebooksTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData), settings);
+        var target = new LorebooksKindTarget(vm);
+        return (target, vm, refData);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, LorebookPoco> _lorebooks = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, LorebookPoco> _byInternalName = new(StringComparer.Ordinal);
+
+        public void AddLorebook(string envelopeKey, LorebookPoco book)
+        {
+            _lorebooks[envelopeKey] = book;
+            if (book.InternalName is not null) _byInternalName[book.InternalName] = book;
+        }
+
+        public IReadOnlyDictionary<string, LorebookPoco> Lorebooks => _lorebooks;
+        public IReadOnlyDictionary<string, LorebookPoco> LorebooksByInternalName => _byInternalName;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -426,6 +426,69 @@ public sealed class SilmarillionReferenceNavigatorTests
     }
 
     [Fact]
+    public void Open_Lorebook_SwitchesToLorebooksTab_AndSelects()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new Mithril.Reference.Models.Misc.Lorebook
+        {
+            Category = "Stories", InternalName = "TheWastedWishes",
+            Title = "The Wasted Wishes", Text = "<h1>The Wasted Wishes</h1>body",
+        });
+        var settings = new Silmarillion.SilmarillionSettings();
+        var lorebooksVm = new LorebooksTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var lorebooksTarget = new LorebooksKindTarget(lorebooksVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            lorebooksTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(new ITabViewModel[] { lorebooksVm }, nav, targets);
+
+        // Deep-link form mithril://silmarillion/lorebook/TheWastedWishes flows through the
+        // target-agnostic handler → EntityRef.Lorebook → this kind target.
+        nav.Open(EntityRef.Lorebook("TheWastedWishes"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(7);
+        lorebooksVm.SelectedLorebook.Should().NotBeNull();
+        lorebooksVm.SelectedLorebook!.InternalName.Should().Be("TheWastedWishes");
+    }
+
+    [Fact]
+    public void Open_Lorebook_UnknownName_DoesNotSelect()
+    {
+        var refData = new FakeReferenceData();
+        var settings = new Silmarillion.SilmarillionSettings();
+        var lorebooksVm = new LorebooksTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new LorebooksKindTarget(lorebooksVm),
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+
+        nav.Open(EntityRef.Lorebook("NoSuchBook"));
+
+        lorebooksVm.SelectedLorebook.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_DuplicateGuard_TripsForLorebook()
+    {
+        // Verifies the duplicate-registration guard still trips with the new kind in the mix.
+        var dup = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Lorebook),
+            new StubTarget(EntityKind.Lorebook),
+        };
+        Action act = () => new SilmarillionReferenceNavigator(dup);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Duplicate IReferenceKindTarget*Lorebook*");
+    }
+
+    [Fact]
     public void Constructor_DuplicateGuard_TripsForEffectAndEffectKeyword()
     {
         // Verifies the duplicate-registration guard still trips with the new kinds in the mix.
@@ -496,6 +559,16 @@ public sealed class SilmarillionReferenceNavigatorTests
 
         private readonly Dictionary<string, AreaEntry> _areas = new(StringComparer.Ordinal);
         public void AddArea(AreaEntry area) => _areas[area.Key] = area;
+
+        private readonly Dictionary<string, Mithril.Reference.Models.Misc.Lorebook> _lorebooks = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Mithril.Reference.Models.Misc.Lorebook> _lorebooksByName = new(StringComparer.Ordinal);
+        public void AddLorebook(string envelopeKey, Mithril.Reference.Models.Misc.Lorebook book)
+        {
+            _lorebooks[envelopeKey] = book;
+            if (book.InternalName is not null) _lorebooksByName[book.InternalName] = book;
+        }
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Misc.Lorebook> Lorebooks => _lorebooks;
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Misc.Lorebook> LorebooksByInternalName => _lorebooksByName;
 
         public IReadOnlyList<string> Keys => Array.Empty<string>();
         public IReadOnlyDictionary<long, Item> Items => _itemsById;

--- a/tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
@@ -1,0 +1,341 @@
+using System.Windows.Input;
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Silmarillion.ViewModels;
+using Xunit;
+using LorebookPoco = Mithril.Reference.Models.Misc.Lorebook;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class LorebookDetailViewModelTests
+{
+    [Fact]
+    public void Header_ResolvesTitle_CategorySubtitle_AndDivergentFooter()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes",
+            Title = "The Wasted Wishes", Text = "<h1>x</h1>body",
+        });
+        var vm = BuildDetail(refData, "TheWastedWishes", categoryDisplay: "Stories");
+
+        vm.DisplayName.Should().Be("The Wasted Wishes");
+        vm.InternalName.Should().Be("TheWastedWishes");
+        vm.EnvelopeKey.Should().Be("Book_101");
+        // Footer shows BOTH identifiers because they diverge.
+        vm.FooterText.Should().Be("Book_101 / TheWastedWishes");
+        vm.CategorySubtitle.Should().Be("from Stories");
+    }
+
+    [Fact]
+    public void AreaChip_ResolvesFromFirstMatchingKeyword()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddArea(new AreaEntry("AreaSerbule", "Serbule", "Serbule"));
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "B", Title = "B",
+            Keywords = new[] { "AreaSerbule" }, Text = "x",
+        });
+        var vm = BuildDetail(refData, "B", areaKey: "AreaSerbule");
+
+        vm.HasArea.Should().BeTrue();
+        vm.AreaChip!.DisplayName.Should().Be("Serbule");
+        vm.AreaChip.Reference.Kind.Should().Be(EntityKind.Area);
+        vm.AreaChip.Reference.InternalName.Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void NullText_RendersExternalGuidePlaceholder()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_155", new LorebookPoco
+        {
+            Category = "GuideProgram", InternalName = "VolunteerGuide", Title = "Volunteer Guide",
+            Text = null,
+        });
+        var vm = BuildDetail(refData, "VolunteerGuide");
+
+        vm.HasBody.Should().BeFalse();
+        vm.BodyText.Should().BeNull();
+    }
+
+    [Fact]
+    public void Body_PassedThroughForFormattedTextRendering()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "B", Title = "B",
+            Text = "<h1>The Title</h1>Body prose.",
+        });
+        var vm = BuildDetail(refData, "B");
+
+        vm.HasBody.Should().BeTrue();
+        // The VM passes raw markup; FormattedText (covered by its own tests) renders it.
+        vm.BodyText.Should().Be("<h1>The Title</h1>Body prose.");
+    }
+
+    // ── #318 Gate-C: bestowing-items popup-from-index ──
+
+    [Fact]
+    public void BestowingItems_PopupMembershipEqualsIndex_DistinctCount_NoHistoryPush()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes", Title = "The Wasted Wishes", Text = "x",
+        });
+        var indexed = new[]
+        {
+            new Item { InternalName = "ItemA", Name = "Item A", IconId = 1 },
+            new Item { InternalName = "ItemB", Name = "Item B", IconId = 2 },
+        };
+        refData.SetBestowing("TheWastedWishes", indexed);
+
+        var captured = (Popup: (ProvenancePopupViewModel?)null, Click: (ICommand?)null);
+        var prior = LorebookDetailViewModel.ProvenancePopupOpener;
+        LorebookDetailViewModel.ProvenancePopupOpener = (vm, click) => captured = (vm, click);
+        try
+        {
+            var nav = new RecordingNavigator();
+            var detail = BuildDetail(refData, "TheWastedWishes", navigator: nav);
+
+            detail.HasBestowingItems.Should().BeTrue();
+            // Count == distinct index members.
+            detail.BestowingItemsTotal.Should().Be(2);
+            detail.BestowingItemsPopup!.TotalCount.Should().Be(2);
+
+            // Single-reason → the popup collapses to a flat list (no provenance sections).
+            detail.BestowingItemsPopup.IsFlat.Should().BeTrue();
+            detail.BestowingItemsPopup.Sections.Should().ContainSingle();
+
+            // Membership == the index collection: same Item objects, same order.
+            detail.BestowingItemsPopup.FlatChips.Select(c => c.Reference.InternalName)
+                .Should().Equal("ItemA", "ItemB");
+            detail.BestowingItemsPopup.FlatChips.Select(c => c.Reference.InternalName)
+                .Should().Equal(indexed.Select(i => i.InternalName));
+
+            // ToQueryCommand is NOT wired for this surface (no query derivation by design).
+            detail.BestowingItemsPopup.ToQueryCommand.Should().BeNull();
+            detail.BestowingItemsPopup.HasToQuery.Should().BeFalse();
+
+            // Opening the popup pushes no navigator history (non-navigating contract #229).
+            detail.ShowBestowingItemsPopupCommand.Execute(null);
+            captured.Popup.Should().BeSameAs(detail.BestowingItemsPopup);
+            nav.OpenCalls.Should().Be(0, "opening a provenance popup is not a navigation");
+        }
+        finally
+        {
+            LorebookDetailViewModel.ProvenancePopupOpener = prior;
+        }
+    }
+
+    [Fact]
+    public void BestowingItems_EmptyIndex_ProducesNoAffordance()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "Lonely", Title = "Lonely", Text = "x",
+        });
+        // No SetBestowing → ItemsBestowingLorebook has no entry for "Lonely".
+        var detail = BuildDetail(refData, "Lonely");
+
+        detail.HasBestowingItems.Should().BeFalse();
+        detail.BestowingItemsPopup.Should().BeNull();
+        detail.BestowingItemsTotal.Should().Be(0);
+        detail.ShowBestowingItemsPopupCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BestowingItems_CountIsDistinctIndexMembers_NotReDerived()
+    {
+        // The index is already dedup'd by item; the popup renders exactly those members.
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "Book", Title = "Book", Text = "x",
+        });
+        refData.SetBestowing("Book",
+            new Item { InternalName = "Only", Name = "Only Item" });
+
+        var detail = BuildDetail(refData, "Book");
+
+        detail.BestowingItemsTotal.Should().Be(1);
+        detail.BestowingItemsPopup!.TotalCount.Should().Be(1);
+        detail.BestowingItemsPopup.FlatChips.Should().ContainSingle()
+            .Which.Reference.InternalName.Should().Be("Only");
+    }
+
+    // ── Real-data sanity walk (cookbook *Verification ladder* — load-bearing per #298) ──
+
+    [Fact]
+    public void RealBundledLorebooks_DiverseMarkupEntries_ProjectSensibly()
+    {
+        var bundled = System.IO.Path.Combine(AppContext.BaseDirectory, "Reference", "BundledData");
+        if (!System.IO.File.Exists(System.IO.Path.Combine(bundled, "lorebooks.json"))) return;
+
+        var refData = BuildRealRefData(bundled);
+        if (refData is null) return;
+
+        var tabVm = new LorebooksTabViewModel(
+            refData,
+            new Silmarillion.Navigation.SilmarillionReferenceNavigator(
+                new[] { (IReferenceKindTarget)new StubKindTarget(EntityKind.Area) }),
+            new ReferenceDataEntityNameResolver(refData),
+            new SilmarillionSettings());
+
+        // Book_101 "The Wasted Wishes" — a short story with <h1> + an area keyword.
+        var wastedWishes = tabVm.AllLorebooks.FirstOrDefault(b => b.InternalName == "TheWastedWishes");
+        wastedWishes.Should().NotBeNull("Book_101 is a stable entry in bundled lorebooks.json");
+        tabVm.SelectedLorebook = wastedWishes;
+        var d1 = tabVm.DetailViewModel!;
+        d1.DisplayName.Should().NotBeNullOrEmpty();
+        d1.DisplayName.Should().NotContain("(unknown)");
+        d1.EnvelopeKey.Should().Be("Book_101");
+        d1.FooterText.Should().Contain("/", "envelope key and InternalName diverge for lorebooks");
+        d1.HasBody.Should().BeTrue();
+        d1.BodyText.Should().Contain("<h1>", "raw markup is passed to FormattedText (which renders it)");
+        d1.HasArea.Should().BeTrue("Book_101 carries the AreaSerbule keyword");
+        d1.AreaChip!.DisplayName.Should().NotStartWith("Area",
+            "the area key should resolve to a friendly name (Serbule), not the raw key");
+
+        // A null-Text book (GuideProgram) → external-guide placeholder, not a blank pane.
+        var nullText = tabVm.AllLorebooks
+            .FirstOrDefault(b => string.IsNullOrEmpty(b.Book.Text));
+        if (nullText is not null)
+        {
+            tabVm.SelectedLorebook = nullText;
+            tabVm.DetailViewModel!.HasBody.Should().BeFalse();
+            tabVm.DetailViewModel!.BodyText.Should().BeNull();
+        }
+
+        // Every projected row has a non-empty title and a resolved category display.
+        tabVm.AllLorebooks.Should().OnlyContain(r => !string.IsNullOrEmpty(r.Title));
+        tabVm.AllLorebooks.Should().OnlyContain(r => !string.IsNullOrEmpty(r.CategoryDisplayTitle));
+        // The category groups resolve via the lorebookinfo.json sidecar (e.g. "The Gods").
+        tabVm.CategoryGroups.Select(g => g.CategoryDisplayTitle).Should().Contain("The Gods");
+    }
+
+    private static IReferenceDataService? BuildRealRefData(string bundled)
+    {
+        try
+        {
+            var cacheDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            System.IO.Directory.CreateDirectory(cacheDir);
+            using var http = new System.Net.Http.HttpClient(new ThrowingHttpHandler());
+            return new ReferenceDataService(cacheDir, http, bundledDir: bundled);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed class ThrowingHttpHandler : System.Net.Http.HttpMessageHandler
+    {
+        protected override Task<System.Net.Http.HttpResponseMessage> SendAsync(
+            System.Net.Http.HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("HTTP must not be called in this test");
+    }
+
+    private sealed class StubKindTarget : IReferenceKindTarget
+    {
+        public StubKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+
+    private static LorebookDetailViewModel BuildDetail(
+        FakeReferenceData refData,
+        string internalName,
+        string categoryDisplay = "Stories",
+        string? areaKey = null,
+        IReferenceNavigator? navigator = null)
+    {
+        var book = refData.LorebooksByInternalName[internalName];
+        var row = new LorebookListRow(
+            Book: book,
+            InternalName: internalName,
+            Title: book.Title ?? internalName,
+            CategoryDisplayTitle: categoryDisplay,
+            CategoryKey: book.Category ?? "",
+            AreaKey: areaKey,
+            HasText: !string.IsNullOrEmpty(book.Text),
+            LocationHint: book.LocationHint);
+        var nav = navigator ?? new RecordingNavigator();
+        return new LorebookDetailViewModel(
+            row, refData, nav, new ReferenceDataEntityNameResolver(refData),
+            new SilmarillionSettings(), openEntityCommand: null);
+    }
+
+    private sealed class RecordingNavigator : IReferenceNavigator
+    {
+        public int OpenCalls { get; private set; }
+        public bool CanOpen(EntityRef reference) => false;
+        public void Open(EntityRef reference) => OpenCalls++;
+        public void Back() { }
+        public void Forward() { }
+        public EntityRef? Current => null;
+        public bool CanGoBack => false;
+        public bool CanGoForward => false;
+        public event EventHandler<NavigatedEventArgs>? Navigated { add { } remove { } }
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, LorebookPoco> _lorebooks = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, LorebookPoco> _byInternalName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<Item>> _bestowing = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, AreaEntry> _areas = new(StringComparer.Ordinal);
+
+        public void AddLorebook(string envelopeKey, LorebookPoco book)
+        {
+            _lorebooks[envelopeKey] = book;
+            if (book.InternalName is not null) _byInternalName[book.InternalName] = book;
+        }
+
+        public void SetBestowing(string bookInternalName, params Item[] items) =>
+            _bestowing[bookInternalName] = items;
+
+        public void AddArea(AreaEntry area) => _areas[area.Key] = area;
+
+        public IReadOnlyDictionary<string, LorebookPoco> Lorebooks => _lorebooks;
+        public IReadOnlyDictionary<string, LorebookPoco> LorebooksByInternalName => _byInternalName;
+        public IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsBestowingLorebook => _bestowing;
+        public IReadOnlyDictionary<string, AreaEntry> Areas => _areas;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/LorebooksTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/LorebooksTabViewModelTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Xunit;
+using LorebookPoco = Mithril.Reference.Models.Misc.Lorebook;
+using LorebookCategoryInfo = Mithril.Reference.Models.Misc.LorebookCategoryInfo;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class LorebooksTabViewModelTests
+{
+    [Fact]
+    public void BuildsRows_ResolvesCategoryDisplayTitleFromSidecar()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddCategory("Gods", new LorebookCategoryInfo { Title = "The Gods" });
+        refData.AddLorebook("Book_103", new LorebookPoco
+        {
+            Category = "Gods",
+            InternalName = "TheChaliceSagaVol1",
+            Title = "The Chalice Saga Vol 1",
+            Keywords = new[] { "AreaSerbule" },
+            Text = "<h1>x</h1>body",
+        });
+
+        var vm = MakeVm(refData);
+
+        var row = vm.AllLorebooks.Should().ContainSingle().Subject;
+        row.InternalName.Should().Be("TheChaliceSagaVol1");
+        row.Title.Should().Be("The Chalice Saga Vol 1");
+        row.CategoryDisplayTitle.Should().Be("The Gods");
+        row.CategoryKey.Should().Be("Gods");
+        row.AreaKey.Should().Be("AreaSerbule");
+        row.HasText.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildsRows_FallsBackToRawCategoryKey_WhenSidecarMissing()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "NotInSidecar",
+            InternalName = "Mystery",
+            Title = "Mystery",
+        });
+
+        var vm = MakeVm(refData);
+
+        vm.AllLorebooks.Single().CategoryDisplayTitle.Should().Be("NotInSidecar");
+        vm.AllLorebooks.Single().HasText.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GroupProjection_GroupsByCategoryDisplayTitle()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddCategory("Gods", new LorebookCategoryInfo { Title = "The Gods" });
+        refData.AddCategory("Stories", new LorebookCategoryInfo { Title = "Stories" });
+        refData.AddLorebook("Book_1", new LorebookPoco { Category = "Gods", InternalName = "A", Title = "Aaa" });
+        refData.AddLorebook("Book_2", new LorebookPoco { Category = "Gods", InternalName = "B", Title = "Bbb" });
+        refData.AddLorebook("Book_3", new LorebookPoco { Category = "Stories", InternalName = "C", Title = "Ccc" });
+
+        var vm = MakeVm(refData);
+
+        vm.CategoryGroups.Should().HaveCount(2);
+        var gods = vm.CategoryGroups.Single(g => g.CategoryDisplayTitle == "The Gods");
+        gods.Rows.Should().HaveCount(2);
+        gods.Heading.Should().Be("The Gods (2)");
+        vm.CategoryGroups.Single(g => g.CategoryDisplayTitle == "Stories").Rows.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void FileUpdated_LorebookInfo_RebuildsCategoryDisplayTitle_WithoutDroppingSelection()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_1", new LorebookPoco { Category = "Gods", InternalName = "A", Title = "Aaa" });
+
+        var vm = MakeVm(refData);
+        vm.SelectedLorebook = vm.AllLorebooks.Single();
+        vm.AllLorebooks.Single().CategoryDisplayTitle.Should().Be("Gods", "no sidecar yet");
+
+        // Sidecar arrives via a CDN refresh of lorebookinfo.json.
+        refData.AddCategory("Gods", new LorebookCategoryInfo { Title = "The Gods" });
+        refData.RaiseFileUpdated("lorebookinfo");
+
+        vm.AllLorebooks.Single().CategoryDisplayTitle.Should().Be("The Gods");
+        vm.SelectedLorebook.Should().NotBeNull();
+        vm.SelectedLorebook!.InternalName.Should().Be("A");
+        vm.DetailViewModel.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FileUpdated_Items_RebuildsBestowingItemsOnDetail_WithoutDroppingSelection()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes", Title = "The Wasted Wishes", Text = "x",
+        });
+
+        var vm = MakeVm(refData);
+        vm.SelectedLorebook = vm.AllLorebooks.Single();
+        vm.DetailViewModel!.HasBestowingItems.Should().BeFalse("no item bestows it yet");
+
+        // An item that bestows the book arrives via an items.json refresh.
+        refData.SetBestowing("TheWastedWishes", new Item { InternalName = "BookItem", Name = "Book Item" });
+        refData.RaiseFileUpdated("items");
+
+        vm.SelectedLorebook.Should().NotBeNull();
+        vm.DetailViewModel!.HasBestowingItems.Should().BeTrue();
+        vm.DetailViewModel!.BestowingItemsTotal.Should().Be(1);
+    }
+
+    [Fact]
+    public void QueryFiltering_ByCategoryKey_IsExpressibleOnTheReflectedSchema()
+    {
+        // The query box parses against LorebookListRow's reflected schema; CategoryKey must
+        // be a public property so 'CategoryKey = "Gods"' is a known column.
+        LorebooksTabViewModel.SchemaSnapshot.Select(c => c.Name)
+            .Should().Contain(new[] { "Title", "CategoryKey", "CategoryDisplayTitle", "AreaKey", "HasText" });
+    }
+
+    private static LorebooksTabViewModel MakeVm(FakeReferenceData refData)
+    {
+        var nav = new Silmarillion.Navigation.SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        return new LorebooksTabViewModel(
+            refData, nav, new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings());
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, LorebookPoco> _lorebooks = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, LorebookPoco> _byInternalName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, LorebookCategoryInfo> _categories = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<Item>> _bestowing = new(StringComparer.Ordinal);
+
+        public void AddLorebook(string envelopeKey, LorebookPoco book)
+        {
+            _lorebooks[envelopeKey] = book;
+            if (book.InternalName is not null) _byInternalName[book.InternalName] = book;
+        }
+
+        public void AddCategory(string key, LorebookCategoryInfo info) => _categories[key] = info;
+
+        public void SetBestowing(string bookInternalName, params Item[] items) =>
+            _bestowing[bookInternalName] = items;
+
+        public void RaiseFileUpdated(string fileKey) => FileUpdated?.Invoke(this, fileKey);
+
+        public IReadOnlyDictionary<string, LorebookPoco> Lorebooks => _lorebooks;
+        public IReadOnlyDictionary<string, LorebookPoco> LorebooksByInternalName => _byInternalName;
+        public IReadOnlyDictionary<string, LorebookCategoryInfo> LorebookCategories => _categories;
+        public IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsBestowingLorebook => _bestowing;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated;
+    }
+}


### PR DESCRIPTION
Tracked in: #247

The 8th Silmarillion master-detail tab (`TabOrder`/`TabIndex` 7). #318 slices 1–3 are merged to `main` (HEAD `28be666`) before this PR was started; the bestowing-items surface is built on the #318 slice-2 shared provenance-popup control.

## Slices

| | |
|---|---|
| **a** | `FormattedText` `<h1>`/`<hr>`/`<br>` extension + tests |
| **b** | Lorebook service plumbing + cross-link index + tests |
| **c/d/f** | Tab (kind target, VM, view, detail, deep-link) + tests |
| **e** | Inbound `Item.BestowLoreBook → Lorebook` 1:1 chip |

## FormattedText extension — Option A (decision)

Took **Option A**: extended the shared `FormattedText` attached property rather than pre-stripping in the Lorebook detail VM. Lorebook bodies use a wider HTML vocabulary than the prior `<i>`/`<b>` subset (51 `<h1>`, 15 `<hr>`, 2 `<br>` across bundled `lorebooks.json`). Extending the shared renderer means quest descriptions and item flavor text retroactively render these tags too — the desired behaviour. **Verified no consumer relied on literal pass-through**: the only producers of these three tags are long-form text fields (lorebook bodies, quest descriptions) that *want* them rendered; nothing asserts a literal `<br>` survives. `<br>`→`LineBreak`, `<hr>`→scene-break (blank line / em-dash row / blank line — no inline `Border` in `TextBlock.Inlines`), `<h1>`→leading break + bold+enlarged run + trailing double break; unbalanced/malformed forms clamp or pass through without throwing (drift-safe, same contract as the existing unbalanced-`<i>`). **Test coverage**: 12 new cases — bare tags, self-closing variants, unclosed `<h1>` fallback, malformed `<h1` literal pass-through, nested `<h1><b>`, realistic lorebook shape (18 `FormattedTextRendererTests` total, all green).

## §5 bestowing-items — popup-from-index (#318), NOT a chip/synthetic-kind/deep-link

The "Items that bestow this book" surface is the #318 popup-from-index. `LorebookDetailViewModel.BuildBestowingItemsPopup` reads `IReferenceDataService.ItemsBestowingLorebook[InternalName]` directly — the single materialization (rebuilt on `items.json` / `lorebooks.json` via the cross-trigger matrix) — and feeds `ProvenancePopupViewModel` a **single flat section**. This is a single-reason relationship (an item qualifies exactly one way: its `BestowLoreBook` id == this book's id), so per the #318 *Discipline* rule a lone trivial reason is noise → no provenance sub-sectioning (`IsFlat`). **No synthetic `EntityKind`, no cap/overflow chip, no Items-tab deep-link, no second query derivation.** `ToQueryCommand` left null (consistent with the slice-2 effect→abilities deferral). Opening is a `Window.Show()` via the injectable `ProvenancePopupOpener` → pushes no navigator history (#229 non-navigating contract). Empty index → no affordance rendered.

**Gate-C test** (`LorebookDetailViewModelTests.BestowingItems_PopupMembershipEqualsIndex_DistinctCount_NoHistoryPush`): popup membership == `ItemsBestowingLorebook[InternalName]` (same objects, same order); affordance `{N}` == distinct index members; single flat section; `ToQueryCommand` null + `HasToQuery` false; opening pushes no navigator history (`RecordingNavigator.OpenCalls == 0`); empty index → no affordance.

## Inbound `Item.BestowLoreBook → Lorebook` 1:1 chip migration (slice e)

The other direction of the cross-link — the natural payoff of shipping the tab. `Item.BestowLoreBook` (`int?` = numeric Book id) resolves via `LorebooksById` to a single navigable "Bestows lorebook" `EntityChip` on Item detail (18 bestowing items in the bundled corpus). This is the **1:1** direction — a normal entity chip, unaffected by #318. Dangling/null ids render no chip. Audit pass: the only pre-existing `EntityRef.Lorebook(...)` call site (`QuestDetailProjector`'s quest-reward lorebook chip) already sets `IsNavigable` via `_navigator.CanOpen` — flips clickable for free now that the kind target ships. No stale hardcoded-`false` sites. `ReferenceDataEntityNameResolver` gained an `EntityKind.Lorebook` case (Title → InternalName fallback).

## Verification

- `dotnet build Mithril.slnx` — **0 warnings, 0 errors** (warnings-as-errors).
- `dotnet test Mithril.slnx` — **2400 passed, 0 failed, 0 skipped** across all projects (Silmarillion.Tests 351, Mithril.Shared.Tests 934). Real-bundled-data sanity walk **ran** (not skipped — bundled data co-located): Book_101 projects with `<h1>` body, resolved area chip ("Serbule"), divergent `Book_101 / TheWastedWishes` footer; "The Gods" category resolves via the `lorebookinfo.json` sidecar.
- Shell launched (`dotnet run --project src/Mithril.Shell`); `boot.log` advanced cleanly past `=== startup done ===` — no DI cycle from the new tab VM + service indices; run log shows no exceptions.

## Concurrency note

Lorebook index additions to `IReferenceDataService.cs` / `ReferenceDataService.cs` are append-style and localized (no shared-region refactor) so the concurrently-merging slice-4 surface-1 PR rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)