### PR TITLE
fix(silmarillion): repair botched #328→#329 merge splice (main is red)

### DIFF
--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -351,14 +351,11 @@ public sealed class ReferenceDataService : IReferenceDataService
         LoadLorebooks();           // After LoadItems so BuildLorebookItemCrossLinkIndex sees
                                    // the final item set on first build.
         LoadPlayerTitles();        // Independent file; no cross-link index (#248).
-    }
-
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects", "lorebooks", "lorebookinfo", "playertitles"];
         LoadStorageVaults();       // Independent of every other file (#249 cross-links are
                                    // 1:1 chips resolved lazily at detail-build, not an index).
     }
 
-    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects", "lorebooks", "lorebookinfo", "storagevaults"];
+    public IReadOnlyList<string> Keys { get; } = ["items", "recipes", "skills", "xptables", "npcs", "areas", "landmarks", "sources_items", "sources_recipes", "abilities", "sources_abilities", "attributes", "tsysclientinfo", "tsysprofiles", "quests", "strings_all", "directedgoals", "abilitykeywords", "abilitydynamicdots", "abilitydynamicspecialvalues", "effects", "lorebooks", "lorebookinfo", "playertitles", "storagevaults"];
 
     public IReadOnlyDictionary<long, Item> Items => _items;
     public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByInternalName;

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -143,6 +143,7 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new PlayerTitlesKindTarget(
             sp.GetRequiredService<PlayerTitlesTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new StorageVaultsKindTarget(
             sp.GetRequiredService<StorageVaultsTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));


### PR DESCRIPTION
**`main` (`62e4d9e`) does not build.** The #248 PlayerTitles (#328) → #249 StorageVaults (#329) sequential merge+rebase interleaved two files instead of appending #329's additions after #328's, producing structural breakage that the post-merge re-verify missed.

## Damage

- **`ReferenceDataService.cs`** — `LoadStorageVaults()` ended up *after* the constructor's closing `}` and *after* a `Keys` declaration; a stray `}` (`CS1519` at 359,5); and a **duplicate `Keys` member**.
- **`SilmarillionModule.cs`** — the `StorageVaultsKindTarget` DI registration was spliced into the *middle* of the `PlayerTitlesKindTarget` registration, dropping its closing `sp.GetService<IDiagnosticsSink>()));` (`CS1026` at 148,48).

## Fix

Both `Load*` calls restored inside the constructor; a single `Keys` array carrying both `"playertitles"` and `"storagevaults"`; both DI registrations whole and sequential. **No logic added or removed beyond restoring the dropped lines** — the shipped #328/#329 behaviour is intended; only the merge resolution was wrong.

## Verification

- `dotnet build Mithril.slnx` — 0 warnings / 0 errors.
- `dotnet test Mithril.slnx` — green: Silmarillion 407, Mithril.Shared 953, **0 failed across all projects**.

Root cause is the same structural-splice hazard called out for the #326/#329 rebases; the gap here was that the #328→#329 post-merge solution re-verify was not run before the phase was declared done. Filing this as the corrective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)