### PR TITLE
feat(crafting): shared demand-driven recipe expander (#226, supersedes #121, closes #42)

### DIFF
--- a/src/Celebrimbor.Module/Services/RecipeAggregator.cs
+++ b/src/Celebrimbor.Module/Services/RecipeAggregator.cs
@@ -1,26 +1,21 @@
 using Celebrimbor.Domain;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Crafting;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Storage;
 
 namespace Celebrimbor.Services;
 
 /// <summary>
-/// Pure aggregation logic. Given a craft list and an expansion depth, compute
-/// the expected demand per item. ChanceToConsume is honoured as expected value,
-/// so the returned TotalNeeded is the ceiling of the raw expectation.
+/// Celebrimbor's shopping-list aggregation. The demand-driven expansion engine
+/// (producer graph, multi-output crediting, on-hand-aware shortfall recursion)
+/// lives in shared <see cref="RecipeExpander"/> (#226); this class owns only the
+/// Celebrimbor-specific projection: the stable chain skeleton, keyword-slot rows,
+/// crafting-step depth, on-hand/override/location plumbing, and the sort.
 /// </summary>
 public sealed class RecipeAggregator
 {
-    /// <summary>
-    /// Synthetic <see cref="AggregatedIngredient.ItemInternalName"/> prefix used for
-    /// rows that represent a keyword-matched ingredient slot (any item whose
-    /// <see cref="Item.Keywords"/> includes every listed tag). The remainder of
-    /// the key is the comma-joined ordinal-sorted keyword list.
-    /// </summary>
-    private const string KeywordKeyPrefix = "#keys:";
-
     /// <summary>
     /// Accumulate ingredient demand across every entry in <paramref name="entries"/>.
     /// When <paramref name="expansionDepth"/> is greater than zero, any aggregated
@@ -36,9 +31,11 @@ public sealed class RecipeAggregator
         IReadOnlyDictionary<string, int>? overridesByInternalName = null,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? ownedInternalNamesByKeyword = null)
     {
+        var expander = new RecipeExpander(refData);
+
         var demand = new Dictionary<string, double>(StringComparer.Ordinal);
         var seeds = new List<string>();
-        var keywordSpecs = new Dictionary<string, KeywordSpec>(StringComparer.Ordinal);
+        var keywordSlots = new Dictionary<string, KeywordSlot>(StringComparer.Ordinal);
 
         foreach (var entry in entries)
         {
@@ -57,15 +54,19 @@ public sealed class RecipeAggregator
             seeds.Add(outInternal);
         }
 
-        var producers = BuildProducerLookup(refData);
+        // First producer in enumeration order — reproduces the old "first recipe wins"
+        // lookup for the chain-skeleton / depth passes; the shared expander uses the
+        // same default policy internally so the two stay consistent.
+        var producers = expander.Producers.ByItemInternalName
+            .ToDictionary(kv => kv.Key, kv => kv.Value[0], StringComparer.Ordinal);
 
         // Chain pass: everything the plan touches at this depth, shortfall-agnostic.
         // Keeps the shopping list visible as a stable skeleton when the demand pass
         // collapses rows to zero (e.g. user overrides a target to match its needed count).
-        var chainItems = BuildChainItems(seeds, expansionDepth, refData, producers, keywordSpecs);
+        var chainItems = BuildChainItems(seeds, expansionDepth, refData, producers, keywordSlots);
 
         if (expansionDepth > 0)
-            Expand(demand, expansionDepth, refData, producers, onHandByInternalName, overridesByInternalName, keywordSpecs);
+            expander.Expand(demand, expansionDepth, onHandByInternalName, overridesByInternalName, keywordSlots);
 
         // Backfill chain items the demand pass dropped or never reached, so projection
         // emits them as 0/0 rows (IsCraftReady=true) rather than hiding the step.
@@ -79,9 +80,9 @@ public sealed class RecipeAggregator
         var rows = new List<AggregatedIngredient>(demand.Count);
         foreach (var (itemName, expected) in demand)
         {
-            if (itemName.StartsWith(KeywordKeyPrefix, StringComparison.Ordinal))
+            if (RecipeExpander.IsKeywordKey(itemName))
             {
-                if (!keywordSpecs.TryGetValue(itemName, out var spec)) continue;
+                if (!keywordSlots.TryGetValue(itemName, out var spec)) continue;
                 rows.Add(BuildKeywordRow(itemName, spec, expected, refData,
                     onHandByInternalName, locationsByInternalName, overridesByInternalName,
                     ownedInternalNamesByKeyword));
@@ -122,7 +123,7 @@ public sealed class RecipeAggregator
 
     private static AggregatedIngredient BuildKeywordRow(
         string syntheticKey,
-        KeywordSpec spec,
+        KeywordSlot spec,
         double expected,
         IReferenceDataService refData,
         IReadOnlyDictionary<string, int>? onHandByInternalName,
@@ -202,7 +203,7 @@ public sealed class RecipeAggregator
         int expansionDepth,
         IReferenceDataService refData,
         IReadOnlyDictionary<string, Recipe> producers,
-        Dictionary<string, KeywordSpec> keywordSpecs)
+        Dictionary<string, KeywordSlot> keywordSlots)
     {
         var chain = new HashSet<string>(seeds, StringComparer.Ordinal);
         var frontier = new HashSet<string>(seeds, StringComparer.Ordinal);
@@ -223,8 +224,8 @@ public sealed class RecipeAggregator
                             if (chain.Add(ing.InternalName!)) next.Add(ing.InternalName!);
                             break;
                         case RecipeKeywordIngredient kwIng:
-                            var key = MakeKeywordKey(kwIng.ItemKeys);
-                            keywordSpecs.TryAdd(key, new KeywordSpec(kwIng.ItemKeys, kwIng.Desc));
+                            var key = RecipeExpander.MakeKeywordKey(kwIng.ItemKeys);
+                            keywordSlots.TryAdd(key, new KeywordSlot(kwIng.ItemKeys, kwIng.Desc));
                             chain.Add(key);
                             // Keyword rows are leaves — no recursion needed; they have no producer.
                             break;
@@ -273,129 +274,6 @@ public sealed class RecipeAggregator
         return depth;
     }
 
-    private static void AddIngredients(
-        Dictionary<string, double> demand,
-        Recipe recipe,
-        double batches,
-        IReferenceDataService refData,
-        Dictionary<string, KeywordSpec> keywordSpecs)
-    {
-        foreach (var ingredient in recipe.Ingredients)
-        {
-            string demandKey;
-            switch (ingredient)
-            {
-                case RecipeItemIngredient itemIng:
-                    if (!refData.Items.TryGetValue(itemIng.ItemCode, out var item)) continue;
-                    if (string.IsNullOrEmpty(item.InternalName)) continue;
-                    demandKey = item.InternalName!;
-                    break;
-                case RecipeKeywordIngredient kwIng:
-                    demandKey = MakeKeywordKey(kwIng.ItemKeys);
-                    keywordSpecs.TryAdd(demandKey, new KeywordSpec(kwIng.ItemKeys, kwIng.Desc));
-                    break;
-                default:
-                    continue;
-            }
-
-            var perBatch = ingredient.StackSize * (ingredient.ChanceToConsume ?? 1.0);
-            if (perBatch <= 0) continue;
-            var add = batches * perBatch;
-
-            demand[demandKey] = demand.TryGetValue(demandKey, out var existing)
-                ? existing + add
-                : add;
-        }
-    }
-
-    private static void Expand(
-        Dictionary<string, double> demand,
-        int depth,
-        IReferenceDataService refData,
-        IReadOnlyDictionary<string, Recipe> producers,
-        IReadOnlyDictionary<string, int>? onHandByInternalName,
-        IReadOnlyDictionary<string, int>? overridesByInternalName,
-        Dictionary<string, KeywordSpec> keywordSpecs)
-    {
-        // Intermediates stay in the output so the user still sees "3x Good Metal Slab".
-        // alreadyExpanded guards against cycles (A → B → A) — once we've expanded a
-        // craftable, we don't touch it again even if it reappears in demand later.
-        var alreadyExpanded = new HashSet<string>(StringComparer.Ordinal);
-
-        for (var level = 0; level < depth; level++)
-        {
-            var candidates = demand
-                .Where(kv => kv.Value > 0
-                             && !alreadyExpanded.Contains(kv.Key)
-                             && producers.ContainsKey(kv.Key))
-                .ToList();
-
-            if (candidates.Count == 0) break;
-
-            foreach (var (itemName, expected) in candidates)
-            {
-                alreadyExpanded.Add(itemName);
-
-                var recipe = producers[itemName];
-                var outputStackSize = FindOutputStackSize(recipe, itemName, refData);
-                if (outputStackSize <= 0) continue;
-
-                // Only the shortfall between demand and effective stock actually needs to be crafted.
-                // A manual override (user-entered count) beats the detected on-hand reading so the
-                // raw ingredient totals update live when the user adjusts an intermediate's count.
-                var onHand = onHandByInternalName is not null
-                    && onHandByInternalName.TryGetValue(itemName, out var stock) ? stock : 0;
-                var effectiveStock = overridesByInternalName is not null
-                    && overridesByInternalName.TryGetValue(itemName, out var ov) ? ov : onHand;
-                var shortfall = expected - effectiveStock;
-                if (shortfall <= 0) continue;
-
-                var batches = shortfall / outputStackSize;
-                AddIngredients(demand, recipe, batches, refData, keywordSpecs);
-            }
-        }
-
-        foreach (var key in demand.Where(kv => kv.Value <= 0).Select(kv => kv.Key).ToList())
-            demand.Remove(key);
-    }
-
-    /// <summary>
-    /// Build a reverse lookup of "item InternalName → recipe that produces it" by
-    /// scanning every recipe's ResultItems (and ProtoResultItems as a fallback).
-    /// The item's own InternalName comes from items.json, which is what the demand
-    /// dictionary is keyed by. This replaces the naive "does any recipe share this
-    /// item's InternalName" match that only worked when recipe and item happened to
-    /// share a name (e.g. Butter) and silently skipped most intermediate crafts.
-    /// </summary>
-    private static IReadOnlyDictionary<string, Recipe> BuildProducerLookup(IReferenceDataService refData)
-    {
-        var map = new Dictionary<string, Recipe>(StringComparer.Ordinal);
-        foreach (var recipe in refData.Recipes.Values)
-        {
-            if (recipe.ResultItems is { } results)
-                RegisterResults(recipe, results, refData, map);
-            if (recipe.ProtoResultItems is { } proto)
-                RegisterResults(recipe, proto, refData, map);
-        }
-        return map;
-    }
-
-    private static void RegisterResults(
-        Recipe recipe,
-        IReadOnlyList<RecipeResultItem> results,
-        IReferenceDataService refData,
-        Dictionary<string, Recipe> map)
-    {
-        foreach (var result in results)
-        {
-            if (!refData.Items.TryGetValue(result.ItemCode, out var item)) continue;
-            if (string.IsNullOrEmpty(item.InternalName)) continue;
-            // First recipe wins. If multiple recipes produce the same item, the
-            // aggregator picks deterministically by enumeration order — stable across runs.
-            map.TryAdd(item.InternalName!, recipe);
-        }
-    }
-
     private static Item? FindPrimaryOutput(Recipe recipe, IReferenceDataService refData)
     {
         if (recipe.ResultItems is { } results)
@@ -406,29 +284,4 @@ public sealed class RecipeAggregator
                 if (refData.Items.TryGetValue(result.ItemCode, out var item)) return item;
         return null;
     }
-
-    private static int FindOutputStackSize(Recipe recipe, string itemInternalName, IReferenceDataService refData)
-    {
-        if (recipe.ResultItems is { } results)
-        {
-            foreach (var result in results)
-            {
-                if (!refData.Items.TryGetValue(result.ItemCode, out var item)) continue;
-                if (item.InternalName == itemInternalName) return Math.Max(1, result.StackSize);
-            }
-            // Fall back to the first result if the recipe doesn't publish the item
-            // we expected (rare but possible with data drift).
-            return results.FirstOrDefault()?.StackSize ?? 1;
-        }
-        return 1;
-    }
-
-    private static string MakeKeywordKey(IReadOnlyList<string> keys)
-    {
-        if (keys.Count == 1) return KeywordKeyPrefix + keys[0];
-        var ordered = keys.OrderBy(k => k, StringComparer.Ordinal);
-        return KeywordKeyPrefix + string.Join(",", ordered);
-    }
-
-    private sealed record KeywordSpec(IReadOnlyList<string> Keys, string? Desc);
 }

--- a/src/Mithril.Shared/Crafting/RecipeExpander.cs
+++ b/src/Mithril.Shared/Crafting/RecipeExpander.cs
@@ -1,0 +1,232 @@
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Crafting;
+
+/// <summary>
+/// A keyword-matched ingredient slot ("any item whose keywords include every listed
+/// tag"). Surfaced as a synthetic demand key (<see cref="RecipeExpander.MakeKeywordKey"/>)
+/// so it flows through expansion like a concrete item; the caller resolves it.
+/// </summary>
+public readonly record struct KeywordSlot(IReadOnlyList<string> Keys, string? Desc);
+
+/// <summary>
+/// Pure, demand-driven recipe expander (#226, supersedes #121). "I need N units of
+/// item X → pick a recipe that produces X → for each ingredient, recurse on the
+/// shortfall vs. on-hand." Cycle-safe (visited-set) and depth-capped.
+///
+/// Multi-output recipes credit <b>all</b> of the chosen recipe's outputs against
+/// outstanding demand — deterministic outputs at full stack, random outputs
+/// (<see cref="RecipeResultItem.PercentChance"/>) at expected value — so an
+/// independently-demanded byproduct isn't crafted twice (closes #42). Variance is
+/// handled at execution time by the plan-aware craft list (#228), not modelled
+/// probabilistically here.
+///
+/// Optimisation (which alternative to pick) and presentation (how to render the
+/// tree) are deliberately *not* here — the caller owns both via
+/// <see cref="RecipeChoicePolicy"/>.
+/// </summary>
+public sealed class RecipeExpander
+{
+    public const string KeywordKeyPrefix = "#keys:";
+
+    private readonly IReferenceDataService _ref;
+
+    public RecipeExpander(IReferenceDataService referenceData, RecipeProducerIndex? producers = null)
+    {
+        _ref = referenceData ?? throw new ArgumentNullException(nameof(referenceData));
+        Producers = producers ?? RecipeProducerIndex.Build(referenceData);
+    }
+
+    public RecipeProducerIndex Producers { get; }
+
+    /// <summary>
+    /// Synthetic demand key for a keyword-matched ingredient slot. Single-key slots
+    /// key on the bare tag; multi-key slots on the ordinal-sorted comma-joined list
+    /// so two recipes citing the same set collapse to one demand row.
+    /// </summary>
+    public static string MakeKeywordKey(IReadOnlyList<string> keys)
+    {
+        if (keys.Count == 1) return KeywordKeyPrefix + keys[0];
+        var ordered = keys.OrderBy(k => k, StringComparer.Ordinal);
+        return KeywordKeyPrefix + string.Join(",", ordered);
+    }
+
+    public static bool IsKeywordKey(string demandKey)
+        => demandKey.StartsWith(KeywordKeyPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Per-craft produced quantity of <paramref name="result"/>: full
+    /// <see cref="RecipeResultItem.StackSize"/> when deterministic, or the
+    /// expected value <c>StackSize × PercentChance/100</c> when random.
+    /// </summary>
+    public static double ExpectedYield(RecipeResultItem result)
+    {
+        var stack = Math.Max(1, result.StackSize);
+        if (result.PercentChance is not { } pct || pct >= 100.0) return stack;
+        if (pct <= 0.0) return 0.0;
+        return stack * (pct / 100.0);
+    }
+
+    /// <summary>
+    /// Stack size of the slot in <paramref name="recipe"/> that yields
+    /// <paramref name="itemInternalName"/>, falling back to the first result on
+    /// data drift. Deterministic value (no expected-value scaling) — used to size
+    /// "how many batches cover this shortfall".
+    /// </summary>
+    public int OutputStackSize(Recipe recipe, string itemInternalName)
+    {
+        if (recipe.ResultItems is { } results)
+        {
+            foreach (var result in results)
+            {
+                if (!_ref.Items.TryGetValue(result.ItemCode, out var item)) continue;
+                if (item.InternalName == itemInternalName) return Math.Max(1, result.StackSize);
+            }
+            if (results.Count > 0) return Math.Max(1, results[0].StackSize);
+        }
+        if (recipe.ProtoResultItems is { } proto)
+        {
+            foreach (var result in proto)
+            {
+                if (!_ref.Items.TryGetValue(result.ItemCode, out var item)) continue;
+                if (item.InternalName == itemInternalName) return Math.Max(1, result.StackSize);
+            }
+        }
+        return 1;
+    }
+
+    /// <summary>
+    /// The recipe's deterministic-or-expected outputs as (itemInternalName → per-batch
+    /// yield) pairs. Used to credit byproducts against demand.
+    /// </summary>
+    private IEnumerable<(string InternalName, double PerBatch)> OutputsOf(Recipe recipe)
+    {
+        IEnumerable<RecipeResultItem> Results()
+        {
+            if (recipe.ResultItems is { } r) foreach (var x in r) yield return x;
+            if (recipe.ProtoResultItems is { } p) foreach (var x in p) yield return x;
+        }
+
+        foreach (var result in Results())
+        {
+            if (!_ref.Items.TryGetValue(result.ItemCode, out var item)) continue;
+            if (string.IsNullOrEmpty(item.InternalName)) continue;
+            var perBatch = ExpectedYield(result);
+            if (perBatch > 0) yield return (item.InternalName!, perBatch);
+        }
+    }
+
+    /// <summary>
+    /// Add <paramref name="recipe"/>'s ingredient demand for <paramref name="batches"/>
+    /// batches. Item slots key on item <c>InternalName</c>; keyword slots on a
+    /// synthetic key recorded into <paramref name="keywordSlots"/>.
+    /// </summary>
+    public void AddIngredients(
+        IDictionary<string, double> demand,
+        Recipe recipe,
+        double batches,
+        IDictionary<string, KeywordSlot> keywordSlots)
+    {
+        foreach (var ingredient in recipe.Ingredients)
+        {
+            string demandKey;
+            switch (ingredient)
+            {
+                case RecipeItemIngredient itemIng:
+                    if (!_ref.Items.TryGetValue(itemIng.ItemCode, out var item)) continue;
+                    if (string.IsNullOrEmpty(item.InternalName)) continue;
+                    demandKey = item.InternalName!;
+                    break;
+                case RecipeKeywordIngredient kwIng:
+                    demandKey = MakeKeywordKey(kwIng.ItemKeys);
+                    if (!keywordSlots.ContainsKey(demandKey))
+                        keywordSlots[demandKey] = new KeywordSlot(kwIng.ItemKeys, kwIng.Desc);
+                    break;
+                default:
+                    continue;
+            }
+
+            var perBatch = ingredient.StackSize * (ingredient.ChanceToConsume ?? 1.0);
+            if (perBatch <= 0) continue;
+            var add = batches * perBatch;
+
+            demand[demandKey] = demand.TryGetValue(demandKey, out var existing) ? existing + add : add;
+        }
+    }
+
+    /// <summary>
+    /// Demand-driven expansion, mutating <paramref name="demand"/> in place.
+    /// Intermediates stay in the map (so the caller can still show "3× Slab"); a
+    /// per-expansion visited-set guards cycles (A→B→A) and the
+    /// <paramref name="maxDepth"/> cap bounds recursion. Each chosen recipe credits
+    /// all its outputs against any independently-outstanding demand (the #42 fix).
+    /// </summary>
+    public void Expand(
+        IDictionary<string, double> demand,
+        int maxDepth,
+        IReadOnlyDictionary<string, int>? onHandByInternalName,
+        IReadOnlyDictionary<string, int>? overridesByInternalName,
+        IDictionary<string, KeywordSlot> keywordSlots,
+        RecipeChoicePolicy? choose = null)
+    {
+        var alreadyExpanded = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var level = 0; level < maxDepth; level++)
+        {
+            var candidates = demand
+                .Where(kv => kv.Value > 0
+                             && !alreadyExpanded.Contains(kv.Key)
+                             && Producers.HasProducer(kv.Key))
+                .Select(kv => kv.Key)
+                .ToList();
+
+            if (candidates.Count == 0) break;
+
+            foreach (var itemName in candidates)
+            {
+                alreadyExpanded.Add(itemName);
+
+                var alternatives = Producers.Alternatives(itemName);
+                if (alternatives.Count == 0) continue;
+                var recipe = choose is not null
+                    ? choose(itemName, alternatives)
+                    : alternatives[0];
+
+                var outputStackSize = OutputStackSize(recipe, itemName);
+                if (outputStackSize <= 0) continue;
+
+                var expected = demand.TryGetValue(itemName, out var d) ? d : 0;
+
+                // Only the shortfall between demand and effective stock needs crafting.
+                // A manual override beats the detected on-hand reading so raw totals
+                // update live when the user adjusts an intermediate's count.
+                var onHand = onHandByInternalName is not null
+                    && onHandByInternalName.TryGetValue(itemName, out var stock) ? stock : 0;
+                var effectiveStock = overridesByInternalName is not null
+                    && overridesByInternalName.TryGetValue(itemName, out var ov) ? ov : onHand;
+                var shortfall = expected - effectiveStock;
+                if (shortfall <= 0) continue;
+
+                var batches = shortfall / outputStackSize;
+
+                // #42: a multi-output recipe also yields its *other* outputs. Credit
+                // them against any independently-outstanding demand so we don't craft
+                // a shared byproduct twice. Single-output recipes have no siblings —
+                // behaviour is unchanged for them.
+                foreach (var (outName, perBatch) in OutputsOf(recipe))
+                {
+                    if (string.Equals(outName, itemName, StringComparison.Ordinal)) continue;
+                    if (!demand.TryGetValue(outName, out var outstanding) || outstanding <= 0) continue;
+                    var produced = batches * perBatch;
+                    demand[outName] = Math.Max(0, outstanding - produced);
+                }
+
+                AddIngredients(demand, recipe, batches, keywordSlots);
+            }
+        }
+
+        foreach (var key in demand.Where(kv => kv.Value <= 0).Select(kv => kv.Key).ToList())
+            demand.Remove(key);
+    }
+}

--- a/src/Mithril.Shared/Crafting/RecipeProducerIndex.cs
+++ b/src/Mithril.Shared/Crafting/RecipeProducerIndex.cs
@@ -1,0 +1,82 @@
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Crafting;
+
+/// <summary>
+/// Reverse index "item <c>InternalName</c> → every recipe that produces it",
+/// built by scanning each recipe's <c>ResultItems</c> (and <c>ProtoResultItems</c>
+/// as a fallback). Unlike the old Celebrimbor-internal "first recipe wins" lookup,
+/// this keeps the *full set of alternatives* (in reference-data enumeration order,
+/// stable across runs) and lets the caller decide which to pick — Celebrimbor's
+/// shopping list, the #121 multi-recipe picker, and the #227 planner all need the
+/// same producer graph but choose differently. (#226, supersedes #121.)
+/// </summary>
+public sealed class RecipeProducerIndex
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<Recipe>> _byItem;
+
+    private RecipeProducerIndex(IReadOnlyDictionary<string, IReadOnlyList<Recipe>> byItem)
+        => _byItem = byItem;
+
+    public static RecipeProducerIndex Build(IReferenceDataService refData)
+    {
+        var map = new Dictionary<string, List<Recipe>>(StringComparer.Ordinal);
+
+        void Register(Recipe recipe, IReadOnlyList<RecipeResultItem>? results)
+        {
+            if (results is null) return;
+            foreach (var result in results)
+            {
+                if (!refData.Items.TryGetValue(result.ItemCode, out var item)) continue;
+                if (string.IsNullOrEmpty(item.InternalName)) continue;
+                if (!map.TryGetValue(item.InternalName!, out var list))
+                    map[item.InternalName!] = list = [];
+                // De-dup: a recipe that lists the same item in both ResultItems and
+                // ProtoResultItems should appear once as a producer of it.
+                if (!list.Contains(recipe)) list.Add(recipe);
+            }
+        }
+
+        foreach (var recipe in refData.Recipes.Values)
+        {
+            Register(recipe, recipe.ResultItems);
+            Register(recipe, recipe.ProtoResultItems);
+        }
+
+        return new RecipeProducerIndex(
+            map.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<Recipe>)kv.Value, StringComparer.Ordinal));
+    }
+
+    /// <summary>Every item that at least one recipe produces → its producing recipes.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> ByItemInternalName => _byItem;
+
+    public bool HasProducer(string itemInternalName) => _byItem.ContainsKey(itemInternalName);
+
+    /// <summary>Producing recipes for <paramref name="itemInternalName"/> (empty if none).</summary>
+    public IReadOnlyList<Recipe> Alternatives(string itemInternalName)
+        => _byItem.TryGetValue(itemInternalName, out var list) ? list : [];
+
+    /// <summary>
+    /// First producing recipe in enumeration order — the deterministic default when a
+    /// caller doesn't supply its own <see cref="RecipeChoicePolicy"/>. Reproduces the
+    /// old "first recipe wins" behaviour exactly.
+    /// </summary>
+    public bool TryGetDefault(string itemInternalName, out Recipe recipe)
+    {
+        if (_byItem.TryGetValue(itemInternalName, out var list) && list.Count > 0)
+        {
+            recipe = list[0];
+            return true;
+        }
+        recipe = null!;
+        return false;
+    }
+}
+
+/// <summary>
+/// Picks which producing recipe to use for an item when several can make it. The
+/// expander stays free of optimisation concerns — Celebrimbor's UI / the #227
+/// planner own the choice. Must return one of <paramref name="alternatives"/>.
+/// </summary>
+public delegate Recipe RecipeChoicePolicy(string itemInternalName, IReadOnlyList<Recipe> alternatives);

--- a/tests/Mithril.Shared.Tests/Crafting/RecipeExpanderTests.cs
+++ b/tests/Mithril.Shared.Tests/Crafting/RecipeExpanderTests.cs
@@ -1,0 +1,244 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Crafting;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Crafting;
+
+/// <summary>
+/// Coverage for the shared demand-driven recipe expander (#226, supersedes #121).
+/// Pins the contract the planner (#227) and Celebrimbor both rely on: producer
+/// *alternatives*, multi-output crediting (the #42 fix), expected-value random
+/// outputs, on-hand-aware shortfall, and cycle / depth safety.
+/// </summary>
+public class RecipeExpanderTests
+{
+    // ── RecipeProducerIndex ──────────────────────────────────────────────
+
+    [Fact]
+    public void ProducerIndex_KeepsAllAlternatives_InEnumerationOrder()
+    {
+        var data = new FakeRef()
+            .AddItem(1, "Plank")
+            .AddRecipe("SawPlank", produces: [(1, 4)], ingredients: [(2, 1)])
+            .AddRecipe("MagicPlank", produces: [(1, 4)], ingredients: [(3, 1)]);
+
+        var idx = RecipeProducerIndex.Build(data);
+
+        idx.Alternatives("Plank").Select(r => r.InternalName)
+            .Should().Equal("SawPlank", "MagicPlank");
+        idx.TryGetDefault("Plank", out var first).Should().BeTrue();
+        first.InternalName.Should().Be("SawPlank", because: "default = first in enumeration order");
+        idx.HasProducer("Nope").Should().BeFalse();
+    }
+
+    // ── ExpectedYield ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, 5, 5.0)]    // deterministic
+    [InlineData(100.0, 5, 5.0)]   // 100% == deterministic
+    [InlineData(50.0, 4, 2.0)]    // random → expected value
+    [InlineData(0.0, 9, 0.0)]     // never drops
+    public void ExpectedYield_DeterministicVsRandom(double? pct, int stack, double expected)
+        => RecipeExpander.ExpectedYield(new RecipeResultItem { StackSize = stack, PercentChance = pct })
+            .Should().Be(expected);
+
+    // ── Single producer / single output (behaviour parity) ───────────────
+
+    [Fact]
+    public void Expand_PullsIngredientsForShortfall()
+    {
+        var data = new FakeRef()
+            .AddItem(1, "Bread").AddItem(2, "Flour").AddItem(3, "Water")
+            .AddRecipe("BakeBread", produces: [(1, 1)], ingredients: [(2, 2), (3, 1)]);
+
+        var demand = new Dictionary<string, double> { ["Bread"] = 3 };
+        var expander = new RecipeExpander(data);
+        expander.Expand(demand, maxDepth: 1, null, null, new Dictionary<string, KeywordSlot>());
+
+        demand["Flour"].Should().Be(6);
+        demand["Water"].Should().Be(3);
+        demand["Bread"].Should().Be(3, because: "intermediates stay in the map for the caller to render");
+    }
+
+    [Fact]
+    public void Expand_OnHandReducesShortfall()
+    {
+        var data = new FakeRef()
+            .AddItem(1, "Bread").AddItem(2, "Flour")
+            .AddRecipe("BakeBread", produces: [(1, 1)], ingredients: [(2, 2)]);
+
+        var demand = new Dictionary<string, double> { ["Bread"] = 10 };
+        new RecipeExpander(data).Expand(
+            demand, maxDepth: 1,
+            onHandByInternalName: new Dictionary<string, int> { ["Bread"] = 4 },
+            overridesByInternalName: null,
+            new Dictionary<string, KeywordSlot>());
+
+        demand["Flour"].Should().Be(12, because: "only the shortfall of 6 needs crafting → 6×2 flour");
+    }
+
+    // ── #42: multi-output sibling crediting ──────────────────────────────
+
+    [Fact]
+    public void Expand_MultiOutputRecipe_CreditsSiblingDemand_Issue42()
+    {
+        // Smelting yields BOTH an Ingot and Slag per batch. The plan independently
+        // wants Slag too. Before #42 the Slag demand was crafted again from a Slag
+        // recipe; now the Ingot batches' Slag byproduct is credited first.
+        var data = new FakeRef()
+            .AddItem(1, "Ingot").AddItem(2, "Slag").AddItem(3, "Ore")
+            .AddRecipe("Smelt", produces: [(1, 1), (2, 1)], ingredients: [(3, 2)]);
+
+        var demand = new Dictionary<string, double> { ["Ingot"] = 10, ["Slag"] = 4 };
+        new RecipeExpander(data).Expand(
+            demand, maxDepth: 1, null, null, new Dictionary<string, KeywordSlot>());
+
+        demand["Ore"].Should().Be(20, because: "10 ingots → 10 batches → 20 ore (NOT re-crafted for slag)");
+        demand.GetValueOrDefault("Slag", 0).Should().Be(0,
+            because: "10 batches also yield 10 slag, fully covering the demand of 4 — "
+                     + "the byproduct is credited, not re-crafted, then the zeroed row is pruned (#42)");
+    }
+
+    [Fact]
+    public void Expand_MultiOutput_RandomSiblingCreditedAtExpectedValue()
+    {
+        var data = new FakeRef()
+            .AddItem(1, "Gem").AddItem(2, "Dust").AddItem(3, "Rock")
+            .AddRecipe("Crack", produces: [(1, 1)], randomProduces: [(2, 2, 50.0)], ingredients: [(3, 1)]);
+
+        // 8 gems → 8 batches; Dust expected = 8 × (2 × 0.5) = 8.
+        var demand = new Dictionary<string, double> { ["Gem"] = 8, ["Dust"] = 30 };
+        new RecipeExpander(data).Expand(
+            demand, maxDepth: 1, null, null, new Dictionary<string, KeywordSlot>());
+
+        demand["Dust"].Should().Be(22, because: "30 wanted − 8 expected byproduct");
+    }
+
+    // ── Choice policy ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_HonoursChoicePolicy()
+    {
+        var data = new FakeRef()
+            .AddItem(1, "Plank").AddItem(2, "Log").AddItem(3, "Mana")
+            .AddRecipe("SawPlank", produces: [(1, 1)], ingredients: [(2, 3)])
+            .AddRecipe("ConjurePlank", produces: [(1, 1)], ingredients: [(3, 1)]);
+
+        var demand = new Dictionary<string, double> { ["Plank"] = 5 };
+        new RecipeExpander(data).Expand(
+            demand, maxDepth: 1, null, null, new Dictionary<string, KeywordSlot>(),
+            choose: (_, alts) => alts.Single(r => r.InternalName == "ConjurePlank"));
+
+        demand.Should().ContainKey("Mana").WhoseValue.Should().Be(5);
+        demand.Should().NotContainKey("Log", because: "the policy picked the conjure recipe");
+    }
+
+    // ── Cycle / depth safety ─────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_CycleSafe()
+    {
+        // A ← needs B; B ← needs A. Must terminate.
+        var data = new FakeRef()
+            .AddItem(1, "A").AddItem(2, "B")
+            .AddRecipe("MakeA", produces: [(1, 1)], ingredients: [(2, 1)])
+            .AddRecipe("MakeB", produces: [(2, 1)], ingredients: [(1, 1)]);
+
+        var demand = new Dictionary<string, double> { ["A"] = 1 };
+        var act = () => new RecipeExpander(data).Expand(
+            demand, maxDepth: 16, null, null, new Dictionary<string, KeywordSlot>());
+
+        act.Should().NotThrow();
+        demand.Should().ContainKey("B");
+    }
+
+    [Fact]
+    public void Expand_DepthCapBoundsRecursion()
+    {
+        // C → B → A. depth 1 only pulls the first level.
+        var data = new FakeRef()
+            .AddItem(1, "A").AddItem(2, "B").AddItem(3, "C").AddItem(4, "Raw")
+            .AddRecipe("MakeC", produces: [(3, 1)], ingredients: [(2, 1)])
+            .AddRecipe("MakeB", produces: [(2, 1)], ingredients: [(1, 1)])
+            .AddRecipe("MakeA", produces: [(1, 1)], ingredients: [(4, 1)]);
+
+        var demand = new Dictionary<string, double> { ["C"] = 1 };
+        new RecipeExpander(data).Expand(
+            demand, maxDepth: 1, null, null, new Dictionary<string, KeywordSlot>());
+
+        demand.Should().ContainKey("B");
+        demand.Should().NotContainKey("A", because: "depth 1 stops after C's direct ingredients");
+    }
+
+    // ── Minimal IReferenceDataService fake ───────────────────────────────
+
+    private sealed class FakeRef : IReferenceDataService
+    {
+        private readonly Dictionary<long, Item> _items = new();
+        private readonly Dictionary<string, Item> _itemsByName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Recipe> _recipesByName = new(StringComparer.Ordinal);
+        private int _serial;
+
+        public FakeRef AddItem(long id, string internalName)
+        {
+            var item = new Item { Id = id, Name = internalName, InternalName = internalName };
+            _items[id] = item;
+            _itemsByName[internalName] = item;
+            return this;
+        }
+
+        public FakeRef AddRecipe(
+            string internalName,
+            (long id, int stack)[] produces,
+            (long id, int stack)[]? ingredients = null,
+            (long id, int stack, double pct)[]? randomProduces = null)
+        {
+            var results = produces
+                .Select(p => new RecipeResultItem { ItemCode = p.id, StackSize = p.stack })
+                .Concat((randomProduces ?? [])
+                    .Select(p => new RecipeResultItem { ItemCode = p.id, StackSize = p.stack, PercentChance = p.pct }))
+                .ToList();
+            var recipe = new Recipe
+            {
+                Key = $"recipe_{++_serial}",
+                Name = internalName,
+                InternalName = internalName,
+                Ingredients = (ingredients ?? [])
+                    .Select(i => (RecipeIngredient)new RecipeItemIngredient { ItemCode = i.id, StackSize = i.stack })
+                    .ToList(),
+                ResultItems = results,
+            };
+            _recipes[recipe.Key] = recipe;
+            _recipesByName[internalName] = recipe;
+            return this;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = ["items", "recipes"];
+        public IReadOnlyDictionary<long, Item> Items => _items;
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByName;
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _recipesByName;
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}


### PR DESCRIPTION
## What

Lifts Celebrimbor's nested-craft recipe expansion into a **pure, shared component** in `Mithril.Shared` so the #121 multi-recipe picker, the #227 cross-skill planner, and Celebrimbor's shopping list all call one engine instead of forking the logic.

Implements #226. **Supersedes #121** (the multi-recipe picker is reframed as a consumer of this expander — alternatives are now first-class) and **closes #42** (the aggregator dropped non-primary outputs in multi-output recipes).

## How

**New `Mithril.Shared/Crafting/`:**

- **`RecipeProducerIndex`** — item `InternalName` → *all* producing recipes (the set of **alternatives**, in stable enumeration order). Replaces the old "first recipe wins" `TryAdd` lookup; callers pick via a `RecipeChoicePolicy` delegate. The default policy is "first", which reproduces the previous behaviour exactly.
- **`RecipeExpander`** — pure, demand-driven: "need N of X → pick a producer → recurse on the shortfall vs. on-hand/override." Cycle-safe (visited-set) and depth-capped. The chosen recipe credits **all** its outputs against outstanding demand — deterministic at full stack, random (`PercentChance`) at **expected value** — so an independently-demanded byproduct is not crafted twice (**the #42 fix**). Variance is left to the #228 plan-aware executor, not modelled probabilistically here. Keyword ingredient slots flow through as synthetic demand keys for the caller to resolve.

**Celebrimbor `RecipeAggregator`** now delegates producer-lookup + demand expansion to the shared engine and keeps only its presentation concerns (the stable chain skeleton, keyword-slot rows, crafting-step depth, on-hand/override/location plumbing, the sort) — UI presentation is explicitly out of #226 scope and stays Celebrimbor's.

## Behaviour change (intended, per the locked design decision)

The #42 fix means multi-output recipes now credit their sibling outputs against demand. This is **invisible to every existing path** (no single-output scenario changes) and only affects plans where a recipe's byproduct is independently demanded — where the old code over-crafted.

## Testing

- `dotnet build Mithril.slnx` clean.
- **Mithril.Shared.Tests: 971 passed** (+12 new): producer alternatives & default, `ExpectedYield` deterministic/100%/random/never, ingredient shortfall, on-hand reduction, the **#42 multi-output sibling-credit** case, expected-value random byproduct, choice-policy override, cycle safety, depth cap.
- **Celebrimbor.Tests: 52 passed, unchanged** — the lift is behaviour-preserving for every non-#42 path.

## Follow-up

#121's multi-recipe **picker UI** in Celebrimbor now has its substrate (alternatives are exposed). Rendering the expanded tree / the picker remains Celebrimbor's, tracked under the Celebrimbor roadmap — out of scope here by #226's own boundary.

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
