### PR TITLE
fix(silmarillion): add missing TabView code-behind; boot version dump (#335)

### DIFF
--- a/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellServiceCollectionExtensions.cs
@@ -20,7 +20,19 @@ public sealed class DiscoveredModules(IReadOnlyList<IMithrilModule> modules)
 
 public static class ShellServiceCollectionExtensions
 {
-    public static IServiceCollection AddMithrilModules(this IServiceCollection services)
+    /// <summary>
+    /// Informational version (Nerdbank.GitVersioning <c>X.Y.Z.N+sha</c>) of an
+    /// assembly, falling back to the plain assembly version. Used for the
+    /// shell/module version dump in boot.log so a stale or mismatched module
+    /// is visible at a glance.
+    /// </summary>
+    internal static string InformationalVersion(this Assembly asm) =>
+        asm.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? asm.GetName().Version?.ToString()
+        ?? "unknown";
+
+    public static IServiceCollection AddMithrilModules(
+        this IServiceCollection services, Action<string>? log = null)
     {
         var modulesDir = Path.Combine(AppContext.BaseDirectory, "modules");
         var modules = new List<IMithrilModule>();
@@ -49,6 +61,8 @@ public static class ShellServiceCollectionExtensions
         {
             module.Register(services);
             services.AddSingleton<IMithrilModule>(module);
+            var asm = module.GetType().Assembly;
+            log?.Invoke($"module loaded: {module.Id} [{asm.GetName().Name}] {asm.InformationalVersion()}");
         }
 
         services.AddSingleton(new DiscoveredModules(modules));

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
@@ -72,6 +73,7 @@ public static class Program
         try
         {
             Boot("=== startup ===");
+            Boot($"shell version: {typeof(Program).Assembly.InformationalVersion()}");
 
             // Extract an activation URI from argv if present. The OS passes it as the first
             // argument when launching via the registered custom scheme (mithril://…).
@@ -175,7 +177,7 @@ public static class Program
                 // Without this ordering, the NoOp would win and CanOpen would always
                 // return false — chip cross-links would render disabled.
                 .AddSingleton<IReferenceNavigator, NoOpReferenceNavigator>()
-                .AddMithrilModules()
+                .AddMithrilModules(Boot)
                 .AddMithrilAttention()
                 .AddMithrilShellUpdates()
                 .AddMithrilShellViews()

--- a/src/Silmarillion.Module/Views/LorebooksTabView.xaml.cs
+++ b/src/Silmarillion.Module/Views/LorebooksTabView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class LorebooksTabView : UserControl
+{
+    public LorebooksTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/StorageVaultsTabView.xaml.cs
+++ b/src/Silmarillion.Module/Views/StorageVaultsTabView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class StorageVaultsTabView : UserControl
+{
+    public StorageVaultsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Silmarillion.Tests/Views/TabViewCodeBehindGuardTests.cs
+++ b/tests/Silmarillion.Tests/Views/TabViewCodeBehindGuardTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Silmarillion.Tests.Views;
+
+/// <summary>
+/// Source-level invariant guard. Every Silmarillion <c>*.xaml</c> that declares an
+/// <c>x:Class</c> MUST ship a hand-authored <c>*.xaml.cs</c> code-behind whose
+/// constructor calls <c>InitializeComponent()</c>.
+/// <para>
+/// If the code-behind is missing, the XAML compiler still emits the partial class
+/// (with <c>InitializeComponent</c>) in <c>obj/**/*.g.cs</c>, so the build SUCCEEDS
+/// and every unit test stays green — but the implicit default constructor never
+/// calls <c>InitializeComponent()</c>, so the control instantiates EMPTY at runtime
+/// (blank tab/pane, no exception). This silently shipped <c>LorebooksTabView</c> and
+/// <c>StorageVaultsTabView</c> on <c>main</c>. xunit never instantiates XAML, so a
+/// source-scan is the cheapest layer that actually catches this class of bug.
+/// </para>
+/// </summary>
+public sealed class TabViewCodeBehindGuardTests
+{
+    [Fact]
+    public void EveryXamlWithXClass_HasCodeBehindCallingInitializeComponent()
+    {
+        var viewsDir = FindViewsDir();
+        if (viewsDir is null) return; // source tree not reachable (packaged run) — skip, don't false-fail
+
+        var offenders = Directory
+            .EnumerateFiles(viewsDir, "*.xaml", SearchOption.AllDirectories)
+            .Where(xaml => File.ReadAllText(xaml).Contains("x:Class=\""))
+            .Where(xaml =>
+            {
+                var codeBehind = xaml + ".cs";
+                return !File.Exists(codeBehind)
+                       || !File.ReadAllText(codeBehind).Contains("InitializeComponent(");
+            })
+            .Select(Path.GetFileName)
+            .OrderBy(n => n)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "every x:Class XAML needs a .xaml.cs calling InitializeComponent() or the "
+            + "control renders blank at runtime while the build/tests stay green");
+    }
+
+    /// <summary>
+    /// Walk up from the test bin dir to the repo root (marked by <c>Mithril.slnx</c>),
+    /// then resolve <c>src/Silmarillion.Module/Views</c>. Returns null if not found.
+    /// </summary>
+    private static string? FindViewsDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mithril.slnx")))
+            dir = dir.Parent;
+
+        if (dir is null) return null;
+        var views = Path.Combine(dir.FullName, "src", "Silmarillion.Module", "Views");
+        return Directory.Exists(views) ? views : null;
+    }
+}


### PR DESCRIPTION
## Problem

On `main` (`81f6e8f`), the **Lorebooks** and **Vaults** tabs render a completely blank content pane — tab header present, but no master list, no placeholder, no exception. The reference-data probe proved the VM/data layer was correct all along (64 lorebooks / 7 categories / 92 vaults project fine), so the break was purely in the view layer.

## Root cause

`LorebooksTabView.xaml.cs` and `StorageVaultsTabView.xaml.cs` were **never created** (git history empty for both; every other tab has its code-behind). The XAML compiler still emits the partial class + `InitializeComponent()` in `obj/**/*.g.cs`, so:

- the build **succeeds** (no error),
- all **407 tests stay green** (xunit never instantiates XAML),
- but the implicit default constructor never calls `InitializeComponent()`, so the `UserControl` instantiates **empty** at runtime.

`-Clean` could never have helped — the defect is missing source, not stale binaries.

## Changes

- **Fix:** add `LorebooksTabView.xaml.cs` / `StorageVaultsTabView.xaml.cs`, identical to the 8 working tabs / `PlayerTitlesTabView`.
- **Regression guard:** `TabViewCodeBehindGuardTests` — zero-dependency source invariant: every Silmarillion `*.xaml` with `x:Class` must ship a `*.xaml.cs` calling `InitializeComponent()`. Verified **red** when a code-behind is removed, **green** once present.
- **Boot version dump:** shell informational version logged at `=== startup ===`; each module's `id [assembly] version` logged as it is loaded (`AddMithrilModules` takes an optional log sink). A stale/mismatched module is now obvious in `boot.log` at a glance.

## Verification

- `Silmarillion.Module` + `Mithril.Shell` build clean (0 warn / 0 err).
- `dotnet test tests/Silmarillion.Tests` → **408 passed** (407 + new guard).
- Guard proven to catch the exact bug class (red with a code-behind removed, green restored).

Closes #335. Related: #333 (stays scoped to VM real-data sanity tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
