### PR TITLE
refactor(reference): canonical StoreCapIncrease record + shared parser (#350)

### DIFF
--- a/docs/mithril-reference-shape-quirks.md
+++ b/docs/mithril-reference-shape-quirks.md
@@ -205,6 +205,44 @@ and the test fakes' `AddRecipe` signatures retyped to match. Real bundled
 data only ships `0.1` as a literal double, so production behaviour matches
 the pre-unification path; the only behaviour change is at the test seam.
 
+### `StoreService.ParsedCapIncreases`: computed companion, not a converter-time deviation
+
+**Where:** [Models/Npcs/NpcService.cs](../src/Mithril.Reference/Models/Npcs/NpcService.cs)
+(`StoreService`), parsed by
+[StoreCapIncreaseParser](../src/Mithril.Reference/Models/Npcs/StoreCapIncreaseParser.cs).
+
+`StoreService.CapIncreases` ships as raw colon strings
+(`"Despised:5000:Armor,Weapon,CorpseTrophy"` — `Tier:GoldCap:keyword,…`). Two
+consumers historically re-parsed it independently: Smaug's
+`ReferenceDataService.ParseCapIncreases` (→ a slim `NpcStoreCapIncrease`
+record) and Silmarillion's `NpcsTabViewModel.FormatCapIncrease` split logic.
+#350 unified both on the canonical `StoreCapIncrease` record + parser in this
+project.
+
+**Why a computed companion, not the `Item.Keywords` converter pattern:** the
+`Item`/`Recipe` deviations *replace* the raw shape at the JSON-converter seam
+(`Keywords: IReadOnlyList<ItemKeyword>?` was `IReadOnlyList<string>?`). Here we
+instead keep `CapIncreases` JSON-faithful and add a get-only
+`ParsedCapIncreases => StoreCapIncreaseParser.Parse(CapIncreases)`. Reasons:
+
+- No bespoke `JsonConverter` needed — the parse is a pure string split, not a
+  deserialization concern; a converter would be ceremony.
+- The model stays **attribute-free** per the `Models/` README. The computed
+  property carries *no* `[JsonIgnore]`: reference data is deserialize-only and
+  no test serializes models back, so a get-only property never round-trips and
+  the attribute would be both unnecessary and a README violation.
+- Both raw and parsed forms stay available — the raw list is still the literal
+  JSON contract for the drift-validation harness; the parsed list is the
+  queryable seam for nested store-cap filtering (#351 `WITH ANY|ALL`).
+
+**The rule this implies:** when a field's parse is a pure transform of its own
+raw value (no cross-field or envelope-key input), prefer a computed companion
+over a converter-time replacement — it keeps the JSON contract honest, needs no
+serialization plumbing, and is the cheapest place to expose a queryable shape.
+Reach for the converter pattern (`Item.Keywords`) only when *every* consumer
+pays the un-shape tax or the lifted value depends on out-of-field context
+(`Item.Id` from the envelope key).
+
 ### `RecipeRequirement` is a separate hierarchy from `QuestRequirement`
 
 **Where:** [Models/Quests/QuestRequirement.cs](../src/Mithril.Reference/Models/Quests/QuestRequirement.cs)

--- a/src/Mithril.Reference/Models/Npcs/NpcService.cs
+++ b/src/Mithril.Reference/Models/Npcs/NpcService.cs
@@ -11,7 +11,11 @@ public abstract class NpcService
 {
     public string Type { get; set; } = "";
 
-    /// <summary>Minimum favor level required to access this service. Always present.</summary>
+    /// <summary>
+    /// Minimum favor level required to access this service <em>at all</em>. Always present.
+    /// Distinct from <see cref="StoreCapIncrease.Tier"/>, which is the per-row threshold at
+    /// which an individual Store gold-cap unlocks — this gates the whole service.
+    /// </summary>
     public string? Favor { get; set; }
 }
 
@@ -52,7 +56,21 @@ public sealed class StorageService : NpcService
 
 public sealed class StoreService : NpcService
 {
+    /// <summary>
+    /// Raw per-tier gold-cap rows, each a colon string
+    /// <c>"&lt;Tier&gt;:&lt;GoldCap&gt;:&lt;keyword,keyword,…&gt;"</c>. JSON-faithful shape;
+    /// consume the parsed view via <see cref="ParsedCapIncreases"/>.
+    /// </summary>
     public IReadOnlyList<string>? CapIncreases { get; set; }
+
+    /// <summary>
+    /// Structured view of <see cref="CapIncreases"/>, parsed via
+    /// <see cref="StoreCapIncreaseParser"/>. Computed get-only (no JSON attribute by
+    /// the attribute-free model convention; reference data is deserialize-only so it
+    /// never round-trips). This is the queryable shape for nested store-cap filtering.
+    /// </summary>
+    public IReadOnlyList<StoreCapIncrease> ParsedCapIncreases =>
+        StoreCapIncreaseParser.Parse(CapIncreases);
 }
 
 public sealed class TrainingService : NpcService

--- a/src/Mithril.Reference/Models/Npcs/StoreCapIncrease.cs
+++ b/src/Mithril.Reference/Models/Npcs/StoreCapIncrease.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Mithril.Reference.Models.Npcs;
+
+/// <summary>
+/// One parsed entry from a <see cref="StoreService.CapIncreases"/> array. The raw
+/// JSON form is the colon string <c>"&lt;Tier&gt;:&lt;GoldCap&gt;:&lt;keyword,keyword,…&gt;"</c>
+/// (e.g. <c>"Despised:5000:Armor,Weapon,CorpseTrophy"</c>). The keyword segment may be
+/// absent or empty, meaning the cap applies to any item.
+/// </summary>
+/// <param name="Tier">
+/// The favor tier at which <em>this gold-cap row</em> unlocks (e.g. <c>"Despised"</c>,
+/// <c>"Neutral"</c>). Kept verbatim — <c>"Despised"</c> is a real tier, not a sentinel.
+/// Distinct from <see cref="NpcService.Favor"/>, which gates access to the Store
+/// service itself; this is the per-row cap-unlock threshold.
+/// </param>
+/// <param name="GoldCap">
+/// Maximum gold the vendor will pay for matching items at <paramref name="Tier"/>.
+/// <see langword="null"/> when the raw middle segment was not an integer.
+/// </param>
+/// <param name="Keywords">
+/// Item keyword tags this cap applies to; an empty list means the cap applies to any item.
+/// </param>
+public sealed record StoreCapIncrease(
+    string Tier,
+    int? GoldCap,
+    IReadOnlyList<string> Keywords);

--- a/src/Mithril.Reference/Models/Npcs/StoreCapIncreaseParser.cs
+++ b/src/Mithril.Reference/Models/Npcs/StoreCapIncreaseParser.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mithril.Reference.Models.Npcs;
+
+/// <summary>
+/// Single source of truth for parsing <see cref="StoreService.CapIncreases"/> raw
+/// colon strings (<c>"&lt;Tier&gt;:&lt;GoldCap&gt;:&lt;keyword,keyword,…&gt;"</c>) into
+/// <see cref="StoreCapIncrease"/> records. Replaces two formerly-duplicated parsers:
+/// Smaug's <c>ReferenceDataService.ParseCapIncreases</c> and Silmarillion's
+/// <c>NpcsTabViewModel.FormatCapIncrease</c> split logic.
+/// </summary>
+public static class StoreCapIncreaseParser
+{
+    /// <summary>
+    /// Parse one raw line. Returns <see langword="null"/> when the line is structurally
+    /// unusable (blank, or fewer than two colon-separated parts). <c>GoldCap</c> is
+    /// <see langword="null"/> when the middle segment is not an integer.
+    /// </summary>
+    public static StoreCapIncrease? ParseLine(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var parts = raw.Split(':', 3);
+        if (parts.Length < 2) return null;
+        int? gold = int.TryParse(parts[1], out var g) ? g : null;
+        var keywords = parts.Length == 3 && !string.IsNullOrWhiteSpace(parts[2])
+            ? (IReadOnlyList<string>)parts[2].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            : [];
+        return new StoreCapIncrease(parts[0], gold, keywords);
+    }
+
+    /// <summary>
+    /// Parse a whole <see cref="StoreService.CapIncreases"/> array, keeping every
+    /// structurally-valid row. A row whose gold segment did not parse is kept with a
+    /// <see langword="null"/> <see cref="StoreCapIncrease.GoldCap"/>.
+    /// </summary>
+    public static IReadOnlyList<StoreCapIncrease> Parse(IReadOnlyList<string>? raw)
+    {
+        if (raw is null || raw.Count == 0) return [];
+        var result = new List<StoreCapIncrease>(raw.Count);
+        foreach (var line in raw)
+        {
+            if (ParseLine(line) is { } cap) result.Add(cap);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Parse a whole array but <em>drop</em> rows whose gold did not parse — byte-identical
+    /// to the pre-unification <c>ReferenceDataService.ParseCapIncreases</c> behaviour,
+    /// used by the Smaug vendor-pricing projection where a missing cap must not be
+    /// treated as "no cap".
+    /// </summary>
+    public static IReadOnlyList<StoreCapIncrease> ParseRequiringGold(IReadOnlyList<string>? raw)
+    {
+        if (raw is null || raw.Count == 0) return [];
+        var result = new List<StoreCapIncrease>(raw.Count);
+        foreach (var line in raw)
+        {
+            if (ParseLine(line) is { GoldCap: not null } cap) result.Add(cap);
+        }
+        return result;
+    }
+}

--- a/src/Mithril.Shared/Reference/NpcEntry.cs
+++ b/src/Mithril.Shared/Reference/NpcEntry.cs
@@ -1,3 +1,7 @@
+// Only StoreCapIncrease is pulled from the Reference models — aliased to avoid
+// colliding with this file's own slim NpcService record.
+using StoreCapIncrease = Mithril.Reference.Models.Npcs.StoreCapIncrease;
+
 namespace Mithril.Shared.Reference;
 
 /// <summary>
@@ -33,14 +37,4 @@ public sealed record NpcPreference(
 public sealed record NpcService(
     string Type,
     string? MinFavorTier,
-    IReadOnlyList<NpcStoreCapIncrease> CapIncreases);
-
-/// <summary>
-/// One entry of a Store service's <c>CapIncreases</c> array. Parsed from the
-/// raw string form <c>"&lt;FavorTier&gt;:&lt;MaxGold&gt;:&lt;keyword,keyword,…&gt;"</c>.
-/// An empty <see cref="Keywords"/> list means the cap applies to any item.
-/// </summary>
-public sealed record NpcStoreCapIncrease(
-    string FavorTier,
-    int MaxGold,
-    IReadOnlyList<string> Keywords);
+    IReadOnlyList<StoreCapIncrease> CapIncreases);

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -21,6 +21,8 @@ using PocoNpc = Mithril.Reference.Models.Npcs.Npc;
 using PocoNpcPreference = Mithril.Reference.Models.Npcs.NpcPreference;
 using PocoNpcService = Mithril.Reference.Models.Npcs.NpcService;
 using PocoNpcStoreService = Mithril.Reference.Models.Npcs.StoreService;
+using StoreCapIncrease = Mithril.Reference.Models.Npcs.StoreCapIncrease;
+using StoreCapIncreaseParser = Mithril.Reference.Models.Npcs.StoreCapIncreaseParser;
 using PocoPower = Mithril.Reference.Models.Misc.PowerProfile;
 using DirectedGoal = Mithril.Reference.Models.Misc.DirectedGoal;
 using AbilityKeyword = Mithril.Reference.Models.Misc.AbilityKeyword;
@@ -1108,7 +1110,7 @@ public sealed class ReferenceDataService : IReferenceDataService
                 .Select(s => new NpcService(
                     s.Type,
                     s.Favor,
-                    s is PocoNpcStoreService store ? ParseCapIncreases(store.CapIncreases) : (IReadOnlyList<NpcStoreCapIncrease>)[]))
+                    s is PocoNpcStoreService store ? StoreCapIncreaseParser.ParseRequiringGold(store.CapIncreases) : (IReadOnlyList<StoreCapIncrease>)[]))
                 .ToList();
 
             var entry = new NpcEntry(
@@ -1359,25 +1361,6 @@ public sealed class ReferenceDataService : IReferenceDataService
         // strings_all changes the answer. The other two indices are unaffected but rebuilding
         // them is cheap (single recipe walk).
         BuildRecipeCrossLinkIndices();
-    }
-
-    /// <summary>Parses <c>"Despised:5000:Armor,Weapon,CorpseTrophy"</c> strings.</summary>
-    private static IReadOnlyList<NpcStoreCapIncrease> ParseCapIncreases(IReadOnlyList<string>? raw)
-    {
-        if (raw is null || raw.Count == 0) return [];
-        var result = new List<NpcStoreCapIncrease>(raw.Count);
-        foreach (var line in raw)
-        {
-            if (string.IsNullOrWhiteSpace(line)) continue;
-            var parts = line.Split(':', 3);
-            if (parts.Length < 2) continue;
-            if (!int.TryParse(parts[1], out var cap)) continue;
-            var keywords = parts.Length == 3 && !string.IsNullOrWhiteSpace(parts[2])
-                ? (IReadOnlyList<string>)parts[2].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                : [];
-            result.Add(new NpcStoreCapIncrease(parts[0], cap, keywords));
-        }
-        return result;
     }
 
     private void ParseAndSwapItemSources(IReadOnlyDictionary<string, PocoSourceEnvelope> raw, ReferenceFileMetadata meta)

--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -211,7 +211,7 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
         // Store caps are kept one-per-row: each tier raises a distinct gold cap and the per-row
         // keyword tuple is surfaced as a chip strip that flips to the Items tab pre-filtered.
         StoreService store when store.CapIncreases is { Count: > 0 } =>
-            store.CapIncreases.Select(FormatCapIncrease).ToList(),
+            store.ParsedCapIncreases.Select(FormatCapIncrease).ToList(),
 
         BarterService barter when barter.AdditionalUnlocks is { Count: > 0 } =>
             BuildLabeledLines(("Unlocks at higher favor", barter.AdditionalUnlocks)),
@@ -275,27 +275,20 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     }
 
     /// <summary>
-    /// Format one Store cap-increase entry. Prose is <c>"Tier → 5,000g"</c>; the keyword tuple
-    /// (when present) becomes the per-line chip strip — each chip targets the Items tab via
-    /// <see cref="EntityKind.ItemByKeyword"/> (the single-keyword Items filter pivot restored
-    /// in #327; not the retired #270 fan-out kind). Mirrors the colon-separated parser shape
-    /// in <see cref="Mithril.Shared.Reference.ReferenceDataService"/>.
+    /// Format one parsed Store <see cref="StoreCapIncrease"/> row. Prose is
+    /// <c>"Tier → 5,000g"</c>; the keyword tuple (when present) becomes the per-line chip
+    /// strip — each chip targets the Items tab via <see cref="EntityKind.ItemByKeyword"/>
+    /// (the single-keyword Items filter pivot restored in #327; not the retired #270 fan-out
+    /// kind). Parsing now lives in <see cref="StoreCapIncreaseParser"/> (#350) — this method
+    /// is presentation only.
     /// </summary>
-    private NpcServiceDetailLine FormatCapIncrease(string raw)
+    private NpcServiceDetailLine FormatCapIncrease(StoreCapIncrease cap)
     {
-        // Raw line shape: "Despised:5000:Armor,Weapon,CorpseTrophy". Three colon-separated parts;
-        // last part may be empty.
-        var parts = raw.Split(':', 3);
-        if (parts.Length < 2) return NpcServiceDetailLine.TextOnly(raw);
-        var tier = parts[0];
-        var gold = int.TryParse(parts[1], out var g) ? g.ToString("N0") + "g" : parts[1];
-        var prose = $"{tier} → {gold}";
-        if (parts.Length < 3 || string.IsNullOrWhiteSpace(parts[2]))
+        var gold = cap.GoldCap is { } g ? g.ToString("N0") + "g" : "—";
+        var prose = $"{cap.Tier} → {gold}";
+        if (cap.Keywords.Count == 0)
             return NpcServiceDetailLine.TextOnly(prose);
-        var keywords = parts[2].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        if (keywords.Length == 0) return NpcServiceDetailLine.TextOnly(prose);
-        var chips = BuildKeywordChips(keywords);
-        return new NpcServiceDetailLine(prose, chips);
+        return new NpcServiceDetailLine(prose, BuildKeywordChips(cap.Keywords));
     }
 
     /// <summary>

--- a/src/Smaug.Module/Domain/VendorCapResolver.cs
+++ b/src/Smaug.Module/Domain/VendorCapResolver.cs
@@ -46,9 +46,11 @@ public static class VendorCapResolver
         int? best = null;
         foreach (var cap in store.CapIncreases)
         {
-            if (FavorTierName.RankOf(cap.FavorTier) > currentRank) continue;
+            if (FavorTierName.RankOf(cap.Tier) > currentRank) continue;
             if (!MatchesKeywords(cap.Keywords, itemKeywords)) continue;
-            if (best is null || cap.MaxGold > best.Value) best = cap.MaxGold;
+            // GoldCap is int? on the canonical record; the Smaug projection uses
+            // ParseRequiringGold so it is never null here, but stay nullable-correct.
+            if (cap.GoldCap is { } g && (best is null || g > best.Value)) best = g;
         }
 
         if (best is null) return null;

--- a/tests/Mithril.Reference.Tests/StoreCapIncreaseParserTests.cs
+++ b/tests/Mithril.Reference.Tests/StoreCapIncreaseParserTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Reference.Models.Npcs;
+using Xunit;
+
+namespace Mithril.Reference.Tests;
+
+/// <summary>
+/// Locks the single-source-of-truth cap-increase parser (#350). The key contract:
+/// <see cref="StoreCapIncreaseParser.Parse"/> keeps structurally-valid rows even when
+/// the gold segment is non-numeric (<c>GoldCap == null</c>), while
+/// <see cref="StoreCapIncreaseParser.ParseRequiringGold"/> drops those — byte-identical
+/// to the pre-unification Smaug projection (<c>ReferenceDataService.ParseCapIncreases</c>).
+/// </summary>
+public class StoreCapIncreaseParserTests
+{
+    [Fact]
+    public void ParseLine_full_three_part_row()
+    {
+        var cap = StoreCapIncreaseParser.ParseLine("Despised:5000:Armor,Weapon,CorpseTrophy");
+
+        cap.Should().NotBeNull();
+        cap!.Tier.Should().Be("Despised");
+        cap.GoldCap.Should().Be(5000);
+        cap.Keywords.Should().Equal("Armor", "Weapon", "CorpseTrophy");
+    }
+
+    [Fact]
+    public void ParseLine_two_part_row_has_empty_keywords()
+    {
+        var cap = StoreCapIncreaseParser.ParseLine("Friends:1000");
+
+        cap.Should().NotBeNull();
+        cap!.Tier.Should().Be("Friends");
+        cap.GoldCap.Should().Be(1000);
+        cap.Keywords.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseLine_empty_third_segment_yields_empty_keywords()
+    {
+        var cap = StoreCapIncreaseParser.ParseLine("Friends:1000:");
+
+        cap!.Keywords.Should().BeEmpty();
+        cap.GoldCap.Should().Be(1000);
+    }
+
+    [Fact]
+    public void ParseLine_trims_and_drops_blank_keywords()
+    {
+        var cap = StoreCapIncreaseParser.ParseLine("Neutral:50: Armor , , Weapon ");
+
+        cap!.Keywords.Should().Equal("Armor", "Weapon");
+    }
+
+    [Fact]
+    public void ParseLine_non_integer_gold_keeps_row_with_null_goldcap()
+    {
+        var cap = StoreCapIncreaseParser.ParseLine("Friends:notanumber:Armor");
+
+        cap.Should().NotBeNull();
+        cap!.Tier.Should().Be("Friends");
+        cap.GoldCap.Should().BeNull();
+        cap.Keywords.Should().Equal("Armor");
+    }
+
+    [Theory]
+    [InlineData("Friends")]      // < 2 colon parts
+    [InlineData("")]             // empty
+    [InlineData("   ")]          // whitespace
+    [InlineData(null)]           // null
+    public void ParseLine_structurally_unusable_returns_null(string? raw)
+    {
+        StoreCapIncreaseParser.ParseLine(raw).Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_keeps_bad_gold_rows()
+    {
+        IReadOnlyList<string> raw =
+            ["Despised:5000:Armor", "Friends:notanumber:Weapon", "single", "  "];
+
+        var parsed = StoreCapIncreaseParser.Parse(raw);
+
+        parsed.Select(c => c.Tier).Should().Equal("Despised", "Friends");
+        parsed[1].GoldCap.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseRequiringGold_drops_bad_gold_rows_matching_legacy_projection()
+    {
+        IReadOnlyList<string> raw =
+            ["Despised:5000:Armor", "Friends:notanumber:Weapon", "single", "  "];
+
+        var parsed = StoreCapIncreaseParser.ParseRequiringGold(raw);
+
+        parsed.Should().ContainSingle();
+        parsed[0].Tier.Should().Be("Despised");
+        parsed[0].GoldCap.Should().Be(5000);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Parse_null_or_empty_input_yields_empty(bool requireGold)
+    {
+        var fromNull = requireGold
+            ? StoreCapIncreaseParser.ParseRequiringGold(null)
+            : StoreCapIncreaseParser.Parse(null);
+        var fromEmpty = requireGold
+            ? StoreCapIncreaseParser.ParseRequiringGold([])
+            : StoreCapIncreaseParser.Parse([]);
+
+        fromNull.Should().BeEmpty();
+        fromEmpty.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #350. Part of #349 (PR-1 of 3 — standalone, lands first).

## What

Unifies the **two duplicated cap-increase parsers** onto one canonical record + parser in `Mithril.Reference` (the leaf project), establishing the structured shape that #351's `WITH ANY|ALL` nested-query engine will later reflect over. Independently valuable: kills the duplication regardless of the engine work.

## Changes

- **New** `StoreCapIncrease(string Tier, int? GoldCap, IReadOnlyList<string> Keywords)` + `StoreCapIncreaseParser` (single source of truth).
  - `Parse` keeps structurally-valid rows even when gold is non-numeric (`GoldCap == null`).
  - `ParseRequiringGold` drops bad-gold rows — **byte-identical** to the deleted `ReferenceDataService.ParseCapIncreases` the Smaug vendor-pricing projection relied on (a missing cap must not read as "no cap").
- `StoreService.ParsedCapIncreases` computed companion. Raw `CapIncreases` stays JSON-faithful; **no `[JsonIgnore]`** — the `Models/` attribute-free convention plus deserialize-only reference data make it unnecessary (and the attribute would violate the README). Pattern recorded in `docs/mithril-reference-shape-quirks.md` as a *computed-companion*, explicitly distinct from the `Item`/`Recipe` converter-time deviations.
- Delete slim `NpcStoreCapIncrease`; retype slim `NpcService.CapIncreases` to the canonical record (alias-imported to avoid the `NpcService` name collision in `NpcEntry.cs`).
- Migrate the one Smaug call site (`VendorCapResolver`) to `Tier`/`GoldCap (int?)`, nullable-correct. `SellPlanner`/`StorageSellback` use `.Keywords` only — recompile clean. Other `FavorTier` hits are unrelated `PriceObservation`/event DTOs.
- `NpcsTabViewModel.FormatCapIncrease` consumes the parsed record; keyword-chip presentation (`KeywordDisplayNames`/`EntityRef.ItemByKeyword`/navigator) stays in the VM unchanged.
- `StoreCapIncrease.Tier` (per-row cap-unlock threshold) explicitly disambiguated from `NpcService.Favor` (service-access gate) in XML docs.

## Verification

- `dotnet build Mithril.slnx` — 0 warnings (warnings-as-errors), .NET 10.
- Full solution suite green. New `StoreCapIncreaseParserTests` (12 cases: 3/2/1-part, empty/bad-gold `Parse`-keeps-vs-`ParseRequiringGold`-drops, whitespace/null, keyword trim).
- **Smaug parity gate**: `tests/Smaug.Tests` (25) pass unchanged — vendor pricing semantics preserved.
- Silmarillion NPC detail tests (well-formed fixtures) produce identical prose/chips through the parser swap — no fixture edits needed.

## Marketplace check

Confirmed `I:\src\Marketplace` does not consume `NpcStoreCapIncrease`/`.FavorTier`/`.MaxGold` — safe to delete the slim record outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
