### PR TITLE
fix(elrond): break #359 DI-cycle boot deadlock (full-install hang)

### DIFF
--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -41,7 +41,12 @@ public sealed class ElrondModule : IMithrilModule
             sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
             sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
             sp.GetRequiredService<ElrondSettings>(),
-            sp.GetService<ICraftListImportTarget>()));
+            // Deferred, NOT sp.GetService<ICraftListImportTarget>() eagerly: resolving it
+            // at VM-construction time closes a DI cycle (→ Celebrimbor's
+            // CraftListImportTarget → IModuleActivator → ShellViewModel → eager
+            // ActivateModule → back to this VM) that MS.DI turns into a silent
+            // UI-thread deadlock. The VM invokes this only on the Send click.
+            () => sp.GetService<ICraftListImportTarget>()));
         services.AddSingleton<IElrondSkillImportTarget>(sp => new Services.ElrondSkillImportTarget(
             sp.GetRequiredService<SkillAdvisorViewModel>(),
             sp.GetService<IModuleActivator>(),

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -58,7 +58,13 @@ public sealed partial class SkillAdvisorViewModel
     private readonly IActiveCharacterService _activeChar;
     private readonly IReferenceDataService _referenceData;
     private readonly ElrondSettings _settings;
-    private readonly ICraftListImportTarget? _craftListImport;
+    // Resolved lazily, ONLY on the explicit Send click. Resolving ICraftListImportTarget
+    // eagerly at ctor time closes a DI cycle: it pulls Celebrimbor's CraftListImportTarget
+    // → IModuleActivator → ShellModuleActivator(ShellViewModel) → ShellViewModel..ctor's
+    // eager ActivateModule() → back to this VM, before any singleton is cached. MS.DI's
+    // StackGuard turns that into a silent UI-thread deadlock (boot.log stops at
+    // "creating App"), invisible to unit tests. Deferring to user-action time breaks it.
+    private readonly Func<ICraftListImportTarget?>? _craftListImportAccessor;
 
     private readonly ObservableCollection<RecipeAnalysis> _recipes = [];
 
@@ -70,14 +76,14 @@ public sealed partial class SkillAdvisorViewModel
         IActiveCharacterService characterData,
         IReferenceDataService referenceData,
         ElrondSettings settings,
-        ICraftListImportTarget? craftListImport = null)
+        Func<ICraftListImportTarget?>? craftListImportAccessor = null)
     {
         _engine = engine;
         _simulator = simulator;
         _activeChar = characterData;
         _referenceData = referenceData;
         _settings = settings;
-        _craftListImport = craftListImport;
+        _craftListImportAccessor = craftListImportAccessor;
 
         _goalLevel = settings.LastGoalLevel;
         _viewMode = settings.ViewMode;
@@ -338,10 +344,11 @@ public sealed partial class SkillAdvisorViewModel
     }
 
     /// <summary>
-    /// True when a craft-list import target (Celebrimbor) is registered. Drives the
-    /// "Send to craft list" button's visibility so it stays hidden if Celebrimbor is absent.
+    /// True when the craft-list import path is wired (Celebrimbor present). Checks only
+    /// whether the accessor exists — it does NOT resolve the target, so command-can-execute
+    /// re-queries during boot can't re-enter the DI graph (see the accessor field comment).
     /// </summary>
-    public bool IsCraftListImportAvailable => _craftListImport is not null;
+    public bool IsCraftListImportAvailable => _craftListImportAccessor is not null;
 
     /// <summary>
     /// Pushes the selected recipe into the craft-list module (Celebrimbor) in-process —
@@ -352,16 +359,21 @@ public sealed partial class SkillAdvisorViewModel
     [RelayCommand(CanExecute = nameof(CanSendToCraftList))]
     private void SendToCraftList()
     {
-        if (_craftListImport is null || SelectedRecipe is not { } recipe) return;
-        if (string.IsNullOrWhiteSpace(recipe.InternalName)) return;
+        if (SelectedRecipe is not { } recipe || string.IsNullOrWhiteSpace(recipe.InternalName)) return;
 
-        _craftListImport.ImportRecipes(
+        // Resolve the target HERE — on the user's click, long after boot — so the
+        // ICraftListImportTarget → ShellViewModel resolution path can never run while
+        // the container is still building the shell graph.
+        var target = _craftListImportAccessor?.Invoke();
+        if (target is null) return;
+
+        target.ImportRecipes(
             [new CraftListImportEntry(recipe.InternalName, 1)],
             $"Elrond · {recipe.RecipeName}");
     }
 
     private bool CanSendToCraftList()
-        => _craftListImport is not null
+        => _craftListImportAccessor is not null
            && SelectedRecipe is { } r
            && !string.IsNullOrWhiteSpace(r.InternalName);
 

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -309,6 +309,33 @@ public class SkillAdvisorViewModelTests
         importTarget.LastSource.Should().Contain(recipe.RecipeName);
     }
 
+    [Fact]
+    public void Ctor_DoesNotResolveImportTarget_DiCycleRegressionGuard()
+    {
+        // The #359 deadlock: the VM factory resolved ICraftListImportTarget eagerly at
+        // construction, closing a DI cycle (→ Celebrimbor → IModuleActivator →
+        // ShellViewModel → eager ActivateModule → back here) that MS.DI turns into a
+        // silent UI-thread hang. Construction must NEVER invoke the accessor — only the
+        // explicit Send click may. An accessor that throws if touched proves it.
+        var refData = new FakeRefData();
+        refData.AddSkill("Cooking", parents: []);
+        refData.AddRecipe(rewardSkill: "Cooking");
+        var characterSvc = new FakeActiveCharacterService();
+        characterSvc.SetCharacter(new CharacterSnapshot(
+            "C", "S", DateTimeOffset.UtcNow,
+            new Dictionary<string, CharacterSkill> { ["Cooking"] = new(10, 0, 0, 100) },
+            new Dictionary<string, int>(), new Dictionary<string, string>()));
+        var engine = new SkillAdvisorEngine(refData);
+        var sim = new LevelingSimulator(refData, engine);
+
+        var act = () => new SkillAdvisorViewModel(
+            engine, sim, characterSvc, refData, new ElrondSettings(),
+            () => throw new InvalidOperationException("import target resolved during construction"));
+
+        act.Should().NotThrow(
+            because: "the VM ctor must not resolve the import target — that edge is the #359 DI cycle");
+    }
+
     private static SkillAdvisorViewModel MakeVmWithImportTarget(
         out FakeRefData refData, out FakeCraftListImportTarget importTarget)
     {
@@ -323,7 +350,9 @@ public class SkillAdvisorViewModelTests
         var engine = new SkillAdvisorEngine(refData);
         var sim = new LevelingSimulator(refData, engine);
         importTarget = new FakeCraftListImportTarget();
-        return new SkillAdvisorViewModel(engine, sim, characterSvc, refData, new ElrondSettings(), importTarget);
+        var captured = importTarget;
+        return new SkillAdvisorViewModel(engine, sim, characterSvc, refData, new ElrondSettings(),
+            () => captured);
     }
 
     private sealed class FakeCraftListImportTarget : Mithril.Shared.Modules.ICraftListImportTarget


### PR DESCRIPTION
## ⚠️ Hotfix — merged `main` is unusable on the full install

`main` (`5bbbae8`) **hangs forever at boot** for any install that has both **Elrond and Celebrimbor** (i.e. the full 12-module ship). `boot.log` stops at `creating App`, never reaches `resolving ShellWindow`; the process stays alive (CDN refreshes keep logging) but the UI thread is deadlocked. No crash dialog, no `crash.log`. A 6-module build without Celebrimbor boots fine — which is why it wasn't caught.

Regression introduced by **#359** (the #224 send-to-craft-list wiring). This PR is the surgical fix. **Recommend fast-track merge** — every full-install user is currently dead on launch.

## Root cause — re-entrant DI cycle

#359 added exactly one edge: `SkillAdvisorViewModel`'s DI factory eagerly called `sp.GetService<ICraftListImportTarget>()` at construction. With Elrond+Celebrimbor both loaded that closes a loop:

```
IDeepLinkRouter → Elrond IDeepLinkHandler → IElrondSkillImportTarget
  → SkillAdvisorViewModel → ICraftListImportTarget (Celebrimbor)
  → IModuleActivator → ShellModuleActivator(ShellViewModel)
  → ShellViewModel..ctor → eager ActivateModule() → Elrond view
  → SkillAdvisorViewModel → ∞
```

`ShellViewModel` is a singleton, but Microsoft.Extensions.DI only caches a singleton *after its constructor returns*. Its ctor eagerly `ActivateModule`s, re-entering resolution that needs `ShellViewModel` again — not yet cached. MS.DI's `StackGuard` offloads the ever-deepening recursion onto fresh worker stacks each blocked on `WaitHandle.WaitOne()` → no "circular dependency" exception, no `StackOverflowException`, just a permanent UI-thread deadlock.

This is the textbook case of the project's recorded `di_cycle_invisible_to_unit_tests` lesson — and I own the miss: I shipped #224 without launching the shell, judging it "low risk." That was wrong; the lesson exists precisely for this.

## Fix (localised to the edge #359 added)

`SkillAdvisorViewModel` now takes `Func<ICraftListImportTarget?>?` instead of the resolved instance; `ElrondModule` passes `() => sp.GetService<ICraftListImportTarget>()`. The accessor is invoked **only on the explicit Send click** — long after boot, when `ShellViewModel` is cached — so the cycle can never form while the container is still building the shell graph. `IsCraftListImportAvailable` / `CanExecute` check only whether the accessor *exists*; they never resolve it.

No behaviour change to the #224 feature: Send still activates Celebrimbor and runs the import dialog.

## Verification (the way the lesson prescribes — not just unit tests)

Launched the **full 12-module shell** and watched `boot.log`:

| Build | Modules | boot.log |
|---|---|---|
| buggy `main` | 12 (incl. Celebrimbor) | `creating App` → **dead stop** ✗ |
| buggy `main` | 6 (no Celebrimbor) | boots → `shell shown` ✓ (explains the slip) |
| **this fix** | **12 (incl. Celebrimbor + Elrond)** | `creating App → resolving ShellWindow → calling shell.Show() → shell shown → === startup done ===` ✓ |

- `dotnet build Mithril.slnx` clean; `start.ps1 -Build` reached `Application started.`.
- **Elrond.Tests: 59 passed**, including a new deterministic regression guard `Ctor_DoesNotResolveImportTarget_DiCycleRegressionGuard` — constructs the VM with an accessor that throws if invoked and asserts construction does not throw, pinning "the ctor must never resolve the import target."

## Merge-order note

This should land before [#364](https://github.com/moumantai-gg/mithril/pull/364) (#227) is merged. #364 only adds a new shared lib (no shell wiring, doesn't touch the cycle), but per the post-merge re-verify rule its branch should be rebuilt+retested on `main` once this fix lands.

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
