### PR TITLE
feat(silmarillion): StorageVaults tab — #249

### DIFF
--- a/docs/agent-plans/silmarillion-249-storagevaults-tab.md
+++ b/docs/agent-plans/silmarillion-249-storagevaults-tab.md
@@ -1,0 +1,93 @@
+# Silmarillion: StorageVaults tab (#249)
+
+**Tracked in:** #249 — `module:silmarillion` / `area:ui` / `type:feature`. #203 umbrella (Bucket B long-tail).
+
+**Companion docs:**
+- [silmarillion-tab-cookbook.md](../silmarillion-tab-cookbook.md) — **read first.** Standard tab scaffolding. The chip-vs-popup rule is fully shipped; **this tab has no 1:N fan-out surface** — every cross-link here is a 1:1 `EntityChip`. Do not invent a popup or a synthetic kind.
+- Reference implementations to mirror (merged): `LorebooksKindTarget`/`LorebooksTabViewModel`/`LorebookDetailViewModel` + views (PR #322) for scaffolding; `AreaDetailViewModel` (PR #324) for the per-group table-style rendering pattern.
+
+> Lowest-payoff tab in Bucket B. Keep it tight. The only non-mechanical work: the `Levels` favor→slots capacity table, the polymorphic `Requirements` rendering, and the **Bilbo-overlap check the issue explicitly demands**.
+
+## Data shape — StorageVault
+
+[`Mithril.Reference.Models.Misc.StorageVault`](../../src/Mithril.Reference/Models/Misc/StorageVault.cs) (`storagevaults.json`, small dataset, envelope key = NPC internal name, `*`-prefixed for account-wide):
+
+```csharp
+public sealed class StorageVault
+{
+    public string? Area { get; set; }                 // e.g. "AreaSerbule" → Area 1:1 chip
+    public int ID { get; set; }
+    public string? NpcFriendlyName { get; set; }       // display label; key is NPC internal name
+    public string? Grouping { get; set; }
+    public IReadOnlyDictionary<string,int>? Levels { get; set; } // favor tier → slot count
+    public int? NumSlots { get; set; }                 // flat slot count when not favor-scaled
+    public IReadOnlyList<string>? RequiredItemKeywords { get; set; }
+    public string? RequirementDescription { get; set; } // e.g. "Potions and Alchemy Ingredients"
+    public bool? HasAssociatedNpc { get; set; }         // false ⇒ no operator NPC chip (e.g. transfer chests)
+    public IReadOnlyList<StorageRequirement>? Requirements { get; set; } // polymorphic, see below
+    public string? SlotAttribute { get; set; }
+    public string? NumSlotsScriptAtomic { get; set; }
+    public int? NumSlotsScriptAtomicMaxValue { get; set; }
+    public int? NumSlotsScriptAtomicMinValue { get; set; }
+    public IReadOnlyDictionary<string,int>? EventLevels { get; set; } // rare (≈1 entry)
+}
+```
+
+`StorageRequirement` is a **polymorphic** base (discriminator `T`) with subclasses: `StorageInteractionFlagSetRequirement` (`InteractionFlag`), `StorageQuestCompletedRequirement` (`Quest` → **Quest 1:1 chip**), `StorageServerRulesFlagSetRequirement` (`Flag`), `StorageIsLongtimeAnimalRequirement`, `StorageIsWardenRequirement`, `UnknownStorageRequirement` (`DiscriminatorValue`). Render by intent grouping (mirror the quest-detail polymorphic-requirements UX: reverse-lookup internal names to display where possible, group by meaning, don't mechanically dump subclass names — see project memory *quest-detail rendering — UX over mechanical projection*).
+
+Real samples: `*AccountStorage_Serbule` (Area `AreaSerbule`, `HasAssociatedNpc:false`, `NumSlots:0` — a transfer chest); `NPC_CharlesThompson` (Area `AreaSerbule`, `Levels{Friends:32,CloseFriends:40,…SoulMates:64}`, `RequiredItemKeywords:[Alchemy,Potion,…]`, `RequirementDescription:"Potions and Alchemy Ingredients"`); `IvynsChest` (`Requirements:{T:InteractionFlagSet, InteractionFlag:"Ivyn_Gave_Passcode"}`).
+
+## ⚠️ Mandatory pre-work — Bilbo overlap check (issue requirement)
+
+The #249 issue explicitly requires: *"Bilbo already consumes related storage data — verify there's no parallel projection that should be consolidated rather than duplicated."* Before building, grep `src/Bilbo.Module/` for any `StorageVault`/`storagevaults` consumption or a parallel storage-location model. Record findings in the PR:
+- If Bilbo has its own storage projection: do **not** silently duplicate. Plumb `IReferenceDataService.StorageVaults` (the canonical source) and note whether Bilbo should later migrate onto it (file/reference a follow-up issue if consolidation is non-trivial — do not expand this PR's scope to refactor Bilbo).
+- If Bilbo only consumes live inventory (not the canonical vault list): no conflict — proceed; note that in the PR.
+
+## Cross-links — all 1:1 chips (no popup)
+
+- **Operator NPC** — only when `HasAssociatedNpc == true`; resolve the envelope key (NPC internal name) → NPC `EntityChip`. Fold into the header/metadata row (single chip → not its own section, per the section-folding lesson).
+- **Parent Area** — `Area` → Area `EntityChip`, metadata row.
+- **Quest requirement** — any `StorageQuestCompletedRequirement.Quest` → Quest `EntityChip` inline in the Requirements rendering.
+
+None of these is a fan-out set. **Do not build a `ProvenancePopupViewModel` here.** ("Vaults in this area" reverse-lookup is an Areas-tab concern, explicitly out of scope.)
+
+## Scope
+
+1. **Service plumbing on `IReferenceDataService`.** `ParseStorageVaults` exists ([`ReferenceDeserializer.cs:207`](../../src/Mithril.Reference/Serialization/ReferenceDeserializer.cs#L207)) but is **not** plumbed onto the service. Add `IReadOnlyDictionary<string, StorageVault> StorageVaults` (envelope key → POCO) + empty-default fallback; wire `LoadStorageVaults`/`ParseAndSwapStorageVaults` into ctor + `RefreshAsync` switch + `RefreshAllAsync` + `Keys` + `GetSnapshot`; `FileUpdated("storagevaults")`. Mirror exactly the Lorebooks plumbing pattern PR #322 established.
+2. **Kind target** `StorageVaultsKindTarget.cs` mirroring `LorebooksKindTarget`. `Kind => EntityKind.StorageVault` (already enumerated); `EntityRef.StorageVault(string)` already exists (`EntityRef.cs:114`) — grep for stale call sites, fix in-PR if any. Next free `TabIndex`; `TrySelectByInternalName`; `TryOpenInWindow`.
+3. **Tab VM + view + detail VM + view + DI**, standard cookbook scaffolding mirroring the Lorebooks set + the `<DataTemplate>` in `SilmarillionView.xaml`. Row record: envelope key (selection), `NpcFriendlyName` (display), Area key, account-wide flag (derived from `*` prefix / `HasAssociatedNpc`), effective slot summary, Grouping facet. Detail sections:
+   - **Header** — `NpcFriendlyName`, internal-name footer (envelope key, mono small per convention).
+   - **Metadata row** — Parent Area chip; Operator NPC chip (only if `HasAssociatedNpc`); account-wide badge (only when true — noise-filter default).
+   - **Capacity** — if `Levels` present, a favor-tier → slot-count table (mirror `AreaDetailViewModel`'s per-group table pattern; order favor tiers canonically, not dict order); else `NumSlots`; surface `SlotAttribute`/script-atomic min–max only when present. `EventLevels` is rare — render only when non-null, clearly labeled as event-gated.
+   - **Access requirements** — `RequirementDescription` (prose), `RequiredItemKeywords` (small chip/label cluster — these are item keyword tags, NOT navigable entities; render as plain tags), and the polymorphic `Requirements` grouped by intent (Quest-completed → Quest chip; flags → human label; longtime-animal/warden → a plain badge; Unknown → its `DiscriminatorValue` behind a noise-filtered "(unrecognised requirement)" so a future schema addition degrades gracefully, not as a crash or blank).
+4. **Deep-link route** `mithril://silmarillion/storagevault/<key>` — pass-through via `SilmarillionDeepLinkHandler` (no code). Add `Open_StorageVault_*` to `SilmarillionReferenceNavigatorTests`. Note the `*`-prefixed account-wide keys — ensure the route + selection round-trip handles the literal `*` (URL-encode/observe the existing handler's behaviour; add a test for a `*`-prefixed key).
+5. **Tab order / `V1TabbedKinds`:** append after the last current tab; add `EntityKind.StorageVault` to `V1TabbedKinds` if not present.
+
+## Tests
+
+Cookbook trio: `StorageVaultsTabViewModelTests` (list construction, account-wide derivation, Grouping facet, `FileUpdated("storagevaults")` rebuild preserving selection), `StorageVaultsKindTargetTests` (incl. a `*`-prefixed key hit), extend `SilmarillionReferenceNavigatorTests` (`Open_StorageVault_*` incl. `*`-prefixed), `StorageVaultDetailViewModelTests` (Area + NPC chip resolution incl. `HasAssociatedNpc:false` ⇒ no NPC chip; favor-table projection ordered canonically; each `StorageRequirement` subclass renders sensibly incl. `UnknownStorageRequirement` graceful degrade; noise filters), `ReferenceDataServiceStorageVaultTests` (plumbing round-trip; refresh rebuilds). Real-bundled-data sanity walk: a transfer chest (`HasAssociatedNpc:false`), a favor-scaled vendor vault (`Levels` populated), an interaction-flag-gated chest (`Requirements`).
+
+## Verification ladder
+
+1. `dotnet build Mithril.slnx` — warnings-as-errors clean.
+2. `dotnet test Mithril.slnx` — full suite green.
+3. **Real-data walk before manual smoke.**
+4. `dotnet run --project src/Mithril.Shell` — Vaults tab appears; pick a favor-scaled vault → capacity table renders ordered; Area/NPC chips navigate; a quest-gated vault shows the Quest chip; a transfer chest shows no NPC chip and doesn't crash on `NumSlots:0`; deep-link to both a plain and a `*`-prefixed key selects.
+
+## Hard constraints (orchestrated)
+
+- **Worktree discipline (non-negotiable):** work ONLY in your assigned worktree; never write/edit/`git` the main repo path `I:\src\project gorgon`; resolve stale-cache/`wpftmp` desync within the worktree against disk truth (an earlier session leaked 186 divergent lines into the main tree). All commits/builds/tests/`gh` inside the worktree.
+- Branch off current `main`; feature branch `feat/249-storagevaults-tab`; PR via `gh pr create` against `moumantai-gg/mithril` main. **Do NOT merge.**
+- Commits **signed** (1Password auto-lock disabled this session — sign, push, open the PR yourself). Fallback: signing fails ⇒ do **not** `--no-gpg-sign`, do not push unsigned — commit locally, stop, report. Author `Arthur Conde <arthur.conde@live.com>`. Commit trailer `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`. PR body opens `Tracked in: #249`, includes the **Bilbo-overlap finding**, and ends with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- `dotnet build Mithril.slnx` (0/0) + `dotnet test Mithril.slnx` green from the worktree; shell boots past `=== startup done ===`.
+- **Concurrency:** the sibling #248 PlayerTitles sub-session runs in parallel and also adds plumbing to `IReferenceDataService.cs`/`ReferenceDataService.cs`. Keep additions localized/append-style so the orchestrator's sequential merge+rebase stays conflict-free.
+
+## Out of scope
+
+- Refactoring Bilbo onto the canonical `StorageVaults` projection (note + reference a follow-up issue if warranted; don't do it here).
+- "Vaults in this area" reverse-lookup (Areas-tab concern).
+- Any synthetic-kind / popup surface — there is no fan-out relationship on this tab.
+
+---
+
+*Drafted by Claude (Opus 4.7), filed by @arthur-conde via Claude Code on 2026-05-15.*

--- a/src/Mithril.Shared.Wpf/Modules/DeepLinkPayload.cs
+++ b/src/Mithril.Shared.Wpf/Modules/DeepLinkPayload.cs
@@ -10,6 +10,8 @@ public static class DeepLinkPayload
 {
     private static readonly Regex InternalNamePattern = new("^[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
 
+    private static readonly Regex EnvelopeKeyPattern = new(@"^\*?[A-Za-z0-9_]{1,128}$", RegexOptions.Compiled);
+
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="name"/> matches the reference-data
     /// internal-name grammar: 1–128 ASCII characters from <c>[A-Za-z0-9_]</c>. The cap
@@ -17,4 +19,16 @@ public static class DeepLinkPayload
     /// that could smuggle URI separators or whitespace.
     /// </summary>
     public static bool IsValidInternalName(string name) => InternalNamePattern.IsMatch(name);
+
+    /// <summary>
+    /// Like <see cref="IsValidInternalName"/> but additionally permits a single optional
+    /// leading <c>'*'</c>. Some envelope keys (StorageVault account-wide / transfer-chest
+    /// entries, e.g. <c>"*AccountStorage_Serbule"</c>) carry a meaningful <c>'*'</c> prefix
+    /// that the bare internal-name grammar would reject. The <c>'*'</c> still can't smuggle
+    /// URI separators or whitespace, so the URI-safety intent of the base grammar holds.
+    /// The module-scoped <c>mithril://silmarillion/&lt;kind&gt;/&lt;key&gt;</c> handler uses
+    /// this so a deep link to a <c>'*'</c>-prefixed key round-trips
+    /// (URL-encoded as <c>%2A</c>; <see cref="System.Uri.AbsolutePath"/> decodes it back).
+    /// </summary>
+    public static bool IsValidEnvelopeKey(string name) => EnvelopeKeyPattern.IsMatch(name);
 }

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -605,6 +605,21 @@ public interface IReferenceDataService
     // "Quests awarding this title" popup-from-index surface is intentionally NOT
     // built; no index, no Gate-C test (the test is merge-blocking only IF the popup
     // ships). See the PR body for the data finding.
+    // ── StorageVaults (#249) ──────────────────────────────────────────────
+
+    /// <summary>
+    /// StorageVault envelope key → <see cref="StorageVault"/> POCO from
+    /// <c>storagevaults.json</c>. The envelope key is the operator NPC's internal name
+    /// (e.g. <c>"NPC_CharlesThompson"</c>), or a <c>"*"</c>-prefixed account-wide form
+    /// (e.g. <c>"*AccountStorage_Serbule"</c> — a transfer chest, no operator NPC). The
+    /// envelope key is the selection / deep-link contract (matches the existing
+    /// <see cref="EntityRef.StorageVault(string)"/> factory). Defaults to empty so test
+    /// fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, StorageVault> StorageVaults => EmptyStorageVaultMap;
+
+    private static readonly IReadOnlyDictionary<string, StorageVault> EmptyStorageVaultMap
+        = new Dictionary<string, StorageVault>(StringComparer.Ordinal);
 
     /// <summary>
     /// All localizable strings from <c>strings_all.json</c>, keyed by their

--- a/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
@@ -25,6 +25,7 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         EntityKind.Effect => ResolveEffect(reference.InternalName),
         EntityKind.Skill => ResolveSkill(reference.InternalName),
         EntityKind.Lorebook => ResolveLorebook(reference.InternalName),
+        EntityKind.StorageVault => ResolveStorageVault(reference.InternalName),
         _ => reference.InternalName,
     };
 
@@ -95,6 +96,18 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         _refData.LorebooksByInternalName.TryGetValue(internalName, out var book) && !string.IsNullOrEmpty(book.Title)
             ? book.Title!
             : internalName;
+
+    /// <summary>
+    /// StorageVault keys are the operator NPC internal name (e.g. <c>"NPC_CharlesThompson"</c>)
+    /// or a <c>"*"</c>-prefixed account-wide form (e.g. <c>"*AccountStorage_Serbule"</c>).
+    /// The display label is <see cref="Mithril.Reference.Models.Misc.StorageVault.NpcFriendlyName"/>;
+    /// fall back to the key with any leading <c>"*"</c> / <c>"NPC_"</c> stripped so an
+    /// unnamed entry reads sensibly rather than as the raw envelope key.
+    /// </summary>
+    private string ResolveStorageVault(string envelopeKey) =>
+        _refData.StorageVaults.TryGetValue(envelopeKey, out var vault) && !string.IsNullOrEmpty(vault.NpcFriendlyName)
+            ? vault.NpcFriendlyName!
+            : StripNpcPrefix(envelopeKey.StartsWith('*') ? envelopeKey[1..] : envelopeKey);
 
     private static string StripNpcPrefix(string internalName) =>
         internalName.StartsWith("NPC_", StringComparison.Ordinal)

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -16,6 +16,7 @@ using Lorebook = Mithril.Reference.Models.Misc.Lorebook;
 using LorebookInfo = Mithril.Reference.Models.Misc.LorebookInfo;
 using LorebookCategoryInfo = Mithril.Reference.Models.Misc.LorebookCategoryInfo;
 using PlayerTitle = Mithril.Reference.Models.Misc.PlayerTitle;
+using StorageVault = Mithril.Reference.Models.Misc.StorageVault;
 using PocoNpc = Mithril.Reference.Models.Npcs.Npc;
 using PocoNpcPreference = Mithril.Reference.Models.Npcs.NpcPreference;
 using PocoNpcService = Mithril.Reference.Models.Npcs.NpcService;
@@ -276,6 +277,12 @@ public sealed class ReferenceDataService : IReferenceDataService
     private IReadOnlyDictionary<string, PlayerTitle> _playerTitles =
         new Dictionary<string, PlayerTitle>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _playerTitlesSnapshot;
+    // StorageVaults (storagevaults.json) — keyed by the operator NPC internal name, or a
+    // "*"-prefixed account-wide form (transfer chests). Plain reference dictionary; no
+    // cross-link index (all #249 cross-links are 1:1 chips resolved at detail-build time).
+    private IReadOnlyDictionary<string, StorageVault> _storageVaults =
+        new Dictionary<string, StorageVault>(StringComparer.Ordinal);
+    private ReferenceFileSnapshot _storageVaultsSnapshot;
 
     public ReferenceDataService(string cacheDir, HttpClient http, IDiagnosticsSink? diag = null, string? bundledDir = null, IPerfTracer? perf = null)
     {
@@ -314,6 +321,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         _lorebooksSnapshot = new ReferenceFileSnapshot("lorebooks", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _lorebookInfoSnapshot = new ReferenceFileSnapshot("lorebookinfo", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
         _playerTitlesSnapshot = new ReferenceFileSnapshot("playertitles", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
+        _storageVaultsSnapshot = new ReferenceFileSnapshot("storagevaults", ReferenceFileSource.Bundled, FallbackCdnVersion, null, 0);
 
         LoadItems();
         LoadRecipes();
@@ -346,6 +354,11 @@ public sealed class ReferenceDataService : IReferenceDataService
     }
 
     public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects", "lorebooks", "lorebookinfo", "playertitles"];
+        LoadStorageVaults();       // Independent of every other file (#249 cross-links are
+                                   // 1:1 chips resolved lazily at detail-build, not an index).
+    }
+
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects", "lorebooks", "lorebookinfo", "storagevaults"];
 
     public IReadOnlyDictionary<long, Item> Items => _items;
     public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByInternalName;
@@ -401,6 +414,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, IReadOnlyList<Item>> ItemsBestowingLorebook => _itemsBestowingLorebook;
     public IReadOnlyDictionary<string, LorebookCategoryInfo> LorebookCategories => _lorebookCategories;
     public IReadOnlyDictionary<string, PlayerTitle> PlayerTitles => _playerTitles;
+    public IReadOnlyDictionary<string, StorageVault> StorageVaults => _storageVaults;
     public IReadOnlyDictionary<string, string> Strings => _strings;
 
     public ReferenceFileSnapshot GetSnapshot(string key) => key switch
@@ -429,6 +443,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "lorebooks" => _lorebooksSnapshot,
         "lorebookinfo" => _lorebookInfoSnapshot,
         "playertitles" => _playerTitlesSnapshot,
+        "storagevaults" => _storageVaultsSnapshot,
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -460,6 +475,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         "lorebooks" => RefreshFileAsync("lorebooks", ReferenceDeserializer.ParseLorebooks, ParseAndSwapLorebooks, ct),
         "lorebookinfo" => RefreshFileAsync("lorebookinfo", ReferenceDeserializer.ParseLorebookInfo, ParseAndSwapLorebookInfo, ct),
         "playertitles" => RefreshFileAsync("playertitles", ReferenceDeserializer.ParsePlayerTitles, ParseAndSwapPlayerTitles, ct),
+        "storagevaults" => RefreshFileAsync("storagevaults", ReferenceDeserializer.ParseStorageVaults, ParseAndSwapStorageVaults, ct),
         _ => throw new ArgumentException($"Unknown reference file key: {key}", nameof(key)),
     };
 
@@ -489,6 +505,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         await RefreshAsync("lorebookinfo", ct).ConfigureAwait(false);
         await RefreshAsync("lorebooks", ct).ConfigureAwait(false);
         await RefreshAsync("playertitles", ct).ConfigureAwait(false);
+        await RefreshAsync("storagevaults", ct).ConfigureAwait(false);
     }
 
     public void BeginBackgroundRefresh()
@@ -678,6 +695,7 @@ public sealed class ReferenceDataService : IReferenceDataService
     private void LoadLorebooks() => LoadFile("lorebooks", ReferenceDeserializer.ParseLorebooks, ParseAndSwapLorebooks);
     private void LoadLorebookInfo() => LoadFile("lorebookinfo", ReferenceDeserializer.ParseLorebookInfo, ParseAndSwapLorebookInfo);
     private void LoadPlayerTitles() => LoadFile("playertitles", ReferenceDeserializer.ParsePlayerTitles, ParseAndSwapPlayerTitles);
+    private void LoadStorageVaults() => LoadFile("storagevaults", ReferenceDeserializer.ParseStorageVaults, ParseAndSwapStorageVaults);
 
     // ── Per-type parse-and-swap ──────────────────────────────────────────
 
@@ -1205,6 +1223,19 @@ public sealed class ReferenceDataService : IReferenceDataService
         _lorebooksById = byId;
         _lorebooksSnapshot = new ReferenceFileSnapshot("lorebooks", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
         BuildLorebookItemCrossLinkIndex();
+    }
+
+    private void ParseAndSwapStorageVaults(IReadOnlyDictionary<string, StorageVault> raw, ReferenceFileMetadata meta)
+    {
+        // Envelope key is the operator NPC internal name (or a "*"-prefixed account-wide
+        // form). Preserve it verbatim — it's the deep-link / selection contract and the
+        // leading "*" is meaningful (account-wide transfer chest). Ordinal comparer keeps
+        // the "*"-prefixed keys distinct from any same-suffix NPC key.
+        var byKey = new Dictionary<string, StorageVault>(raw.Count, StringComparer.Ordinal);
+        foreach (var (key, v) in raw)
+            byKey[key] = v;
+        _storageVaults = byKey;
+        _storageVaultsSnapshot = new ReferenceFileSnapshot("storagevaults", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
     }
 
     private void ParseAndSwapLorebookInfo(LorebookInfo raw, ReferenceFileMetadata meta)

--- a/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
+++ b/src/Silmarillion.Module/Navigation/SilmarillionDeepLinkHandler.cs
@@ -42,9 +42,19 @@ public sealed class SilmarillionDeepLinkHandler : IDeepLinkHandler
         }
 
         var kind = parts[0];
-        var name = parts[1];
+        // Uri.AbsolutePath (the DeepLinkRouter source) leaves percent-encoding intact, so a
+        // '*'-prefixed StorageVault key arrives URL-encoded as "%2A...". Decode the name
+        // segment before validation. This is safe: a decoded URI separator or whitespace
+        // would simply fail IsValidEnvelopeKey below (the grammar is the gate, not the
+        // decode), and bare internal names (no '%') are unaffected by the round-trip.
+        var name = Uri.UnescapeDataString(parts[1]);
 
-        if (!DeepLinkPayload.IsValidInternalName(name))
+        // IsValidEnvelopeKey == IsValidInternalName plus an optional single leading '*'
+        // (StorageVault account-wide / transfer-chest keys like "*AccountStorage_Serbule";
+        // URL-encoded as %2A, decoded back by Uri.AbsolutePath in DeepLinkRouter). Bare
+        // internal names — every other kind — are a strict subset, so this stays a no-op
+        // for item/recipe/npc/etc. routes.
+        if (!DeepLinkPayload.IsValidEnvelopeKey(name))
         {
             diag?.Info("DeepLink", $"Rejected: silmarillion name '{name}' failed validation.");
             return false;

--- a/src/Silmarillion.Module/Navigation/StorageVaultsKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/StorageVaultsKindTarget.cs
@@ -1,0 +1,56 @@
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for the StorageVaults tab. Resolves selection
+/// against the tab VM's bound <see cref="StorageVaultsTabViewModel.AllVaults"/> collection
+/// rather than <see cref="IReferenceDataService"/> directly — same instance-identity
+/// concern as every other Silmarillion tab (cookbook *Pattern walkthrough → ItemsKindTarget*).
+/// <para>
+/// The <c>internalName</c> argument is the StorageVault <see cref="StorageVaultListRow.EnvelopeKey"/>
+/// — the operator NPC internal name (e.g. <c>"NPC_CharlesThompson"</c>) or a <c>"*"</c>-
+/// prefixed account-wide form (e.g. <c>"*AccountStorage_Serbule"</c>). This matches the
+/// existing <see cref="EntityRef.StorageVault(string)"/> factory and the deep-link route.
+/// </para>
+/// </summary>
+public sealed class StorageVaultsKindTarget : IReferenceKindTarget
+{
+    private readonly StorageVaultsTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public StorageVaultsKindTarget(StorageVaultsTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.StorageVault;
+
+    public int TabIndex => 8;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var row = _vm.AllVaults.FirstOrDefault(v => v.EnvelopeKey == internalName);
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"StorageVaults.TrySelect '{internalName}' → not found (AllVaults={_vm.AllVaults.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"StorageVaults.TrySelect '{internalName}' → found, selecting.");
+        // Clear any residual filter so the target row isn't filtered out of the visible list.
+        _vm.QueryText = "";
+        _vm.SelectedVault = row;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new StorageVaultDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -71,6 +71,11 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetRequiredService<SilmarillionSettings>()));
         services.AddSingleton<PlayerTitlesTabViewModel>(sp => new PlayerTitlesTabViewModel(
             sp.GetRequiredService<IReferenceDataService>()));
+        services.AddSingleton<StorageVaultsTabViewModel>(sp => new StorageVaultsTabViewModel(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IReferenceNavigator>(),
+            sp.GetRequiredService<IEntityNameResolver>(),
+            sp.GetRequiredService<SilmarillionSettings>()));
         // Forward each concrete tab VM to ITabViewModel so SilmarillionViewModel can compose
         // its Tabs collection from IEnumerable<ITabViewModel>. Adding a future tab is a single
         // pair of registrations here — no SilmarillionViewModel ctor change (refactor #243).
@@ -83,6 +88,7 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<AreasTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<LorebooksTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<PlayerTitlesTabViewModel>());
+        services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<StorageVaultsTabViewModel>());
         services.AddSingleton<SilmarillionViewModel>();
 
         // Kind targets registered after the tab VMs so DI can resolve them.
@@ -137,6 +143,8 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new PlayerTitlesKindTarget(
             sp.GetRequiredService<PlayerTitlesTabViewModel>(),
+        services.AddSingleton<IReferenceKindTarget>(sp => new StorageVaultsKindTarget(
+            sp.GetRequiredService<StorageVaultsTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).

--- a/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
@@ -1,0 +1,326 @@
+using Mithril.Reference.Models.Misc;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// StorageVault detail-pane view-model. Sections top-down:
+/// <list type="number">
+/// <item><b>Header</b> — <see cref="StorageVaultPoco.NpcFriendlyName"/> (large),
+/// internal-name footer (the envelope key, mono small per the detail-view footer
+/// convention).</item>
+/// <item><b>Metadata row</b> — parent Area chip; operator NPC chip (only when
+/// <see cref="StorageVaultPoco.HasAssociatedNpc"/> is true — false ⇒ a transfer chest with
+/// no operator); an account-wide badge rendered only when true (noise-filter default —
+/// every persistent badge carries information).</item>
+/// <item><b>Capacity</b> — the favor-tier → slot-count table (<see cref="CapacityRows"/>)
+/// when <see cref="StorageVaultPoco.Levels"/> is present, ordered by the canonical in-game
+/// favor progression (NOT dict order); else the flat <see cref="FlatSlots"/>; the
+/// script-atomic min–max range only when present; the rare event-gated
+/// <see cref="StorageVaultPoco.EventLevels"/> rendered only when non-null, clearly
+/// labeled.</item>
+/// <item><b>Access requirements</b> — <see cref="RequirementDescription"/> prose, the
+/// <see cref="ItemKeywordTags"/> plain tag cluster (item-keyword tags, NOT navigable
+/// entities), and the polymorphic <see cref="Requirements"/> grouped by intent. An
+/// <c>UnknownStorageRequirement</c> degrades to a noise-filtered "(unrecognised
+/// requirement)" line so a future schema addition surfaces gracefully, not as a crash or
+/// a blank.</item>
+/// </list>
+/// <para>
+/// Every cross-link here is a 1:1 <see cref="EntityChipVm"/> (operator NPC, parent Area,
+/// quest-completed requirement → Quest). There is no 1:N fan-out surface and therefore
+/// no provenance popup / synthetic kind on this tab (#318 retired the synthetic-kind
+/// family; "Vaults in this area" reverse-lookup is an Areas-tab concern, out of scope).
+/// </para>
+/// </summary>
+public sealed class StorageVaultDetailViewModel
+{
+    /// <summary>
+    /// Canonical in-game favor progression (mirrors <c>Arwen.Domain.FavorTier</c>, kept
+    /// local to avoid a cross-module dependency). The favor table orders rows by this, NOT
+    /// by the JSON dictionary's enumeration order. Any unrecognised future tier sorts last
+    /// (alpha) so a PG patch surfaces visibly rather than silently.
+    /// </summary>
+    private static readonly string[] FavorOrder =
+    {
+        "Despised", "Hatred", "Disliked", "Tolerated", "Neutral", "Comfortable",
+        "Friends", "CloseFriends", "BestFriends", "LikeFamily", "SoulMates",
+    };
+
+    public StorageVaultDetailViewModel(
+        StorageVaultListRow row,
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver)
+    {
+        Row = row;
+        var vault = row.Vault;
+        DisplayName = row.DisplayName;
+        EnvelopeKey = row.EnvelopeKey;
+        IsAccountWide = row.IsAccountWide;
+        Grouping = string.IsNullOrEmpty(vault.Grouping) ? null : vault.Grouping;
+
+        AreaChip = BuildAreaChip(vault.Area, refData, nameResolver, navigator);
+
+        // Operator NPC chip ONLY when the vault has an associated NPC. Account-wide
+        // transfer chests (HasAssociatedNpc:false) have no operator — folding in an NPC
+        // chip there would be a dead reference.
+        OperatorNpcChip = vault.HasAssociatedNpc == true
+            ? BuildNpcChip(row.EnvelopeKey, refData, nameResolver, navigator)
+            : null;
+
+        // ── Capacity ──
+        CapacityRows = BuildCapacityRows(vault.Levels);
+        HasCapacityTable = CapacityRows.Count > 0;
+        FlatSlots = !HasCapacityTable && vault.NumSlots is { } n ? n : (int?)null;
+        HasFlatSlots = FlatSlots is not null && FlatSlots.Value > 0;
+
+        if (!string.IsNullOrEmpty(vault.NumSlotsScriptAtomic)
+            && vault.NumSlotsScriptAtomicMinValue is { } lo
+            && vault.NumSlotsScriptAtomicMaxValue is { } hi)
+        {
+            ScriptAtomicRange = $"Dynamic: {lo}–{hi} slots";
+        }
+
+        EventLevelRows = vault.EventLevels is { Count: > 0 } ev
+            ? ev.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+                 .Select(kv => new StorageVaultCapacityRow(kv.Key, kv.Value))
+                 .ToList()
+            : (IReadOnlyList<StorageVaultCapacityRow>)Array.Empty<StorageVaultCapacityRow>();
+        HasEventLevels = EventLevelRows.Count > 0;
+
+        // ── Access requirements ──
+        RequirementDescription = string.IsNullOrEmpty(vault.RequirementDescription)
+            ? null
+            : vault.RequirementDescription;
+
+        ItemKeywordTags = vault.RequiredItemKeywords is { Count: > 0 } kws
+            ? kws.Where(k => !string.IsNullOrEmpty(k)).ToList()
+            : (IReadOnlyList<string>)Array.Empty<string>();
+        HasItemKeywordTags = ItemKeywordTags.Count > 0;
+
+        var (reqLines, questChips) = BuildRequirements(vault.Requirements, refData, nameResolver, navigator);
+        RequirementLines = reqLines;
+        QuestRequirementChips = questChips;
+        HasRequirementLines = RequirementLines.Count > 0;
+        HasQuestRequirements = QuestRequirementChips.Count > 0;
+
+        HasAccessRequirements =
+            RequirementDescription is not null
+            || HasItemKeywordTags
+            || HasRequirementLines
+            || HasQuestRequirements;
+    }
+
+    public StorageVaultListRow Row { get; }
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Envelope key (operator NPC internal name, or a <c>"*"</c>-prefixed account-wide
+    /// form) — rendered as the bottom-right monospace footer per the detail-view
+    /// internal-name footer convention.
+    /// </summary>
+    public string EnvelopeKey { get; }
+
+    /// <summary>True when the vault is account-wide (derived from the <c>"*"</c> prefix).</summary>
+    public bool IsAccountWide { get; }
+
+    /// <summary>Grouping facet (e.g. <c>"AreaSerbule"</c>), or null when absent.</summary>
+    public string? Grouping { get; }
+    public bool HasGrouping => Grouping is not null;
+
+    // ── Metadata chips ──
+    public EntityChipVm? AreaChip { get; }
+    public bool HasArea => AreaChip is not null;
+
+    /// <summary>Operator NPC chip, or null for a transfer chest (HasAssociatedNpc:false).</summary>
+    public EntityChipVm? OperatorNpcChip { get; }
+    public bool HasOperatorNpc => OperatorNpcChip is not null;
+
+    // ── Capacity ──
+
+    /// <summary>
+    /// Favor-tier → slot-count rows, canonically ordered (NOT JSON dict order). Empty when
+    /// the vault is not favor-scaled (then <see cref="FlatSlots"/> carries the count).
+    /// </summary>
+    public IReadOnlyList<StorageVaultCapacityRow> CapacityRows { get; }
+    public bool HasCapacityTable { get; }
+
+    public int? FlatSlots { get; }
+    public bool HasFlatSlots { get; }
+
+    /// <summary>"Dynamic: lo–hi slots" when the vault sizes via a server script atomic.</summary>
+    public string? ScriptAtomicRange { get; }
+    public bool HasScriptAtomicRange => ScriptAtomicRange is not null;
+
+    /// <summary>Rare event-gated slot overrides (≈1 entry in the corpus); labeled distinctly.</summary>
+    public IReadOnlyList<StorageVaultCapacityRow> EventLevelRows { get; }
+    public bool HasEventLevels { get; }
+
+    // ── Access requirements ──
+    public string? RequirementDescription { get; }
+
+    /// <summary>
+    /// Item-keyword tags that gate what may be stored. These are item-keyword <i>tags</i>,
+    /// NOT navigable entities (per the keyword-vs-item discrimination rule) — rendered as a
+    /// plain tag cluster.
+    /// </summary>
+    public IReadOnlyList<string> ItemKeywordTags { get; }
+    public bool HasItemKeywordTags { get; }
+
+    /// <summary>
+    /// Human-readable lines for the non-quest polymorphic requirements (interaction flag,
+    /// server-rules flag, longtime-animal, warden, and the graceful "(unrecognised
+    /// requirement)" degrade for <c>UnknownStorageRequirement</c>).
+    /// </summary>
+    public IReadOnlyList<string> RequirementLines { get; }
+    public bool HasRequirementLines { get; }
+
+    /// <summary>Quest-completed requirements as 1:1 navigable Quest chips.</summary>
+    public IReadOnlyList<EntityChipVm> QuestRequirementChips { get; }
+    public bool HasQuestRequirements { get; }
+
+    public bool HasAccessRequirements { get; }
+
+    // ── Helpers ──
+
+    private static EntityChipVm? BuildAreaChip(
+        string? areaKey,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator)
+    {
+        if (string.IsNullOrEmpty(areaKey)) return null;
+        var reference = EntityRef.Area(areaKey);
+        var displayName = refData.Areas.TryGetValue(areaKey, out var area)
+            ? area.FriendlyName
+            : nameResolver.Resolve(reference);
+        return new EntityChipVm(
+            DisplayName: displayName,
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: navigator.CanOpen(reference));
+    }
+
+    private static EntityChipVm BuildNpcChip(
+        string envelopeKey,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator)
+    {
+        // The envelope key IS the operator NPC internal name when HasAssociatedNpc.
+        var reference = EntityRef.Npc(envelopeKey);
+        var displayName = refData.NpcsByInternalName.TryGetValue(envelopeKey, out var npc)
+                          && !string.IsNullOrEmpty(npc.Name)
+            ? npc.Name!
+            : nameResolver.Resolve(reference);
+        return new EntityChipVm(
+            DisplayName: displayName,
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: navigator.CanOpen(reference));
+    }
+
+    private static IReadOnlyList<StorageVaultCapacityRow> BuildCapacityRows(
+        IReadOnlyDictionary<string, int>? levels)
+    {
+        if (levels is null || levels.Count == 0)
+            return Array.Empty<StorageVaultCapacityRow>();
+
+        int Rank(string tier)
+        {
+            var i = Array.IndexOf(FavorOrder, tier);
+            return i < 0 ? int.MaxValue : i;
+        }
+
+        return levels
+            // A 0-slot favor tier (e.g. Despised:0, Comfortable:0) is the universal
+            // default — no capacity granted yet. Drop it: every row should carry
+            // information (cookbook *Default-value noise filtering*).
+            .Where(kv => kv.Value > 0)
+            .OrderBy(kv => Rank(kv.Key))
+            .ThenBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kv => new StorageVaultCapacityRow(SplitTier(kv.Key), kv.Value))
+            .ToList();
+    }
+
+    /// <summary>"CloseFriends" → "Close Friends" (favor tiers are PascalCase in JSON).</summary>
+    private static string SplitTier(string tier) =>
+        System.Text.RegularExpressions.Regex.Replace(tier, "(?<=[a-z])([A-Z])", " $1");
+
+    /// <summary>
+    /// Renders the polymorphic <see cref="StorageRequirement"/> list grouped by intent
+    /// (the quest-detail UX rule — reverse-lookup internal names to display, group by
+    /// meaning, never mechanically dump subclass names). Quest-completed requirements
+    /// become 1:1 navigable Quest chips; flags / identity gates become plain human labels;
+    /// an <see cref="UnknownStorageRequirement"/> degrades to a single noise-filtered
+    /// "(unrecognised requirement: …)" line so a future PG schema addition surfaces
+    /// gracefully rather than crashing or rendering blank.
+    /// </summary>
+    private static (IReadOnlyList<string> Lines, IReadOnlyList<EntityChipVm> QuestChips) BuildRequirements(
+        IReadOnlyList<StorageRequirement>? requirements,
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver,
+        IReferenceNavigator navigator)
+    {
+        if (requirements is null || requirements.Count == 0)
+            return (Array.Empty<string>(), Array.Empty<EntityChipVm>());
+
+        var lines = new List<string>();
+        var questChips = new List<EntityChipVm>();
+
+        foreach (var req in requirements)
+        {
+            switch (req)
+            {
+                case StorageQuestCompletedRequirement q when !string.IsNullOrEmpty(q.Quest):
+                {
+                    var reference = EntityRef.Quest(q.Quest!);
+                    questChips.Add(new EntityChipVm(
+                        DisplayName: nameResolver.Resolve(reference),
+                        IconId: 0,
+                        Reference: reference,
+                        IsNavigable: navigator.CanOpen(reference)));
+                    break;
+                }
+                case StorageInteractionFlagSetRequirement f when !string.IsNullOrEmpty(f.InteractionFlag):
+                    lines.Add($"Requires the interaction flag “{HumaniseFlag(f.InteractionFlag!)}”");
+                    break;
+                case StorageServerRulesFlagSetRequirement s when !string.IsNullOrEmpty(s.Flag):
+                    lines.Add($"Requires the server-rules flag “{HumaniseFlag(s.Flag!)}”");
+                    break;
+                case StorageIsLongtimeAnimalRequirement:
+                    lines.Add("Requires a long-time animal character");
+                    break;
+                case StorageIsWardenRequirement:
+                    lines.Add("Requires Warden status");
+                    break;
+                case UnknownStorageRequirement u:
+                    // Graceful degrade — a future PG-added discriminator. Surface the raw
+                    // discriminator so it's diagnosable, but behind a clearly-noise-filtered
+                    // label (never a crash, never a blank).
+                    lines.Add(string.IsNullOrEmpty(u.DiscriminatorValue)
+                        ? "(unrecognised requirement)"
+                        : $"(unrecognised requirement: {u.DiscriminatorValue})");
+                    break;
+                default:
+                    // A known subclass with an empty payload (defensive — shouldn't occur
+                    // in the corpus). Skip silently rather than emit a blank line.
+                    break;
+            }
+        }
+
+        return (lines, questChips);
+    }
+
+    /// <summary>"Ivyn_Gave_Passcode" → "Ivyn Gave Passcode" — flags use '_' as a word sep.</summary>
+    private static string HumaniseFlag(string flag) => flag.Replace('_', ' ');
+}
+
+/// <summary>
+/// One capacity row: a favor-tier (or event) label and its granted slot count. Used both
+/// for the favor table and the rare event-gated table.
+/// </summary>
+public sealed record StorageVaultCapacityRow(string Tier, int Slots);

--- a/src/Silmarillion.Module/ViewModels/StorageVaultListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultListRow.cs
@@ -1,0 +1,26 @@
+using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Master-list row projection for the StorageVaults tab. The raw
+/// <see cref="StorageVaultPoco"/> doesn't carry the envelope key (the selection / deep-link
+/// contract) nor the derived account-wide flag or effective-slot summary, so — like
+/// Recipes / Lorebooks — the tab projects a row record rather than binding the POCO.
+/// <para>
+/// <see cref="EnvelopeKey"/> is the selection key (matches the
+/// <see cref="Mithril.Shared.Reference.EntityRef.StorageVault(string)"/> factory and the
+/// <c>StorageVaults</c> service contract). It is the operator NPC's internal name, or a
+/// <c>"*"</c>-prefixed account-wide form (transfer chest). The <c>MithrilQueryBox</c>
+/// schema is reflected from this record, so every queryable facet (name, area key,
+/// grouping, account-wide flag, slot summary) must be a public property here.
+/// </para>
+/// </summary>
+public sealed record StorageVaultListRow(
+    StorageVaultPoco Vault,
+    string EnvelopeKey,
+    string DisplayName,
+    string? AreaKey,
+    string? Grouping,
+    bool IsAccountWide,
+    string SlotSummary);

--- a/src/Silmarillion.Module/ViewModels/StorageVaultsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultsTabViewModel.cs
@@ -1,0 +1,150 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
+using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// StorageVaults master-detail view-model. Small dataset (≈92 entries — no virtualization
+/// concern). Row type is <see cref="StorageVaultListRow"/> because the raw
+/// <see cref="StorageVaultPoco"/> doesn't carry the envelope key (selection contract), the
+/// account-wide flag (derived from the <c>"*"</c> prefix) nor the effective-slot summary.
+/// <para>
+/// Subscribes to <see cref="IReferenceDataService.FileUpdated"/> for
+/// <c>"storagevaults"</c>; selection preserved by <see cref="StorageVaultListRow.EnvelopeKey"/>.
+/// All #249 cross-links are 1:1 chips resolved lazily in the detail VM, so the tab depends
+/// only on its own source file.
+/// </para>
+/// </summary>
+public sealed partial class StorageVaultsTabViewModel : ObservableObject, ITabViewModel
+{
+    /// <summary>
+    /// Reflected schema for <see cref="StorageVaultListRow"/> exposed to
+    /// <c>MithrilQueryBox.Schema</c> so the query box offers completion / highlights known
+    /// columns (DisplayName / AreaKey / Grouping / IsAccountWide / SlotSummary / …).
+    /// </summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(StorageVaultListRow)));
+
+    public string TabHeader => "Vaults";
+    public int TabOrder => 8;
+
+    private readonly IReferenceDataService _refData;
+    private readonly IReferenceNavigator _navigator;
+    private readonly IEntityNameResolver _nameResolver;
+
+    public StorageVaultsTabViewModel(
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        Silmarillion.SilmarillionSettings settings)
+    {
+        _refData = refData;
+        _navigator = navigator;
+        _nameResolver = nameResolver;
+        _ = settings; // reserved for parity with the cookbook ctor shape; no setting read yet
+        OpenEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
+        _allVaults = BuildAllVaults(refData, nameResolver);
+        refData.FileUpdated += OnFileUpdated;
+    }
+
+    public RelayCommand<EntityRef?> OpenEntityCommand { get; }
+
+    [ObservableProperty]
+    private IReadOnlyList<StorageVaultListRow> _allVaults;
+
+    [ObservableProperty]
+    private string _queryText = "";
+
+    [ObservableProperty]
+    private string? _queryError;
+
+    [ObservableProperty]
+    private StorageVaultListRow? _selectedVault;
+
+    [ObservableProperty]
+    private StorageVaultDetailViewModel? _detailViewModel;
+
+    partial void OnSelectedVaultChanged(StorageVaultListRow? value)
+    {
+        DetailViewModel = value is null ? null : BuildDetailViewModel(value);
+    }
+
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        if (fileKey != "storagevaults") return;
+
+        UiThread.Run(() =>
+        {
+            var capturedKey = SelectedVault?.EnvelopeKey;
+            AllVaults = BuildAllVaults(_refData, _nameResolver);
+            if (!string.IsNullOrEmpty(capturedKey))
+            {
+                var resolved = AllVaults.FirstOrDefault(v => v.EnvelopeKey == capturedKey);
+                // Toggle through null so OnSelectedVaultChanged rebuilds the detail VM
+                // against the fresh refData snapshot ([ObservableProperty] suppresses a
+                // same-reference reassignment).
+                SelectedVault = null;
+                SelectedVault = resolved;
+            }
+        });
+    }
+
+    private static IReadOnlyList<StorageVaultListRow> BuildAllVaults(
+        IReferenceDataService refData, IEntityNameResolver nameResolver)
+    {
+        return refData.StorageVaults
+            .Where(kv => !string.IsNullOrEmpty(kv.Key))
+            .Select(kv => ProjectRow(kv.Key, kv.Value, nameResolver))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(r => r.EnvelopeKey, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static StorageVaultListRow ProjectRow(
+        string envelopeKey, StorageVaultPoco vault, IEntityNameResolver nameResolver)
+    {
+        var isAccountWide = envelopeKey.StartsWith('*');
+        var displayName = !string.IsNullOrEmpty(vault.NpcFriendlyName)
+            ? vault.NpcFriendlyName!
+            : nameResolver.Resolve(EntityRef.StorageVault(envelopeKey));
+
+        return new StorageVaultListRow(
+            Vault: vault,
+            EnvelopeKey: envelopeKey,
+            DisplayName: displayName,
+            AreaKey: string.IsNullOrEmpty(vault.Area) ? null : vault.Area,
+            Grouping: string.IsNullOrEmpty(vault.Grouping) ? null : vault.Grouping,
+            IsAccountWide: isAccountWide,
+            SlotSummary: SummariseSlots(vault));
+    }
+
+    /// <summary>
+    /// Plain card secondary-line summary per the cookbook card convention (no unit-letter
+    /// prefixes). Favor-scaled vaults show the max favor-tier slot count; flat vaults show
+    /// the count; dynamic vaults show the script-atomic range; transfer chests (NumSlots:0,
+    /// no Levels) show "transfer".
+    /// </summary>
+    private static string SummariseSlots(StorageVaultPoco vault)
+    {
+        if (vault.Levels is { Count: > 0 } levels)
+        {
+            var max = levels.Values.DefaultIfEmpty(0).Max();
+            return max > 0 ? $"up to {max} slots" : "favor-scaled";
+        }
+        if (!string.IsNullOrEmpty(vault.NumSlotsScriptAtomic)
+            && vault.NumSlotsScriptAtomicMaxValue is { } hi)
+        {
+            return $"up to {hi} slots";
+        }
+        if (vault.NumSlots is { } n && n > 0)
+            return $"{n} slots";
+        return "transfer";
+    }
+
+    private StorageVaultDetailViewModel BuildDetailViewModel(StorageVaultListRow row) =>
+        new StorageVaultDetailViewModel(row, _refData, _navigator, _nameResolver);
+}

--- a/src/Silmarillion.Module/Views/Resources.xaml
+++ b/src/Silmarillion.Module/Views/Resources.xaml
@@ -216,4 +216,28 @@
         </DockPanel>
     </DataTemplate>
 
+    <!-- Compact two-line row for StorageVaults tab. Bound DataContext:
+         Silmarillion.ViewModels.StorageVaultListRow. Secondary line is the plain
+         '<area-or-grouping> <slot-summary>' shape per the cookbook card
+         secondary-line convention (no unit prefixes / parentheticals). -->
+    <DataTemplate x:Key="StorageVaultCardTemplate">
+        <DockPanel LastChildFill="True">
+            <Border DockPanel.Dock="Left" Width="24" Height="24" Margin="6,3,6,3"
+                    VerticalAlignment="Center" Background="#FF1F1F1F" CornerRadius="3">
+                <icon:PackIconLucide Kind="Vault" Width="14" Height="14" Foreground="#88FFFFFF"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+            <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"
+                           Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                <TextBlock Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeSmall}"
+                           TextTrimming="CharacterEllipsis">
+                    <Run Text="{Binding SlotSummary, Mode=OneWay}"/>
+                </TextBlock>
+            </StackPanel>
+        </DockPanel>
+    </DataTemplate>
+
 </ResourceDictionary>

--- a/src/Silmarillion.Module/Views/SilmarillionView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionView.xaml
@@ -43,6 +43,9 @@
             <DataTemplate DataType="{x:Type vm:PlayerTitlesTabViewModel}">
                 <local:PlayerTitlesTabView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:StorageVaultsTabViewModel}">
+                <local:StorageVaultsTabView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.InputBindings>

--- a/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml
@@ -1,0 +1,193 @@
+<UserControl x:Class="Silmarillion.Views.StorageVaultDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance vm:StorageVaultDetailViewModel}"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- One capacity row: favor tier (or event key) — mono slot count (gold). -->
+            <DataTemplate DataType="{x:Type vm:StorageVaultCapacityRow}">
+                <Grid Margin="0,0,0,2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="{Binding Tier}"
+                               Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"/>
+                    <TextBlock Grid.Column="1" Text="{Binding Slots}"
+                               FontFamily="{DynamicResource AppMonoFontFamily}"
+                               Foreground="#FFD4A847"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Margin="12,0,0,0"/>
+                </Grid>
+            </DataTemplate>
+
+            <!-- Plain item-keyword tag (NOT navigable — these are keyword tags, not entities). -->
+            <DataTemplate x:Key="ItemKeywordTagTemplate">
+                <Border Background="#FF2A2A2A" CornerRadius="3" Padding="6,2" Margin="0,0,4,4">
+                    <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeSmall}"/>
+                </Border>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border Padding="14,12">
+        <DockPanel>
+            <!-- Footer: envelope key (mono, bottom-right) — per detail-view convention. -->
+            <TextBlock DockPanel.Dock="Bottom" Text="{Binding EnvelopeKey}"
+                       Foreground="#88FFFFFF"
+                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                       FontSize="{DynamicResource AppFontSizeSmall}"
+                       Margin="0,8,0,0" HorizontalAlignment="Right"
+                       VerticalAlignment="Bottom"/>
+
+            <StackPanel>
+                <!-- ─── Header ─── -->
+                <StackPanel Margin="0,0,0,10">
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" TextWrapping="Wrap"/>
+                </StackPanel>
+
+                <!-- ─── Metadata row ─── -->
+                <WrapPanel Margin="0,0,0,10">
+                    <!-- Account-wide badge: rendered only when true (noise-filter default). -->
+                    <Border Background="#332E7DD2" BorderBrush="#662E7DD2" BorderThickness="1"
+                            CornerRadius="3" Padding="6,2" Margin="0,0,6,4"
+                            Visibility="{Binding IsAccountWide, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="Account-wide" Foreground="#FF9CC3EA"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
+                    </Border>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,6,4"
+                                Visibility="{Binding HasArea, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="Area: " Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <ContentControl Content="{Binding AreaChip}">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,6,4"
+                                Visibility="{Binding HasOperatorNpc, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="Operator: " Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <ContentControl Content="{Binding OperatorNpcChip}">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
+                    </StackPanel>
+                </WrapPanel>
+
+                <!-- ─── Capacity ─── -->
+                <StackPanel Margin="0,0,0,10">
+                    <TextBlock Text="Capacity" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+
+                    <!-- Favor-scaled: ordered favor-tier table. -->
+                    <ItemsControl ItemsSource="{Binding CapacityRows}"
+                                  Visibility="{Binding HasCapacityTable, Converter={StaticResource BoolToVis}}"/>
+
+                    <!-- Flat slot count. -->
+                    <TextBlock Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Visibility="{Binding HasFlatSlots, Converter={StaticResource BoolToVis}}">
+                        <Run Text="{Binding FlatSlots, Mode=OneWay}"/><Run Text=" slots"/>
+                    </TextBlock>
+
+                    <!-- Dynamic / script-atomic range. -->
+                    <TextBlock Text="{Binding ScriptAtomicRange}" Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Margin="0,2,0,0"
+                               Visibility="{Binding HasScriptAtomicRange, Converter={StaticResource NullOrEmptyToVis}}"/>
+
+                    <!-- Rare event-gated overrides. -->
+                    <StackPanel Margin="0,6,0,0"
+                                Visibility="{Binding HasEventLevels, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="Event-gated capacity" Foreground="#88FFFFFF"
+                                   FontStyle="Italic"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                   Margin="0,0,0,2"/>
+                        <ItemsControl ItemsSource="{Binding EventLevelRows}"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- ─── Access requirements ─── -->
+                <StackPanel Visibility="{Binding HasAccessRequirements, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="Access requirements" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+
+                    <TextBlock Text="{Binding RequirementDescription}"
+                               Foreground="#CCFFFFFF" FontStyle="Italic"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               TextWrapping="Wrap" Margin="0,0,0,4"
+                               Visibility="{Binding RequirementDescription, Converter={StaticResource NullOrEmptyToVis}}"/>
+
+                    <ItemsControl ItemsSource="{Binding ItemKeywordTags}"
+                                  ItemTemplate="{StaticResource ItemKeywordTagTemplate}"
+                                  Margin="0,0,0,4"
+                                  Visibility="{Binding HasItemKeywordTags, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+
+                    <!-- Quest-completed requirements → 1:1 navigable Quest chips. -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4"
+                                Visibility="{Binding HasQuestRequirements, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="Completed: " Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <ItemsControl ItemsSource="{Binding QuestRequirementChips}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <!-- Non-quest polymorphic requirements as human labels (incl. the
+                         graceful "(unrecognised requirement)" degrade). -->
+                    <ItemsControl ItemsSource="{Binding RequirementLines}"
+                                  Visibility="{Binding HasRequirementLines, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </StackPanel>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml.cs
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class StorageVaultDetailView : UserControl
+{
+    public StorageVaultDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/StorageVaultDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailWindow.xaml
@@ -1,0 +1,52 @@
+<Window x:Class="Silmarillion.Views.StorageVaultDetailWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Silmarillion.Views"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="{Binding DisplayName}"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        FontFamily="{DynamicResource AppFontFamily}"
+        FontSize="{DynamicResource AppFontSize}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+            MinWidth="420" MaxWidth="680" MaxHeight="760">
+        <DockPanel>
+            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
+                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
+                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                            ToolTip="Close" Click="CloseButton_Click">
+                        <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
+                    </Button>
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                </DockPanel>
+            </Border>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          MaxHeight="700">
+                <local:StorageVaultDetailView/>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</Window>

--- a/src/Silmarillion.Module/Views/StorageVaultDetailWindow.xaml.cs
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Silmarillion.Views;
+
+public partial class StorageVaultDetailWindow : Window
+{
+    public StorageVaultDetailWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) DragMove();
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/Silmarillion.Module/Views/StorageVaultsTabView.xaml
+++ b/src/Silmarillion.Module/Views/StorageVaultsTabView.xaml
@@ -1,0 +1,106 @@
+<UserControl x:Class="Silmarillion.Views.StorageVaultsTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320" MinWidth="240"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
+            <StackPanel>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:StorageVaultsTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. IsAccountWide = true"/>
+                <TextBlock Text="{Binding QueryError}"
+                           Foreground="#FFD96A6A" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="0,4,0,0"
+                           Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </Border>
+
+        <ListBox Grid.Row="1" Grid.Column="0"
+                 ItemsSource="{Binding AllVaults}"
+                 ItemTemplate="{StaticResource StorageVaultCardTemplate}"
+                 SelectedItem="{Binding SelectedVault, Mode=TwoWay}"
+                 query:QueryFilter.QueryText="{Binding QueryText}"
+                 query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"
+                 Background="#FF1A1A1A" BorderThickness="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 VirtualizingStackPanel.IsVirtualizing="True"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
+
+        <Grid Grid.Row="1" Grid.Column="1" Background="#FF1A1A1A">
+            <ScrollViewer x:Name="DetailScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <ContentControl Content="{Binding DetailViewModel}"
+                                MinHeight="{Binding ViewportHeight, ElementName=DetailScroller}">
+                    <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type vm:StorageVaultDetailViewModel}">
+                            <local:StorageVaultDetailView/>
+                        </DataTemplate>
+                    </ContentControl.Resources>
+                </ContentControl>
+            </ScrollViewer>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="320">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DetailViewModel}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <icon:PackIconLucide Kind="Vault" Width="48" Height="48"
+                                     Foreground="#33FFFFFF"
+                                     HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                <TextBlock Text="Browse Storage Vaults"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeLarge}"
+                           Foreground="#CCFFFFFF"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Select a vault to see its capacity and access requirements."
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Foreground="#88FFFFFF"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceStorageVaultTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceStorageVaultTests.cs
@@ -1,0 +1,194 @@
+using System.IO;
+using System.Net.Http;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+/// <summary>
+/// Synthetic-fixture round-trip for the #249 StorageVault service plumbing: the
+/// envelope-keyed <c>StorageVaults</c> lookup (including the <c>"*"</c>-prefixed
+/// account-wide form), the polymorphic <c>Requirements</c> deserialization, and the
+/// refresh path rebuilding the dictionary. Mirrors the #247 Lorebook plumbing test.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class ReferenceDataServiceStorageVaultTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cacheDir;
+    private readonly string _bundledDir;
+
+    public ReferenceDataServiceStorageVaultTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-ref-storagevault-tests");
+        _cacheDir = Path.Combine(_root, "cache");
+        _bundledDir = Path.Combine(_root, "bundled");
+        Directory.CreateDirectory(_cacheDir);
+        Directory.CreateDirectory(_bundledDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static HttpClient NeverCallHttp() =>
+        new(new ThrowingHandler("HTTP must not be called in this test"));
+
+    private const string StorageVaults = """
+        {
+          "*AccountStorage_Serbule": {
+            "Area": "AreaSerbule",
+            "HasAssociatedNpc": false,
+            "ID": 105,
+            "NpcFriendlyName": "Serbule Transfer Chest",
+            "NumSlots": 0
+          },
+          "NPC_CharlesThompson": {
+            "Area": "AreaSerbule",
+            "Grouping": "AreaSerbule",
+            "ID": 305,
+            "Levels": { "Friends": 32, "CloseFriends": 40, "SoulMates": 64 },
+            "NpcFriendlyName": "Charles Thompson",
+            "RequiredItemKeywords": [ "Alchemy", "Potion" ],
+            "RequirementDescription": "Potions and Alchemy Ingredients"
+          },
+          "IvynsChest": {
+            "Area": "AreaSerbule",
+            "ID": 303,
+            "NpcFriendlyName": "Ivyn's Chest",
+            "NumSlots": 32,
+            "Requirements": { "InteractionFlag": "Ivyn_Gave_Passcode", "T": "InteractionFlagSet" }
+          },
+          "NPC_CynthiaRolfe": {
+            "Area": "AreaStatehelm",
+            "ID": 2003,
+            "NpcFriendlyName": "Cynthia Rolfe",
+            "Requirements": { "Quest": "GoblinsArmpitRoaches", "T": "QuestCompleted" }
+          }
+        }
+        """;
+
+    private void WriteFixture(string storageVaultsJson) =>
+        File.WriteAllText(Path.Combine(_bundledDir, "storagevaults.json"), storageVaultsJson);
+
+    [Fact]
+    public void StorageVaults_KeyedByEnvelopeKey_IncludingStarPrefixed()
+    {
+        WriteFixture(StorageVaults);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.StorageVaults.Should().ContainKey("*AccountStorage_Serbule");
+        svc.StorageVaults.Should().ContainKey("NPC_CharlesThompson");
+        svc.StorageVaults["*AccountStorage_Serbule"].NpcFriendlyName.Should().Be("Serbule Transfer Chest");
+        svc.StorageVaults["*AccountStorage_Serbule"].HasAssociatedNpc.Should().BeFalse();
+        svc.StorageVaults["*AccountStorage_Serbule"].NumSlots.Should().Be(0);
+    }
+
+    [Fact]
+    public void StorageVaults_DeserialisesPolymorphicRequirements()
+    {
+        WriteFixture(StorageVaults);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        var ivyn = svc.StorageVaults["IvynsChest"];
+        ivyn.Requirements.Should().ContainSingle()
+            .Which.Should().BeOfType<Mithril.Reference.Models.Misc.StorageInteractionFlagSetRequirement>()
+            .Which.InteractionFlag.Should().Be("Ivyn_Gave_Passcode");
+
+        var cynthia = svc.StorageVaults["NPC_CynthiaRolfe"];
+        cynthia.Requirements.Should().ContainSingle()
+            .Which.Should().BeOfType<Mithril.Reference.Models.Misc.StorageQuestCompletedRequirement>()
+            .Which.Quest.Should().Be("GoblinsArmpitRoaches");
+    }
+
+    [Fact]
+    public void StorageVaults_FavorLevelsRoundTrip()
+    {
+        WriteFixture(StorageVaults);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        var charles = svc.StorageVaults["NPC_CharlesThompson"];
+        charles.Levels.Should().NotBeNull();
+        charles.Levels!["SoulMates"].Should().Be(64);
+        charles.RequiredItemKeywords.Should().BeEquivalentTo(new[] { "Alchemy", "Potion" });
+    }
+
+    [Fact]
+    public void StorageVaults_LoadsFromCache_OverBundled_ProvingParseAndSwapPath()
+    {
+        // LoadStorageVaults → LoadFile reads the cache file in preference to bundled. A
+        // cached payload exercises the same ParseAndSwapStorageVaults path a live CDN
+        // refresh runs, and proves the snapshot count is recomputed from the swapped set.
+        WriteFixture(StorageVaults); // 4 bundled
+        File.WriteAllText(Path.Combine(_cacheDir, "storagevaults.json"), """
+            { "OnlyOne": { "ID": 9, "NpcFriendlyName": "Solo", "NumSlots": 5 } }
+            """);
+        File.WriteAllText(Path.Combine(_cacheDir, "storagevaults.meta.json"),
+            "{\"cdnVersion\":\"v2\",\"source\":1}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.StorageVaults.Should().ContainSingle().Which.Key.Should().Be("OnlyOne");
+        svc.GetSnapshot("storagevaults").EntryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RefreshStorageVaults_HttpUnavailable_KeepsExistingData_DoesNotThrow()
+    {
+        // RefreshAsync fetches from CDN; on failure it keeps the existing (bundled) set
+        // rather than throwing — the documented refresh contract. This locks that the
+        // "storagevaults" switch arm is wired (an unknown key would throw ArgumentException).
+        WriteFixture(StorageVaults);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        var act = async () => await svc.RefreshAsync("storagevaults");
+        await act.Should().NotThrowAsync();
+        svc.StorageVaults.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void StorageVaults_IsAKnownRefreshKey()
+    {
+        WriteFixture(StorageVaults);
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.Keys.Should().Contain("storagevaults");
+        // GetSnapshot must not throw for the new key.
+        svc.GetSnapshot("storagevaults").Key.Should().Be("storagevaults");
+    }
+
+    [Fact]
+    public void RealBundledStorageVaultsJson_ParsesAndCoversKnownVariants()
+    {
+        var realBundled = Path.Combine(AppContext.BaseDirectory, "Reference", "BundledData");
+        if (!File.Exists(Path.Combine(realBundled, "storagevaults.json"))) return;
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: realBundled);
+
+        svc.StorageVaults.Should().NotBeEmpty();
+        // The three real-data variants the handoff calls out.
+        svc.StorageVaults.Should().ContainKey("*AccountStorage_Serbule")
+            .WhoseValue.HasAssociatedNpc.Should().BeFalse("transfer chest");
+        svc.StorageVaults["NPC_CharlesThompson"].Levels.Should()
+            .NotBeNull("favor-scaled vendor vault");
+        svc.StorageVaults["IvynsChest"].Requirements.Should()
+            .ContainSingle().Which.Should()
+            .BeOfType<Mithril.Reference.Models.Misc.StorageInteractionFlagSetRequirement>();
+        // No UnknownStorageRequirement should appear in the current corpus (drift guard —
+        // if PG adds a new discriminator this surfaces here before the UI degrades).
+        svc.StorageVaults.Values
+            .SelectMany(v => v.Requirements ?? Array.Empty<Mithril.Reference.Models.Misc.StorageRequirement>())
+            .OfType<Mithril.Reference.Models.Misc.UnknownStorageRequirement>()
+            .Should().BeEmpty("the modelled subclasses cover the entire bundled corpus");
+    }
+
+    private sealed class ThrowingHandler(string message) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException(message);
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
@@ -73,6 +73,54 @@ public sealed class SilmarillionDeepLinkHandlerTests
         nav.LastOpened.Should().BeNull();
     }
 
+    [Theory]
+    [InlineData("storagevault/NPC_CharlesThompson", "NPC_CharlesThompson")]
+    [InlineData("storagevault/*AccountStorage_Serbule", "*AccountStorage_Serbule")]
+    [InlineData("StorageVault/*AdminStorage", "*AdminStorage")]
+    public void TryHandle_StorageVault_AcceptsStarPrefixedEnvelopeKey(string subPath, string expectedName)
+    {
+        // #249: StorageVault account-wide / transfer-chest keys carry a meaningful leading
+        // '*'. The handler validates with IsValidEnvelopeKey (IsValidInternalName + an
+        // optional single leading '*'), so the literal '*' round-trips. Bare internal-name
+        // routes (every other kind) are unaffected — they're a strict subset of the grammar.
+        var nav = new PermissiveNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        handler.TryHandle(subPath, diag: null).Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.StorageVault(expectedName));
+    }
+
+    [Fact]
+    public void DeepLinkRouter_UrlEncodedStar_DecodesAndDispatchesToStorageVault()
+    {
+        // End-to-end: mithril://silmarillion/storagevault/%2AAccountStorage_Serbule —
+        // Uri.AbsolutePath decodes %2A → '*', the Silmarillion handler accepts it.
+        var nav = new PermissiveNavigator();
+        var router = new Mithril.Shared.Modules.DeepLinkRouter(
+            new[] { new SilmarillionDeepLinkHandler(nav) });
+
+        router.Handle("mithril://silmarillion/storagevault/%2AAccountStorage_Serbule")
+            .Should().BeTrue();
+        nav.LastOpened.Should().Be(EntityRef.StorageVault("*AccountStorage_Serbule"));
+    }
+
+    [Fact]
+    public void DeepLinkPayload_StillRejectsSeparatorsAndWhitespace_EvenWithStarAllowed()
+    {
+        // The '*'-permissive envelope-key grammar must NOT regress the URI-safety intent:
+        // separators / whitespace / a non-leading or doubled '*' stay rejected. The
+        // original strict internal-name grammar (every other handler) is unchanged.
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("*AccountStorage_Serbule").Should().BeTrue();
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("NPC_Joeh").Should().BeTrue();
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("a*b").Should().BeFalse("'*' is only valid as a single leading char");
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("**x").Should().BeFalse();
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("has space").Should().BeFalse();
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("a/b").Should().BeFalse();
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("").Should().BeFalse();
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidEnvelopeKey("*").Should().BeFalse("a lone '*' has no key body");
+        Mithril.Shared.Modules.DeepLinkPayload.IsValidInternalName("*AccountStorage_Serbule").Should().BeFalse();
+    }
+
     [Fact]
     public void TryHandle_PayloadOverLengthCap_IsRejected()
     {

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -337,6 +337,93 @@ public sealed class SilmarillionReferenceNavigatorTests
     }
 
     [Fact]
+    public void Open_StorageVault_SwitchesToStorageVaultsTab_AndSelects()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddVault("NPC_CharlesThompson", new Mithril.Reference.Models.Misc.StorageVault
+        {
+            NpcFriendlyName = "Charles Thompson", NumSlots = 24,
+        });
+        var settings = new Silmarillion.SilmarillionSettings();
+        var vaultsVm = new StorageVaultsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var vaultsTarget = new StorageVaultsKindTarget(vaultsVm);
+
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StubTarget(EntityKind.Recipe),
+            vaultsTarget,
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(new ITabViewModel[] { vaultsVm }, nav, targets);
+
+        nav.Open(EntityRef.StorageVault("NPC_CharlesThompson"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(8);
+        vaultsVm.SelectedVault.Should().NotBeNull();
+        vaultsVm.SelectedVault!.EnvelopeKey.Should().Be("NPC_CharlesThompson");
+    }
+
+    [Fact]
+    public void Open_StorageVault_StarPrefixedAccountWideKey_RoundTrips()
+    {
+        // The '*'-prefixed account-wide envelope key must select via the navigator
+        // unchanged — the literal '*' is the deep-link / selection contract.
+        var refData = new FakeReferenceData();
+        refData.AddVault("*AccountStorage_Serbule", new Mithril.Reference.Models.Misc.StorageVault
+        {
+            NpcFriendlyName = "Serbule Transfer Chest", HasAssociatedNpc = false, NumSlots = 0,
+        });
+        var settings = new Silmarillion.SilmarillionSettings();
+        var vaultsVm = new StorageVaultsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StorageVaultsKindTarget(vaultsVm),
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+        var silmarillionVm = new SilmarillionViewModel(new ITabViewModel[] { vaultsVm }, nav, targets);
+
+        nav.Open(EntityRef.StorageVault("*AccountStorage_Serbule"));
+
+        silmarillionVm.SelectedTabIndex.Should().Be(8);
+        vaultsVm.SelectedVault.Should().NotBeNull();
+        vaultsVm.SelectedVault!.EnvelopeKey.Should().Be("*AccountStorage_Serbule");
+        vaultsVm.SelectedVault.IsAccountWide.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Open_StorageVault_UnknownKey_DoesNotSelect()
+    {
+        var refData = new FakeReferenceData();
+        var settings = new Silmarillion.SilmarillionSettings();
+        var vaultsVm = new StorageVaultsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData), settings);
+        var targets = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.Item),
+            new StorageVaultsKindTarget(vaultsVm),
+        };
+        var nav = new SilmarillionReferenceNavigator(targets);
+
+        nav.Open(EntityRef.StorageVault("NPC_NoSuchVault"));
+
+        vaultsVm.SelectedVault.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_DuplicateGuard_TripsForStorageVault()
+    {
+        var dup = new IReferenceKindTarget[]
+        {
+            new StubTarget(EntityKind.StorageVault),
+            new StubTarget(EntityKind.StorageVault),
+        };
+        Action act = () => new SilmarillionReferenceNavigator(dup);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Duplicate IReferenceKindTarget*StorageVault*");
+    }
+
+    [Fact]
     public void Open_Lorebook_UnknownName_DoesNotSelect()
     {
         var refData = new FakeReferenceData();
@@ -514,6 +601,9 @@ public sealed class SilmarillionReferenceNavigatorTests
         public void AddPlayerTitle(string envelopeKey, Mithril.Reference.Models.Misc.PlayerTitle title)
             => _playerTitles[envelopeKey] = title;
         public IReadOnlyDictionary<string, Mithril.Reference.Models.Misc.PlayerTitle> PlayerTitles => _playerTitles;
+        private readonly Dictionary<string, Mithril.Reference.Models.Misc.StorageVault> _storageVaults = new(StringComparer.Ordinal);
+        public void AddVault(string envelopeKey, Mithril.Reference.Models.Misc.StorageVault vault) => _storageVaults[envelopeKey] = vault;
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Misc.StorageVault> StorageVaults => _storageVaults;
 
         public IReadOnlyList<string> Keys => Array.Empty<string>();
         public IReadOnlyDictionary<long, Item> Items => _itemsById;

--- a/tests/Silmarillion.Tests/Navigation/StorageVaultsKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/StorageVaultsKindTargetTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class StorageVaultsKindTargetTests
+{
+    [Fact]
+    public void Kind_IsStorageVault()
+    {
+        var (target, _, _) = BuildTarget();
+        target.Kind.Should().Be(EntityKind.StorageVault);
+    }
+
+    [Fact]
+    public void TabIndex_IsEight()
+    {
+        // Items=0 … Lorebooks=7, StorageVaults=8 — ninth tab. Must match TabOrder.
+        var (target, _, _) = BuildTarget();
+        target.TabIndex.Should().Be(8);
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_KnownVault_SelectsOnTabVm_ReturnsTrue()
+    {
+        var (target, vm, _) = BuildTarget(
+            ("NPC_CharlesThompson", "Charles Thompson"));
+
+        var ok = target.TrySelectByInternalName("NPC_CharlesThompson");
+
+        ok.Should().BeTrue();
+        vm.SelectedVault.Should().NotBeNull();
+        vm.SelectedVault!.EnvelopeKey.Should().Be("NPC_CharlesThompson");
+        vm.DetailViewModel.Should().NotBeNull();
+        vm.DetailViewModel!.DisplayName.Should().Be("Charles Thompson");
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_StarPrefixedAccountWideKey_Selects()
+    {
+        // The '*'-prefixed account-wide envelope key must round-trip through the kind
+        // target unchanged (it's the literal selection / deep-link contract).
+        var (target, vm, _) = BuildTarget(
+            ("*AccountStorage_Serbule", "Serbule Transfer Chest"));
+
+        target.TrySelectByInternalName("*AccountStorage_Serbule").Should().BeTrue();
+
+        vm.SelectedVault.Should().NotBeNull();
+        vm.SelectedVault!.EnvelopeKey.Should().Be("*AccountStorage_Serbule");
+        vm.SelectedVault.IsAccountWide.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_UnknownVault_ReturnsFalse_VmUnchanged()
+    {
+        var (target, vm, _) = BuildTarget();
+        vm.SelectedVault.Should().BeNull();
+
+        target.TrySelectByInternalName("NPC_DoesNotExist").Should().BeFalse();
+        vm.SelectedVault.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySelectByInternalName_ClearsResidualQueryText()
+    {
+        var (target, vm, _) = BuildTarget(("NPC_A", "A"));
+        vm.QueryText = "IsAccountWide = true";
+
+        target.TrySelectByInternalName("NPC_A").Should().BeTrue();
+
+        vm.QueryText.Should().BeEmpty(because: "the kind target clears any prior filter before selecting");
+        vm.SelectedVault!.EnvelopeKey.Should().Be("NPC_A");
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetailSelected_ReturnsFalse()
+    {
+        var (target, _, _) = BuildTarget();
+        target.TryOpenInWindow().Should().BeFalse();
+    }
+
+    private static (StorageVaultsKindTarget Target, StorageVaultsTabViewModel Vm, FakeReferenceData RefData)
+        BuildTarget(params (string EnvelopeKey, string FriendlyName)[] vaults)
+    {
+        var refData = new FakeReferenceData();
+        foreach (var (key, name) in vaults)
+            refData.AddVault(key, new StorageVaultPoco { NpcFriendlyName = name, NumSlots = 10 });
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var settings = new SilmarillionSettings();
+        var vm = new StorageVaultsTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData), settings);
+        var target = new StorageVaultsKindTarget(vm);
+        return (target, vm, refData);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, StorageVaultPoco> _vaults = new(StringComparer.Ordinal);
+        public void AddVault(string envelopeKey, StorageVaultPoco vault) => _vaults[envelopeKey] = vault;
+        public IReadOnlyDictionary<string, StorageVaultPoco> StorageVaults => _vaults;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
@@ -1,0 +1,270 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Misc;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class StorageVaultDetailViewModelTests
+{
+    [Fact]
+    public void Header_Footer_AreaChip_Resolve()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddArea(new AreaEntry("AreaSerbule", "Serbule", "Serbule"));
+        var vm = Build(refData, "NPC_CharlesThompson", new StorageVaultPoco
+        {
+            Area = "AreaSerbule", NpcFriendlyName = "Charles Thompson",
+            HasAssociatedNpc = true, NumSlots = 24,
+        });
+
+        vm.DisplayName.Should().Be("Charles Thompson");
+        vm.EnvelopeKey.Should().Be("NPC_CharlesThompson");
+        vm.HasArea.Should().BeTrue();
+        vm.AreaChip!.DisplayName.Should().Be("Serbule");
+        vm.AreaChip.Reference.Kind.Should().Be(EntityKind.Area);
+    }
+
+    [Fact]
+    public void OperatorNpcChip_OnlyWhenHasAssociatedNpc()
+    {
+        var refData = new FakeReferenceData();
+
+        var withNpc = Build(refData, "NPC_CharlesThompson", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Charles Thompson", HasAssociatedNpc = true, NumSlots = 1,
+        });
+        withNpc.HasOperatorNpc.Should().BeTrue();
+        withNpc.OperatorNpcChip!.Reference.Kind.Should().Be(EntityKind.Npc);
+        withNpc.OperatorNpcChip.Reference.InternalName.Should().Be("NPC_CharlesThompson");
+
+        // Transfer chest — HasAssociatedNpc:false ⇒ no operator chip (dead reference otherwise).
+        var transfer = Build(refData, "*AccountStorage_Serbule", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Serbule Transfer Chest", HasAssociatedNpc = false, NumSlots = 0,
+        });
+        transfer.HasOperatorNpc.Should().BeFalse();
+        transfer.OperatorNpcChip.Should().BeNull();
+        transfer.IsAccountWide.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FavorTable_OrderedCanonically_NotDictOrder_ZeroSlotsFiltered()
+    {
+        var refData = new FakeReferenceData();
+        // Deliberately out-of-order dict with a 0-slot universal-default tier.
+        var vm = Build(refData, "NPC_X", new StorageVaultPoco
+        {
+            NpcFriendlyName = "X",
+            Levels = new Dictionary<string, int>
+            {
+                ["SoulMates"] = 64,
+                ["Despised"] = 0,        // universal default — filtered
+                ["Friends"] = 32,
+                ["CloseFriends"] = 40,
+            },
+        });
+
+        vm.HasCapacityTable.Should().BeTrue();
+        vm.CapacityRows.Select(r => r.Tier).Should()
+            .ContainInOrder("Friends", "Close Friends", "Soul Mates");
+        vm.CapacityRows.Should().NotContain(r => r.Tier.Contains("Despised"),
+            "a 0-slot favor tier is the universal default and is filtered as noise");
+        vm.CapacityRows.Single(r => r.Tier == "Soul Mates").Slots.Should().Be(64);
+    }
+
+    [Fact]
+    public void FlatSlots_WhenNoLevels_AndTransferChestDoesNotCrashOnZero()
+    {
+        var refData = new FakeReferenceData();
+
+        var flat = Build(refData, "IvynsChest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Ivyn's Chest", NumSlots = 32,
+        });
+        flat.HasCapacityTable.Should().BeFalse();
+        flat.HasFlatSlots.Should().BeTrue();
+        flat.FlatSlots.Should().Be(32);
+
+        var transfer = Build(refData, "*AccountStorage_Serbule", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Serbule Transfer Chest", NumSlots = 0, HasAssociatedNpc = false,
+        });
+        transfer.HasCapacityTable.Should().BeFalse();
+        transfer.HasFlatSlots.Should().BeFalse("NumSlots:0 carries no information");
+    }
+
+    [Fact]
+    public void ScriptAtomicRange_RendersMinMax_WhenPresent()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "SerbuleCommunityChest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Serbule Dynamic Safebox",
+            NumSlotsScriptAtomic = "SerbuleCommunityChestSize",
+            NumSlotsScriptAtomicMinValue = 1,
+            NumSlotsScriptAtomicMaxValue = 150,
+        });
+
+        vm.HasScriptAtomicRange.Should().BeTrue();
+        vm.ScriptAtomicRange.Should().Be("Dynamic: 1–150 slots");
+    }
+
+    [Fact]
+    public void EventLevels_RenderedOnlyWhenPresent_AndLabelled()
+    {
+        var refData = new FakeReferenceData();
+        var none = Build(refData, "NPC_A", new StorageVaultPoco { NpcFriendlyName = "A", NumSlots = 1 });
+        none.HasEventLevels.Should().BeFalse();
+
+        var ev = Build(refData, "RiShinStorageChest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Ri-Shin Shrine Storage Chest",
+            EventLevels = new Dictionary<string, int>
+            {
+                ["RiShinShrine_Storage1On"] = 25,
+                ["RiShinShrine_Storage2On"] = 50,
+            },
+        });
+        ev.HasEventLevels.Should().BeTrue();
+        ev.EventLevelRows.Should().HaveCount(2);
+        ev.EventLevelRows.Should().Contain(r => r.Tier == "RiShinShrine_Storage2On" && r.Slots == 50);
+    }
+
+    [Fact]
+    public void Requirements_QuestCompleted_BecomesNavigableQuestChip()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddQuest("GoblinsArmpitRoaches", "Goblins' Armpit Roaches");
+        var vm = Build(refData, "NPC_CynthiaRolfe", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Cynthia Rolfe",
+            Requirements = new StorageRequirement[]
+            {
+                new StorageQuestCompletedRequirement { T = "QuestCompleted", Quest = "GoblinsArmpitRoaches" },
+            },
+        });
+
+        vm.HasQuestRequirements.Should().BeTrue();
+        var chip = vm.QuestRequirementChips.Should().ContainSingle().Subject;
+        chip.Reference.Kind.Should().Be(EntityKind.Quest);
+        chip.Reference.InternalName.Should().Be("GoblinsArmpitRoaches");
+        chip.DisplayName.Should().Be("Goblins' Armpit Roaches");
+    }
+
+    [Fact]
+    public void Requirements_FlagsAndIdentityGates_RenderAsHumanLabels()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "Chest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Chest",
+            Requirements = new StorageRequirement[]
+            {
+                new StorageInteractionFlagSetRequirement { T = "InteractionFlagSet", InteractionFlag = "Ivyn_Gave_Passcode" },
+                new StorageServerRulesFlagSetRequirement { T = "ServerRulesFlagSet", Flag = "Some_Rule" },
+                new StorageIsLongtimeAnimalRequirement { T = "IsLongtimeAnimal" },
+                new StorageIsWardenRequirement { T = "IsWarden" },
+            },
+        });
+
+        vm.HasRequirementLines.Should().BeTrue();
+        vm.RequirementLines.Should().Contain(l => l.Contains("Ivyn Gave Passcode"));
+        vm.RequirementLines.Should().Contain(l => l.Contains("Some Rule"));
+        vm.RequirementLines.Should().Contain(l => l.Contains("long-time animal"));
+        vm.RequirementLines.Should().Contain(l => l.Contains("Warden"));
+    }
+
+    [Fact]
+    public void Requirements_Unknown_DegradesGracefully_NotCrashOrBlank()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "Chest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Chest",
+            Requirements = new StorageRequirement[]
+            {
+                new UnknownStorageRequirement { T = "SomeFuturePgType", DiscriminatorValue = "SomeFuturePgType" },
+            },
+        });
+
+        vm.HasRequirementLines.Should().BeTrue();
+        vm.RequirementLines.Should().ContainSingle()
+            .Which.Should().Be("(unrecognised requirement: SomeFuturePgType)");
+    }
+
+    [Fact]
+    public void ItemKeywordTags_RenderedAsPlainTags_NotEntities()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "NPC_CharlesThompson", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Charles Thompson",
+            RequiredItemKeywords = new[] { "Alchemy", "Potion" },
+            RequirementDescription = "Potions and Alchemy Ingredients",
+        });
+
+        vm.HasItemKeywordTags.Should().BeTrue();
+        vm.ItemKeywordTags.Should().BeEquivalentTo(new[] { "Alchemy", "Potion" });
+        vm.RequirementDescription.Should().Be("Potions and Alchemy Ingredients");
+        vm.HasAccessRequirements.Should().BeTrue();
+    }
+
+    private static StorageVaultDetailViewModel Build(
+        FakeReferenceData refData, string envelopeKey, StorageVaultPoco vault)
+    {
+        refData.AddVault(envelopeKey, vault);
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+        var settings = new SilmarillionSettings();
+        var tab = new StorageVaultsTabViewModel(refData, nav, resolver, settings);
+        var row = tab.AllVaults.Single(r => r.EnvelopeKey == envelopeKey);
+        return new StorageVaultDetailViewModel(row, refData, nav, resolver);
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private readonly Dictionary<string, StorageVaultPoco> _vaults = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, AreaEntry> _areas = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Quest> _quests = new(StringComparer.Ordinal);
+
+        public void AddVault(string envelopeKey, StorageVaultPoco vault) => _vaults[envelopeKey] = vault;
+        public void AddArea(AreaEntry area) => _areas[area.Key] = area;
+        public void AddQuest(string internalName, string name) =>
+            _quests[internalName] = new Quest { InternalName = internalName, Name = name };
+
+        public IReadOnlyDictionary<string, StorageVaultPoco> StorageVaults => _vaults;
+        public IReadOnlyDictionary<string, AreaEntry> Areas => _areas;
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName => _quests;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/StorageVaultsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/StorageVaultsTabViewModelTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Xunit;
+using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class StorageVaultsTabViewModelTests
+{
+    [Fact]
+    public void BuildsRows_ProjectsDisplayName_AreaKey_Grouping_SlotSummary()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddVault("NPC_CharlesThompson", new StorageVaultPoco
+        {
+            Area = "AreaSerbule",
+            Grouping = "AreaSerbule",
+            NpcFriendlyName = "Charles Thompson",
+            Levels = new Dictionary<string, int> { ["Friends"] = 32, ["SoulMates"] = 64 },
+        });
+
+        var vm = MakeVm(refData);
+
+        var row = vm.AllVaults.Should().ContainSingle().Subject;
+        row.EnvelopeKey.Should().Be("NPC_CharlesThompson");
+        row.DisplayName.Should().Be("Charles Thompson");
+        row.AreaKey.Should().Be("AreaSerbule");
+        row.Grouping.Should().Be("AreaSerbule");
+        row.IsAccountWide.Should().BeFalse();
+        row.SlotSummary.Should().Be("up to 64 slots");
+    }
+
+    [Fact]
+    public void AccountWideDerivation_FromStarPrefix()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddVault("*AccountStorage_Serbule", new StorageVaultPoco
+        {
+            Area = "AreaSerbule",
+            HasAssociatedNpc = false,
+            NpcFriendlyName = "Serbule Transfer Chest",
+            NumSlots = 0,
+        });
+
+        var row = MakeVm(refData).AllVaults.Single();
+
+        row.IsAccountWide.Should().BeTrue();
+        row.EnvelopeKey.Should().Be("*AccountStorage_Serbule");
+        row.SlotSummary.Should().Be("transfer", "NumSlots:0 with no Levels is a transfer chest");
+    }
+
+    [Fact]
+    public void GroupingFacet_IsExposedOnReflectedSchema()
+    {
+        // The query box parses against StorageVaultListRow's reflected schema; the facets
+        // must be public properties so e.g. 'IsAccountWide = true' is a known column.
+        StorageVaultsTabViewModel.SchemaSnapshot.Select(c => c.Name)
+            .Should().Contain(new[] { "DisplayName", "AreaKey", "Grouping", "IsAccountWide", "SlotSummary" });
+    }
+
+    [Fact]
+    public void FileUpdated_StorageVaults_RebuildsList_PreservingSelection_IncludingStarKey()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddVault("*AccountStorage_Serbule", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Serbule Transfer Chest", NumSlots = 0,
+        });
+
+        var vm = MakeVm(refData);
+        vm.SelectedVault = vm.AllVaults.Single();
+        vm.DetailViewModel.Should().NotBeNull();
+
+        // A CDN refresh swaps the source dictionary; the same '*'-prefixed key must round-trip.
+        refData.AddVault("*AccountStorage_Serbule", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Serbule Transfer Chest", NumSlots = 0, Area = "AreaSerbule",
+        });
+        refData.RaiseFileUpdated("storagevaults");
+
+        vm.SelectedVault.Should().NotBeNull();
+        vm.SelectedVault!.EnvelopeKey.Should().Be("*AccountStorage_Serbule");
+        vm.SelectedVault.AreaKey.Should().Be("AreaSerbule", "the row was rebuilt from the fresh snapshot");
+        vm.DetailViewModel.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FileUpdated_UnrelatedFile_IsIgnored()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddVault("NPC_A", new StorageVaultPoco { NpcFriendlyName = "A", NumSlots = 1 });
+        var vm = MakeVm(refData);
+        var before = vm.AllVaults;
+
+        refData.RaiseFileUpdated("items");
+
+        vm.AllVaults.Should().BeSameAs(before);
+    }
+
+    private static StorageVaultsTabViewModel MakeVm(FakeReferenceData refData)
+    {
+        var nav = new Silmarillion.Navigation.SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        return new StorageVaultsTabViewModel(
+            refData, nav, new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings());
+    }
+
+    private sealed class FakeReferenceData : IReferenceDataService
+    {
+        private Dictionary<string, StorageVaultPoco> _vaults = new(StringComparer.Ordinal);
+
+        public void AddVault(string envelopeKey, StorageVaultPoco vault) => _vaults[envelopeKey] = vault;
+        public void RaiseFileUpdated(string fileKey) => FileUpdated?.Invoke(this, fileKey);
+
+        public IReadOnlyDictionary<string, StorageVaultPoco> StorageVaults => _vaults;
+
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated;
+    }
+}


### PR DESCRIPTION
**Tracked in:** #249 — Silmarillion StorageVaults tab (Bucket B long-tail; #203 umbrella).

Implements the #249 StorageVaults tab per `docs/agent-plans/silmarillion-249-storagevaults-tab.md`, mirroring the #322 Lorebooks plumbing pattern.

## What's in scope

- **Service plumbing on `IReferenceDataService`** (append-style / localized so the concurrent #248 PlayerTitles sibling stays conflict-free): `StorageVaults` envelope-key → POCO dictionary + empty default; `LoadStorageVaults` / `ParseAndSwapStorageVaults` wired into ctor + `RefreshAsync` switch + `RefreshAllAsync` + `Keys` + `GetSnapshot`; `FileUpdated("storagevaults")`. The `ParseStorageVaults` parser already existed but was unplumbed.
- **`StorageVaultsKindTarget`** (`Kind => EntityKind.StorageVault`, `TabIndex 8` — after Lorebooks=7; `EntityRef.StorageVault` already existed, no stale call sites).
- **Tab VM + view, detail VM + view + window, DI, deep-link pass-through, `SilmarillionView` DataTemplate, row card**, plus a `StorageVault` case on `ReferenceDataEntityNameResolver`.
- Deep-link route `mithril://silmarillion/storagevault/<key>` is pass-through (no handler edit needed for dispatch); see the `*`-key handling below.

## Cross-links — all 1:1 chips, no popup, no synthetic kind

Operator NPC chip (only when `HasAssociatedNpc == true`), parent Area chip, quest-completed requirement → Quest chip. No 1:N fan-out surface on this tab, so **no `ProvenancePopupViewModel`** and **no synthetic kind** — the synthetic-kind family stays fully retired (#318). "Vaults in this area" reverse-lookup is an Areas-tab concern and is out of scope.

## Non-mechanical work

- **Favor capacity table**: canonical in-game favor progression (Despised → … → SoulMates, kept local to avoid a cross-module dependency on Arwen), NOT JSON dict order; 0-slot tiers noise-filtered (universal default).
- **Polymorphic `Requirements`** grouped by intent (quest-completed → navigable Quest chip; interaction/server-rules flags → humanised labels; longtime-animal / warden → plain badges); `UnknownStorageRequirement` degrades to a single noise-filtered `(unrecognised requirement: …)` line so a future PG schema addition surfaces gracefully rather than crashing or blanking.
- `RequiredItemKeywords` rendered as plain tags (item-keyword tags, NOT navigable entities); script-atomic min–max and the rare `EventLevels` surfaced only when present; account-wide badge only when true.

## `*`-prefixed account-wide envelope keys

Account-wide / transfer-chest keys (e.g. `*AccountStorage_Serbule`) carry a meaningful leading `*` that the strict internal-name grammar rejected. Added `DeepLinkPayload.IsValidEnvelopeKey` (internal-name grammar + an optional single leading `*`); the Silmarillion handler URL-decodes the name segment (`Uri.AbsolutePath` leaves `%2A` intact) then validates with it. The strict `IsValidInternalName` (every other handler) is unchanged. Covered by a kind-target `*`-key hit test, a navigator `Open_StorageVault_*` round-trip, a handler `*`-key test, a `%2A` `DeepLinkRouter` round-trip, and a grammar-safety test (separators / whitespace / doubled-or-non-leading `*` still rejected).

## Bilbo-overlap check (issue requirement)

Bilbo consumes the player's exported `StorageReport` — **live inventory contents** keyed via `StorageItem.StorageVault` location labels (same `*` / `NPC_` prefix conventions, normalised in `Mithril.Shared.Storage.StorageReportLoader.NormalizeLocation`). It does **not** consume `storagevaults.json` (the canonical reference vault catalog) and has no `IReferenceDataService.StorageVaults` / `ParseStorageVaults` usage. There is **no parallel projection of the canonical vault catalog** to consolidate and **no conflict** — Silmarillion is the first/only consumer of `IReferenceDataService.StorageVaults`. No follow-up consolidation issue is warranted (the two surfaces answer different questions: "what's in my chests right now" vs "what vaults exist and how do I access them").

## Tests

`ReferenceDataServiceStorageVaultTests` (plumbing round-trip incl. the `*`-key, polymorphic `Requirements`, refresh-unavailable contract, cache-over-bundled parse path, and a **real-bundled sanity walk** with a drift guard asserting the modelled subclasses cover the entire corpus — no `UnknownStorageRequirement`), `StorageVaultsTabViewModelTests`, `StorageVaultsKindTargetTests` (incl. a `*`-prefixed key hit), `StorageVaultDetailViewModelTests` (canonical favor ordering, `HasAssociatedNpc:false` ⇒ no NPC chip, each requirement subclass incl. graceful Unknown degrade, noise filters), and extensions to `SilmarillionReferenceNavigatorTests` + `SilmarillionDeepLinkHandlerTests`.

## Verification

- `dotnet build Mithril.slnx` — **0 warnings / 0 errors** (warnings-as-errors clean; XamlResourceLint OK).
- `dotnet test Mithril.slnx` — **2433 passed, 0 failed, 0 skipped** across 16 test projects (no regressions in `IReferenceDataService` consumers).
- Real-data sanity walk through the actual bundled `storagevaults.json` (transfer chest / favor-scaled vendor / flag-gated chest) passes as an automated test.
- `dotnet run --project src/Mithril.Shell` — boots past `=== startup done ===` cleanly (no DI cycle, no dangling XAML resource).

🤖 Generated with [Claude Code](https://claude.com/claude-code)