### PR TITLE
harden(shell): defuse + guard the #359-class re-entrant DI startup deadlock (closes #365)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -40,6 +40,7 @@
     <Project Path="tests/Saruman.Tests/Saruman.Tests.csproj" />
     <Project Path="tests/Silmarillion.Tests/Silmarillion.Tests.csproj" />
     <Project Path="tests/Smaug.Tests/Smaug.Tests.csproj" />
+    <Project Path="tests/Mithril.Shell.Tests/Mithril.Shell.Tests.csproj" />
     <Project Path="tests/Celebrimbor.Tests/Celebrimbor.Tests.csproj" />
     <Project Path="tests/Palantir.Tests/Palantir.Tests.csproj" />
     <Project Path="tests/RefreshAndValidate.Tests/RefreshAndValidate.Tests.csproj" />

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -1,0 +1,77 @@
+using Mithril.Shared.Audio;
+using Mithril.Shared.Character;
+using Mithril.GameState.DependencyInjection;
+using Mithril.Shared.DependencyInjection;
+using Mithril.Shared.Diagnostics.Performance;
+using Mithril.Shared.Game;
+using Mithril.Shared.Hotkeys;
+using Mithril.Shared.Icons;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Settings;
+using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mithril.Shell.DependencyInjection;
+
+/// <summary>
+/// Inputs the shell service graph needs that are computed by the bootstrap before
+/// the host is built (settings already loaded, cache directories resolved). Carried
+/// as a record so the <em>one</em> composition is shared verbatim between the real
+/// launch path (<c>Program</c>) and the headless self-check (<c>--selfcheck</c> /
+/// the DI-cycle guard test) — no second hand-maintained copy of the registration
+/// chain to drift out of sync (#365, Layer 2).
+/// </summary>
+public sealed record ShellCompositionOptions(
+    string PreferencesPath,
+    ISettingsStore<ShellSettings> ShellStore,
+    ShellSettings ShellSettings,
+    GameConfig GameConfig,
+    string LogDir,
+    string PerfDir,
+    string CharactersRootDir,
+    string ReferenceCacheDir,
+    string CommunityCalibrationCacheDir,
+    string IconCacheDir,
+    Action<string>? ModuleLog = null);
+
+public static class ShellComposition
+{
+    /// <summary>
+    /// The complete shell service registration, in order. This is the single source
+    /// of truth for the runtime DI graph; <c>Program</c> and the self-check both call
+    /// it so the guard validates exactly what ships.
+    /// </summary>
+    public static IServiceCollection AddMithrilShell(
+        this IServiceCollection services, ShellCompositionOptions o) =>
+        services
+            .AddMithrilSettings<UserPreferences>(o.PreferencesPath, UserPreferencesJsonContext.Default.UserPreferences)
+            .AddSingleton<ISettingsStore<ShellSettings>>(o.ShellStore)
+            .AddSingleton(o.ShellSettings)
+            .AddSingleton<IActiveCharacterPersistence>(o.ShellSettings)
+            .AddSingleton(o.GameConfig)
+            .AddMithrilDiagnostics(o.LogDir)
+            .AddMithrilPerfTrace(o.PerfDir, sp => () => sp.GetRequiredService<ShellSettings>().VerboseFrameEvents)
+            .AddMithrilGameServices()
+            .AddMithrilGameState()
+            .AddMithrilPerCharacterStorage(o.CharactersRootDir)
+            .AddMithrilReferenceData(o.ReferenceCacheDir)
+            .AddMithrilCommunityCalibration(o.CommunityCalibrationCacheDir)
+            .AddMithrilIcons(o.IconCacheDir)
+            .AddMithrilAudio()
+            .AddMithrilHotkeys()
+            .AddMithrilDialogs()
+            .AddMithrilModuleGates()
+            // Register NoOp navigator BEFORE modules so module Register() calls
+            // (which run inside AddMithrilModules) can override via AddSingleton.
+            // Without this ordering, the NoOp would win and CanOpen would always
+            // return false — chip cross-links would render disabled.
+            .AddSingleton<IReferenceNavigator, NoOpReferenceNavigator>()
+            .AddMithrilModules(o.ModuleLog)
+            .AddMithrilAttention()
+            .AddMithrilShellUpdates()
+            .AddMithrilShellViews()
+            .AddMithrilItemDetail()
+            .AddMithrilIngredientSources()
+            .AddMithrilShellCommands();
+}

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -243,7 +243,8 @@ public static class Program
 
             Boot("resolving ShellWindow");
             var shell = host.Services.GetRequiredService<ShellWindow>();
-            shell.DataContext = host.Services.GetRequiredService<ShellViewModel>();
+            var shellViewModel = host.Services.GetRequiredService<ShellViewModel>();
+            shell.DataContext = shellViewModel;
             shell.Left = shellSettings.WindowLeft;
             shell.Top = shellSettings.WindowTop;
             shell.Width = shellSettings.WindowWidth;
@@ -253,6 +254,10 @@ public static class Program
 
             Boot("calling shell.Show()");
             shell.Show();
+            // Activate the initial module now — after the window is shown and the
+            // ShellViewModel singleton is fully constructed/cached. Doing this in the
+            // VM ctor risks a re-entrant resolution deadlock (#365).
+            shellViewModel.Initialize();
             shell.Closing += (_, _) =>
             {
                 if (shell.WindowState == WindowState.Normal)

--- a/src/Mithril.Shell/Program.cs
+++ b/src/Mithril.Shell/Program.cs
@@ -65,6 +65,14 @@ public static class Program
             return;
         }
 
+        // Headless DI-graph self-check (#365 guard). Process-isolated, before the
+        // single-instance mutex and any UI/host work: composes the real graph,
+        // resolves every startup root under a hard watchdog, exits 0/1/2.
+        if (Array.IndexOf(args, SelfCheck.Switch) >= 0)
+        {
+            Environment.Exit(SelfCheck.Run(args));
+        }
+
         Mutex? mutex = null;
         EventWaitHandle? activateEvent = null;
         CancellationTokenSource? activateCts = null;
@@ -154,36 +162,10 @@ public static class Program
             // shared across modules, not nested under Shell/.
             var preferencesPath = Path.Combine(localApp, "Mithril", "preferences.json");
 
-            builder.Services
-                .AddMithrilSettings<UserPreferences>(preferencesPath, UserPreferencesJsonContext.Default.UserPreferences)
-                .AddSingleton<ISettingsStore<ShellSettings>>(shellStore)
-                .AddSingleton(shellSettings)
-                .AddSingleton<IActiveCharacterPersistence>(shellSettings)
-                .AddSingleton(gameConfig)
-                .AddMithrilDiagnostics(logDir)
-                .AddMithrilPerfTrace(perfDir, sp => () => sp.GetRequiredService<ShellSettings>().VerboseFrameEvents)
-                .AddMithrilGameServices()
-                .AddMithrilGameState()
-                .AddMithrilPerCharacterStorage(charactersRootDir)
-                .AddMithrilReferenceData(referenceCacheDir)
-                .AddMithrilCommunityCalibration(communityCalibrationCacheDir)
-                .AddMithrilIcons(iconCacheDir)
-                .AddMithrilAudio()
-                .AddMithrilHotkeys()
-                .AddMithrilDialogs()
-                .AddMithrilModuleGates()
-                // Register NoOp navigator BEFORE modules so module Register() calls
-                // (which run inside AddMithrilModules) can override via AddSingleton.
-                // Without this ordering, the NoOp would win and CanOpen would always
-                // return false — chip cross-links would render disabled.
-                .AddSingleton<IReferenceNavigator, NoOpReferenceNavigator>()
-                .AddMithrilModules(Boot)
-                .AddMithrilAttention()
-                .AddMithrilShellUpdates()
-                .AddMithrilShellViews()
-                .AddMithrilItemDetail()
-                .AddMithrilIngredientSources()
-                .AddMithrilShellCommands();
+            builder.Services.AddMithrilShell(new ShellCompositionOptions(
+                preferencesPath, shellStore, shellSettings, gameConfig,
+                logDir, perfDir, charactersRootDir, referenceCacheDir,
+                communityCalibrationCacheDir, iconCacheDir, Boot));
 
             Boot($"modules discovered: {builder.Services.Count(d => d.ServiceType == typeof(IMithrilModule))}");
             host = builder.Build();

--- a/src/Mithril.Shell/SelfCheck.cs
+++ b/src/Mithril.Shell/SelfCheck.cs
@@ -1,0 +1,170 @@
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Mithril.Shared.Game;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Settings;
+using Mithril.Shell.DependencyInjection;
+using Mithril.Shell.ViewModels;
+using Mithril.Shell.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.Shell;
+
+/// <summary>
+/// <c>--selfcheck</c>: a process-isolated headless boot that composes the <em>real</em>
+/// shell service graph (same <see cref="ShellComposition.AddMithrilShell"/> as the live
+/// launch), builds the provider, and resolves every startup root — but does <strong>not</strong>
+/// start hosted services (no CDN refresh) and never shows or runs the window. Its only job is
+/// to prove the DI graph resolves without a re-entrant cycle (#365).
+/// </summary>
+/// <remarks>
+/// A re-entrant factory-lambda cycle does not throw — Microsoft.Extensions.DI's
+/// <c>StackGuard</c> offloads the unbounded recursion onto worker stacks and blocks forever,
+/// so <c>ValidateOnBuild</c> can't see it (it only walks constructor call sites, not
+/// factory delegates) and a plain resolve-and-assert would itself hang. The guard is
+/// therefore a hard wall-clock watchdog on a separate thread: if resolution hasn't finished
+/// by the deadline the process is killed with a distinctive exit code. Exit codes:
+/// <c>0</c> all roots resolved; <c>1</c> a root threw; <c>2</c> watchdog timeout (the
+/// silent-deadlock signature).
+/// </remarks>
+internal static class SelfCheck
+{
+    public const string Switch = "--selfcheck";
+
+    public static int Run(string[] args)
+    {
+        var timeout = TimeSpan.FromSeconds(
+            ArgValue(args, "--selfcheck-timeout-seconds", out var s) && int.TryParse(s, out var t)
+                ? t
+                : 120);
+
+        // Hard watchdog: runs regardless of what the main thread is doing. A real
+        // cycle hangs the main thread inside GetRequiredService forever, so the only
+        // reliable escape is to terminate the process from elsewhere.
+        var watchdog = new Thread(() =>
+        {
+            Thread.Sleep(timeout);
+            Console.Error.WriteLine(
+                $"selfcheck: FAIL - DI root resolution did not complete within {timeout.TotalSeconds:0}s. " +
+                "This is the silent re-entrant-cycle signature (#365): a factory-lambda graph " +
+                "resolving back into a still-constructing singleton. Capture a managed stack " +
+                "(dotnet-stack) of the hung thread to find the offending edge.");
+            Environment.Exit(2);
+        })
+        { IsBackground = true, Name = "selfcheck-watchdog" };
+        watchdog.Start();
+
+        try
+        {
+            var localApp = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var shellDir = Path.Combine(localApp, "Mithril", "Shell");
+            Directory.CreateDirectory(shellDir);
+
+            var shellStore = new JsonSettingsStore<ShellSettings>(
+                Path.Combine(shellDir, "shell.json"), ShellSettingsJsonContext.Default.ShellSettings);
+#pragma warning disable VSTHRD002 // no dispatcher yet; mirrors Program's pre-host load
+            var shellSettings = shellStore.LoadAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+            var gameConfig = new GameConfig { GameRoot = shellSettings.GameRoot };
+
+            var options = new ShellCompositionOptions(
+                PreferencesPath: Path.Combine(localApp, "Mithril", "preferences.json"),
+                ShellStore: shellStore,
+                ShellSettings: shellSettings,
+                GameConfig: gameConfig,
+                LogDir: Path.Combine(shellDir, "logs"),
+                PerfDir: Path.Combine(shellDir, "perf"),
+                CharactersRootDir: Path.Combine(localApp, "Mithril", "characters"),
+                ReferenceCacheDir: Path.Combine(localApp, "Mithril", "Reference"),
+                CommunityCalibrationCacheDir: Path.Combine(localApp, "Mithril", "Reference", "CommunityCalibration"),
+                IconCacheDir: Path.Combine(localApp, "Mithril", "Icons"),
+                ModuleLog: m => Console.Out.WriteLine($"selfcheck: {m}"));
+
+            var builder = Host.CreateApplicationBuilder(
+                args.Where(a => a != Switch).ToArray());
+            // Same provider options as the live launch — validate what ships.
+            builder.ConfigureContainer(new DefaultServiceProviderFactory(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true,
+            }));
+            builder.Services.AddMithrilShell(options);
+
+            // Self-test hook (CI guard-of-the-guard, never set in prod): inject a
+            // re-entrant factory-lambda cycle of the exact shape #365 was — two
+            // singletons whose factories resolve each other. MS.DI's StackGuard
+            // offloads the unbounded recursion and blocks, so the watchdog must be
+            // what trips (exit 2). Proves the guard detects, not just that a clean
+            // graph passes.
+            if (Environment.GetEnvironmentVariable("MITHRIL_SELFCHECK_SELFTEST_CYCLE") == "1")
+            {
+                builder.Services.AddSingleton<CycleA>(sp => new CycleA(sp.GetRequiredService<CycleB>()));
+                builder.Services.AddSingleton<CycleB>(sp => new CycleB(sp.GetRequiredService<CycleA>()));
+            }
+
+            using var host = builder.Build(); // does NOT StartAsync — no hosted services, no CDN
+
+            if (Environment.GetEnvironmentVariable("MITHRIL_SELFCHECK_SELFTEST_CYCLE") == "1")
+            {
+                _ = host.Services.GetRequiredService<CycleA>(); // hangs → watchdog exit 2
+            }
+
+            // App provides Application.Current + App.xaml resource dictionaries that
+            // view ctors (StaticResource) need. Resources only; never Run().
+            var app = new App();
+            app.InitializeComponent();
+
+            int resolved = 0;
+            var modules = host.Services.GetServices<IMithrilModule>().ToList();
+            foreach (var m in modules)
+            {
+                host.Services.GetRequiredService(m.ViewType); resolved++;
+                if (m.SettingsViewType is not null)
+                {
+                    host.Services.GetRequiredService(m.SettingsViewType); resolved++;
+                }
+            }
+
+            // The roots Program resolves between "creating App" and "shell shown" —
+            // the exact window #359's cycle bit (IDeepLinkRouter pulls every handler).
+            _ = host.Services.GetRequiredService<IDeepLinkRouter>(); resolved++;
+            resolved += host.Services.GetServices<IDeepLinkHandler>().Count();
+            _ = host.Services.GetRequiredService<IModuleActivator>(); resolved++;
+            _ = host.Services.GetRequiredService<ShellWindow>(); resolved++;
+            var shellViewModel = host.Services.GetRequiredService<ShellViewModel>(); resolved++;
+            // Exercise the activation path too: post-Layer-3 this is where module
+            // ViewTypes resolve, so a cycle through ActivateModule is caught here.
+            shellViewModel.Initialize();
+
+            Console.Out.WriteLine(
+                $"selfcheck: OK - {modules.Count} modules, {resolved} roots resolved, no DI cycle.");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"selfcheck: FAIL - a startup root threw:\n{ex}");
+            return 1;
+        }
+    }
+
+    // Self-test cycle types (see MITHRIL_SELFCHECK_SELFTEST_CYCLE above). Mutually
+    // factory-resolving singletons — the re-entrant pathology #365 guards against.
+    private sealed class CycleA(CycleB b) { public CycleB B { get; } = b; }
+    private sealed class CycleB(CycleA a) { public CycleA A { get; } = a; }
+
+    private static bool ArgValue(string[] args, string name, out string? value)
+    {
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == name && i + 1 < args.Length) { value = args[i + 1]; return true; }
+            if (args[i].StartsWith(name + "=", StringComparison.Ordinal))
+            {
+                value = args[i][(name.Length + 1)..]; return true;
+            }
+        }
+        value = null;
+        return false;
+    }
+}

--- a/src/Mithril.Shell/ShellModuleActivator.cs
+++ b/src/Mithril.Shell/ShellModuleActivator.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Mithril.Shared.Modules;
 using Mithril.Shell.ViewModels;
 
@@ -8,18 +9,29 @@ namespace Mithril.Shell;
 /// the <see cref="ModuleEntry"/> for a module id and assigns it as <c>SelectedModule</c>, which
 /// triggers the normal activate flow (gate open, view resolution, settings persistence).
 /// </summary>
+/// <remarks>
+/// <see cref="ShellViewModel"/> is resolved <em>lazily</em>, not via constructor injection.
+/// Deep-link handlers (and anything else that pulls <see cref="IModuleActivator"/>) are
+/// constructed eagerly while the root provider is still building
+/// (<c>GetRequiredService&lt;IDeepLinkRouter&gt;</c> at startup); a hard ctor dependency on
+/// <see cref="ShellViewModel"/> turned any module→activator→shell edge into a re-entrant
+/// singleton-construction deadlock (#365, regression from #359). Resolving on first
+/// <see cref="Activate"/> instead means the shell is fully built and cached by the time this
+/// is ever called.
+/// </remarks>
 public sealed class ShellModuleActivator : IModuleActivator
 {
-    private readonly ShellViewModel _shell;
+    private readonly IServiceProvider _services;
 
-    public ShellModuleActivator(ShellViewModel shell) => _shell = shell;
+    public ShellModuleActivator(IServiceProvider services) => _services = services;
 
     public bool Activate(string moduleId)
     {
-        var entry = _shell.Modules.FirstOrDefault(e =>
+        var shell = _services.GetRequiredService<ShellViewModel>();
+        var entry = shell.Modules.FirstOrDefault(e =>
             string.Equals(e.Module.Id, moduleId, StringComparison.OrdinalIgnoreCase));
         if (entry is null) return false;
-        _shell.SelectedModule = entry;
+        shell.SelectedModule = entry;
         return true;
     }
 }

--- a/src/Mithril.Shell/ViewModels/ShellViewModel.cs
+++ b/src/Mithril.Shell/ViewModels/ShellViewModel.cs
@@ -87,9 +87,6 @@ public sealed partial class ShellViewModel : ObservableObject
         _perf = perf;
         _allModules = modules.OrderBy(m => m.SortOrder).ToList();
         RebuildVisibleModules();
-        var initial = Modules.FirstOrDefault(e => e.Module.Id == settings.ActiveModuleId)
-                      ?? Modules.FirstOrDefault();
-        if (initial is not null) ActivateModule(initial);
 
         _activeChar.ActiveCharacterChanged += (_, _) => DispatchRefreshCharacter();
         _activeChar.CharacterExportsChanged += (_, _) => DispatchRefreshCharacter();
@@ -108,6 +105,25 @@ public sealed partial class ShellViewModel : ObservableObject
         _gameClockTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
         _gameClockTimer.Tick += (_, _) => RefreshGameTime();
         _gameClockTimer.Start();
+    }
+
+    private bool _initialized;
+
+    /// <summary>
+    /// Activates the initial module (last-session <see cref="ShellSettings.ActiveModuleId"/>,
+    /// else the first). Deliberately <em>not</em> done in the constructor: activation resolves
+    /// a module's <c>ViewType</c> through the container, and if that graph transitively reaches
+    /// <see cref="ShellViewModel"/> again the singleton would be constructed re-entrantly and
+    /// deadlock the provider (#365). Call this once, from the shell bootstrap, <em>after</em>
+    /// the window is shown and this singleton is fully built and cached. Idempotent.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        _initialized = true;
+        var initial = Modules.FirstOrDefault(e => e.Module.Id == _settings.ActiveModuleId)
+                      ?? Modules.FirstOrDefault();
+        if (initial is not null) ActivateModule(initial);
     }
 
     private void RefreshGameTime()

--- a/tests/Mithril.Shell.Tests/Mithril.Shell.Tests.csproj
+++ b/tests/Mithril.Shell.Tests/Mithril.Shell.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.Shell.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <!--
+    Build-order/deploy only (ReferenceOutputAssembly=false): we never reference
+    shell/module APIs from the test — we launch the built Mithril.exe out of
+    process and assert its exit code. Referencing Mithril.Shell builds the
+    apphost; referencing every *.Module triggers Directory.Build.targets to
+    deploy all 12 module DLLs into the shell's bin/<cfg>/modules/, so the
+    self-check sees the real full-install graph (#365 Layer 2 guard).
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.Shell\Mithril.Shell.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Arwen.Module\Arwen.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Bilbo.Module\Bilbo.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Celebrimbor.Module\Celebrimbor.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Elrond.Module\Elrond.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Gandalf.Module\Gandalf.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Legolas.Module\Legolas.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Palantir.Module\Palantir.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Pippin.Module\Pippin.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Samwise.Module\Samwise.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Saruman.Module\Saruman.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Silmarillion.Module\Silmarillion.Module.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Smaug.Module\Smaug.Module.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/tests/Mithril.Shell.Tests/ShellSelfCheckGuardTests.cs
+++ b/tests/Mithril.Shell.Tests/ShellSelfCheckGuardTests.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Mithril.Shell.Tests;
+
+/// <summary>
+/// #365 Layer 2 guard. Launches the built <c>Mithril.exe --selfcheck</c> out of
+/// process: it composes the <em>real</em> 12-module shell DI graph and resolves
+/// every startup root under a hard watchdog (no hosted services / CDN). A
+/// re-entrant factory-lambda cycle (#359's pathology) does not throw — it hangs —
+/// so the contract is exit code, not an exception:
+/// <list type="bullet">
+/// <item><c>0</c> — full graph resolved, no cycle (the regression guard).</item>
+/// <item><c>2</c> — watchdog timeout, i.e. the silent-deadlock signature.</item>
+/// </list>
+/// Out-of-process isolation is deliberate: it sandboxes the WPF
+/// <c>Application</c> singleton / STA teardown and makes a hang hard-killable
+/// instead of wedging the test runner.
+/// </summary>
+[Trait("Category", "Integration")]
+public class ShellSelfCheckGuardTests
+{
+    private const string Config =
+#if DEBUG
+        "Debug";
+#else
+        "Release";
+#endif
+
+    private static string ShellExePath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mithril.slnx")))
+            dir = dir.Parent;
+        dir.Should().NotBeNull("the test must run inside the repo tree (Mithril.slnx not found walking up)");
+        var exe = Path.Combine(dir!.FullName, "src", "Mithril.Shell", "bin", Config,
+            "net10.0-windows", "Mithril.exe");
+        File.Exists(exe).Should().BeTrue(
+            $"the solution must be built before this test ({exe} missing — run `dotnet build Mithril.slnx`)");
+        return exe;
+    }
+
+    private static (int ExitCode, string Output) RunSelfCheck(
+        int selfCheckTimeoutSeconds, int waitMs, (string, string)? env = null)
+    {
+        var psi = new ProcessStartInfo(ShellExePath())
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("--selfcheck");
+        psi.ArgumentList.Add("--selfcheck-timeout-seconds");
+        psi.ArgumentList.Add(selfCheckTimeoutSeconds.ToString());
+        if (env is { } e) psi.Environment[e.Item1] = e.Item2;
+
+        using var p = Process.Start(psi)!;
+        var sb = new StringBuilder();
+        p.OutputDataReceived += (_, a) => { if (a.Data is not null) sb.AppendLine(a.Data); };
+        p.ErrorDataReceived += (_, a) => { if (a.Data is not null) sb.AppendLine(a.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+
+        if (!p.WaitForExit(waitMs))
+        {
+            try { p.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new Xunit.Sdk.XunitException(
+                $"selfcheck process did not exit within {waitMs}ms even though its own watchdog " +
+                $"was {selfCheckTimeoutSeconds}s — the watchdog itself failed to fire.\n{sb}");
+        }
+        p.WaitForExit(); // flush async readers
+        return (p.ExitCode, sb.ToString());
+    }
+
+    [Fact]
+    public void Real_full_module_graph_resolves_with_no_DI_cycle()
+    {
+        var (exit, output) = RunSelfCheck(selfCheckTimeoutSeconds: 120, waitMs: 200_000);
+
+        exit.Should().Be(0,
+            $"the full shell DI graph must resolve every startup root without a re-entrant " +
+            $"cycle (#365). Exit 2 = silent deadlock, 1 = a root threw.\n--- selfcheck output ---\n{output}");
+        output.Should().Contain("no DI cycle");
+    }
+
+    [Fact]
+    public void Watchdog_trips_on_a_re_entrant_factory_cycle()
+    {
+        // Guard-of-the-guard: an injected mutually-factory-resolving singleton pair
+        // (the exact #365 shape) must make the watchdog fire with exit 2 — proving
+        // the guard detects the pathology, not merely that a clean graph passes.
+        var (exit, output) = RunSelfCheck(
+            selfCheckTimeoutSeconds: 25, waitMs: 90_000,
+            env: ("MITHRIL_SELFCHECK_SELFTEST_CYCLE", "1"));
+
+        exit.Should().Be(2,
+            $"an injected re-entrant factory cycle must trip the watchdog (exit 2), not pass " +
+            $"or throw.\n--- selfcheck output ---\n{output}");
+    }
+}


### PR DESCRIPTION
Closes #365 (hardening; the live breakage was hotfixed by #366).

## Context

#359 introduced a re-entrant DI resolution cycle (`IDeepLinkRouter` → Elrond handler → `SkillAdvisorViewModel` → `ICraftListImportTarget` → `IModuleActivator` → `ShellModuleActivator(ShellViewModel)` → `ShellViewModel..ctor` eager `ActivateModule` → resolves Elrond view → … ∞). `ShellViewModel` is a singleton cached only *after* its ctor returns, so the ctor re-enters resolution of the not-yet-cached singleton; MS.DI's `StackGuard` offloads the unbounded recursion and blocks on `WaitOne` forever — **no exception, no crash log, silent UI-thread deadlock**. Full installs (12 modules) couldn't launch. #366 removed the one offending edge; this PR hardens the *class*.

## The three layers

**Layer 1 — already in place.** Program.cs already sets `ValidateOnBuild = true, ValidateScopes = true`. It did **not** catch #359 because `ValidateOnBuild` builds call-site graphs through *constructors* only; a `FactoryCallSite` (`AddSingleton<T>(sp => …)`) is opaque to it and never invoked at `Build()`. Every module wires via factory lambdas, so it's structurally blind to this class. No code change — documented so nobody trusts it to catch factory cycles.

**Layer 2 — the regression net (`e452cb2`).** A process-isolated headless boot:
- Program's registration chain extracted into one shared `ShellComposition.AddMithrilShell(ShellCompositionOptions)` — single source of truth; Program and the guard compose **identically** so the guard validates exactly what ships (no drift). Behaviour-identical refactor.
- `--selfcheck`: composes the real 12-module graph, builds the provider (same options), creates `App` for resources, resolves **every startup root** (all `IDeepLinkHandler`/`IDeepLinkRouter`/`IModuleActivator`/each module `ViewType`+`SettingsViewType`/`ShellWindow`/`ShellViewModel`+`Initialize()`). Does **not** `StartAsync` — no hosted services, no CDN, ~15s, deterministic, network-free. A cycle hangs (doesn't throw), so a hard wall-clock watchdog on a separate thread hard-exits the process: `0` clean / `1` a root threw / `2` watchdog timeout (the silent-deadlock signature). An env-gated self-test injects the exact re-entrant factory shape to prove the watchdog *detects*, not just that a clean graph passes.
- `tests/Mithril.Shell.Tests` launches the built `Mithril.exe --selfcheck` out of process (sandboxes the WPF `Application` singleton/STA; a hang is hard-killable, never wedges the runner). Runs under the existing `dotnet test Mithril.slnx` release gate, so a shell that would deadlock at boot now **fails the release** instead of shipping.

**Layer 3 — defuse the footgun (`8deacf9`).** Both (a) and (b):
- (a) `ShellModuleActivator` resolves `ShellViewModel` lazily via `IServiceProvider` instead of a hard ctor dependency — eagerly-constructed deep-link handlers no longer drag the shell VM into a still-building provider.
- (b) `ShellViewModel`'s initial `ActivateModule` moves out of the ctor into an idempotent `Initialize()` invoked after `shell.Show()` — the ctor resolves no module `ViewType`.

Together a stray cross-module → `ShellViewModel` edge degrades to a slightly-late resolution instead of a silent provider deadlock. Behaviour unchanged: same initial module/order; perf-trace auto-start still precedes the first `ActivateModule`.

## Verification

- `dotnet build Mithril.slnx` clean (warnings-as-errors).
- Full `dotnet test Mithril.slnx` **0 failed** — Mithril.Shared 1009, Silmarillion 452, Gandalf 331, … + new Mithril.Shell.Tests **2/2** (~36s). No Layer-3 regressions.
- Guard proven both ways: clean 12-module graph → `selfcheck: OK - 12 modules, 32 roots resolved` (exit 0); injected re-entrant factory cycle → watchdog → exit 2 with the diagnostic.
- Live 12-module launch: `creating App → resolving ShellWindow → shell shown → === startup done ===` (the final marker is logged *after* `Initialize()`, proving initial activation completed post-`Show()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

