### PR TITLE
fix(smaug): order FavorTierName.Ordered by favor floor — Tolerated < Neutral (closes #371)

### DIFF
--- a/src/Smaug.Module/Domain/FavorTierName.cs
+++ b/src/Smaug.Module/Domain/FavorTierName.cs
@@ -20,10 +20,14 @@ public static class FavorTierName
     public const string LikeFamily = "LikeFamily";
     public const string SoulMates = "SoulMates";
 
-    /// <summary>Ascending order from lowest (Despised) to highest (SoulMates).</summary>
+    /// <summary>
+    /// Ascending order from lowest (Despised) to highest (SoulMates). Grounded in the
+    /// signed favor-point scale: Tolerated (−100) is below Neutral (0). See #371 / the
+    /// floor table in Arwen.Domain.FavorTiers, the authority for ordering.
+    /// </summary>
     public static readonly IReadOnlyList<string> Ordered =
     [
-        Despised, Hated, Disliked, Neutral, Tolerated, Comfortable,
+        Despised, Hated, Disliked, Tolerated, Neutral, Comfortable,
         Friends, CloseFriends, BestFriends, LikeFamily, SoulMates,
     ];
 
@@ -42,11 +46,13 @@ public static class FavorTierName
     /// <summary>
     /// Rank a typed <see cref="FavorTier"/> on <em>this</em> ladder by round-tripping
     /// through its reference-data token. Deliberately delegates to the string
-    /// <see cref="RankOf(string?)"/> so Smaug's existing (currently mis-ordered, see
-    /// #371) <see cref="Ordered"/> semantics are preserved byte-identically — the
-    /// #368 type change must not shift vendor pricing. <see cref="FavorTier.Unknown"/>
-    /// → token "Unknown" → not in <see cref="Ordered"/> → -1, exactly as an
-    /// unrecognised raw string was before.
+    /// <see cref="RankOf(string?)"/> so the typed and raw-string paths rank
+    /// byte-identically on the one <see cref="Ordered"/> ladder (now floor-grounded —
+    /// #371 corrected the prior Tolerated/Neutral mis-order). The #368 type change is
+    /// itself pricing-neutral; the only intended pricing shift is #371's boundary fix,
+    /// which both paths inherit equally. <see cref="FavorTier.Unknown"/> → token
+    /// "Unknown" → not in <see cref="Ordered"/> → -1, exactly as an unrecognised raw
+    /// string was before.
     /// </summary>
     public static int RankOf(FavorTier tier) => RankOf(tier.ToToken());
 }

--- a/tests/Smaug.Tests/FavorTierNameParityTests.cs
+++ b/tests/Smaug.Tests/FavorTierNameParityTests.cs
@@ -10,9 +10,10 @@ namespace Smaug.Tests;
 /// Parity lock for #368: <see cref="StoreCapIncrease.Tier"/> became a typed
 /// <see cref="FavorTier"/>, so Smaug now ranks it via the new
 /// <see cref="FavorTierName.RankOf(FavorTier)"/> overload. That overload MUST be
-/// byte-identical to the old raw-string path against Smaug's existing
-/// <see cref="FavorTierName.Ordered"/> ladder — the (separately tracked, #371)
-/// mis-order is intentionally preserved here so vendor pricing does not shift.
+/// byte-identical to the raw-string path against Smaug's <see cref="FavorTierName.Ordered"/>
+/// ladder — these tests lock the typed↔string delegation and the Unknown→-1 sentinel,
+/// not any specific order, so they hold across #371's order correction (which both
+/// paths inherit equally).
 /// </summary>
 public sealed class FavorTierNameParityTests
 {

--- a/tests/Smaug.Tests/PriceCalibrationTests.cs
+++ b/tests/Smaug.Tests/PriceCalibrationTests.cs
@@ -68,6 +68,20 @@ public sealed class PriceCalibrationTests
         FavorTierName.IsAtLeast(FavorTierName.Neutral, FavorTierName.Friends).Should().BeFalse();
     }
 
+    // #371: Tolerated is favor -100, below Neutral (0). The prior assertions did not
+    // exercise this boundary, which is exactly why the inversion slipped. Pin the full
+    // ladder to the floor-grounded order (matching Arwen.Domain.FavorTiers).
+    [Fact]
+    public void FavorTierName_Ordered_IsFloorGrounded()
+    {
+        FavorTierName.RankOf(FavorTierName.Tolerated)
+            .Should().BeLessThan(FavorTierName.RankOf(FavorTierName.Neutral));
+
+        FavorTierName.Ordered.Should().Equal(
+            "Despised", "Hated", "Disliked", "Tolerated", "Neutral", "Comfortable",
+            "Friends", "CloseFriends", "BestFriends", "LikeFamily", "SoulMates");
+    }
+
     private static PriceObservation Make(string npc, string internalName, long value, long paid, string tier, int cp) =>
         new()
         {

--- a/tests/Smaug.Tests/VendorCapResolverTests.cs
+++ b/tests/Smaug.Tests/VendorCapResolverTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using Smaug.Domain;
+using Xunit;
+using NpcService = Mithril.Shared.Reference.NpcService;
+using StoreCapIncrease = Mithril.Reference.Models.Npcs.StoreCapIncrease;
+using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
+
+namespace Smaug.Tests;
+
+public sealed class VendorCapResolverTests
+{
+    // #371 regression guard. Tolerated is favor -100, BELOW Neutral (favor 0), so a
+    // Neutral-favor player has *more* than enough favor to qualify for a Tolerated-tier
+    // cap. FavorTierName.Ordered placing Neutral before Tolerated inverted that: the
+    // Tolerated cap ranked ABOVE the player and ResolveMaxGold (VendorCapResolver.cs:49)
+    // skipped it, returning null. The parity/replay corpus cannot cover this (no captured
+    // Player.log lines below Neutral), so this synthetic test is the correctness proof.
+    [Fact]
+    public void ResolveMaxGold_NeutralPlayer_AppliesLowerToleratedTierCap()
+    {
+        var store = new NpcService(
+            Type: "Store",
+            MinFavorTier: null,
+            CapIncreases: new[]
+            {
+                new StoreCapIncrease(FavorTier.Tolerated, 500, []),
+            });
+
+        var result = VendorCapResolver.ResolveMaxGold(
+            store,
+            playerFavorTier: FavorTierName.Neutral,
+            itemKeywords: new HashSet<string>(),
+            civicPrideLevel: 0);
+
+        result.Should().Be(500);
+    }
+
+    // The upper side of the same boundary must stay excluded: Comfortable is favor +100,
+    // ABOVE Neutral, so a Neutral-favor player must NOT receive a Comfortable-tier cap.
+    [Fact]
+    public void ResolveMaxGold_NeutralPlayer_ExcludesHigherComfortableTierCap()
+    {
+        var store = new NpcService(
+            Type: "Store",
+            MinFavorTier: null,
+            CapIncreases: new[]
+            {
+                new StoreCapIncrease(FavorTier.Comfortable, 9999, []),
+            });
+
+        var result = VendorCapResolver.ResolveMaxGold(
+            store,
+            playerFavorTier: FavorTierName.Neutral,
+            itemKeywords: new HashSet<string>(),
+            civicPrideLevel: 0);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
Closes #371. Child of #370 (favor-tier divergence umbrella).

## Problem

`FavorTierName.Ordered` hand-placed `Neutral` before `Tolerated`. Favor is a signed point scale: `Tolerated` is −100, `Neutral` is 0 (Arwen's floor table is the ordering authority). `RankOf`/`IsAtLeast` are relative comparisons in `VendorCapResolver.ResolveMaxGold` (cap-skip, MinFavorTier gate) and `SellPlannerService` accessibility — so a `Tolerated`-tier `StoreCapIncrease` was treated as *higher* favor than `Neutral` and wrongly skipped for a Neutral-favor player, resolving no cap (`null`) instead of the Tolerated cap.

## Fix

Reorder `Ordered` to the floor-grounded sequence (`Tolerated` immediately below `Neutral`). Spelling already correct (`Hated`) — untouched.

## Tests

New `VendorCapResolverTests` (none existed — that gap hid this): a Neutral player now resolves a Tolerated-tier cap (was `null` pre-fix — watched **red→green**); a Comfortable-tier cap stays excluded. Also pinned `FavorTierName.Ordered` to the full floor-grounded ladder (the prior rank test never exercised this boundary).

⚠️ **Honest test-scope note:** the price-calibration parity/replay corpus is captured from real Player.log and has **no lines below Neutral**, so it structurally cannot cover this boundary. Its green run proves only *no-collateral-regression*, not correctness — the synthetic unit test is the correctness proof. **Smaug 31/31** on the rebased tree.

## Relation to #373

Rebased onto #373 (canonical `Mithril.Reference.FavorTier` / #368), which co-edited this file. That PR changed `StoreCapIncrease.Tier` `string → FavorTier`:

- `VendorCapResolverTests` now constructs caps with the typed `FavorTier` (string-const args no longer compile post-#373); semantics unchanged — `cap.Tier` routes through #373's `RankOf(FavorTier)` overload onto the same `Ordered`.
- Reconciled two #373-authored comments (the `RankOf(FavorTier)` doc + the `FavorTierNameParityTests` class doc) that asserted the #371 mis-order was "intentionally preserved" — now false. #373's parity tests lock the typed↔string delegation + `Unknown→-1` sentinel (order-agnostic), so they stay green across this reorder.

## Scope

Scoped to Smaug. Full convergence onto the canonical type is #370's closing task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
