### PR TITLE
fix(silmarillion): provenance popup chips are dead on click (#353)

### DIFF
--- a/src/Mithril.Shared.Wpf/ProvenancePopupWindow.xaml
+++ b/src/Mithril.Shared.Wpf/ProvenancePopupWindow.xaml
@@ -60,7 +60,7 @@
                 <Setter Property="ItemTemplate">
                     <Setter.Value>
                         <DataTemplate>
-                            <c:EntityChip ClickCommand="{Binding DataContext.ChipClickCommand,
+                            <c:EntityChip ClickCommand="{Binding ChipClickCommand,
                                               RelativeSource={RelativeSource AncestorType={x:Type local:ProvenancePopupWindow}}}"/>
                         </DataTemplate>
                     </Setter.Value>


### PR DESCRIPTION
Closes #353.

## Problem

Clicking an `EntityChip` inside the shared `ProvenancePopupWindow` (the "View all N →" popup from summary sections in every Silmarillion `*DetailView`) did nothing.

## Root cause

`ProvenancePopupWindow.xaml` bound the chip `ClickCommand` via `DataContext.ChipClickCommand`, resolving to `ProvenancePopupViewModel.ChipClickCommand` — which does not exist. `ChipClickCommand` is a `DependencyProperty` on the **window**, set by the host. The binding silently failed, `EntityChip.ClickCommand` stayed null, and the click handler early-returned for every chip across all detail views.

## Fix

One line: drop the `DataContext.` prefix so the binding targets the window's own DP (the `RelativeSource` already points at the window). The sibling "To Query" button keeps `DataContext.` because `ToQueryCommand` genuinely lives on the VM.

## Verification

XAML-only — no unit-test coverage. Verified live in a clean worktree build: Silmarillion detail view → "View all N →" → chip click now navigates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
