### PR TITLE
feat(query): WITH ANY|ALL quantified subqueries — engine (#351, PR-2 of #349)

### DIFF
--- a/docs/query-quantified-subqueries.md
+++ b/docs/query-quantified-subqueries.md
@@ -1,0 +1,144 @@
+# Quantified subqueries (`WITH ANY|ALL`) — design note
+
+**Tracked in:** [#349](https://github.com/moumantai-gg/mithril/issues/349)
+(umbrella), [#350](https://github.com/moumantai-gg/mithril/issues/350)
+(canonical `StoreCapIncrease`, PR-1),
+[#351](https://github.com/moumantai-gg/mithril/issues/351) (engine, PR-2),
+[#352](https://github.com/moumantai-gg/mithril/issues/352) (consumer wiring,
+PR-3). Companion to [`query-system.md`](query-system.md) (user-facing
+behaviour); this file is the *why*.
+
+## The problem
+
+Silmarillion queries reference data, and almost every dataset it owns is a
+nested repeating group: recipes→ingredients, abilities→dots,
+quests→requirements, NPCs→services/cap-increases. The query engine is flat —
+only top-level row properties are queryable, plus a string-collection
+`CONTAINS`. The originating question, *"which NPCs sell into a given keyword,
+optionally at a tier / under a gold cap?"*, cannot be expressed: the data
+lives in `StoreService.CapIncreases` (colon-packed strings) inside the
+polymorphic `Npc.Services` collection, and `CONTAINS` can only test one
+flattened token at a time — it cannot correlate *tier* and *gold cap* on the
+**same** cap-increase row.
+
+## A vs B: why an engine quantifier, not per-tab pivots
+
+- **Option A — per-tab pivot grids / bespoke filters.** Each tab that needs
+  nested filtering grows its own UI and its own ad-hoc predicate plumbing.
+  Fast for the first tab, then N divergent idioms; the query box (the thing
+  users already know) still can't express the question; every new dataset
+  re-litigates it.
+- **Option B — one engine quantifier** (chosen). `WITH ANY|ALL` is the
+  structured-record analogue of the existing `IQueryStringValue` `CONTAINS`
+  path: same grammar, same completion/highlighter, every tab gets it for
+  free, and the correlation is *accurate* because the inner predicate is
+  evaluated per element. Cost: the engine has to understand element schemas
+  and polymorphism. We pay that once, centrally, with heavy unit coverage.
+
+Locked corollaries (from the #349/#351 discussion):
+
+- **No flat ride-along projection.** A duplicated flattened column would be a
+  second idiom and double the data; the originating question is gated behind
+  the engine track with no interim shortcut.
+- **Ship the full engine up front (Option-2 scope):** both `ANY` and `ALL`,
+  the build-time per-hierarchy collision classifier, and the
+  mandatory-narrowing path — even though the only v1-wired consumer (store
+  cap-increases) is homogeneous. Consumer wiring stays incremental (PR-3).
+- **Grammar is column-first:** `<column> WITH ANY (<pred>)` /
+  `<column> WITH ALL (<pred>)`, mirroring every other predicate; negation via
+  the existing prefix `NOT ( … )`. This supersedes the `ANY … WHERE` form
+  sketched in early #351/#352 comments.
+
+## Semantics
+
+- `ANY` ⇒ at least one element satisfies `<pred>` (short-circuits).
+- `ALL` ⇒ every element satisfies it, **vacuously true over an empty
+  collection**; a null collection is false for both (matches the
+  `CONTAINS`-over-null-collection convention).
+- `<pred>` binds against the **element** sub-schema, not the outer row, and
+  is evaluated per element — so `WITH ANY (Tier='Despised' AND GoldCap>1000)`
+  is true only if *one* element is both, never a column-wise OR across the
+  collection. This is the headline correctness property.
+- Negation is the existing prefix `NOT ( … )`; there is no inline `NOT WITH`.
+- String / `IQueryStringValue` collections are rejected — they keep using
+  `CONTAINS`, the single way to match a flat keyword list.
+
+## Per-hierarchy narrowing contract
+
+Element schema construction:
+
+- **Homogeneous element** (a plain record like `StoreCapIncrease`) →
+  `ColumnBindingHelper.BuildFromProperties` (the slice-1 path).
+- **Polymorphic element** (a discriminated-union base registered in
+  `Mithril.Reference`'s `DiscriminatorRegistry`) → the **union** of every
+  concrete subtype's public properties plus the discriminator pseudo-column.
+  Each binding reflects on the element's **runtime** subtype: a property the
+  subtype doesn't declare yields the `QueryAbsent` sentinel — **distinct from
+  present-but-null**. Every leaf predicate treats absent as an unconditional
+  non-match (absent ≠ null; even `IS NULL` is false), so naming a
+  sibling-subtype field skips that element rather than throwing. Wrong-subtype
+  vs present-null is decided by reflecting on the concrete type, *never* by a
+  swallowed reflection exception.
+
+Narrowing mode is **per hierarchy, schema-derived** (not a global toggle).
+`PolymorphicSchemaClassifier` unions the subtype property types:
+
+- A property name with **one consistent type** across subtypes → no narrowing
+  needed.
+- A property name with **>1 distinct type** across subtypes (e.g.
+  `QuestRequirement.Level` — `string?` on `MinSkillLevelRequirement`,
+  `int?` on `MinCombatSkillLevelRequirement`) makes the hierarchy
+  **Mandatory**: a reference to that property is a compile error unless an
+  in-conjunction `<discriminator> = '<literal>'` equality scopes it (the
+  guard resolves the colliding property to a single concrete type for that
+  scope). A `!=` is **not** a guard; a guard inside a `NOT` subtree does not
+  count (it isn't a positive narrowing).
+- No collisions → **Optional**: a property declared on only one subtype, used
+  without a guard, emits a non-fatal `QueryDiagnostic` *warning* (it can only
+  match that subtype's elements) — it never throws.
+
+The classifier walks the inner AST **per conjunctive scope**: split on `OR`
+(each arm is a fresh scope), descend `AND` (same scope, DNF cross-product), a
+`NOT` subtree contributes no positive guard but its references still need a
+type. Today only `QuestRequirement` is Mandatory and it is **not
+consumer-wired** (PR-3 wires the homogeneous `StoreCapIncrease`; `NpcService`
+is Optional), so the mandatory path is exercised by unit tests only in v1.
+
+### v1 limitations (documented, intentional)
+
+The inner predicate of a quantifier compiles **once**, so a single flat
+element sub-schema can give a colliding property exactly one
+`ColumnBinding.ValueType`. Therefore:
+
+- A colliding property that resolves to **different** types across the
+  OR-branches of one quantifier (e.g. `int?` in one arm, `string?` in
+  another) is rejected with a `QueryException` telling the user to split the
+  query. Single-type-per-query is fine; divergent multi-scope is the v1 wall.
+- The `QueryDiagnostic` soft-warning channel is plumbed end-to-end
+  (`QueryCompiler.Compile(node, columns, ICollection<QueryDiagnostic>
+  warnings, caseSensitive)` — additive overload; the existing public API is
+  unchanged) but **UI surfacing is out of v1 scope**.
+
+These are acceptable because the only Mandatory hierarchy is test-only in v1;
+the shipped consumer is homogeneous and `NpcService` is Optional.
+
+## Sequencing
+
+Linear **PR-1 (#350) → PR-2 (#351 engine) → PR-3 (#351 wiring)**. #350
+(canonical `StoreCapIncrease` record + parser) is independent of PR-2 and
+unblocks PR-3. PR-2 is large, internal, zero-UX, high test density — it bakes
+before any consumer is exposed. PR-3 is small and UX-facing: it surfaces
+`CapIncreases` on the Silmarillion NPC list-row projection and plumbs the
+warning collector into that tab.
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`QueryAst.cs`](../src/Mithril.Shared.Wpf/Query/QueryAst.cs) | `QuantifiedNode`, `Quantifier`, `QueryDiagnostic` |
+| [`QueryParser.cs`](../src/Mithril.Shared.Wpf/Query/QueryParser.cs) | `WITH ANY|ALL (…)` lexing + parse |
+| [`QueryCompiler.cs`](../src/Mithril.Shared.Wpf/Query/QueryCompiler.cs) | `CompileQuantified`, `EnforceNarrowing`, conjunctive-scope expansion, `QueryAbsent` leaf guards |
+| [`ColumnBindingHelper.cs`](../src/Mithril.Shared.Wpf/Query/ColumnBindingHelper.cs) | `BuildElementSchema`, `TryGetElementSchema` |
+| [`PolymorphicSchemaClassifier.cs`](../src/Mithril.Shared.Wpf/Query/PolymorphicSchemaClassifier.cs) | per-hierarchy collision classification (cached) |
+| [`QueryAbsent.cs`](../src/Mithril.Shared.Wpf/Query/QueryAbsent.cs) | absent-on-subtype sentinel (≠ null) |
+| `Mithril.Reference/Serialization/Discriminators/` | `DiscriminatorRegistry`, `PolymorphicHierarchy`, per-family `*Discriminators` |

--- a/docs/query-system.md
+++ b/docs/query-system.md
@@ -25,6 +25,8 @@ MinLevel IS NULL / IS NOT NULL               — null check
 avg > 1m30s                                  — duration literals: 30s, 1m30s, 2h, 150ms
 Timestamp BEFORE NOW()                       — English-aliased <, >; NOW() and TODAY() functions
 NOT LIKE / NOT IN / NOT BETWEEN              — negation prefix
+Services WITH ANY (Type='Store' AND Favor='Friends')   — quantified subquery over an object collection
+Reqs WITH ALL (T='MinSkillLevel')            — ANY = ≥1 element; ALL = every element (vacuously true if empty)
 ORDER BY Cost DESC, Name                     — sort clause (SORT BY also accepted; ASC implicit)
 ```
 
@@ -247,6 +249,40 @@ returning a string from `QueryStringValue` — this is how
 `Item.Keywords` (`IReadOnlyList<ItemKeyword>`) supports
 `Keywords CONTAINS 'Crystal'` from the Silmarillion Items tab.
 `STARTSWITH` / `ENDSWITH` remain string-column-only.
+
+### `WITH ANY|ALL` — quantified subqueries over object collections
+
+`CONTAINS` flattens a collection to a single keyword test; it cannot ask
+"is there *one* element that is `Tier='Despised'` **and** `GoldCap>1000`
+together?". `<col> WITH ANY (<pred>)` / `<col> WITH ALL (<pred>)` does:
+`<pred>` is a full predicate compiled against the collection's **element**
+sub-schema and evaluated **per element**, so a conjunction inside the parens
+correlates on one element (the accuracy property the feature exists for).
+`ANY` ⇒ ≥1 matching element (short-circuits); `ALL` ⇒ every element matches
+and is **vacuously true over an empty collection**; a null collection is
+false for both (matching the `CONTAINS`-over-null convention). Negate with
+the existing prefix `NOT ( … )` — there is no inline `NOT WITH`. String /
+`IQueryStringValue` collections are rejected — those keep using `CONTAINS`,
+the one way to match a flat keyword list.
+
+For a **polymorphic** element collection (a discriminated-union base
+registered in `DiscriminatorRegistry`, e.g. `Npc.Services`,
+`Quest.Requirements`), the element schema is the **union** of every concrete
+subtype's properties plus the discriminator pseudo-column. A property absent
+from an element's runtime subtype reads as *absent* (distinct from
+present-but-null): every comparison against it — including `IS NULL` — is
+false, so naming a sibling-subtype field simply skips that element instead of
+erroring. When the same property name has **different types** across subtypes
+(the hierarchy is *Mandatory*-narrowing), scope it with an in-conjunction
+`<discriminator> = '<value>'` equality so the engine can resolve its concrete
+type; an unguarded reference (or a `!=` "guard") is a compile error with
+guidance. **v1 limitations:** a colliding property that would resolve to
+*different* types across the OR-branches of one quantifier is rejected (the
+inner predicate compiles once) — split it into separate queries; the
+soft-warning channel (`QueryCompiler.Compile(…, ICollection<QueryDiagnostic>
+warnings, …)`) is plumbed but not yet surfaced in the UI. Rationale, the
+A-vs-B decision, and the per-hierarchy narrowing contract are in
+[`query-quantified-subqueries.md`](query-quantified-subqueries.md).
 
 ### Schema is reflected, not declared
 

--- a/src/Mithril.Reference/Serialization/Discriminators/AbilityDiscriminators.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/AbilityDiscriminators.cs
@@ -16,6 +16,9 @@ internal static class AbilityDiscriminators
         BuildSpecialCasterRequirementConverter()
         => new("T", RequirementMap);
 
+    internal static PolymorphicHierarchy Hierarchy =>
+        new(typeof(AbilitySpecialCasterRequirement), "T", RequirementMap);
+
     private static readonly IReadOnlyDictionary<string, Type> RequirementMap = new Dictionary<string, Type>
     {
         ["EffectKeywordUnset"] = typeof(EffectKeywordUnsetAbilityRequirement),

--- a/src/Mithril.Reference/Serialization/Discriminators/DiscriminatorRegistry.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/DiscriminatorRegistry.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Mithril.Reference.Serialization.Discriminators;
+
+/// <summary>
+/// Public catalogue of every discriminated-union hierarchy in the reference model.
+/// Aggregates the per-family <c>*Discriminators</c> projections so cross-assembly
+/// consumers (the query engine's polymorphic-schema classifier) can enumerate
+/// subtypes without reaching into serializer internals — the maps themselves stay
+/// private to their family classes.
+/// </summary>
+/// <remarks>
+/// <see cref="Models.Recipes.RecipeIngredient"/> is intentionally absent: it is a
+/// field-presence union with no JSON discriminator string, so it has no
+/// discriminator map to project. The seven entries here are the discriminator-keyed
+/// families.
+/// </remarks>
+public static class DiscriminatorRegistry
+{
+    public static IReadOnlyList<PolymorphicHierarchy> All { get; } = new[]
+    {
+        NpcDiscriminators.Hierarchy,
+        AbilityDiscriminators.Hierarchy,
+        QuestDiscriminators.RequirementHierarchy,
+        QuestDiscriminators.RewardHierarchy,
+        RecipeDiscriminators.Hierarchy,
+        SourceDiscriminators.Hierarchy,
+        StorageDiscriminators.Hierarchy,
+    };
+}

--- a/src/Mithril.Reference/Serialization/Discriminators/NpcDiscriminators.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/NpcDiscriminators.cs
@@ -15,6 +15,9 @@ internal static class NpcDiscriminators
         BuildServiceConverter()
         => new("Type", ServiceMap);
 
+    internal static PolymorphicHierarchy Hierarchy =>
+        new(typeof(NpcService), "Type", ServiceMap);
+
     private static readonly IReadOnlyDictionary<string, Type> ServiceMap = new Dictionary<string, Type>
     {
         ["AnimalHusbandry"] = typeof(AnimalHusbandryService),

--- a/src/Mithril.Reference/Serialization/Discriminators/PolymorphicHierarchy.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/PolymorphicHierarchy.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mithril.Reference.Serialization.Discriminators;
+
+/// <summary>
+/// A public projection of one discriminated-union family: its abstract base type,
+/// the JSON discriminator field name, and the discriminator-value → concrete-subtype
+/// map. The per-family <c>*Discriminators</c> classes keep their maps private and
+/// expose only this read-only view, so the query engine's polymorphic-schema
+/// classifier (in <c>Mithril.Shared.Wpf</c>) can enumerate subtypes for
+/// <c>WITH ANY|ALL</c> element-schema building without taking a dependency on the
+/// serializer internals.
+/// </summary>
+public sealed record PolymorphicHierarchy(
+    Type BaseType,
+    string DiscriminatorField,
+    IReadOnlyDictionary<string, Type> KnownTypes);

--- a/src/Mithril.Reference/Serialization/Discriminators/QuestDiscriminators.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/QuestDiscriminators.cs
@@ -22,6 +22,12 @@ internal static class QuestDiscriminators
         BuildRewardConverter()
         => new("T", RewardMap);
 
+    internal static PolymorphicHierarchy RequirementHierarchy =>
+        new(typeof(QuestRequirement), "T", RequirementMap);
+
+    internal static PolymorphicHierarchy RewardHierarchy =>
+        new(typeof(QuestReward), "T", RewardMap);
+
     private static readonly IReadOnlyDictionary<string, Type> RequirementMap = new Dictionary<string, Type>
     {
         ["MinSkillLevel"] = typeof(MinSkillLevelRequirement),

--- a/src/Mithril.Reference/Serialization/Discriminators/RecipeDiscriminators.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/RecipeDiscriminators.cs
@@ -16,6 +16,9 @@ internal static class RecipeDiscriminators
         BuildRequirementConverter()
         => new("T", RequirementMap);
 
+    internal static PolymorphicHierarchy Hierarchy =>
+        new(typeof(RecipeRequirement), "T", RequirementMap);
+
     private static readonly IReadOnlyDictionary<string, Type> RequirementMap = new Dictionary<string, Type>
     {
         ["AlwaysFail"] = typeof(AlwaysFailRequirement),

--- a/src/Mithril.Reference/Serialization/Discriminators/SourceDiscriminators.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/SourceDiscriminators.cs
@@ -18,6 +18,9 @@ internal static class SourceDiscriminators
         BuildEntryConverter()
         => new("type", EntryMap);
 
+    internal static PolymorphicHierarchy Hierarchy =>
+        new(typeof(SourceEntry), "type", EntryMap);
+
     private static readonly IReadOnlyDictionary<string, Type> EntryMap = new Dictionary<string, Type>
     {
         ["Angling"] = typeof(AnglingSource),

--- a/src/Mithril.Reference/Serialization/Discriminators/StorageDiscriminators.cs
+++ b/src/Mithril.Reference/Serialization/Discriminators/StorageDiscriminators.cs
@@ -15,6 +15,9 @@ internal static class StorageDiscriminators
         BuildRequirementConverter()
         => new("T", RequirementMap);
 
+    internal static PolymorphicHierarchy Hierarchy =>
+        new(typeof(StorageRequirement), "T", RequirementMap);
+
     private static readonly IReadOnlyDictionary<string, Type> RequirementMap = new Dictionary<string, Type>
     {
         ["InteractionFlagSet"] = typeof(StorageInteractionFlagSetRequirement),

--- a/src/Mithril.Shared.Wpf/Query/ColumnBindingHelper.cs
+++ b/src/Mithril.Shared.Wpf/Query/ColumnBindingHelper.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Mithril.Shared.Wpf.Query;
@@ -19,6 +21,56 @@ public static class ColumnBindingHelper
             map[prop.Name] = new ColumnBinding(prop.Name, prop.PropertyType, item =>
             {
                 try { return captured.GetValue(item); }
+                catch { return null; }
+            });
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Build the element sub-schema for a <c>WITH ANY|ALL</c> over a
+    /// <em>polymorphic</em> collection. The schema is the <em>union</em> of every
+    /// concrete subtype's public properties (the discriminator base property is part
+    /// of that union and stays queryable). Each binding reflects the property on the
+    /// element's <strong>runtime</strong> type: a property absent from that subtype
+    /// yields <see cref="QueryAbsent.Value"/> (distinct from a present-but-null
+    /// value), so a predicate referencing a sibling-subtype field simply fails to
+    /// match that element instead of throwing.
+    /// </summary>
+    /// <param name="classification">The hierarchy classification (subtypes, union
+    /// property types, colliding names).</param>
+    /// <param name="resolvedCollidingTypes">Per-query resolved CLR type for each
+    /// type-colliding property name, computed by the compiler's narrowing pass from
+    /// the in-scope discriminator guard. Non-colliding names use the union's
+    /// representative type.</param>
+    internal static Dictionary<string, ColumnBinding> BuildElementSchema(
+        HierarchyClassification classification,
+        IReadOnlyDictionary<string, Type>? resolvedCollidingTypes = null)
+    {
+        var map = new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, unionType) in classification.UnionPropTypes)
+        {
+            var valueType = unionType;
+            if (resolvedCollidingTypes is not null
+                && resolvedCollidingTypes.TryGetValue(name, out var resolved))
+            {
+                valueType = resolved;
+            }
+            var propName = name;
+            map[name] = new ColumnBinding(name, valueType, element =>
+            {
+                if (element is null) return QueryAbsent.Value;
+                // Reflect on the element's CONCRETE runtime subtype. A null PropertyInfo
+                // means this subtype doesn't declare the property → genuinely absent
+                // (≠ present-but-null). We never use a swallowed reflection exception to
+                // mean "absent" — that would conflate the two.
+                var pi = element.GetType().GetProperty(
+                    propName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (pi is null || pi.GetIndexParameters().Length > 0)
+                {
+                    return QueryAbsent.Value;
+                }
+                try { return pi.GetValue(element); }
                 catch { return null; }
             });
         }

--- a/src/Mithril.Shared.Wpf/Query/ColumnBindingHelper.cs
+++ b/src/Mithril.Shared.Wpf/Query/ColumnBindingHelper.cs
@@ -77,6 +77,31 @@ public static class ColumnBindingHelper
         return map;
     }
 
+    /// <summary>
+    /// The element sub-schema for an object-collection column (the schema the
+    /// completion provider / highlighter should use <em>inside</em> a
+    /// <c>WITH ANY|ALL ( … )</c> block for that column), or <see langword="null"/>
+    /// when <paramref name="collectionType"/> is not a quantifiable object
+    /// collection (a scalar, a string collection, or an <c>IQueryStringValue</c>
+    /// collection — those use <c>CONTAINS</c>, not a quantifier).
+    /// </summary>
+    internal static IReadOnlyList<ColumnSchema>? TryGetElementSchema(Type collectionType)
+    {
+        var underlying = Nullable.GetUnderlyingType(collectionType) ?? collectionType;
+        var elementType = QueryCompiler.GetCollectionElementType(underlying);
+        if (elementType is null
+            || elementType == typeof(string)
+            || typeof(Mithril.Reference.IQueryStringValue).IsAssignableFrom(elementType))
+        {
+            return null;
+        }
+        var classification = PolymorphicSchemaClassifier.Classify(elementType);
+        var bindings = classification is null
+            ? BuildFromProperties(elementType)
+            : BuildElementSchema(classification);
+        return ToSchema(bindings);
+    }
+
     public static IReadOnlyList<ColumnSchema> ToSchema(IReadOnlyDictionary<string, ColumnBinding> bindings)
     {
         var list = new List<ColumnSchema>(bindings.Count);

--- a/src/Mithril.Shared.Wpf/Query/PolymorphicSchemaClassifier.cs
+++ b/src/Mithril.Shared.Wpf/Query/PolymorphicSchemaClassifier.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Mithril.Reference.Serialization.Discriminators;
+
+namespace Mithril.Shared.Wpf.Query;
+
+/// <summary>How a polymorphic collection's element schema narrows by discriminator.</summary>
+public enum NarrowingMode
+{
+    /// <summary>No same-name/different-type collisions. The union element schema is
+    /// unambiguous; a discriminator guard is allowed but not required.</summary>
+    Optional,
+
+    /// <summary>At least one property name has different types across subtypes. A
+    /// reference to a colliding property is a compile error unless a discriminator
+    /// equality (<c>T = 'X'</c>) scopes it in the same conjunction — the guard is what
+    /// resolves the colliding property to a single type.</summary>
+    Mandatory,
+}
+
+/// <summary>
+/// The classified shape of one polymorphic element hierarchy: its narrowing mode,
+/// the union of subtype property types, the set of type-colliding property names, and
+/// the discriminator field plus value→subtype map. Built once per element type and
+/// cached.
+/// </summary>
+public sealed class HierarchyClassification
+{
+    public required Type BaseType { get; init; }
+    public required string DiscriminatorField { get; init; }
+    public required NarrowingMode Mode { get; init; }
+
+    /// <summary>Property names whose declared type differs across subtypes.</summary>
+    public required IReadOnlySet<string> CollidingProps { get; init; }
+
+    /// <summary>discriminator value → concrete subtype.</summary>
+    public required IReadOnlyDictionary<string, Type> SubtypeByDiscriminator { get; init; }
+
+    /// <summary>Every union property name → a representative type (for non-colliding
+    /// names this is the single consistent type; colliding names are resolved per
+    /// discriminator guard at compile time).</summary>
+    public required IReadOnlyDictionary<string, Type> UnionPropTypes { get; init; }
+
+    /// <summary>Property names declared on exactly one subtype (used for the
+    /// optional-narrowing soft warning).</summary>
+    public required IReadOnlySet<string> SingleSubtypeProps { get; init; }
+
+    /// <summary>The declared type of <paramref name="prop"/> on the subtype selected
+    /// by discriminator value <paramref name="discriminatorValue"/>, or null if the
+    /// value is unknown or that subtype doesn't declare the property.</summary>
+    public Type? ResolvePropType(string discriminatorValue, string prop)
+    {
+        if (!SubtypeByDiscriminator.TryGetValue(discriminatorValue, out var subtype)) return null;
+        var pi = subtype.GetProperty(prop, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+        return pi?.PropertyType;
+    }
+}
+
+/// <summary>
+/// Classifies a <c>WITH ANY|ALL</c> collection's element type against the reference
+/// <see cref="DiscriminatorRegistry"/>. Returns null for a type that is not a
+/// registered polymorphic base (i.e. a homogeneous element — caller falls back to
+/// plain property reflection). Results are cached; classification is deterministic.
+/// </summary>
+public static class PolymorphicSchemaClassifier
+{
+    private static readonly ConcurrentDictionary<Type, HierarchyClassification?> Cache = new();
+
+    public static HierarchyClassification? Classify(Type elementType) =>
+        Cache.GetOrAdd(elementType, Build);
+
+    private static HierarchyClassification? Build(Type elementType)
+    {
+        PolymorphicHierarchy? hierarchy = null;
+        foreach (var h in DiscriminatorRegistry.All)
+        {
+            if (h.BaseType == elementType) { hierarchy = h; break; }
+        }
+        if (hierarchy is null) return null;
+
+        // name -> distinct declared types across all concrete subtypes (incl. inherited
+        // base props like the discriminator/Favor, which GetProperties surfaces).
+        var typesByName = new Dictionary<string, HashSet<Type>>(StringComparer.Ordinal);
+        var subtypeCountByName = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var subtype in hierarchy.KnownTypes.Values)
+        {
+            foreach (var p in subtype.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (p.GetIndexParameters().Length > 0) continue;
+                if (!typesByName.TryGetValue(p.Name, out var set))
+                {
+                    set = new HashSet<Type>();
+                    typesByName[p.Name] = set;
+                    subtypeCountByName[p.Name] = 0;
+                }
+                set.Add(p.PropertyType);
+                subtypeCountByName[p.Name]++;
+            }
+        }
+
+        var colliding = new HashSet<string>(
+            typesByName.Where(kv => kv.Value.Count > 1).Select(kv => kv.Key), StringComparer.Ordinal);
+        var single = new HashSet<string>(
+            subtypeCountByName.Where(kv => kv.Value == 1).Select(kv => kv.Key), StringComparer.Ordinal);
+        var unionTypes = typesByName.ToDictionary(kv => kv.Key, kv => kv.Value.First(), StringComparer.Ordinal);
+
+        return new HierarchyClassification
+        {
+            BaseType = hierarchy.BaseType,
+            DiscriminatorField = hierarchy.DiscriminatorField,
+            Mode = colliding.Count > 0 ? NarrowingMode.Mandatory : NarrowingMode.Optional,
+            CollidingProps = colliding,
+            SubtypeByDiscriminator = hierarchy.KnownTypes,
+            UnionPropTypes = unionTypes,
+            SingleSubtypeProps = single,
+        };
+    }
+}

--- a/src/Mithril.Shared.Wpf/Query/QueryAbsent.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryAbsent.cs
@@ -1,0 +1,25 @@
+namespace Mithril.Shared.Wpf.Query;
+
+/// <summary>
+/// Singleton sentinel returned by a polymorphic element-schema binding when the
+/// queried property is <em>not declared on the runtime subtype</em> of the element
+/// (e.g. <c>Level</c> queried against a <c>QuestRequirement</c> element whose actual
+/// subtype has no <c>Level</c>).
+/// </summary>
+/// <remarks>
+/// This is deliberately distinct from a present-but-<see langword="null"/> value.
+/// "Absent" means the property does not exist on this element at all, so every
+/// comparison against it — including <c>IS NULL</c> — yields <see langword="false"/>
+/// (absent ≠ null). "Present but null" still flows the real <see langword="null"/>
+/// through and <c>IS NULL</c> can match it. The two are disambiguated by reflecting
+/// the property on the element's concrete runtime type, never by swallowing a
+/// reflection exception.
+/// </remarks>
+internal sealed class QueryAbsent
+{
+    public static QueryAbsent Value { get; } = new();
+
+    private QueryAbsent()
+    {
+    }
+}

--- a/src/Mithril.Shared.Wpf/Query/QueryAst.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryAst.cs
@@ -45,6 +45,31 @@ public sealed record BetweenNode(string Column, ValueNode Low, ValueNode High, b
 
 public sealed record IsNullNode(string Column, bool Negated) : QueryNode;
 
+public enum Quantifier
+{
+    Any,
+    All,
+}
+
+/// <summary>
+/// Quantified subquery over an object-collection column:
+/// <c>&lt;Column&gt; WITH ANY (&lt;Inner&gt;)</c> / <c>&lt;Column&gt; WITH ALL (&lt;Inner&gt;)</c>.
+/// <see cref="Inner"/> is a full predicate AST whose column names bind against the
+/// collection's <em>element-type</em> sub-schema, not the outer row schema, so a
+/// conjunction inside the parens is evaluated <em>per element</em> (this is what
+/// makes correlated nested filtering accurate). Negation is the engine's existing
+/// prefix <c>NOT (...)</c> wrapping a <see cref="NotNode"/> — there is no inline
+/// <c>NOT WITH</c>.
+/// </summary>
+public sealed record QuantifiedNode(string Column, Quantifier Quantifier, QueryNode Inner) : QueryNode;
+
+/// <summary>
+/// A non-fatal compile diagnostic (e.g. an optional-narrowing single-subtype-field
+/// reference with no discriminator guard). Collected via the warnings overload of
+/// <c>QueryCompiler.Compile</c>; never thrown.
+/// </summary>
+public readonly record struct QueryDiagnostic(string Message, int Position);
+
 public abstract record ValueNode;
 
 public sealed record StringValue(string Text) : ValueNode;

--- a/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
@@ -306,7 +306,7 @@ public static class QueryCompiler
     /// the string-collection <c>CONTAINS</c> path and the <c>WITH ANY|ALL</c>
     /// quantified-subquery path.
     /// </summary>
-    private static Type? GetCollectionElementType(Type t)
+    internal static Type? GetCollectionElementType(Type t)
     {
         if (t == typeof(string)) return null;
         foreach (var iface in t.GetInterfaces())

--- a/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
@@ -82,6 +82,8 @@ public static class QueryCompiler
                 return CompileBetween(b, columns);
             case IsNullNode n:
                 return CompileIsNull(n, columns);
+            case QuantifiedNode q:
+                return CompileQuantified(q, columns, caseSensitive);
             default:
                 throw new QueryException($"Unsupported node: {node.GetType().Name}", 0);
         }
@@ -246,21 +248,92 @@ public static class QueryCompiler
     // can be matched by tag without flattening to string at the model layer).
     private static bool IsStringCollection(Type t)
     {
-        if (t == typeof(string)) return false;
+        var element = GetCollectionElementType(t);
+        return element is not null
+            && (element == typeof(string) || typeof(IQueryStringValue).IsAssignableFrom(element));
+    }
+
+    /// <summary>
+    /// The element type of the first <see cref="IEnumerable{T}"/> a column type
+    /// implements, or <see langword="null"/> when the type is not a generic
+    /// collection (<see cref="string"/> is treated as a non-collection). Shared by
+    /// the string-collection <c>CONTAINS</c> path and the <c>WITH ANY|ALL</c>
+    /// quantified-subquery path.
+    /// </summary>
+    private static Type? GetCollectionElementType(Type t)
+    {
+        if (t == typeof(string)) return null;
         foreach (var iface in t.GetInterfaces())
         {
             if (iface.IsGenericType
                 && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
-                var element = iface.GetGenericArguments()[0];
-                if (element == typeof(string)
-                    || typeof(IQueryStringValue).IsAssignableFrom(element))
-                {
-                    return true;
-                }
+                return iface.GetGenericArguments()[0];
             }
         }
-        return false;
+        return null;
+    }
+
+    /// <summary>
+    /// Compile a <c>&lt;col&gt; WITH ANY|ALL (&lt;inner&gt;)</c> quantified subquery.
+    /// The inner predicate is compiled once against a sub-schema reflected from the
+    /// collection's element type and evaluated <em>per element</em>, so a conjunction
+    /// inside the parens correlates on a single element (the accuracy property the
+    /// whole feature exists for). <c>ANY</c> short-circuits on first match; <c>ALL</c>
+    /// is vacuously true over an empty collection; a null collection is false for
+    /// both (matching the <c>CONTAINS</c>-over-null-collection convention).
+    /// String / <see cref="IQueryStringValue"/> collections are rejected — those use
+    /// <c>CONTAINS</c>, the single way to match flat keyword lists.
+    /// </summary>
+    private static Func<object, bool> CompileQuantified(
+        QuantifiedNode node, Dictionary<string, ColumnBinding> columns, bool caseSensitive)
+    {
+        var col = ResolveColumn(node.Column, columns);
+        var underlying = Nullable.GetUnderlyingType(col.ValueType) ?? col.ValueType;
+        var elementType = GetCollectionElementType(underlying);
+        if (elementType is null
+            || elementType == typeof(string)
+            || typeof(IQueryStringValue).IsAssignableFrom(elementType))
+        {
+            throw new QueryException(
+                $"{node.Quantifier.ToString().ToUpperInvariant()} requires an object-collection column; " +
+                $"'{node.Column}' is {underlying.Name}. Use CONTAINS for string/keyword collections.", 0);
+        }
+
+        var subSchema = NormalizeColumns(
+            ColumnBindingHelper.BuildFromProperties(elementType), caseSensitive);
+        var elementPredicate = CompileNode(node.Inner, subSchema, caseSensitive);
+        bool isAll = node.Quantifier == Quantifier.All;
+
+        return item =>
+        {
+            if (col.GetValue(item) is not System.Collections.IEnumerable seq)
+            {
+                return false;
+            }
+            bool sawAny = false;
+            bool allMatch = true;
+            bool anyMatch = false;
+            foreach (var element in seq)
+            {
+                if (element is null) continue;
+                sawAny = true;
+                bool m;
+                try { m = elementPredicate(element); }
+                catch { m = false; }
+                if (m)
+                {
+                    anyMatch = true;
+                    if (!isAll) break;
+                }
+                else
+                {
+                    allMatch = false;
+                    if (isAll) break;
+                }
+            }
+            return isAll ? (!sawAny || allMatch) : (sawAny && anyMatch);
+        };
     }
 
     private static Func<object, bool> CompileLike(

--- a/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Mithril.Reference;
@@ -20,18 +21,42 @@ public static class QueryCompiler
         QueryNode node,
         IReadOnlyDictionary<string, ColumnBinding> columns,
         bool caseSensitive = false)
+        => Compile(node, columns, warnings: null, caseSensitive);
+
+    /// <summary>
+    /// Compile <paramref name="node"/>, collecting any non-fatal narrowing
+    /// diagnostics (optional-hierarchy single-subtype field referenced without a
+    /// discriminator guard) into <paramref name="warnings"/>. Additive overload —
+    /// the no-warnings overloads delegate here with <paramref name="warnings"/> null,
+    /// so the public surface stays backward compatible.
+    /// </summary>
+    public static Func<object, bool> Compile(
+        QueryNode node,
+        IReadOnlyDictionary<string, ColumnBinding> columns,
+        ICollection<QueryDiagnostic>? warnings,
+        bool caseSensitive = false)
     {
         var normalized = NormalizeColumns(columns, caseSensitive);
-        return CompileNode(node, normalized, caseSensitive);
+        return CompileNode(node, normalized, caseSensitive, warnings);
     }
 
     public static Func<object, bool>? Compile(
         string query,
         IReadOnlyDictionary<string, ColumnBinding> columns,
         bool caseSensitive = false)
+        => Compile(query, columns, warnings: null, caseSensitive);
+
+    /// <summary>Warnings-collecting counterpart of the string overload.</summary>
+    public static Func<object, bool>? Compile(
+        string query,
+        IReadOnlyDictionary<string, ColumnBinding> columns,
+        ICollection<QueryDiagnostic>? warnings,
+        bool caseSensitive = false)
     {
         var parsed = QueryParser.Parse(query);
-        return parsed?.Predicate is null ? null : Compile(parsed.Predicate, columns, caseSensitive);
+        return parsed?.Predicate is null
+            ? null
+            : Compile(parsed.Predicate, columns, warnings, caseSensitive);
     }
 
     private static Dictionary<string, ColumnBinding> NormalizeColumns(
@@ -49,25 +74,26 @@ public static class QueryCompiler
     private static Func<object, bool> CompileNode(
         QueryNode node,
         Dictionary<string, ColumnBinding> columns,
-        bool caseSensitive)
+        bool caseSensitive,
+        ICollection<QueryDiagnostic>? warnings)
     {
         switch (node)
         {
             case AndNode a:
             {
-                var l = CompileNode(a.Left, columns, caseSensitive);
-                var r = CompileNode(a.Right, columns, caseSensitive);
+                var l = CompileNode(a.Left, columns, caseSensitive, warnings);
+                var r = CompileNode(a.Right, columns, caseSensitive, warnings);
                 return item => l(item) && r(item);
             }
             case OrNode o:
             {
-                var l = CompileNode(o.Left, columns, caseSensitive);
-                var r = CompileNode(o.Right, columns, caseSensitive);
+                var l = CompileNode(o.Left, columns, caseSensitive, warnings);
+                var r = CompileNode(o.Right, columns, caseSensitive, warnings);
                 return item => l(item) || r(item);
             }
             case NotNode n:
             {
-                var inner = CompileNode(n.Inner, columns, caseSensitive);
+                var inner = CompileNode(n.Inner, columns, caseSensitive, warnings);
                 return item => !inner(item);
             }
             case ComparisonNode c:
@@ -83,11 +109,17 @@ public static class QueryCompiler
             case IsNullNode n:
                 return CompileIsNull(n, columns);
             case QuantifiedNode q:
-                return CompileQuantified(q, columns, caseSensitive);
+                return CompileQuantified(q, columns, caseSensitive, warnings);
             default:
                 throw new QueryException($"Unsupported node: {node.GetType().Name}", 0);
         }
     }
+
+    // A polymorphic element-schema binding returns this when the queried property is
+    // not declared on the element's runtime subtype. Every leaf predicate treats it
+    // as an unconditional non-match (absent ≠ null; even IS NULL is false), so a
+    // predicate that names a sibling-subtype field just skips that element.
+    private static bool IsAbsent(object? v) => ReferenceEquals(v, QueryAbsent.Value);
 
     private static ColumnBinding ResolveColumn(string name, Dictionary<string, ColumnBinding> columns)
     {
@@ -106,11 +138,11 @@ public static class QueryCompiler
         {
             if (node.Op == ComparisonOp.Eq)
             {
-                return item => col.GetValue(item) is null;
+                return item => { var v = col.GetValue(item); return !IsAbsent(v) && v is null; };
             }
             if (node.Op == ComparisonOp.Neq)
             {
-                return item => col.GetValue(item) is not null;
+                return item => { var v = col.GetValue(item); return !IsAbsent(v) && v is not null; };
             }
             throw new QueryException($"NULL only supports '=' and '!=' (use IS NULL / IS NOT NULL).", 0);
         }
@@ -123,8 +155,8 @@ public static class QueryCompiler
             var stringCmp = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             return node.Op switch
             {
-                ComparisonOp.Eq => item => StringEquals(col.GetValue(item), rhs, stringCmp),
-                ComparisonOp.Neq => item => !StringEquals(col.GetValue(item), rhs, stringCmp),
+                ComparisonOp.Eq => item => { var v = col.GetValue(item); return !IsAbsent(v) && StringEquals(v, rhs, stringCmp); },
+                ComparisonOp.Neq => item => { var v = col.GetValue(item); return !IsAbsent(v) && !StringEquals(v, rhs, stringCmp); },
                 _ => throw new QueryException($"String columns only support '=' and '!='; use LIKE for pattern matching.", 0),
             };
         }
@@ -151,6 +183,10 @@ public static class QueryCompiler
         return item =>
         {
             var v = col.GetValue(item);
+            if (IsAbsent(v))
+            {
+                return false;
+            }
             if (v is null)
             {
                 return op == ComparisonOp.Neq;
@@ -198,7 +234,12 @@ public static class QueryCompiler
             var elementCmp = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
             return item =>
             {
-                if (col.GetValue(item) is not System.Collections.IEnumerable seq)
+                var raw = col.GetValue(item);
+                if (IsAbsent(raw))
+                {
+                    return false;
+                }
+                if (raw is not System.Collections.IEnumerable seq)
                 {
                     return negated;
                 }
@@ -234,7 +275,12 @@ public static class QueryCompiler
         };
         return item =>
         {
-            if (col.GetValue(item) is not string s)
+            var raw = col.GetValue(item);
+            if (IsAbsent(raw))
+            {
+                return false;
+            }
+            if (raw is not string s)
             {
                 return negated;
             }
@@ -286,7 +332,10 @@ public static class QueryCompiler
     /// <c>CONTAINS</c>, the single way to match flat keyword lists.
     /// </summary>
     private static Func<object, bool> CompileQuantified(
-        QuantifiedNode node, Dictionary<string, ColumnBinding> columns, bool caseSensitive)
+        QuantifiedNode node,
+        Dictionary<string, ColumnBinding> columns,
+        bool caseSensitive,
+        ICollection<QueryDiagnostic>? warnings)
     {
         var col = ResolveColumn(node.Column, columns);
         var underlying = Nullable.GetUnderlyingType(col.ValueType) ?? col.ValueType;
@@ -300,9 +349,25 @@ public static class QueryCompiler
                 $"'{node.Column}' is {underlying.Name}. Use CONTAINS for string/keyword collections.", 0);
         }
 
-        var subSchema = NormalizeColumns(
-            ColumnBindingHelper.BuildFromProperties(elementType), caseSensitive);
-        var elementPredicate = CompileNode(node.Inner, subSchema, caseSensitive);
+        // Homogeneous element (the v1 consumer's shape) → plain property reflection.
+        // Polymorphic element (a registered discriminated-union base) → union schema
+        // with per-query narrowing: a colliding property is typed by the in-scope
+        // discriminator guard; a sibling-subtype property reads as QueryAbsent.
+        var classification = PolymorphicSchemaClassifier.Classify(elementType);
+        Dictionary<string, ColumnBinding> subSchema;
+        if (classification is null)
+        {
+            subSchema = NormalizeColumns(
+                ColumnBindingHelper.BuildFromProperties(elementType), caseSensitive);
+        }
+        else
+        {
+            var resolved = EnforceNarrowing(node, classification, warnings);
+            subSchema = NormalizeColumns(
+                ColumnBindingHelper.BuildElementSchema(classification, resolved), caseSensitive);
+        }
+
+        var elementPredicate = CompileNode(node.Inner, subSchema, caseSensitive, warnings);
         bool isAll = node.Quantifier == Quantifier.All;
 
         return item =>
@@ -336,6 +401,214 @@ public static class QueryCompiler
         };
     }
 
+    /// <summary>
+    /// Per-hierarchy narrowing for a polymorphic <c>WITH ANY|ALL</c>. The inner
+    /// predicate is compiled <em>once</em>, so a type-colliding property
+    /// (e.g. <c>QuestRequirement.Level</c> — <c>string?</c> on some subtypes,
+    /// <c>int?</c> on others) can only have one <see cref="ColumnBinding.ValueType"/>.
+    /// We expand the inner AST to DNF conjunctive scopes (split on OR, descend AND;
+    /// a <c>NOT</c> subtree gives no positive guard but still counts as a reference),
+    /// and within each scope a <c>&lt;discriminator&gt; = 'literal'</c> equality
+    /// resolves each colliding/subtype-specific property to its concrete type.
+    /// </summary>
+    /// <returns>colliding property name → its resolved CLR type for this query.</returns>
+    /// <remarks>
+    /// v1 limitations (documented in <c>docs/query-system.md</c> and the #349 design
+    /// note): a Mandatory-hierarchy colliding/subtype-specific property referenced
+    /// with no in-scope guard throws; a colliding property that resolves to
+    /// <em>divergent</em> types across OR-branches throws (split the query). Only
+    /// <c>QuestRequirement</c> is Mandatory today and it is test-only (not
+    /// consumer-wired), so the mandatory path never fires for a shipped consumer.
+    /// </remarks>
+    private static IReadOnlyDictionary<string, Type> EnforceNarrowing(
+        QuantifiedNode node,
+        HierarchyClassification cls,
+        ICollection<QueryDiagnostic>? warnings)
+    {
+        var perPropTypes = new Dictionary<string, HashSet<Type>>(StringComparer.OrdinalIgnoreCase);
+        var warnedSingles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var scope in ConjunctiveScopes(node.Inner))
+        {
+            string? guard = FindDiscriminatorGuard(scope, cls.DiscriminatorField);
+
+            foreach (var prop in ReferencedProps(scope, cls.DiscriminatorField))
+            {
+                bool colliding = cls.CollidingProps.Contains(prop);
+                bool single = cls.SingleSubtypeProps.Contains(prop);
+                if (!colliding && !single)
+                {
+                    // Non-colliding, multi-subtype: one consistent union type — fine.
+                    continue;
+                }
+
+                if (guard is null)
+                {
+                    if (cls.Mode == NarrowingMode.Mandatory)
+                    {
+                        throw new QueryException(
+                            $"'{prop}' is not the same type across {cls.BaseType.Name} subtypes; " +
+                            $"scope it with a {cls.DiscriminatorField} = '<value>' guard in the same " +
+                            $"conjunction (e.g. {cls.DiscriminatorField} = 'MinCombatSkillLevel' AND {prop} > 5).",
+                            0);
+                    }
+
+                    // Optional hierarchy, subtype-specific property, no guard: soft
+                    // warning (matches no other subtype's elements), never fatal.
+                    if (single && warnedSingles.Add(prop))
+                    {
+                        warnings?.Add(new QueryDiagnostic(
+                            $"'{prop}' is declared on only one {cls.BaseType.Name} subtype; " +
+                            $"without a {cls.DiscriminatorField} = '<value>' guard it can only ever " +
+                            $"match that subtype's elements.", 0));
+                    }
+                    continue;
+                }
+
+                // Guarded: resolve the property's concrete type on the guarded subtype.
+                var resolvedType = cls.ResolvePropType(guard, prop);
+                if (resolvedType is null)
+                {
+                    throw new QueryException(
+                        $"{cls.DiscriminatorField} = '{guard}' does not declare '{prop}' " +
+                        $"(or '{guard}' is not a known {cls.BaseType.Name} discriminator).", 0);
+                }
+                if (colliding)
+                {
+                    if (!perPropTypes.TryGetValue(prop, out var set))
+                    {
+                        set = new HashSet<Type>();
+                        perPropTypes[prop] = set;
+                    }
+                    set.Add(resolvedType);
+                }
+            }
+        }
+
+        var resolved = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (prop, types) in perPropTypes)
+        {
+            if (types.Count > 1)
+            {
+                var names = string.Join(", ", types.Select(t => t.Name));
+                throw new QueryException(
+                    $"'{prop}' resolves to multiple types ({names}) across the OR-branches of this " +
+                    $"quantifier; the inner predicate compiles once so this is a v1 limitation — " +
+                    $"split it into separate {node.Quantifier.ToString().ToUpperInvariant()} queries.",
+                    0);
+            }
+            resolved[prop] = types.First();
+        }
+        return resolved;
+    }
+
+    /// <summary>
+    /// DNF-expand <paramref name="node"/> into conjunctive scopes: OR yields separate
+    /// scopes, AND is the cross-product (a single scope is a flat conjunct list), and
+    /// any other node (including <see cref="NotNode"/>) is an opaque leaf. Inner
+    /// predicates are tiny, so the cross-product never blows up in practice.
+    /// </summary>
+    private static List<List<QueryNode>> ConjunctiveScopes(QueryNode node)
+    {
+        switch (node)
+        {
+            case OrNode o:
+            {
+                var scopes = ConjunctiveScopes(o.Left);
+                scopes.AddRange(ConjunctiveScopes(o.Right));
+                return scopes;
+            }
+            case AndNode a:
+            {
+                var left = ConjunctiveScopes(a.Left);
+                var right = ConjunctiveScopes(a.Right);
+                var combined = new List<List<QueryNode>>(left.Count * right.Count);
+                foreach (var l in left)
+                {
+                    foreach (var r in right)
+                    {
+                        var merged = new List<QueryNode>(l.Count + r.Count);
+                        merged.AddRange(l);
+                        merged.AddRange(r);
+                        combined.Add(merged);
+                    }
+                }
+                return combined;
+            }
+            default:
+                return new List<List<QueryNode>> { new() { node } };
+        }
+    }
+
+    // A positive discriminator guard is a top-of-scope `<disc> = 'literal'` equality.
+    // `!=` does not count; a guard nested inside a NOT subtree does not count (the
+    // NotNode is an opaque scope leaf, so its inner equality is never inspected here).
+    private static string? FindDiscriminatorGuard(
+        IReadOnlyList<QueryNode> scope, string discriminatorField)
+    {
+        string? value = null;
+        foreach (var n in scope)
+        {
+            if (n is ComparisonNode { Op: ComparisonOp.Eq } c
+                && string.Equals(c.Column, discriminatorField, StringComparison.OrdinalIgnoreCase)
+                && c.Value is StringValue sv)
+            {
+                if (value is not null && !string.Equals(value, sv.Text, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new QueryException(
+                        $"Conflicting {discriminatorField} guards ('{value}' and '{sv.Text}') in one " +
+                        $"conjunction — an element can only have one discriminator value.", 0);
+                }
+                value = sv.Text;
+            }
+        }
+        return value;
+    }
+
+    // Every property name referenced anywhere in the scope (descending NOT subtrees:
+    // a colliding property used under NOT still needs a concrete type to compile),
+    // excluding the discriminator field itself.
+    private static IEnumerable<string> ReferencedProps(
+        IReadOnlyList<QueryNode> scope, string discriminatorField)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var stack = new Stack<QueryNode>(scope);
+        while (stack.Count > 0)
+        {
+            var n = stack.Pop();
+            switch (n)
+            {
+                case AndNode a: stack.Push(a.Left); stack.Push(a.Right); break;
+                case OrNode o: stack.Push(o.Left); stack.Push(o.Right); break;
+                case NotNode not: stack.Push(not.Inner); break;
+                case QuantifiedNode q:
+                    // A nested quantifier rebinds to its own element schema; its
+                    // Column is the only name resolved in THIS scope.
+                    if (!string.Equals(q.Column, discriminatorField, StringComparison.OrdinalIgnoreCase)
+                        && seen.Add(q.Column))
+                    {
+                        yield return q.Column;
+                    }
+                    break;
+                case ComparisonNode c: foreach (var p in Emit(c.Column)) yield return p; break;
+                case LikeNode l: foreach (var p in Emit(l.Column)) yield return p; break;
+                case StringMatchNode sm: foreach (var p in Emit(sm.Column)) yield return p; break;
+                case InNode i: foreach (var p in Emit(i.Column)) yield return p; break;
+                case BetweenNode b: foreach (var p in Emit(b.Column)) yield return p; break;
+                case IsNullNode isn: foreach (var p in Emit(isn.Column)) yield return p; break;
+            }
+        }
+
+        IEnumerable<string> Emit(string column)
+        {
+            if (!string.Equals(column, discriminatorField, StringComparison.OrdinalIgnoreCase)
+                && seen.Add(column))
+            {
+                yield return column;
+            }
+        }
+    }
+
     private static Func<object, bool> CompileLike(
         LikeNode node, Dictionary<string, ColumnBinding> columns, bool caseSensitive)
     {
@@ -349,8 +622,12 @@ public static class QueryCompiler
         bool negated = node.Negated;
         return item =>
         {
-            var v = col.GetValue(item) as string;
-            if (v is null)
+            var raw = col.GetValue(item);
+            if (IsAbsent(raw))
+            {
+                return false;
+            }
+            if (raw is not string v)
             {
                 return negated;
             }
@@ -404,8 +681,12 @@ public static class QueryCompiler
             bool negated = node.Negated;
             return item =>
             {
-                var s = col.GetValue(item) as string;
-                if (s is null)
+                var raw = col.GetValue(item);
+                if (IsAbsent(raw))
+                {
+                    return false;
+                }
+                if (raw is not string s)
                 {
                     return negated;
                 }
@@ -423,6 +704,10 @@ public static class QueryCompiler
         return item =>
         {
             var v = col.GetValue(item);
+            if (IsAbsent(v))
+            {
+                return false;
+            }
             if (v is null)
             {
                 return neg;
@@ -453,6 +738,10 @@ public static class QueryCompiler
         return item =>
         {
             var v = col.GetValue(item);
+            if (IsAbsent(v))
+            {
+                return false;
+            }
             if (v is null)
             {
                 return negated;
@@ -467,7 +756,17 @@ public static class QueryCompiler
     {
         var col = ResolveColumn(node.Column, columns);
         bool wantNull = !node.Negated;
-        return item => (col.GetValue(item) is null) == wantNull;
+        // Absent ≠ null: an element whose subtype doesn't declare this property does
+        // not match IS NULL *or* IS NOT NULL — it is simply skipped.
+        return item =>
+        {
+            var v = col.GetValue(item);
+            if (IsAbsent(v))
+            {
+                return false;
+            }
+            return (v is null) == wantNull;
+        };
     }
 
     // ──────────────── coercion ────────────────

--- a/src/Mithril.Shared.Wpf/Query/QueryCompletionProvider.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompletionProvider.cs
@@ -52,16 +52,21 @@ public static class QueryCompletionProvider
         if (caret > query.Length) caret = query.Length;
 
         var tokens = QueryParser.LexPermissive(query);
+        // Inside a `<col> WITH ANY|ALL ( … )` block the caret binds against that
+        // column's element sub-schema, not the outer row schema (nested blocks /
+        // grouping parens balance on the same stack, so closing a block restores the
+        // outer schema). Everywhere else this is just `columns`.
+        var scopeColumns = ResolveScopeColumns(tokens, caret, columns);
         // The last non-EOF token strictly before the caret. "Strictly before" means
         // its end position is <= caret, so typing adjacent to a keyword still suggests
         // things that *follow* it.
-        var context = BuildContext(query, caret, tokens, columns);
+        var context = BuildContext(query, caret, tokens, scopeColumns);
 
         var results = new List<CompletionItem>();
         switch (context.Expecting)
         {
             case Expecting.ColumnOrBool:
-                AddColumnSuggestions(results, context, columns);
+                AddColumnSuggestions(results, context, scopeColumns);
                 // NOT can also begin a predicate — allow it at the top.
                 AddKeywordIfStartsWith(results, "NOT", context);
                 break;
@@ -79,7 +84,7 @@ public static class QueryCompletionProvider
                 AddKeywordIfStartsWith(results, "OR", context);
                 break;
             case Expecting.OrderColumn:
-                AddColumnSuggestions(results, context, columns);
+                AddColumnSuggestions(results, context, scopeColumns);
                 break;
             case Expecting.OrderDirection:
                 AddKeywordIfStartsWith(results, "ASC", context);
@@ -121,6 +126,49 @@ public static class QueryCompletionProvider
         int ReplaceStart,
         int ReplaceEnd,
         ColumnSchema? CurrentColumn);
+
+    /// <summary>
+    /// Single forward pass over the tokens before <paramref name="caret"/>,
+    /// maintaining a stack of "schema in effect". A <c>(</c> immediately preceded by
+    /// <c>&lt;ident&gt; WITH ANY|ALL</c> pushes that column's element sub-schema;
+    /// any other <c>(</c> pushes the current schema again (so grouping parens balance
+    /// without changing scope); <c>)</c> pops. The top of the stack is the schema the
+    /// caret should complete against — element schema inside a quantifier block,
+    /// outer schema once the block (and any nesting) is closed.
+    /// </summary>
+    private static IReadOnlyList<ColumnSchema> ResolveScopeColumns(
+        IReadOnlyList<QueryParser.Token> tokens, int caret, IReadOnlyList<ColumnSchema> outer)
+    {
+        var stack = new Stack<IReadOnlyList<ColumnSchema>>();
+        stack.Push(outer);
+        var toks = tokens.Where(t => t.Kind != QueryParser.TokenKind.Eof).ToList();
+        for (int i = 0; i < toks.Count; i++)
+        {
+            var t = toks[i];
+            if (t.Position >= caret) break; // only already-typed tokens shape the scope
+            if (t.Kind == QueryParser.TokenKind.LParen)
+            {
+                IReadOnlyList<ColumnSchema>? element = null;
+                if (i >= 3
+                    && toks[i - 1].Kind is QueryParser.TokenKind.Any or QueryParser.TokenKind.All
+                    && toks[i - 2].Kind == QueryParser.TokenKind.With
+                    && toks[i - 3].Kind == QueryParser.TokenKind.Identifier)
+                {
+                    var col = LookupColumn(toks[i - 3].Text, stack.Peek());
+                    if (col is not null)
+                    {
+                        element = ColumnBindingHelper.TryGetElementSchema(col.ValueType);
+                    }
+                }
+                stack.Push(element ?? stack.Peek());
+            }
+            else if (t.Kind == QueryParser.TokenKind.RParen)
+            {
+                if (stack.Count > 1) stack.Pop();
+            }
+        }
+        return stack.Peek();
+    }
 
     private static Context BuildContext(
         string query, int caret, IReadOnlyList<QueryParser.Token> tokens, IReadOnlyList<ColumnSchema> columns)
@@ -365,6 +413,20 @@ public static class QueryCompletionProvider
 
     private static void AddOperatorSuggestions(List<CompletionItem> results, Context ctx, ColumnSchema? col)
     {
+        // An object-collection column takes a quantifier, not scalar operators —
+        // offer only WITH ANY|ALL (and IS [NOT] NULL when the collection is nullable).
+        if (col is not null && ColumnBindingHelper.TryGetElementSchema(col.ValueType) is not null)
+        {
+            Add(results, ctx, "WITH ANY (", CompletionKind.Keyword);
+            Add(results, ctx, "WITH ALL (", CompletionKind.Keyword);
+            if (col.IsNullable)
+            {
+                Add(results, ctx, "IS NULL", CompletionKind.Keyword);
+                Add(results, ctx, "IS NOT NULL", CompletionKind.Keyword);
+            }
+            return;
+        }
+
         var underlying = col is null ? null : Nullable.GetUnderlyingType(col.ValueType) ?? col.ValueType;
         var isString = underlying == typeof(string);
         var isBool = underlying == typeof(bool);

--- a/src/Mithril.Shared.Wpf/Query/QueryHighlighter.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryHighlighter.cs
@@ -89,6 +89,9 @@ public static class QueryHighlighter
             or QueryParser.TokenKind.Lte or QueryParser.TokenKind.Gt or QueryParser.TokenKind.Gte => HighlightKind.Operator,
         QueryParser.TokenKind.And or QueryParser.TokenKind.Or or QueryParser.TokenKind.Not
             or QueryParser.TokenKind.Like or QueryParser.TokenKind.In or QueryParser.TokenKind.Between
+            or QueryParser.TokenKind.Contains or QueryParser.TokenKind.StartsWith
+            or QueryParser.TokenKind.EndsWith
+            or QueryParser.TokenKind.With or QueryParser.TokenKind.Any or QueryParser.TokenKind.All
             or QueryParser.TokenKind.Is or QueryParser.TokenKind.Null
             or QueryParser.TokenKind.True or QueryParser.TokenKind.False
             or QueryParser.TokenKind.OrderBy or QueryParser.TokenKind.SortBy

--- a/src/Mithril.Shared.Wpf/Query/QueryParser.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryParser.cs
@@ -26,6 +26,7 @@ public static class QueryParser
         "AND", "OR", "NOT", "LIKE", "IN", "BETWEEN", "IS", "NULL", "TRUE", "FALSE",
         "BEFORE", "AFTER",
         "CONTAINS", "STARTSWITH", "ENDSWITH",
+        "WITH", "ANY", "ALL",
         "ASC", "ASCENDING", "DESC", "DESCENDING",
     };
 
@@ -111,6 +112,9 @@ public static class QueryParser
         EndsWith,
         In,
         Between,
+        With,
+        Any,
+        All,
         Is,
         Null,
         True,
@@ -136,6 +140,9 @@ public static class QueryParser
         ["ENDSWITH"] = TokenKind.EndsWith,
         ["IN"] = TokenKind.In,
         ["BETWEEN"] = TokenKind.Between,
+        ["WITH"] = TokenKind.With,
+        ["ANY"] = TokenKind.Any,
+        ["ALL"] = TokenKind.All,
         ["IS"] = TokenKind.Is,
         ["NULL"] = TokenKind.Null,
         ["TRUE"] = TokenKind.True,
@@ -621,7 +628,7 @@ public static class QueryParser
             {
                 var nextKind = PeekAhead(1).Kind;
                 if (nextKind is TokenKind.Like or TokenKind.Contains or TokenKind.StartsWith
-                    or TokenKind.EndsWith or TokenKind.In or TokenKind.Between)
+                    or TokenKind.EndsWith or TokenKind.In or TokenKind.Between or TokenKind.With)
                 {
                     negated = true;
                     Consume();
@@ -690,6 +697,37 @@ public static class QueryParser
                     Expect(TokenKind.And, "AND");
                     var high = ParseValue();
                     return new BetweenNode(column, low, high, negated);
+                }
+                case TokenKind.With:
+                {
+                    if (negated)
+                    {
+                        throw new QueryException(
+                            "For a negated quantifier use prefix form: `NOT (col WITH ANY (...))`.", Peek.Position);
+                    }
+                    Consume(); // WITH
+                    Quantifier quant;
+                    if (Peek.Kind == TokenKind.Any)
+                    {
+                        quant = Quantifier.Any;
+                    }
+                    else if (Peek.Kind == TokenKind.All)
+                    {
+                        quant = Quantifier.All;
+                    }
+                    else
+                    {
+                        throw new QueryException($"Expected ANY or ALL after WITH but found '{Peek.Text}'.", Peek.Position);
+                    }
+                    Consume(); // ANY | ALL
+                    Expect(TokenKind.LParen, "'('");
+                    if (Peek.Kind == TokenKind.RParen)
+                    {
+                        throw new QueryException("Expected a predicate inside `WITH ANY/ALL (...)`.", Peek.Position);
+                    }
+                    var inner = ParseExpression();
+                    Expect(TokenKind.RParen, "')'");
+                    return new QuantifiedNode(column, quant, inner);
                 }
                 case TokenKind.Is:
                 {

--- a/tests/Mithril.Shared.Tests/Wpf/Query/PolymorphicSchemaClassifierTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/PolymorphicSchemaClassifierTests.cs
@@ -1,0 +1,81 @@
+using System;
+using FluentAssertions;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Serialization.Discriminators;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+/// <summary>
+/// <see cref="PolymorphicSchemaClassifier"/> over the real reference hierarchies.
+/// The load-bearing facts: <c>QuestRequirement</c> is <em>Mandatory</em> because
+/// <c>Level</c> is <c>string?</c> on some subtypes and <c>int?</c> on another;
+/// <c>NpcService</c> is <em>Optional</em> (no type collisions); every registered
+/// family classifies; results are cached.
+/// </summary>
+public class PolymorphicSchemaClassifierTests
+{
+    [Fact]
+    public void QuestRequirement_is_Mandatory_with_Level_colliding()
+    {
+        var c = PolymorphicSchemaClassifier.Classify(typeof(QuestRequirement));
+
+        c.Should().NotBeNull();
+        c!.Mode.Should().Be(NarrowingMode.Mandatory);
+        c.DiscriminatorField.Should().Be("T");
+        c.CollidingProps.Should().Contain("Level");
+        // The split that forces Mandatory: same name, different concrete type.
+        c.ResolvePropType("MinSkillLevel", "Level").Should().Be(typeof(string));
+        c.ResolvePropType("MinCombatSkillLevel", "Level").Should().Be(typeof(int?));
+        // Subtype-specific scalar declared on exactly one subtype
+        // (AllowSkill is only on ActiveCombatSkillRequirement; Skill is on two
+        // subtypes with the same type, so it is NOT single-subtype).
+        c.SingleSubtypeProps.Should().Contain("AllowSkill");
+        c.SingleSubtypeProps.Should().NotContain("Skill");
+    }
+
+    [Fact]
+    public void NpcService_is_Optional_no_collisions()
+    {
+        var c = PolymorphicSchemaClassifier.Classify(typeof(NpcService));
+
+        c.Should().NotBeNull();
+        c!.Mode.Should().Be(NarrowingMode.Optional);
+        c.DiscriminatorField.Should().Be("Type");
+        c.CollidingProps.Should().BeEmpty();
+        // CapIncreases lives only on StoreService → single-subtype (drives the
+        // optional soft warning).
+        c.SingleSubtypeProps.Should().Contain("CapIncreases");
+        // Unlocks is on Consignment + Training with the SAME type → not single.
+        c.SingleSubtypeProps.Should().NotContain("Unlocks");
+    }
+
+    [Fact]
+    public void Every_registered_hierarchy_classifies()
+    {
+        DiscriminatorRegistry.All.Should().HaveCount(7);
+        foreach (var h in DiscriminatorRegistry.All)
+        {
+            PolymorphicSchemaClassifier.Classify(h.BaseType)
+                .Should().NotBeNull($"{h.BaseType.Name} is a registered polymorphic base");
+        }
+    }
+
+    [Fact]
+    public void Unregistered_type_classifies_to_null()
+    {
+        PolymorphicSchemaClassifier.Classify(typeof(string)).Should().BeNull();
+        PolymorphicSchemaClassifier.Classify(typeof(PolymorphicSchemaClassifierTests))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Classification_is_cached()
+    {
+        var a = PolymorphicSchemaClassifier.Classify(typeof(QuestRequirement));
+        var b = PolymorphicSchemaClassifier.Classify(typeof(QuestRequirement));
+        ReferenceEquals(a, b).Should().BeTrue();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryQuantifierCompletionTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryQuantifierCompletionTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Reference.Models.Quests;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+/// <summary>
+/// Slice 3: completion + highlighter context-awareness for <c>WITH ANY|ALL</c>.
+/// WITH/ANY/ALL highlight as keywords; an object-collection column offers the
+/// quantifier instead of scalar operators; inside the block the caret completes
+/// against the element sub-schema; closing the block (and any nested grouping)
+/// restores the outer schema.
+/// </summary>
+public class QueryQuantifierCompletionTests
+{
+    private sealed record Cap(string Tier, int? GoldCap, IReadOnlyList<string> Keywords);
+
+    private static readonly IReadOnlyList<ColumnSchema> Columns = new[]
+    {
+        new ColumnSchema("name", typeof(string), IsNullable: false),
+        new ColumnSchema("caps", typeof(IReadOnlyList<Cap>), IsNullable: true),
+        new ColumnSchema("reqs", typeof(IReadOnlyList<QuestRequirement>), IsNullable: true),
+    };
+
+    private static List<string> Labels(string query, int caret)
+        => QueryCompletionProvider.Suggest(query, caret, Columns).Select(r => r.Label).ToList();
+
+    private static HighlightKind At(string query, int pos)
+    {
+        var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "caps", "reqs", "name" };
+        var span = QueryHighlighter.Highlight(query, known)
+            .Single(s => pos >= s.Start && pos < s.Start + s.Length);
+        return span.Kind;
+    }
+
+    // ─────────────── highlighter ───────────────
+
+    [Fact]
+    public void With_any_all_highlight_as_keyword()
+    {
+        const string q = "caps WITH ANY (Tier = 'x')";
+        At(q, q.IndexOf("WITH", StringComparison.Ordinal)).Should().Be(HighlightKind.Keyword);
+        At(q, q.IndexOf("ANY", StringComparison.Ordinal)).Should().Be(HighlightKind.Keyword);
+        At("caps WITH ALL (Tier = 'x')", 10).Should().Be(HighlightKind.Keyword); // 'ALL'
+    }
+
+    // ─────────────── completion ───────────────
+
+    [Fact]
+    public void Object_collection_column_offers_quantifier_not_scalar_ops()
+    {
+        var labels = Labels("caps ", 5);
+        labels.Should().Contain(new[] { "WITH ANY (", "WITH ALL (" });
+        // Scalar/string operators must NOT be offered for a collection column.
+        labels.Should().NotContain(new[] { "=", "<", "BETWEEN", "CONTAINS" });
+        // caps is nullable → IS [NOT] NULL still valid.
+        labels.Should().Contain(new[] { "IS NULL", "IS NOT NULL" });
+    }
+
+    [Fact]
+    public void Inside_block_completes_against_homogeneous_element_schema()
+    {
+        var labels = Labels("caps WITH ANY (", 15);
+        labels.Should().Contain(new[] { "Tier", "GoldCap", "Keywords" });
+        labels.Should().NotContain("name"); // outer column is out of scope here
+    }
+
+    [Fact]
+    public void Inside_block_polymorphic_offers_union_props_and_discriminator()
+    {
+        var labels = Labels("reqs WITH ANY (", 15);
+        labels.Should().Contain("T");          // discriminator pseudo-column
+        labels.Should().Contain("Level");      // colliding union prop
+        labels.Should().Contain("Skill");      // subtype prop
+        labels.Should().NotContain("caps");
+    }
+
+    [Fact]
+    public void Closing_block_restores_outer_schema()
+    {
+        // After the matching ) the caret is back at row scope: OR → expect a column,
+        // and that column list is the OUTER schema, not the element schema.
+        var labels = Labels("caps WITH ANY (Tier = 'x') OR ", 30);
+        labels.Should().Contain(new[] { "name", "caps" });
+        labels.Should().NotContain("Tier");
+    }
+
+    [Fact]
+    public void Nested_grouping_paren_does_not_leak_scope()
+    {
+        // Grouping parens inside the block keep the element schema; the block's own
+        // close still pops correctly afterwards.
+        const string q = "caps WITH ANY ((Tier = 'a') AND ";
+        var inside = Labels(q, q.Length);
+        inside.Should().Contain(new[] { "Tier", "GoldCap" });
+        inside.Should().NotContain("name");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryQuantifierPolymorphicTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryQuantifierPolymorphicTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+/// <summary>
+/// <c>WITH ANY|ALL</c> over a <em>polymorphic</em> element collection (slice 2c).
+/// Uses the real reference hierarchies: <see cref="QuestRequirement"/> (Mandatory —
+/// <c>Level</c> is <c>string?</c>/<c>int?</c> across subtypes) and
+/// <see cref="NpcService"/> (Optional — no collisions, single-subtype soft warning).
+/// The points proven: per-element narrowing by discriminator guard, a
+/// sibling-subtype property reads as absent (no match, no throw), mandatory
+/// enforcement, and the optional soft warning.
+/// </summary>
+public class QueryQuantifierPolymorphicTests
+{
+    private sealed record QHolder(string Name, IReadOnlyList<QuestRequirement>? Reqs);
+
+    private static readonly QHolder[] Quests =
+    {
+        // A skill-level row (Level is string "Friends") + a combat row (Level is int 10).
+        new("mixed",
+        [
+            new MinSkillLevelRequirement { T = "MinSkillLevel", Skill = "Cooking", Level = "Friends" },
+            new MinCombatSkillLevelRequirement { T = "MinCombatSkillLevel", Level = 10 },
+        ]),
+        // Only a combat row, Level int 3.
+        new("combatOnly",
+        [
+            new MinCombatSkillLevelRequirement { T = "MinCombatSkillLevel", Level = 3 },
+        ]),
+        new("none", []),
+        new("nullreqs", null),
+    };
+
+    private static readonly IReadOnlyDictionary<string, ColumnBinding> QuestCols =
+        new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["name"] = new("name", typeof(string), r => ((QHolder)r).Name),
+            ["reqs"] = new("reqs", typeof(IReadOnlyList<QuestRequirement>), r => ((QHolder)r).Reqs),
+        };
+
+    private static string[] FilterQuests(string query, ICollection<QueryDiagnostic>? w = null)
+    {
+        var predicate = QueryCompiler.Compile(query, QuestCols, w);
+        return predicate is null
+            ? Quests.Select(h => h.Name).ToArray()
+            : Quests.Where(h => predicate(h)).Select(h => h.Name).ToArray();
+    }
+
+    // ─────────────── per-element narrowing + absent ───────────────
+
+    [Fact]
+    public void Guarded_int_path_compiles_against_the_combat_subtype()
+    {
+        // Level > 5 is only valid because the T='MinCombatSkillLevel' guard resolves
+        // Level to int? in this scope. "mixed" has a combat row Level=10; "combatOnly"
+        // has Level=3 (fails > 5).
+        FilterQuests("reqs WITH ANY (T = 'MinCombatSkillLevel' AND Level > 5)")
+            .Should().BeEquivalentTo("mixed");
+    }
+
+    [Fact]
+    public void Guarded_string_path_compiles_against_the_skill_subtype()
+    {
+        FilterQuests("reqs WITH ANY (T = 'MinSkillLevel' AND Level = 'Friends')")
+            .Should().BeEquivalentTo("mixed");
+    }
+
+    [Fact]
+    public void Sibling_subtype_property_reads_as_absent_no_match_no_throw()
+    {
+        // Skill exists only on MinSkillLevelRequirement. The guard scopes it; the
+        // combat element has no Skill → absent → that element just doesn't match.
+        FilterQuests("reqs WITH ANY (T = 'MinSkillLevel' AND Skill = 'Cooking')")
+            .Should().BeEquivalentTo("mixed");
+        FilterQuests("reqs WITH ANY (T = 'MinSkillLevel' AND Skill = 'Nope')")
+            .Should().BeEmpty();
+    }
+
+    // ─────────────── mandatory enforcement ───────────────
+
+    [Fact]
+    public void Mandatory_colliding_prop_without_guard_throws()
+    {
+        Action act = () => QueryCompiler.Compile("reqs WITH ANY (Level > 5)", QuestCols);
+        act.Should().Throw<QueryException>().WithMessage("*Level*");
+    }
+
+    [Fact]
+    public void Mandatory_subtype_specific_prop_without_guard_throws()
+    {
+        // AllowSkill is declared on exactly one subtype; in a Mandatory hierarchy a
+        // subtype-specific reference still needs a discriminator guard.
+        Action act = () => QueryCompiler.Compile("reqs WITH ANY (AllowSkill = 'Sword')", QuestCols);
+        act.Should().Throw<QueryException>();
+    }
+
+    [Fact]
+    public void Not_equals_does_not_count_as_a_guard()
+    {
+        Action act = () => QueryCompiler.Compile(
+            "reqs WITH ANY (T != 'MinSkillLevel' AND Level = 'x')", QuestCols);
+        act.Should().Throw<QueryException>();
+    }
+
+    [Fact]
+    public void OR_arm_guard_does_not_scope_the_sibling_arm()
+    {
+        // First arm is guarded; second arm references the colliding Level with no
+        // guard of its own → still a mandatory violation.
+        Action act = () => QueryCompiler.Compile(
+            "reqs WITH ANY ((T = 'MinSkillLevel' AND Level = 'a') OR (Level = 'b'))", QuestCols);
+        act.Should().Throw<QueryException>();
+    }
+
+    [Fact]
+    public void Divergent_multi_scope_colliding_type_is_a_v1_limitation_throw()
+    {
+        // Level resolves to string? in one OR-branch and int? in the other; the
+        // inner predicate compiles once so v1 rejects it with guidance.
+        Action act = () => QueryCompiler.Compile(
+            "reqs WITH ANY ((T = 'MinCombatSkillLevel' AND Level > 5) " +
+            "OR (T = 'MinSkillLevel' AND Level = 'x'))", QuestCols);
+        act.Should().Throw<QueryException>().WithMessage("*multiple types*");
+    }
+
+    // ─────────────── optional soft warning (NpcService) ───────────────
+
+    private sealed record SHolder(string Name, IReadOnlyList<NpcService>? Services);
+
+    private static readonly SHolder[] Npcs =
+    {
+        new("store",
+        [
+            new StoreService { Type = "Store", CapIncreases = ["Despised:5000:Armor"] },
+            new AnimalHusbandryService { Type = "AnimalHusbandry" },
+        ]),
+        new("husbandryOnly",
+        [
+            new AnimalHusbandryService { Type = "AnimalHusbandry" },
+        ]),
+    };
+
+    private static readonly IReadOnlyDictionary<string, ColumnBinding> NpcCols =
+        new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["name"] = new("name", typeof(string), r => ((SHolder)r).Name),
+            ["services"] = new("services", typeof(IReadOnlyList<NpcService>), r => ((SHolder)r).Services),
+        };
+
+    [Fact]
+    public void Optional_single_subtype_prop_without_guard_warns_but_works()
+    {
+        var warnings = new List<QueryDiagnostic>();
+        var predicate = QueryCompiler.Compile(
+            "services WITH ANY (CapIncreases CONTAINS 'Despised:5000:Armor')", NpcCols, warnings);
+
+        predicate.Should().NotBeNull();
+        // The husbandry element in "store" has no CapIncreases → absent → skipped;
+        // the StoreService element matches → "store" passes; "husbandryOnly" doesn't.
+        Npcs.Where(h => predicate!(h)).Select(h => h.Name)
+            .Should().BeEquivalentTo("store");
+        warnings.Should().ContainSingle()
+            .Which.Message.Should().Contain("CapIncreases");
+    }
+
+    [Fact]
+    public void Optional_single_subtype_prop_with_guard_does_not_warn()
+    {
+        var warnings = new List<QueryDiagnostic>();
+        var predicate = QueryCompiler.Compile(
+            "services WITH ANY (Type = 'Store' AND CapIncreases CONTAINS 'Despised:5000:Armor')",
+            NpcCols, warnings);
+
+        Npcs.Where(h => predicate!(h)).Select(h => h.Name)
+            .Should().BeEquivalentTo("store");
+        warnings.Should().BeEmpty();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryQuantifierTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryQuantifierTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+/// <summary>
+/// <c>&lt;col&gt; WITH ANY|ALL (&lt;pred&gt;)</c> quantified subqueries over a homogeneous
+/// object collection (slice 1 — the v1 consumer's shape). The headline guarantee is the
+/// <em>per-element correlation</em> test: a conjunction inside the parens must be satisfied
+/// by a single element, not column-wise across the collection.
+/// </summary>
+public class QueryQuantifierTests
+{
+    private sealed record Cap(string Tier, int? GoldCap, IReadOnlyList<string> Keywords);
+
+    private sealed record Holder(string Name, IReadOnlyList<Cap>? Caps, IReadOnlyList<string>? Tags);
+
+    private static readonly Holder[] Dataset =
+    {
+        // Single element satisfies "Neutral AND Armor" together.
+        new("together", [new("Neutral", 5000, ["Armor", "Weapon"])], ["x"]),
+        // Neutral and Armor exist but on DIFFERENT elements — the correlation trap.
+        new("split", [new("Neutral", 100, ["Potion"]), new("BestFriends", 9000, ["Armor"])], ["y"]),
+        new("empty", [], []),
+        new("nullcaps", null, null),
+    };
+
+    private static readonly IReadOnlyDictionary<string, ColumnBinding> Columns =
+        new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["name"] = new("name", typeof(string), r => ((Holder)r).Name),
+            ["caps"] = new("caps", typeof(IReadOnlyList<Cap>), r => ((Holder)r).Caps),
+            ["tags"] = new("tags", typeof(IReadOnlyList<string>), r => ((Holder)r).Tags),
+        };
+
+    private static string[] Filter(string query)
+    {
+        var predicate = QueryCompiler.Compile(query, Columns);
+        if (predicate is null) return Dataset.Select(h => h.Name).ToArray();
+        return Dataset.Where(h => predicate(h)).Select(h => h.Name).ToArray();
+    }
+
+    // ─────────────── parser ───────────────
+
+    [Fact]
+    public void Parses_WITH_ANY_into_QuantifiedNode()
+    {
+        var parsed = QueryParser.Parse("caps WITH ANY (Tier = 'Neutral')");
+        var node = parsed!.Predicate.Should().BeOfType<QuantifiedNode>().Subject;
+        node.Column.Should().Be("caps");
+        node.Quantifier.Should().Be(Quantifier.Any);
+        node.Inner.Should().BeOfType<ComparisonNode>();
+    }
+
+    [Fact]
+    public void Parses_WITH_ALL_and_nested_conjunction()
+    {
+        var node = QueryParser.Parse("caps WITH ALL (Tier = 'Neutral' AND GoldCap > 100)")!
+            .Predicate.Should().BeOfType<QuantifiedNode>().Subject;
+        node.Quantifier.Should().Be(Quantifier.All);
+        node.Inner.Should().BeOfType<AndNode>();
+    }
+
+    [Fact]
+    public void Prefix_NOT_wraps_the_quantifier()
+    {
+        QueryParser.Parse("NOT (caps WITH ANY (Tier = 'Neutral'))")!
+            .Predicate.Should().BeOfType<NotNode>()
+            .Which.Inner.Should().BeOfType<QuantifiedNode>();
+    }
+
+    [Fact]
+    public void Nested_quantifier_parses()
+    {
+        var outer = QueryParser.Parse("caps WITH ANY (Keywords WITH ALL (x = 'y'))");
+        outer!.Predicate.Should().BeOfType<QuantifiedNode>()
+            .Which.Inner.Should().BeOfType<QuantifiedNode>();
+    }
+
+    [Theory]
+    [InlineData("caps WITH ANY")]                 // missing (
+    [InlineData("caps WITH ANY ()")]              // empty predicate
+    [InlineData("caps WITH (Tier = 'x')")]        // missing ANY/ALL
+    [InlineData("caps NOT WITH ANY (Tier = 'x')")] // inline NOT not allowed
+    public void Malformed_quantifier_throws(string query)
+    {
+        Action act = () => QueryParser.Parse(query);
+        act.Should().Throw<QueryException>();
+    }
+
+    // ─────────────── compiler ───────────────
+
+    [Fact]
+    public void ANY_correlates_per_element_not_column_wise()
+    {
+        // The whole point: "Neutral AND GoldCap>=500" must be true for ONE element.
+        // "together" has Neutral@5000; "split" has Neutral@100 and Armor@9000 separately.
+        Filter("caps WITH ANY (Tier = 'Neutral' AND GoldCap >= 500)")
+            .Should().BeEquivalentTo("together");
+    }
+
+    [Fact]
+    public void ANY_true_when_one_element_matches()
+    {
+        Filter("caps WITH ANY (Keywords CONTAINS 'Armor')")
+            .Should().BeEquivalentTo("together", "split");
+    }
+
+    [Fact]
+    public void ALL_requires_every_element_and_is_vacuously_true_over_empty()
+    {
+        // "together" (one Neutral elem) passes; "split" has a BestFriends elem so fails;
+        // "empty" has no elements → vacuously true; "nullcaps" (null) → false.
+        Filter("caps WITH ALL (Tier = 'Neutral')")
+            .Should().BeEquivalentTo("together", "empty");
+    }
+
+    [Fact]
+    public void ANY_over_empty_or_null_is_false()
+    {
+        Filter("caps WITH ANY (GoldCap > 0)")
+            .Should().BeEquivalentTo("together", "split");
+    }
+
+    [Fact]
+    public void Prefix_NOT_negates_the_quantifier()
+    {
+        // NOT (caps WITH ANY Armor) → everything that does NOT have an Armor element.
+        Filter("NOT (caps WITH ANY (Keywords CONTAINS 'Armor'))")
+            .Should().BeEquivalentTo("empty", "nullcaps");
+    }
+
+    [Fact]
+    public void Non_collection_column_rejects_quantifier()
+    {
+        Action act = () => QueryCompiler.Compile("name WITH ANY (Tier = 'x')", Columns);
+        act.Should().Throw<QueryException>().WithMessage("*object-collection*");
+    }
+
+    [Fact]
+    public void String_collection_rejects_quantifier_use_CONTAINS()
+    {
+        Action act = () => QueryCompiler.Compile("tags WITH ANY (x = 'y')", Columns);
+        act.Should().Throw<QueryException>().WithMessage("*CONTAINS*");
+    }
+}


### PR DESCRIPTION
Closes part of #349. **PR-2 of 3** (engine only — no consumer wired): PR-1 #350 (canonical `StoreCapIncrease`, merged as 291bbaa) → **this** → PR-3 #352 (Silmarillion NPC wiring).

## What

`<column> WITH ANY (<pred>)` / `<column> WITH ALL (<pred>)` — a quantified subquery over an object-collection column. `<pred>` is a full predicate compiled against the collection's **element** sub-schema and evaluated **per element**, so a conjunction inside the parens correlates on one element (the accuracy property the feature exists for). `ANY` = ≥1 match (short-circuits); `ALL` = every element, vacuously true over empty; null collection false for both; negate with the existing prefix `NOT ( … )`. String / `IQueryStringValue` collections are rejected — they keep `CONTAINS`.

Polymorphic element collections (discriminated-union bases in `DiscriminatorRegistry`) get a **union** element schema + discriminator pseudo-column. A property absent from an element's runtime subtype reads as the `QueryAbsent` sentinel — **distinct from present-but-null** (every comparison, incl. `IS NULL`, is false) — so naming a sibling-subtype field skips that element instead of throwing. Per-hierarchy, schema-derived narrowing: a type-**colliding** property (e.g. `QuestRequirement.Level` is `string?`/`int?` across subtypes) makes the hierarchy *Mandatory* and requires an in-conjunction `<disc> = '<value>'` guard; no collisions → *Optional* (single-subtype prop without a guard → soft `QueryDiagnostic` warning, never throws).

## Slices (one commit each)

1. core `WITH ANY|ALL` AST/parser/compiler (homogeneous element) — *already on branch*
2a. public `DiscriminatorRegistry` over the 7 polymorphic families — *already on branch*
2b. `PolymorphicSchemaClassifier` (cached per-hierarchy classification) — *already on branch*
2c. `QueryAbsent` + polymorphic `BuildElementSchema` + `EnforceNarrowing` (per-conjunctive-scope, DNF) + `ICollection<QueryDiagnostic>` warnings threaded via additive `Compile` overloads
3. completion (object-collection col offers `WITH ANY|ALL`; inside-block element schema with a paren-stack tracker) + highlighter (`WITH`/`ANY`/`ALL` — and the previously-misclassified `CONTAINS`/`STARTSWITH`/`ENDSWITH` — now Keyword not Error)
+ docs: new `docs/query-quantified-subqueries.md` (#349 design note: A-vs-B, narrowing contract, v1 limits) + `docs/query-system.md` grammar/behaviour

## v1 limitations (documented in the design note)

The inner predicate compiles **once**: a colliding property that would resolve to *different* types across the OR-branches of one quantifier is rejected with guidance (split the query). The warning channel is plumbed end-to-end but UI surfacing is out of v1 scope. Acceptable because the only Mandatory hierarchy (`QuestRequirement`) is **test-only** in v1 — the shipped consumer is homogeneous and `NpcService` is Optional.

## Verification

- `dotnet build Mithril.slnx` — clean (warnings-as-errors)
- Full `dotnet test Mithril.slnx` green on a fresh rebase onto `main` (370f1d0): Mithril.Shared.Tests **1007**, Smaug parity gate **25**, Gandalf **331**, Silmarillion **450** — 0 failed across all projects.
- Public `QueryCompiler.Compile` API kept additive (new overloads delegate with `warnings: null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
