### PR TITLE
Lorebook detail footer: independently copyable identifier segments

### DIFF
--- a/docs/superpowers/plans/2026-05-15-detail-footer-copyable-segments.md
+++ b/docs/superpowers/plans/2026-05-15-detail-footer-copyable-segments.md
@@ -1,0 +1,486 @@
+# Detail-footer copyable segments — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each identifier in the Lorebook detail footer independently click-to-copy, without changing any other detail view or the exported card image dimensions.
+
+**Architecture:** Add a general `FooterSegments` (`IEnumerable<string>`) dependency property to the shared `DetailExportHost`. When set, the footer template renders the strings as independent click-to-copy chips joined by an inert middot, each with its own ~1.2 s "copied" ack; when unset, the existing single-button `FooterText` path is unchanged. `LorebookDetailViewModel` exposes `FooterSegments` = `[EnvelopeKey, InternalName]` (or one element when they coincide); the Lorebook view binds it instead of `FooterText`.
+
+**Tech Stack:** .NET 10 / WPF, C# (nullable, warnings-as-errors), CommunityToolkit.Mvvm, xunit + FluentAssertions. Spec: `docs/superpowers/specs/2026-05-15-detail-footer-copyable-segments-design.md`.
+
+---
+
+## File Structure
+
+- **Modify** `src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs` — add `FooterSegments`; keep `FooterText`.
+- **Modify** `tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs` — new `FooterSegments` cases.
+- **Modify** `src/Mithril.Shared.Wpf/DetailExportHost.cs` — add `FooterSegments` DP, the `FooterSegmentItem` projection type, `FooterSegmentItems`/`HasFooterSegments` read-only DPs, per-segment copy + ack.
+- **Modify** `src/Mithril.Shared.Wpf/Resources.xaml` — `DetailExportHost` template: add the segment `ItemsControl` path; collapse the single-button footer when segments are present.
+- **Modify** `src/Silmarillion.Module/Views/LorebookDetailView.xaml` — bind `FooterSegments` instead of `FooterText`.
+
+No other detail view, VM, or test is touched. Build auto-copies module DLLs (`Directory.Build.targets`); close Mithril/VS before building to avoid silent stale-DLL file locks.
+
+---
+
+## Task 1: Lorebook VM — `FooterSegments` (TDD)
+
+**Files:**
+- Modify: `src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs`
+- Test: `tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two tests to `tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs` (after `Header_ResolvesTitle_CategorySubtitle_AndDivergentFooter`, before `AreaChip_ResolvesFromFirstMatchingKeyword`):
+
+```csharp
+    [Fact]
+    public void FooterSegments_DivergentKeyAndName_AreTwoIndependentSegments()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes",
+            Title = "The Wasted Wishes", Text = "x",
+        });
+        var vm = BuildDetail(refData, "TheWastedWishes");
+
+        // Each is its own atomic copyable identifier (no " / " mashup).
+        vm.FooterSegments.Should().Equal("Book_101", "TheWastedWishes");
+        // Back-compat: joined FooterText preserved for non-UI consumers.
+        vm.FooterText.Should().Be("Book_101 / TheWastedWishes");
+    }
+
+    [Fact]
+    public void FooterSegments_KeyEqualsName_IsSingleSegment()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("SameName", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "SameName",
+            Title = "Same", Text = "x",
+        });
+        var vm = BuildDetail(refData, "SameName");
+
+        vm.FooterSegments.Should().ContainSingle().Which.Should().Be("SameName");
+        vm.FooterText.Should().Be("SameName");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Silmarillion.Tests --filter "FullyQualifiedName~LorebookDetailViewModelTests.FooterSegments"`
+
+Expected: FAIL — compilation error `'LorebookDetailViewModel' does not contain a definition for 'FooterSegments'`.
+
+- [ ] **Step 3: Implement `FooterSegments`**
+
+In `src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs`, immediately after the `FooterText` property (the block ending at the line `: $"{EnvelopeKey} / {InternalName}";`), add:
+
+```csharp
+    /// <summary>
+    /// Footer identifiers as independent copyable segments, bound to
+    /// <c>DetailExportHost.FooterSegments</c> (each renders as its own click-to-copy
+    /// chip joined by an inert middot). For real lorebooks the envelope key and
+    /// InternalName always diverge → two segments <c>[Book_101, TheWastedWishes]</c>;
+    /// the defensive equal case collapses to a single segment. This replaces copying
+    /// the joined <see cref="FooterText"/> slug, which was never a valid identifier.
+    /// </summary>
+    public IReadOnlyList<string> FooterSegments =>
+        string.Equals(EnvelopeKey, InternalName, StringComparison.Ordinal)
+            ? new[] { InternalName }
+            : new[] { EnvelopeKey, InternalName };
+```
+
+If `System.Collections.Generic` is not already in scope (it is via the global usings for this project, but verify), no `using` change is needed — `IReadOnlyList<>` resolves through the project's implicit usings. Do **not** modify or remove the existing `FooterText` property.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Silmarillion.Tests --filter "FullyQualifiedName~LorebookDetailViewModelTests.FooterSegments"`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Run the full Lorebook test class to confirm no regression**
+
+Run: `dotnet test tests/Silmarillion.Tests --filter "FullyQualifiedName~LorebookDetailViewModelTests"`
+Expected: PASS — all existing tests (incl. `Header_ResolvesTitle_CategorySubtitle_AndDivergentFooter` asserting `FooterText == "Book_101 / TheWastedWishes"`) still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
+git -c commit.gpgsign=false commit -m "feat(silmarillion): Lorebook FooterSegments — split key/name into copyable parts
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `DetailExportHost` — `FooterSegments` DP, projection, per-segment copy + ack
+
+**Files:**
+- Modify: `src/Mithril.Shared.Wpf/DetailExportHost.cs`
+
+This is shared WPF control code. It has no existing unit coverage (the current footer copy has none either — it is STA/clipboard UI); verification is the build gate here plus the manual smoke in Task 5, consistent with the spec.
+
+- [ ] **Step 1: Add usings**
+
+At the top of `src/Mithril.Shared.Wpf/DetailExportHost.cs`, the current usings are:
+
+```csharp
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+```
+
+Replace that block with:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+```
+
+- [ ] **Step 2: Add the `FooterSegments` DP and the projected read-only DPs**
+
+In `DetailExportHost`, immediately after the existing `FooterText` property block (the `get`/`set` ending at `set => SetValue(FooterTextProperty, value);` and its closing `}`), add:
+
+```csharp
+    public static readonly DependencyProperty FooterSegmentsProperty =
+        DependencyProperty.Register(
+            nameof(FooterSegments), typeof(IEnumerable<string>),
+            typeof(DetailExportHost),
+            new PropertyMetadata(null, OnFooterSegmentsChanged));
+
+    /// <summary>
+    /// When non-null and non-empty, the footer renders these strings as independent
+    /// click-to-copy chips joined by an inert middot, instead of the single
+    /// <see cref="FooterText"/> button. Each chip copies exactly its own string —
+    /// the separator is never part of any copy payload. Null/empty → the
+    /// <see cref="FooterText"/> path is used unchanged.
+    /// </summary>
+    public IEnumerable<string>? FooterSegments
+    {
+        get => (IEnumerable<string>?)GetValue(FooterSegmentsProperty);
+        set => SetValue(FooterSegmentsProperty, value);
+    }
+
+    private static readonly DependencyPropertyKey FooterSegmentItemsKey =
+        DependencyProperty.RegisterReadOnly(
+            nameof(FooterSegmentItems), typeof(IReadOnlyList<FooterSegmentItem>),
+            typeof(DetailExportHost),
+            new PropertyMetadata(System.Array.Empty<FooterSegmentItem>()));
+
+    public static readonly DependencyProperty FooterSegmentItemsProperty =
+        FooterSegmentItemsKey.DependencyProperty;
+
+    /// <summary>Projected, per-item-ack-bearing view of <see cref="FooterSegments"/>
+    /// for the template's <c>ItemsControl</c>. Empty when no segments.</summary>
+    public IReadOnlyList<FooterSegmentItem> FooterSegmentItems =>
+        (IReadOnlyList<FooterSegmentItem>)GetValue(FooterSegmentItemsProperty);
+
+    private static readonly DependencyPropertyKey HasFooterSegmentsKey =
+        DependencyProperty.RegisterReadOnly(
+            nameof(HasFooterSegments), typeof(bool), typeof(DetailExportHost),
+            new PropertyMetadata(false));
+
+    public static readonly DependencyProperty HasFooterSegmentsProperty =
+        HasFooterSegmentsKey.DependencyProperty;
+
+    /// <summary>True when <see cref="FooterSegments"/> has ≥1 non-empty entry; the
+    /// template then shows the segment ItemsControl and hides the single-button
+    /// footer.</summary>
+    public bool HasFooterSegments => (bool)GetValue(HasFooterSegmentsProperty);
+
+    private static void OnFooterSegmentsChanged(
+        DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var host = (DetailExportHost)d;
+        var segments = (e.NewValue as IEnumerable<string>)?
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList() ?? new List<string>();
+
+        var items = new List<FooterSegmentItem>(segments.Count);
+        for (var i = 0; i < segments.Count; i++)
+        {
+            var item = new FooterSegmentItem(segments[i], isFirst: i == 0);
+            item.CopyCommand = new RelayCommand(() => host.CopySegment(item));
+            items.Add(item);
+        }
+
+        host.SetValue(FooterSegmentItemsKey, items);
+        host.SetValue(HasFooterSegmentsKey, items.Count > 0);
+    }
+
+    private void CopySegment(FooterSegmentItem item)
+    {
+        try
+        {
+            Clipboard.SetDataObject(
+                new DataObject(DataFormats.UnicodeText, item.Text), copy: true);
+        }
+        catch
+        {
+            return; // clipboard can transiently fail; no ack, user can retry
+        }
+
+        item.Copied = true;
+        var timer = new DispatcherTimer { Interval = AckHold };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            item.Copied = false;
+        };
+        timer.Start();
+    }
+```
+
+- [ ] **Step 3: Add the `FooterSegmentItem` type**
+
+At the end of `src/Mithril.Shared.Wpf/DetailExportHost.cs`, *after* the closing brace of the `DetailExportHost` class but inside the namespace, add:
+
+```csharp
+/// <summary>
+/// One copyable footer chip. <see cref="Copied"/> drives a transient "copied" ack on
+/// just this segment (the other segments are unaffected); <see cref="IsFirst"/>
+/// suppresses the leading middot separator for the first chip. Public because the
+/// <c>DetailExportHost</c> template binds to these properties (WPF binding requires
+/// public members).
+/// </summary>
+public sealed partial class FooterSegmentItem : ObservableObject
+{
+    public FooterSegmentItem(string text, bool isFirst)
+    {
+        Text = text;
+        IsFirst = isFirst;
+    }
+
+    /// <summary>The atomic identifier shown and copied verbatim.</summary>
+    public string Text { get; }
+
+    /// <summary>First chip in the row → no leading separator.</summary>
+    public bool IsFirst { get; }
+
+    [ObservableProperty]
+    private bool _copied;
+
+    /// <summary>Set by the host immediately after construction; copies
+    /// <see cref="Text"/> and triggers this segment's ack.</summary>
+    public IRelayCommand CopyCommand { get; set; } = null!;
+}
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `dotnet build src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj`
+Expected: Build succeeded, 0 errors (warnings-as-errors is on — must be 0 warnings too). `[ObservableProperty]` on `_copied` generates the public `Copied` property used by the template.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Mithril.Shared.Wpf/DetailExportHost.cs
+git -c commit.gpgsign=false commit -m "feat(shared-wpf): DetailExportHost FooterSegments — independent copyable footer chips
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `DetailExportHost` template — segment `ItemsControl` path
+
+**Files:**
+- Modify: `src/Mithril.Shared.Wpf/Resources.xaml` (the `DetailExportHost` `Style`, currently lines ~935-994)
+
+- [ ] **Step 1: Collapse the single-button footer when segments are present**
+
+In `src/Mithril.Shared.Wpf/Resources.xaml`, find `PART_FooterButton`. Its opening tag currently ends with this inline attribute:
+
+```xml
+                                    Visibility="{Binding FooterText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullOrEmptyToVis}}">
+```
+
+Remove that `Visibility="..."` attribute from the opening tag (so the tag now ends `ToolTip="Click to copy the internal name">`), and add this `Button.Style` as the **first child** of the `<Button x:Name="PART_FooterButton" ...>` element (before `<Button.Template>`):
+
+```xml
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Visibility"
+                                                Value="{Binding FooterText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullOrEmptyToVis}}"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasFooterSegments, RelativeSource={RelativeSource TemplatedParent}}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+```
+
+- [ ] **Step 2: Add the segment ItemsControl directly after `PART_FooterButton`**
+
+Immediately after the `</Button>` that closes `PART_FooterButton`, and **before** the `<ContentPresenter/>` line, insert:
+
+```xml
+                            <!-- Segment footer (#Lorebook): N independent click-to-copy
+                                 chips joined by an inert middot. Shown only when
+                                 FooterSegments is set; mutually exclusive with
+                                 PART_FooterButton. Single-line → export height
+                                 unchanged. -->
+                            <ItemsControl x:Name="PART_FooterSegments"
+                                          DockPanel.Dock="Bottom"
+                                          HorizontalAlignment="Right"
+                                          Margin="0,8,14,12"
+                                          ItemsSource="{Binding FooterSegmentItems, RelativeSource={RelativeSource TemplatedParent}}"
+                                          Visibility="{Binding HasFooterSegments, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToVis}}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="  ·  " Foreground="#55FFFFFF"
+                                                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsFirst}" Value="True">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <Button Command="{Binding CopyCommand}" Cursor="Hand"
+                                                    Background="Transparent" BorderThickness="0"
+                                                    Padding="0" ToolTip="Click to copy">
+                                                <Button.Template>
+                                                    <ControlTemplate TargetType="Button">
+                                                        <ContentPresenter/>
+                                                    </ControlTemplate>
+                                                </Button.Template>
+                                                <TextBlock FontFamily="{DynamicResource AppMonoFontFamily}"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="{Binding Text}"/>
+                                                            <Setter Property="Foreground" Value="#88FFFFFF"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Copied}" Value="True">
+                                                                    <Setter Property="Text" Value="copied ✓"/>
+                                                                    <Setter Property="Foreground" Value="#FFD4A847"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+```
+
+- [ ] **Step 3: Build to verify the XAML compiles**
+
+Run: `dotnet build src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj`
+Expected: Build succeeded, 0 errors/0 warnings. (`BoolToVis` and `NullOrEmptyToVis` are already-defined resources in this same `Resources.xaml`; `AppMonoFontFamily`/`AppFontSizeSmall` are existing dynamic resources used by the original footer.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Mithril.Shared.Wpf/Resources.xaml
+git -c commit.gpgsign=false commit -m "feat(shared-wpf): DetailExportHost template renders FooterSegments chips
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Lorebook view binds `FooterSegments`
+
+**Files:**
+- Modify: `src/Silmarillion.Module/Views/LorebookDetailView.xaml:23`
+
+- [ ] **Step 1: Switch the binding**
+
+In `src/Silmarillion.Module/Views/LorebookDetailView.xaml`, change line 23 from:
+
+```xml
+    <c:DetailExportHost FooterText="{Binding FooterText}">
+```
+
+to:
+
+```xml
+    <c:DetailExportHost FooterSegments="{Binding FooterSegments}">
+```
+
+Leave the comment on line 27 (`<!-- Footer ... is owned by the wrapping DetailExportHost ... -->`) as-is; it still describes ownership correctly.
+
+- [ ] **Step 2: Build the module**
+
+Run: `dotnet build src/Silmarillion.Module/Silmarillion.Module.csproj`
+Expected: Build succeeded, 0 errors/0 warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Silmarillion.Module/Views/LorebookDetailView.xaml
+git -c commit.gpgsign=false commit -m "feat(silmarillion): Lorebook detail footer uses copyable segments
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full solution build**
+
+Run: `dotnet build Mithril.slnx`
+Expected: Build succeeded, 0 errors, 0 warnings. (If `MSB3026/MSB3027` file-lock errors appear, Mithril or VS is holding a module DLL — close them and rebuild; a "no effect" rebuild is a deploy failure, not a code issue.)
+
+- [ ] **Step 2: Full test run**
+
+Run: `dotnet test Mithril.slnx`
+Expected: All tests pass. Pay attention to `Silmarillion.Tests` — `LorebookDetailViewModelTests` (new `FooterSegments` cases + unchanged `FooterText` cases) and the smoke-walk test asserting `FooterText.Should().Contain("/")` must all be green.
+
+- [ ] **Step 3: Manual smoke (the WPF behavior with no unit coverage)**
+
+Run: `dotnet run --project src/Mithril.Shell`
+
+Verify:
+1. Silmarillion → **Lorebooks** tab → select "The Wasted Wishes". Footer reads `Book_101 · TheWastedWishes` (middot separator, single line, bottom-right, mono).
+2. Click `Book_101` → it alone flips to `copied ✓` (gold) for ~1.2 s; the other segment is unaffected. Paste elsewhere → clipboard is exactly `Book_101` (no ` / `, no name).
+3. Click `TheWastedWishes` → it alone acks; clipboard is exactly `TheWastedWishes`.
+4. Switch to a detail view that does **not** set segments (e.g. Abilities tab → any ability). Footer is the single `InternalName` button as before; clicking it still copies and acks (regression check on the unchanged `FooterText` path).
+5. On a Lorebook detail, click the top-right camera "Copy as image". Exported card looks the same height as before (footer still one line) and includes the dot-separated footer.
+
+- [ ] **Step 4: Final state check**
+
+Run: `git status --short && git log --oneline -5`
+Expected: clean working tree (aside from pre-existing unrelated `scripts/start.ps1` and untracked `docs/agent-plans/*`); the 4 feature commits + the spec commit present on `feat/silmarillion-footer-copyable-segments`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 shared control `FooterSegments` + per-item ack + single-segment fallback → Task 2 + Task 3 (collapse trigger). ✓
+- §2 Lorebook VM `FooterSegments`, `FooterText` kept → Task 1. ✓
+- §3 view binding swap → Task 4. ✓
+- §4 data flow (click → copy own string, separator never copied) → Task 2 `CopySegment` + Task 3 inert middot. ✓
+- §5 export height unchanged (single line) → Task 3 horizontal layout + Task 5 step 3.5 manual check. ✓
+- §6 testing (VM TDD; control verified manually) → Task 1 (TDD) + Task 5 step 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; commands have expected output. ✓
+
+**Type consistency:** `FooterSegments` is `IEnumerable<string>` on the host DP, `IReadOnlyList<string>` on the VM (assignable to the DP) — consistent. `FooterSegmentItem` members (`Text`, `IsFirst`, `Copied`, `CopyCommand`) match exactly between Task 2 (definition) and Task 3 (template bindings). `FooterSegmentItems`/`HasFooterSegments` names match between Task 2 DPs and Task 3 bindings. ✓

--- a/docs/superpowers/specs/2026-05-15-detail-footer-copyable-segments-design.md
+++ b/docs/superpowers/specs/2026-05-15-detail-footer-copyable-segments-design.md
@@ -1,0 +1,140 @@
+# Detail-footer copyable segments
+
+**Status:** Approved design, pre-implementation
+**Date:** 2026-05-15
+**Tracked in:** _no issue yet_
+
+## Problem
+
+Silmarillion detail views carry a click-to-copy internal-name footer, owned by the
+shared `DetailExportHost` (`src/Mithril.Shared.Wpf/DetailExportHost.cs`). Clicking the
+footer copies `FooterText` **verbatim** to the clipboard.
+
+For every detail view except Lorebook, `FooterText` is a single clean identifier
+(`Book_101`, `TheWastedWishes`, …) so the copy yields a usable value. The Lorebook
+footer is deliberately a **concatenation of two different identifiers** —
+`LorebookDetailViewModel.FooterText` renders `"{EnvelopeKey} / {InternalName}"`
+(e.g. `Book_101 / TheWastedWishes`) because for lorebooks the `lorebooks.json`
+dictionary key (`Book_NNN`) and the POCO `InternalName` (PascalCase name) always
+diverge and both are useful.
+
+The recently-added click-to-copy therefore copies the display mashup
+`Book_101 / TheWastedWishes` — a string that is **not a valid identifier**: not the
+JSON key, not the InternalName, just the joined display form with a ` / ` separator.
+The footer *display* is fine; the *copy payload* is broken for Lorebook specifically.
+
+## Goal
+
+Make each identifier in the Lorebook footer independently copyable, without changing
+behaviour for any other detail view and without changing the exported card image
+dimensions.
+
+## Design
+
+### 1. Shared control — `DetailExportHost`
+
+Add one public dependency property:
+
+- **`FooterSegments`** : `IEnumerable<string>?` — when non-null and non-empty, the
+  footer renders these strings as independent click-to-copy chips joined by an inert,
+  dim middot (`·`). When null, the existing `FooterText` single-button path renders
+  exactly as today.
+
+`FooterText` and its `FooterCopied` ack are **untouched**. All six non-Lorebook views
+and their image-export sizing keep working with zero changes — they never set
+`FooterSegments`.
+
+Internally the host projects the strings into small private item objects, each
+carrying its own `Copied` flag. The public API stays `IEnumerable<string>`; callers
+never see the item type. The template's `ItemsControl` binds to that projection so
+each segment gets its own click handler and its own ~1.2 s "copied" ack
+(reusing the existing `AckHold = 1200 ms`). The single global `FooterCopied` bool
+stays for the `FooterText` path; the segment path uses per-item ack instead.
+
+Both render paths live in the template, mutually exclusive by visibility
+(`FooterSegments` present → segment `ItemsControl`; else → existing
+`PART_FooterButton`).
+
+Because each split segment displays the same atomic string it copies (the root
+problem was display ≠ a copyable value — once split, `Book_101` and
+`TheWastedWishes` are each both the label and the payload), a segment is just a
+`string`. No label/value pair, no per-segment copy-override.
+
+### 2. Lorebook VM — `LorebookDetailViewModel`
+
+Add **`FooterSegments`** : `IReadOnlyList<string>`:
+
+- `EnvelopeKey != InternalName` (always true for real lorebooks) →
+  `[EnvelopeKey, InternalName]` → renders `Book_101 · TheWastedWishes`, each chip
+  copies its own atomic value.
+- Defensive equal-case (`EnvelopeKey == InternalName`) → single segment
+  `[InternalName]` → renders as one chip, no separator.
+
+`FooterText` is **kept** (still returns the joined string per the existing
+`string.Equals` ternary) so existing non-UI consumers and tests stay green; the
+view simply stops binding it.
+
+### 3. View — `LorebookDetailView.xaml`
+
+`<c:DetailExportHost FooterText="{Binding FooterText}">`
+→ `<c:DetailExportHost FooterSegments="{Binding FooterSegments}">`.
+
+### 4. Data flow
+
+```
+row
+  → EnvelopeKey + InternalName
+  → LorebookDetailViewModel.FooterSegments (IReadOnlyList<string>)
+  → DetailExportHost.FooterSegments
+  → ItemsControl of N click-to-copy chips (· drawn between, never copied)
+click chip i → Clipboard.SetDataObject(segment[i])
+            → chip i Copied = true for 1.2 s → reverts
+```
+
+The separator is template chrome between items and is never part of any copy
+payload.
+
+### 5. Export image
+
+The footer stays single-line (dot-separated), so `PART_ExportContent` height is
+unchanged — exported card dimensions are unaffected. This is a hard constraint:
+the stacked-lines layout was explicitly rejected for this reason.
+
+### 6. Testing
+
+- TDD (`tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs`):
+  - new: `FooterSegments` equals `["Book_101", "TheWastedWishes"]` for the
+    divergent (real-data) case.
+  - new: `FooterSegments` is a single element for the defensive equal case.
+  - existing `FooterText` assertions stay unchanged (back-compat preserved).
+- `DetailExportHost` clipboard write + per-segment ack is WPF-thread UI with no
+  existing unit coverage (the current footer copy has none either). Verified
+  manually/visually, consistent with how the existing footer copy is verified.
+
+## Scope of file changes
+
+- `src/Mithril.Shared.Wpf/DetailExportHost.cs` — add `FooterSegments` DP, segment
+  item projection, per-item copy + ack handler.
+- `src/Mithril.Shared.Wpf/Resources.xaml` — `DetailExportHost` template: add the
+  segment `ItemsControl` path alongside the existing single-button path.
+- `src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs` — add
+  `FooterSegments`; keep `FooterText`.
+- `src/Silmarillion.Module/Views/LorebookDetailView.xaml` — bind `FooterSegments`
+  instead of `FooterText`.
+- `tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs` — new
+  `FooterSegments` cases.
+
+No other detail view, VM, or test is touched.
+
+## Rejected alternatives
+
+- **Lorebook-only special case** (hardcoded two-field footer in shared code):
+  bakes a Lorebook concern into shared infra and isn't reusable; not meaningfully
+  less code than the general list once per-field ack is accounted for.
+- **Change which single identifier is copied** (InternalName-only or
+  EnvelopeKey-only): loses one of two genuinely useful identifiers; the user wants
+  both independently copyable.
+- **Stacked two-line footer**: taller footer changes exported card image height —
+  violates the export-dimensions constraint.
+- **Slash separator retained**: cosmetic; dot separator chosen to visually signal
+  the segments are now distinct interactive targets rather than one slug.

--- a/docs/superpowers/specs/2026-05-15-detail-footer-copyable-segments-design.md
+++ b/docs/superpowers/specs/2026-05-15-detail-footer-copyable-segments-design.md
@@ -40,9 +40,11 @@ Add one public dependency property:
   dim middot (`·`). When null, the existing `FooterText` single-button path renders
   exactly as today.
 
-`FooterText` and its `FooterCopied` ack are **untouched**. All six non-Lorebook views
-and their image-export sizing keep working with zero changes — they never set
-`FooterSegments`.
+`FooterText` and its `FooterCopied` ack are **untouched**. All eight non-Lorebook views
+keep working with zero changes — they never set `FooterSegments`. Six of those views
+(Ability, Area, Npc, PlayerTitle, Quest, Recipe) bind `FooterText` and are wholly
+unaffected; two (Effect, StorageVault) bind neither footer property and are likewise
+unaffected. Image-export sizing is unchanged for all eight.
 
 Internally the host projects the strings into small private item objects, each
 carrying its own `Copied` flag. The public API stays `IEnumerable<string>`; callers

--- a/src/Mithril.Shared.Wpf/DetailExportHost.cs
+++ b/src/Mithril.Shared.Wpf/DetailExportHost.cs
@@ -90,6 +90,12 @@ public sealed class DetailExportHost : ContentControl
     /// footer.</summary>
     public bool HasFooterSegments => (bool)GetValue(HasFooterSegmentsProperty);
 
+    // Rebuilds the projected chip items whenever FooterSegments is (re)assigned.
+    // Detail hosts are recreated per entity selection (the master-detail ContentControl
+    // swaps in a fresh view per selection), so this fires once per host in practice;
+    // an in-flight ack DispatcherTimer from a prior set is not explicitly cancelled
+    // (consistent with OnFooterClick) — safe only because hosts are not reused for
+    // in-place navigation. Revisit if DetailExportHost is ever reused across selections.
     private static void OnFooterSegmentsChanged(
         DependencyObject d, DependencyPropertyChangedEventArgs e)
     {

--- a/src/Mithril.Shared.Wpf/DetailExportHost.cs
+++ b/src/Mithril.Shared.Wpf/DetailExportHost.cs
@@ -96,13 +96,15 @@ public sealed class DetailExportHost : ContentControl
         var host = (DetailExportHost)d;
         var segments = (e.NewValue as IEnumerable<string>)?
             .Where(s => !string.IsNullOrEmpty(s))
-            .ToList() ?? new List<string>();
+            .ToList() ?? [];
 
         var items = new List<FooterSegmentItem>(segments.Count);
         for (var i = 0; i < segments.Count; i++)
         {
-            var item = new FooterSegmentItem(segments[i], isFirst: i == 0);
-            item.CopyCommand = new RelayCommand(() => host.CopySegment(item));
+            FooterSegmentItem? item = null;
+            item = new FooterSegmentItem(
+                segments[i], isFirst: i == 0,
+                new RelayCommand(() => host.CopySegment(item!)));
             items.Add(item);
         }
 
@@ -219,10 +221,11 @@ public sealed class DetailExportHost : ContentControl
 /// </summary>
 public sealed partial class FooterSegmentItem : ObservableObject
 {
-    public FooterSegmentItem(string text, bool isFirst)
+    public FooterSegmentItem(string text, bool isFirst, IRelayCommand copyCommand)
     {
         Text = text;
         IsFirst = isFirst;
+        CopyCommand = copyCommand;
     }
 
     /// <summary>The atomic identifier shown and copied verbatim.</summary>
@@ -234,7 +237,7 @@ public sealed partial class FooterSegmentItem : ObservableObject
     [ObservableProperty]
     private bool _copied;
 
-    /// <summary>Set by the host immediately after construction; copies
-    /// <see cref="Text"/> and triggers this segment's ack.</summary>
-    public IRelayCommand CopyCommand { get; set; } = null!;
+    /// <summary>Copies <see cref="Text"/> and triggers this segment's ack.
+    /// Injected by the host at construction.</summary>
+    public IRelayCommand CopyCommand { get; }
 }

--- a/src/Mithril.Shared.Wpf/DetailExportHost.cs
+++ b/src/Mithril.Shared.Wpf/DetailExportHost.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Mithril.Shared.Wpf;
 
@@ -38,6 +42,94 @@ public sealed class DetailExportHost : ContentControl
     {
         get => (string?)GetValue(FooterTextProperty);
         set => SetValue(FooterTextProperty, value);
+    }
+
+    public static readonly DependencyProperty FooterSegmentsProperty =
+        DependencyProperty.Register(
+            nameof(FooterSegments), typeof(IEnumerable<string>),
+            typeof(DetailExportHost),
+            new PropertyMetadata(null, OnFooterSegmentsChanged));
+
+    /// <summary>
+    /// When non-null and non-empty, the footer renders these strings as independent
+    /// click-to-copy chips joined by an inert middot, instead of the single
+    /// <see cref="FooterText"/> button. Each chip copies exactly its own string —
+    /// the separator is never part of any copy payload. Null/empty → the
+    /// <see cref="FooterText"/> path is used unchanged.
+    /// </summary>
+    public IEnumerable<string>? FooterSegments
+    {
+        get => (IEnumerable<string>?)GetValue(FooterSegmentsProperty);
+        set => SetValue(FooterSegmentsProperty, value);
+    }
+
+    private static readonly DependencyPropertyKey FooterSegmentItemsKey =
+        DependencyProperty.RegisterReadOnly(
+            nameof(FooterSegmentItems), typeof(IReadOnlyList<FooterSegmentItem>),
+            typeof(DetailExportHost),
+            new PropertyMetadata(System.Array.Empty<FooterSegmentItem>()));
+
+    public static readonly DependencyProperty FooterSegmentItemsProperty =
+        FooterSegmentItemsKey.DependencyProperty;
+
+    /// <summary>Projected, per-item-ack-bearing view of <see cref="FooterSegments"/>
+    /// for the template's <c>ItemsControl</c>. Empty when no segments.</summary>
+    public IReadOnlyList<FooterSegmentItem> FooterSegmentItems =>
+        (IReadOnlyList<FooterSegmentItem>)GetValue(FooterSegmentItemsProperty);
+
+    private static readonly DependencyPropertyKey HasFooterSegmentsKey =
+        DependencyProperty.RegisterReadOnly(
+            nameof(HasFooterSegments), typeof(bool), typeof(DetailExportHost),
+            new PropertyMetadata(false));
+
+    public static readonly DependencyProperty HasFooterSegmentsProperty =
+        HasFooterSegmentsKey.DependencyProperty;
+
+    /// <summary>True when <see cref="FooterSegments"/> has ≥1 non-empty entry; the
+    /// template then shows the segment ItemsControl and hides the single-button
+    /// footer.</summary>
+    public bool HasFooterSegments => (bool)GetValue(HasFooterSegmentsProperty);
+
+    private static void OnFooterSegmentsChanged(
+        DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var host = (DetailExportHost)d;
+        var segments = (e.NewValue as IEnumerable<string>)?
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList() ?? new List<string>();
+
+        var items = new List<FooterSegmentItem>(segments.Count);
+        for (var i = 0; i < segments.Count; i++)
+        {
+            var item = new FooterSegmentItem(segments[i], isFirst: i == 0);
+            item.CopyCommand = new RelayCommand(() => host.CopySegment(item));
+            items.Add(item);
+        }
+
+        host.SetValue(FooterSegmentItemsKey, items);
+        host.SetValue(HasFooterSegmentsKey, items.Count > 0);
+    }
+
+    private void CopySegment(FooterSegmentItem item)
+    {
+        try
+        {
+            Clipboard.SetDataObject(
+                new DataObject(DataFormats.UnicodeText, item.Text), copy: true);
+        }
+        catch
+        {
+            return; // clipboard can transiently fail; no ack, user can retry
+        }
+
+        item.Copied = true;
+        var timer = new DispatcherTimer { Interval = AckHold };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            item.Copied = false;
+        };
+        timer.Start();
     }
 
     private static readonly DependencyPropertyKey FooterCopiedKey =
@@ -116,4 +208,33 @@ public sealed class DetailExportHost : ContentControl
         };
         timer.Start();
     }
+}
+
+/// <summary>
+/// One copyable footer chip. <see cref="Copied"/> drives a transient "copied" ack on
+/// just this segment (the other segments are unaffected); <see cref="IsFirst"/>
+/// suppresses the leading middot separator for the first chip. Public because the
+/// <c>DetailExportHost</c> template binds to these properties (WPF binding requires
+/// public members).
+/// </summary>
+public sealed partial class FooterSegmentItem : ObservableObject
+{
+    public FooterSegmentItem(string text, bool isFirst)
+    {
+        Text = text;
+        IsFirst = isFirst;
+    }
+
+    /// <summary>The atomic identifier shown and copied verbatim.</summary>
+    public string Text { get; }
+
+    /// <summary>First chip in the row → no leading separator.</summary>
+    public bool IsFirst { get; }
+
+    [ObservableProperty]
+    private bool _copied;
+
+    /// <summary>Set by the host immediately after construction; copies
+    /// <see cref="Text"/> and triggers this segment's ack.</summary>
+    public IRelayCommand CopyCommand { get; set; } = null!;
 }

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -989,9 +989,13 @@
                             <!-- Segment footer (#Lorebook): N independent click-to-copy
                                  chips joined by an inert middot. Shown only when
                                  FooterSegments is set; mutually exclusive with
-                                 PART_FooterButton. Single-line → export height
-                                 unchanged. -->
-                            <ItemsControl x:Name="PART_FooterSegments"
+                                 PART_FooterButton (exactly one is non-Collapsed).
+                                 NOTE: declaration order here is load-bearing — these
+                                 two are sibling Dock="Bottom" elements; the contract
+                                 is that only one is ever visible. Don't insert another
+                                 Dock="Bottom" sibling between them or make both visible.
+                                 Single-line → export height unchanged. -->
+                            <ItemsControl x:Name="FooterSegmentsItemsControl"
                                           DockPanel.Dock="Bottom"
                                           HorizontalAlignment="Right"
                                           Margin="0,8,14,12"

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -953,8 +953,18 @@
                                     HorizontalAlignment="Right" Cursor="Hand"
                                     Background="Transparent" BorderThickness="0" Padding="0"
                                     Margin="0,8,14,12"
-                                    ToolTip="Click to copy the internal name"
-                                    Visibility="{Binding FooterText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullOrEmptyToVis}}">
+                                    ToolTip="Click to copy the internal name">
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Visibility"
+                                                Value="{Binding FooterText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullOrEmptyToVis}}"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasFooterSegments, RelativeSource={RelativeSource TemplatedParent}}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
                                 <Button.Template>
                                     <ControlTemplate TargetType="Button">
                                         <ContentPresenter/>
@@ -976,6 +986,68 @@
                                     </TextBlock.Style>
                                 </TextBlock>
                             </Button>
+                            <!-- Segment footer (#Lorebook): N independent click-to-copy
+                                 chips joined by an inert middot. Shown only when
+                                 FooterSegments is set; mutually exclusive with
+                                 PART_FooterButton. Single-line → export height
+                                 unchanged. -->
+                            <ItemsControl x:Name="PART_FooterSegments"
+                                          DockPanel.Dock="Bottom"
+                                          HorizontalAlignment="Right"
+                                          Margin="0,8,14,12"
+                                          ItemsSource="{Binding FooterSegmentItems, RelativeSource={RelativeSource TemplatedParent}}"
+                                          Visibility="{Binding HasFooterSegments, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToVis}}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="  ·  " Foreground="#55FFFFFF"
+                                                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsFirst}" Value="True">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <Button Command="{Binding CopyCommand}" Cursor="Hand"
+                                                    Background="Transparent" BorderThickness="0"
+                                                    Padding="0" ToolTip="Click to copy">
+                                                <Button.Template>
+                                                    <ControlTemplate TargetType="Button">
+                                                        <ContentPresenter/>
+                                                    </ControlTemplate>
+                                                </Button.Template>
+                                                <TextBlock FontFamily="{DynamicResource AppMonoFontFamily}"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="{Binding Text}"/>
+                                                            <Setter Property="Foreground" Value="#88FFFFFF"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Copied}" Value="True">
+                                                                    <Setter Property="Text" Value="copied ✓"/>
+                                                                    <Setter Property="Foreground" Value="#FFD4A847"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                             <ContentPresenter/>
                         </DockPanel>
                         <Button x:Name="PART_ExportButton"

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1009,12 +1009,14 @@
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="  ·  " Foreground="#55FFFFFF"
-                                                       FontFamily="{DynamicResource AppMonoFontFamily}"
-                                                       FontSize="{DynamicResource AppFontSizeSmall}"
-                                                       VerticalAlignment="Center">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
+                                            <!-- Separator drawn as a centered Ellipse, not a
+                                                 font glyph: U+00B7 sits on the baseline in the
+                                                 mono font and reads as a period. A shape is
+                                                 font-independent and always vertically centered. -->
+                                            <Ellipse Width="3" Height="3" Margin="7,0"
+                                                     VerticalAlignment="Center" Fill="#88FFFFFF">
+                                                <Ellipse.Style>
+                                                    <Style TargetType="Ellipse">
                                                         <Setter Property="Visibility" Value="Visible"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding IsFirst}" Value="True">
@@ -1022,8 +1024,8 @@
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
+                                                </Ellipse.Style>
+                                            </Ellipse>
                                             <Button Command="{Binding CopyCommand}" Cursor="Hand"
                                                     Background="Transparent" BorderThickness="0"
                                                     Padding="0" ToolTip="Click to copy">

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1009,10 +1009,13 @@
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
-                                            <!-- Separator drawn as a centered Ellipse, not a
-                                                 font glyph: U+00B7 sits on the baseline in the
-                                                 mono font and reads as a period. A shape is
-                                                 font-independent and always vertically centered. -->
+                                            <!-- All three row items (Ellipse + both chip Buttons)
+                                                 are VerticalAlignment=Center so the dot sits at
+                                                 the text's optical centre. Without centring, the
+                                                 chip text stretches and draws from the top of its
+                                                 line box while a centred dot lands near the
+                                                 baseline — reading as a period. The separator is a
+                                                 shape, not a glyph, so it is also font-independent. -->
                                             <Ellipse Width="3" Height="3" Margin="7,0"
                                                      VerticalAlignment="Center" Fill="#88FFFFFF">
                                                 <Ellipse.Style>
@@ -1028,14 +1031,16 @@
                                             </Ellipse>
                                             <Button Command="{Binding CopyCommand}" Cursor="Hand"
                                                     Background="Transparent" BorderThickness="0"
-                                                    Padding="0" ToolTip="Click to copy">
+                                                    Padding="0" VerticalAlignment="Center"
+                                                    ToolTip="Click to copy">
                                                 <Button.Template>
                                                     <ControlTemplate TargetType="Button">
                                                         <ContentPresenter/>
                                                     </ControlTemplate>
                                                 </Button.Template>
                                                 <TextBlock FontFamily="{DynamicResource AppMonoFontFamily}"
-                                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                                           FontSize="{DynamicResource AppFontSizeSmall}"
+                                                           VerticalAlignment="Center">
                                                     <TextBlock.Style>
                                                         <Style TargetType="TextBlock">
                                                             <Setter Property="Text" Value="{Binding Text}"/>

--- a/src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs
@@ -106,6 +106,19 @@ public sealed class LorebookDetailViewModel
             ? InternalName
             : $"{EnvelopeKey} / {InternalName}";
 
+    /// <summary>
+    /// Footer identifiers as independent copyable segments, bound to
+    /// <c>DetailExportHost.FooterSegments</c> (each renders as its own click-to-copy
+    /// chip joined by an inert middot). For real lorebooks the envelope key and
+    /// InternalName always diverge → two segments <c>[Book_101, TheWastedWishes]</c>;
+    /// the defensive equal case collapses to a single segment. This replaces copying
+    /// the joined <see cref="FooterText"/> slug, which was never a valid identifier.
+    /// </summary>
+    public IReadOnlyList<string> FooterSegments =>
+        string.Equals(EnvelopeKey, InternalName, StringComparison.Ordinal)
+            ? new[] { InternalName }
+            : new[] { EnvelopeKey, InternalName };
+
     /// <summary><c>"from &lt;category display title&gt;"</c> or null when uncategorized.</summary>
     public string? CategorySubtitle { get; }
 

--- a/src/Silmarillion.Module/Views/LorebookDetailView.xaml
+++ b/src/Silmarillion.Module/Views/LorebookDetailView.xaml
@@ -24,7 +24,7 @@
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Footer ("Book_NNN / Name") is owned by the wrapping DetailExportHost (FooterText). -->
+            <!-- Footer is owned by the wrapping DetailExportHost via FooterSegments (independent click-to-copy chips: envelope key + InternalName). -->
 
             <StackPanel>
                 <!-- ─── Header: title + category subtitle ─── -->

--- a/src/Silmarillion.Module/Views/LorebookDetailView.xaml
+++ b/src/Silmarillion.Module/Views/LorebookDetailView.xaml
@@ -20,7 +20,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterText="{Binding FooterText}">
+    <c:DetailExportHost FooterSegments="{Binding FooterSegments}">
 
     <Border Padding="14,12">
         <DockPanel>

--- a/tests/Mithril.Shared.Tests/Wpf/DetailExportHostSegmentTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/DetailExportHostSegmentTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Threading;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Locks the null/empty-filter projection contract of
+/// <c>DetailExportHost.OnFooterSegmentsChanged</c>. <c>DetailExportHost</c> is a
+/// <c>ContentControl</c> and requires an STA thread; we follow the same pattern as
+/// <c>QueryFilterTests</c> — each test runs inside a short-lived STA thread.
+/// </summary>
+public sealed class DetailExportHostSegmentTests
+{
+    [Fact]
+    public void FooterSegments_NullAndEmpty_AreFiltered_ValidSegmentsProjected()
+    {
+        RunOnSta(() =>
+        {
+            var host = new DetailExportHost();
+            host.FooterSegments = ["A", null!, "", "B"];
+
+            host.FooterSegmentItems.Should().HaveCount(2);
+            host.FooterSegmentItems[0].Text.Should().Be("A");
+            host.FooterSegmentItems[0].IsFirst.Should().BeTrue();
+            host.FooterSegmentItems[1].Text.Should().Be("B");
+            host.FooterSegmentItems[1].IsFirst.Should().BeFalse();
+            host.HasFooterSegments.Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public void FooterSegments_NullInput_ProducesEmptyItemsAndFalseFlag()
+    {
+        RunOnSta(() =>
+        {
+            var host = new DetailExportHost();
+            host.FooterSegments = null;
+
+            host.FooterSegmentItems.Should().BeEmpty();
+            host.HasFooterSegments.Should().BeFalse();
+        });
+    }
+
+    [Fact]
+    public void FooterSegments_AllNullOrEmpty_ProducesEmptyItemsAndFalseFlag()
+    {
+        RunOnSta(() =>
+        {
+            var host = new DetailExportHost();
+            host.FooterSegments = [null!, "", null!];
+
+            host.FooterSegmentItems.Should().BeEmpty();
+            host.HasFooterSegments.Should().BeFalse();
+        });
+    }
+
+    [Fact]
+    public void FooterSegments_WhitespaceOnly_IsNotFiltered()
+    {
+        // The filter is !string.IsNullOrEmpty, so whitespace-only strings pass through.
+        RunOnSta(() =>
+        {
+            var host = new DetailExportHost();
+            host.FooterSegments = [" "];
+
+            host.FooterSegmentItems.Should().ContainSingle()
+                .Which.Text.Should().Be(" ");
+            host.HasFooterSegments.Should().BeTrue();
+        });
+    }
+
+    private static void RunOnSta(Action action)
+    {
+        Exception? captured = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+            finally
+            {
+                System.Windows.Threading.Dispatcher.CurrentDispatcher.InvokeShutdown();
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.IsBackground = true;
+        thread.Start();
+        thread.Join();
+        if (captured is not null) throw captured;
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
@@ -34,6 +34,38 @@ public sealed class LorebookDetailViewModelTests
     }
 
     [Fact]
+    public void FooterSegments_DivergentKeyAndName_AreTwoIndependentSegments()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes",
+            Title = "The Wasted Wishes", Text = "x",
+        });
+        var vm = BuildDetail(refData, "TheWastedWishes");
+
+        // Each is its own atomic copyable identifier (no " / " mashup).
+        vm.FooterSegments.Should().Equal("Book_101", "TheWastedWishes");
+        // Back-compat: joined FooterText preserved for non-UI consumers.
+        vm.FooterText.Should().Be("Book_101 / TheWastedWishes");
+    }
+
+    [Fact]
+    public void FooterSegments_KeyEqualsName_IsSingleSegment()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("SameName", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "SameName",
+            Title = "Same", Text = "x",
+        });
+        var vm = BuildDetail(refData, "SameName");
+
+        vm.FooterSegments.Should().ContainSingle().Which.Should().Be("SameName");
+        vm.FooterText.Should().Be("SameName");
+    }
+
+    [Fact]
     public void AreaChip_ResolvesFromFirstMatchingKeyword()
     {
         var refData = new FakeReferenceData();


### PR DESCRIPTION
## Summary

The Lorebook detail footer rendered a single joined slug `Book_101 / TheWastedWishes`, and the recently-added click-to-copy on `DetailExportHost` copied that mashup verbatim — not a valid identifier. This splits it into independently click-to-copy segments.

- **`DetailExportHost`** (shared): new general `FooterSegments` (`IEnumerable<string>`) DP, projected to per-item-ack `FooterSegmentItem`s rendered as independent click-to-copy chips joined by an inert separator. Single-segment views keep using `FooterText` unchanged — the 6 `FooterText` views + Effect/StorageVault (no footer) are provably unaffected (`HasFooterSegments` defaults false, only set by the segments path).
- **`LorebookDetailViewModel`**: `FooterSegments` = `[EnvelopeKey, InternalName]` (single element when they coincide). `FooterText` kept for back-compat.
- **`LorebookDetailView`**: binds `FooterSegments`.
- Separator drawn as a vertically-centered `Ellipse` (not a font glyph) and all chip row items centered — fixes a period-looking separator caused by line-box top-alignment of stretched chip text (not the glyph).

Spec: `docs/superpowers/specs/2026-05-15-detail-footer-copyable-segments-design.md`
Plan: `docs/superpowers/plans/2026-05-15-detail-footer-copyable-segments.md`

## Test Plan

- [x] `dotnet build Mithril.slnx` clean on a fresh checkout (RG1000 BAML race was a local stale-`obj` artifact only; verified clean via isolated module build + fresh-pull build)
- [x] `dotnet test Mithril.slnx` — all assemblies green incl. Silmarillion.Tests 423/423 and Mithril.Shared.Tests 959/959
- [x] New TDD tests: `LorebookDetailViewModelTests.FooterSegments_*` (divergent → 2 segments, equal → 1; `FooterText` back-compat preserved)
- [x] New projection contract test: `DetailExportHostSegmentTests` (null/empty filtered, `HasFooterSegments`, `IsFirst`)
- [x] Manual smoke: Lorebooks tab → select a book → footer shows `Book_NNN  ·  InternalName`; click each chip → only that chip acks "copied ✓" and clipboard holds exactly that one identifier; a `FooterText`-only view (e.g. Abilities) still copies/acks as before; exported card image height unchanged; separator reads as a centered dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)