### PR TITLE
fix(silmarillion): StorageVault detail chips don't navigate (#340)

### DIFF
--- a/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
@@ -1,3 +1,4 @@
+using System.Windows.Input;
 using Mithril.Reference.Models.Misc;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
@@ -53,9 +54,11 @@ public sealed class StorageVaultDetailViewModel
         StorageVaultListRow row,
         IReferenceDataService refData,
         IReferenceNavigator navigator,
-        IEntityNameResolver nameResolver)
+        IEntityNameResolver nameResolver,
+        ICommand? openEntityCommand = null)
     {
         Row = row;
+        OpenEntityCommand = openEntityCommand;
         var vault = row.Vault;
         DisplayName = row.DisplayName;
         EnvelopeKey = row.EnvelopeKey;
@@ -116,6 +119,14 @@ public sealed class StorageVaultDetailViewModel
 
     public StorageVaultListRow Row { get; }
     public string DisplayName { get; }
+
+    /// <summary>
+    /// Cross-link navigation command, supplied by the hosting tab. Bound by every
+    /// <see cref="EntityChip"/> in the view (Area, operator NPC, quest-requirement).
+    /// Null when constructed outside the tab (e.g. design-time / unit fixtures) — the
+    /// chips then render as inert, which is the correct degrade.
+    /// </summary>
+    public ICommand? OpenEntityCommand { get; }
 
     /// <summary>
     /// Envelope key (operator NPC internal name, or a <c>"*"</c>-prefixed account-wide

--- a/src/Silmarillion.Module/ViewModels/StorageVaultsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultsTabViewModel.cs
@@ -146,5 +146,5 @@ public sealed partial class StorageVaultsTabViewModel : ObservableObject, ITabVi
     }
 
     private StorageVaultDetailViewModel BuildDetailViewModel(StorageVaultListRow row) =>
-        new StorageVaultDetailViewModel(row, _refData, _navigator, _nameResolver);
+        new StorageVaultDetailViewModel(row, _refData, _navigator, _nameResolver, OpenEntityCommand);
 }

--- a/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
@@ -217,6 +217,40 @@ public sealed class StorageVaultDetailViewModelTests
         vm.HasAccessRequirements.Should().BeTrue();
     }
 
+    [Fact]
+    public void Chips_Click_NavigatesViaOpenEntityCommand_ThreadedThroughTheTab()
+    {
+        // #340 regression: StorageVaultDetailView.xaml binds every chip's ClickCommand
+        // to DataContext.OpenEntityCommand. If the tab does not thread its command into
+        // the detail VM (every other tab does), the binding resolves to null and the
+        // chip is a dead no-op despite rendering as navigable. Exercise the real tab →
+        // detail wiring (BuildDetailViewModel), not the direct ctor.
+        var refData = new FakeReferenceData();
+        refData.AddArea(new AreaEntry("AreaSerbule", "Serbule", "Serbule"));
+        refData.AddVault("NPC_CharlesThompson", new StorageVaultPoco
+        {
+            Area = "AreaSerbule", NpcFriendlyName = "Charles Thompson",
+            HasAssociatedNpc = true, NumSlots = 24,
+        });
+
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+        var settings = new SilmarillionSettings();
+        var tab = new StorageVaultsTabViewModel(refData, nav, resolver, settings);
+        tab.SelectedVault = tab.AllVaults.Single(r => r.EnvelopeKey == "NPC_CharlesThompson");
+
+        var detail = tab.DetailViewModel!;
+        detail.OpenEntityCommand.Should().NotBeNull(
+            "the chip ClickCommand binds to DetailViewModel.OpenEntityCommand — a null " +
+            "command makes the Area/Operator/Quest chips dead no-ops (#340)");
+
+        detail.OpenEntityCommand!.Execute(detail.AreaChip!.Reference);
+
+        nav.Current.Should().NotBeNull("clicking the Area chip should drive navigation");
+        nav.Current!.Kind.Should().Be(EntityKind.Area);
+        nav.Current.InternalName.Should().Be("AreaSerbule");
+    }
+
     private static StorageVaultDetailViewModel Build(
         FakeReferenceData refData, string envelopeKey, StorageVaultPoco vault)
     {


### PR DESCRIPTION
Closes #340.

## Problem

In the StorageVaults tab, the **Area**, **Operator NPC**, and **Quest-requirement** chips on the detail pane render as navigable (accent style, hand cursor) but clicking them does nothing.

## Root cause

`StorageVaultDetailView.xaml` binds every chip's `ClickCommand` to `DataContext.OpenEntityCommand` (RelativeSource → `StorageVaultDetailView`). That property **did not exist** on `StorageVaultDetailViewModel`, and `StorageVaultsTabViewModel.BuildDetailViewModel` never threaded its command in. WPF resolves the missing property to `null` silently; `EntityChip.OnChipClicked` early-returns when `ClickCommand is null`. The chip still *looked* clickable because `IsNavigable` is independently `true` (`AreasKindTarget` is registered).

Every other detail VM (`Ability`, `Area`, `Effect`, …) takes an `openEntityCommand` ctor param, exposes `OpenEntityCommand`, and its tab threads it in. This tab was built without that step.

## Fix

- `StorageVaultDetailViewModel`: optional `ICommand? openEntityCommand` ctor param + `public ICommand? OpenEntityCommand { get; }` — mirrors `AbilityDetailViewModel`.
- `StorageVaultsTabViewModel.BuildDetailViewModel`: pass `OpenEntityCommand`.

No XAML / navigator / `EntityChip` changes — the binding was correct, it just had no target. Affects Area, Operator-NPC, and Quest-requirement chips (all shared the same dead binding).

## Tests

Added `Chips_Click_NavigatesViaOpenEntityCommand_ThreadedThroughTheTab` — exercises the real tab → detail `BuildDetailViewModel` path (not the direct ctor) and asserts executing the command drives the navigator. Confirmed red (compile failure: missing member) before the fix. Full `Silmarillion.Tests`: **424 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)