### PR TITLE
feat(query): collection cardinality — IS [NOT] EMPTY + WITH NONE (closes #375)

### DIFF
--- a/docs/query-system.md
+++ b/docs/query-system.md
@@ -22,11 +22,13 @@ Name CONTAINS 'fire' / STARTSWITH 'X'        — substring helpers (friendlier t
 Power IN (10, 20, 30)                        — set membership
 Cost BETWEEN 5 AND 15                        — inclusive range
 MinLevel IS NULL / IS NOT NULL               — null check
+Keywords IS EMPTY / IS NOT EMPTY             — collection cardinality (null counts as empty)
 avg > 1m30s                                  — duration literals: 30s, 1m30s, 2h, 150ms
 Timestamp BEFORE NOW()                       — English-aliased <, >; NOW() and TODAY() functions
 NOT LIKE / NOT IN / NOT BETWEEN              — negation prefix
 Services WITH ANY (Type='Store' AND Favor='Friends')   — quantified subquery over an object collection
 Reqs WITH ALL (T='MinSkillLevel')            — ANY = ≥1 element; ALL = every element (vacuously true if empty)
+Reqs WITH NONE (T='MinSkillLevel')           — NONE = no element matches (≡ NOT(WITH ANY); vacuously true if empty)
 ORDER BY Cost DESC, Name                     — sort clause (SORT BY also accepted; ASC implicit)
 ```
 
@@ -283,6 +285,27 @@ soft-warning channel (`QueryCompiler.Compile(…, ICollection<QueryDiagnostic>
 warnings, …)`) is plumbed but not yet surfaced in the UI. Rationale, the
 A-vs-B decision, and the per-hierarchy narrowing contract are in
 [`query-quantified-subqueries.md`](query-quantified-subqueries.md).
+
+### Collection cardinality — `IS [NOT] EMPTY`, `WITH NONE`
+
+`<col> IS EMPTY` / `IS NOT EMPTY` tests a *collection* column's cardinality
+(any collection: string, `IQueryStringValue`, or object). A **null** collection
+counts as empty — it contains nothing, consistent with `CONTAINS`-over-null.
+It's a compile error on a non-collection column (use `IS NULL` / `= ''` for
+scalars). Because it's an ordinary leaf predicate it composes inside a
+quantifier element schema — e.g. *Store NPCs with a cap row that applies to any
+item* (empty keyword list):
+
+```
+ServiceTypes CONTAINS 'Store' AND CapIncreases WITH ANY (Keywords IS EMPTY)
+```
+
+`<col> WITH NONE (<pred>)` completes the `ANY`/`ALL`/`NONE` quantifier trio:
+true when *no* element satisfies `<pred>` — exactly `NOT (col WITH ANY (<pred>))`,
+including vacuously true over an empty or null collection. There is no
+`COUNT()` / arbitrary-cardinality operator by design (deliberately deferred —
+`IS EMPTY` covers the empty-vs-populated case without a function-expression
+grammar).
 
 ### Ordinal enum columns (e.g. favor `Tier`)
 

--- a/src/Mithril.Shared.Wpf/Query/QueryAst.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryAst.cs
@@ -45,10 +45,24 @@ public sealed record BetweenNode(string Column, ValueNode Low, ValueNode High, b
 
 public sealed record IsNullNode(string Column, bool Negated) : QueryNode;
 
+/// <summary>
+/// Collection cardinality test: <c>&lt;Column&gt; IS EMPTY</c> /
+/// <c>&lt;Column&gt; IS NOT EMPTY</c> (<see cref="Negated"/> = the NOT form).
+/// Distinct from <see cref="IsNullNode"/>: a non-null but zero-element collection
+/// is empty, and a <see langword="null"/> collection also counts as empty (it
+/// contains nothing — consistent with <c>CONTAINS</c>-over-null).
+/// </summary>
+public sealed record IsEmptyNode(string Column, bool Negated) : QueryNode;
+
 public enum Quantifier
 {
     Any,
     All,
+
+    /// <summary><c>WITH NONE</c> — no element satisfies the inner predicate.
+    /// Equivalent to <c>NOT (col WITH ANY (...))</c>; vacuously true over an
+    /// empty or null collection.</summary>
+    None,
 }
 
 /// <summary>

--- a/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompiler.cs
@@ -108,6 +108,8 @@ public static class QueryCompiler
                 return CompileBetween(b, columns);
             case IsNullNode n:
                 return CompileIsNull(n, columns);
+            case IsEmptyNode e:
+                return CompileIsEmpty(e, columns);
             case QuantifiedNode q:
                 return CompileQuantified(q, columns, caseSensitive, warnings);
             default:
@@ -369,12 +371,16 @@ public static class QueryCompiler
 
         var elementPredicate = CompileNode(node.Inner, subSchema, caseSensitive, warnings);
         bool isAll = node.Quantifier == Quantifier.All;
+        bool isNone = node.Quantifier == Quantifier.None;
 
         return item =>
         {
             if (col.GetValue(item) is not System.Collections.IEnumerable seq)
             {
-                return false;
+                // null / non-enumerable: ANY = false, ALL = false (the
+                // CONTAINS-over-null convention, #351), NONE = true (nothing
+                // matches → equivalent to NOT (col WITH ANY (...))).
+                return isNone;
             }
             bool sawAny = false;
             bool allMatch = true;
@@ -397,6 +403,7 @@ public static class QueryCompiler
                     if (isAll) break;
                 }
             }
+            if (isNone) return !anyMatch;
             return isAll ? (!sawAny || allMatch) : (sawAny && anyMatch);
         };
     }
@@ -596,6 +603,7 @@ public static class QueryCompiler
                 case InNode i: foreach (var p in Emit(i.Column)) yield return p; break;
                 case BetweenNode b: foreach (var p in Emit(b.Column)) yield return p; break;
                 case IsNullNode isn: foreach (var p in Emit(isn.Column)) yield return p; break;
+                case IsEmptyNode ise: foreach (var p in Emit(ise.Column)) yield return p; break;
             }
         }
 
@@ -766,6 +774,48 @@ public static class QueryCompiler
                 return false;
             }
             return (v is null) == wantNull;
+        };
+    }
+
+    /// <summary>
+    /// <c>&lt;col&gt; IS [NOT] EMPTY</c> — collection cardinality. Compile-time error
+    /// on a non-collection column (use <c>= ''</c> / <c>IS NULL</c> for scalars). A
+    /// <see langword="null"/> collection counts as empty (it contains nothing —
+    /// consistent with <c>CONTAINS</c>-over-null). Honours the <see cref="QueryAbsent"/>
+    /// sentinel like every other leaf, so it composes inside a <c>WITH ANY|ALL</c>
+    /// element schema (e.g. <c>CapIncreases WITH ANY (Keywords IS EMPTY)</c>).
+    /// </summary>
+    private static Func<object, bool> CompileIsEmpty(
+        IsEmptyNode node, Dictionary<string, ColumnBinding> columns)
+    {
+        var col = ResolveColumn(node.Column, columns);
+        var underlying = Nullable.GetUnderlyingType(col.ValueType) ?? col.ValueType;
+        if (GetCollectionElementType(underlying) is null)
+        {
+            throw new QueryException(
+                $"IS [NOT] EMPTY requires a collection column; '{node.Column}' is " +
+                $"{underlying.Name}. Use IS NULL / = '' for scalar columns.", 0);
+        }
+        bool wantEmpty = !node.Negated;
+        return item =>
+        {
+            var v = col.GetValue(item);
+            if (IsAbsent(v))
+            {
+                return false;
+            }
+            bool empty;
+            if (v is null)
+            {
+                empty = true;
+            }
+            else
+            {
+                var e = ((System.Collections.IEnumerable)v).GetEnumerator();
+                empty = !e.MoveNext();
+                (e as IDisposable)?.Dispose();
+            }
+            return empty == wantEmpty;
         };
     }
 

--- a/src/Mithril.Shared.Wpf/Query/QueryCompletionProvider.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryCompletionProvider.cs
@@ -151,6 +151,7 @@ public static class QueryCompletionProvider
                 IReadOnlyList<ColumnSchema>? element = null;
                 if (i >= 3
                     && toks[i - 1].Kind is QueryParser.TokenKind.Any or QueryParser.TokenKind.All
+                        or QueryParser.TokenKind.None
                     && toks[i - 2].Kind == QueryParser.TokenKind.With
                     && toks[i - 3].Kind == QueryParser.TokenKind.Identifier)
                 {
@@ -241,7 +242,8 @@ public static class QueryCompletionProvider
     private static bool IsKeywordKind(QueryParser.TokenKind k) =>
         k is QueryParser.TokenKind.And or QueryParser.TokenKind.Or or QueryParser.TokenKind.Not
           or QueryParser.TokenKind.Like or QueryParser.TokenKind.In or QueryParser.TokenKind.Between
-          or QueryParser.TokenKind.Is or QueryParser.TokenKind.Null
+          or QueryParser.TokenKind.Is or QueryParser.TokenKind.Null or QueryParser.TokenKind.Empty
+          or QueryParser.TokenKind.None
           or QueryParser.TokenKind.True or QueryParser.TokenKind.False;
 
     private static (Expecting, ColumnSchema?) ClassifyExpecting(
@@ -413,12 +415,16 @@ public static class QueryCompletionProvider
 
     private static void AddOperatorSuggestions(List<CompletionItem> results, Context ctx, ColumnSchema? col)
     {
-        // An object-collection column takes a quantifier, not scalar operators —
-        // offer only WITH ANY|ALL (and IS [NOT] NULL when the collection is nullable).
+        // An object-collection column takes a quantifier or a cardinality test,
+        // not scalar operators — WITH ANY|ALL|NONE, IS [NOT] EMPTY, and IS [NOT]
+        // NULL when nullable.
         if (col is not null && ColumnBindingHelper.TryGetElementSchema(col.ValueType) is not null)
         {
             Add(results, ctx, "WITH ANY (", CompletionKind.Keyword);
             Add(results, ctx, "WITH ALL (", CompletionKind.Keyword);
+            Add(results, ctx, "WITH NONE (", CompletionKind.Keyword);
+            Add(results, ctx, "IS EMPTY", CompletionKind.Keyword);
+            Add(results, ctx, "IS NOT EMPTY", CompletionKind.Keyword);
             if (col.IsNullable)
             {
                 Add(results, ctx, "IS NULL", CompletionKind.Keyword);

--- a/src/Mithril.Shared.Wpf/Query/QueryHighlighter.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryHighlighter.cs
@@ -92,7 +92,8 @@ public static class QueryHighlighter
             or QueryParser.TokenKind.Contains or QueryParser.TokenKind.StartsWith
             or QueryParser.TokenKind.EndsWith
             or QueryParser.TokenKind.With or QueryParser.TokenKind.Any or QueryParser.TokenKind.All
-            or QueryParser.TokenKind.Is or QueryParser.TokenKind.Null
+            or QueryParser.TokenKind.None
+            or QueryParser.TokenKind.Is or QueryParser.TokenKind.Null or QueryParser.TokenKind.Empty
             or QueryParser.TokenKind.True or QueryParser.TokenKind.False
             or QueryParser.TokenKind.OrderBy or QueryParser.TokenKind.SortBy
             or QueryParser.TokenKind.Asc or QueryParser.TokenKind.Desc => HighlightKind.Keyword,

--- a/src/Mithril.Shared.Wpf/Query/QueryParser.cs
+++ b/src/Mithril.Shared.Wpf/Query/QueryParser.cs
@@ -26,7 +26,7 @@ public static class QueryParser
         "AND", "OR", "NOT", "LIKE", "IN", "BETWEEN", "IS", "NULL", "TRUE", "FALSE",
         "BEFORE", "AFTER",
         "CONTAINS", "STARTSWITH", "ENDSWITH",
-        "WITH", "ANY", "ALL",
+        "WITH", "ANY", "ALL", "NONE", "EMPTY",
         "ASC", "ASCENDING", "DESC", "DESCENDING",
     };
 
@@ -115,8 +115,10 @@ public static class QueryParser
         With,
         Any,
         All,
+        None,
         Is,
         Null,
+        Empty,
         True,
         False,
         OrderBy,        // single token: lexer joins "ORDER" + "BY"
@@ -143,8 +145,10 @@ public static class QueryParser
         ["WITH"] = TokenKind.With,
         ["ANY"] = TokenKind.Any,
         ["ALL"] = TokenKind.All,
+        ["NONE"] = TokenKind.None,
         ["IS"] = TokenKind.Is,
         ["NULL"] = TokenKind.Null,
+        ["EMPTY"] = TokenKind.Empty,
         ["TRUE"] = TokenKind.True,
         ["FALSE"] = TokenKind.False,
         ["ASC"] = TokenKind.Asc,
@@ -715,15 +719,19 @@ public static class QueryParser
                     {
                         quant = Quantifier.All;
                     }
+                    else if (Peek.Kind == TokenKind.None)
+                    {
+                        quant = Quantifier.None;
+                    }
                     else
                     {
-                        throw new QueryException($"Expected ANY or ALL after WITH but found '{Peek.Text}'.", Peek.Position);
+                        throw new QueryException($"Expected ANY, ALL or NONE after WITH but found '{Peek.Text}'.", Peek.Position);
                     }
-                    Consume(); // ANY | ALL
+                    Consume(); // ANY | ALL | NONE
                     Expect(TokenKind.LParen, "'('");
                     if (Peek.Kind == TokenKind.RParen)
                     {
-                        throw new QueryException("Expected a predicate inside `WITH ANY/ALL (...)`.", Peek.Position);
+                        throw new QueryException("Expected a predicate inside `WITH ANY/ALL/NONE (...)`.", Peek.Position);
                     }
                     var inner = ParseExpression();
                     Expect(TokenKind.RParen, "')'");
@@ -733,17 +741,22 @@ public static class QueryParser
                 {
                     if (negated)
                     {
-                        throw new QueryException("Use `IS NOT NULL` instead of `NOT IS NULL`.", Peek.Position);
+                        throw new QueryException("Use `IS NOT NULL` / `IS NOT EMPTY` instead of `NOT IS …`.", Peek.Position);
                     }
                     Consume();
-                    bool isNotNull = false;
+                    bool isNot = false;
                     if (Peek.Kind == TokenKind.Not)
                     {
                         Consume();
-                        isNotNull = true;
+                        isNot = true;
                     }
-                    Expect(TokenKind.Null, "NULL");
-                    return new IsNullNode(column, Negated: isNotNull);
+                    if (Peek.Kind == TokenKind.Empty)
+                    {
+                        Consume();
+                        return new IsEmptyNode(column, Negated: isNot);
+                    }
+                    Expect(TokenKind.Null, "NULL or EMPTY");
+                    return new IsNullNode(column, Negated: isNot);
                 }
                 default:
                     throw new QueryException($"Expected comparison operator, LIKE, IN, BETWEEN, or IS after column '{column}'.", Peek.Position);

--- a/tests/Mithril.Shared.Tests/Wpf/Query/QuerySetOpsTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/Query/QuerySetOpsTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Mithril.Shared.Wpf.Query;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf.Query;
+
+/// <summary>
+/// #375: collection cardinality grammar — <c>IS [NOT] EMPTY</c> and the
+/// <c>WITH NONE (…)</c> quantifier. Locks: null collection counts as empty;
+/// non-collection column is a compile error; <c>IS EMPTY</c> composes inside a
+/// <c>WITH ANY</c> element schema (the motivating case); <c>WITH NONE</c> ≡
+/// <c>NOT (WITH ANY)</c> incl. vacuous-true over empty/null.
+/// </summary>
+public class QuerySetOpsTests
+{
+    private sealed record Cap(string Tier, IReadOnlyList<string> Keywords);
+
+    private sealed record Holder(string Name, IReadOnlyList<Cap>? Caps, IReadOnlyList<string>? Tags);
+
+    private static readonly Holder[] Dataset =
+    {
+        new("emptytags", [new("Neutral", [])], []),                 // Tags=[]   ; a cap w/ empty Keywords
+        new("hastags",   [new("Neutral", ["Armor"])], ["x"]),       // Tags=["x"]; cap w/ Keywords
+        new("nulltags",  null, null),                               // both null
+        new("mixedcaps", [new("A", ["Armor"]), new("B", [])], ["y"]), // one cap empty-kw, one not
+    };
+
+    private static readonly IReadOnlyDictionary<string, ColumnBinding> Columns =
+        new Dictionary<string, ColumnBinding>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["name"] = new("name", typeof(string), r => ((Holder)r).Name),
+            ["caps"] = new("caps", typeof(IReadOnlyList<Cap>), r => ((Holder)r).Caps),
+            ["tags"] = new("tags", typeof(IReadOnlyList<string>), r => ((Holder)r).Tags),
+        };
+
+    private static string[] Filter(string q)
+    {
+        var p = QueryCompiler.Compile(q, Columns);
+        return p is null ? [] : Dataset.Where(h => p(h)).Select(h => h.Name).ToArray();
+    }
+
+    // ─────────── parser ───────────
+
+    [Fact]
+    public void Parses_IS_EMPTY_and_IS_NOT_EMPTY()
+    {
+        QueryParser.Parse("tags IS EMPTY")!.Predicate
+            .Should().BeOfType<IsEmptyNode>().Which.Negated.Should().BeFalse();
+        QueryParser.Parse("tags IS NOT EMPTY")!.Predicate
+            .Should().BeOfType<IsEmptyNode>().Which.Negated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IS_NULL_still_parses_to_IsNullNode_not_IsEmpty()
+    {
+        QueryParser.Parse("tags IS NULL")!.Predicate.Should().BeOfType<IsNullNode>();
+        QueryParser.Parse("tags IS NOT NULL")!.Predicate
+            .Should().BeOfType<IsNullNode>().Which.Negated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parses_WITH_NONE_into_QuantifiedNode()
+    {
+        QueryParser.Parse("caps WITH NONE (Tier = 'A')")!.Predicate
+            .Should().BeOfType<QuantifiedNode>().Which.Quantifier.Should().Be(Quantifier.None);
+    }
+
+    [Theory]
+    [InlineData("tags IS")]                 // neither NULL nor EMPTY
+    [InlineData("tags IS NOT")]             // dangling
+    [InlineData("caps WITH FOO (Tier='A')")] // bad quantifier
+    [InlineData("caps WITH NONE")]          // missing (
+    [InlineData("caps WITH NONE ()")]       // empty predicate
+    public void Malformed_throws(string q)
+    {
+        Action act = () => QueryParser.Parse(q);
+        act.Should().Throw<QueryException>();
+    }
+
+    // ─────────── compiler: IS [NOT] EMPTY ───────────
+
+    [Fact]
+    public void IS_EMPTY_true_for_empty_list_and_null_collection()
+        => Filter("tags IS EMPTY").Should().BeEquivalentTo("emptytags", "nulltags");
+
+    [Fact]
+    public void IS_NOT_EMPTY_is_the_inverse()
+        => Filter("tags IS NOT EMPTY").Should().BeEquivalentTo("hastags", "mixedcaps");
+
+    [Fact]
+    public void IS_EMPTY_on_a_non_collection_column_is_a_compile_error()
+    {
+        Action act = () => QueryCompiler.Compile("name IS EMPTY", Columns);
+        act.Should().Throw<QueryException>().WithMessage("*collection*");
+    }
+
+    [Fact]
+    public void IS_EMPTY_composes_inside_WITH_ANY_element_schema()
+    {
+        // The motivating #375 query shape: a cap row whose Keywords is empty.
+        Filter("caps WITH ANY (Keywords IS EMPTY)")
+            .Should().BeEquivalentTo("emptytags", "mixedcaps");
+    }
+
+    // ─────────── compiler: WITH NONE ───────────
+
+    [Fact]
+    public void WITH_NONE_matches_when_no_element_satisfies_and_is_vacuous_over_empty_or_null()
+    {
+        // No cap with empty Keywords: hastags (Armor only); nulltags (null → none
+        // vacuously true). emptytags/mixedcaps each have an empty-Keywords cap.
+        Filter("caps WITH NONE (Keywords IS EMPTY)")
+            .Should().BeEquivalentTo("hastags", "nulltags");
+    }
+
+    [Fact]
+    public void WITH_NONE_equals_NOT_WITH_ANY()
+    {
+        var none = Filter("caps WITH NONE (Tier = 'A')");
+        var notAny = Filter("NOT (caps WITH ANY (Tier = 'A'))");
+        none.Should().BeEquivalentTo(notAny);
+    }
+
+    // ─────────── highlighter / completion ───────────
+
+    [Fact]
+    public void EMPTY_and_NONE_highlight_as_keyword()
+    {
+        var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "tags", "caps" };
+        HighlightKind At(string q, int pos) => QueryHighlighter
+            .Highlight(q, known).Single(s => pos >= s.Start && pos < s.Start + s.Length).Kind;
+
+        const string e = "tags IS NOT EMPTY";
+        At(e, e.IndexOf("EMPTY", StringComparison.Ordinal)).Should().Be(HighlightKind.Keyword);
+        const string n = "caps WITH NONE (Tier = 'A')";
+        At(n, n.IndexOf("NONE", StringComparison.Ordinal)).Should().Be(HighlightKind.Keyword);
+    }
+
+    [Fact]
+    public void Object_collection_column_offers_NONE_and_IS_EMPTY()
+    {
+        var schema = new[]
+        {
+            new ColumnSchema("name", typeof(string), IsNullable: false),
+            new ColumnSchema("caps", typeof(IReadOnlyList<Cap>), IsNullable: true),
+        };
+        var labels = QueryCompletionProvider.Suggest("caps ", 5, schema)
+            .Select(r => r.Label).ToList();
+        labels.Should().Contain(new[] { "WITH ANY (", "WITH ALL (", "WITH NONE (", "IS EMPTY", "IS NOT EMPTY" });
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -919,6 +919,37 @@ public sealed class NpcsTabViewModelTests
             .Should().BeEquivalentTo(["NPC_Friends", "NPC_Closer"]);
     }
 
+    [Fact]
+    public void QueryText_StoreNpcs_WithAnEmptyKeywordCapRow_ViaIsEmpty()
+    {
+        // The motivating #375 query, end-to-end over the NPC list-row schema:
+        // Store NPCs that have a cap row applying to ANY item (empty Keywords).
+        var refData = new StubReferenceData
+        {
+            NpcsByKey =
+            {
+                // "Despised:5000" → no keyword segment → Keywords == [] (any item).
+                ["NPC_AnyItemCap"] = StoreNpc("AnyItemCap", "Despised:5000", "Friends:9000:Armor"),
+                // Every cap row is keyword-scoped → no empty-Keywords row.
+                ["NPC_Scoped"] = StoreNpc("Scoped", "Despised:5000:Armor", "Friends:9000:Weapon"),
+                ["NPC_NoStore"] = new Npc
+                {
+                    Name = "NoStore",
+                    Services = new NpcServicePoco[] { new NpcTrainingServicePoco { Type = "Training" } },
+                },
+            },
+        };
+        var vm = new NpcsTabViewModel(refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()), new ReferenceDataEntityNameResolver(refData));
+
+        var columns = ColumnBindingHelper.BuildFromProperties(typeof(NpcListRow));
+        var predicate = QueryCompiler.Compile(
+            "ServiceTypes CONTAINS 'Store' AND CapIncreases WITH ANY (Keywords IS EMPTY)", columns);
+        predicate.Should().NotBeNull();
+
+        vm.AllNpcs.Where(r => predicate!(r)).Select(r => r.InternalName)
+            .Should().BeEquivalentTo(["NPC_AnyItemCap"]);
+    }
+
     private static Npc StoreNpc(string name, params string[] capIncreases) => new()
     {
         Name = name,


### PR DESCRIPTION
Closes #375. Generic collection-cardinality grammar — the design we settled on (minimal coherent set; `COUNT` deferred). Supersedes the narrow `AppliesToAnyItem` idea (no domain-specific bool needed).

## What

- **`<col> IS [NOT] EMPTY`** — postfix cardinality test, mirrors `IS [NOT] NULL` (shared `IS` parse branch + new `EMPTY` keyword/token; `IsEmptyNode`). Works on any collection column (string / `IQueryStringValue` / object); **compile error on a non-collection column** (use `IS NULL` / `= ''` for scalars). A **null collection counts as empty** (it contains nothing — consistent with `CONTAINS`-over-null). Honours the `QueryAbsent` sentinel like every leaf, so it **composes inside a `WITH ANY|ALL` element schema** — the motivating query:

  ```
  ServiceTypes CONTAINS 'Store' AND CapIncreases WITH ANY (Keywords IS EMPTY)
  ```

- **`<col> WITH NONE (<pred>)`** — completes the `ANY`/`ALL`/`NONE` quantifier trio. Exactly `NOT (col WITH ANY (<pred>))`; vacuously true over an empty/null collection. Reuses `CompileQuantified` — `ANY`/`ALL` paths are byte-identical (regression-safe).

- **Out of scope by design:** `COUNT(col) <op> n` / aggregate expressions (would require a function-expression grammar + scope creep). `IS EMPTY` covers empty-vs-populated.

- Completion offers `WITH NONE (` / `IS [NOT] EMPTY` on object-collection columns and tracks `WITH NONE (` as an element scope; highlighter classifies `EMPTY`/`NONE` as keywords; `docs/query-system.md` documents both + the null-is-empty rule + the deliberate `COUNT` deferral.

## Verification

- `dotnet build Mithril.slnx` clean (warnings-as-errors).
- New `QuerySetOpsTests` (16): parser (`IS [NOT] EMPTY`, `WITH NONE`, malformed, `IS NULL` regression-guarded), compiler (null=empty, non-collection→compile error, compose-inside-`WITH ANY`, `WITH NONE` truth incl. vacuous + ≡ `NOT(WITH ANY)`), highlighter, completion. Silmarillion end-to-end test for the motivating query.
- Full `dotnet test Mithril.slnx`: **Wpf.Query 255** (was 239; +16, 0 fail), Silmarillion 454, Smaug 28 (parity intact), Mithril.Shared 1025, Shell DI guard 2 — all 0-failed.
- One **unrelated pre-existing** `Mithril.GameState.Tests` parallel-flake under the concurrent run (passes **97/97 in isolation**; GameState doesn't touch the query engine — not a regression from this change). Same class as the documented Gandalf parallel flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
