### PR TITLE
docs: module charters (responsibility boundaries)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Modules are discovered at runtime via reflection from the `modules/` folder (`Sh
 | Gandalf | gandalf | User-created timers with alarms | Eager |
 | Bilbo | bilbo | Storage/inventory management | Lazy |
 
+This table is purpose-only and non-exhaustive (Silmarillion and Celebrimbor also ship). **Before proposing or building work for a module, read [docs/module-charters.md](docs/module-charters.md)** — it records each module's responsibility *boundaries* (what it explicitly does **not** own, and why). A data-availability gap is not a feature unless it serves the module's charter.
+
 ### Shell Bootstrap (Program.cs)
 
 Single-instance mutex guard &rarr; game root detection &rarr; settings load &rarr; `IHost` build &rarr; eager module gates opened &rarr; WPF `App.Run()`. Second-instance attempts raise the existing window via `EventWaitHandle`.

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -27,15 +27,18 @@ what the module legitimately consumes within its charter (not everything it *cou
 
 ---
 
-## Samwise — garden/crop tracking
+## Samwise — garden tracker
 
-- **Owns:** identification of garden events from `Player.log`, per-plot crop state,
-  growth/ripeness timing, and harvest-ready alarms. The authority on *when a plot is
-  ready* and *what is planted*, derived from the log. (See `samwise-parser` memory:
-  identification trade-offs, alias-learning convergence.)
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — Samwise is *first and foremost a garden
+  tracker*. It interprets `Player.log` to track what the player has planted, tracks
+  crop state transitions, and raises alarms **so plants don't die**. The authority on
+  *what is planted* and *where each plot is in its lifecycle*, derived from the log.
+  Alarms are loss-prevention, not merely a ripeness/harvest-ready notification.
+  (See `samwise-parser` memory: identification trade-offs, alias-learning convergence.)
 - **Does NOT own:**
   - ⚠️ *What to plant / crop economics / yield optimization.* It tracks the garden; it
-    does not advise on it.
+    does not advise on it. (The "first and foremost a *tracker*" framing leans this
+    way, but the exact boundary is not owner-confirmed.)
   - ⚠️ *Cooking/crafting use of crops.* Crop-as-ingredient is Celebrimbor/Pippin.
 - **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`).
 
@@ -156,6 +159,11 @@ libraries; the charter follows the code:
   owner/design-doc-confirmed (Gandalf eligibility confirmed by owner this date; Elrond
   recipe-anchoring and Silmarillion browser-not-calculator from existing design docs).
   All ⚠️ entries are unconfirmed Claude drafts pending owner sign-off.
+- **2026-05-16** — Samwise charter confirmed by owner: first and foremost a garden
+  tracker — interprets `Player.log` to track plantings + state transitions and alarms
+  so plants don't die (loss-prevention, not just ripeness). Owns promoted to ✅
+  confirmed; ⚠️ tracker-not-advisor boundary left inferred (framing leans that way,
+  not explicitly ruled on).
 - **2026-05-16** — Pippin charter corrected by owner: it supplements the **Gourmand**
   skill (food-novelty tracking — foods *not yet eaten*), not buff/consumption tracking.
   Owns + the no-buffs boundary promoted to ✅ confirmed. The earlier draft's

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -251,11 +251,19 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   **data-availability ceiling, not a charter line**: no module can show roll resolution
   from reference data because it isn't there (same class as Samwise's gardening-XP
   absence), distinct from "calculation Silmarillion is barred from."
-  **Consequence:** Silmarillion *can* surface what's in the data — cross-link an
-  enchanted recipe → its `Crystal` slot → candidate crystals → each crystal's
-  associated skill / enchantment family, alongside the template's pool (browsing /
-  cross-linking, within charter). It cannot show roll *resolution* — not because that
-  would be calculation, but because the data simply doesn't carry it. Relates to #214.
+  **Consequence:** Silmarillion *can* surface what's in the data — browse an enchanted
+  recipe → its `Crystal` slot → candidate crystals, and on each crystal show its
+  enchantment-family **text**. ⚠️ That text is **prose/category, frequently NOT a
+  resolvable `skills.json` entity**, and the data is **heterogeneous**: the only
+  consistent signal is `Item.DynamicCraftingSummary` (*"…<family> enchantments"*); a
+  `Description` `"Associated Primary Skill: <X>"` line exists on *some* crystals
+  (Moonstone, LapisLazuli, Tsavorite) but **not others** (Rubywall Crystal has none),
+  and the family term is often not a skill at all — *"survival-related"* has no
+  `Survival` skill. So treat it as **display text, not a guaranteed navigable Skill
+  cross-link** — it degrades to plain text per Silmarillion's existing
+  chip-degradation rule; don't promise a skill-entity link. It cannot show roll
+  *resolution* — not because that would be calculation, but because the data simply
+  doesn't carry it. Relates to #214.
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
     Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
@@ -368,7 +376,16 @@ libraries; the charter follows the code:
   all**. Reframed the "what's out" from "calculation Silmarillion is barred from" to a
   **data-availability ceiling** (same class as gardening-XP absence) — Silmarillion
   surfaces the data-backed association; roll resolution is unshowable because it's
-  absent upstream, not because it'd be calculation. This is the settled version.
+  absent upstream, not because it'd be calculation.
+- **2026-05-16** — Resolvability precision (owner pointed at Rubywall Crystal,
+  `item_1002`): the crystal enchantment-family signal is **prose/category, often not a
+  `skills.json` entity**, and **heterogeneous** — `DynamicCraftingSummary` is the only
+  consistent field; the `Description` "Associated Primary Skill" line is present on
+  some crystals (Moonstone/LapisLazuli/Tsavorite) but absent on others (Rubywall), and
+  *"survival-related"* maps to no `Survival` skill. Corrected the charter's
+  overclaimed "cross-link to the associated skill" → surface as **text, degrading per
+  the chip-degradation rule**, not a guaranteed Skill cross-link. This is the settled
+  version.
 - **2026-05-16** — Layering corrected after code verification: split the single-owner
   rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
   is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -46,6 +46,14 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   *via* recipes — is owned by **Elrond** (leveling advice) or **Celebrimbor** (planning
   / execution), never by the module that happens to produce or hold the item. Cited by
   Samwise (crops), Pippin (food), and Bilbo (craftables) below.
+- **Displaying reference data is not turf; *being the browser* is.** Any module may
+  *render* reference data when its own purpose needs it (Celebrimbor shows
+  recipes/effects to plan crafts; Pippin shows food provenance for Gourmand). That
+  does **not** make it a co-owner of browsing. **Silmarillion is *the* reference-data
+  browser** — the dedicated, general, authoritative surface; every other module is
+  "just another place the data happens to be displayed." "Renders some data" ≠ "owns
+  the browser role." (Same shape as the shared-infra rule: ubiquitous capability,
+  single owner.)
 
 ---
 
@@ -173,9 +181,12 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ## Silmarillion — reference-data browser
 
-- **Owns: ✅ confirmed** — browsing and cross-linking reference data (master-detail,
-  navigator, provenance popups). Field-level scope is governed by
-  [silmarillion-field-coverage.md](silmarillion-field-coverage.md); tab scope by
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — *Silmarillion is **the** reference-data
+  browser*: the dedicated, authoritative surface for browsing and cross-linking **all**
+  reference data (master-detail, navigator, provenance popups). Other modules may
+  render reference data incidentally to their own purpose, but "being the browser" is
+  Silmarillion's charter alone. Field-level scope:
+  [silmarillion-field-coverage.md](silmarillion-field-coverage.md); tab scope:
   [silmarillion-roadmap.md](silmarillion-roadmap.md).
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
@@ -203,14 +214,14 @@ Applies to *every* module; owner-confirmed 2026-05-16:
     *consumes* a target list; whatever decides that list (Elrond / the #227 cross-skill
     planner) is upstream. #228's "plan-aware craft list" means Celebrimbor *receives* a
     computed plan as targets — it does not compute it.
-  - **✅ confirmed (owner, 2026-05-16)** — *Generic reference browsing / cross-link
-    navigation* → Silmarillion. **Recipe *display* deliberately overlaps** — both
-    modules show a recipe — differentiated by *purpose*: Silmarillion browses it;
-    Celebrimbor shows it in service of a craft plan and additionally previews its
-    treasure (ResultEffects) outcomes ("what you might get"). The effect-preview
-    capability is **shared infra** (`Mithril.Shared.ResultEffectsParser`), owned by
-    neither; Silmarillion just does not consume it yet — tracked as #214, a *gap, not
-    a boundary*.
+  - **✅ confirmed (owner, 2026-05-16)** — *Reference browsing.* Silmarillion is **the**
+    reference browser; Celebrimbor rendering recipe/effect data is **incidental to
+    planning, not a co-owned browsing role** — "just another place the data is
+    displayed." It shows a recipe in service of a craft plan and previews its treasure
+    (ResultEffects) outcomes. That effect-preview capability is **shared infra**
+    (`Mithril.Shared.ResultEffectsParser`), owned by neither; Silmarillion simply does
+    not consume it yet — #214, a *gap, not a boundary*. (Displaying data ≠ owning the
+    browser role — see the data-display cross-cutting rule above.)
 - **Reference data:** `Recipes`, `Items`, `ResultEffectsParser` previews, `Areas`
   (source resolution), inventory.
 
@@ -251,6 +262,12 @@ libraries; the charter follows the code:
   while Silmarillion currently does not (#214: gap, not boundary). Added a carve-out
   to Silmarillion's "no computation" line so #214 can't be misread as a charter
   violation; listed `ResultEffectsParser` as shipped shared infra owned by neither.
+- **2026-05-16** — Owner sharpened the asymmetry: it is *not* symmetric overlap —
+  **Silmarillion is *the* reference browser; Celebrimbor is just another place the
+  data is displayed.** Generalised into a cross-cutting rule ("displaying data is not
+  turf; being the browser is"), parallel to the shared-infra rule. Silmarillion Owns
+  + the Celebrimbor browsing line reworded from "deliberate overlap" to this
+  asymmetric framing.
 - **2026-05-16** — Pippin data source corrected: the in-game report is *dumped into*
   `Player.log` (Pippin reads it there today) and *also* exists as an un-consumed
   standalone raw text file — the prior flat "not `Player.log`" was wrong. Endorsed

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -230,12 +230,21 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   `AugmentPoolPreview` pool surface Celebrimbor uses, fed by the shared
   `ResultEffectsParser`. Silmarillion is the **master** view (full pool for any
   browsed recipe); **Celebrimbor is the planning-narrowed slice** of that *same* data
-  (the pool for recipes in your craft plan). Mechanic (owner-stated): the roll pool is
-  influenced by the **crystal** (keyword ingredient) used in recipes whose name
-  contains *"(enchanted)"* — the `*E` enchanted-equipment recipes with
-  `RecipeKeywordIngredient` crystal slots. Showing the *possible* pool is **browsing**
-  (within charter, consistent with the carve-out below); it is **not** simulating a
-  specific roll. Relates to #214.
+  (the pool for recipes in your craft plan). **Mechanic — verified against `recipes.json` + `ResultEffectsParser`
+  2026-05-16:** the `*E` *"(enchanted)"* recipes carry generic `Crystal`
+  keyword-ingredient slots (`ItemKeys:["Crystal"]`) and a
+  `TSysCraftedEquipment(template)` ResultEffect; `TryBuildCraftedEquipmentPool`
+  derives the displayable pool from the crafted-equipment template's `TSysProfile` →
+  `IReferenceDataService.Profiles` — so the pool is **template/profile-derived and
+  crystal-independent in reference data.** ⚠️ **Correction:** the owner-stated "rolls
+  influenced by the crystal used" is **not reflected in reference data or the parser**
+  — the crystal slots are consumed ingredients with no effect on the parsed pool; any
+  crystal→roll influence is game-engine *runtime* behaviour, outside browsable data.
+  Consequence: Silmarillion can show the **full possible pool per recipe/template**
+  (browsing, within charter); it **cannot** show "crystal X narrows the pool" — that
+  linkage isn't in the data, and deriving it would be calculation, not browsing
+  (reinforces the no-computation carve-out below). Showing the *possible* pool is
+  **browsing**; it is **not** simulating a specific roll. Relates to #214.
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
     Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
@@ -326,9 +335,16 @@ libraries; the charter follows the code:
   popup (the `AugmentPoolPreview` surface, shared `ResultEffectsParser`) — promoted
   from "#214 gap" to explicit in-scope. Sharpened the Silmarillion↔Celebrimbor
   relationship: Silmarillion = master list / full pool; Celebrimbor = planning-narrowed
-  slice of the same data. Recorded the mechanic (roll pool influenced by the crystal /
-  keyword ingredient in *"(enchanted)"* `*E` recipes). Browsing the *possible* pool ≠
-  simulating a roll, so consistent with the no-computation carve-out.
+  slice of the same data.
+- **2026-05-16** — TSys-pool shape **verified** against `recipes.json` +
+  `ResultEffectsParser`. Confirmed the popup is data-supported (`*E` "(enchanted)" →
+  `Crystal` keyword slots + `TSysCraftedEquipment(template)` → `AugmentPoolPreview`
+  from `template.TSysProfile`/`Profiles`). **Corrected:** owner-stated "rolls
+  influenced by the crystal" is *not* in reference data — pool is template/profile-
+  derived, crystal-independent; any crystal influence is engine runtime, not
+  browsable. Charter mechanic line moved from owner-stated to verified, discrepancy
+  flagged ⚠️. (Verification overturned the stated mechanic — same pattern as gardening
+  XP and the inv-layering corrections.)
 - **2026-05-16** — Layering corrected after code verification: split the single-owner
   rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
   is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -141,8 +141,14 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ## Elrond — skill leveling advisor
 
-- **Owns:** per-recipe leveling math (effective XP, first-time bonuses, drop-off),
-  the optimal grind path *within a skill*, and the cookbook view.
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — (1) the **player's progression state**
+  — learned skills, skill progress, and known recipes — which is the *constraint set*
+  the leveling calculator runs against; (2) per-recipe leveling math (effective XP,
+  first-time bonuses, drop-off) and the optimal grind path *within a skill*; (3) the
+  cookbook view. Scope of "player state" here is the **progression facet only** —
+  inventory/storage state is Bilbo's, raw character-data parsing is shared
+  (`ICharacterDataService`); Elrond owns the progression model the calculator
+  constrains on.
 - **Does NOT own:**
   - **✅ confirmed** — *Non-recipe skills.* Recipe-anchored by design: skills without
     recipes (combat/gathering/etc.) intentionally never appear; Elrond cannot advise
@@ -150,8 +156,11 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   - **✅ confirmed (by entailment, 2026-05-16)** — *Multi-recipe shopping / inventory.*
     Celebrimbor's Owns is owner-confirmed as exactly this; Elrond not owning it is the
     direct complement.
-  - ⚠️ *The skill-XP math itself, post-#225.* Slated to lift into shared
-    `Mithril.Leveling`; after #225 Elrond consumes that engine rather than owning it.
+  - **✅ confirmed (owner, 2026-05-16) — provisional/future** — *The skill-XP **math**,
+    post-#225.* Owner-confirmed technically correct: the math is slated to lift into
+    shared `Mithril.Leveling`; after #225 Elrond *consumes* that engine, not owns the
+    math. Clean split: **math → shared `Mithril.Leveling`; the player-progression-state
+    constraints it runs against stay Elrond's** (see Owns). Contingent on #225 landing.
 - **Reference data:** `Recipes`, `Skills`, `XpTables`.
 
 ## Gandalf — timers & repeatable-quest cooldowns
@@ -237,8 +246,10 @@ libraries; the charter follows the code:
   module: consumed by Celebrimbor today, by Silmarillion per #214. The canonical
   "shared infra, not module turf" case — effect *display* is appropriate in any
   recipe surface; the parser is the single source of truth both lean on.
-- **`Mithril.Leveling` (#225)** — skill-XP math, lifted from Elrond. Future owner of
-  the math both Elrond and the #227 planner consume.
+- **`Mithril.Leveling` (#225)** — skill-XP **math**, lifted from Elrond; future owner
+  of the math both Elrond and the #227 planner consume. **Player-progression state
+  (learned skills, progress, known recipes) does *not* lift — it stays Elrond's**, fed
+  into the calculator as its constraint set (owner-confirmed 2026-05-16).
 - **Shared demand-driven recipe expander (#226, supersedes #121)** — generalises
   Celebrimbor's aggregator; future shared consumer set = Bilbo + Elrond + #227 planner.
 - **`PrereqRecipe` resolver (latent, unfiled)** — three surfaces want the same
@@ -262,6 +273,13 @@ libraries; the charter follows the code:
   while Silmarillion currently does not (#214: gap, not boundary). Added a carve-out
   to Silmarillion's "no computation" line so #214 can't be misread as a charter
   violation; listed `ResultEffectsParser` as shipped shared infra owned by neither.
+- **2026-05-16** — Elrond Owns expanded by owner: Elrond owns the **player's
+  progression state** (learned skills, progress, known recipes) as the leveling
+  calculator's constraint set — scoped to the progression facet (distinct from Bilbo's
+  inventory state and shared character-data parsing). Post-#225 split clarified: math
+  lifts to `Mithril.Leveling`, progression-state constraints stay Elrond's. The #225
+  line owner-confirmed technically correct — retagged ✅ provisional/future, no longer
+  bare ⚠️.
 - **2026-05-16** — Owner sharpened the asymmetry: it is *not* symmetric overlap —
   **Silmarillion is *the* reference browser; Celebrimbor is just another place the
   data is displayed.** Generalised into a cross-cutting rule ("displaying data is not

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -98,12 +98,16 @@ Applies to *every* module; owner-confirmed 2026-05-16:
     recipe/crafting rule. (Pippin may *point at* where a food comes from, including
     "it's crafted"; it does not own the crafting.)
 - **Primary data source: ✅ owner-stated (2026-05-16)** — the **in-game reporting
-  tool**'s character report (the eaten-food record). *Not* `Player.log`, *not* the CDN.
+  tool**'s character report (the eaten-food record). That report is *dumped into*
+  `Player.log` — where Pippin reads it today — and is *also* written as a standalone
+  raw text file that Pippin does **not** currently consume (a potentially cleaner
+  input). Not the CDN. (An earlier draft's flat "*not* `Player.log`" was wrong —
+  corrected: the report content lands in `Player.log`.)
 - **Reference data:** CDN `Items` (`FoodDesc`) for the food catalog/identity — used to
   compute not-yet-eaten and to resolve where un-eaten foods come from.
-- **Endorsed opportunity (owner, 2026-05-16; untracked):** combine the two — "what
-  haven't I eaten *and where do I find it*." Genuinely useful per owner; not yet an
-  issue. (Charters don't list issues — file separately and link back here if pursued.)
+- **Endorsed opportunity → Tracked: #348** — combine the two: "what haven't I eaten
+  *and where do I find it*." Owner-endorsed (2026-05-16) as good value; filed as #348.
+  (Charter carries the stable pointer; the issue holds the spec.)
 
 ## Legolas — surveying & route optimization
 
@@ -247,6 +251,11 @@ libraries; the charter follows the code:
   while Silmarillion currently does not (#214: gap, not boundary). Added a carve-out
   to Silmarillion's "no computation" line so #214 can't be misread as a charter
   violation; listed `ResultEffectsParser` as shipped shared infra owned by neither.
+- **2026-05-16** — Pippin data source corrected: the in-game report is *dumped into*
+  `Player.log` (Pippin reads it there today) and *also* exists as an un-consumed
+  standalone raw text file — the prior flat "not `Player.log`" was wrong. Endorsed
+  food-provenance opportunity filed as **#348**; charter now carries the pointer
+  instead of "untracked".
 - **2026-05-16** — Pippin corrected again by owner: **food provenance IS in scope**
   — the prior ⚠️ "→ Silmarillion" was a wrong inference, removed. Primary data source
   clarified as the in-game reporting tool's character report (not `Player.log`/CDN; the

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -81,21 +81,29 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   data-level reason crop-selection optimization stays a soft non-feature, not a
   temporary gap.
 
-## Pippin — Gourmand support (food-variety tracking)
+## Pippin — Gourmand support (food-variety + provenance)
 
 - **Owns: ✅ confirmed (owner, 2026-05-16)** — supplementing PG's **Gourmand** skill,
   which levels from eating foods *not previously eaten*. Pippin tracks the per-character
-  set of foods already eaten (from the log) against the food catalog and surfaces the
-  not-yet-eaten foods so the player can progress Gourmand. It is about food
-  *novelty/variety*, not buffs.
+  set of foods already eaten against the food catalog and surfaces the not-yet-eaten
+  foods so the player can progress Gourmand. **Food provenance is in scope** — *where*
+  a not-yet-eaten food can be obtained is part of Pippin's responsibility. (This is
+  food-specific provenance in service of Gourmand; it does not collide with
+  Silmarillion's *generic* reference browsing — different surface, different purpose.)
+  About food *novelty/variety*, not buffs.
 - **Does NOT own:**
   - **✅ confirmed (owner, 2026-05-16)** — *Food buffs.* Pippin tracks nothing about
     buff effects or buff uptime. Gourmand novelty only.
-  - **✅ confirmed** — *Crafting food* → Celebrimbor, per the cross-cutting
-    recipe/crafting rule.
-  - ⚠️ *Food provenance browsing* (where a food comes from). That's Silmarillion.
-- **Reference data:** `Items` (food catalog / `FoodDesc` to enumerate the universe of
-  foods and identify which items are food).
+  - **✅ confirmed** — *Crafting food itself* → Celebrimbor, per the cross-cutting
+    recipe/crafting rule. (Pippin may *point at* where a food comes from, including
+    "it's crafted"; it does not own the crafting.)
+- **Primary data source: ✅ owner-stated (2026-05-16)** — the **in-game reporting
+  tool**'s character report (the eaten-food record). *Not* `Player.log`, *not* the CDN.
+- **Reference data:** CDN `Items` (`FoodDesc`) for the food catalog/identity — used to
+  compute not-yet-eaten and to resolve where un-eaten foods come from.
+- **Endorsed opportunity (owner, 2026-05-16; untracked):** combine the two — "what
+  haven't I eaten *and where do I find it*." Genuinely useful per owner; not yet an
+  issue. (Charters don't list issues — file separately and link back here if pursued.)
 
 ## Legolas — surveying & route optimization
 
@@ -217,6 +225,12 @@ libraries; the charter follows the code:
   tracker — interprets `Player.log` to track plantings + state transitions and alarms
   so plants don't die (loss-prevention, not just ripeness). Owns promoted to ✅
   confirmed.
+- **2026-05-16** — Pippin corrected again by owner: **food provenance IS in scope**
+  — the prior ⚠️ "→ Silmarillion" was a wrong inference, removed. Primary data source
+  clarified as the in-game reporting tool's character report (not `Player.log`/CDN; the
+  earlier "from the log" Owns wording was also wrong). Owner endorsed an integrated
+  "what haven't I eaten + where to find it" feature — recorded as an untracked
+  opportunity (charter doesn't list issues; filing offered separately).
 - **2026-05-16** — Celebrimbor charter confirmed & tightened by owner: scope is exactly
   "what is needed to make N units of X" + on-hand, no logic beyond the quantity math.
   Owns + the no-extra-logic boundary → ✅; Elrond's reciprocal "multi-recipe shopping →

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -243,16 +243,19 @@ Applies to *every* module; owner-confirmed 2026-05-16:
      `"…create items that have <Skill> enchantments."` (e.g. `Moonstone` →
      *Lycanthropy*; `LapisLazuli` → *Priest*; `Tsavorite` → *Ice Magic*). The crystal
      slotted into the recipe selects the enchantment family/skill.
-  So the owner-stated "rolls are influenced by the crystal used" **is data-backed** —
-  the linkage lives on the crystal item (`items.json`), not the recipe/parser path
-  (which is why the first verification, tracing only recipe→parser, wrongly concluded
-  "crystal-independent"). **Consequence:** because both pieces are browsable reference
-  data, Silmarillion **can** surface the relationship — browse an enchanted recipe →
-  its `Crystal` slot → candidate crystals → each crystal's associated skill /
-  enchantment family, alongside the template's pool. That is **browsing/cross-linking
-  (within charter)**, *not* calculation. What would be calculation (still not
-  Silmarillion's): computing the precise rolled-power probabilities or the exact
-  template-pool ∩ crystal-skill intersection. Relates to #214.
+  **Settled (owner, 2026-05-16):** crystals **do** influence enchanted crafts, and the
+  crystal→enchantment-family *association* is in CDN data (the crystal item's
+  `Description`/`DynamicCraftingSummary`, plus the template's `TSysProfile` pool). But
+  the **treasure-system *specifics* — how a roll actually resolves (probabilities, the
+  precise rolled power) — are not in CDN data at all.** That second fact is a
+  **data-availability ceiling, not a charter line**: no module can show roll resolution
+  from reference data because it isn't there (same class as Samwise's gardening-XP
+  absence), distinct from "calculation Silmarillion is barred from."
+  **Consequence:** Silmarillion *can* surface what's in the data — cross-link an
+  enchanted recipe → its `Crystal` slot → candidate crystals → each crystal's
+  associated skill / enchantment family, alongside the template's pool (browsing /
+  cross-linking, within charter). It cannot show roll *resolution* — not because that
+  would be calculation, but because the data simply doesn't carry it. Relates to #214.
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
     Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
@@ -359,6 +362,13 @@ libraries; the charter follows the code:
   cross-link recipe→crystal→skill (browsing). Lesson: verifying one path and
   generalising to "not in data" is itself an unverified assertion — scope the check to
   the claim, not the first path that comes to hand.
+- **2026-05-16** — Owner settled the boundary: crystals **do** influence enchanted
+  crafts; the crystal→enchantment-family *association* is in CDN data, but the
+  treasure-system *specifics* (roll resolution/probabilities) are **not in CDN data at
+  all**. Reframed the "what's out" from "calculation Silmarillion is barred from" to a
+  **data-availability ceiling** (same class as gardening-XP absence) — Silmarillion
+  surfaces the data-backed association; roll resolution is unshowable because it's
+  absent upstream, not because it'd be calculation. This is the settled version.
 - **2026-05-16** — Layering corrected after code verification: split the single-owner
   rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
   is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -50,21 +50,31 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   satisfies* is a read-only state query owned by **Bilbo** (its data domain), not
   planning/leveling. This rule governs crafting-*as-activity* (plan / level / execute),
   not "what is makeable from what I hold right now."
-- **Each data domain has exactly one owning browser/evaluator; *rendering* it
-  elsewhere is not turf.** Any module may render data its own purpose needs
-  (Celebrimbor shows recipes/effects to plan; modules surface bits of state in
-  passing). That does **not** make it a co-owner. Each domain has a single owner,
-  all owner-confirmed 2026-05-16:
-  - **Silmarillion** — reference (CDN) data.
-  - **Bilbo** — the player's inventory/storage export (incl. immediate craftability).
-  - **Pippin** — the player's eaten-food state (Gourmand novelty + provenance).
-  - **Elrond** — the player's progression state (as leveling constraints).
+- **Two layers: the *data* (a shared single-source service) and the *browse/evaluate
+  surface* (exactly one owning module). Rendering elsewhere is not turf.** Plumbing
+  verified against code 2026-05-16:
 
-  "Renders some data" ≠ "owns the browser/evaluator role." (Same shape as the
-  shared-infra rule: ubiquitous capability, single owner. The owner may *consume*
-  shared infra — e.g. a shared inventory-query service — while remaining the owner.)
+  | Domain | Data owner — shared single source of truth | Surface owner — module |
+  |---|---|---|
+  | Reference (CDN) data | `IReferenceDataService` (Mithril.Shared) | **Silmarillion** |
+  | Static storage *export* | `IActiveCharacterService` / `StorageReport` (Mithril.Shared) | **Bilbo** (+ immediate craftability) |
+  | Live inventory simulation | `IInventoryService` (**Mithril.GameState**) — tails `IPlayerLogStream` `ProcessAddItem/…` + chat `[Status]` for stack sizes | **Palantir** (`LiveInventoryView`) |
+  | Eaten-food state | in-game report (dumped to `Player.log`) | **Pippin** (Gourmand) |
+  | Progression state | character export | **Elrond** (as leveling constraints) |
+
+  Owning a *surface* ≠ owning the *data*: the shared service is the single source of
+  truth; modules `Subscribe`/query it (this is *why* it's centralised — the service
+  docstring calls out the late-subscribe race a per-module rebuild would hit).
+  "Renders some data" ≠ "owns the surface," and "owns the surface" ≠ "owns the data."
+  *Recollection correction, verified:* the live-inventory sim is in **Mithril.GameState**,
+  not Mithril.Shared; Mithril.Shared owns the static *export* only.
 
 ---
+
+> **Not yet charactered:** **Palantir** (live-inventory surface over
+> `IInventoryService`), **Smaug**, and **Saruman** are real modules with no charter
+> entry yet — out of scope for this pass. The data-domain table references Palantir
+> only as the live-inventory surface owner; its full charter is owed.
 
 ## Samwise — garden tracker
 
@@ -187,24 +197,24 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ## Bilbo — storage/inventory management
 
-- **Owns: ✅ confirmed (owner, 2026-05-16)** — Bilbo is, at root, **the browser/
-  evaluator for the player's inventory/storage export** (parallel to Silmarillion for
-  reference data): (1) parse the inv/storage export, query it, location chips; (2) a
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — the **browse/evaluate *surface* over
+  the static storage export**: (1) present/query the export, location chips; (2) a
   read-only **craftability evaluator** — "what is craftable *right now* given current
-  inv/storage state." Both are properties/queries *over the player-state export*, not
-  forward activity.
+  export state." Bilbo owns the *surface*, **not the data**: the export is
+  `IActiveCharacterService` / `StorageReport` (Mithril.Shared, single source of truth);
+  Bilbo consumes it.
 - **Does NOT own:**
-  - **✅ confirmed** — *Craft planning* (multi-recipe shopping lists, what-to-acquire,
-    quantity math) → Celebrimbor. The line: "what can I make from what I hold *now*"
-    is Bilbo (a state property); "what do I need to make N of X" is Celebrimbor (a
-    plan). See the recipe/crafting carve-out above.
-  - **✅ confirmed** — *Leveling advice* → Elrond, per the cross-cutting rule
-    (leveling via recipes is Elrond's).
-- **Reference data:** `Items`, `Recipes`, keyword index — joined *against the inv/
-  storage state* to compute immediate craftability.
-  *(The inventory-query surface is a candidate for shared extraction — Celebrimbor §1
-  `IInventoryQueryService`; Bilbo would consume the shared service while remaining the
-  owning evaluator.)*
+  - **✅ confirmed (verified 2026-05-16)** — *Live inventory simulation.* The live
+    `instanceId→item` + stack-size model is `IInventoryService` in **Mithril.GameState**
+    (tails `ProcessAddItem/…` + chat `[Status]`); its user-facing surface is
+    **Palantir** (`LiveInventoryView`), not Bilbo. Bilbo is export-*snapshot*, not live.
+  - **✅ confirmed** — *Craft planning* (shopping lists, what-to-acquire, quantity
+    math) → Celebrimbor. "What can I make from what I hold *now*" is Bilbo (a state
+    property); "what do I need to make N of X" is Celebrimbor (a plan). See the
+    recipe/crafting carve-out above.
+  - **✅ confirmed** — *Leveling advice* → Elrond (cross-cutting rule).
+- **Reference data:** `Items`, `Recipes`, keyword index — joined against the export
+  state to compute immediate craftability.
 
 ## Silmarillion — reference-data browser
 
@@ -298,6 +308,14 @@ libraries; the charter follows the code:
   cross-cutting rule: each data domain has exactly one owning browser/evaluator. Added
   a recipe/crafting carve-out so "what's makeable from what I hold now" stays Bilbo's
   (state query) vs. Celebrimbor's planning.
+- **2026-05-16** — Layering corrected after code verification: split the single-owner
+  rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
+  is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from
+  `ProcessAddItem/…` + chat `[Status]`; its surface is **Palantir**, not Bilbo. Bilbo
+  scoped to the static-*export* surface (data = Mithril.Shared `IActiveCharacterService`/
+  `StorageReport`). Dropped the stale "candidate for shared extraction" note (the
+  shared inventory service already exists). Added a "not yet charactered" note
+  (Palantir/Smaug/Saruman).
 - **2026-05-16** — Elrond Owns expanded by owner: Elrond owns the **player's
   progression state** (learned skills, progress, known recipes) as the leveling
   calculator's constraint set — scoped to the progression facet (distinct from Bilbo's

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -39,14 +39,20 @@ what the module legitimately consumes within its charter (not everything it *cou
   - ⚠️ *Cooking/crafting use of crops.* Crop-as-ingredient is Celebrimbor/Pippin.
 - **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`).
 
-## Pippin — food consumption tracking
+## Pippin — Gourmand support (food-variety tracking)
 
-- **Owns:** tracking food/buff consumption from the log and the food catalog
-  (`FoodDesc` extraction).
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — supplementing PG's **Gourmand** skill,
+  which levels from eating foods *not previously eaten*. Pippin tracks the per-character
+  set of foods already eaten (from the log) against the food catalog and surfaces the
+  not-yet-eaten foods so the player can progress Gourmand. It is about food
+  *novelty/variety*, not buffs.
 - **Does NOT own:**
-  - ⚠️ *Recommending what to eat, or crafting food.* Advice/crafting is Elrond/Celebrimbor.
+  - **✅ confirmed (owner, 2026-05-16)** — *Food buffs.* Pippin tracks nothing about
+    buff effects or buff uptime. Gourmand novelty only.
+  - ⚠️ *Crafting food.* That's Celebrimbor.
   - ⚠️ *Food provenance browsing* (where a food comes from). That's Silmarillion.
-- **Reference data:** `Items` (food descriptors).
+- **Reference data:** `Items` (food catalog / `FoodDesc` to enumerate the universe of
+  foods and identify which items are food).
 
 ## Legolas — surveying & route optimization
 
@@ -150,3 +156,8 @@ libraries; the charter follows the code:
   owner/design-doc-confirmed (Gandalf eligibility confirmed by owner this date; Elrond
   recipe-anchoring and Silmarillion browser-not-calculator from existing design docs).
   All ⚠️ entries are unconfirmed Claude drafts pending owner sign-off.
+- **2026-05-16** — Pippin charter corrected by owner: it supplements the **Gourmand**
+  skill (food-novelty tracking — foods *not yet eaten*), not buff/consumption tracking.
+  Owns + the no-buffs boundary promoted to ✅ confirmed. The earlier draft's
+  "recommending what to eat" non-ownership was deleted — it contradicted the real
+  charter (surfacing un-eaten foods *is* Pippin's job).

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -177,6 +177,11 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
     Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
     Celebrimbor's territory, "not a Silmarillion tab."
+    **Carve-out (owner-clarified 2026-05-16):** *displaying* parsed treasure-effect
+    previews via the shared `ResultEffectsParser` is browsing, not calculation — it is
+    within Silmarillion's charter and is exactly the intent of #214. "Does not
+    calculate" ≠ "cannot render parser output." Silmarillion not showing effects today
+    is a gap, not a prohibition.
 - **Reference data:** effectively all sources (it is the browser), per the bucketing
   rule in the roadmap.
 
@@ -194,8 +199,14 @@ Applies to *every* module; owner-confirmed 2026-05-16:
     *consumes* a target list; whatever decides that list (Elrond / the #227 cross-skill
     planner) is upstream. #228's "plan-aware craft list" means Celebrimbor *receives* a
     computed plan as targets — it does not compute it.
-  - ⚠️ *Reference browsing.* That's Silmarillion. (The "no logic beyond N-of-X" scope
-    strongly implies this, but Celebrimbor↔Silmarillion was not explicitly ruled on.)
+  - **✅ confirmed (owner, 2026-05-16)** — *Generic reference browsing / cross-link
+    navigation* → Silmarillion. **Recipe *display* deliberately overlaps** — both
+    modules show a recipe — differentiated by *purpose*: Silmarillion browses it;
+    Celebrimbor shows it in service of a craft plan and additionally previews its
+    treasure (ResultEffects) outcomes ("what you might get"). The effect-preview
+    capability is **shared infra** (`Mithril.Shared.ResultEffectsParser`), owned by
+    neither; Silmarillion just does not consume it yet — tracked as #214, a *gap, not
+    a boundary*.
 - **Reference data:** `Recipes`, `Items`, `ResultEffectsParser` previews, `Areas`
   (source resolution), inventory.
 
@@ -206,6 +217,11 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 Some responsibilities are deliberately being lifted *out* of modules into shared
 libraries; the charter follows the code:
 
+- **`ResultEffectsParser` (Mithril.Shared) — shipped, shared.** Parses recipe
+  treasure-effect strings into typed previews. Owned by *neither* recipe-displaying
+  module: consumed by Celebrimbor today, by Silmarillion per #214. The canonical
+  "shared infra, not module turf" case — effect *display* is appropriate in any
+  recipe surface; the parser is the single source of truth both lean on.
 - **`Mithril.Leveling` (#225)** — skill-XP math, lifted from Elrond. Future owner of
   the math both Elrond and the #227 planner consume.
 - **Shared demand-driven recipe expander (#226, supersedes #121)** — generalises
@@ -225,6 +241,12 @@ libraries; the charter follows the code:
   tracker — interprets `Player.log` to track plantings + state transitions and alarms
   so plants don't die (loss-prevention, not just ripeness). Owns promoted to ✅
   confirmed.
+- **2026-05-16** — Celebrimbor↔Silmarillion ⚠️ resolved by owner (the last genuine
+  open charter ruling): recipe *display* deliberately overlaps — both show recipes,
+  differentiated by purpose — and Celebrimbor additionally previews treasure effects
+  while Silmarillion currently does not (#214: gap, not boundary). Added a carve-out
+  to Silmarillion's "no computation" line so #214 can't be misread as a charter
+  violation; listed `ResultEffectsParser` as shipped shared infra owned by neither.
 - **2026-05-16** — Pippin corrected again by owner: **food provenance IS in scope**
   — the prior ⚠️ "→ Silmarillion" was a wrong inference, removed. Primary data source
   clarified as the in-game reporting tool's character report (not `Player.log`/CDN; the

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -46,14 +46,23 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   *via* recipes — is owned by **Elrond** (leveling advice) or **Celebrimbor** (planning
   / execution), never by the module that happens to produce or hold the item. Cited by
   Samwise (crops), Pippin (food), and Bilbo (craftables) below.
-- **Displaying reference data is not turf; *being the browser* is.** Any module may
-  *render* reference data when its own purpose needs it (Celebrimbor shows
-  recipes/effects to plan crafts; Pippin shows food provenance for Gourmand). That
-  does **not** make it a co-owner of browsing. **Silmarillion is *the* reference-data
-  browser** — the dedicated, general, authoritative surface; every other module is
-  "just another place the data happens to be displayed." "Renders some data" ≠ "owns
-  the browser role." (Same shape as the shared-infra rule: ubiquitous capability,
-  single owner.)
+  **Carve-out:** *evaluating which recipes the player's current inv/storage already
+  satisfies* is a read-only state query owned by **Bilbo** (its data domain), not
+  planning/leveling. This rule governs crafting-*as-activity* (plan / level / execute),
+  not "what is makeable from what I hold right now."
+- **Each data domain has exactly one owning browser/evaluator; *rendering* it
+  elsewhere is not turf.** Any module may render data its own purpose needs
+  (Celebrimbor shows recipes/effects to plan; modules surface bits of state in
+  passing). That does **not** make it a co-owner. Each domain has a single owner,
+  all owner-confirmed 2026-05-16:
+  - **Silmarillion** — reference (CDN) data.
+  - **Bilbo** — the player's inventory/storage export (incl. immediate craftability).
+  - **Pippin** — the player's eaten-food state (Gourmand novelty + provenance).
+  - **Elrond** — the player's progression state (as leveling constraints).
+
+  "Renders some data" ≠ "owns the browser/evaluator role." (Same shape as the
+  shared-infra rule: ubiquitous capability, single owner. The owner may *consume*
+  shared infra — e.g. a shared inventory-query service — while remaining the owner.)
 
 ---
 
@@ -178,15 +187,24 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ## Bilbo — storage/inventory management
 
-- **Owns:** parsing storage/inventory exports, inventory query, and location chips.
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — Bilbo is, at root, **the browser/
+  evaluator for the player's inventory/storage export** (parallel to Silmarillion for
+  reference data): (1) parse the inv/storage export, query it, location chips; (2) a
+  read-only **craftability evaluator** — "what is craftable *right now* given current
+  inv/storage state." Both are properties/queries *over the player-state export*, not
+  forward activity.
 - **Does NOT own:**
-  - **✅ confirmed** — *Craft planning* (multi-recipe shopping lists) → Celebrimbor,
-    per the cross-cutting recipe/crafting rule.
+  - **✅ confirmed** — *Craft planning* (multi-recipe shopping lists, what-to-acquire,
+    quantity math) → Celebrimbor. The line: "what can I make from what I hold *now*"
+    is Bilbo (a state property); "what do I need to make N of X" is Celebrimbor (a
+    plan). See the recipe/crafting carve-out above.
   - **✅ confirmed** — *Leveling advice* → Elrond, per the cross-cutting rule
     (leveling via recipes is Elrond's).
-- **Reference data:** `Items`, `Recipes`, keyword index (craftable-from-on-hand).
+- **Reference data:** `Items`, `Recipes`, keyword index — joined *against the inv/
+  storage state* to compute immediate craftability.
   *(The inventory-query surface is a candidate for shared extraction — Celebrimbor §1
-  `IInventoryQueryService`; Bilbo would consume the shared service.)*
+  `IInventoryQueryService`; Bilbo would consume the shared service while remaining the
+  owning evaluator.)*
 
 ## Silmarillion — reference-data browser
 
@@ -273,6 +291,13 @@ libraries; the charter follows the code:
   while Silmarillion currently does not (#214: gap, not boundary). Added a carve-out
   to Silmarillion's "no computation" line so #214 can't be misread as a charter
   violation; listed `ResultEffectsParser` as shipped shared infra owned by neither.
+- **2026-05-16** — Bilbo reframed by owner: at root **the browser/evaluator for the
+  player's inv/storage export** (parallel to Silmarillion for reference data) + a
+  read-only "craftable from on-hand now" evaluator. Generalised the four
+  session-confirmed single-owner facts (Silmarillion/Bilbo/Pippin/Elrond) into one
+  cross-cutting rule: each data domain has exactly one owning browser/evaluator. Added
+  a recipe/crafting carve-out so "what's makeable from what I hold now" stays Bilbo's
+  (state query) vs. Celebrimbor's planning.
 - **2026-05-16** — Elrond Owns expanded by owner: Elrond owns the **player's
   progression state** (learned skills, progress, known recipes) as the leveling
   calculator's constraint set — scoped to the progression facet (distinct from Bilbo's

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -67,16 +67,19 @@ Applies to *every* module; owner-confirmed 2026-05-16:
     ingredients, cooking with crops, **and Gardening crafting recipes** — see data
     note) → Elrond/Celebrimbor, per the cross-cutting rule.
 - **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`).
-- **Data note (verified v470, 2026-05-16):** an earlier draft asserted "gardening XP
-  is not in reference data" — **false, corrected.** `Gardening` is a real skill and
-  Gardening *crafting* recipes (`BasicFertilizer1/2/3`, …) are in `recipes.json` with
-  full `RewardSkillXp`/first-time/drop-off, so recipe-based Gardening leveling is
-  Elrond's via the cross-cutting rule like any craft skill. **Verification owed:**
-  whether the *crop-lifecycle actions themselves* (plant / water / apply-fertilizer /
-  harvest) grant XP and whether that lives anywhere in reference data is unverified —
-  not recipe-shaped, so likely absent, but neither owner nor a data check has
-  confirmed. That open question is the only thing that would gate a hypothetical
-  lifecycle-XP feature.
+- **Data note (verified v470, 2026-05-16; refined by owner):** Gardening's **primary**
+  XP source is the planting loop (plant → water → fertilize → harvest) — owner-confirmed
+  it grants XP. A **secondary** source is a handful of Gardening *crafting* recipes
+  (`BasicFertilizer1/2/3`, …), which are in `recipes.json` with full
+  `RewardSkillXp`/first-time/drop-off and so fall to Elrond via the cross-cutting rule
+  like any craft skill. Structural consequence: Elrond is recipe-anchored, so it sees
+  *only the secondary slice* — Gardening's primary progression sits outside both
+  Samwise's charter (tracker, not advisor) and Elrond's (recipe-anchored). **Verification
+  owed:** the planting-loop per-action XP values do not appear to be in reference data
+  (owner's observation; not exhaustively checked). If confirmed absent, no data-feasible
+  XP-driven gardening advisor is possible for the primary source — which is the
+  data-level reason crop-selection optimization stays a soft non-feature, not a
+  temporary gap.
 
 ## Pippin — Gourmand support (food-variety tracking)
 
@@ -124,7 +127,9 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   - **✅ confirmed** — *Non-recipe skills.* Recipe-anchored by design: skills without
     recipes (combat/gathering/etc.) intentionally never appear; Elrond cannot advise
     on them. (Design doc + `elrond_recipe_anchored_design` memory.)
-  - ⚠️ *Multi-recipe shopping / inventory.* That's Celebrimbor.
+  - **✅ confirmed (by entailment, 2026-05-16)** — *Multi-recipe shopping / inventory.*
+    Celebrimbor's Owns is owner-confirmed as exactly this; Elrond not owning it is the
+    direct complement.
   - ⚠️ *The skill-XP math itself, post-#225.* Slated to lift into shared
     `Mithril.Leveling`; after #225 Elrond consumes that engine rather than owning it.
 - **Reference data:** `Recipes`, `Skills`, `XpTables`.
@@ -169,13 +174,20 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ## Celebrimbor — crafting planner
 
-- **Owns:** multi-recipe selection, shopping-list aggregation, on-hand cross-reference,
-  and the craft-step ladder. (See [celebrimbor-roadmap.md](celebrimbor-roadmap.md).)
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — build a shopping list and craft a given
+  set of targets, accounting for what is on hand. Scope is *exactly* "what is needed to
+  make N units of X": multi-recipe selection, shopping-list aggregation, on-hand
+  cross-reference, the craft-step ladder. **It accounts for no logic beyond the
+  quantity math** — no optimization, no strategy, no decision about *what* or *how
+  much* to make. (See [celebrimbor-roadmap.md](celebrimbor-roadmap.md).)
 - **Does NOT own:**
-  - ⚠️ *Leveling optimization.* The cross-skill planner (#227) is the Elrond/Celebrimbor
-    convergence; Celebrimbor *executes* a plan (#228), it does not compute the leveling
-    strategy.
-  - ⚠️ *Reference browsing.* That's Silmarillion.
+  - **✅ confirmed (owner, 2026-05-16)** — *Any logic beyond "make N of X".* Leveling
+    optimization, what-to-craft strategy, ROI — all out. Celebrimbor only ever
+    *consumes* a target list; whatever decides that list (Elrond / the #227 cross-skill
+    planner) is upstream. #228's "plan-aware craft list" means Celebrimbor *receives* a
+    computed plan as targets — it does not compute it.
+  - ⚠️ *Reference browsing.* That's Silmarillion. (The "no logic beyond N-of-X" scope
+    strongly implies this, but Celebrimbor↔Silmarillion was not explicitly ruled on.)
 - **Reference data:** `Recipes`, `Items`, `ResultEffectsParser` previews, `Areas`
   (source resolution), inventory.
 
@@ -205,6 +217,15 @@ libraries; the charter follows the code:
   tracker — interprets `Player.log` to track plantings + state transitions and alarms
   so plants don't die (loss-prevention, not just ripeness). Owns promoted to ✅
   confirmed.
+- **2026-05-16** — Celebrimbor charter confirmed & tightened by owner: scope is exactly
+  "what is needed to make N units of X" + on-hand, no logic beyond the quantity math.
+  Owns + the no-extra-logic boundary → ✅; Elrond's reciprocal "multi-recipe shopping →
+  Celebrimbor" → ✅ by entailment. Celebrimbor↔Silmarillion left ⚠️ (strongly implied,
+  not explicitly ruled).
+- **2026-05-16** — Samwise gardening note refined by owner: planting loop is the
+  *primary* Gardening XP source (grants XP — confirmed); recipes are secondary and in
+  ref data. Recorded that Elrond (recipe-anchored) sees only the secondary slice;
+  primary-loop XP presence in ref data remains Verification owed.
 - **2026-05-16** — Legolas & Arwen sections confirmed accurate by owner; their ⚠️
   entries promoted to ✅.
 - **2026-05-16** — Samwise gardening-XP claim corrected after a v470 data check: the

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -230,21 +230,29 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   `AugmentPoolPreview` pool surface Celebrimbor uses, fed by the shared
   `ResultEffectsParser`. Silmarillion is the **master** view (full pool for any
   browsed recipe); **Celebrimbor is the planning-narrowed slice** of that *same* data
-  (the pool for recipes in your craft plan). **Mechanic — verified against `recipes.json` + `ResultEffectsParser`
-  2026-05-16:** the `*E` *"(enchanted)"* recipes carry generic `Crystal`
-  keyword-ingredient slots (`ItemKeys:["Crystal"]`) and a
-  `TSysCraftedEquipment(template)` ResultEffect; `TryBuildCraftedEquipmentPool`
-  derives the displayable pool from the crafted-equipment template's `TSysProfile` →
-  `IReferenceDataService.Profiles` — so the pool is **template/profile-derived and
-  crystal-independent in reference data.** ⚠️ **Correction:** the owner-stated "rolls
-  influenced by the crystal used" is **not reflected in reference data or the parser**
-  — the crystal slots are consumed ingredients with no effect on the parsed pool; any
-  crystal→roll influence is game-engine *runtime* behaviour, outside browsable data.
-  Consequence: Silmarillion can show the **full possible pool per recipe/template**
-  (browsing, within charter); it **cannot** show "crystal X narrows the pool" — that
-  linkage isn't in the data, and deriving it would be calculation, not browsing
-  (reinforces the no-computation carve-out below). Showing the *possible* pool is
-  **browsing**; it is **not** simulating a specific roll. Relates to #214.
+  (the pool for recipes in your craft plan). **Mechanic — verified against `recipes.json`, `items.json` &
+  `ResultEffectsParser` 2026-05-16 (owner was right; a first, too-narrow check was
+  wrong — see History):** two reference-data pieces combine.
+  1. *Base pool:* the `*E` *"(enchanted)"* recipe's `TSysCraftedEquipment(template)`
+     ResultEffect → `TryBuildCraftedEquipmentPool` → the crafted-equipment template's
+     `TSysProfile` → `IReferenceDataService.Profiles`. This is the full power pool for
+     that equipment template.
+  2. *Crystal scoping:* each `Crystal`-keyword item carries the enchantment family on
+     **its own item record** — `Item.Description` `"Associated Primary Skill: <Skill>"`
+     (+ optional Secondary) and `Item.DynamicCraftingSummary`
+     `"…create items that have <Skill> enchantments."` (e.g. `Moonstone` →
+     *Lycanthropy*; `LapisLazuli` → *Priest*; `Tsavorite` → *Ice Magic*). The crystal
+     slotted into the recipe selects the enchantment family/skill.
+  So the owner-stated "rolls are influenced by the crystal used" **is data-backed** —
+  the linkage lives on the crystal item (`items.json`), not the recipe/parser path
+  (which is why the first verification, tracing only recipe→parser, wrongly concluded
+  "crystal-independent"). **Consequence:** because both pieces are browsable reference
+  data, Silmarillion **can** surface the relationship — browse an enchanted recipe →
+  its `Crystal` slot → candidate crystals → each crystal's associated skill /
+  enchantment family, alongside the template's pool. That is **browsing/cross-linking
+  (within charter)**, *not* calculation. What would be calculation (still not
+  Silmarillion's): computing the precise rolled-power probabilities or the exact
+  template-pool ∩ crystal-skill intersection. Relates to #214.
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
     Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
@@ -337,14 +345,20 @@ libraries; the charter follows the code:
   relationship: Silmarillion = master list / full pool; Celebrimbor = planning-narrowed
   slice of the same data.
 - **2026-05-16** — TSys-pool shape **verified** against `recipes.json` +
-  `ResultEffectsParser`. Confirmed the popup is data-supported (`*E` "(enchanted)" →
+  `ResultEffectsParser`: confirmed the popup is data-supported (`*E` "(enchanted)" →
   `Crystal` keyword slots + `TSysCraftedEquipment(template)` → `AugmentPoolPreview`
-  from `template.TSysProfile`/`Profiles`). **Corrected:** owner-stated "rolls
-  influenced by the crystal" is *not* in reference data — pool is template/profile-
-  derived, crystal-independent; any crystal influence is engine runtime, not
-  browsable. Charter mechanic line moved from owner-stated to verified, discrepancy
-  flagged ⚠️. (Verification overturned the stated mechanic — same pattern as gardening
-  XP and the inv-layering corrections.)
+  from `template.TSysProfile`/`Profiles`).
+- **2026-05-16** — **Self-correction reverted.** The above check also concluded
+  "crystal-independent / engine-runtime only" and flagged the owner's mechanic as
+  unsupported. That was wrong — the check traced only recipe→parser and missed the
+  crystal *item* record. Owner pointed at `Moonstone` (`item_18038`): `Description`
+  *"Associated Primary Skill: Lycanthropy"* + `DynamicCraftingSummary` *"…Lycanthropy
+  enchantments"* (siblings: LapisLazuli→Priest, Tsavorite→Ice Magic). The crystal→
+  enchantment-family linkage **is** in `items.json` — owner was right, the correction
+  was the error. Charter rewritten: two-piece data-backed mechanic; Silmarillion *can*
+  cross-link recipe→crystal→skill (browsing). Lesson: verifying one path and
+  generalising to "not in data" is itself an unverified assertion — scope the check to
+  the claim, not the first path that comes to hand.
 - **2026-05-16** — Layering corrected after code verification: split the single-owner
   rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
   is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -25,6 +25,28 @@ Each **Does NOT own** entry is tagged:
 `Owns` lines are grounded in current code and are lower-risk; `Reference data` lists
 what the module legitimately consumes within its charter (not everything it *could*).
 
+A **Does NOT own** entry is one of two kinds, and the distinction matters:
+
+- **Hard (authority):** another module or the game engine is the source of truth;
+  doing it here would duplicate/contradict authority. Example: Gandalf vs. quest
+  eligibility. *Must not.*
+- **Soft (empty):** on-charter-adjacent and not prohibited, but a deliberate
+  non-feature — the underlying mechanic is trivial or the data doesn't exist, so there
+  is nothing worth building. Example: Samwise vs. crop-selection advice. *Won't,
+  because empty.* These are still binding decisions, just for a different reason.
+
+---
+
+## Cross-cutting ownership (confirmed)
+
+Applies to *every* module; owner-confirmed 2026-05-16:
+
+- **Recipe / crafting → Elrond or Celebrimbor.** Anything recipe- or crafting-related
+  — items as crafting ingredients, crafting *use* of an item, craft planning, leveling
+  *via* recipes — is owned by **Elrond** (leveling advice) or **Celebrimbor** (planning
+  / execution), never by the module that happens to produce or hold the item. Cited by
+  Samwise (crops), Pippin (food), and Bilbo (craftables) below.
+
 ---
 
 ## Samwise — garden tracker
@@ -36,11 +58,17 @@ what the module legitimately consumes within its charter (not everything it *cou
   Alarms are loss-prevention, not merely a ripeness/harvest-ready notification.
   (See `samwise-parser` memory: identification trade-offs, alias-learning convergence.)
 - **Does NOT own:**
-  - ⚠️ *What to plant / crop economics / yield optimization.* It tracks the garden; it
-    does not advise on it. (The "first and foremost a *tracker*" framing leans this
-    way, but the exact boundary is not owner-confirmed.)
-  - ⚠️ *Cooking/crafting use of crops.* Crop-as-ingredient is Celebrimbor/Pippin.
-- **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`).
+  - **✅ confirmed (owner, 2026-05-16) — soft/empty** — *Crop-selection / yield
+    optimization.* Not prohibited (Samwise *could* suggest what to plant) but a
+    deliberate non-feature: PG gardening is intentionally trivial (plant → water when
+    thirsty → fertilize when hungry → collect when ready), so there is nothing to
+    optimize. Gardening XP is likely deterministic but, unlike recipe XP, the values
+    are **not in reference data** — so XP-driven advice isn't even data-feasible.
+  - **✅ confirmed (owner, 2026-05-16)** — *Anything recipe/crafting* (crops as
+    ingredients, cooking with crops) → Elrond/Celebrimbor, per the cross-cutting rule.
+- **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`). Gardening
+  XP is *not* in reference data (contrast: recipe XP tables are), so no XP-driven
+  gardening feature is data-feasible today.
 
 ## Pippin — Gourmand support (food-variety tracking)
 
@@ -52,7 +80,8 @@ what the module legitimately consumes within its charter (not everything it *cou
 - **Does NOT own:**
   - **✅ confirmed (owner, 2026-05-16)** — *Food buffs.* Pippin tracks nothing about
     buff effects or buff uptime. Gourmand novelty only.
-  - ⚠️ *Crafting food.* That's Celebrimbor.
+  - **✅ confirmed** — *Crafting food* → Celebrimbor, per the cross-cutting
+    recipe/crafting rule.
   - ⚠️ *Food provenance browsing* (where a food comes from). That's Silmarillion.
 - **Reference data:** `Items` (food catalog / `FoodDesc` to enumerate the universe of
   foods and identify which items are food).
@@ -106,8 +135,10 @@ what the module legitimately consumes within its charter (not everything it *cou
 
 - **Owns:** parsing storage/inventory exports, inventory query, and location chips.
 - **Does NOT own:**
-  - ⚠️ *Craft planning* (multi-recipe shopping lists). That's Celebrimbor.
-  - ⚠️ *Leveling advice.* That's Elrond.
+  - **✅ confirmed** — *Craft planning* (multi-recipe shopping lists) → Celebrimbor,
+    per the cross-cutting recipe/crafting rule.
+  - **✅ confirmed** — *Leveling advice* → Elrond, per the cross-cutting rule
+    (leveling via recipes is Elrond's).
 - **Reference data:** `Items`, `Recipes`, keyword index (craftable-from-on-hand).
   *(The inventory-query surface is a candidate for shared extraction — Celebrimbor §1
   `IInventoryQueryService`; Bilbo would consume the shared service.)*
@@ -162,8 +193,13 @@ libraries; the charter follows the code:
 - **2026-05-16** — Samwise charter confirmed by owner: first and foremost a garden
   tracker — interprets `Player.log` to track plantings + state transitions and alarms
   so plants don't die (loss-prevention, not just ripeness). Owns promoted to ✅
-  confirmed; ⚠️ tracker-not-advisor boundary left inferred (framing leans that way,
-  not explicitly ruled on).
+  confirmed.
+- **2026-05-16** — Samwise boundaries refined by owner: crop-selection/yield advice is
+  a *soft* non-feature (PG gardening trivial; gardening XP absent from ref data), not a
+  prohibition — promoted to ✅. Recipe/crafting confirmed as Elrond/Celebrimbor
+  territory and lifted into a new "Cross-cutting ownership (confirmed)" section
+  (recurs for Pippin/Bilbo). Added the hard-vs-soft does-not-own distinction to the
+  reading guide.
 - **2026-05-16** — Pippin charter corrected by owner: it supplements the **Gourmand**
   skill (food-novelty tracking — foods *not yet eaten*), not buff/consumption tracking.
   Owns + the no-buffs boundary promoted to ✅ confirmed. The earlier draft's

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -62,13 +62,21 @@ Applies to *every* module; owner-confirmed 2026-05-16:
     optimization.* Not prohibited (Samwise *could* suggest what to plant) but a
     deliberate non-feature: PG gardening is intentionally trivial (plant → water when
     thirsty → fertilize when hungry → collect when ready), so there is nothing to
-    optimize. Gardening XP is likely deterministic but, unlike recipe XP, the values
-    are **not in reference data** — so XP-driven advice isn't even data-feasible.
+    optimize.
   - **✅ confirmed (owner, 2026-05-16)** — *Anything recipe/crafting* (crops as
-    ingredients, cooking with crops) → Elrond/Celebrimbor, per the cross-cutting rule.
-- **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`). Gardening
-  XP is *not* in reference data (contrast: recipe XP tables are), so no XP-driven
-  gardening feature is data-feasible today.
+    ingredients, cooking with crops, **and Gardening crafting recipes** — see data
+    note) → Elrond/Celebrimbor, per the cross-cutting rule.
+- **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`).
+- **Data note (verified v470, 2026-05-16):** an earlier draft asserted "gardening XP
+  is not in reference data" — **false, corrected.** `Gardening` is a real skill and
+  Gardening *crafting* recipes (`BasicFertilizer1/2/3`, …) are in `recipes.json` with
+  full `RewardSkillXp`/first-time/drop-off, so recipe-based Gardening leveling is
+  Elrond's via the cross-cutting rule like any craft skill. **Verification owed:**
+  whether the *crop-lifecycle actions themselves* (plant / water / apply-fertilizer /
+  harvest) grant XP and whether that lives anywhere in reference data is unverified —
+  not recipe-shaped, so likely absent, but neither owner nor a data check has
+  confirmed. That open question is the only thing that would gate a hypothetical
+  lifecycle-XP feature.
 
 ## Pippin — Gourmand support (food-variety tracking)
 
@@ -88,21 +96,24 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ## Legolas — surveying & route optimization
 
-- **Owns:** the survey FSM, position-anchor/projection, survey-run route optimization,
-  and the map overlay. (See `legolas-overview` doc + `legolas_position_anchor_constraint`
-  memory: surveying produces inventory items; movement invalidates the projector.)
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — the survey FSM, position-anchor/projection,
+  survey-run route optimization, and the map overlay. (See `legolas-overview` doc +
+  `legolas_position_anchor_constraint` memory: surveying produces inventory items;
+  movement invalidates the projector.)
 - **Does NOT own:**
-  - ⚠️ *General geographic reference* (where places/landmarks are). Areas/landmarks
-    browsing is Silmarillion.
-  - ⚠️ *Item acquisition guidance.*
+  - **✅ confirmed (owner, 2026-05-16)** — *General geographic reference* (where
+    places/landmarks are). Areas/landmarks browsing is Silmarillion.
+  - **✅ confirmed (owner, 2026-05-16)** — *Item acquisition guidance.*
 - **Reference data:** `Items` (survey items).
 
 ## Arwen — NPC favor & gift tracking
 
-- **Owns:** per-NPC favor state, gift-rate calibration, and gift-outcome tracking.
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — per-NPC favor state, gift-rate
+  calibration, and gift-outcome tracking.
 - **Does NOT own:**
-  - ⚠️ *NPC location/services browsing.* The NPC reference card is Silmarillion.
-  - ⚠️ *Quest-giving / favor-quest adjudication.*
+  - **✅ confirmed (owner, 2026-05-16)** — *NPC location/services browsing.* The NPC
+    reference card is Silmarillion.
+  - **✅ confirmed (owner, 2026-05-16)** — *Quest-giving / favor-quest adjudication.*
 - **Reference data:** `Npcs` (preferences), `Items` (gift identity).
 
 ## Elrond — skill leveling advisor
@@ -194,6 +205,14 @@ libraries; the charter follows the code:
   tracker — interprets `Player.log` to track plantings + state transitions and alarms
   so plants don't die (loss-prevention, not just ripeness). Owns promoted to ✅
   confirmed.
+- **2026-05-16** — Legolas & Arwen sections confirmed accurate by owner; their ⚠️
+  entries promoted to ✅.
+- **2026-05-16** — Samwise gardening-XP claim corrected after a v470 data check: the
+  asserted "gardening XP not in reference data" was **false** — `Gardening` is a skill
+  and `BasicFertilizer1/2/3` recipes carry full Gardening XP, so recipe-based Gardening
+  leveling is Elrond's via the cross-cutting rule. Crop-*lifecycle* XP availability
+  recorded as explicit Verification owed. Both the prior draft and the owner's
+  assumption were off; checking the data resolved it.
 - **2026-05-16** — Samwise boundaries refined by owner: crop-selection/yield advice is
   a *soft* non-feature (PG gardening trivial; gardening XP absent from ref data), not a
   prohibition — promoted to ✅. Recipe/crafting confirmed as Elrond/Celebrimbor

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -225,6 +225,17 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   Silmarillion's charter alone. Field-level scope:
   [silmarillion-field-coverage.md](silmarillion-field-coverage.md); tab scope:
   [silmarillion-roadmap.md](silmarillion-roadmap.md).
+- **In scope — owner-endorsed (2026-05-16):** Silmarillion should be able to show a
+  recipe's **possible TSys (treasure-system) rolls** in a popup — the same
+  `AugmentPoolPreview` pool surface Celebrimbor uses, fed by the shared
+  `ResultEffectsParser`. Silmarillion is the **master** view (full pool for any
+  browsed recipe); **Celebrimbor is the planning-narrowed slice** of that *same* data
+  (the pool for recipes in your craft plan). Mechanic (owner-stated): the roll pool is
+  influenced by the **crystal** (keyword ingredient) used in recipes whose name
+  contains *"(enchanted)"* — the `*E` enchanted-equipment recipes with
+  `RecipeKeywordIngredient` crystal slots. Showing the *possible* pool is **browsing**
+  (within charter, consistent with the carve-out below); it is **not** simulating a
+  specific roll. Relates to #214.
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
     Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
@@ -255,10 +266,13 @@ Applies to *every* module; owner-confirmed 2026-05-16:
     reference browser; Celebrimbor rendering recipe/effect data is **incidental to
     planning, not a co-owned browsing role** — "just another place the data is
     displayed." It shows a recipe in service of a craft plan and previews its treasure
-    (ResultEffects) outcomes. That effect-preview capability is **shared infra**
-    (`Mithril.Shared.ResultEffectsParser`), owned by neither; Silmarillion simply does
-    not consume it yet — #214, a *gap, not a boundary*. (Displaying data ≠ owning the
-    browser role — see the data-display cross-cutting rule above.)
+    (ResultEffects) outcomes — including the TSys augment **pool** for that recipe.
+    Celebrimbor's view is the **planning-narrowed slice** of the master catalogue
+    Silmarillion browses: the *same* shared `ResultEffectsParser` pool surface, scoped
+    to the recipes in the plan rather than the full list. The capability is **shared
+    infra**, owned by neither; Silmarillion does not consume it yet — #214 (*gap, not
+    boundary*; owner-endorsed, see Silmarillion's *In scope*). (Displaying data ≠
+    owning the browser role — see the data-display cross-cutting rule above.)
 - **Reference data:** `Recipes`, `Items`, `ResultEffectsParser` previews, `Areas`
   (source resolution), inventory.
 
@@ -308,6 +322,13 @@ libraries; the charter follows the code:
   cross-cutting rule: each data domain has exactly one owning browser/evaluator. Added
   a recipe/crafting carve-out so "what's makeable from what I hold now" stays Bilbo's
   (state query) vs. Celebrimbor's planning.
+- **2026-05-16** — Owner endorsed Silmarillion showing **possible TSys rolls** via a
+  popup (the `AugmentPoolPreview` surface, shared `ResultEffectsParser`) — promoted
+  from "#214 gap" to explicit in-scope. Sharpened the Silmarillion↔Celebrimbor
+  relationship: Silmarillion = master list / full pool; Celebrimbor = planning-narrowed
+  slice of the same data. Recorded the mechanic (roll pool influenced by the crystal /
+  keyword ingredient in *"(enchanted)"* `*E` recipes). Browsing the *possible* pool ≠
+  simulating a roll, so consistent with the no-computation carve-out.
 - **2026-05-16** — Layering corrected after code verification: split the single-owner
   rule into *data owner (shared service)* vs *surface owner (module)*. `IInventoryService`
   is in **Mithril.GameState** (not Mithril.Shared as recalled) — live sim from

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -58,9 +58,11 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   |---|---|---|
   | Reference (CDN) data | `IReferenceDataService` (Mithril.Shared) | **Silmarillion** |
   | Static storage *export* | `IActiveCharacterService` / `StorageReport` (Mithril.Shared) | **Bilbo** (+ immediate craftability) |
-  | Live inventory simulation | `IInventoryService` (**Mithril.GameState**) — tails `IPlayerLogStream` `ProcessAddItem/…` + chat `[Status]` for stack sizes | **Palantir** (`LiveInventoryView`) |
+  | Live inventory simulation | `IInventoryService` (**Mithril.GameState**) — tails `IPlayerLogStream` `ProcessAddItem/…` + chat `[Status]` for stack sizes | **Palantir** (debug surface — `LiveInventoryView`) |
   | Eaten-food state | in-game report (dumped to `Player.log`) | **Pippin** (Gourmand) |
   | Progression state | character export | **Elrond** (as leveling constraints) |
+  | NPC store state | **Smaug** mines it itself (no shared service) | **Smaug** — the one domain where a single module owns *both* layers |
+  | Words-of-Power known-state | player logs (learn + utterance) | **Saruman** |
 
   Owning a *surface* ≠ owning the *data*: the shared service is the single source of
   truth; modules `Subscribe`/query it (this is *why* it's centralised — the service
@@ -71,10 +73,10 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 
 ---
 
-> **Not yet charactered:** **Palantir** (live-inventory surface over
-> `IInventoryService`), **Smaug**, and **Saruman** are real modules with no charter
-> entry yet — out of scope for this pass. The data-domain table references Palantir
-> only as the live-inventory surface owner; its full charter is owed.
+> **Coverage:** all 12 `*.Module` projects are charactered (owner-confirmed
+> 2026-05-16). `Mithril.Shared` / `Mithril.GameState` / `Mithril.Shell` are shared
+> libraries, not modules — they appear in the data-domain table as *data owners*, not
+> as charter entries.
 
 ## Samwise — garden tracker
 
@@ -304,6 +306,54 @@ Applies to *every* module; owner-confirmed 2026-05-16:
 - **Reference data:** `Recipes`, `Items`, `ResultEffectsParser` previews, `Areas`
   (source resolution), inventory.
 
+## Palantir — debug / dev tools
+
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — a **debug module** (not player-facing):
+  the browser/inspector over **Mithril.GameState** state (incl. the live-inventory
+  view, `LiveInventoryView` over `IInventoryService`), plus dev tools — currently a
+  **badge tester**. A development/diagnostic surface.
+- **Does NOT own:**
+  - **✅ confirmed (owner, 2026-05-16)** — *Any player-facing feature.* Debug-only by
+    charter: exposes engine/GameState internals for development, never a user workflow.
+    (Hard boundary, by the module's nature.)
+- **Data:** reads Mithril.GameState services (`IInventoryService`, …) as a debug
+  surface — owns no player data domain of its own.
+
+## Smaug — NPC stores & sale economics
+
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — viewing NPC stores; the **gold value of
+  the player's inv/storage**; **mining store states** (capturing NPC store
+  contents/state); **sale min/maxing** (optimising what/where to sell).
+- **Does NOT own:**
+  - **✅ confirmed** — *NPC favor / gifts* → Arwen. Smaug is NPC *economics*
+    (buy/sell, store contents, gold) — a distinct purpose from Arwen's relationship/favor.
+  - **✅ confirmed** — *Inv/storage browsing & craftability* → Bilbo. Smaug *consumes*
+    inv/storage state to value it in gold / optimise sales (a distinct purpose-surface
+    over the same shared data); it does not own the inventory browser.
+  - ⚠️ *NPC gold tracking* — owner-noted as a **possible future**, not current scope;
+    provisional until built (cf. the Elrond/#225 line).
+- **Data:** NPC store state — **Smaug mines it itself** (owns both acquisition and
+  surface for this domain). Inv/storage from the shared owners
+  (`IActiveCharacterService`/`StorageReport`) + `Item.Value` for gold valuation.
+
+## Saruman — Words of Power
+
+- **Owns: ✅ confirmed (owner, 2026-05-16)** — the **Words of Power** mechanic: a WoP
+  is an RNG'd string gained via a recipe or item; typing it into chat activates
+  effects. Saruman **monitors the logs** to detect when a WoP is *learned* and tracks
+  the known set, and detects when a known word is *uttered* while logged in and
+  **strikes it from the record** (consumed). Owns the player's WoP known-state
+  lifecycle.
+- **Does NOT own:**
+  - **✅ confirmed** — *The recipe/item as a WoP source in reference data* — that's
+    `ResultEffectsParser` `WordOfPowerPreview` (`DiscoverWordOfPower{N}`), browsable in
+    Silmarillion. Saruman owns the *player's* learned/known/consumed state, not the
+    reference datum "this recipe grants WoP N." (Same data-owner-vs-surface split.)
+- **Data source: ✅ owner-stated (2026-05-16)** — log monitoring: learn-detection +
+  utterance/consumption while logged in. ⚠️ Channel split inferred (not owner-stated):
+  learn likely `Player.log` (recipe/item), utterance the chat log (typed into chat) —
+  verify when the module is next touched.
+
 ---
 
 ## Cross-module shared infra (charter-adjacent)
@@ -329,6 +379,14 @@ libraries; the charter follows the code:
 
 ## History
 
+- **2026-05-16** — Final three modules charactered by owner, closing the set (all 12
+  `*.Module` projects now covered): **Palantir** (debug module — browser over
+  Mithril.GameState + badge tester; not player-facing), **Smaug** (NPC stores, inv/
+  storage gold valuation, store-state mining, sale min/maxing; NPC-gold tracking ⚠️
+  future), **Saruman** (Words-of-Power known-state lifecycle from log monitoring).
+  Added NPC-store-state and WoP-known-state rows to the data-domain table (Smaug is
+  the one domain where a single module owns both acquisition and surface). "Not yet
+  charactered" note replaced with a coverage statement.
 - **2026-05-16** — Doc created. `Owns` grounded in current code; ✅ entries are
   owner/design-doc-confirmed (Gandalf eligibility confirmed by owner this date; Elrond
   recipe-anchoring and Silmarillion browser-not-calculator from existing design docs).

--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -1,0 +1,152 @@
+# Module charters
+
+> **Why this exists.** A module's *purpose* (one line in CLAUDE.md's table) doesn't
+> prevent scope errors — its *boundaries* do. This doc records, per module, what it
+> **owns**, what it **explicitly does not own and why**, and which reference data it is
+> responsible for sourcing. The negative space is the load-bearing part.
+>
+> **The filter this enforces.** A data-availability gap is **not** a feature backlog.
+> "Module X *could* read reference data Y" is only a gap if Y serves X's *Owns*. A
+> "what can modules consume now" pass that ranks by data-reachability will manufacture
+> non-gaps (it did: it proposed Gandalf adjudicate quest eligibility — a direct charter
+> violation). Before proposing work for a module, check its charter: does it serve what
+> the module owns? If not, it belongs to a different module or to no module.
+
+## How to read confidence markers
+
+Each **Does NOT own** entry is tagged:
+
+- **✅ confirmed** — backed by the module owner, an existing design doc, or an
+  established design decision. Treat as binding.
+- **⚠️ inferred** — drafted from code behaviour by Claude, *not* owner-confirmed.
+  A wrong charter is worse than none (it gets cited as authority), so these are
+  **proposals pending sign-off**, not yet binding. Owner: confirm, correct, or delete.
+
+`Owns` lines are grounded in current code and are lower-risk; `Reference data` lists
+what the module legitimately consumes within its charter (not everything it *could*).
+
+---
+
+## Samwise — garden/crop tracking
+
+- **Owns:** identification of garden events from `Player.log`, per-plot crop state,
+  growth/ripeness timing, and harvest-ready alarms. The authority on *when a plot is
+  ready* and *what is planted*, derived from the log. (See `samwise-parser` memory:
+  identification trade-offs, alias-learning convergence.)
+- **Does NOT own:**
+  - ⚠️ *What to plant / crop economics / yield optimization.* It tracks the garden; it
+    does not advise on it.
+  - ⚠️ *Cooking/crafting use of crops.* Crop-as-ingredient is Celebrimbor/Pippin.
+- **Reference data:** `Items` (seed→crop identity via `ItemsByInternalName`).
+
+## Pippin — food consumption tracking
+
+- **Owns:** tracking food/buff consumption from the log and the food catalog
+  (`FoodDesc` extraction).
+- **Does NOT own:**
+  - ⚠️ *Recommending what to eat, or crafting food.* Advice/crafting is Elrond/Celebrimbor.
+  - ⚠️ *Food provenance browsing* (where a food comes from). That's Silmarillion.
+- **Reference data:** `Items` (food descriptors).
+
+## Legolas — surveying & route optimization
+
+- **Owns:** the survey FSM, position-anchor/projection, survey-run route optimization,
+  and the map overlay. (See `legolas-overview` doc + `legolas_position_anchor_constraint`
+  memory: surveying produces inventory items; movement invalidates the projector.)
+- **Does NOT own:**
+  - ⚠️ *General geographic reference* (where places/landmarks are). Areas/landmarks
+    browsing is Silmarillion.
+  - ⚠️ *Item acquisition guidance.*
+- **Reference data:** `Items` (survey items).
+
+## Arwen — NPC favor & gift tracking
+
+- **Owns:** per-NPC favor state, gift-rate calibration, and gift-outcome tracking.
+- **Does NOT own:**
+  - ⚠️ *NPC location/services browsing.* The NPC reference card is Silmarillion.
+  - ⚠️ *Quest-giving / favor-quest adjudication.*
+- **Reference data:** `Npcs` (preferences), `Items` (gift identity).
+
+## Elrond — skill leveling advisor
+
+- **Owns:** per-recipe leveling math (effective XP, first-time bonuses, drop-off),
+  the optimal grind path *within a skill*, and the cookbook view.
+- **Does NOT own:**
+  - **✅ confirmed** — *Non-recipe skills.* Recipe-anchored by design: skills without
+    recipes (combat/gathering/etc.) intentionally never appear; Elrond cannot advise
+    on them. (Design doc + `elrond_recipe_anchored_design` memory.)
+  - ⚠️ *Multi-recipe shopping / inventory.* That's Celebrimbor.
+  - ⚠️ *The skill-XP math itself, post-#225.* Slated to lift into shared
+    `Mithril.Leveling`; after #225 Elrond consumes that engine rather than owning it.
+- **Reference data:** `Recipes`, `Skills`, `XpTables`.
+
+## Gandalf — timers & repeatable-quest cooldowns
+
+- **Owns: time.** When you completed a repeatable, when it is re-attemptable, and
+  user-defined timers/alarms. The authority on *temporal bookkeeping* only.
+- **Does NOT own:**
+  - **✅ confirmed (owner, 2026-05-16)** — *Quest eligibility / "can you do this now".*
+    The game engine is the source of truth for requirements; Gandalf never adjudicates
+    them from `Quest.Requirements`. Recomputing eligibility would duplicate authority it
+    deliberately disclaims and risk disagreeing with the engine. This is the canonical
+    example of why charters exist.
+- **Reference data:** `Quests` (reuse-time fields for cooldown anchoring only),
+  `Strings`/`Areas` (display resolution).
+
+## Bilbo — storage/inventory management
+
+- **Owns:** parsing storage/inventory exports, inventory query, and location chips.
+- **Does NOT own:**
+  - ⚠️ *Craft planning* (multi-recipe shopping lists). That's Celebrimbor.
+  - ⚠️ *Leveling advice.* That's Elrond.
+- **Reference data:** `Items`, `Recipes`, keyword index (craftable-from-on-hand).
+  *(The inventory-query surface is a candidate for shared extraction — Celebrimbor §1
+  `IInventoryQueryService`; Bilbo would consume the shared service.)*
+
+## Silmarillion — reference-data browser
+
+- **Owns: ✅ confirmed** — browsing and cross-linking reference data (master-detail,
+  navigator, provenance popups). Field-level scope is governed by
+  [silmarillion-field-coverage.md](silmarillion-field-coverage.md); tab scope by
+  [silmarillion-roadmap.md](silmarillion-roadmap.md).
+- **Does NOT own:**
+  - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
+    Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
+    Celebrimbor's territory, "not a Silmarillion tab."
+- **Reference data:** effectively all sources (it is the browser), per the bucketing
+  rule in the roadmap.
+
+## Celebrimbor — crafting planner
+
+- **Owns:** multi-recipe selection, shopping-list aggregation, on-hand cross-reference,
+  and the craft-step ladder. (See [celebrimbor-roadmap.md](celebrimbor-roadmap.md).)
+- **Does NOT own:**
+  - ⚠️ *Leveling optimization.* The cross-skill planner (#227) is the Elrond/Celebrimbor
+    convergence; Celebrimbor *executes* a plan (#228), it does not compute the leveling
+    strategy.
+  - ⚠️ *Reference browsing.* That's Silmarillion.
+- **Reference data:** `Recipes`, `Items`, `ResultEffectsParser` previews, `Areas`
+  (source resolution), inventory.
+
+---
+
+## Cross-module shared infra (charter-adjacent)
+
+Some responsibilities are deliberately being lifted *out* of modules into shared
+libraries; the charter follows the code:
+
+- **`Mithril.Leveling` (#225)** — skill-XP math, lifted from Elrond. Future owner of
+  the math both Elrond and the #227 planner consume.
+- **Shared demand-driven recipe expander (#226, supersedes #121)** — generalises
+  Celebrimbor's aggregator; future shared consumer set = Bilbo + Elrond + #227 planner.
+- **`PrereqRecipe` resolver (latent, unfiled)** — three surfaces want the same
+  prereq-chain modelling: #341 (Silmarillion *displays*), Celebrimbor §2 (*visualises*),
+  #227 (*gates on*). If the planner work lands first, downstream surfaces should consume
+  its resolver rather than re-derive.
+
+## History
+
+- **2026-05-16** — Doc created. `Owns` grounded in current code; ✅ entries are
+  owner/design-doc-confirmed (Gandalf eligibility confirmed by owner this date; Elrond
+  recipe-anchoring and Silmarillion browser-not-calculator from existing design docs).
+  All ⚠️ entries are unconfirmed Claude drafts pending owner sign-off.


### PR DESCRIPTION
## What

New `docs/module-charters.md` + a pointer from CLAUDE.md's module table.

Records, per module, **Owns / Does-NOT-own (with why) / reference data it sources**. The negative space is the point: CLAUDE.md's purpose-only table structurally can't say "Gandalf does *not* adjudicate quest eligibility — the engine is the source of truth," and that omission directly produced a scope error this session (a data-availability gap pass proposed exactly that charter violation).

## Why now

A "what reference data can modules consume now" exploration ranked opportunities by data-reachability and manufactured non-gaps: two were already subsumed by the #225–#228 Elrond/Celebrimbor spine, one violated Gandalf's charter. The doc encodes the filter that prevents this: *a data-availability gap is not a feature unless it serves the module's charter.*

## Trust model (important for review)

- **`Owns`** lines are grounded in current code — lower risk.
- **`Does NOT own`** entries are explicitly tagged:
  - **✅ confirmed** — owner/design-doc backed. Binding. (Gandalf eligibility — owner-confirmed this session; Elrond recipe-anchoring — existing design doc + memory; Silmarillion browser-not-calculator — roadmap.)
  - **⚠️ inferred** — Claude drafts from code behaviour, **not** owner-confirmed. Explicitly *proposals pending sign-off*, not binding. A wrong charter is worse than none, so these are flagged rather than asserted.

**Review ask:** the ⚠️ entries need an owner pass — confirm, correct, or delete each. They are intentionally not authoritative until that happens.

## Scope / safety

Docs only (new doc + one CLAUDE.md pointer paragraph). No code. Branch cut fresh from current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— drafted by Claude (Opus 4.7), posted by @arthur-conde
