### PR TITLE
fix(arwen): rename FavorTier.Hatred → Hated (closes #372)

### DIFF
--- a/src/Arwen.Module/Domain/FavorTier.cs
+++ b/src/Arwen.Module/Domain/FavorTier.cs
@@ -3,7 +3,7 @@ namespace Arwen.Domain;
 public enum FavorTier
 {
     Despised,
-    Hatred,
+    Hated,
     Disliked,
     Tolerated,
     Neutral,
@@ -20,7 +20,7 @@ public static class FavorTiers
     private static readonly (FavorTier Tier, int Floor, int? Cap)[] Table =
     [
         (FavorTier.Despised,     -99999, 1800),
-        (FavorTier.Hatred,       -600,   300),
+        (FavorTier.Hated,        -600,   300),
         (FavorTier.Disliked,     -300,   200),
         (FavorTier.Tolerated,    -100,   100),
         (FavorTier.Neutral,      0,      100),

--- a/src/Arwen.Module/State/FavorStateService.cs
+++ b/src/Arwen.Module/State/FavorStateService.cs
@@ -51,15 +51,10 @@ public sealed class FavorStateService : IFavorLookupService
     public string? GetFavorTier(string npcKey)
     {
         if (string.IsNullOrEmpty(npcKey)) return null;
-        return _tierByNpcKey.TryGetValue(npcKey, out var tier) ? ToGameLogName(tier) : null;
+        // FavorTier member names are the canonical game-log tokens (incl. "Hated"),
+        // which is exactly what IFavorLookupService consumers (Smaug) expect.
+        return _tierByNpcKey.TryGetValue(npcKey, out var tier) ? tier.ToString() : null;
     }
-
-    // Arwen's enum uses "Hatred"; the game's log emits "Hated". Everything else already matches.
-    private static string ToGameLogName(FavorTier tier) => tier switch
-    {
-        FavorTier.Hatred => "Hated",
-        _ => tier.ToString(),
-    };
 
     public FavorStateService(
         IReferenceDataService refData,

--- a/tests/Arwen.Tests/FavorTierTests.cs
+++ b/tests/Arwen.Tests/FavorTierTests.cs
@@ -21,7 +21,7 @@ public sealed class FavorTierTests
     [InlineData(-1, FavorTier.Tolerated)]
     [InlineData(-100, FavorTier.Tolerated)]
     [InlineData(-101, FavorTier.Disliked)]
-    [InlineData(-600, FavorTier.Hatred)]
+    [InlineData(-600, FavorTier.Hated)]
     [InlineData(-601, FavorTier.Despised)]
     public void TierForFavor_ReturnsCorrectTier(double favor, FavorTier expected) =>
         FavorTiers.TierForFavor(favor).Should().Be(expected);
@@ -91,5 +91,25 @@ public sealed class FavorTierTests
         var result = FavorTiers.TryParse(input, out var tier);
         result.Should().Be(expectedSuccess);
         tier.Should().Be(expectedTier);
+    }
+
+    // Guard for #372: every FavorTier member name must be the canonical game-log token,
+    // so it round-trips through TryParse of its own name. (Regression: "Hatred" vs "Hated".)
+    [Theory]
+    [MemberData(nameof(AllTiers))]
+    public void TryParse_RoundTripsEveryMemberName(FavorTier tier)
+    {
+        FavorTiers.TryParse(tier.ToString(), out var parsed).Should().BeTrue();
+        parsed.Should().Be(tier);
+    }
+
+    public static TheoryData<FavorTier> AllTiers() =>
+        [.. Enum.GetValues<FavorTier>()];
+
+    [Fact]
+    public void TryParse_Hated_ResolvesToHatedTier()
+    {
+        FavorTiers.TryParse("Hated", out var tier).Should().BeTrue();
+        tier.Should().Be(FavorTier.Hated);
     }
 }


### PR DESCRIPTION
Closes #372. Child of #370 (favor-tier divergence umbrella).

## Problem

`Arwen.Domain.FavorTier` spelled the −600 rung `Hatred`. The game/reference token is `Hated` (npcs.json, character-export `FavorLevel`); `"Hatred"` appears in **no** data — a code-only typo. `FavorTiers.TryParse` is `Enum.TryParse`, so a real `"Hated"` from the character export found no member, returned false, and the NPC fell through to the Priority-3 path → displayed as **Neutral**. The Player.log path was unaffected (numeric favor, ordinal-indexed) which is why this stayed hidden.

## Fix

- Rename `FavorTier.Hatred → Hated` (enum member + floor `Table` row).
- Delete `FavorStateService.ToGameLogName` — it existed *only* to paper over the misspelling for Smaug's `IFavorLookupService` contract; with names now canonical it is a pure identity, so `GetFavorTier` returns `tier.ToString()` directly.

## Tests

Guard tests added: every `FavorTier` member round-trips through `TryParse` of its own name, and `TryParse("Hated")` resolves to `FavorTier.Hated`. **Arwen 122/122** on the rebased tree.

## Scope / relation to #370 & #373

Scoped to Arwen. Independent of #373's canonical `Mithril.Reference.FavorTier` (no overlap, no name clash — Arwen imports only `Mithril.Reference.Models.Items`). Converging Arwen onto the canonical type (deleting this enum) remains #370's closing task, deliberately out of scope here. Rebased onto #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
