### PR TITLE
fix(silmarillion): rank vault capacity by canonical FavorTier — drop FavorOrder (closes #374)

### DIFF
--- a/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using Mithril.Reference.Models.Misc;
+using Mithril.Reference.Models.Npcs;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
 using StorageVaultPoco = Mithril.Reference.Models.Misc.StorageVault;
@@ -38,18 +39,6 @@ namespace Silmarillion.ViewModels;
 /// </summary>
 public sealed class StorageVaultDetailViewModel
 {
-    /// <summary>
-    /// Canonical in-game favor progression (mirrors <c>Arwen.Domain.FavorTier</c>, kept
-    /// local to avoid a cross-module dependency). The favor table orders rows by this, NOT
-    /// by the JSON dictionary's enumeration order. Any unrecognised future tier sorts last
-    /// (alpha) so a PG patch surfaces visibly rather than silently.
-    /// </summary>
-    private static readonly string[] FavorOrder =
-    {
-        "Despised", "Hatred", "Disliked", "Tolerated", "Neutral", "Comfortable",
-        "Friends", "CloseFriends", "BestFriends", "LikeFamily", "SoulMates",
-    };
-
     public StorageVaultDetailViewModel(
         StorageVaultListRow row,
         IReferenceDataService refData,
@@ -240,11 +229,12 @@ public sealed class StorageVaultDetailViewModel
         if (levels is null || levels.Count == 0)
             return Array.Empty<StorageVaultCapacityRow>();
 
-        int Rank(string tier)
-        {
-            var i = Array.IndexOf(FavorOrder, tier);
-            return i < 0 ? int.MaxValue : i;
-        }
+        // Order by the canonical favor ladder (#370/#373): FavorTier's underlying
+        // value IS a signed, floor-grounded rank, so the enum cast is the sort key.
+        // An unrecognised future token → FavorTier.Unknown (int.MinValue) and sorts
+        // below every real tier (the canonical sentinel contract); the alpha ThenBy
+        // keeps such rows deterministic.
+        static int Rank(string tier) => (int)FavorTierExtensions.Parse(tier);
 
         return levels
             // A 0-slot favor tier (e.g. Despised:0, Comfortable:0) is the universal

--- a/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
@@ -81,6 +81,29 @@ public sealed class StorageVaultDetailViewModelTests
     }
 
     [Fact]
+    public void FavorTable_HatedTier_SortsByFavorFloor_NotCollapsedToLast()
+    {
+        // #374: capacity rows now rank via the canonical Mithril.Reference.FavorTier
+        // (#373), replacing a hand-rolled FavorOrder array that misspelled the -600 rung
+        // "Hatred". A "Hated" Levels key must rank near the bottom of the ladder
+        // (FavorTier.Hated = -3), not collapse to last as the old misspelling did.
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "NPC_H", new StorageVaultPoco
+        {
+            NpcFriendlyName = "H",
+            Levels = new Dictionary<string, int>
+            {
+                ["SoulMates"] = 64,
+                ["Hated"] = 8,
+                ["Comfortable"] = 16,
+            },
+        });
+
+        vm.CapacityRows.Select(r => r.Tier).Should()
+            .ContainInOrder("Hated", "Comfortable", "Soul Mates");
+    }
+
+    [Fact]
     public void FlatSlots_WhenNoLevels_AndTransferChestDoesNotCrashOnZero()
     {
         var refData = new FakeReferenceData();


### PR DESCRIPTION
Closes #374. Child of #370 (favor-tier divergence umbrella).

## Problem

`StorageVaultDetailViewModel` ranked capacity rows via a private `FavorOrder` string array that misspelled the −600 rung `Hatred` (game/data token is `Hated`). A `Hated` `Levels` key failed `Array.IndexOf → int.MaxValue` → the row collapsed *below* `SoulMates` instead of near the bottom of the ladder. This was the **fourth** independent favor-ladder copy #370 catalogued.

## Fix — converge, don't just patch

#373 (#368) landed canonical `Mithril.Reference.FavorTier` whose underlying values **are** a signed, floor-grounded rank. Rather than just fix the typo, this PR **deletes `FavorOrder` entirely** and ranks via `(int)FavorTierExtensions.Parse(key)`. This fixes the misspelling *and* retires the duplicate ladder — Silmarillion now shares the one canonical type.

**Behaviour delta (honest):** an unrecognised future token now ranks `FavorTier.Unknown` (`int.MinValue`) and sorts *below* every real tier (the canonical sentinel contract), where the old miss sorted it last; the alpha `ThenBy` keeps such rows deterministic. Bundled `storagevaults.json` `Levels` use only real tiers, so no live row reorders today beyond the corrected `Hated` placement.

## Tests

Behavioral test: a vault with a `Hated` rung sorts `Hated < Comfortable < SoulMates` (was last under the old array — watched **red→green**). **Silmarillion 454/454** on the rebased tree.

## Scope / relation to #370

Scoped to Silmarillion; advances #370 by eliminating one of the four duplicates. Arwen (#372) and Smaug (#371) fix their bugs but keep their duplicate types — full convergence (deleting those too) is #370's closing task. Rebased onto #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
