### PR TITLE
feat(silmarillion): wire CapIncreases WITH ANY|ALL on the NPC tab (closes #349, #351)

### DIFF
--- a/src/Mithril.Shared.Wpf/Query/QueryFilter.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryFilter.cs
@@ -46,6 +46,16 @@ public static class QueryFilter
         "QueryError", typeof(string), typeof(QueryFilter),
         new FrameworkPropertyMetadata(null));
 
+    /// <summary>
+    /// Non-fatal narrowing diagnostics from the last successful compile, joined into
+    /// one string (null when there are none). Surfaced separately from
+    /// <see cref="QueryErrorProperty"/> because the query <em>did</em> run — bind it
+    /// <c>OneWayToSource</c> like <c>QueryError</c> and render it as a soft hint.
+    /// </summary>
+    public static readonly DependencyProperty QueryWarningProperty = DependencyProperty.RegisterAttached(
+        "QueryWarning", typeof(string), typeof(QueryFilter),
+        new FrameworkPropertyMetadata(null));
+
     private static readonly DependencyProperty StateProperty = DependencyProperty.RegisterAttached(
         "State", typeof(FilterState), typeof(QueryFilter),
         new PropertyMetadata(null));
@@ -58,6 +68,9 @@ public static class QueryFilter
 
     public static string? GetQueryError(DependencyObject obj) => (string?)obj.GetValue(QueryErrorProperty);
     public static void SetQueryError(DependencyObject obj, string? value) => obj.SetValue(QueryErrorProperty, value);
+
+    public static string? GetQueryWarning(DependencyObject obj) => (string?)obj.GetValue(QueryWarningProperty);
+    public static void SetQueryWarning(DependencyObject obj, string? value) => obj.SetValue(QueryWarningProperty, value);
 
     private static void OnQueryInputChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -291,6 +304,7 @@ public static class QueryFilter
             if (string.IsNullOrWhiteSpace(text))
             {
                 SetQueryError(_control, null);
+                SetQueryWarning(_control, null);
                 return (null, Array.Empty<OrderSpec>());
             }
             var knownColumns = new HashSet<string>(_columns.Keys, StringComparer.OrdinalIgnoreCase);
@@ -301,11 +315,15 @@ public static class QueryFilter
                     var parsed = QueryParser.Parse(text);
                     SetQueryError(_control, null);
                     Predicate<object>? predicate = null;
+                    var warnings = new List<QueryDiagnostic>();
                     if (parsed?.Predicate is not null)
                     {
-                        var compiled = QueryCompiler.Compile(parsed.Predicate, _columns, caseSensitive);
+                        var compiled = QueryCompiler.Compile(parsed.Predicate, _columns, warnings, caseSensitive);
                         predicate = item => compiled(item);
                     }
+                    SetQueryWarning(_control, warnings.Count == 0
+                        ? null
+                        : string.Join(" ", warnings.Select(w => w.Message)));
                     _lastGoodInputPredicate = predicate;
                     return (predicate, parsed?.Order ?? Array.Empty<OrderSpec>());
                 }
@@ -315,11 +333,14 @@ public static class QueryFilter
                     // does not — it returns empty so SortDescriptions clears to the VM's
                     // captured baseline. Two clauses, two consumer surfaces; the predicate
                     // protects the *visible filter*, the order falls back to a stable default.
+                    // A hard error supersedes any stale warning.
                     SetQueryError(_control, ex.Message);
+                    SetQueryWarning(_control, null);
                     return (_lastGoodInputPredicate, Array.Empty<OrderSpec>());
                 }
             }
             SetQueryError(_control, null);
+            SetQueryWarning(_control, null);
             var bareTextPredicate = BuildBareTextPredicate(text!, caseSensitive);
             _lastGoodInputPredicate = bareTextPredicate;
             return (bareTextPredicate, Array.Empty<OrderSpec>());

--- a/src/Silmarillion.Module/ViewModels/NpcListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcListRow.cs
@@ -8,6 +8,10 @@ namespace Silmarillion.ViewModels;
 /// alongside pre-resolved display names. <see cref="ServiceTypes"/> is the flat, deduplicated
 /// set of <c>NpcService.Type</c> values across the NPC's services — queryable via the engine's
 /// collection-<c>CONTAINS</c> path (powers <c>ServiceTypes CONTAINS "Store"</c> and friends).
+/// <see cref="CapIncreases"/> is the flattened, parsed store cap-increase rows across every
+/// <c>StoreService</c> the NPC offers — a homogeneous <see cref="StoreCapIncrease"/> collection,
+/// so the engine's quantified-subquery path answers the originating #349 question:
+/// <c>CapIncreases WITH ANY (Tier = 'Friends' AND GoldCap &gt; 1000)</c>.
 /// <para>
 /// <see cref="AreaName"/> is the area envelope key (e.g. <c>"AreaSerbule"</c>), distinct from
 /// the friendly-name fallback in <see cref="AreaDisplayName"/>. Kept queryable so a user can
@@ -23,4 +27,5 @@ public sealed record NpcListRow(
     string Name,
     string AreaName,
     string AreaDisplayName,
-    IReadOnlyList<NpcServiceTypeValue> ServiceTypes);
+    IReadOnlyList<NpcServiceTypeValue> ServiceTypes,
+    IReadOnlyList<StoreCapIncrease> CapIncreases);

--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -65,6 +65,15 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     private string? _queryError;
 
     /// <summary>
+    /// Non-fatal narrowing diagnostics from the last compiled query (e.g. an
+    /// optional-hierarchy single-subtype field referenced without a discriminator
+    /// guard). Distinct from <see cref="QueryError"/> — the query still ran. Wired
+    /// from <c>QueryFilter.QueryWarning</c> OneWayToSource; surfaced as an amber hint.
+    /// </summary>
+    [ObservableProperty]
+    private string? _queryWarning;
+
+    /// <summary>
     /// ListBox-bound selection. Setting it from an <see cref="Npc"/> POCO (in tests or via the
     /// navigator) resolves to the matching row.
     /// </summary>
@@ -123,7 +132,25 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
         Name: _nameResolver.Resolve(EntityRef.Npc(internalName)),
         AreaName: npc.AreaName ?? "",
         AreaDisplayName: npc.AreaFriendlyName ?? npc.AreaName ?? "(unknown)",
-        ServiceTypes: BuildServiceTypes(npc));
+        ServiceTypes: BuildServiceTypes(npc),
+        CapIncreases: BuildCapIncreases(npc));
+
+    /// <summary>
+    /// Flatten every <see cref="StoreService"/>'s parsed cap-increase rows into one
+    /// homogeneous list on the row so the query box can ask the originating #349
+    /// question (<c>CapIncreases WITH ANY (Tier = 'Friends' AND GoldCap &gt; 1000)</c>).
+    /// Parsing lives in <see cref="StoreCapIncreaseParser"/> (#350) — this is a pure
+    /// projection. NPCs with no store service yield an empty list (the engine's
+    /// quantifier treats that as no-match for <c>ANY</c>, vacuously true for <c>ALL</c>).
+    /// </summary>
+    private static IReadOnlyList<StoreCapIncrease> BuildCapIncreases(Npc npc)
+    {
+        if (npc.Services is null || npc.Services.Count == 0) return [];
+        return npc.Services
+            .OfType<StoreService>()
+            .SelectMany(s => s.ParsedCapIncreases)
+            .ToList();
+    }
 
     private static IReadOnlyList<NpcServiceTypeValue> BuildServiceTypes(Npc npc)
     {

--- a/src/Silmarillion.Module/Views/NpcsTabView.xaml
+++ b/src/Silmarillion.Module/Views/NpcsTabView.xaml
@@ -40,6 +40,11 @@
                            FontSize="{DynamicResource AppFontSizeHint}"
                            Margin="0,4,0,0"
                            Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
+                <TextBlock Text="{Binding QueryWarning}"
+                           Foreground="#FFD9B36A" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="0,4,0,0" TextWrapping="Wrap"
+                           Visibility="{Binding QueryWarning, Converter={StaticResource NullOrEmptyToVis}}"/>
             </StackPanel>
         </Border>
 
@@ -49,6 +54,7 @@
                  SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
                  query:QueryFilter.QueryText="{Binding QueryText}"
                  query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"
+                 query:QueryFilter.QueryWarning="{Binding QueryWarning, Mode=OneWayToSource}"
                  Background="#FF1A1A1A" BorderThickness="0"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                  ScrollViewer.VerticalScrollBarVisibility="Auto"

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QueryFilterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QueryFilterTests.cs
@@ -3,9 +3,11 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
+using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Data;
 using FluentAssertions;
+using Mithril.Reference.Models.Npcs;
 using Mithril.Shared.Wpf.Query;
 using Xunit;
 
@@ -223,6 +225,58 @@ public class QueryFilterTests
             view.SortDescriptions.Should().ContainSingle()
                 .Which.PropertyName.Should().Be("Crop");
             view.Cast<Row>().Select(r => r.Crop).Should().BeInAscendingOrder();
+        });
+    }
+
+    // Polymorphic-collection row exercising the QueryWarning attached DP wiring
+    // (the channel PR-3 plumbs for the Silmarillion NPC tab). NpcService is an
+    // Optional-narrowing hierarchy; CapIncreases is single-subtype (StoreService),
+    // so an unguarded reference is a soft warning, never a hard error.
+    private sealed record NpcRow(string Name, IReadOnlyList<NpcService> Services);
+
+    private static ObservableCollection<NpcRow> NpcDataset() => new(new[]
+    {
+        new NpcRow("Vendor", new NpcService[]
+        {
+            new StoreService { Type = "Store", CapIncreases = ["Friends:5000:Armor"] },
+            new AnimalHusbandryService { Type = "AnimalHusbandry" },
+        }),
+        new NpcRow("Trainer", new NpcService[]
+        {
+            new TrainingService { Type = "Training", Skills = ["Unarmed"] },
+        }),
+    });
+
+    [Fact]
+    public void Optional_unguarded_subtype_field_surfaces_QueryWarning_but_still_filters()
+    {
+        RunOnSta(() =>
+        {
+            var listBox = new ListBox { ItemsSource = NpcDataset() };
+            QueryFilter.SetQueryText(listBox, "Services WITH ANY (CapIncreases CONTAINS 'Friends:5000:Armor')");
+            QueryFilter.ForceAttachForTests(listBox);
+
+            var view = CollectionViewSource.GetDefaultView(listBox.ItemsSource);
+            view.Cast<NpcRow>().Select(r => r.Name).Should().BeEquivalentTo("Vendor");
+            QueryFilter.GetQueryError(listBox).Should().BeNull();
+            QueryFilter.GetQueryWarning(listBox).Should()
+                .NotBeNullOrEmpty().And.Contain("CapIncreases");
+        });
+    }
+
+    [Fact]
+    public void Guarded_query_clears_QueryWarning()
+    {
+        RunOnSta(() =>
+        {
+            var listBox = new ListBox { ItemsSource = NpcDataset() };
+            QueryFilter.SetQueryText(listBox,
+                "Services WITH ANY (Type = 'Store' AND CapIncreases CONTAINS 'Friends:5000:Armor')");
+            QueryFilter.ForceAttachForTests(listBox);
+
+            var view = CollectionViewSource.GetDefaultView(listBox.ItemsSource);
+            view.Cast<NpcRow>().Select(r => r.Name).Should().BeEquivalentTo("Vendor");
+            QueryFilter.GetQueryWarning(listBox).Should().BeNull();
         });
     }
 

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -806,6 +806,92 @@ public sealed class NpcsTabViewModelTests
         vm.DetailViewModel!.Description.Should().Be("Fresh after refresh.");
     }
 
+    [Fact]
+    public void NpcListRow_CapIncreases_FlattenedAndParsed_AcrossStoreServices()
+    {
+        // #352: surface the parsed store cap-increase rows on the list-row so the
+        // query box can ask the originating #349 question. Two StoreServices flatten
+        // into one homogeneous list; parsing (tier/gold/keywords) is #350's parser.
+        var npc = new Npc
+        {
+            Name = "Big Vendor",
+            Services = new NpcServicePoco[]
+            {
+                new NpcStoreServicePoco
+                {
+                    Type = "Store",
+                    CapIncreases = ["Friends:5000:Armor,Weapon", "Comfortable:50000:"],
+                },
+                new NpcTrainingServicePoco { Type = "Training", Skills = ["Unarmed"] },
+                new NpcStoreServicePoco
+                {
+                    Type = "Store",
+                    CapIncreases = ["Despised:200000"],
+                },
+            },
+        };
+        var refData = new StubReferenceData { NpcsByKey = { ["NPC_Vendor"] = npc } };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        var caps = vm.AllNpcs.Single().CapIncreases;
+        caps.Select(c => c.Tier).Should().Equal("Friends", "Comfortable", "Despised");
+        caps.Select(c => c.GoldCap).Should().Equal(5000, 50000, 200000);
+        caps[0].Keywords.Should().Equal("Armor", "Weapon");
+        caps[1].Keywords.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void QueryText_CapIncreasesWithAny_CorrelatesTierAndGoldCapPerElement()
+    {
+        // The originating #349 question, end-to-end through the engine over the
+        // NPC list-row schema: "a Friends-tier cap above 1000g". The correlation
+        // trap NPC has Friends and >1000 on DIFFERENT cap rows — it must NOT match.
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["NPC_Match"] = new Npc
+                {
+                    Name = "Match",
+                    Services = new NpcServicePoco[]
+                    {
+                        new NpcStoreServicePoco
+                        {
+                            Type = "Store",
+                            CapIncreases = ["Friends:5000:Armor", "Despised:100:Food"],
+                        },
+                    },
+                },
+                ["NPC_SplitTrap"] = new Npc
+                {
+                    Name = "Split Trap",
+                    Services = new NpcServicePoco[]
+                    {
+                        new NpcStoreServicePoco
+                        {
+                            Type = "Store",
+                            CapIncreases = ["Friends:100:Armor", "Despised:9000:Food"],
+                        },
+                    },
+                },
+                ["NPC_NoStore"] = new Npc
+                {
+                    Name = "No Store",
+                    Services = new NpcServicePoco[] { new NpcTrainingServicePoco { Type = "Training" } },
+                },
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        const string query = "CapIncreases WITH ANY (Tier = 'Friends' AND GoldCap > 1000)";
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(NpcListRow));
+        var predicate = QueryCompiler.Compile(query, columns);
+        predicate.Should().NotBeNull();
+
+        var matches = vm.AllNpcs.Where(r => predicate!(r)).Select(r => r.InternalName).ToList();
+        matches.Should().BeEquivalentTo(["NPC_Match"]);
+    }
+
     private sealed class StubReferenceData : IReferenceDataService
     {
         public Dictionary<string, Npc> NpcsByKey { get; } = new(StringComparer.Ordinal);


### PR DESCRIPTION
**Closes #349** (originating question now answerable end-to-end) and **closes #351** (the engine plus its first opt-in consumer is wired — nothing left in #351's scope). **PR-3 of 3**: PR-1 #350 (canonical `StoreCapIncrease`, `291bbaa`) → PR-2 #362 (engine, merged) → **this**.

> Note: #352 ("guarded dot-notation sugar over ANY/ALL") is a *separate, optional* ergonomics follow-up — explicitly "lands after #351, or never" — **not** this PR. My PR-2 description mislabelled it as the wiring PR; this corrects that.

## What

The #349 originating question — *"which NPCs sell into a keyword, optionally at a tier / under a gold cap?"* — is now expressible on the Silmarillion NPCs tab:

```
CapIncreases WITH ANY (Tier = 'Friends' AND GoldCap > 1000)
```

- **`NpcListRow.CapIncreases`** — `IReadOnlyList<StoreCapIncrease>`, the flattened parsed cap-increase rows across every `StoreService` the NPC offers (homogeneous record; parsing is #350's `StoreCapIncreaseParser`, this is a pure projection). `SchemaSnapshot` and `QueryFilter` pick the column up by reflection, so the query box, completion, and highlighter get it with no further wiring. The conjunction is evaluated **per cap-row**, so an NPC with `Friends` and `>1000g` on *different* rows correctly does **not** match.
- **`QueryFilter.QueryWarning`** — a new additive attached DP. The warnings-collecting `QueryCompiler.Compile` overload (from PR-2) feeds non-fatal narrowing diagnostics out `OneWayToSource`, mirroring `QueryError`. Cleared on empty / bare-text / parse-error input; a hard error supersedes a stale warning. `NpcsTabViewModel.QueryWarning` renders it as an amber soft hint under the red error line. (No v1 NPC query emits one — `CapIncreases` is homogeneous — but the channel is now plumbed for future polymorphic consumers, per the #349 design note.)

## Verification

- `dotnet build Mithril.slnx` clean (warnings-as-errors).
- Full `dotnet test Mithril.slnx` **0 failed** — Silmarillion **452** (+2), Mithril.Shared.Tests **1009** (+2), all other projects green.
- New tests: `NpcsTabViewModelTests` — CapIncreases flattened+parsed across two `StoreService`s; the #349 query correlates Tier+GoldCap per element (split-trap NPC excluded). `QueryFilterTests` — over a polymorphic `NpcService` row, the `QueryWarning` DP populates for an unguarded optional-subtype field and clears when guarded (exercises the real attached-behaviour STA path).
- Public API kept additive (`QueryWarning` is a new attached DP; no signature changes).

Interactive shell smoke (`dotnet run --project src/Mithril.Shell`) **not** performed — worktree single-instance-mutex makes a headless launch unreliable; deferred to maintainer. The `QueryFilter` STA tests cover the real `QueryText → QueryCompiler → filtered view + QueryWarning` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
