### PR TITLE
docs(silmarillion): field-coverage doc + roadmap reconciliation

### DIFF
--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -1,0 +1,141 @@
+# Silmarillion · detail-view field coverage
+
+> **Companion to [silmarillion-roadmap.md](silmarillion-roadmap.md).** The roadmap
+> answers *which entities get a tab* (the Bucket A/B/C/D rule). This doc answers a
+> different question: *within a shipped detail view, which POCO properties reach the
+> user, which are deliberately omitted, and which are genuine gaps.*
+
+## Why this is its own axis
+
+Every CDN source has a faithful `Mithril.Reference` POCO (parser coverage is total —
+see [mithril-reference-roadmap.md](mithril-reference-roadmap.md)). A detail view is a
+*curated projection* of that POCO, not a property dump: the right design surfaces the
+player-relevant mechanics and drops engine noise. So "property X is not bound" is not
+automatically a defect — it is only a defect if X is player-relevant.
+
+The purpose of this doc is to make that judgement **once, explicitly**, so the
+deliberate omissions don't get re-flagged as gaps every time someone eyeballs a POCO
+next to its view (the same phantom-gap problem ai.json / itemuses.json had at the
+reference-library layer).
+
+## Omission taxonomy
+
+Unsurfaced properties fall into one of these classes. The first four are
+**deliberate-by-design** and should stay omitted; the last is the only one worth
+filing issues against.
+
+| Class | Examples | Verdict |
+|---|---|---|
+| **VFX / appearance** | `Particle`, `LoopParticle`, `SelfParticle`, `TargetParticle`, `*Appearance*` | Omit — irrelevant to a reference browser |
+| **Animation timing** | `UsageAnimation`, `UsageAnimationEnd`, `UsageDelay`, `*Delay*` | Omit — engine playback detail |
+| **Engine / lifecycle flags** | `IsClientLocal`, `DeleteFromHistoryIfVersionChanged`, `AttuneOnPickup`, internal IDs (`ID`, envelope `Key`) | Omit — not player-facing semantics |
+| **Raw keyword/tag lists** | `Keywords` on most entities | Usually omit — internal predicate tokens, not human-readable; surface only when a slot/filter consumes them |
+| **Player-relevant mechanic, unsurfaced** | recipe gating, costs, cooldowns, prerequisite chains; quest narrative prose | **Candidate gap — file an issue** |
+
+A property is a *candidate gap* only if it changes what a player would do/expect and
+we already render the same class of data on another entity. Consistency across tabs is
+the test: if Quest and StorageVault render a polymorphic `Requirements` block but
+Recipe drops its `OtherRequirements`, that asymmetry is a gap, not a design choice.
+
+---
+
+## Recipe — VERIFIED 2026-05-16
+
+The one entity audited against source directly
+([Recipe.cs](../src/Mithril.Reference/Models/Recipes/Recipe.cs),
+[RecipeDetailViewModel.cs](../src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs),
+[RecipeDetailView.xaml](../src/Silmarillion.Module/Views/RecipeDetailView.xaml)).
+
+**Surfaced:** `IconId`, `Name`→`DisplayName`, `InternalName` (footer), `Description`,
+`Skill`+`SkillLevelReq` (chip, skill resolved to display name), `MaxUses` (chip),
+`Ingredients` (item chips), keyword-slot ingredients (provenance popup, #318),
+`ResultItems`/`ProtoResultItems`→"Produces", `ResultEffects` (plain-text stub, #214),
+recipe sources ("Taught by", from `sources_recipes.json`).
+
+**Deliberate omissions** (taxonomy classes 1–4): `Key`, `UsageAnimation`,
+`UsageAnimationEnd`, `UsageDelay`, `UsageDelayMessage`, `ActionLabel`, `Particle`,
+`LoopParticle`, `SortSkill`, `DyeColor`, all `ItemMenu*`, `Keywords`,
+`ValidationIngredientKeywords`, `RewardSkillXpDropOff*`, `RewardAllowBonusXp`,
+`NumResultItems`, `RequiredAttributeNonZero`, `ResultEffectsThatCanFail`.
+
+**Candidate gaps — player-relevant, unsurfaced (class 5).** Prevalence measured
+against the bundled `recipes.json` (v470, 4427 entries) on 2026-05-16 — the gap is
+*not* uniform, so it is not one issue:
+
+| Property | Recipes carrying it | Why it matters | Precedent |
+|---|---|---|---|
+| **`PrereqRecipe`** | **2004 (~45%)** | Prerequisite-recipe chain — a primary crafting-progression axis | Navigable cross-link shape already exists (`EntityRef` → same Recipes tab); identical to how `Ingredients`/`Produces` chips work |
+| `OtherRequirements` | 90 (~2%) | Polymorphic recipe gating (who/what can run it) | Quest & StorageVault render their `Requirements` as typed rows |
+| `ResetTimeInSeconds` | 51 (~1.2%) | Cooldown duration | We render the *cap* half (`MaxUsesChip`, 91 recipes ≈ same prevalence); the *cooldown* half is conspicuously absent |
+| `SharesResetTimerWith` | 21 (~0.5%) | Shared-cooldown grouping | Pairs with the above |
+| `Costs` | 55 (~1.2%) | Currency/item cost to perform the recipe | No equivalent rendered anywhere; standalone |
+
+**This is two findings, not one:**
+
+1. **`PrereqRecipe` — broad, structural, high-value.** ~45% of all recipes have a
+   prerequisite the browser shows nowhere. It is a *navigable cross-link* (recipe →
+   prerequisite recipe), which is precisely what Silmarillion's chip model is built for
+   — the same shape as the already-shipped ingredient/produces chips, just an unwired
+   edge. This is the priority and stands alone as an issue.
+2. **`OtherRequirements` + `Costs` + reset-timer pair — long-tail completeness.**
+   1–2% each. Worth a single "recipe-detail completeness" pass for parity with how we
+   treat Quest/StorageVault requirements and our own `MaxUsesChip`, but low-traffic and
+   clearly secondary to (1). The reset-timer omission is the sharpest of these because
+   the *consistency* break is measurable: comparable prevalence to `MaxUses`, which we
+   do surface.
+
+**Tracked in:** #341 (`PrereqRecipe` cross-link — priority) · #342 (completeness
+trio: `OtherRequirements` + `Costs` + reset-timer — lower-priority).
+
+---
+
+## Other shipped detail views — AUDIT BASELINE (unverified) 2026-05-16
+
+> **Verification owed.** The rows below come from an automated field-coverage audit,
+> not a line-by-line source read. Treat as a baseline, not ground truth: when a tab is
+> next touched, spot-verify its row and promote it to a VERIFIED section like Recipe's.
+> Coverage is described qualitatively on purpose — the audit's percentages were
+> estimates and are deliberately not reproduced here as fact.
+
+| Entity | Coverage shape | Deliberate omissions (taxonomy 1–4) | Candidate gaps (class 5) |
+|---|---|---|---|
+| **Npc** | Comprehensive — slim POCO, fully surfaced | `AreaFriendlyName` (resolution fallback only) | None apparent |
+| **Area** | Comprehensive | `ShortFriendlyName` filtered when == `FriendlyName` | None apparent |
+| **Effect** | Near-complete | `Particle` (VFX), `SpewText` (combat-log string) | None apparent |
+| **Lorebook** | Near-complete | `IsClientLocal`, `Visibility`, `Keywords`, `InternalName` | None apparent |
+| **PlayerTitle** | Near-complete | `Keywords` | None apparent |
+| **StorageVault** | Near-complete | `ID`, `Grouping` label, `SlotAttribute` | None apparent |
+| **Ability** | Moderate — large POCO, core mechanics surfaced | Many VFX/animation/flag fields, attribute-delta lists, `SpecialInfo` | None confirmed — large flag tail is mostly class-3 noise |
+| **Quest** | Moderate — typed objectives/requirements/rewards surfaced | Engine flags, `Reward_SkillLevels` dict | `PrefaceText` / `SuccessText` / `MidwayText` narrative prose — debatable; some players want lore text |
+
+### Modeled but no detail view (by design — not gaps)
+
+- **Item** — browsable in the Items master list; dedicated detail pane deferred per
+  the roadmap ("cheapest standalone win once core entity tabs are in"). Cross-link
+  infrastructure exists; the right-pane view does not. Tracked on the Roadmap Project.
+- **Skill** — intentionally folded into Recipe/Ability tabs as chip/metadata
+  (~30 skills; a dedicated tab adds little). No standalone tab planned.
+- **Landmark** — non-standalone by design: renders inside Area detail as grouped
+  provenance rows. Not a defect.
+
+---
+
+## Acting on this doc
+
+- **`PrereqRecipe` cross-link** (#341) — the priority. ~45% of recipes affected; a
+  navigable edge in Silmarillion's existing chip model.
+- **Recipe-detail completeness pass** (#342) — `OtherRequirements` + `Costs` +
+  reset-timer; long-tail (1–2% each) but a parity/consistency fix. Do after #341.
+- Quest narrative prose is a *judgement call*, not a clear gap — decide before filing.
+- Everything else unsurfaced is deliberate; do not file "increase coverage" issues
+  against it. If a future audit re-flags class 1–4 properties, point it here.
+
+## History
+
+- **2026-05-16** — Recipe candidate gaps quantified against bundled `recipes.json`
+  (v470). Reframed from one combined issue to two: `PrereqRecipe` (~45%, broad,
+  cross-linkable — priority) vs. a long-tail completeness trio (1–2% each). Grounding
+  measure, not inference. Filed as #341 (priority) and #342 (completeness).
+- **2026-05-16** — Doc created. Recipe verified against source; remaining eight
+  shipped detail views recorded as an unverified audit baseline. Field-coverage
+  established as an axis distinct from the roadmap's tab-bucketing rule.

--- a/docs/silmarillion-roadmap.md
+++ b/docs/silmarillion-roadmap.md
@@ -1,6 +1,8 @@
 # Silmarillion · Reference Browser — roadmap
 
 > **Active backlog:** [Mithril Roadmap Project — `Module: Silmarillion`](https://github.com/users/arthur-conde/projects/3/views/1?filterQuery=module%3A%22Silmarillion%22).
+>
+> **Sibling doc:** [silmarillion-field-coverage.md](silmarillion-field-coverage.md) — *within* a shipped tab, which POCO fields render vs. are deliberately omitted vs. are gaps. This doc is the *which-entities-get-a-tab* axis; that one is the *which-fields-within-a-tab* axis.
 
 What shipped in v1 and the rationale for which CDN sources will (and won't) become future tabs. Per-item *task tracking* lives in Issues; this doc keeps the design narrative — *why* each piece was scoped this way, and the bucketing rule that decides what becomes a tab.
 
@@ -11,9 +13,9 @@ Project Gorgon's CDN serves **29 reference-data files** (pg-data MCP, v470). Eve
 Silmarillion v1 (PR #236, merged 2026-05-13) shipped the two highest-payoff browse surfaces: **Items** and **Recipes**. The architecture is built to fan out:
 
 - [`EntityRef`](../src/Mithril.Shared/Reference/EntityRef.cs) enumerates 11 entity kinds — `Item, Recipe, Ability, Effect, Npc, Quest, Lorebook, Landmark, Area, PlayerTitle, StorageVault` — plus one synthetic deep-link variant (`RecipeIngredientKeyword`, added by #259) used to route keyword chips into a pre-filtered Recipes tab; the synthetic kind isn't a CDN source and isn't part of the Bucket A/B/C/D classification below. Cross-link chips for kinds without a registered `IReferenceKindTarget` render as plain text and silently become navigable the moment that target ships (#239 retired the old `V1TabbedKinds` HashSet).
-- The master-detail pattern (`MithrilQueryBox` → virtualised list → detail pane with cross-link chips) is duplicable per tab — adding a tab is `TabItem + View + ViewModel + EntityKind handling + V1TabbedKinds entry`.
+- The master-detail pattern (`MithrilQueryBox` → virtualised list → detail pane with cross-link chips) is duplicable per tab — adding a tab is `TabItem + View + ViewModel + EntityKind handling` plus registering an `IReferenceKindTarget` (the old `V1TabbedKinds` gate was retired by #239).
 
-This doc is the rationale for which of the remaining 27 CDN sources warrant that duplication.
+This doc is the rationale for which of the CDN sources warrant that duplication. **As of 2026-05-15 every Bucket B tab has shipped** — the sections below are now the *as-built record + design rationale*, not a deferral plan. The bucketing rule itself still governs any future source.
 
 ## What shipped in v1
 
@@ -30,71 +32,83 @@ A CDN source earns a tab if it is **an enumerable set of player-recognisable ent
 
 Applied to the 29 sources:
 
-| Bucket | Count | Treatment |
-|---|---|---|
-| A — Already a tab | 2 | `items`, `recipes` |
-| B — Should become a tab | 9 | Every remaining `EntityKind` value (see deferred sections below) |
-| C — Fold into a Bucket-A or -B tab | 10 | Provider / index / sub-tables that surface as sections, filters, or sidecars within a parent tab |
-| D — Never a tab | 8 | Lookup / engine-internal / raw-projection feeds |
+| Bucket | Count | Status | Treatment |
+|---|---|---|---|
+| A — Tab (v1) | 2 | ✅ Shipped 2026-05-13 | `items`, `recipes` (#207, PR #236) |
+| B — Tab | 9 | ✅ All shipped 2026-05-14 → 05-15 | One tab per remaining `EntityKind` — **except `Landmark`, which folded into the Areas tab as a provenance section rather than a sibling tab** (#318 slice 4, PR #324). 8 tabs cover the 9 kinds. |
+| C — Fold into a Bucket-A or -B tab | 10 | Mixed (see table) | Provider / index / sub-tables that surface as sections, filters, or sidecars within a parent tab |
+| D — Never a tab | 8 | n/a | Lookup / engine-internal / raw-projection feeds |
 
 Totals: 2 + 9 + 10 + 8 = 29, and Bucket A + Bucket B covers every `EntityKind` value that maps to a CDN source. (`EntityKind` also carries the synthetic `RecipeIngredientKeyword` variant noted above; it's deep-link routing, not a tab.)
 
-## Out of scope for v1 — tabs deferred (Bucket B)
+> **Field-level coverage is a separate axis.** A shipped tab does not mean every POCO
+> field is rendered — see [silmarillion-field-coverage.md](silmarillion-field-coverage.md)
+> for which properties each detail view surfaces, omits by design, or genuinely misses.
 
-### NPCs
+## Bucket B — shipped (as-built record + design rationale)
 
-**Why deferred:** Highest cross-link payoff in Bucket B (recipe teachers, item sources, gift preferences via Arwen, quest givers / turn-ins) — but a full NPC card has its own polymorphism (`Services`, `Preferences`, `ItemGifts`) that wasn't in scope for the v1 master-detail spike. v1 prioritised proving the pattern on simpler entities first.
+All eight tabs landed 2026-05-14 → 05-15, in roughly cross-link-dependency order. The
+*why this shape* rationale is retained because it still explains how each detail view
+is built; status and any deviation-from-plan are called out per entity.
 
-**Likely approach:** Third tab using the same `TabItem + View + ViewModel` shape. Detail pane surfaces Services (Store / Barter / Consignment / Training), gift-preference chips, and back-links to areas. Unblocks the recipe-sources cross-link target (i.e. "this recipe is taught by NPC X" becomes a live link).
+### NPCs — ✅ #241 (PR #280, 2026-05-14), first Bucket B tab
 
-### Quests
+**Design rationale:** Highest cross-link payoff in Bucket B (recipe teachers, item sources, gift preferences via Arwen, quest givers / turn-ins). A full NPC card has its own polymorphism (`Services`, `Preferences`, `ItemGifts`) — built first among Bucket B so the recipe-sources cross-link target ("this recipe is taught by NPC X") became a live link.
 
-**Why deferred:** Quest POCOs are the most mature in the codebase (Phase 1 canary: 25 requirement T-values, 9 reward T-values, full validation harness coverage). The deferral is UI-only — no parser obstacle.
+**As built:** Same `TabItem + View + ViewModel` shape. Detail pane surfaces Services (Store / Barter / Consignment / Training), gift-preference chips, and back-links to areas. Follow-ups: skill-name resolution in Training rows + Store cap-keyword chips (#292, PR #294), Consignment ItemTypes as keyword chips (#299, PR #300).
 
-**Likely approach:** Card-style tab listing quests; detail pane renders objectives, requirements, and rewards as typed chips. `directedgoals.json` folds in as a filter chip ("guided objectives"), not its own tab.
+### Quests — ✅ #242 (PR #286, 2026-05-14)
 
-### Abilities and Effects
+**Design rationale:** Quest POCOs are the most mature in the codebase (Phase 1 canary: 25 requirement T-values, 9 reward T-values, full validation harness coverage). The deferral was UI-only — no parser obstacle.
 
-**Why deferred together:** Abilities (8.7 MB) and Effects (6.5 MB) are paired — items and abilities already reference effect strings, so neither tab is complete without the other. Both are large enough that the master-detail spike needs a real design pass, not a copy-paste from Recipes.
+**As built:** Card-style tab; detail pane renders objectives, requirements, and rewards as typed chips. `directedgoals.json` fold-in as a "guided objectives" filter chip is the *intended* sidecar treatment (Bucket C) — verify it actually shipped before relying on it; the tab itself does not depend on it.
 
-**Likely approach:** Sequence Abilities first (so Effects' cross-link chips have destinations on both ends), then Effects. The three conditional-rule sub-tables (`abilitykeywords`, `abilitydynamicdots`, `abilitydynamicspecialvalues`) fold into the **Effects tab**, not Abilities — they're predicate-shaped rules engines (`ReqAbilityKeywords` / `ReqEffectKeywords` / `ReqActiveSkill` → attribute deltas / DoTs / tooltip values), more naturally consumed effect-side than ability-side. Plumbing tracked separately as #288.
+### Abilities and Effects — ✅ Abilities #243 (PR #293, 2026-05-14), Effects #244 (PR #298, 2026-05-14)
 
-### Areas and Landmarks
+**Design rationale:** Abilities (8.7 MB) and Effects (6.5 MB) are paired — items and abilities reference effect strings, so neither tab is complete without the other. Sequenced Abilities first so Effects' cross-link chips had destinations on both ends, then Effects. Abilities shipped with the `ITabViewModel` refactor that the multi-tab module needed.
 
-**Why deferred:** Geographic browsing is genuinely useful for context (where does this quest happen, where does this NPC live) but lower-payoff than the entity-centric tabs above. Areas and Landmarks share a near-identical card shape, so they're best built as a pair.
+**As built:** The three conditional-rule sub-tables (`abilitykeywords`, `abilitydynamicdots`, `abilitydynamicspecialvalues`) fold into the **Effects tab**, not Abilities — they're predicate-shaped rules engines (`ReqAbilityKeywords` / `ReqEffectKeywords` / `ReqActiveSkill` → attribute deltas / DoTs / tooltip values), naturally consumed effect-side. That sub-table plumbing is tracked separately as **#288**; the Effects tab shipped independently of it. The effect→abilities cross-link was reworked to a provenance-retaining index + popup (#318 slices 1–3, PRs #320/#321).
 
-**Likely approach:** Areas tab as the parent (geographic root, contextualises NPCs and Quests); Landmarks as a sibling that always cross-links to its parent Area.
+### Areas and Landmarks — ✅ Areas #245 (closes #246, PR #310, 2026-05-15)
 
-### Lorebooks
+**Design rationale:** Geographic browsing contextualises quests and NPCs (where does this happen, where does this NPC live) — lower-payoff than the entity-centric tabs, so built after them.
 
-**Why deferred:** Self-contained narrative content; ideal master-detail shape (list of titles → page body) but no urgent cross-link demand. `lorebookinfo` becomes sidecar metadata in the same tab.
+**Deviation from plan:** The original plan was "Landmarks as a sibling tab cross-linking to its parent Area." **As built, Landmark did not get its own tab** — it folds into the Areas detail pane as a grouped provenance popup ("NPCs in this area" + landmarks by type), via #318 slice 4 surface 4 (PR #324, folds in #311). `Landmark` remains an `EntityKind` for deep-link routing but is not independently browsable. This is the one Bucket B entity whose treatment changed from the plan.
 
-**Likely approach:** Standalone tab with a long-form detail body. The cheapest standalone win once the core entity tabs are in.
+### Lorebooks — ✅ #247 (PR #322, 2026-05-15)
 
-### PlayerTitles and StorageVaults
+**Design rationale:** Self-contained narrative content; ideal master-detail shape (list of titles → page body), no urgent cross-link demand — a cheap standalone win once the core entity tabs were in. `lorebookinfo` is the intended in-tab metadata sidecar (Bucket C).
 
-**Why deferred:** Both are completionist / long-tail tabs — small, low-traffic, no blocking dependency. PlayerTitles cross-links from Quests; StorageVaults complements Bilbo's existing inventory view.
+**As built:** Standalone tab with a long-form detail body; inbound `Item.BestowLoreBook → Lorebook` 1:1 chip (#247 slice e). Detail footer later reworked to copyable key/name segments (2026-05-15).
 
-**Likely approach:** Ship together when higher-priority tabs are done, or defer if Bucket B scope tightens.
+### PlayerTitles and StorageVaults — ✅ PlayerTitles #248 (PR #328), StorageVaults #249 (PR #329), 2026-05-15
+
+**Design rationale:** Completionist / long-tail tabs — small, low-traffic, no blocking dependency. PlayerTitles cross-links from Quests; StorageVaults complements Bilbo's existing inventory view. Shipped last, together, as the Bucket B closeout.
+
+**As built:** Both standard master-detail tabs. (A sequential-merge splice between #328 and #329 was caught and repaired — #331, PR #331 — with no shipped impact.)
 
 ---
 
 ## Bucket C — folded into existing tabs (not their own tab)
 
-| Source | Folds into | How it surfaces |
-|---|---|---|
-| `sources_items` | Items tab | Sources section in item detail (already used in v1) |
-| `sources_recipes` | Recipes tab | Sources section in recipe detail (filed as a v1 follow-up) |
-| `sources_abilities` | Abilities tab (when shipped) | Sources section in ability detail |
-| `itemuses` | Items tab | "Where is this consumed" reverse-lookup section |
-| `lorebookinfo` | Lorebooks tab (when shipped) | Title / category metadata sidecar |
-| `directedgoals` | Quests tab (when shipped) | Filter chip alongside regular quests |
-| `abilitykeywords` | Effects tab (when shipped) | Conditional attribute-delta rules predicated on `MustHaveAbilityKeywords` — effect-side, not ability-side. Tracked: #288 |
-| `abilitydynamicdots` | Effects tab (when shipped) | Conditional DoT rules predicated on `ReqAbilityKeywords` + `ReqActiveSkill` + `ReqEffectKeywords`. Tracked: #288 |
-| `abilitydynamicspecialvalues` | Effects tab (when shipped) | Conditional ability-tooltip values predicated on `ReqAbilityKeywords` + `ReqEffectKeywords`. Tracked: #288 |
-| `skills` | Recipes + Abilities tabs | Filter chips and skill-level metadata; small enough (~30 skills) that a dedicated tab adds little |
+All parent tabs now exist, so "(when shipped)" no longer applies. The remaining
+distinction is whether the *fold-in itself* has landed (verified) vs. is still the
+intended-but-unverified treatment.
 
-These would each require their own master-detail just to render a row count and a few fields — better as enrichment of a parent entity.
+| Source | Folds into | Fold-in status | How it surfaces |
+|---|---|---|---|
+| `sources_items` | Items tab | ✅ Shipped v1 (#236) | Sources section in item detail |
+| `sources_recipes` | Recipes tab | ✅ Shipped (#235, PR #258) | "Taught by" / sources section in recipe detail |
+| `itemuses` | Items tab | ✅ Shipped (#318 slice 4, PRs #323/#325) | "Used in" / "Used as" → provenance popup (replaced the naive synthetic-kind fan-out; retired `RecipeIngredientItem`/`RecipeIngredientKeyword`) |
+| `sources_abilities` | Abilities tab | ✅ Shipped (#243) | Sources block in ability detail (`AbilityDetailViewModel` reads `IReferenceDataService.AbilitySources`; `AbilitiesTabViewModel` subscribes to the file) |
+| `lorebookinfo` | Lorebooks tab | ✅ Shipped (#247) | Category-title resolution + grouping — `LorebooksTabViewModel` consumes `IReferenceDataService.LorebookCategories` to build `LorebookCategoryGroup`s with resolved `CategoryDisplayTitle` (it is a list grouping, not a per-detail sidecar) |
+| `directedgoals` | ~~Quests tab~~ — none | ✋ **Skipped by decision (2026-05-16)** | Originally planned as a "guided objectives" filter chip in the Quests tab; consciously **not built**. Grounded reason (data inspected v470): it is the *only* Bucket C source with **no foreign keys to any other entity**. Contents = 9 zone "category gates" + freeform newbie hint cards (`Label` + two prose paragraphs `LargeHint`/`SmallHint`). `Zone` is a display string, not an `areas.json` key; `CategoryGateId` only self-joins within `directedgoals`; entity mentions ("Ivyn the farmer", "Therese in Serbule") exist only as English prose in the hint text — extracting them is NLP, not a join. Every other Bucket C source is a join/cross-link provider, which is exactly what Silmarillion's chip-driven master-detail exploits; this one offers nothing to anchor, so the module's core strength can't be applied. Effectively Bucket D in hindsight, kept in this row for traceability rather than re-numbering the buckets. Not a backlog item — no issue to file. |
+| `abilitykeywords` | Effects tab | 🔲 Tracked #288 | Conditional attribute-delta rules predicated on `MustHaveAbilityKeywords` — effect-side, not ability-side |
+| `abilitydynamicdots` | Effects tab | 🔲 Tracked #288 | Conditional DoT rules predicated on `ReqAbilityKeywords` + `ReqActiveSkill` + `ReqEffectKeywords` |
+| `abilitydynamicspecialvalues` | Effects tab | 🔲 Tracked #288 | Conditional ability-tooltip values predicated on `ReqAbilityKeywords` + `ReqEffectKeywords` |
+| `skills` | Recipes + Abilities tabs | ✅ Shipped | Filter chips and skill-level metadata; small enough (~30 skills) that a dedicated tab adds little |
+
+These would each require their own master-detail just to render a row count and a few fields — better as enrichment of a parent entity. All fold-ins above were verified against source on 2026-05-16 except the three #288 sub-tables (still tracked) and `directedgoals`, which was **consciously dropped** as low-value (see its row). This is a closed decision, not an open gap — do not re-file it as a backlog item when a future audit notices the Quests tab has no guided-objectives chip; point that audit here.
 
 ## Bucket D — never a tab
 
@@ -116,3 +130,6 @@ These would each require their own master-detail just to render a row count and 
 - **2026-05-13** — v1 shipped (PR #236, Items + Recipes tabs, cross-link navigator, master-detail scaffold). Bucketing rationale captured in this doc; per-tab follow-ups filed against `module:silmarillion` on the [Roadmap Project](https://github.com/users/arthur-conde/projects/3/views/1?filterQuery=module%3A%22Silmarillion%22).
 - **2026-05-13** — `EntityKind` grew the synthetic `RecipeIngredientKeyword` variant via PR #259 (keyword-collapse design for the item-detail "Used as" section, replacing a naive fan-out widening of `RecipesByIngredientItem`). Sets the precedent for "deep-link to a tab with pre-filled query" as a kind-target shape distinct from "select a row by name."
 - **2026-05-14** — Bucket C reclassification: `abilitykeywords`, `abilitydynamicdots`, `abilitydynamicspecialvalues` move from "folds into Abilities tab" to "folds into Effects tab" (#288). Data-shape verification during the #243 Abilities handoff drafting showed these are predicate-keyed conditional rules engines, not per-ability metadata; their natural rendering destination is effect-side, not ability-side. Bucket math unchanged (still 10 entries in C, 29 total).
+- **2026-05-14 → 05-15** — **Bucket B fully shipped.** NPCs #241 (PR #280), Quests #242 (#286), Abilities #243 (#293), Effects #244 (#298) on 05-14; Areas #245 (#310), Lorebooks #247 (#322), PlayerTitles #248 (#328), StorageVaults #249 (#329) on 05-15. Cross-link-dependency order (NPCs first to light up recipe-teacher links; Abilities before Effects). The #233 tab-style refactor (PR #272) and the #243 `ITabViewModel` refactor were the multi-tab enablers.
+- **2026-05-15** — **Plan deviation recorded:** `Landmark` did *not* become a sibling tab as the Areas/Landmarks section predicted. It folded into the Areas detail pane as a grouped provenance popup (#318 slice 4 surface 4, PR #324). Bucket B count unchanged (9 kinds, 8 tabs).
+- **2026-05-16** — Doc reframed from deferral plan to as-built record now that all Bucket B tabs shipped; [silmarillion-field-coverage.md](silmarillion-field-coverage.md) split off as the per-field axis. Bucket C "(when shipped)" markers resolved against source: `sources_abilities` and `lorebookinfo` fold-ins confirmed shipped; **`directedgoals` confirmed *not* built** (no module reference; Quests tab shipped without it) — and, by decision the same day, **consciously dropped** after inspecting the v470 data: it is the only Bucket C source with no foreign keys (self-contained prose hint cards), so Silmarillion's cross-link model has nothing to anchor. Recorded as a closed, evidence-backed decision in its Bucket C row.


### PR DESCRIPTION
## What

Documentation-only. Two changes:

1. **New: `docs/silmarillion-field-coverage.md`** — a per-detail-view field-coverage record for the Silmarillion module. Captures, for each shipped tab, which POCO properties are surfaced vs. deliberately omitted vs. a genuine gap, anchored by an **omission taxonomy** (VFX / animation / engine flags / raw keyword lists = deliberate-by-design; player-relevant-unsurfaced = the only class worth filing against). Different axis from the roadmap (which entities get a tab); exists so deliberate omissions don't get re-flagged as gaps on every future audit. Recipe is verified against source; the other eight tabs are a dated, explicitly-marked audit baseline.

2. **Reconciled: `docs/silmarillion-roadmap.md`** — the doc still described Bucket B as "deferred / out of scope for v1" when all eight tabs had in fact shipped. Reframed from a deferral plan to an as-built record with real issue/PR refs, verified from merge history:
   - Bucket B shipping wave recorded (NPCs #241 → StorageVaults #249).
   - **Landmark plan-deviation** recorded honestly: it folded into Areas as a provenance popup rather than the predicted sibling tab.
   - Bucket C `(when shipped)` markers resolved against source — fold-ins confirmed/corrected.
   - **`directedgoals` recorded as a grounded, deliberate skip**: inspecting v470 data showed it is the only Bucket C source with zero foreign keys (self-contained prose hint cards), so Silmarillion's cross-link model has nothing to anchor. Closed decision, not an open gap.

## Issues filed alongside

Recipe candidate gaps were quantified against bundled `recipes.json` (v470) rather than asserted:

- **#341** — `Recipe.PrereqRecipe` unsurfaced; **~45% of recipes (2004/4427)**. Broad, cross-linkable, priority.
- **#342** — completeness trio (`OtherRequirements` / `Costs` / `ResetTimeInSeconds` / `SharesResetTimerWith`), 1–2% each, lower-priority parity fix.

## Scope / safety

Docs only — no code, no build impact. The `roadmap.md` base is byte-identical between this branch and `main`, so the diff is exactly the intended edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— drafted by Claude (Opus 4.7), posted by @arthur-conde
