### PR TITLE
feat(planning): cross-skill leveling planner — engine-only (#227)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -5,6 +5,7 @@
     <Project Path="src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj" />
     <Project Path="src/Mithril.GameState/Mithril.GameState.csproj" />
     <Project Path="src/Mithril.Leveling/Mithril.Leveling.csproj" />
+    <Project Path="src/Mithril.Planning/Mithril.Planning.csproj" />
     <Project Path="src/Mithril.Shell/Mithril.Shell.csproj" />
     <Project Path="src/Samwise.Module/Samwise.Module.csproj" />
     <Project Path="src/Legolas.Module/Legolas.Module.csproj" />
@@ -28,6 +29,7 @@
     <Project Path="tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj" />
     <Project Path="tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj" />
     <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
+    <Project Path="tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj" />
     <Project Path="tests/Pippin.Tests/Pippin.Tests.csproj" />
     <Project Path="tests/Samwise.Tests/Samwise.Tests.csproj" />
     <Project Path="tests/Legolas.Tests/Legolas.Tests.csproj" />

--- a/src/Mithril.Planning/CrossSkillPlanner.cs
+++ b/src/Mithril.Planning/CrossSkillPlanner.cs
@@ -1,0 +1,369 @@
+using Mithril.Leveling;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Crafting;
+using Mithril.Shared.Reference;
+
+namespace Mithril.Planning;
+
+/// <summary>
+/// The cross-skill leveling planner (#227, engine-only — the UI surface is a
+/// separate follow-up). Takes a player's skill state and a goal and returns a
+/// <see cref="LevelingPlan"/>: an ordered sequence of grind phases with
+/// skill-source unlock events marked between them.
+///
+/// Closes the loop Elrond's forward-simulator leaves open — it *discovers* which
+/// recipe to grind (auto-considering recipes that unlock as the skill rises),
+/// credits intermediate crafts you have to make anyway, and emits explicit
+/// recipe-switch phases when a higher-XP recipe unlocks mid-grind.
+///
+/// v1 scope (per the issue): single scalar skill target; objective is pure craft
+/// count (acquisition-cost weighting / #122 is an explicit follow-up). The
+/// multi-skill substrate (<see cref="SkillState"/>) is present so vector targets
+/// are an additive follow-up, not a rewrite.
+/// </summary>
+public sealed class CrossSkillPlanner
+{
+    private readonly IReferenceDataService _ref;
+    private readonly LevelingMath _math;
+    private readonly RecipeExpander _expander;
+
+    /// <summary>Depth-1 intermediate-reuse credit for v1 — deeper DAG reuse is a follow-up.</summary>
+    private const int ReuseExpansionDepth = 1;
+
+    public CrossSkillPlanner(IReferenceDataService referenceData, LevelingMath math, RecipeExpander? expander = null)
+    {
+        _ref = referenceData ?? throw new ArgumentNullException(nameof(referenceData));
+        _math = math ?? throw new ArgumentNullException(nameof(math));
+        _expander = expander ?? new RecipeExpander(referenceData);
+    }
+
+    /// <summary>
+    /// Plan from <paramref name="state"/> to <paramref name="target"/>. Returns
+    /// <c>null</c> when the skill has no XP table (umbrella skills can't be
+    /// planned) or the skill is absent from the state.
+    /// </summary>
+    public LevelingPlan? Plan(
+        SkillTarget target,
+        SkillState state,
+        RecipeHistory history,
+        IReadOnlyDictionary<string, int>? onHand = null,
+        SourcingPolicy? sourcing = null,
+        AssertedUnlocks? asserted = null)
+    {
+        sourcing ??= SourcingPolicy.CraftEverything;
+        asserted ??= AssertedUnlocks.None;
+        onHand ??= new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var skill = target.Skill;
+        var xpAmounts = _math.ResolveXpTable(skill);
+        if (xpAmounts is null) return null;
+        if (!state.TryGet(skill, out var start)) return null;
+
+        var startLevel = start.Level;
+        if (target.GoalLevel <= startLevel)
+            return new LevelingPlan(skill, startLevel, target.GoalLevel,
+                TotalXpNeeded: 0, TotalCrafts: 0, Phases: [], Unlocks: [], FinalState: state);
+
+        var totalXpNeeded = _math.XpToGoal(
+            skill, start.Level, start.XpTowardNextLevel, start.XpNeededForNextLevel, target.GoalLevel);
+
+        // Candidate recipes: award XP in the target skill, have an InternalName,
+        // and their output isn't policy-Ignored.
+        var candidates = _ref.Recipes.Values
+            .Where(r => string.Equals(r.RewardSkill, skill, StringComparison.Ordinal)
+                        && !string.IsNullOrEmpty(r.InternalName)
+                        && (r.RewardSkillXp > 0 || r.RewardSkillXpFirstTime > 0)
+                        && !IsOutputIgnored(r, sourcing))
+            .ToList();
+        if (candidates.Count == 0) return null;
+
+        // Mutable run state.
+        var completions = new Dictionary<string, int>(history.Completions, StringComparer.Ordinal);
+        var completed = new HashSet<string>(
+            history.Completions.Where(kv => kv.Value > 0).Select(kv => kv.Key), StringComparer.Ordinal);
+        var unusedBonuses = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var r in candidates)
+        {
+            if (r.RewardSkillXpFirstTime <= 0) continue;
+            var name = r.InternalName!;
+            if (history.IsKnown(name))
+            {
+                if (history.CompletionCount(name) == 0) unusedBonuses.Add(r.Key);
+            }
+            else if (asserted.IsAsserted(name) || r.SkillLevelReq > 0)
+            {
+                // Auto-considered: a skill-gated recipe's first craft still carries
+                // its one-shot bonus once we reach the gate.
+                unusedBonuses.Add(r.Key);
+            }
+        }
+
+        var level = start.Level;
+        var xp = start.XpTowardNextLevel;
+        var xpForLevel = start.XpNeededForNextLevel;
+
+        var rawSteps = new List<PlanPhase>();
+        var unlocks = new List<SkillSourceUnlock>();
+        var unlockEmitted = new HashSet<string>(StringComparer.Ordinal);
+        var reuseCache = new Dictionary<(string, int), int>();
+
+        // Seed: any skill-gated recipe already past its gate at the start level is
+        // not an "unlock event" — only crossings *during* the plan are marked.
+        foreach (var r in candidates)
+            if (IsAvailable(r, level, state, completed, history, asserted))
+                unlockEmitted.Add(r.Key);
+
+        var guard = 0;
+        while (level < target.GoalLevel && guard++ < 100_000)
+        {
+            if (xp >= xpForLevel)
+            {
+                xp -= xpForLevel;
+                level++;
+                if (level - 1 < xpAmounts.Count) xpForLevel = xpAmounts[level - 1];
+                EmitNewUnlocks(candidates, level, state, completed, history, asserted,
+                    unlockEmitted, unlocks, reuseCache);
+                continue;
+            }
+
+            var available = candidates
+                .Where(r => IsAvailable(r, level, state, completed, history, asserted))
+                .Select(r =>
+                {
+                    var baseXp = _math.EffectiveXpPerCraft(r, level);
+                    var reuse = IntermediateReuseXpPerCraft(r, level, state, completed, history, asserted, onHand, sourcing, reuseCache);
+                    return (recipe: r, baseXp, reuse, effXp: baseXp + reuse);
+                })
+                .Where(x => x.effXp > 0 || unusedBonuses.Contains(x.recipe.Key))
+                .ToList();
+
+            if (available.Count == 0) break;
+
+            // Phase 1: spend the highest first-time bonus available.
+            var bonus = available
+                .Where(x => unusedBonuses.Contains(x.recipe.Key) && x.recipe.RewardSkillXpFirstTime > 0)
+                .OrderByDescending(x => x.recipe.RewardSkillXpFirstTime)
+                .ThenBy(x => x.recipe.Key, StringComparer.Ordinal)
+                .FirstOrDefault();
+
+            if (bonus.recipe is not null)
+            {
+                var bonusXp = bonus.recipe.RewardSkillXpFirstTime;
+                var before = level;
+                xp += bonusXp;
+                unusedBonuses.Remove(bonus.recipe.Key);
+                completed.Add(bonus.recipe.InternalName!);
+                Bump(completions, bonus.recipe.InternalName!, 1);
+                while (xp >= xpForLevel && level < target.GoalLevel)
+                {
+                    xp -= xpForLevel;
+                    level++;
+                    if (level - 1 < xpAmounts.Count) xpForLevel = xpAmounts[level - 1]; else break;
+                }
+                EmitNewUnlocks(candidates, level, state, completed, history, asserted,
+                    unlockEmitted, unlocks, reuseCache);
+                rawSteps.Add(new PlanPhase(0, bonus.recipe.Key, bonus.recipe.InternalName!,
+                    bonus.recipe.Name ?? "", bonus.recipe.IconId, PredictedCrafts: 1,
+                    XpPerCraft: bonus.baseXp, UsesFirstTimeBonus: true, FirstTimeBonusXp: bonusXp,
+                    LevelAtStart: before, LevelAtEnd: level, IntermediateReuseXpPerCraft: bonus.reuse));
+                continue;
+            }
+
+            // Phase 2: grind the best effective-XP recipe toward the next level.
+            var best = available
+                .OrderByDescending(x => x.effXp)
+                .ThenBy(x => x.recipe.Key, StringComparer.Ordinal)
+                .First();
+            if (best.effXp <= 0) break;
+
+            var grindBefore = level;
+            var needed = xpForLevel - xp;
+            var crafts = (int)Math.Ceiling((double)needed / best.effXp);
+            if (crafts < 1) crafts = 1;
+
+            xp += (long)crafts * best.effXp;
+            completed.Add(best.recipe.InternalName!);
+            Bump(completions, best.recipe.InternalName!, crafts);
+            while (xp >= xpForLevel && level < target.GoalLevel)
+            {
+                xp -= xpForLevel;
+                level++;
+                if (level - 1 < xpAmounts.Count) xpForLevel = xpAmounts[level - 1]; else break;
+            }
+            EmitNewUnlocks(candidates, level, state, completed, history, asserted,
+                unlockEmitted, unlocks, reuseCache);
+            rawSteps.Add(new PlanPhase(0, best.recipe.Key, best.recipe.InternalName!,
+                best.recipe.Name ?? "", best.recipe.IconId, PredictedCrafts: crafts,
+                XpPerCraft: best.baseXp, UsesFirstTimeBonus: false, FirstTimeBonusXp: 0,
+                LevelAtStart: grindBefore, LevelAtEnd: level, IntermediateReuseXpPerCraft: best.reuse));
+        }
+
+        var phases = MergeAndNumber(rawSteps);
+
+        // Goal not met and nothing could be ground (every candidate gated/unknown/
+        // unasserted, or all recipes give 0 effective XP) → no viable path. This is
+        // distinct from "goal already met" (handled above as a complete empty plan).
+        if (phases.Count == 0 && level < target.GoalLevel) return null;
+
+        var finalSkills = new Dictionary<string, SkillProgress>(state.Skills, StringComparer.Ordinal)
+        {
+            [skill] = new SkillProgress(level, start.BonusLevels, xp, xpForLevel),
+        };
+
+        return new LevelingPlan(
+            skill, startLevel, target.GoalLevel, totalXpNeeded,
+            TotalCrafts: phases.Sum(p => p.PredictedCrafts),
+            Phases: phases, Unlocks: unlocks, FinalState: new SkillState(finalSkills));
+    }
+
+    private bool IsOutputIgnored(Recipe recipe, SourcingPolicy sourcing)
+    {
+        foreach (var output in EnumerateOutputs(recipe))
+            if (sourcing.For(output) == SourcingMode.Ignore) return true;
+        return false;
+    }
+
+    private IEnumerable<string> EnumerateOutputs(Recipe recipe)
+    {
+        IEnumerable<RecipeResultItem> All()
+        {
+            if (recipe.ResultItems is { } r) foreach (var x in r) yield return x;
+            if (recipe.ProtoResultItems is { } p) foreach (var x in p) yield return x;
+        }
+        foreach (var result in All())
+            if (_ref.Items.TryGetValue(result.ItemCode, out var item) && !string.IsNullOrEmpty(item.InternalName))
+                yield return item.InternalName!;
+    }
+
+    /// <summary>
+    /// A recipe is grindable when its skill gate is met, its prereq is complete,
+    /// and it's either known, user-asserted, or skill-gated (skill-source unlocks
+    /// are auto-considered — that's the planner's job vs. Elrond's sim).
+    /// </summary>
+    private bool IsAvailable(
+        Recipe recipe, int targetSkillLevel, SkillState state,
+        ISet<string> completed, RecipeHistory history, AssertedUnlocks asserted)
+    {
+        var name = recipe.InternalName ?? "";
+        var gatingSkill = string.IsNullOrEmpty(recipe.Skill) ? null : recipe.Skill;
+        int gatingLevel;
+        if (gatingSkill is null || string.Equals(gatingSkill, recipe.RewardSkill, StringComparison.Ordinal))
+            gatingLevel = targetSkillLevel; // gate sits on the skill we're levelling
+        else
+            gatingLevel = state.LevelOf(gatingSkill); // cross-gated; static in v1 (single target)
+
+        if (recipe.SkillLevelReq > gatingLevel) return false;
+        if (!string.IsNullOrEmpty(recipe.PrereqRecipe) && !completed.Contains(recipe.PrereqRecipe!)) return false;
+
+        return history.IsKnown(name) || asserted.IsAsserted(name) || recipe.SkillLevelReq > 0;
+    }
+
+    private void EmitNewUnlocks(
+        IReadOnlyList<Recipe> candidates, int level, SkillState state,
+        ISet<string> completed, RecipeHistory history, AssertedUnlocks asserted,
+        ISet<string> unlockEmitted, List<SkillSourceUnlock> unlocks,
+        Dictionary<(string, int), int> reuseCache)
+    {
+        foreach (var r in candidates)
+        {
+            if (unlockEmitted.Contains(r.Key)) continue;
+            if (r.SkillLevelReq <= 0) continue; // only skill-source unlocks are auto-marked
+            if (!IsAvailable(r, level, state, completed, history, asserted)) continue;
+
+            unlockEmitted.Add(r.Key);
+            unlocks.Add(new SkillSourceUnlock(
+                AtLevel: level,
+                RecipeKey: r.Key,
+                RecipeInternalName: r.InternalName!,
+                RecipeName: r.Name ?? "",
+                XpPerCraftAtUnlock: _math.EffectiveXpPerCraft(r, level),
+                Reason: $"Reaches {r.Skill ?? r.RewardSkill} {r.SkillLevelReq}"));
+        }
+    }
+
+    /// <summary>
+    /// XP/craft credited from sub-crafts a single craft of <paramref name="recipe"/>
+    /// requires anyway. Depth-1 for v1: expand the recipe's ingredients once; any
+    /// ingredient produced by a recipe that also rewards the target skill (and is
+    /// available) contributes its XP, weighted by how many sub-batches one craft
+    /// needs. Sourcing-pruned and on-hand-aware via the shared expander.
+    /// </summary>
+    private int IntermediateReuseXpPerCraft(
+        Recipe recipe, int level, SkillState state, ISet<string> completed,
+        RecipeHistory history, AssertedUnlocks asserted,
+        IReadOnlyDictionary<string, int> onHand, SourcingPolicy sourcing,
+        Dictionary<(string, int), int> cache)
+    {
+        if (cache.TryGetValue((recipe.Key, level), out var cached)) return cached;
+        cache[(recipe.Key, level)] = 0; // cycle guard while computing
+
+        var seed = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var output in EnumerateOutputs(recipe)) { seed[output] = 1; break; }
+        if (seed.Count == 0) return 0;
+
+        // Prune sub-DAGs the user supplies externally / ignores by treating them as
+        // effectively in-stock so the expander won't recurse into them.
+        var effOnHand = new Dictionary<string, int>(onHand, StringComparer.Ordinal);
+        foreach (var (item, mode) in sourcing.ByItemInternalName)
+            if (mode is SourcingMode.SupplyExternally or SourcingMode.Ignore)
+                effOnHand[item] = int.MaxValue;
+
+        var demand = new Dictionary<string, double>(seed, StringComparer.Ordinal);
+        _expander.Expand(demand, ReuseExpansionDepth, effOnHand, null,
+            new Dictionary<string, KeywordSlot>());
+
+        var credit = 0;
+        foreach (var (itemName, qty) in demand)
+        {
+            if (RecipeExpander.IsKeywordKey(itemName)) continue;
+            if (string.Equals(itemName, seed.Keys.First(), StringComparison.Ordinal)) continue;
+            if (qty <= 0) continue;
+            if (!_expander.Producers.TryGetDefault(itemName, out var sub)) continue;
+            if (!string.Equals(sub.RewardSkill, recipe.RewardSkill, StringComparison.Ordinal)) continue;
+            if (!IsAvailable(sub, level, state, completed, history, asserted)) continue;
+
+            var stack = Math.Max(1, _expander.OutputStackSize(sub, itemName));
+            var subBatches = (int)Math.Ceiling(qty / stack);
+            credit += subBatches * _math.EffectiveXpPerCraft(sub, level);
+        }
+
+        cache[(recipe.Key, level)] = credit;
+        return credit;
+    }
+
+    private static void Bump(IDictionary<string, int> map, string key, int by)
+        => map[key] = map.TryGetValue(key, out var v) ? v + by : by;
+
+    /// <summary>
+    /// Merge consecutive non-bonus steps for the same recipe into one phase, then
+    /// assign sequential <see cref="PlanPhase.PhaseIndex"/>.
+    /// </summary>
+    private static IReadOnlyList<PlanPhase> MergeAndNumber(List<PlanPhase> steps)
+    {
+        var merged = new List<PlanPhase>();
+        foreach (var step in steps)
+        {
+            if (merged.Count > 0)
+            {
+                var prev = merged[^1];
+                if (prev.RecipeKey == step.RecipeKey
+                    && !prev.UsesFirstTimeBonus && !step.UsesFirstTimeBonus
+                    && prev.XpPerCraft == step.XpPerCraft
+                    && prev.IntermediateReuseXpPerCraft == step.IntermediateReuseXpPerCraft)
+                {
+                    merged[^1] = prev with
+                    {
+                        PredictedCrafts = prev.PredictedCrafts + step.PredictedCrafts,
+                        LevelAtEnd = step.LevelAtEnd,
+                    };
+                    continue;
+                }
+            }
+            merged.Add(step);
+        }
+
+        for (var i = 0; i < merged.Count; i++)
+            merged[i] = merged[i] with { PhaseIndex = i };
+        return merged;
+    }
+}

--- a/src/Mithril.Planning/DependencyInjection/PlanningServiceCollectionExtensions.cs
+++ b/src/Mithril.Planning/DependencyInjection/PlanningServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Mithril.Leveling.DependencyInjection;
+using Mithril.Shared.Crafting;
+
+namespace Mithril.Planning.DependencyInjection;
+
+public static class PlanningServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the cross-skill leveling planner (<see cref="CrossSkillPlanner"/>).
+    /// Pulls in <c>AddMithrilLeveling()</c> (the XP math, #225) and registers the
+    /// shared recipe expander (#226). Idempotent — safe from any consumer (#228
+    /// today, a planner UI follow-up later).
+    /// </summary>
+    public static IServiceCollection AddMithrilPlanning(this IServiceCollection services)
+    {
+        services.AddMithrilLeveling();
+        services.TryAddSingleton<RecipeExpander>();
+        services.TryAddSingleton<CrossSkillPlanner>();
+        return services;
+    }
+}

--- a/src/Mithril.Planning/LevelingPlan.cs
+++ b/src/Mithril.Planning/LevelingPlan.cs
@@ -1,0 +1,60 @@
+using Mithril.Leveling;
+
+namespace Mithril.Planning;
+
+/// <summary>
+/// One phase of the plan: grind a single recipe for a predicted number of
+/// crafts. Quantities are predictions — the #228 executor verifies them against
+/// actual inventory at phase boundaries (random-output variance, externally
+/// supplied ingredients, partial completion).
+/// <para><see cref="IntermediateReuseXpPerCraft"/> is XP per craft credited from
+/// intermediate crafts this recipe requires anyway (a sub-craft that also rewards
+/// the target skill); it is folded into the phase's effective rate and surfaced
+/// for explainability.</para>
+/// </summary>
+public sealed record PlanPhase(
+    int PhaseIndex,
+    string RecipeKey,
+    string RecipeInternalName,
+    string RecipeName,
+    int IconId,
+    int PredictedCrafts,
+    int XpPerCraft,
+    bool UsesFirstTimeBonus,
+    int FirstTimeBonusXp,
+    int LevelAtStart,
+    int LevelAtEnd,
+    int IntermediateReuseXpPerCraft = 0);
+
+/// <summary>
+/// A skill-source unlock crossed between phases: reaching this level made a new,
+/// higher-value recipe available (recipe-availability gated by
+/// <c>SkillLevelReq ≤ currentLevel</c>). Marked so the executor can show
+/// "Phase 3 unlocks at Smithing 45 → Bronze Boots".
+/// </summary>
+public sealed record SkillSourceUnlock(
+    int AtLevel,
+    string RecipeKey,
+    string RecipeInternalName,
+    string RecipeName,
+    int XpPerCraftAtUnlock,
+    string Reason);
+
+/// <summary>
+/// A phased craft plan from current skill state to the goal, with skill-source
+/// unlock events marked between phases. The plan is a prediction; the #228
+/// plan-aware executor walks and re-verifies it.
+/// </summary>
+public sealed record LevelingPlan(
+    string Skill,
+    int StartLevel,
+    int GoalLevel,
+    long TotalXpNeeded,
+    int TotalCrafts,
+    IReadOnlyList<PlanPhase> Phases,
+    IReadOnlyList<SkillSourceUnlock> Unlocks,
+    SkillState FinalState)
+{
+    /// <summary>The goal is already met — empty plan, no crafts.</summary>
+    public bool IsComplete => Phases.Count == 0;
+}

--- a/src/Mithril.Planning/Mithril.Planning.csproj
+++ b/src/Mithril.Planning/Mithril.Planning.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.Planning</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.Leveling\Mithril.Leveling.csproj" />
+    <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+</Project>

--- a/src/Mithril.Planning/PlanInputs.cs
+++ b/src/Mithril.Planning/PlanInputs.cs
@@ -1,0 +1,68 @@
+namespace Mithril.Planning;
+
+/// <summary>The leveling goal. v1 is a single scalar skill target; vector
+/// (multi-skill) targets are a follow-up — the math substrate already supports
+/// multi-skill credit, only the planner objective stays scalar for v1.</summary>
+public readonly record struct SkillTarget(string Skill, int GoalLevel);
+
+/// <summary>How an ingredient is obtained when walking the plan.</summary>
+public enum SourcingMode
+{
+    /// <summary>Craft it (recurse into its recipe).</summary>
+    Craft,
+
+    /// <summary>The user buys/farms it — prune its sub-DAG, don't plan its crafts.</summary>
+    SupplyExternally,
+
+    /// <summary>Ignore entirely (neither craft nor account).</summary>
+    Ignore,
+}
+
+/// <summary>
+/// Per-ingredient (by item <c>InternalName</c>) sourcing decisions. Resolves
+/// cross-skill prereq complexity — "this recipe needs ingots, I'll buy those"
+/// prunes the ingot sub-DAG. Unlisted items fall back to <see cref="Default"/>.
+/// </summary>
+public sealed class SourcingPolicy
+{
+    private readonly IReadOnlyDictionary<string, SourcingMode> _byItem;
+
+    public SourcingPolicy(
+        IReadOnlyDictionary<string, SourcingMode>? byItemInternalName = null,
+        SourcingMode @default = SourcingMode.Craft)
+    {
+        _byItem = byItemInternalName ?? new Dictionary<string, SourcingMode>(StringComparer.Ordinal);
+        Default = @default;
+    }
+
+    public static SourcingPolicy CraftEverything { get; } = new();
+
+    public SourcingMode Default { get; }
+
+    public IReadOnlyDictionary<string, SourcingMode> ByItemInternalName => _byItem;
+
+    public SourcingMode For(string itemInternalName)
+        => _byItem.TryGetValue(itemInternalName, out var m) ? m : Default;
+}
+
+/// <summary>
+/// User-asserted future unlocks: "assume I'll have favor X / quest Y / lorebook Z
+/// done by phase N." The planner does NOT pursue favor/quests/lorebooks itself —
+/// non-skill unlocks are user-asserted. v1 models them as recipe
+/// <c>InternalName</c>s the user asserts will be known/available. Skill-gated
+/// unlocks are auto-considered by the planner and need not be listed here.
+/// </summary>
+public sealed class AssertedUnlocks
+{
+    private readonly IReadOnlySet<string> _recipes;
+
+    public AssertedUnlocks(IEnumerable<string>? assertedRecipeInternalNames = null)
+        => _recipes = assertedRecipeInternalNames is null
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : new HashSet<string>(assertedRecipeInternalNames, StringComparer.Ordinal);
+
+    public static AssertedUnlocks None { get; } = new();
+
+    public bool IsAsserted(string recipeInternalName)
+        => !string.IsNullOrEmpty(recipeInternalName) && _recipes.Contains(recipeInternalName);
+}

--- a/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
+++ b/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Mithril.Leveling;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Crafting;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Planning.Tests;
+
+/// <summary>
+/// Coverage for the cross-skill leveling planner (#227, engine-only). Pins the
+/// v1 contract: goal/umbrella guards, single-recipe grind, recipe-switch +
+/// skill-source unlock events, first-time-bonus ordering, sourcing-policy
+/// pruning, asserted unlocks, and depth-1 intermediate-craft reuse credit.
+/// </summary>
+public class CrossSkillPlannerTests
+{
+    private const string Skill = "Smithing";
+
+    private static CrossSkillPlanner Planner(FakeRef data)
+        => new(data, new LevelingMath(data), new RecipeExpander(data));
+
+    private static SkillState State(int level, long xpToward = 0, long xpNeeded = 100)
+        => new(new Dictionary<string, SkillProgress>
+        {
+            [Skill] = new(level, 0, xpToward, xpNeeded),
+        });
+
+    // ── Guards ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GoalAlreadyMet_ReturnsCompleteEmptyPlan()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100);
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 5), State(5), RecipeHistory.Empty);
+
+        plan.Should().NotBeNull();
+        plan!.IsComplete.Should().BeTrue();
+        plan.Phases.Should().BeEmpty();
+        plan.TotalCrafts.Should().Be(0);
+    }
+
+    [Fact]
+    public void UmbrellaSkill_NoXpTable_ReturnsNull()
+    {
+        var data = new FakeRef().AddSkill(Skill, xpTable: "");
+        Planner(data).Plan(new SkillTarget(Skill, 5), State(1), RecipeHistory.Empty)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void SkillAbsentFromState_ReturnsNull()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100);
+        Planner(data).Plan(new SkillTarget(Skill, 5), SkillState.Empty, RecipeHistory.Empty)
+            .Should().BeNull();
+    }
+
+    // ── Single-recipe grind ──────────────────────────────────────────────
+
+    [Fact]
+    public void SingleKnownRecipe_GrindsToGoal_MergedIntoOnePhase()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Nail")
+            .AddRecipe("ForgeNail", Skill, xp: 50, produces: (1, 1));
+
+        var history = new RecipeHistory(new Dictionary<string, int> { ["ForgeNail"] = 1 });
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 3), State(1), history);
+
+        plan.Should().NotBeNull();
+        plan!.Phases.Should().ContainSingle();
+        var phase = plan.Phases[0];
+        phase.RecipeInternalName.Should().Be("ForgeNail");
+        phase.LevelAtStart.Should().Be(1);
+        phase.LevelAtEnd.Should().Be(3);
+        phase.PredictedCrafts.Should().Be(4, because: "200 XP @ 50/craft");
+        plan.TotalCrafts.Should().Be(4);
+        plan.FinalState.LevelOf(Skill).Should().Be(3);
+    }
+
+    // ── Recipe-switch point + skill-source unlock ────────────────────────
+
+    [Fact]
+    public void HigherXpRecipe_UnlocksMidGrind_EmitsSwitchPhaseAndUnlockEvent()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Tack").AddItem(2, "Spike")
+            .AddRecipe("ForgeTack", Skill, xp: 20, produces: (1, 1))             // always available (known)
+            .AddRecipe("ForgeSpike", Skill, xp: 100, skillLevelReq: 3, produces: (2, 1)); // unlocks @ L3
+
+        var history = new RecipeHistory(new Dictionary<string, int> { ["ForgeTack"] = 1 });
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 5), State(1), history)!;
+
+        // Grind the low recipe, then switch to the higher-XP one when it unlocks.
+        plan.Phases.Select(p => p.RecipeInternalName)
+            .Should().Equal(new[] { "ForgeTack", "ForgeSpike" });
+        plan.Phases[0].LevelAtEnd.Should().Be(3);
+        plan.Phases[1].LevelAtStart.Should().Be(3);
+
+        plan.Unlocks.Should().ContainSingle();
+        plan.Unlocks[0].RecipeInternalName.Should().Be("ForgeSpike");
+        plan.Unlocks[0].AtLevel.Should().Be(3);
+    }
+
+    // ── First-time bonus ─────────────────────────────────────────────────
+
+    [Fact]
+    public void FirstTimeBonus_SpentBeforeGrinding_HighestFirst()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(1000)
+            .AddItem(1, "A").AddItem(2, "B")
+            .AddRecipe("RecipeLowBonus", Skill, xp: 10, firstTime: 100, produces: (1, 1))
+            .AddRecipe("RecipeHighBonus", Skill, xp: 10, firstTime: 400, produces: (2, 1));
+
+        var history = new RecipeHistory(new Dictionary<string, int>
+        {
+            ["RecipeLowBonus"] = 0,   // known, bonus unspent
+            ["RecipeHighBonus"] = 0,
+        });
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 2), State(1, xpNeeded: 1000), history)!;
+
+        var bonusPhases = plan.Phases.Where(p => p.UsesFirstTimeBonus).ToList();
+        bonusPhases.Should().NotBeEmpty();
+        bonusPhases[0].RecipeInternalName.Should().Be("RecipeHighBonus",
+            because: "the largest first-time bonus is spent first");
+    }
+
+    // ── Sourcing policy ──────────────────────────────────────────────────
+
+    [Fact]
+    public void SourcingIgnore_ExcludesRecipeWhoseOutputIsIgnored()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Junk")
+            .AddRecipe("ForgeJunk", Skill, xp: 50, produces: (1, 1));
+
+        var history = new RecipeHistory(new Dictionary<string, int> { ["ForgeJunk"] = 1 });
+        var sourcing = new SourcingPolicy(new Dictionary<string, SourcingMode>
+        {
+            ["Junk"] = SourcingMode.Ignore,
+        });
+
+        // Only candidate is ignored → no usable recipes → null.
+        Planner(data).Plan(new SkillTarget(Skill, 3), State(1), history, sourcing: sourcing)
+            .Should().BeNull();
+    }
+
+    // ── Asserted unlocks ─────────────────────────────────────────────────
+
+    [Fact]
+    public void NonSkillGatedUnknownRecipe_OnlyConsideredWhenAsserted()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Charm")
+            .AddRecipe("WeaveCharm", Skill, xp: 50, skillLevelReq: 0, produces: (1, 1));
+
+        // Unknown, not skill-gated, not asserted → unusable → null.
+        Planner(data).Plan(new SkillTarget(Skill, 3), State(1), RecipeHistory.Empty)
+            .Should().BeNull();
+
+        // Asserted → considered.
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 3), State(1), RecipeHistory.Empty,
+            asserted: new AssertedUnlocks(["WeaveCharm"]));
+        plan.Should().NotBeNull();
+        plan!.Phases.Should().ContainSingle().Which.RecipeInternalName.Should().Be("WeaveCharm");
+    }
+
+    // ── Intermediate-craft reuse credit (depth 1) ────────────────────────
+
+    [Fact]
+    public void IntermediateCraftThatAlsoLevels_CreditsItsXpAgainstThePhase()
+    {
+        // Crafting 1 Widget requires 1 Gear; making Gear also rewards Smithing.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Widget").AddItem(2, "Gear").AddItem(3, "Ore")
+            .AddRecipe("MakeWidget", Skill, xp: 10, produces: (1, 1), ingredients: (2, 1))
+            .AddRecipe("MakeGear", Skill, xp: 5, produces: (2, 1), ingredients: (3, 1));
+
+        var history = new RecipeHistory(new Dictionary<string, int>
+        {
+            ["MakeWidget"] = 1,
+            ["MakeGear"] = 1,
+        });
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 2), State(1), history)!;
+
+        var widgetPhase = plan.Phases.Single(p => p.RecipeInternalName == "MakeWidget");
+        widgetPhase.XpPerCraft.Should().Be(10, because: "base XP excludes reuse");
+        widgetPhase.IntermediateReuseXpPerCraft.Should().Be(5,
+            because: "each Widget needs a Gear craft, which also grants 5 Smithing XP");
+        // Effective 15 XP/craft → ceil(100/15) = 7 crafts, fewer than the naive 10.
+        widgetPhase.PredictedCrafts.Should().Be(7);
+    }
+
+    // ── Minimal IReferenceDataService fake ───────────────────────────────
+
+    private sealed class FakeRef : IReferenceDataService
+    {
+        private readonly Dictionary<long, Item> _items = new();
+        private readonly Dictionary<string, Item> _itemsByName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Recipe> _recipesByName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, XpTableEntry> _xp = new(StringComparer.Ordinal);
+        private int _serial;
+
+        public FakeRef AddSkill(string key, string xpTable = "T")
+        {
+            _skills[key] = new SkillEntry(key, key, 0, false, xpTable, 0, [],
+                new Dictionary<string, SkillRewardEntry>());
+            return this;
+        }
+
+        public FakeRef AddXpTable(long perLevel, string name = "T", int levels = 50)
+        {
+            _xp[name] = new XpTableEntry(name, Enumerable.Repeat(perLevel, levels).ToList());
+            return this;
+        }
+
+        public FakeRef AddItem(long id, string internalName)
+        {
+            var it = new Item { Id = id, Name = internalName, InternalName = internalName };
+            _items[id] = it;
+            _itemsByName[internalName] = it;
+            return this;
+        }
+
+        public FakeRef AddRecipe(
+            string internalName, string rewardSkill, int xp,
+            (long id, int stack) produces,
+            int firstTime = 0, int skillLevelReq = 0, (long id, int stack)? ingredients = null)
+        {
+            var r = new Recipe
+            {
+                Key = $"recipe_{++_serial}",
+                Name = internalName,
+                InternalName = internalName,
+                Skill = rewardSkill,
+                SkillLevelReq = skillLevelReq,
+                RewardSkill = rewardSkill,
+                RewardSkillXp = xp,
+                RewardSkillXpFirstTime = firstTime,
+                Ingredients = ingredients is { } ing
+                    ? [new RecipeItemIngredient { ItemCode = ing.id, StackSize = ing.stack }]
+                    : [],
+                ResultItems = [new RecipeResultItem { ItemCode = produces.id, StackSize = produces.stack }],
+            };
+            _recipes[r.Key] = r;
+            _recipesByName[internalName] = r;
+            return this;
+        }
+
+        public IReadOnlyList<string> Keys { get; } = ["skills", "xptables", "recipes", "items"];
+        public IReadOnlyDictionary<long, Item> Items => _items;
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByName;
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _recipesByName;
+        public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xp;
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+}

--- a/tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj
+++ b/tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.Planning.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.Planning\Mithril.Planning.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Leveling\Mithril.Leveling.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## What

The **cross-skill leveling planner** — the "guide A→B" tool. Takes a player's skill state + a goal and returns a *phased craft plan*, closing the loop Elrond's forward simulator leaves open: Elrond *evaluates* one recipe; the planner *discovers* the path (which recipe to grind, when a higher-XP recipe unlocks mid-grind, what intermediate crafts already pay XP).

Implements #227. Per your decision: **engine-only shared lib now**; a dedicated planner *view* is a separate follow-up. The immediate consumer is #228 (the Celebrimbor executor that walks the plan).

## How

- **New `src/Mithril.Planning`** — non-WPF shared lib, mirrors `Mithril.Leveling`/`Mithril.GameState`. Consumes #225 `LevelingMath` (XP math) + #226 `RecipeExpander` (ingredient discovery). Added to `Mithril.slnx` + `tests/Mithril.Planning.Tests`. `AddMithrilPlanning()` DI extension for #228.
- **Inputs:** `SkillTarget`, `SkillState`/`RecipeHistory` (#225 neutral types), on-hand, `SourcingPolicy` (`craft | supply externally | ignore` — prunes sub-DAGs via the expander), `AssertedUnlocks` (user-asserted non-skill unlocks; skill-gated unlocks are auto-considered — that's the planner's job vs. Elrond's sim).
- **Output:** `LevelingPlan` — ordered `(recipe, predicted-crafts)` phases with `SkillSourceUnlock` events marked between them. Quantities are predictions the #228 executor re-verifies. `null` = no viable path / umbrella skill; goal-already-met = a complete empty plan.
- **Optimization passes:** recipe discovery (auto-considers skill-gated recipes as the skill rises), recipe-switch-point detection (grind low → cross threshold → switch to the unlocked higher-XP recipe, emitted as explicit phases + an unlock event), first-time-bonus ordering (largest first), and **depth-1 intermediate-craft reuse credit** (a sub-craft you must make anyway that also levels the target skill folds its XP into the phase's effective rate, reducing predicted crafts), consecutive-phase merge.

## v1 scope (per the issue)

- Single scalar skill target; pure **craft-count** objective. #122 acquisition-cost weighting is an explicit follow-up; the multi-skill `SkillState` substrate is present so vector targets are additive, not a rewrite.
- Intermediate-reuse credit is **depth-1** for v1 (deeper DAG reuse is a follow-up) — clearly bounded and documented.
- Out of scope (unchanged): planner UI/surface; plan persistence (lives in #228).

## Testing

- `dotnet build Mithril.slnx` clean.
- **Mithril.Planning.Tests: 9 passed** — guards (goal-met / umbrella / skill-absent), single-recipe grind→merged phase, recipe-switch + unlock event @ correct level, first-time-bonus highest-first, sourcing-`Ignore` pruning, asserted-vs-unasserted unknown recipe, depth-1 reuse credit math.
- **Post-merge re-verify**: branched off fresh `main` after #225/#226 merged; rebuilt + retested the merged tree green (Mithril.Leveling 12 / Mithril.Shared 1009 / Celebrimbor 52 / Elrond 58) *before* building #227, per the non-negotiable re-verify rule. #227 adds only the new project — no edits to existing code.

## Next

#228 (plan-aware executor in Celebrimbor) consumes this. It also carries the prerequisite I flagged during grounding: migrating `CelebrimborSettings` to `IVersionedState<T>` for the phase-metadata schema bump.

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
