### PR TITLE
feat(reference): ordinal, display-decorated FavorTier for StoreCapIncrease.Tier (closes #368)

### DIFF
--- a/docs/query-system.md
+++ b/docs/query-system.md
@@ -284,6 +284,22 @@ warnings, …)`) is plumbed but not yet surfaced in the UI. Rationale, the
 A-vs-B decision, and the per-hierarchy narrowing contract are in
 [`query-quantified-subqueries.md`](query-quantified-subqueries.md).
 
+### Ordinal enum columns (e.g. favor `Tier`)
+
+Enum-typed columns compare **by the enum's underlying value, not its name** — the
+engine coerces a quoted literal via case-insensitive name match and then compares
+ordinally. So a rank-encoded enum is queryable with the full operator set, no
+special-casing: `StoreCapIncrease.Tier` is `FavorTier` (a Neutral-centred signed
+rank — `Despised −4 … Tolerated −1, Neutral 0 … SoulMates +6`), so
+`CapIncreases WITH ANY (Tier >= 'Friends')` means *Friends-or-better by favor
+rank* (not string ≥), and `=`, `BETWEEN`, etc. work the same way. The literal is
+the raw token (`'CloseFriends'`), not the friendly label. Display surfaces use the
+curated `FavorTier.DisplayName()` ("Close Friends") because every tier token is
+**absent from the game's `strings_all.json`** — there is no upstream string to
+resolve through, so the map is deliberately curated rather than CamelCase-split.
+(Favor-tier model convergence across modules is tracked separately — see issue
+#370; this is the narrow query-facing slice.)
+
 ### Schema is reflected, not declared
 
 `QueryableSource<T>()` and `QueryFilter` both reflect over the item type's

--- a/src/Mithril.Reference/Models/Npcs/FavorTier.cs
+++ b/src/Mithril.Reference/Models/Npcs/FavorTier.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace Mithril.Reference.Models.Npcs;
+
+/// <summary>
+/// An NPC favor tier, as a <strong>Neutral-centred signed rank</strong> — PG models
+/// favor as a signed point scale around Neutral (you <em>lose</em> favor below it),
+/// so the underlying values double as the ordinal rank: a higher value is strictly
+/// better favor. This makes the query engine compare it correctly with no engine
+/// changes (it already coerces enum literals by name and compares enums by
+/// underlying value), so <c>CapIncreases WITH ANY (Tier &gt;= 'Friends')</c> works.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ordering is floor-grounded (real favor-point thresholds): <c>Tolerated</c> sits
+/// <em>below</em> <c>Neutral</c>. Spelling matches the reference-data token exactly
+/// (<c>Hated</c>, not <c>Hatred</c>), so <see cref="ToToken"/> round-trips and a
+/// member maps 1:1 to what <c>npcs.json</c> emits. Every real PG tier is a named
+/// member — this is not a sentinel-bearing string; <see cref="Unknown"/> is the
+/// <em>only</em> not-a-real-tier value and sorts strictly below every real tier
+/// (and is distinct from <see cref="Tolerated"/> = −1).
+/// </para>
+/// <para>
+/// This type is deliberately local to the reference model (issue #368, narrow
+/// scope). Smaug's <c>FavorTierName</c> and Arwen's <c>FavorTier</c> model the same
+/// ladder with their own (divergent, partly-buggy) spelling/order — converging all
+/// three onto one canonical type is tracked by the umbrella #370 (with the Smaug
+/// order bug #371 and Arwen spelling bug #372). Do not "fix" them from here.
+/// </para>
+/// </remarks>
+public enum FavorTier
+{
+    /// <summary>Token absent or not a known tier. Sorts below every real tier;
+    /// never equals a real rank.</summary>
+    Unknown = int.MinValue,
+
+    Despised = -4,
+    Hated = -3,
+    Disliked = -2,
+    Tolerated = -1,
+    Neutral = 0,
+    Comfortable = 1,
+    Friends = 2,
+    CloseFriends = 3,
+    BestFriends = 4,
+    LikeFamily = 5,
+    SoulMates = 6,
+}
+
+/// <summary>Parsing / display / round-trip helpers for <see cref="FavorTier"/>.</summary>
+public static class FavorTierExtensions
+{
+    /// <summary>
+    /// Maps a raw reference-data tier token (e.g. <c>"LikeFamily"</c>) to a
+    /// <see cref="FavorTier"/>. Case-insensitive. Blank or unrecognised → <see
+    /// cref="FavorTier.Unknown"/> (never throws). A numeric string is rejected
+    /// (so a stray <c>"-4"</c> does not silently become <c>Despised</c>).
+    /// </summary>
+    public static FavorTier Parse(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token)) return FavorTier.Unknown;
+        if (Enum.TryParse<FavorTier>(token, ignoreCase: true, out var t)
+            && Enum.IsDefined(t)
+            && !char.IsDigit(token[0]) && token[0] != '-')
+        {
+            return t;
+        }
+        return FavorTier.Unknown;
+    }
+
+    /// <summary>
+    /// The exact reference-data token for a tier (the enum member name;
+    /// <see cref="FavorTier.Unknown"/> → <c>"Unknown"</c>). Lets string-keyed
+    /// consumers (e.g. Smaug's existing <c>FavorTierName.RankOf</c>) keep working
+    /// unchanged against a typed value — preserving their semantics verbatim.
+    /// </summary>
+    public static string ToToken(this FavorTier tier) => tier.ToString();
+
+    /// <summary>
+    /// Human-friendly label. Curated because <em>every</em> tier token is absent
+    /// from the game's <c>strings_all.json</c> (verified) — there is no upstream
+    /// localization to resolve through, so this map is the source of truth.
+    /// </summary>
+    public static string DisplayName(this FavorTier tier) => tier switch
+    {
+        FavorTier.CloseFriends => "Close Friends",
+        FavorTier.BestFriends => "Best Friends",
+        FavorTier.LikeFamily => "Like Family",
+        FavorTier.SoulMates => "Soul Mates",
+        FavorTier.Unknown => "Unknown",
+        _ => tier.ToString(),
+    };
+}

--- a/src/Mithril.Reference/Models/Npcs/StoreCapIncrease.cs
+++ b/src/Mithril.Reference/Models/Npcs/StoreCapIncrease.cs
@@ -9,8 +9,11 @@ namespace Mithril.Reference.Models.Npcs;
 /// absent or empty, meaning the cap applies to any item.
 /// </summary>
 /// <param name="Tier">
-/// The favor tier at which <em>this gold-cap row</em> unlocks (e.g. <c>"Despised"</c>,
-/// <c>"Neutral"</c>). Kept verbatim — <c>"Despised"</c> is a real tier, not a sentinel.
+/// The favor tier at which <em>this gold-cap row</em> unlocks, as the ordinal
+/// <see cref="FavorTier"/> (every real tier — incl. <c>Despised</c> — is a named
+/// member; an unrecognised token parses to <see cref="FavorTier.Unknown"/>, never a
+/// silent sentinel). Ordinal so the query engine answers <c>Tier &gt;= 'Friends'</c>;
+/// the raw token still round-trips via <see cref="FavorTierExtensions.ToToken"/>.
 /// Distinct from <see cref="NpcService.Favor"/>, which gates access to the Store
 /// service itself; this is the per-row cap-unlock threshold.
 /// </param>
@@ -22,6 +25,6 @@ namespace Mithril.Reference.Models.Npcs;
 /// Item keyword tags this cap applies to; an empty list means the cap applies to any item.
 /// </param>
 public sealed record StoreCapIncrease(
-    string Tier,
+    FavorTier Tier,
     int? GoldCap,
     IReadOnlyList<string> Keywords);

--- a/src/Mithril.Reference/Models/Npcs/StoreCapIncreaseParser.cs
+++ b/src/Mithril.Reference/Models/Npcs/StoreCapIncreaseParser.cs
@@ -26,7 +26,7 @@ public static class StoreCapIncreaseParser
         var keywords = parts.Length == 3 && !string.IsNullOrWhiteSpace(parts[2])
             ? (IReadOnlyList<string>)parts[2].Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
             : [];
-        return new StoreCapIncrease(parts[0], gold, keywords);
+        return new StoreCapIncrease(FavorTierExtensions.Parse(parts[0]), gold, keywords);
     }
 
     /// <summary>

--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -312,7 +312,7 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     private NpcServiceDetailLine FormatCapIncrease(StoreCapIncrease cap)
     {
         var gold = cap.GoldCap is { } g ? g.ToString("N0") + "g" : "—";
-        var prose = $"{cap.Tier} → {gold}";
+        var prose = $"{cap.Tier.DisplayName()} → {gold}";
         if (cap.Keywords.Count == 0)
             return NpcServiceDetailLine.TextOnly(prose);
         return new NpcServiceDetailLine(prose, BuildKeywordChips(cap.Keywords));

--- a/src/Smaug.Module/Domain/FavorTierName.cs
+++ b/src/Smaug.Module/Domain/FavorTierName.cs
@@ -1,3 +1,5 @@
+using Mithril.Reference.Models.Npcs;
+
 namespace Smaug.Domain;
 
 /// <summary>
@@ -36,4 +38,15 @@ public static class FavorTierName
 
     public static bool IsAtLeast(string? current, string? required) =>
         RankOf(current) >= RankOf(required);
+
+    /// <summary>
+    /// Rank a typed <see cref="FavorTier"/> on <em>this</em> ladder by round-tripping
+    /// through its reference-data token. Deliberately delegates to the string
+    /// <see cref="RankOf(string?)"/> so Smaug's existing (currently mis-ordered, see
+    /// #371) <see cref="Ordered"/> semantics are preserved byte-identically — the
+    /// #368 type change must not shift vendor pricing. <see cref="FavorTier.Unknown"/>
+    /// → token "Unknown" → not in <see cref="Ordered"/> → -1, exactly as an
+    /// unrecognised raw string was before.
+    /// </summary>
+    public static int RankOf(FavorTier tier) => RankOf(tier.ToToken());
 }

--- a/tests/Mithril.Reference.Tests/FavorTierTests.cs
+++ b/tests/Mithril.Reference.Tests/FavorTierTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Reference.Models.Npcs;
+using Xunit;
+
+namespace Mithril.Reference.Tests;
+
+/// <summary>
+/// #368: the narrow, correct favor-tier model used by <see cref="StoreCapIncrease.Tier"/>.
+/// Locks the floor-grounded Neutral-centred ordering, the curated display strings
+/// (every token is absent from <c>strings_all.json</c>), and the <see
+/// cref="FavorTier.Unknown"/> sentinel that must never collide with a real rank.
+/// </summary>
+public class FavorTierTests
+{
+    private static readonly FavorTier[] RealTiers =
+    [
+        FavorTier.Despised, FavorTier.Hated, FavorTier.Disliked, FavorTier.Tolerated,
+        FavorTier.Neutral, FavorTier.Comfortable, FavorTier.Friends, FavorTier.CloseFriends,
+        FavorTier.BestFriends, FavorTier.LikeFamily, FavorTier.SoulMates,
+    ];
+
+    [Fact]
+    public void Neutral_is_zero_and_order_is_floor_grounded()
+    {
+        ((int)FavorTier.Neutral).Should().Be(0);
+        // The schism fix: Tolerated sits BELOW Neutral (real favor floor -100 < 0),
+        // unlike Smaug's mis-ordered ladder (#371).
+        ((int)FavorTier.Tolerated).Should().BeLessThan((int)FavorTier.Neutral);
+        // Strictly ascending in declared favor order.
+        RealTiers.Select(t => (int)t).Should().BeInAscendingOrder()
+            .And.OnlyHaveUniqueItems();
+        ((int)FavorTier.Despised).Should().Be(-4);
+        ((int)FavorTier.SoulMates).Should().Be(6);
+    }
+
+    [Fact]
+    public void Unknown_sorts_below_every_real_tier_and_collides_with_none()
+    {
+        foreach (var t in RealTiers)
+            ((int)FavorTier.Unknown).Should().BeLessThan((int)t);
+        // Distinct from Tolerated (-1) — the bug the sentinel-fix guards against.
+        ((int)FavorTier.Unknown).Should().NotBe((int)FavorTier.Tolerated);
+        ((int)FavorTier.Unknown).Should().Be(int.MinValue);
+    }
+
+    [Theory]
+    [InlineData("Despised", FavorTier.Despised)]
+    [InlineData("Hated", FavorTier.Hated)]          // data token is "Hated", not "Hatred"
+    [InlineData("likefamily", FavorTier.LikeFamily)] // case-insensitive
+    [InlineData("SoulMates", FavorTier.SoulMates)]
+    public void Parse_maps_real_tokens(string token, FavorTier expected) =>
+        FavorTierExtensions.Parse(token).Should().Be(expected);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Hatred")]   // Arwen's misspelling (#372) is NOT accepted here
+    [InlineData("Nonsense")]
+    [InlineData("-4")]       // numeric must not backdoor into Despised
+    [InlineData("3")]
+    public void Parse_unrecognised_is_Unknown(string? token) =>
+        FavorTierExtensions.Parse(token).Should().Be(FavorTier.Unknown);
+
+    [Fact]
+    public void Every_real_tier_round_trips_token_and_parse()
+    {
+        foreach (var t in RealTiers)
+            FavorTierExtensions.Parse(t.ToToken()).Should().Be(t);
+    }
+
+    [Fact]
+    public void Every_tier_has_a_non_empty_display_string()
+    {
+        // strings_all.json has no entry for any tier (verified), so the curated map
+        // is the only source — none may be blank.
+        foreach (FavorTier t in Enum.GetValues<FavorTier>())
+            t.DisplayName().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData(FavorTier.CloseFriends, "Close Friends")]
+    [InlineData(FavorTier.BestFriends, "Best Friends")]
+    [InlineData(FavorTier.LikeFamily, "Like Family")]
+    [InlineData(FavorTier.SoulMates, "Soul Mates")]
+    [InlineData(FavorTier.Despised, "Despised")]
+    [InlineData(FavorTier.Friends, "Friends")]
+    public void DisplayName_splits_only_the_compound_tokens(FavorTier t, string expected) =>
+        t.DisplayName().Should().Be(expected);
+}

--- a/tests/Mithril.Reference.Tests/StoreCapIncreaseParserTests.cs
+++ b/tests/Mithril.Reference.Tests/StoreCapIncreaseParserTests.cs
@@ -21,7 +21,7 @@ public class StoreCapIncreaseParserTests
         var cap = StoreCapIncreaseParser.ParseLine("Despised:5000:Armor,Weapon,CorpseTrophy");
 
         cap.Should().NotBeNull();
-        cap!.Tier.Should().Be("Despised");
+        cap!.Tier.Should().Be(FavorTier.Despised);
         cap.GoldCap.Should().Be(5000);
         cap.Keywords.Should().Equal("Armor", "Weapon", "CorpseTrophy");
     }
@@ -32,7 +32,7 @@ public class StoreCapIncreaseParserTests
         var cap = StoreCapIncreaseParser.ParseLine("Friends:1000");
 
         cap.Should().NotBeNull();
-        cap!.Tier.Should().Be("Friends");
+        cap!.Tier.Should().Be(FavorTier.Friends);
         cap.GoldCap.Should().Be(1000);
         cap.Keywords.Should().BeEmpty();
     }
@@ -60,7 +60,7 @@ public class StoreCapIncreaseParserTests
         var cap = StoreCapIncreaseParser.ParseLine("Friends:notanumber:Armor");
 
         cap.Should().NotBeNull();
-        cap!.Tier.Should().Be("Friends");
+        cap!.Tier.Should().Be(FavorTier.Friends);
         cap.GoldCap.Should().BeNull();
         cap.Keywords.Should().Equal("Armor");
     }
@@ -83,7 +83,7 @@ public class StoreCapIncreaseParserTests
 
         var parsed = StoreCapIncreaseParser.Parse(raw);
 
-        parsed.Select(c => c.Tier).Should().Equal("Despised", "Friends");
+        parsed.Select(c => c.Tier).Should().Equal(FavorTier.Despised, FavorTier.Friends);
         parsed[1].GoldCap.Should().BeNull();
     }
 
@@ -96,7 +96,7 @@ public class StoreCapIncreaseParserTests
         var parsed = StoreCapIncreaseParser.ParseRequiringGold(raw);
 
         parsed.Should().ContainSingle();
-        parsed[0].Tier.Should().Be("Despised");
+        parsed[0].Tier.Should().Be(FavorTier.Despised);
         parsed[0].GoldCap.Should().Be(5000);
     }
 

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -834,7 +834,7 @@ public sealed class NpcsTabViewModelTests
         var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
 
         var caps = vm.AllNpcs.Single().CapIncreases;
-        caps.Select(c => c.Tier).Should().Equal("Friends", "Comfortable", "Despised");
+        caps.Select(c => c.Tier).Should().Equal(FavorTier.Friends, FavorTier.Comfortable, FavorTier.Despised);
         caps.Select(c => c.GoldCap).Should().Equal(5000, 50000, 200000);
         caps[0].Keywords.Should().Equal("Armor", "Weapon");
         caps[1].Keywords.Should().BeEmpty();
@@ -891,6 +891,42 @@ public sealed class NpcsTabViewModelTests
         var matches = vm.AllNpcs.Where(r => predicate!(r)).Select(r => r.InternalName).ToList();
         matches.Should().BeEquivalentTo(["NPC_Match"]);
     }
+
+    [Fact]
+    public void QueryText_CapIncreasesWithAny_TierIsOrdinal_FriendsOrBetter()
+    {
+        // #368: Tier is now FavorTier (ordinal). "Friends or better" must filter by
+        // favor RANK, not string equality/alphabetical — Comfortable (below Friends)
+        // is excluded; CloseFriends (above) is included.
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                ["NPC_Friends"] = StoreNpc("Friends", "Friends:5000:Armor"),
+                ["NPC_Closer"] = StoreNpc("Closer", "CloseFriends:5000:Armor"),
+                ["NPC_TooLow"] = StoreNpc("TooLow", "Comfortable:5000:Armor"),
+                ["NPC_WayLow"] = StoreNpc("WayLow", "Despised:5000:Armor"),
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(NpcListRow));
+        var predicate = QueryCompiler.Compile(
+            "CapIncreases WITH ANY (Tier >= 'Friends')", columns);
+        predicate.Should().NotBeNull();
+
+        vm.AllNpcs.Where(r => predicate!(r)).Select(r => r.InternalName)
+            .Should().BeEquivalentTo(["NPC_Friends", "NPC_Closer"]);
+    }
+
+    private static Npc StoreNpc(string name, params string[] capIncreases) => new()
+    {
+        Name = name,
+        Services = new NpcServicePoco[]
+        {
+            new NpcStoreServicePoco { Type = "Store", CapIncreases = capIncreases },
+        },
+    };
 
     private sealed class StubReferenceData : IReferenceDataService
     {

--- a/tests/Smaug.Tests/FavorTierNameParityTests.cs
+++ b/tests/Smaug.Tests/FavorTierNameParityTests.cs
@@ -1,0 +1,45 @@
+using System;
+using FluentAssertions;
+using Mithril.Reference.Models.Npcs;
+using Smaug.Domain;
+using Xunit;
+
+namespace Smaug.Tests;
+
+/// <summary>
+/// Parity lock for #368: <see cref="StoreCapIncrease.Tier"/> became a typed
+/// <see cref="FavorTier"/>, so Smaug now ranks it via the new
+/// <see cref="FavorTierName.RankOf(FavorTier)"/> overload. That overload MUST be
+/// byte-identical to the old raw-string path against Smaug's existing
+/// <see cref="FavorTierName.Ordered"/> ladder — the (separately tracked, #371)
+/// mis-order is intentionally preserved here so vendor pricing does not shift.
+/// </summary>
+public sealed class FavorTierNameParityTests
+{
+    [Fact]
+    public void RankOf_typed_equals_RankOf_token_for_every_tier()
+    {
+        foreach (FavorTier t in Enum.GetValues<FavorTier>())
+            FavorTierName.RankOf(t).Should().Be(FavorTierName.RankOf(t.ToToken()),
+                $"the typed overload must delegate to the string ladder for {t}");
+    }
+
+    [Fact]
+    public void Unknown_ranks_as_the_legacy_unrecognised_sentinel()
+    {
+        // Pre-#368 an unparseable raw cap tier string yielded RankOf == -1
+        // ("sorts before Despised"); FavorTier.Unknown must reproduce that exactly.
+        FavorTierName.RankOf(FavorTier.Unknown).Should().Be(-1);
+        FavorTierName.RankOf(FavorTier.Unknown)
+            .Should().Be(FavorTierName.RankOf("definitely-not-a-tier"));
+    }
+
+    [Fact]
+    public void Known_tiers_resolve_on_the_existing_ladder()
+    {
+        // Spelling round-trips into Smaug's Ordered list (esp. "Hated", which Arwen
+        // mis-spells — see #372): a real tier never falls through to -1.
+        foreach (var name in FavorTierName.Ordered)
+            FavorTierName.RankOf(FavorTierExtensions.Parse(name)).Should().BeGreaterThanOrEqualTo(0);
+    }
+}


### PR DESCRIPTION
Closes #368 (narrow slice of the favor-tier reconciliation umbrella #370). Does **not** touch Smaug/Arwen semantics — the Smaug order bug (#371) and Arwen spelling bug (#372) are separate children of #370.

## What & why

The #349 originating question is *"…at a tier…"*, which naturally means *that tier or better*. `StoreCapIncrease.Tier` was a plain `string`, and the query engine compiles string columns as equality/LIKE/CONTAINS only — so `CapIncreases WITH ANY (Tier >= 'Friends')` was inexpressible (and string `>` would be alphabetical nonsense). The tier tokens are also entirely absent from the game's `strings_all.json` (verified manually + CDN `v470`), so there's no upstream localization to resolve through.

## Approach — engine-free

The query engine already coerces enum literals by name (case-insensitive) and compares enums **by underlying value**. So `Tier` becomes a `FavorTier` **enum** whose underlying values *are* a **Neutral-centred signed rank**, and ordinal `Tier >= 'Friends'` works with **zero query-engine changes**.

| Tier | Rank | | Tier | Rank |
|---|---|---|---|---|
| Despised | −4 | | Comfortable | +1 |
| Hated | −3 | | Friends | +2 |
| Disliked | −2 | | CloseFriends | +3 |
| Tolerated | −1 | | BestFriends | +4 |
| Neutral | 0 | | LikeFamily | +5 |
| | | | SoulMates | +6 |
| Unknown | `int.MinValue` | | | |

Order is **floor-grounded** (from Arwen's real favor-point thresholds — the authority for ordering; `Tolerated −1 < Neutral 0`, *correcting* the Smaug/earlier-draft mis-order). Spelling is the data token `Hated`. `Unknown = int.MinValue` so an unrecognised token can never collide with a real rank (the sentinel-fix the umbrella calls out).

## Scope discipline / parity

- New `FavorTier` + `FavorTierExtensions` (`Parse`, `ToToken`, curated `DisplayName`) in **`Mithril.Reference`** (leaf, where `StoreCapIncrease` lives).
- `StoreCapIncrease.Tier`: `string → FavorTier`; parser maps the token; Silmarillion prose uses `DisplayName()` ("Like Family → 5,000g").
- **Smaug untouched semantically**: one additive `FavorTierName.RankOf(FavorTier)` overload delegating to the existing string ladder via `ToToken`, so Smaug's current (mis-ordered, #371) `Ordered` behaviour is preserved **byte-identically** — vendor pricing cannot shift. New `FavorTierNameParityTests` lock `RankOf(typed) == RankOf(token)` for every tier and `Unknown == -1` (the legacy unrecognised sentinel).
- `docs/query-system.md`: new "Ordinal enum columns" section + the curated-display rationale (strings_all gap), pointing at #370 for the broader convergence.

## Verification

- `dotnet build Mithril.slnx` clean (warnings-as-errors).
- Full `dotnet test Mithril.slnx` **0 failed** — Mithril.Reference 67 (incl. new `FavorTierTests` + retyped parser tests), **Smaug 28 (parity unchanged)**, Silmarillion 453 (incl. new ordinal `Tier >= 'Friends'` filters by rank not string), Mithril.Shared 1009, Mithril.Shell DI guard 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
