### PR TITLE
feat(leveling): lift skill-XP math into shared Mithril.Leveling (#225)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/Mithril.Shared/Mithril.Shared.csproj" />
     <Project Path="src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj" />
     <Project Path="src/Mithril.GameState/Mithril.GameState.csproj" />
+    <Project Path="src/Mithril.Leveling/Mithril.Leveling.csproj" />
     <Project Path="src/Mithril.Shell/Mithril.Shell.csproj" />
     <Project Path="src/Samwise.Module/Samwise.Module.csproj" />
     <Project Path="src/Legolas.Module/Legolas.Module.csproj" />
@@ -26,6 +27,7 @@
     <Project Path="tests/Mithril.Reference.Tests/Mithril.Reference.Tests.csproj" />
     <Project Path="tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj" />
     <Project Path="tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj" />
+    <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
     <Project Path="tests/Pippin.Tests/Pippin.Tests.csproj" />
     <Project Path="tests/Samwise.Tests/Samwise.Tests.csproj" />
     <Project Path="tests/Legolas.Tests/Legolas.Tests.csproj" />

--- a/src/Elrond.Module/Elrond.Module.csproj
+++ b/src/Elrond.Module/Elrond.Module.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="MahApps.Metro.IconPacks.Lucide" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Mithril.Leveling\Mithril.Leveling.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
     <ProjectReference Include="..\Mithril.Shared.Wpf\Mithril.Shared.Wpf.csproj" />
   </ItemGroup>

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -3,6 +3,7 @@ using Elrond.Domain;
 using Elrond.Services;
 using Elrond.ViewModels;
 using Elrond.Views;
+using Mithril.Leveling.DependencyInjection;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Modules;
 using MahApps.Metro.IconPacks;
@@ -30,6 +31,7 @@ public sealed class ElrondModule : IMithrilModule
 
         services.AddMithrilSettings<ElrondSettings>(settingsPath, ElrondSettingsJsonContext.Default.ElrondSettings);
 
+        services.AddMithrilLeveling();
         services.AddSingleton<SkillAdvisorEngine>();
         services.AddSingleton<LevelingSimulator>();
 

--- a/src/Elrond.Module/Services/SkillAdvisorEngine.cs
+++ b/src/Elrond.Module/Services/SkillAdvisorEngine.cs
@@ -1,4 +1,5 @@
 using Elrond.Domain;
+using Mithril.Leveling;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
@@ -7,15 +8,21 @@ namespace Elrond.Services;
 
 /// <summary>
 /// Pure computation engine that cross-references CDN reference data with a
-/// character snapshot to produce skill-leveling analysis.
+/// character snapshot to produce skill-leveling analysis. The skill-XP math
+/// (drop-off, first-time bonus, XP-to-goal, table resolution) lives in shared
+/// <see cref="LevelingMath"/> per #225; this engine owns the Elrond-specific
+/// projection to <see cref="SkillAnalysis"/> / <see cref="RecipeAnalysis"/> rows
+/// and the cookbook-section model.
 /// </summary>
 public sealed class SkillAdvisorEngine
 {
     private readonly IReferenceDataService _ref;
+    private readonly LevelingMath _math;
 
-    public SkillAdvisorEngine(IReferenceDataService referenceData)
+    public SkillAdvisorEngine(IReferenceDataService referenceData, LevelingMath? math = null)
     {
         _ref = referenceData;
+        _math = math ?? new LevelingMath(referenceData);
     }
 
     /// <summary>
@@ -244,82 +251,25 @@ public sealed class SkillAdvisorEngine
             IsUmbrellaSection: isUmbrellaSection);
     }
 
+    // Math delegated to shared Mithril.Leveling (#225). These thin pass-throughs
+    // keep the engine's and LevelingSimulator's existing call sites untouched.
     internal int ComputeEffectiveXp(Recipe recipe, int playerLevel)
-    {
-        if (recipe.RewardSkillXpDropOffLevel is not { } dropOffLevel) return recipe.RewardSkillXp;
-        if (recipe.RewardSkillXpDropOffPct is not { } dropOffPct) return recipe.RewardSkillXp;
-
-        if (playerLevel < dropOffLevel) return recipe.RewardSkillXp;
-
-        var rate = recipe.RewardSkillXpDropOffRate ?? 1;
-        if (rate <= 0) rate = 1;
-
-        // RewardSkillXpDropOffLevel is the level AT WHICH the first reduction
-        // already applies — not the level after which drop-off begins. So at
-        // playerLevel == dropOffLevel we owe one reduction; the early-out above
-        // covers playerLevel < dropOffLevel. Each additional 'rate' levels past
-        // drop-off compounds another reduction. (Closes #159 — first tier was
-        // silently skipped, making Elrond's effective XP one tier too high.)
-        var levelsPast = playerLevel - dropOffLevel;
-        var reductions = levelsPast / rate + 1;
-        var remaining = 1.0;
-        for (var i = 0; i < reductions; i++)
-        {
-            remaining *= (1.0 - dropOffPct);
-            if (remaining <= 0) return 0;
-        }
-
-        return Math.Max(0, (int)(recipe.RewardSkillXp * remaining));
-    }
+        => _math.EffectiveXpPerCraft(recipe, playerLevel);
 
     /// <summary>
     /// Computes the total XP needed from the current position to reach <paramref name="goalLevel"/>.
     /// </summary>
     internal long ComputeXpToGoal(string skillName, int currentLevel, long currentXp, long currentLevelXpNeeded, int goalLevel)
-    {
-        // XP remaining in the current level
-        var total = currentLevelXpNeeded - currentXp;
-        if (total < 0) total = 0;
-
-        var xpAmounts = ResolveXpTable(skillName);
-        if (xpAmounts is null) return total;
-
-        // Add XP for each full level between currentLevel+1 and goalLevel-1,
-        // plus XP for goalLevel-1 index (to reach goalLevel)
-        for (var lvl = currentLevel + 1; lvl < goalLevel; lvl++)
-        {
-            if (lvl - 1 < xpAmounts.Count)
-                total += xpAmounts[lvl - 1];
-            else
-                break;
-        }
-
-        return total;
-    }
+        => _math.XpToGoal(skillName, currentLevel, currentXp, currentLevelXpNeeded, goalLevel);
 
     /// <summary>Resolves the XP amounts array for a given skill.</summary>
     internal IReadOnlyList<long>? ResolveXpTable(string skillName)
-    {
-        if (_ref.Skills.TryGetValue(skillName, out var skillEntry) &&
-            !string.IsNullOrEmpty(skillEntry.XpTable) &&
-            _ref.XpTables.TryGetValue(skillEntry.XpTable, out var xpTable))
-        {
-            return xpTable.XpAmounts;
-        }
-        return null;
-    }
+        => _math.ResolveXpTable(skillName);
 
     private IReadOnlyList<XpMilestone> BuildMilestones(
         string skillName, int currentLevel, long currentXp, long currentLevelXpNeeded, int maxLevels)
     {
-        // Resolve XP table for the skill
-        IReadOnlyList<long>? xpAmounts = null;
-        if (_ref.Skills.TryGetValue(skillName, out var skillEntry) &&
-            !string.IsNullOrEmpty(skillEntry.XpTable) &&
-            _ref.XpTables.TryGetValue(skillEntry.XpTable, out var xpTable))
-        {
-            xpAmounts = xpTable.XpAmounts;
-        }
+        var xpAmounts = _math.ResolveXpTable(skillName);
 
         var milestones = new List<XpMilestone>();
         var cumulative = currentLevelXpNeeded - currentXp; // XP remaining in current level

--- a/src/Mithril.Leveling/DependencyInjection/LevelingServiceCollectionExtensions.cs
+++ b/src/Mithril.Leveling/DependencyInjection/LevelingServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Mithril.Leveling.DependencyInjection;
+
+public static class LevelingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the shared skill-XP math (<see cref="LevelingMath"/>). Depends only on
+    /// <c>IReferenceDataService</c>, which is registered by <c>AddMithrilReferenceData()</c>;
+    /// safe to call from any module (Elrond today, the #227 planner next) — the singleton
+    /// is idempotent under repeated registration via <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection)"/>.
+    /// </summary>
+    public static IServiceCollection AddMithrilLeveling(this IServiceCollection services)
+    {
+        services.TryAddSingleton<LevelingMath>();
+        return services;
+    }
+}

--- a/src/Mithril.Leveling/LevelingMath.cs
+++ b/src/Mithril.Leveling/LevelingMath.cs
@@ -1,0 +1,141 @@
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Leveling;
+
+/// <summary>
+/// The skill-XP contribution one craft of a recipe makes, evaluated against a
+/// <see cref="SkillState"/> and <see cref="RecipeHistory"/>.
+/// </summary>
+public readonly record struct XpDelta(
+    string RewardSkill,
+    int BaseXp,
+    int EffectiveXp,
+    int FirstTimeBonusXp,
+    bool FirstTimeBonusAvailable,
+    int NextCraftXp);
+
+/// <summary>
+/// Shared skill-XP math, lifted out of Elrond per #225. Pure and time-stateless
+/// (PG has no cooldowns / daily resets) but cumulative-in-completion via
+/// <see cref="RecipeHistory"/> for the first-time-per-character bonus.
+///
+/// Owns *only* the math: drop-off curve, first-time bonus, XP-to-goal, and
+/// skill→XP-table resolution. UI / sort / filter / sim policy stay in Elrond;
+/// the player-progression-state constraints it runs against are supplied by the
+/// caller as <see cref="SkillState"/> / <see cref="RecipeHistory"/>.
+/// </summary>
+public sealed class LevelingMath
+{
+    private readonly IReferenceDataService _ref;
+
+    public LevelingMath(IReferenceDataService referenceData)
+        => _ref = referenceData ?? throw new ArgumentNullException(nameof(referenceData));
+
+    /// <summary>
+    /// Effective XP for one craft of <paramref name="recipe"/> at
+    /// <paramref name="rewardSkillLevel"/> in the recipe's reward skill, after the
+    /// diminishing-returns drop-off curve.
+    /// </summary>
+    public int EffectiveXpPerCraft(Recipe recipe, int rewardSkillLevel)
+    {
+        if (recipe.RewardSkillXpDropOffLevel is not { } dropOffLevel) return recipe.RewardSkillXp;
+        if (recipe.RewardSkillXpDropOffPct is not { } dropOffPct) return recipe.RewardSkillXp;
+
+        if (rewardSkillLevel < dropOffLevel) return recipe.RewardSkillXp;
+
+        var rate = recipe.RewardSkillXpDropOffRate ?? 1;
+        if (rate <= 0) rate = 1;
+
+        // RewardSkillXpDropOffLevel is the level AT WHICH the first reduction
+        // already applies — not the level after which drop-off begins. So at
+        // rewardSkillLevel == dropOffLevel we owe one reduction; the early-out above
+        // covers rewardSkillLevel < dropOffLevel. Each additional 'rate' levels past
+        // drop-off compounds another reduction. (Closes #159 — first tier was
+        // silently skipped, making Elrond's effective XP one tier too high.)
+        var levelsPast = rewardSkillLevel - dropOffLevel;
+        var reductions = levelsPast / rate + 1;
+        var remaining = 1.0;
+        for (var i = 0; i < reductions; i++)
+        {
+            remaining *= (1.0 - dropOffPct);
+            if (remaining <= 0) return 0;
+        }
+
+        return Math.Max(0, (int)(recipe.RewardSkillXp * remaining));
+    }
+
+    /// <summary>
+    /// The XP a single craft of <paramref name="recipe"/> contributes, including
+    /// whether the first-time-per-character bonus is still available for it.
+    /// "Known + zero completions" is the bonus-available rule (matching Elrond's
+    /// recipe-row semantics); the simulator's looser "unlearned recipes might still
+    /// be learnable" treatment is a *policy* and stays with the caller.
+    /// </summary>
+    public XpDelta XpForCraft(Recipe recipe, SkillState skillState, RecipeHistory recipeHistory)
+    {
+        var rewardSkill = recipe.RewardSkill ?? "";
+        var rewardLevel = skillState.LevelOf(rewardSkill);
+
+        var internalName = recipe.InternalName ?? "";
+        var isKnown = recipeHistory.IsKnown(internalName);
+        var timesCompleted = recipeHistory.CompletionCount(internalName);
+        var firstTimeBonusAvailable =
+            isKnown && timesCompleted == 0 && recipe.RewardSkillXpFirstTime > 0;
+
+        var effectiveXp = EffectiveXpPerCraft(recipe, rewardLevel);
+        var nextCraftXp = firstTimeBonusAvailable && recipe.RewardSkillXpFirstTime > 0
+            ? recipe.RewardSkillXpFirstTime
+            : effectiveXp;
+
+        return new XpDelta(
+            RewardSkill: rewardSkill,
+            BaseXp: recipe.RewardSkillXp,
+            EffectiveXp: effectiveXp,
+            FirstTimeBonusXp: recipe.RewardSkillXpFirstTime,
+            FirstTimeBonusAvailable: firstTimeBonusAvailable,
+            NextCraftXp: nextCraftXp);
+    }
+
+    /// <summary>
+    /// Total XP needed from the current position to reach <paramref name="goalLevel"/>
+    /// in <paramref name="skillName"/>.
+    /// </summary>
+    public long XpToGoal(
+        string skillName, int currentLevel, long currentXp, long currentLevelXpNeeded, int goalLevel)
+    {
+        // XP remaining in the current level
+        var total = currentLevelXpNeeded - currentXp;
+        if (total < 0) total = 0;
+
+        var xpAmounts = ResolveXpTable(skillName);
+        if (xpAmounts is null) return total;
+
+        // Add XP for each full level between currentLevel+1 and goalLevel-1,
+        // plus XP for goalLevel-1 index (to reach goalLevel)
+        for (var lvl = currentLevel + 1; lvl < goalLevel; lvl++)
+        {
+            if (lvl - 1 < xpAmounts.Count)
+                total += xpAmounts[lvl - 1];
+            else
+                break;
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// XP amounts array for <paramref name="skillName"/> (index 0 = XP for level 1),
+    /// or <c>null</c> when the skill has no XP table (umbrella skills).
+    /// </summary>
+    public IReadOnlyList<long>? ResolveXpTable(string skillName)
+    {
+        if (_ref.Skills.TryGetValue(skillName, out var skillEntry) &&
+            !string.IsNullOrEmpty(skillEntry.XpTable) &&
+            _ref.XpTables.TryGetValue(skillEntry.XpTable, out var xpTable))
+        {
+            return xpTable.XpAmounts;
+        }
+        return null;
+    }
+}

--- a/src/Mithril.Leveling/Mithril.Leveling.csproj
+++ b/src/Mithril.Leveling/Mithril.Leveling.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Leveling</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+</Project>

--- a/src/Mithril.Leveling/SkillState.cs
+++ b/src/Mithril.Leveling/SkillState.cs
@@ -1,0 +1,71 @@
+namespace Mithril.Leveling;
+
+/// <summary>
+/// One skill's progression facet — the neutral equivalent of the export's per-skill
+/// record, decoupled from <c>CharacterSnapshot</c> so callers can feed *hypothetical*
+/// states (e.g. the #227 planner projecting a future level) rather than only real exports.
+/// </summary>
+public readonly record struct SkillProgress(
+    int Level,
+    int BonusLevels,
+    long XpTowardNextLevel,
+    long XpNeededForNextLevel);
+
+/// <summary>
+/// Multi-skill progression state. Recipes can grant XP in more than one skill at once
+/// (and the planner exploits that), so this is keyed by skill rather than scoped to a
+/// single target. Stateless in time — PG has no cooldowns / daily resets — so a
+/// <see cref="SkillState"/> fully describes the leveling inputs at a point in the plan.
+/// </summary>
+public sealed class SkillState
+{
+    private readonly IReadOnlyDictionary<string, SkillProgress> _skills;
+
+    public SkillState(IReadOnlyDictionary<string, SkillProgress> skills)
+        => _skills = skills ?? throw new ArgumentNullException(nameof(skills));
+
+    /// <summary>Empty state — every skill reads as level 0 / unknown.</summary>
+    public static SkillState Empty { get; } =
+        new(new Dictionary<string, SkillProgress>(StringComparer.Ordinal));
+
+    public IReadOnlyDictionary<string, SkillProgress> Skills => _skills;
+
+    public bool TryGet(string skill, out SkillProgress progress)
+        => _skills.TryGetValue(skill, out progress);
+
+    /// <summary>Current level in <paramref name="skill"/>, or 0 if the skill is absent.</summary>
+    public int LevelOf(string skill)
+        => _skills.TryGetValue(skill, out var p) ? p.Level : 0;
+
+    public bool Knows(string skill) => _skills.ContainsKey(skill);
+}
+
+/// <summary>
+/// Cumulative-in-completion recipe history (recipe <c>InternalName</c> → times completed).
+/// Backs the first-time-per-character bonus: the math is time-stateless but the bonus is
+/// a one-shot keyed on whether the recipe has ever been completed on this character.
+/// </summary>
+public sealed class RecipeHistory
+{
+    private readonly IReadOnlyDictionary<string, int> _completions;
+
+    public RecipeHistory(IReadOnlyDictionary<string, int> completions)
+        => _completions = completions ?? throw new ArgumentNullException(nameof(completions));
+
+    /// <summary>Empty history — nothing has been crafted yet.</summary>
+    public static RecipeHistory Empty { get; } =
+        new(new Dictionary<string, int>(StringComparer.Ordinal));
+
+    public IReadOnlyDictionary<string, int> Completions => _completions;
+
+    /// <summary>
+    /// True when the recipe is in the history at all. Mirrors Elrond's "known" convention:
+    /// a recipe with a completion entry (even count 0) has been learned.
+    /// </summary>
+    public bool IsKnown(string recipeInternalName)
+        => !string.IsNullOrEmpty(recipeInternalName) && _completions.ContainsKey(recipeInternalName);
+
+    public int CompletionCount(string recipeInternalName)
+        => !string.IsNullOrEmpty(recipeInternalName)
+           && _completions.TryGetValue(recipeInternalName, out var c) ? c : 0;
+}

--- a/tests/Mithril.Leveling.Tests/LevelingMathTests.cs
+++ b/tests/Mithril.Leveling.Tests/LevelingMathTests.cs
@@ -1,0 +1,255 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Leveling.Tests;
+
+/// <summary>
+/// Coverage for the skill-XP math lifted out of Elrond (#225). The drop-off cases
+/// pin the #159 fix (first reduction applies AT the drop-off level, not after it);
+/// the <c>XpForCraft</c> cases pin the first-time-per-character bonus semantics.
+/// </summary>
+public class LevelingMathTests
+{
+    // ── EffectiveXpPerCraft / drop-off ───────────────────────────────────
+
+    [Fact]
+    public void NoDropOffMetadata_ReturnsBaseXp()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe { RewardSkill = "Cooking", RewardSkillXp = 100 };
+
+        math.EffectiveXpPerCraft(recipe, rewardSkillLevel: 999).Should().Be(100);
+    }
+
+    [Fact]
+    public void BelowDropOffLevel_ReturnsBaseXp()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            RewardSkill = "Cooking",
+            RewardSkillXp = 100,
+            RewardSkillXpDropOffLevel = 20,
+            RewardSkillXpDropOffPct = 0.5,
+            RewardSkillXpDropOffRate = 5,
+        };
+
+        math.EffectiveXpPerCraft(recipe, rewardSkillLevel: 19).Should().Be(100);
+    }
+
+    [Fact]
+    public void AtDropOffLevel_AppliesFirstReduction_159Regression()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            RewardSkill = "Cooking",
+            RewardSkillXp = 100,
+            RewardSkillXpDropOffLevel = 20,
+            RewardSkillXpDropOffPct = 0.5,
+            RewardSkillXpDropOffRate = 5,
+        };
+
+        // At exactly the drop-off level one reduction already applies (×0.5),
+        // NOT zero reductions. This is the #159 behaviour.
+        math.EffectiveXpPerCraft(recipe, rewardSkillLevel: 20).Should().Be(50);
+    }
+
+    [Fact]
+    public void CompoundsOnePerRatePastDropOff()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            RewardSkill = "Cooking",
+            RewardSkillXp = 100,
+            RewardSkillXpDropOffLevel = 20,
+            RewardSkillXpDropOffPct = 0.5,
+            RewardSkillXpDropOffRate = 5,
+        };
+
+        // level 20 → 1 reduction (×0.5 = 50); level 25 → 2 reductions (×0.25 = 25);
+        // level 30 → 3 reductions (×0.125 → (int)12.5 = 12).
+        math.EffectiveXpPerCraft(recipe, 25).Should().Be(25);
+        math.EffectiveXpPerCraft(recipe, 30).Should().Be(12);
+    }
+
+    // ── XpForCraft / first-time bonus ────────────────────────────────────
+
+    [Fact]
+    public void XpForCraft_KnownWithZeroCompletions_BonusAvailable()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            InternalName = "MakeBread",
+            RewardSkill = "Cooking",
+            RewardSkillXp = 40,
+            RewardSkillXpFirstTime = 250,
+        };
+        var skills = new SkillState(new Dictionary<string, SkillProgress>
+        {
+            ["Cooking"] = new(Level: 5, BonusLevels: 0, XpTowardNextLevel: 0, XpNeededForNextLevel: 100),
+        });
+        var history = new RecipeHistory(new Dictionary<string, int> { ["MakeBread"] = 0 });
+
+        var delta = math.XpForCraft(recipe, skills, history);
+
+        delta.RewardSkill.Should().Be("Cooking");
+        delta.BaseXp.Should().Be(40);
+        delta.EffectiveXp.Should().Be(40);
+        delta.FirstTimeBonusAvailable.Should().BeTrue();
+        delta.NextCraftXp.Should().Be(250, because: "the unconsumed first-time bonus applies to the next craft");
+    }
+
+    [Fact]
+    public void XpForCraft_AlreadyCompleted_BonusConsumed()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            InternalName = "MakeBread",
+            RewardSkill = "Cooking",
+            RewardSkillXp = 40,
+            RewardSkillXpFirstTime = 250,
+        };
+        var skills = new SkillState(new Dictionary<string, SkillProgress>
+        {
+            ["Cooking"] = new(5, 0, 0, 100),
+        });
+        var history = new RecipeHistory(new Dictionary<string, int> { ["MakeBread"] = 3 });
+
+        var delta = math.XpForCraft(recipe, skills, history);
+
+        delta.FirstTimeBonusAvailable.Should().BeFalse();
+        delta.NextCraftXp.Should().Be(40, because: "the bonus is spent once the recipe has any completions");
+    }
+
+    [Fact]
+    public void XpForCraft_NotKnown_NoBonus()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            InternalName = "MakeBread",
+            RewardSkill = "Cooking",
+            RewardSkillXp = 40,
+            RewardSkillXpFirstTime = 250,
+        };
+
+        var delta = math.XpForCraft(recipe, SkillState.Empty, RecipeHistory.Empty);
+
+        delta.FirstTimeBonusAvailable.Should().BeFalse(
+            because: "an unlearned recipe has no available bonus per the row semantics — "
+                     + "the simulator's looser policy stays in Elrond");
+        delta.NextCraftXp.Should().Be(40);
+    }
+
+    [Fact]
+    public void XpForCraft_AppliesDropOffAtRewardSkillLevel()
+    {
+        var math = new LevelingMath(new FakeRef());
+        var recipe = new Recipe
+        {
+            InternalName = "MakeBread",
+            RewardSkill = "Cooking",
+            RewardSkillXp = 100,
+            RewardSkillXpDropOffLevel = 10,
+            RewardSkillXpDropOffPct = 0.5,
+            RewardSkillXpDropOffRate = 5,
+        };
+        var skills = new SkillState(new Dictionary<string, SkillProgress>
+        {
+            ["Cooking"] = new(Level: 10, BonusLevels: 0, XpTowardNextLevel: 0, XpNeededForNextLevel: 1),
+        });
+
+        math.XpForCraft(recipe, skills, RecipeHistory.Empty).EffectiveXp.Should().Be(50);
+    }
+
+    // ── ResolveXpTable / XpToGoal ────────────────────────────────────────
+
+    [Fact]
+    public void ResolveXpTable_MissingSkill_ReturnsNull()
+    {
+        var math = new LevelingMath(new FakeRef());
+        math.ResolveXpTable("Nope").Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveXpTable_ResolvesSkillToTable()
+    {
+        var fake = new FakeRef();
+        fake.SkillsRaw["Cooking"] = Skill("Cooking", "TypicalNoncombatSkill");
+        fake.XpTablesRaw["TypicalNoncombatSkill"] = new XpTableEntry("TypicalNoncombatSkill", [100, 200, 400]);
+        var math = new LevelingMath(fake);
+
+        math.ResolveXpTable("Cooking").Should().Equal([100, 200, 400]);
+    }
+
+    [Fact]
+    public void XpToGoal_NoTable_ReturnsRemainingInCurrentLevelOnly()
+    {
+        var math = new LevelingMath(new FakeRef());
+
+        // 100 needed, 30 in → 70 remaining; no table → can't project further levels.
+        math.XpToGoal("Cooking", currentLevel: 5, currentXp: 30, currentLevelXpNeeded: 100, goalLevel: 9)
+            .Should().Be(70);
+    }
+
+    [Fact]
+    public void XpToGoal_SumsCurrentRemainderPlusInterveningLevels()
+    {
+        var fake = new FakeRef();
+        fake.SkillsRaw["Cooking"] = Skill("Cooking", "T");
+        // index 0 = XP for level 1, ... index 4 = XP for level 5, ...
+        fake.XpTablesRaw["T"] = new XpTableEntry("T", [10, 20, 30, 40, 50, 60, 70, 80, 90]);
+        var math = new LevelingMath(fake);
+
+        // current level 5, 30 toward next, 100 needed → remainder 70.
+        // goal 8 → add levels 6 and 7 = xpAmounts[5] + xpAmounts[6] = 60 + 70.
+        math.XpToGoal("Cooking", currentLevel: 5, currentXp: 30, currentLevelXpNeeded: 100, goalLevel: 8)
+            .Should().Be(70 + 60 + 70);
+    }
+
+    private static SkillEntry Skill(string key, string xpTable)
+        => new(Key: key, DisplayName: key, Id: 0, Combat: false,
+               XpTable: xpTable, MaxBonusLevels: 0, Parents: [],
+               Rewards: new Dictionary<string, SkillRewardEntry>());
+
+    /// <summary>
+    /// Minimal <see cref="IReferenceDataService"/> fake — only Skills + XpTables
+    /// are mutable (all <see cref="LevelingMath"/> touches); the rest are empty.
+    /// </summary>
+    private sealed class FakeRef : IReferenceDataService
+    {
+        public Dictionary<string, SkillEntry> SkillsRaw { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, XpTableEntry> XpTablesRaw { get; } = new(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, SkillEntry> Skills => SkillsRaw;
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables => XpTablesRaw;
+
+        public IReadOnlyList<string> Keys { get; } = ["skills", "xptables"];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj
+++ b/tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.Leveling.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.Leveling\Mithril.Leveling.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## What

Lifts Elrond's per-craft skill-XP math into a new shared **`Mithril.Leveling`** library so Celebrimbor and the #227 cross-skill planner can compute "what does this craft / queue contribute to skill X?" against the same engine — instead of screen-scraping Elrond's UI rows.

Implements #225. Prerequisite for #227 (planner) and #228 (plan-aware executor). Aligns with the module-charters split: *math → shared `Mithril.Leveling`; player-progression-state constraints stay Elrond's.*

## How

- **New project** `src/Mithril.Leveling` — mirrors `Mithril.GameState` exactly (net10 non-WPF, depends only on `Mithril.Shared`). Added to `Mithril.slnx` + new `tests/Mithril.Leveling.Tests`.
- **Neutral inputs** (the locked design decision): `SkillState` (multi-skill progression record) + `RecipeHistory`, decoupled from `CharacterSnapshot` so the planner can feed *hypothetical projected* states (asserted future unlocks), not only real exports. State is keyed by skill — recipes can grant XP in several skills at once and the planner will exploit that.
- **`LevelingMath`** owns *only* the math: the drop-off curve (preserves the #159 "first reduction applies **at** the drop-off level" behaviour verbatim), the first-time-per-character bonus, XP-to-goal, skill→XP-table resolution, plus the issue's headline `XpForCraft(recipe, skillState, recipeHistory) -> XpDelta`.
- **Elrond** `SkillAdvisorEngine` delegates the three math methods to `LevelingMath` via thin pass-throughs. The ctor stays back-compatible (optional `LevelingMath` param) so `LevelingSimulator` and all existing tests are untouched. UI / sort / filter / sim policy stay in Elrond.
- **`AddMithrilLeveling()`** DI extension (idempotent `TryAddSingleton`) — Elrond today, the #227 planner next.

## Scope (per the issue)

- The skill-XP **math** moves; the **simulator algorithm** stays in Elrond (it's the forward-sim UX, and #227 is a separate, new optimiser). This is the minimal correct lift the charter calls for and the lowest-regression path.
- Out of scope: UI / sort / filter / `SimOnlyAlreadyLearnedRecipes` policy; acquisition-cost weighting (#122).

## Testing

- `dotnet build Mithril.slnx` clean (0 warnings, 0 errors).
- **Mithril.Leveling.Tests: 12 passed** — drop-off tiers incl. the #159 regression, first-time-bonus availability semantics, `XpToGoal`, table resolution.
- **Elrond.Tests: 55 passed, unchanged** — the extraction is behaviour-preserving (engine + simulator delegate; the regression net stays green).

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
