### PR TITLE
feat(silmarillion): quest cadence as a typed, queryable projection (#345)

### DIFF
--- a/src/Silmarillion.Module/ViewModels/QuestCadence.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestCadence.cs
@@ -1,0 +1,94 @@
+using Mithril.Reference.Models.Quests;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Friendly repeatability bucket for a <see cref="Quest"/>. This is the <em>classification</em>
+/// half of repeatability; the exact interval is carried separately as
+/// <see cref="QuestCadenceClassifier.ReuseMinutes"/> so a coarse, glanceable label and a
+/// precise, queryable number don't have to be the same value.
+/// </summary>
+public enum QuestCadence
+{
+    /// <summary>No reuse timer — the quest can be completed once.</summary>
+    OneTime,
+
+    /// <summary>
+    /// Resets roughly once a calendar day. PG's daily quests use a deliberate ~20h
+    /// cooldown (so the reset time doesn't drift later each day); the 20–24h band maps here.
+    /// </summary>
+    Daily,
+
+    /// <summary>Exactly a 7-day reuse.</summary>
+    Weekly,
+
+    /// <summary>Repeatable on some other cadence (e.g. 12h, 3d, 30m).</summary>
+    Other,
+}
+
+/// <summary>
+/// Single home for the quest-repeatability heuristic. Both the detail-pane badge
+/// (<c>QuestDetailViewModel.RepeatabilityChip</c>) and the queryable
+/// <see cref="QuestListRow.Cadence"/> column read from here, so the "20–24h is Daily,
+/// exactly 7d is Weekly" rule lives in exactly one tested place rather than being
+/// duplicated as an inline expression per consumer.
+/// </summary>
+public static class QuestCadenceClassifier
+{
+    /// <summary>
+    /// Total reuse interval in minutes, or <c>0</c> when the quest has no reuse timer.
+    /// This is the precise value — unlike <see cref="Classify"/> it does not round 20h up
+    /// to "a day" — so query predicates like <c>ReuseMinutes &lt;= 720</c> stay exact.
+    /// </summary>
+    public static int ReuseMinutes(Quest quest)
+    {
+        var days = quest.ReuseTime_Days ?? 0;
+        var hours = quest.ReuseTime_Hours ?? 0;
+        var minutes = quest.ReuseTime_Minutes ?? 0;
+        return (days * 24 * 60) + (hours * 60) + minutes;
+    }
+
+    /// <summary>
+    /// Buckets a quest into a friendly cadence. See <see cref="QuestCadence"/> for the
+    /// rationale behind the 20–24h → <see cref="QuestCadence.Daily"/> band.
+    /// </summary>
+    public static QuestCadence Classify(Quest quest)
+    {
+        var days = quest.ReuseTime_Days ?? 0;
+        var hours = quest.ReuseTime_Hours ?? 0;
+        var minutes = quest.ReuseTime_Minutes ?? 0;
+
+        if (days == 0 && hours == 0 && minutes == 0) return QuestCadence.OneTime;
+        if (days == 7 && hours == 0 && minutes == 0) return QuestCadence.Weekly;
+        if (days == 0 && hours is >= 20 and <= 24 && minutes == 0) return QuestCadence.Daily;
+        return QuestCadence.Other;
+    }
+
+    /// <summary>
+    /// Header-badge text: <c>null</c> for one-time quests (the chip collapses), the friendly
+    /// name for <see cref="QuestCadence.Daily"/>/<see cref="QuestCadence.Weekly"/>, and a
+    /// compact <c>"Every 3d 12h 30m"</c> form otherwise. Keeps the friendly-vs-compact
+    /// decision tied to <see cref="Classify"/> so the two never disagree.
+    /// </summary>
+    public static string? BadgeText(Quest quest)
+    {
+        switch (Classify(quest))
+        {
+            case QuestCadence.OneTime:
+                return null;
+            case QuestCadence.Daily:
+                return "Daily";
+            case QuestCadence.Weekly:
+                return "Weekly";
+            default:
+                var days = quest.ReuseTime_Days ?? 0;
+                var hours = quest.ReuseTime_Hours ?? 0;
+                var minutes = quest.ReuseTime_Minutes ?? 0;
+                var parts = new List<string>(3);
+                if (days > 0) parts.Add($"{days}d");
+                if (hours > 0) parts.Add($"{hours}h");
+                if (minutes > 0) parts.Add($"{minutes}m");
+                return $"Every {string.Join(" ", parts)}";
+        }
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/QuestCadence.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestCadence.cs
@@ -65,6 +65,26 @@ public static class QuestCadenceClassifier
     }
 
     /// <summary>
+    /// Precise long-form interval for a tooltip on the (friendly) badge —
+    /// <c>"Repeatable every 20 hours"</c>. <c>null</c> for one-time quests, where the badge
+    /// is collapsed and there is nothing to qualify. This is the exact value the friendly
+    /// <see cref="BadgeText"/> rounds (20h → "Daily"), so hovering recovers the precision.
+    /// </summary>
+    public static string? DetailText(Quest quest)
+    {
+        if (Classify(quest) == QuestCadence.OneTime) return null;
+
+        var days = quest.ReuseTime_Days ?? 0;
+        var hours = quest.ReuseTime_Hours ?? 0;
+        var minutes = quest.ReuseTime_Minutes ?? 0;
+        var parts = new List<string>(3);
+        if (days > 0) parts.Add($"{days} day{(days == 1 ? "" : "s")}");
+        if (hours > 0) parts.Add($"{hours} hour{(hours == 1 ? "" : "s")}");
+        if (minutes > 0) parts.Add($"{minutes} minute{(minutes == 1 ? "" : "s")}");
+        return $"Repeatable every {string.Join(" ", parts)}";
+    }
+
+    /// <summary>
     /// Header-badge text: <c>null</c> for one-time quests (the chip collapses), the friendly
     /// name for <see cref="QuestCadence.Daily"/>/<see cref="QuestCadence.Weekly"/>, and a
     /// compact <c>"Every 3d 12h 30m"</c> form otherwise. Keeps the friendly-vs-compact

--- a/src/Silmarillion.Module/ViewModels/QuestDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestDetailViewModel.cs
@@ -59,8 +59,7 @@ public sealed class QuestDetailViewModel
         PreGiveItemChips = BuildItemChips(quest.PreGiveItems, refData, nameResolver, navigator);
         PreGiveRecipeChips = BuildRecipeChips(quest.PreGiveRecipes, refData, nameResolver, navigator);
 
-        RepeatabilityDisplay = BuildRepeatability(quest);
-        RepeatabilityChip = BuildRepeatabilityChip(quest);
+        RepeatabilityChip = QuestCadenceClassifier.BadgeText(quest);
         FavorRewardDisplay = BuildFavorRewardDisplay(quest, refData, nameResolver);
         BadgesDisplay = BuildBadgesDisplay(IsCancellable, IsGuildQuest, IsWorkOrder, WorkOrderSkillDisplay);
 
@@ -93,13 +92,12 @@ public sealed class QuestDetailViewModel
     public IReadOnlyList<EntityChipVm> PreGiveItemChips { get; }
     public IReadOnlyList<EntityChipVm> PreGiveRecipeChips { get; }
 
-    public string RepeatabilityDisplay { get; }
-
     /// <summary>
     /// Short-form repeatability for a header badge: <c>"Daily"</c>, <c>"Weekly"</c>,
     /// <c>"Every 20h"</c>, etc. Null for one-time quests so the chip collapses entirely —
     /// most story quests are one-shot, and an explicit "One-time" chip on every one would
-    /// be noise.
+    /// be noise. Sourced from <see cref="QuestCadenceClassifier.BadgeText"/>; the precise
+    /// interval is exposed for querying as <see cref="QuestListRow.ReuseMinutes"/>.
     /// </summary>
     public string? RepeatabilityChip { get; }
 
@@ -248,41 +246,6 @@ public sealed class QuestDetailViewModel
                 IsNavigable: navigator.CanOpen(reference)));
         }
         return list;
-    }
-
-    private static string BuildRepeatability(Quest quest)
-    {
-        var parts = new List<string>(3);
-        if (quest.ReuseTime_Days is int d && d > 0) parts.Add($"{d} day{(d == 1 ? "" : "s")}");
-        if (quest.ReuseTime_Hours is int h && h > 0) parts.Add($"{h} hour{(h == 1 ? "" : "s")}");
-        if (quest.ReuseTime_Minutes is int m && m > 0) parts.Add($"{m} minute{(m == 1 ? "" : "s")}");
-        return parts.Count == 0 ? "One-time quest" : $"Repeatable every {string.Join(" ", parts)}";
-    }
-
-    /// <summary>
-    /// Short-form repeatability for the header badge. Common cadences get friendly names
-    /// ("Daily" for 20–24h, "Weekly" for 7d); other durations fall through to compact units
-    /// ("Every 12h", "Every 3d", "Every 30m"). Null when the quest is one-time so the chip
-    /// drops out of the header.
-    /// </summary>
-    private static string? BuildRepeatabilityChip(Quest quest)
-    {
-        var days = quest.ReuseTime_Days ?? 0;
-        var hours = quest.ReuseTime_Hours ?? 0;
-        var minutes = quest.ReuseTime_Minutes ?? 0;
-        if (days == 0 && hours == 0 && minutes == 0) return null;
-
-        // Common cadence shorthands. PG's "daily" quests typically use a 20h cooldown so
-        // the player can play at the same in-game time each calendar day; treat 20–24h as
-        // daily and 7d exact as weekly.
-        if (days == 7 && hours == 0 && minutes == 0) return "Weekly";
-        if (days == 0 && hours is >= 20 and <= 24 && minutes == 0) return "Daily";
-
-        var parts = new List<string>(3);
-        if (days > 0) parts.Add($"{days}d");
-        if (hours > 0) parts.Add($"{hours}h");
-        if (minutes > 0) parts.Add($"{minutes}m");
-        return $"Every {string.Join(" ", parts)}";
     }
 
     private static string? BuildFavorRewardDisplay(Quest quest, IReferenceDataService refData, IEntityNameResolver resolver)

--- a/src/Silmarillion.Module/ViewModels/QuestDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestDetailViewModel.cs
@@ -60,6 +60,7 @@ public sealed class QuestDetailViewModel
         PreGiveRecipeChips = BuildRecipeChips(quest.PreGiveRecipes, refData, nameResolver, navigator);
 
         RepeatabilityChip = QuestCadenceClassifier.BadgeText(quest);
+        RepeatabilityDetail = QuestCadenceClassifier.DetailText(quest);
         FavorRewardDisplay = BuildFavorRewardDisplay(quest, refData, nameResolver);
         BadgesDisplay = BuildBadgesDisplay(IsCancellable, IsGuildQuest, IsWorkOrder, WorkOrderSkillDisplay);
 
@@ -100,6 +101,13 @@ public sealed class QuestDetailViewModel
     /// interval is exposed for querying as <see cref="QuestListRow.ReuseMinutes"/>.
     /// </summary>
     public string? RepeatabilityChip { get; }
+
+    /// <summary>
+    /// Precise long-form interval ("Repeatable every 20 hours") shown as a tooltip on the
+    /// friendly <see cref="RepeatabilityChip"/> badge, so hovering "Daily" recovers the
+    /// exact cooldown the badge rounds. Null for one-time quests (badge collapsed).
+    /// </summary>
+    public string? RepeatabilityDetail { get; }
 
     public string? FavorRewardDisplay { get; }
     public string? BadgesDisplay { get; }

--- a/src/Silmarillion.Module/ViewModels/QuestListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestListRow.cs
@@ -17,6 +17,14 @@ namespace Silmarillion.ViewModels;
 /// can run <c>Keywords CONTAINS "MainStory"</c> against the collection per the
 /// <c>IQueryStringValue</c> path shipped in #261.
 /// </para>
+/// <para>
+/// <see cref="Cadence"/> is the friendly repeatability bucket (queryable as
+/// <c>Cadence = "Daily"</c>) and <see cref="ReuseMinutes"/> is the exact interval
+/// (queryable as <c>ReuseMinutes &lt;= 720</c>). Both come from
+/// <see cref="QuestCadenceClassifier"/> so the coarse label and the precise number
+/// never disagree. <see cref="IsRepeatable"/> is retained for existing queries and is
+/// simply <c>Cadence != OneTime</c>. See #345.
+/// </para>
 /// </summary>
 public sealed record QuestListRow(
     Quest Quest,
@@ -29,4 +37,6 @@ public sealed record QuestListRow(
     bool IsCancellable,
     bool IsGuildQuest,
     bool IsWorkOrder,
-    bool IsRepeatable);
+    bool IsRepeatable,
+    QuestCadence Cadence,
+    int ReuseMinutes);

--- a/src/Silmarillion.Module/ViewModels/QuestsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestsTabViewModel.cs
@@ -119,9 +119,7 @@ public sealed partial class QuestsTabViewModel : ObservableObject, ITabViewModel
             .Where(k => !string.IsNullOrEmpty(k))
             .Select(k => new QuestKeywordValue(k))
             .ToList();
-        var isRepeatable = quest.ReuseTime_Days is > 0
-            || quest.ReuseTime_Hours is > 0
-            || quest.ReuseTime_Minutes is > 0;
+        var cadence = QuestCadenceClassifier.Classify(quest);
 
         return new QuestListRow(
             Quest: quest,
@@ -134,7 +132,9 @@ public sealed partial class QuestsTabViewModel : ObservableObject, ITabViewModel
             IsCancellable: quest.IsCancellable ?? false,
             IsGuildQuest: quest.IsGuildQuest ?? false,
             IsWorkOrder: !string.IsNullOrEmpty(quest.WorkOrderSkill),
-            IsRepeatable: isRepeatable);
+            IsRepeatable: cadence != QuestCadence.OneTime,
+            Cadence: cadence,
+            ReuseMinutes: QuestCadenceClassifier.ReuseMinutes(quest));
     }
 
     private QuestDetailViewModel BuildDetailViewModel(QuestListRow row) =>

--- a/src/Silmarillion.Module/Views/QuestDetailView.xaml
+++ b/src/Silmarillion.Module/Views/QuestDetailView.xaml
@@ -192,6 +192,7 @@
                              a daily from a one-shot is the first piece of info a player wants. -->
                         <Border Background="#FF2A2418" BorderBrush="#55D4A847" BorderThickness="1"
                                 CornerRadius="3" Padding="6,2" Margin="6,0,0,0"
+                                ToolTip="{Binding RepeatabilityDetail}"
                                 Visibility="{Binding RepeatabilityChip, Converter={StaticResource NullOrEmptyToVis}}">
                             <TextBlock Text="{Binding RepeatabilityChip}" Foreground="#FFD4A847"
                                        FontWeight="SemiBold"

--- a/tests/Silmarillion.Tests/ViewModels/QuestCadenceClassifierTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestCadenceClassifierTests.cs
@@ -84,4 +84,22 @@ public sealed class QuestCadenceClassifierTests
         QuestCadenceClassifier.BadgeText(Q(minutes: 30)).Should().Be("Every 30m");
         QuestCadenceClassifier.BadgeText(Q(days: 2, minutes: 15)).Should().Be("Every 2d 15m");
     }
+
+    [Fact]
+    public void DetailText_RecoversPrecisionBehindFriendlyBadge()
+    {
+        // The case from #345: badge says "Daily", tooltip says the real 20h.
+        QuestCadenceClassifier.BadgeText(Q(hours: 20)).Should().Be("Daily");
+        QuestCadenceClassifier.DetailText(Q(hours: 20)).Should().Be("Repeatable every 20 hours");
+
+        QuestCadenceClassifier.DetailText(Q(days: 7)).Should().Be("Repeatable every 7 days");
+        QuestCadenceClassifier.DetailText(Q(days: 1, hours: 1, minutes: 1))
+            .Should().Be("Repeatable every 1 day 1 hour 1 minute");
+    }
+
+    [Fact]
+    public void DetailText_NullForOneTime()
+    {
+        QuestCadenceClassifier.DetailText(Q()).Should().BeNull();
+    }
 }

--- a/tests/Silmarillion.Tests/ViewModels/QuestCadenceClassifierTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestCadenceClassifierTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Quests;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+public sealed class QuestCadenceClassifierTests
+{
+    private static Quest Q(int? days = null, int? hours = null, int? minutes = null) =>
+        new() { ReuseTime_Days = days, ReuseTime_Hours = hours, ReuseTime_Minutes = minutes };
+
+    [Fact]
+    public void NoReuseFields_IsOneTime()
+    {
+        QuestCadenceClassifier.Classify(Q()).Should().Be(QuestCadence.OneTime);
+        QuestCadenceClassifier.ReuseMinutes(Q()).Should().Be(0);
+        QuestCadenceClassifier.BadgeText(Q()).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(20)] // PG's actual daily cooldown — the case that started #345
+    [InlineData(21)]
+    [InlineData(24)] // top of the band
+    public void TwentyToTwentyFourHours_IsDaily(int hours)
+    {
+        QuestCadenceClassifier.Classify(Q(hours: hours)).Should().Be(QuestCadence.Daily);
+        QuestCadenceClassifier.BadgeText(Q(hours: hours)).Should().Be("Daily");
+    }
+
+    [Theory]
+    [InlineData(19)]  // just below the band
+    [InlineData(12)]
+    public void HoursBelowDailyBand_IsOther(int hours)
+    {
+        QuestCadenceClassifier.Classify(Q(hours: hours)).Should().Be(QuestCadence.Other);
+        QuestCadenceClassifier.BadgeText(Q(hours: hours)).Should().Be($"Every {hours}h");
+    }
+
+    [Fact]
+    public void TwentyHoursPlusMinutes_FallsOutOfDailyBand()
+    {
+        // 20h is daily; 20h30m is not — minutes must be zero for the friendly bucket.
+        var q = Q(hours: 20, minutes: 30);
+        QuestCadenceClassifier.Classify(q).Should().Be(QuestCadence.Other);
+        QuestCadenceClassifier.BadgeText(q).Should().Be("Every 20h 30m");
+        QuestCadenceClassifier.ReuseMinutes(q).Should().Be(20 * 60 + 30);
+    }
+
+    [Fact]
+    public void TwentyFiveHours_IsOther()
+    {
+        QuestCadenceClassifier.Classify(Q(hours: 25)).Should().Be(QuestCadence.Other);
+    }
+
+    [Fact]
+    public void ExactlySevenDays_IsWeekly()
+    {
+        QuestCadenceClassifier.Classify(Q(days: 7)).Should().Be(QuestCadence.Weekly);
+        QuestCadenceClassifier.BadgeText(Q(days: 7)).Should().Be("Weekly");
+        QuestCadenceClassifier.ReuseMinutes(Q(days: 7)).Should().Be(7 * 24 * 60);
+    }
+
+    [Theory]
+    [InlineData(7, 0, 1)]   // 7d1m — not exactly a week
+    [InlineData(6, 23, 0)]  // just under a week
+    [InlineData(14, 0, 0)]  // fortnight
+    public void NearWeekButNotExact_IsOther(int days, int hours, int minutes)
+    {
+        QuestCadenceClassifier.Classify(Q(days, hours, minutes)).Should().Be(QuestCadence.Other);
+    }
+
+    [Fact]
+    public void ReuseMinutes_SumsAllThreeFields()
+    {
+        QuestCadenceClassifier.ReuseMinutes(Q(days: 1, hours: 2, minutes: 3))
+            .Should().Be((1 * 24 * 60) + (2 * 60) + 3);
+    }
+
+    [Fact]
+    public void Other_BadgeText_OmitsZeroParts()
+    {
+        QuestCadenceClassifier.BadgeText(Q(days: 3)).Should().Be("Every 3d");
+        QuestCadenceClassifier.BadgeText(Q(minutes: 30)).Should().Be("Every 30m");
+        QuestCadenceClassifier.BadgeText(Q(days: 2, minutes: 15)).Should().Be("Every 2d 15m");
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/QuestCadenceQueryIntegrationTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestCadenceQueryIntegrationTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Quests;
+using Mithril.Shared.Wpf.Query;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+/// <summary>
+/// End-to-end check of the exact runtime query path the Quests tab uses:
+/// <c>ColumnBindingHelper.BuildFromProperties(typeof(QuestListRow))</c> +
+/// <c>QueryCompiler.Compile(string, …)</c> (which runs <see cref="QueryParser"/>).
+/// Guards the #345 promise that the friendly "Daily" badge and the queryable
+/// <see cref="QuestListRow.Cadence"/> column agree for the canonical 20h quest.
+/// </summary>
+public sealed class QuestCadenceQueryIntegrationTests
+{
+    // Mirrors QuestsTabViewModel.BuildRow for the fields under test (KilltheDenMotherRepeat
+    // ships ReuseTime_Hours = 20 in the bundled data).
+    private static QuestListRow DenMotherRow()
+    {
+        var quest = new Quest
+        {
+            InternalName = "KilltheDenMotherRepeat",
+            Name = "Kill the Ranalon Den Mother",
+            ReuseTime_Hours = 20,
+        };
+        var cadence = QuestCadenceClassifier.Classify(quest);
+        return new QuestListRow(
+            Quest: quest,
+            InternalName: quest.InternalName!,
+            Name: quest.Name!,
+            Level: null,
+            FavorNpcDisplayName: null,
+            DisplayedLocation: null,
+            Keywords: [],
+            IsCancellable: true,
+            IsGuildQuest: false,
+            IsWorkOrder: false,
+            IsRepeatable: cadence != QuestCadence.OneTime,
+            Cadence: cadence,
+            ReuseMinutes: QuestCadenceClassifier.ReuseMinutes(quest));
+    }
+
+    private static bool Matches(string query)
+    {
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(QuestListRow));
+        var predicate = QueryCompiler.Compile(query, columns);
+        predicate.Should().NotBeNull($"'{query}' should parse as grammar");
+        return predicate!(DenMotherRow());
+    }
+
+    [Fact]
+    public void BadgeSaysDaily_ForTheRow()
+    {
+        QuestCadenceClassifier.BadgeText(DenMotherRow().Quest).Should().Be("Daily");
+    }
+
+    [Theory]
+    [InlineData("Cadence = \"Daily\"")]
+    [InlineData("Cadence = \"daily\"")]          // case-insensitive enum parse
+    [InlineData("Cadence != \"Weekly\"")]
+    [InlineData("ReuseMinutes = 1200")]
+    [InlineData("ReuseMinutes >= 720")]
+    [InlineData("Cadence = \"Daily\" AND ReuseMinutes > 60")]
+    public void DenMother_MatchesDailyQueries(string query)
+    {
+        Matches(query).Should().BeTrue($"the 20h Den Mother quest should satisfy: {query}");
+    }
+
+    [Theory]
+    [InlineData("Cadence = \"Weekly\"")]
+    [InlineData("Cadence = \"OneTime\"")]
+    [InlineData("ReuseMinutes <= 720")]
+    public void DenMother_DoesNotMatchNonDailyQueries(string query)
+    {
+        Matches(query).Should().BeFalse($"the 20h Den Mother quest should NOT satisfy: {query}");
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/QuestsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestsTabViewModelTests.cs
@@ -101,7 +101,7 @@ public sealed class QuestsTabViewModelTests
     }
 
     [Fact]
-    public void QuestListRow_IsRepeatable_TrueWhenAnyReuseTimeFieldIsPositive()
+    public void QuestListRow_CadenceProjection_FlowsFromClassifier()
     {
         var refData = new StubReferenceData
         {
@@ -114,9 +114,20 @@ public sealed class QuestsTabViewModelTests
         };
         var vm = BuildVm(refData);
 
-        vm.AllQuests.Single(r => r.InternalName == "OneOff").IsRepeatable.Should().BeFalse();
-        vm.AllQuests.Single(r => r.InternalName == "DailyHours").IsRepeatable.Should().BeTrue();
-        vm.AllQuests.Single(r => r.InternalName == "WeeklyDays").IsRepeatable.Should().BeTrue();
+        var oneOff = vm.AllQuests.Single(r => r.InternalName == "OneOff");
+        oneOff.IsRepeatable.Should().BeFalse();
+        oneOff.Cadence.Should().Be(QuestCadence.OneTime);
+        oneOff.ReuseMinutes.Should().Be(0);
+
+        var daily = vm.AllQuests.Single(r => r.InternalName == "DailyHours");
+        daily.IsRepeatable.Should().BeTrue();
+        daily.Cadence.Should().Be(QuestCadence.Daily);
+        daily.ReuseMinutes.Should().Be(20 * 60);
+
+        var weekly = vm.AllQuests.Single(r => r.InternalName == "WeeklyDays");
+        weekly.IsRepeatable.Should().BeTrue();
+        weekly.Cadence.Should().Be(QuestCadence.Weekly);
+        weekly.ReuseMinutes.Should().Be(7 * 24 * 60);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #345.

## What

Promotes quest repeatability cadence from a display-only heuristic to a typed, queryable projection — and keeps the precise interval visible on the detail view via a tooltip.

- **`QuestCadence` enum + `QuestCadenceClassifier`** — single tested home for the "20–24h → Daily, exactly 7d → Weekly" rule, plus exact `ReuseMinutes` and the long-form `DetailText`. Badge, tooltip, and query column all read from here so they can't drift.
- **`QuestListRow` += `Cadence`, `ReuseMinutes`** — both flow into the reflected query schema automatically (`QueryCompiler` already handles enum + numeric columns), so `Cadence = "Daily"` and `ReuseMinutes <= 720` now work from the Quests query box. `IsRepeatable` is retained for existing queries, redefined as `Cadence != OneTime`.
- **`QuestDetailViewModel`** — `RepeatabilityChip` sourced from the classifier; the dead `RepeatabilityDisplay` / `BuildRepeatability` (computed, bound nowhere) are deleted. **Badge text is unchanged.**
- **Detail-view tooltip** — `RepeatabilityDetail` ("Repeatable every 20 hours") bound as the badge's `ToolTip`, so hovering the friendly "Daily" recovers the exact cooldown. This is the on-view counterpart to the queryable column — addresses the original "I can't see the real interval anywhere" report.

## Why

Investigating "why does a 20h quest say *Daily*" surfaced that (a) the badge is an intentional friendly heuristic, (b) the precise interval was computed into `RepeatabilityDisplay` but rendered nowhere — dead code, no fallback for the imprecision, and (c) cadence wasn't queryable at all (only the coarse `IsRepeatable` bool). This keeps the friendly badge while making the exact interval both **queryable** and **visible on hover**.

## Scope

Gandalf's `QuestSource` has its own reuse-time logic; intentionally **not** unified in this pass (separate consumer).

## Tests

- `QuestCadenceClassifierTests` — band edges (19h/20h/24h/25h, 20h+30m), week-adjacent (7d / 7d1m / 6d23h / 14d), `ReuseMinutes` sums, badge formatting, `DetailText` precision + null-for-one-time.
- `QuestsTabViewModelTests` extended to assert `Cadence`/`ReuseMinutes` flow through the row projection.
- Full Silmarillion suite: 440 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
