### PR TITLE
feat(elrond): send recipe to Celebrimbor craft list in-process (#224)

### DIFF
--- a/src/Celebrimbor.Module/Services/CraftListImportTarget.cs
+++ b/src/Celebrimbor.Module/Services/CraftListImportTarget.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Celebrimbor.Domain;
 using Celebrimbor.ViewModels;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Modules;
@@ -34,21 +35,44 @@ public sealed class CraftListImportTarget : ICraftListImportTarget
     public void ImportFromLinkPayload(string base64UrlPayload)
     {
         var result = CraftListFormat.DecodeShareLink(base64UrlPayload, _refData);
-
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null || dispatcher.CheckAccess())
-            Apply(result);
-        else
-            dispatcher.InvokeAsync(() => Apply(result));
+        Dispatch(() => Apply(result, "Import from link"));
     }
 
-    private void Apply(ParseResult result)
+    public void ImportRecipes(IReadOnlyList<CraftListImportEntry> recipes, string source)
+    {
+        var entries = new List<CraftListEntry>();
+        var warnings = new List<string>();
+        foreach (var r in recipes)
+        {
+            if (string.IsNullOrWhiteSpace(r.RecipeInternalName) || r.Quantity <= 0) continue;
+            if (!_refData.RecipesByInternalName.ContainsKey(r.RecipeInternalName))
+            {
+                warnings.Add($"Unknown recipe: \"{r.RecipeInternalName}\"");
+                continue;
+            }
+            entries.Add(new CraftListEntry { RecipeInternalName = r.RecipeInternalName, Quantity = r.Quantity });
+        }
+
+        var result = new ParseResult(entries, warnings);
+        Dispatch(() => Apply(result, source));
+    }
+
+    private static void Dispatch(Action action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            action();
+        else
+            dispatcher.InvokeAsync(action);
+    }
+
+    private void Apply(ParseResult result, string dialogTitleSuffix)
     {
         // Bring the Celebrimbor tab forward first so the dialog owner is the right window and
         // the user sees the list populate after confirming.
         if (_activator is not null && !_activator.Activate("celebrimbor"))
-            _diag?.Info("Celebrimbor", "Deep-link import: module activator could not find 'celebrimbor'.");
+            _diag?.Info("Celebrimbor", "Craft-list import: module activator could not find 'celebrimbor'.");
 
-        _picker.PromptAndApply(result, "Import from link");
+        _picker.PromptAndApply(result, dialogTitleSuffix);
     }
 }

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -38,7 +38,8 @@ public sealed class ElrondModule : IMithrilModule
             sp.GetRequiredService<LevelingSimulator>(),
             sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
             sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
-            sp.GetRequiredService<ElrondSettings>()));
+            sp.GetRequiredService<ElrondSettings>(),
+            sp.GetService<ICraftListImportTarget>()));
         services.AddSingleton<IElrondSkillImportTarget>(sp => new Services.ElrondSkillImportTarget(
             sp.GetRequiredService<SkillAdvisorViewModel>(),
             sp.GetService<IModuleActivator>(),

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using Elrond.Domain;
 using Elrond.Services;
 using Mithril.Shared.Character;
+using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf.Filtering;
 using Mithril.Shared.Wpf.Query;
@@ -57,6 +58,7 @@ public sealed partial class SkillAdvisorViewModel
     private readonly IActiveCharacterService _activeChar;
     private readonly IReferenceDataService _referenceData;
     private readonly ElrondSettings _settings;
+    private readonly ICraftListImportTarget? _craftListImport;
 
     private readonly ObservableCollection<RecipeAnalysis> _recipes = [];
 
@@ -67,13 +69,15 @@ public sealed partial class SkillAdvisorViewModel
         LevelingSimulator simulator,
         IActiveCharacterService characterData,
         IReferenceDataService referenceData,
-        ElrondSettings settings)
+        ElrondSettings settings,
+        ICraftListImportTarget? craftListImport = null)
     {
         _engine = engine;
         _simulator = simulator;
         _activeChar = characterData;
         _referenceData = referenceData;
         _settings = settings;
+        _craftListImport = craftListImport;
 
         _goalLevel = settings.LastGoalLevel;
         _viewMode = settings.ViewMode;
@@ -203,6 +207,7 @@ public sealed partial class SkillAdvisorViewModel
     };
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SendToCraftListCommand))]
     private RecipeAnalysis? _selectedRecipe;
 
     [ObservableProperty]
@@ -331,6 +336,34 @@ public sealed partial class SkillAdvisorViewModel
     {
         _activeChar.Refresh();
     }
+
+    /// <summary>
+    /// True when a craft-list import target (Celebrimbor) is registered. Drives the
+    /// "Send to craft list" button's visibility so it stays hidden if Celebrimbor is absent.
+    /// </summary>
+    public bool IsCraftListImportAvailable => _craftListImport is not null;
+
+    /// <summary>
+    /// Pushes the selected recipe into the craft-list module (Celebrimbor) in-process —
+    /// activates its tab and runs the shared Append/Replace/Cancel dialog. v1 sends quantity
+    /// 1 per recipe; the user dials in counts in Celebrimbor. The importer contract is
+    /// list-based, so multi-select is a non-breaking UI follow-up.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanSendToCraftList))]
+    private void SendToCraftList()
+    {
+        if (_craftListImport is null || SelectedRecipe is not { } recipe) return;
+        if (string.IsNullOrWhiteSpace(recipe.InternalName)) return;
+
+        _craftListImport.ImportRecipes(
+            [new CraftListImportEntry(recipe.InternalName, 1)],
+            $"Elrond · {recipe.RecipeName}");
+    }
+
+    private bool CanSendToCraftList()
+        => _craftListImport is not null
+           && SelectedRecipe is { } r
+           && !string.IsNullOrWhiteSpace(r.InternalName);
 
     /// <summary>
     /// Toggle the chip with the given Id. Bound to chip clicks in the sort popup.

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -452,6 +452,14 @@
                                                 <DockPanel Margin="0,0,0,10">
                                                     <wpf:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
                                                                    Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
+                                                    <Button DockPanel.Dock="Right" Padding="8,4" VerticalAlignment="Top"
+                                                            Command="{Binding DataContext.SendToCraftListCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                            ToolTip="Send this recipe to Celebrimbor's craft list (quantity 1; adjust counts there)">
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <icon:PackIconLucide Kind="ListPlus" Width="12" Height="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                                            <TextBlock Text="Send to craft list" VerticalAlignment="Center"/>
+                                                        </StackPanel>
+                                                    </Button>
                                                     <StackPanel VerticalAlignment="Center">
                                                         <TextBlock Text="{Binding RecipeName}" FontWeight="Bold"
                                                                    Foreground="{StaticResource AccentBrush}" FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>

--- a/src/Mithril.Shared/Modules/ICraftListImportTarget.cs
+++ b/src/Mithril.Shared/Modules/ICraftListImportTarget.cs
@@ -1,10 +1,18 @@
 namespace Mithril.Shared.Modules;
 
 /// <summary>
-/// Optional target that handles <c>mithril://list/&lt;payload&gt;</c> deep links. Implemented by
-/// Celebrimbor to decode the share payload, activate its tab, and run the existing
-/// Append/Replace/Cancel import dialog. The router treats it as optional — if no module has
-/// registered a handler, list links are logged and dropped.
+/// One recipe to import into the craft list, identified by its reference-data
+/// <c>InternalName</c> (the same key used by <c>RecipesByInternalName</c> and the
+/// plain-text/deep-link share format). Used by the in-process import path so producing
+/// modules (e.g. Elrond) don't take a hard reference on the craft-list module's domain types.
+/// </summary>
+public readonly record struct CraftListImportEntry(string RecipeInternalName, int Quantity);
+
+/// <summary>
+/// Optional target that handles incoming craft-list imports. Implemented by Celebrimbor to
+/// activate its tab and run the existing Append/Replace/Cancel dialog. The router treats the
+/// deep-link path as optional — if no module has registered a handler, list links are logged
+/// and dropped; the in-process path is no-op when the target isn't registered.
 /// </summary>
 public interface ICraftListImportTarget
 {
@@ -14,4 +22,14 @@ public interface ICraftListImportTarget
     /// activation handlers that mustn't throw.
     /// </summary>
     void ImportFromLinkPayload(string base64UrlPayload);
+
+    /// <summary>
+    /// Imports recipes resolved in-process (no wire format). Activates the craft-list module's
+    /// tab and runs the same Append/Replace/Cancel dialog as the deep-link path. Entries whose
+    /// <see cref="CraftListImportEntry.RecipeInternalName"/> is unknown to reference data, or
+    /// whose quantity is non-positive, are skipped (surfaced as dialog warnings). The
+    /// <paramref name="source"/> label is shown in the dialog caption (e.g. "Elrond skills").
+    /// All errors are logged and swallowed — callers mustn't throw.
+    /// </summary>
+    void ImportRecipes(IReadOnlyList<CraftListImportEntry> recipes, string source);
 }

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -261,6 +261,83 @@ public class SkillAdvisorViewModelTests
         settings.LastQueryText.Should().Be("ORDER BY EffectiveXp DESC, RecipeName");
     }
 
+    // ── Send to craft list (#224) ────────────────────────────────────────
+
+    [Fact]
+    public void SendToCraftList_NoTargetRegistered_CommandDisabled()
+    {
+        var (vm, _, _, _) = MakeFixture(
+            characterSkills: new Dictionary<string, CharacterSkill> { ["Cooking"] = new(10, 0, 0, 100) },
+            register: r => { r.AddSkill("Cooking", parents: []); r.AddRecipe(rewardSkill: "Cooking"); });
+
+        vm.SelectedSkill = "Cooking";
+        vm.SelectedRecipe = vm.Analysis!.Recipes.First();
+
+        vm.IsCraftListImportAvailable.Should().BeFalse();
+        vm.SendToCraftListCommand.CanExecute(null).Should().BeFalse(
+            because: "no craft-list import target (Celebrimbor) was registered");
+    }
+
+    [Fact]
+    public void SendToCraftList_NoSelection_CommandDisabled()
+    {
+        var vm = MakeVmWithImportTarget(out _, out var importTarget);
+
+        vm.SelectedRecipe.Should().BeNull();
+        vm.IsCraftListImportAvailable.Should().BeTrue();
+        vm.SendToCraftListCommand.CanExecute(null).Should().BeFalse(
+            because: "no recipe is selected");
+        importTarget.LastRecipes.Should().BeNull();
+    }
+
+    [Fact]
+    public void SendToCraftList_SendsSelectedRecipeAtQuantityOne()
+    {
+        var vm = MakeVmWithImportTarget(out _, out var importTarget);
+
+        vm.SelectedSkill = "Cooking";
+        var recipe = vm.Analysis!.Recipes.First();
+        vm.SelectedRecipe = recipe;
+
+        vm.SendToCraftListCommand.CanExecute(null).Should().BeTrue();
+        vm.SendToCraftListCommand.Execute(null);
+
+        importTarget.LastRecipes.Should().ContainSingle();
+        importTarget.LastRecipes![0].RecipeInternalName.Should().Be(recipe.InternalName);
+        importTarget.LastRecipes![0].Quantity.Should().Be(1,
+            because: "v1 sends quantity 1; the user dials in counts in Celebrimbor");
+        importTarget.LastSource.Should().Contain(recipe.RecipeName);
+    }
+
+    private static SkillAdvisorViewModel MakeVmWithImportTarget(
+        out FakeRefData refData, out FakeCraftListImportTarget importTarget)
+    {
+        refData = new FakeRefData();
+        refData.AddSkill("Cooking", parents: []);
+        refData.AddRecipe(rewardSkill: "Cooking");
+        var characterSvc = new FakeActiveCharacterService();
+        characterSvc.SetCharacter(new CharacterSnapshot(
+            "C", "S", DateTimeOffset.UtcNow,
+            new Dictionary<string, CharacterSkill> { ["Cooking"] = new(10, 0, 0, 100) },
+            new Dictionary<string, int>(), new Dictionary<string, string>()));
+        var engine = new SkillAdvisorEngine(refData);
+        var sim = new LevelingSimulator(refData, engine);
+        importTarget = new FakeCraftListImportTarget();
+        return new SkillAdvisorViewModel(engine, sim, characterSvc, refData, new ElrondSettings(), importTarget);
+    }
+
+    private sealed class FakeCraftListImportTarget : Mithril.Shared.Modules.ICraftListImportTarget
+    {
+        public IReadOnlyList<Mithril.Shared.Modules.CraftListImportEntry>? LastRecipes { get; private set; }
+        public string? LastSource { get; private set; }
+        public void ImportFromLinkPayload(string base64UrlPayload) { }
+        public void ImportRecipes(IReadOnlyList<Mithril.Shared.Modules.CraftListImportEntry> recipes, string source)
+        {
+            LastRecipes = recipes;
+            LastSource = source;
+        }
+    }
+
     // ── Fixture ──────────────────────────────────────────────────────────
 
     private static (SkillAdvisorViewModel vm, FakeRefData refData, FakeActiveCharacterService characterSvc, ElrondSettings settings)

--- a/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Modules/DeepLinkRouterTests.cs
@@ -201,7 +201,14 @@ public class DeepLinkRouterTests
     private sealed class RecordingListTarget : ICraftListImportTarget
     {
         public string? LastPayload { get; private set; }
+        public IReadOnlyList<CraftListImportEntry>? LastRecipes { get; private set; }
+        public string? LastSource { get; private set; }
         public void ImportFromLinkPayload(string base64UrlPayload) => LastPayload = base64UrlPayload;
+        public void ImportRecipes(IReadOnlyList<CraftListImportEntry> recipes, string source)
+        {
+            LastRecipes = recipes;
+            LastSource = source;
+        }
     }
 
     private sealed class RecordingPippinTarget : IPippinShareImportTarget


### PR DESCRIPTION
## What

Elrond's skill advisor recommends recipes to grind a skill; Celebrimbor is where you queue and execute crafts. This wires the two in-process: select a recipe in Elrond, click **Send to craft list**, and Celebrimbor activates with the standard Append/Replace/Cancel import dialog — no retyping, no deep-link round-trip.

Implements #224 (standalone; the planner-aware version that sends predicted quantities is tracked separately on #227/#228 — this remains useful when those land).

## How

- **Mithril.Shared** — `ICraftListImportTarget` gains `ImportRecipes(IReadOnlyList<CraftListImportEntry>, string source)` plus a shared `CraftListImportEntry` record, so producing modules don't take a hard reference on Celebrimbor's domain types.
- **Celebrimbor** — implements `ImportRecipes`: validates names against reference data (unknown / non-positive quantities become dialog warnings, mirroring the deep-link path), activates the tab via `IModuleActivator`, and reuses the existing `PromptAndApply` dialog. The dispatcher marshalling is now shared between the deep-link and in-process paths.
- **Elrond** — `SendToCraftList` command + a toolbar button on the recipe detail header. `ICraftListImportTarget` is injected optionally (`GetService`), so headless/test and Celebrimbor-absent configurations degrade gracefully (button disabled via `CanExecute`).

## Scope (per the issue)

- **v1 quantity is 1 per recipe** — the user dials in counts in Celebrimbor.
- **Single-recipe send for v1.** The importer contract is list-based, so multi-select is a pure, non-breaking UI follow-up (the Elrond grid is single-select today and its detail pane is bound to that single selection).

## Testing

- `dotnet build Mithril.slnx` clean.
- Elrond.Tests **58 passed** (new: command sends selected recipe @ qty 1; `CanExecute` gated on selection + target presence; no-target disables).
- Celebrimbor.Tests **52 passed**, Mithril.Shared.Tests **959 passed** (DeepLinkRouter test fake updated for the new interface member).

## Acceptance

- [x] Selecting a recipe in Elrond and clicking "Send to craft list" activates Celebrimbor and shows the import dialog with that recipe.
- [x] Cancel/Append/Replace behave like the existing deep-link import path (same `PromptAndApply`).

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
