### PR TITLE
feat(celebrimbor): Plans manager + walker — #228 PR-B/B1

### DIFF
--- a/src/Celebrimbor.Module/CelebrimborModule.cs
+++ b/src/Celebrimbor.Module/CelebrimborModule.cs
@@ -51,12 +51,15 @@ public sealed class CelebrimborModule : IMithrilModule
         services.AddSingleton<OnHandInventoryQuery>();
         services.AddSingleton<PlanExecutor>();
         services.AddSingleton<ICraftListImportTarget, CraftListImportTarget>();
+        services.AddSingleton<ISavedLevelingPlanImportTarget, SavedLevelingPlanImportTarget>();
         services.AddSingleton<IDeepLinkHandler>(sp =>
             new CraftListDeepLinkHandler(sp.GetRequiredService<ICraftListImportTarget>()));
         services.AddSingleton<IAugmentPoolPresenter, CelebrimborAugmentPoolPresenter>();
 
         services.AddSingleton<RecipePickerViewModel>();
         services.AddSingleton<ShoppingListViewModel>();
+        services.AddSingleton<PlanWalkerViewModel>();
+        services.AddSingleton<PlansViewModel>();
         services.AddSingleton<CelebrimborShellViewModel>();
         services.AddSingleton<CelebrimborSettingsViewModel>();
 

--- a/src/Celebrimbor.Module/Services/SavedLevelingPlanImportTarget.cs
+++ b/src/Celebrimbor.Module/Services/SavedLevelingPlanImportTarget.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using System.Windows;
+using Celebrimbor.ViewModels;
+using Mithril.Planning;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Modules;
+
+namespace Celebrimbor.Services;
+
+/// <summary>
+/// Celebrimbor's implementation of <see cref="ISavedLevelingPlanImportTarget"/>
+/// (#228 PR-B/B1). Deserializes the canonical plan JSON, upserts it into the
+/// <see cref="LevelingPlanStore"/> by id, brings the Celebrimbor tab forward
+/// and surfaces the imported plan in the Plans area. Mirrors
+/// <see cref="CraftListImportTarget"/>: UI-thread marshalled, all failures
+/// logged and swallowed (callers are module hand-off / file activation paths
+/// that must not throw).
+/// </summary>
+public sealed class SavedLevelingPlanImportTarget : ISavedLevelingPlanImportTarget
+{
+    private readonly LevelingPlanStore _store;
+    private readonly PlansViewModel _plans;
+    private readonly IModuleActivator? _activator;
+    private readonly IDiagnosticsSink? _diag;
+
+    public SavedLevelingPlanImportTarget(
+        LevelingPlanStore store,
+        PlansViewModel plans,
+        IModuleActivator? activator = null,
+        IDiagnosticsSink? diag = null)
+    {
+        _store = store;
+        _plans = plans;
+        _activator = activator;
+        _diag = diag;
+    }
+
+    public void ImportPlan(string planJson, string source)
+    {
+        if (string.IsNullOrWhiteSpace(planJson))
+        {
+            _diag?.Info("Celebrimbor", $"Plan import from \"{source}\": empty payload, dropped.");
+            return;
+        }
+
+        SavedLevelingPlan? plan;
+        try
+        {
+            plan = JsonSerializer.Deserialize(planJson, SavedLevelingPlanJsonContext.Default.SavedLevelingPlan);
+        }
+        catch (JsonException ex)
+        {
+            _diag?.Info("Celebrimbor", $"Plan import from \"{source}\": invalid JSON ({ex.Message}), dropped.");
+            return;
+        }
+
+        if (plan is null || plan.Phases.Count == 0)
+        {
+            _diag?.Info("Celebrimbor", $"Plan import from \"{source}\": no phases, dropped.");
+            return;
+        }
+
+        Dispatch(() =>
+        {
+            _store.Upsert(plan);
+            if (_activator is not null && !_activator.Activate("celebrimbor"))
+                _diag?.Info("Celebrimbor", "Plan import: module activator could not find 'celebrimbor'.");
+            _plans.SurfaceImported(plan.Id);
+            _diag?.Info("Celebrimbor", $"Imported leveling plan \"{plan.Skill} → {plan.GoalLevel}\" from \"{source}\".");
+        });
+    }
+
+    private static void Dispatch(Action action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+            action();
+        else
+            dispatcher.InvokeAsync(action);
+    }
+}

--- a/src/Celebrimbor.Module/ViewModels/CelebrimborShellViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/CelebrimborShellViewModel.cs
@@ -5,10 +5,14 @@ namespace Celebrimbor.ViewModels;
 
 public sealed partial class CelebrimborShellViewModel : ObservableObject
 {
-    public CelebrimborShellViewModel(RecipePickerViewModel picker, ShoppingListViewModel shopping)
+    private CelebrimborViewMode _lastCraftingView = CelebrimborViewMode.Picker;
+
+    public CelebrimborShellViewModel(
+        RecipePickerViewModel picker, ShoppingListViewModel shopping, PlansViewModel plans)
     {
         Picker = picker;
         Shopping = shopping;
+        Plans = plans;
 
         Picker.FinalizeRequested += (_, _) =>
         {
@@ -27,11 +31,24 @@ public sealed partial class CelebrimborShellViewModel : ObservableObject
 
     public RecipePickerViewModel Picker { get; }
     public ShoppingListViewModel Shopping { get; }
+    public PlansViewModel Plans { get; }
 
     [ObservableProperty]
     private CelebrimborViewMode _currentView = CelebrimborViewMode.Picker;
 
     public bool IsShoppingAvailable => Picker.HasCraftList;
+
+    /// <summary>The crafting wizard (Pick → Shop) is one peer area; Plans is the other.</summary>
+    public bool IsCraftingArea => CurrentView is CelebrimborViewMode.Picker or CelebrimborViewMode.Shopping;
+    public bool IsPlansArea => CurrentView is CelebrimborViewMode.Plans;
+
+    partial void OnCurrentViewChanged(CelebrimborViewMode value)
+    {
+        if (value is CelebrimborViewMode.Picker or CelebrimborViewMode.Shopping)
+            _lastCraftingView = value;
+        OnPropertyChanged(nameof(IsCraftingArea));
+        OnPropertyChanged(nameof(IsPlansArea));
+    }
 
     [RelayCommand]
     private void GoToPicker() => CurrentView = CelebrimborViewMode.Picker;
@@ -42,4 +59,16 @@ public sealed partial class CelebrimborShellViewModel : ObservableObject
         Shopping.Rebuild();
         CurrentView = CelebrimborViewMode.Shopping;
     }
+
+    /// <summary>Header pivot → Plans area (independent of the crafting wizard).</summary>
+    [RelayCommand]
+    private void GoToPlans()
+    {
+        Plans.Reload();
+        CurrentView = CelebrimborViewMode.Plans;
+    }
+
+    /// <summary>Header pivot → back to the crafting wizard at its last sub-step.</summary>
+    [RelayCommand]
+    private void GoToCrafting() => CurrentView = _lastCraftingView;
 }

--- a/src/Celebrimbor.Module/ViewModels/CelebrimborViewMode.cs
+++ b/src/Celebrimbor.Module/ViewModels/CelebrimborViewMode.cs
@@ -2,6 +2,12 @@ namespace Celebrimbor.ViewModels;
 
 public enum CelebrimborViewMode
 {
+    // Crafting wizard (sequential: build a list → shop for it).
     Picker,
     Shopping,
+
+    // Plans — a peer area, not a wizard step: an independent library of saved
+    // leveling plans you walk. Reached from outside the wizard (Elrond hand-off,
+    // file import) and feeds back into it via "Send phase to craft list" (#228).
+    Plans,
 }

--- a/src/Celebrimbor.Module/ViewModels/PlanRailItemViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/PlanRailItemViewModel.cs
@@ -1,0 +1,70 @@
+namespace Celebrimbor.ViewModels;
+
+/// <summary>Phase position in the walker rail relative to the walk cursor.</summary>
+public enum PhaseRailState
+{
+    Done,
+    Current,
+    Upcoming,
+}
+
+/// <summary>
+/// One item in the walker's phase rail (#228 PR-B/B1, frame 03). The rail
+/// interleaves phases with the skill-source unlock callouts that fall between
+/// them; <see cref="IsUnlock"/> discriminates. Unlock callouts that the live
+/// character already knows are flagged (<see cref="AlreadyKnown"/>) for the
+/// stale-walker view (frame 07).
+/// </summary>
+public sealed class PlanRailItemViewModel
+{
+    private PlanRailItemViewModel() { }
+
+    public bool IsUnlock { get; private init; }
+
+    // ── Phase ────────────────────────────────────────────────────────────
+    public PhaseRailState State { get; private init; }
+    public string RecipeName { get; private init; } = "";
+    public string LevelRange { get; private init; } = "";
+    public string Meta { get; private init; } = "";
+    public bool UsesFirstTimeBonus { get; private init; }
+    public bool ShowMiniProgress { get; private init; }
+    public int MiniOnHand { get; private init; }
+    public int MiniThreshold { get; private init; }
+    public double MiniFraction { get; private init; }
+
+    // ── Unlock callout ───────────────────────────────────────────────────
+    public int UnlockAtLevel { get; private init; }
+    public int UnlockXp { get; private init; }
+    public string UnlockReason { get; private init; } = "";
+    public bool AlreadyKnown { get; private init; }
+
+    public static PlanRailItemViewModel Phase(
+        PhaseRailState state, string recipeName, int levelStart, int levelEnd,
+        int predictedCrafts, int xpPerCraft, bool usesFirstTimeBonus,
+        bool showMiniProgress = false, int onHand = 0, int threshold = 0)
+        => new()
+        {
+            IsUnlock = false,
+            State = state,
+            RecipeName = recipeName,
+            LevelRange = $"L{levelStart} → L{levelEnd}",
+            Meta = $"×{predictedCrafts} · {xpPerCraft} xp",
+            UsesFirstTimeBonus = usesFirstTimeBonus,
+            ShowMiniProgress = showMiniProgress,
+            MiniOnHand = onHand,
+            MiniThreshold = threshold,
+            MiniFraction = threshold <= 0 ? 0d : Math.Clamp((double)onHand / threshold, 0d, 1d),
+        };
+
+    public static PlanRailItemViewModel Unlock(
+        int atLevel, string recipeName, int xpAtUnlock, string reason, bool alreadyKnown)
+        => new()
+        {
+            IsUnlock = true,
+            UnlockAtLevel = atLevel,
+            RecipeName = recipeName,
+            UnlockXp = xpAtUnlock,
+            UnlockReason = reason,
+            AlreadyKnown = alreadyKnown,
+        };
+}

--- a/src/Celebrimbor.Module/ViewModels/PlanWalkerViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/PlanWalkerViewModel.cs
@@ -1,0 +1,317 @@
+using System.Collections.ObjectModel;
+using Celebrimbor.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Planning;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+
+namespace Celebrimbor.ViewModels;
+
+/// <summary>
+/// Walks one <see cref="SavedLevelingPlan"/> (#228 PR-B/B1, frames 03/06/07):
+/// phase rail with unlock callouts, the inventory-vs-threshold completion
+/// predicate, per-ingredient sourcing toggles, send-phase-to-craft-list, the
+/// stale-refresh banner and the plan-complete terminal.
+///
+/// <para>Inventory-driven only: completion is <see cref="PlanExecutor"/>'s
+/// on-hand ≥ produced-threshold predicate. The craft-count-telemetry frames
+/// (drift "output ran short", 2 s auto-advance countdown, walked/xp-banked
+/// stats) are deferred — they need a Player.log craft tracker that the PR-A
+/// foundation doesn't provide. Phase advance here is therefore an explicit
+/// user action, not a timed auto-advance.</para>
+/// </summary>
+public sealed partial class PlanWalkerViewModel : ObservableObject
+{
+    private readonly LevelingPlanStore _store;
+    private readonly PlanExecutor _executor;
+    private readonly OnHandInventoryQuery _onHand;
+    private readonly IReferenceDataService _ref;
+    private readonly ICraftListImportTarget _craftList;
+
+    private SavedLevelingPlan? _plan;
+    private bool _staleDismissed;
+
+    public PlanWalkerViewModel(
+        LevelingPlanStore store,
+        PlanExecutor executor,
+        OnHandInventoryQuery onHand,
+        IReferenceDataService referenceData,
+        ICraftListImportTarget craftList)
+    {
+        _store = store;
+        _executor = executor;
+        _onHand = onHand;
+        _ref = referenceData;
+        _craftList = craftList;
+    }
+
+    /// <summary>Raised when the user leaves the walker (back to the library).</summary>
+    public event EventHandler? BackRequested;
+
+    /// <summary>Raised when the plan was mutated (advance / re-plan) so the manager re-reads.</summary>
+    public event EventHandler? PlanChanged;
+
+    public void Load(SavedLevelingPlan plan)
+    {
+        _plan = plan;
+        _staleDismissed = false;
+        Recompute();
+    }
+
+    // ── Header ───────────────────────────────────────────────────────────
+    [ObservableProperty] private string _skill = "";
+    [ObservableProperty] private string _characterLabel = "";
+    [ObservableProperty] private string _goalLabel = "";
+    [ObservableProperty] private string _phaseCountLabel = "";
+
+    // ── Rail ─────────────────────────────────────────────────────────────
+    [ObservableProperty] private ObservableCollection<PlanRailItemViewModel> _rail = [];
+
+    // ── Current-phase detail ─────────────────────────────────────────────
+    [ObservableProperty] private bool _hasCurrentPhase;
+    [ObservableProperty] private string _detailTitle = "";
+    [ObservableProperty] private string _detailLevels = "";
+    [ObservableProperty] private int _detailPredictedCrafts;
+    [ObservableProperty] private int _detailXpPerCraft;
+    [ObservableProperty] private int _detailReuseXp;
+    [ObservableProperty] private bool _detailUsesFirstTimeBonus;
+
+    // ── Predicate ────────────────────────────────────────────────────────
+    [ObservableProperty] private int _predicateOnHand;
+    [ObservableProperty] private int _predicateThreshold;
+    [ObservableProperty] private double _predicateFraction;
+    [ObservableProperty] private bool _predicateComplete;
+
+    // ── Sourcing ─────────────────────────────────────────────────────────
+    [ObservableProperty] private ObservableCollection<SourcingRowViewModel> _sourcingRows = [];
+
+    // ── Footer ───────────────────────────────────────────────────────────
+    [ObservableProperty] private string _positionText = "";
+    [ObservableProperty] private string _remainingText = "";
+
+    // ── Terminal / stale ─────────────────────────────────────────────────
+    [ObservableProperty] private bool _isPlanComplete;
+    [ObservableProperty] private bool _isStale;
+    [ObservableProperty] private string _staleSummary = "";
+    [ObservableProperty] private string _createdAgeText = "";
+
+    public bool CanAdvance => _plan is not null && !IsPlanComplete && PredicateComplete;
+
+    private void Recompute()
+    {
+        if (_plan is null) return;
+        var plan = _plan;
+
+        var onHand = _onHand.QueryActiveCharacter().Counts;
+        var walk = _executor.Evaluate(plan, onHand);
+        var live = _executor.ResolveLiveSnapshot(plan.Character);
+
+        Skill = plan.Skill;
+        CharacterLabel = plan.Character is { } c ? $"{c.Name} @ {c.Server}" : "hypothetical";
+        GoalLabel = $"Goal L{plan.GoalLevel}";
+        var phaseCount = plan.Phases.Count;
+        IsPlanComplete = walk.IsPlanComplete || plan.CurrentPhaseIndex >= phaseCount;
+
+        // Auto-finalize: when the last phase's predicate is satisfied the plan is
+        // complete, but the cursor only advances *between* phases (TryAdvance is a
+        // no-op on the last). Persist the terminal sentinel (cursor == Phases.Count)
+        // so the manager's cursor-based Done state matches reality. Idempotent.
+        if (IsPlanComplete && phaseCount > 0 && plan.CurrentPhaseIndex < phaseCount)
+        {
+            plan.CurrentPhaseIndex = phaseCount;
+            _store.Upsert(plan);
+            PlanChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        var completed = Math.Min(Math.Max(plan.CurrentPhaseIndex, 0), phaseCount);
+        PhaseCountLabel = IsPlanComplete ? $"{phaseCount} / {phaseCount} complete" : $"{phaseCount} total";
+
+        IsStale = !_staleDismissed && live is not null && plan.IsInitialStateStaleAgainst(live);
+        StaleSummary = IsStale ? BuildStaleSummary(plan, live!) : "";
+        CreatedAgeText = HumanizeAge(DateTimeOffset.Now - plan.CreatedAt);
+
+        BuildRail(plan, walk, live);
+
+        if (!IsPlanComplete && walk.CurrentPhase is { } cur)
+        {
+            HasCurrentPhase = true;
+            DetailTitle = cur.RecipeName;
+            DetailLevels = $"L{cur.LevelAtStart} → L{cur.LevelAtEnd}";
+            DetailPredictedCrafts = cur.PredictedCrafts;
+            DetailXpPerCraft = cur.XpPerCraft;
+            DetailReuseXp = cur.IntermediateReuseXpPerCraft;
+            DetailUsesFirstTimeBonus = cur.UsesFirstTimeBonus;
+
+            var eval = walk.CurrentEvaluation;
+            PredicateOnHand = eval?.OnHand ?? 0;
+            PredicateThreshold = eval?.Threshold ?? 0;
+            PredicateFraction = PredicateThreshold <= 0
+                ? 0d : Math.Clamp((double)PredicateOnHand / PredicateThreshold, 0d, 1d);
+            PredicateComplete = eval?.IsComplete ?? false;
+
+            BuildSourcing(plan, cur);
+
+            var remainingCrafts = plan.Phases.Skip(plan.CurrentPhaseIndex).Sum(p => p.PredictedCrafts);
+            PositionText = $"Phase {plan.CurrentPhaseIndex + 1} of {phaseCount}";
+            RemainingText = $"Σ {remainingCrafts} predicted crafts remaining";
+        }
+        else
+        {
+            HasCurrentPhase = false;
+            SourcingRows = [];
+            PositionText = $"Phase {completed} of {phaseCount}";
+            RemainingText = "plan terminal";
+        }
+
+        AdvancePhaseCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(CanAdvance));
+    }
+
+    private void BuildRail(SavedLevelingPlan plan, PlanWalkState walk, Mithril.Shared.Character.CharacterSnapshot? live)
+    {
+        var rail = new ObservableCollection<PlanRailItemViewModel>();
+        var unlocks = plan.Unlocks.OrderBy(u => u.AtLevel).ToList();
+
+        for (var i = 0; i < plan.Phases.Count; i++)
+        {
+            var p = plan.Phases[i];
+            var state = i < plan.CurrentPhaseIndex || IsPlanComplete ? PhaseRailState.Done
+                : i == plan.CurrentPhaseIndex ? PhaseRailState.Current
+                : PhaseRailState.Upcoming;
+
+            var isCurrent = state == PhaseRailState.Current && walk.CurrentEvaluation is { } e;
+            rail.Add(PlanRailItemViewModel.Phase(
+                state, p.RecipeName, p.LevelAtStart, p.LevelAtEnd,
+                p.PredictedCrafts, p.XpPerCraft, p.UsesFirstTimeBonus,
+                showMiniProgress: state == PhaseRailState.Current,
+                onHand: isCurrent ? walk.CurrentEvaluation!.OnHand : 0,
+                threshold: isCurrent ? walk.CurrentEvaluation!.Threshold : 0));
+
+            // Unlock callouts belong to the phase whose level band covers them
+            // (displayed as the interstitial leading into the next phase).
+            foreach (var u in unlocks.Where(u =>
+                         u.AtLevel >= p.LevelAtStart &&
+                         (i == plan.Phases.Count - 1 || u.AtLevel < plan.Phases[i + 1].LevelAtStart)))
+            {
+                var alreadyKnown = live is not null
+                    && !string.IsNullOrEmpty(u.RecipeInternalName)
+                    && live.RecipeCompletions.ContainsKey(u.RecipeInternalName);
+                rail.Add(PlanRailItemViewModel.Unlock(
+                    u.AtLevel, u.RecipeName, u.XpPerCraftAtUnlock, u.Reason, alreadyKnown));
+            }
+        }
+
+        Rail = rail;
+    }
+
+    private void BuildSourcing(SavedLevelingPlan plan, PersistedPlanPhase phase)
+    {
+        var rows = new ObservableCollection<SourcingRowViewModel>();
+        if (_ref.RecipesByInternalName.TryGetValue(phase.RecipeInternalName, out var recipe))
+        {
+            var policy = plan.ToSourcingPolicy();
+            foreach (var ing in recipe.Ingredients.OfType<RecipeItemIngredient>())
+            {
+                if (!_ref.Items.TryGetValue(ing.ItemCode, out var item)) continue;
+                if (string.IsNullOrEmpty(item.InternalName)) continue;
+                rows.Add(new SourcingRowViewModel(
+                    item.InternalName!,
+                    item.Name ?? item.InternalName!,
+                    Math.Max(1, ing.StackSize) * phase.PredictedCrafts,
+                    policy.For(item.InternalName!),
+                    OnSourcingChanged));
+            }
+        }
+        SourcingRows = rows;
+    }
+
+    private void OnSourcingChanged(string itemInternalName, SourcingMode mode)
+    {
+        if (_plan is null) return;
+        _plan.Sourcing = _plan.Sourcing
+            .Where(s => !string.Equals(s.ItemInternalName, itemInternalName, StringComparison.Ordinal))
+            .Append(new PersistedSourcingEntry { ItemInternalName = itemInternalName, Mode = mode })
+            .ToList();
+        _store.Upsert(_plan);
+        PlanChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void SendPhaseToCraftList()
+    {
+        if (_plan is null) return;
+        var walk = _executor.Evaluate(_plan, _onHand.QueryActiveCharacter().Counts);
+        if (walk.CurrentPhase is not { } cur || string.IsNullOrEmpty(cur.RecipeInternalName)) return;
+        _craftList.ImportRecipes(
+            [new CraftListImportEntry(cur.RecipeInternalName, Math.Max(1, cur.PredictedCrafts))],
+            $"Leveling plan · {_plan.Skill}");
+    }
+
+    /// <summary>
+    /// Advance past a satisfied <i>non-last</i> phase. The last phase needs no
+    /// click — <see cref="Recompute"/> auto-finalizes the terminal sentinel when
+    /// its predicate trips. (No telemetry auto-advance; this stays explicit.)
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanAdvance))]
+    private void AdvancePhase()
+    {
+        if (_plan is null) return;
+        if (!_executor.TryAdvance(_plan, _onHand.QueryActiveCharacter().Counts)) return;
+        _store.Upsert(_plan);
+        Recompute();
+        PlanChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void Replan()
+    {
+        if (_plan is null) return;
+        var refreshed = _executor.Replan(_plan, _onHand.QueryActiveCharacter().Counts);
+        if (refreshed is null) return;
+        _store.Upsert(refreshed);
+        _plan = refreshed;
+        _staleDismissed = false;
+        Recompute();
+        PlanChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Stale banner primary action — identical to <see cref="Replan"/>:
+    /// <see cref="PlanExecutor.Replan"/> already refreshes the embedded state from
+    /// the live export when the weak character ref resolves.</summary>
+    [RelayCommand]
+    private void RefreshAndReplan() => Replan();
+
+    /// <summary>"Walk anyway" — dismiss the stale warning for this session.</summary>
+    [RelayCommand]
+    private void DismissStale()
+    {
+        _staleDismissed = true;
+        Recompute();
+    }
+
+    [RelayCommand]
+    private void BackToLibrary() => BackRequested?.Invoke(this, EventArgs.Empty);
+
+    private static string BuildStaleSummary(SavedLevelingPlan plan, Mithril.Shared.Character.CharacterSnapshot live)
+    {
+        var newRecipes = live.RecipeCompletions.Keys
+            .Count(k => !plan.InitialRecipeCompletions.ContainsKey(k));
+        var skillNote = plan.InitialSkills.TryGetValue(plan.Skill, out var was)
+            && live.Skills.TryGetValue(plan.Skill, out var now) && now.Level != was.Level
+            ? $"{plan.Skill} L{was.Level} → L{now.Level}"
+            : $"{plan.Skill} baseline unchanged";
+        return newRecipes > 0
+            ? $"{skillNote} · {newRecipes} new recipe(s) since this plan was generated"
+            : $"{skillNote} · progression changed since this plan was generated";
+    }
+
+    private static string HumanizeAge(TimeSpan age)
+    {
+        if (age < TimeSpan.FromMinutes(1)) return "just now";
+        if (age < TimeSpan.FromHours(1)) return $"{(int)age.TotalMinutes}m ago";
+        if (age < TimeSpan.FromDays(1)) return $"{(int)age.TotalHours}h ago";
+        return $"{(int)age.TotalDays}d ago";
+    }
+}

--- a/src/Celebrimbor.Module/ViewModels/PlansViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/PlansViewModel.cs
@@ -1,0 +1,227 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text.Json;
+using Celebrimbor.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+using Mithril.Shared.Modules;
+
+namespace Celebrimbor.ViewModels;
+
+/// <summary>
+/// The Plans manager + host for the walker (#228 PR-B/B1, frames 01–02).
+/// A peer area to the crafting wizard — not a wizard step: an independent,
+/// id-keyed library of <see cref="SavedLevelingPlan"/> artifacts the user
+/// walks. Plans arrive from outside (Elrond hand-off / file import) and feed
+/// back into the wizard via the walker's "Send phase to craft list".
+///
+/// <para>Headless: file-pick and delete-confirm are injectable seams so the
+/// VM is unit-testable without WPF dialogs.</para>
+/// </summary>
+public sealed partial class PlansViewModel : ObservableObject
+{
+    private readonly LevelingPlanStore _store;
+    private readonly PlanExecutor _executor;
+    private readonly OnHandInventoryQuery _onHand;
+    private readonly IActiveCharacterService _activeChar;
+    private readonly IModuleActivator? _activator;
+    private readonly Func<string?> _pickPlanFile;
+    private readonly Func<SavedPlanRowViewModel, bool> _confirmDelete;
+
+    public PlansViewModel(
+        LevelingPlanStore store,
+        PlanExecutor executor,
+        OnHandInventoryQuery onHand,
+        IActiveCharacterService activeChar,
+        PlanWalkerViewModel walker,
+        IModuleActivator? activator = null,
+        Func<string?>? pickPlanFile = null,
+        Func<SavedPlanRowViewModel, bool>? confirmDelete = null)
+    {
+        _store = store;
+        _executor = executor;
+        _onHand = onHand;
+        _activeChar = activeChar;
+        _activator = activator;
+        _pickPlanFile = pickPlanFile ?? DefaultPickPlanFile;
+        _confirmDelete = confirmDelete ?? DefaultConfirmDelete;
+        Walker = walker;
+
+        Walker.BackRequested += (_, _) =>
+        {
+            IsWalking = false;
+            Reload();
+        };
+        Walker.PlanChanged += (_, _) => Reload();
+
+        _activeChar.ActiveCharacterChanged += (_, _) => DispatchOnUi(Reload);
+        _activeChar.CharacterExportsChanged += (_, _) => DispatchOnUi(Reload);
+
+        Reload();
+    }
+
+    public PlanWalkerViewModel Walker { get; }
+
+    [ObservableProperty]
+    private ObservableCollection<SavedPlanRowViewModel> _rows = [];
+
+    [ObservableProperty]
+    private SavedPlanRowViewModel? _selectedRow;
+
+    [ObservableProperty]
+    private string _searchText = "";
+
+    [ObservableProperty]
+    private PlanFilter _activeFilter = PlanFilter.All;
+
+    /// <summary>True while the walker sub-view is showing instead of the library list.</summary>
+    [ObservableProperty]
+    private bool _isWalking;
+
+    public bool IsEmpty => _store.All().Count == 0;
+
+    public int AllCount { get; private set; }
+    public int InProgressCount { get; private set; }
+    public int StaleCount { get; private set; }
+    public int DoneCount { get; private set; }
+
+    partial void OnSearchTextChanged(string value) => ApplyView();
+    partial void OnActiveFilterChanged(PlanFilter value) => ApplyView();
+
+    /// <summary>Rebuild every row from the store (staleness vs the live character).</summary>
+    public void Reload()
+    {
+        var live = _activeChar.ActiveCharacter;
+        _allRows = _store.All()
+            .OrderByDescending(p => p.CreatedAt)
+            .Select(p => new SavedPlanRowViewModel(p, IsStale(p, live)))
+            .ToList();
+
+        AllCount = _allRows.Count;
+        InProgressCount = _allRows.Count(r => r.Status == SavedPlanStatus.InProgress);
+        StaleCount = _allRows.Count(r => r.Status == SavedPlanStatus.Stale);
+        DoneCount = _allRows.Count(r => r.Status == SavedPlanStatus.Done);
+        OnPropertyChanged(nameof(AllCount));
+        OnPropertyChanged(nameof(InProgressCount));
+        OnPropertyChanged(nameof(StaleCount));
+        OnPropertyChanged(nameof(DoneCount));
+        OnPropertyChanged(nameof(IsEmpty));
+
+        ApplyView();
+    }
+
+    private List<SavedPlanRowViewModel> _allRows = [];
+
+    private void ApplyView()
+    {
+        var filtered = _allRows
+            .Where(r => r.MatchesFilter(ActiveFilter) && r.MatchesSearch(SearchText))
+            .ToList();
+        Rows = new ObservableCollection<SavedPlanRowViewModel>(filtered);
+        if (SelectedRow is null || filtered.All(r => !string.Equals(r.Id, SelectedRow.Id, StringComparison.Ordinal)))
+            SelectedRow = filtered.FirstOrDefault();
+    }
+
+    private static bool IsStale(SavedLevelingPlan plan, CharacterSnapshot? live)
+        => live is not null && plan.IsInitialStateStaleAgainst(live);
+
+    [RelayCommand]
+    private void SetFilter(PlanFilter filter) => ActiveFilter = filter;
+
+    [RelayCommand]
+    private void OpenWalker(SavedPlanRowViewModel? row)
+    {
+        var target = row ?? SelectedRow;
+        if (target is null) return;
+        Walker.Load(target.Plan);
+        IsWalking = true;
+    }
+
+    [RelayCommand]
+    private void Replan(SavedPlanRowViewModel? row)
+    {
+        var target = row ?? SelectedRow;
+        if (target is null) return;
+        var refreshed = _executor.Replan(target.Plan, OnHandCounts());
+        if (refreshed is null) return; // no viable path — leave the old plan untouched
+        _store.Upsert(refreshed);
+        Reload();
+    }
+
+    [RelayCommand]
+    private void Delete(SavedPlanRowViewModel? row)
+    {
+        var target = row ?? SelectedRow;
+        if (target is null || !_confirmDelete(target)) return;
+        _store.Delete(target.Id);
+        Reload();
+    }
+
+    [RelayCommand]
+    private void ImportPlanFromFile()
+    {
+        var path = _pickPlanFile();
+        if (string.IsNullOrEmpty(path) || !File.Exists(path)) return;
+
+        SavedLevelingPlan? plan;
+        try
+        {
+            plan = JsonSerializer.Deserialize(File.ReadAllText(path),
+                SavedLevelingPlanJsonContext.Default.SavedLevelingPlan);
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            return;
+        }
+        if (plan is null || plan.Phases.Count == 0) return;
+
+        _store.Upsert(plan);
+        Reload();
+        SelectedRow = Rows.FirstOrDefault(r => string.Equals(r.Id, plan.Id, StringComparison.Ordinal));
+    }
+
+    /// <summary>Empty-state CTA: the plan source is Elrond (the advisor), not the Picker.</summary>
+    [RelayCommand]
+    private void OpenPlanSource() => _activator?.Activate("elrond");
+
+    /// <summary>
+    /// Called by the import target after a hand-off lands: refresh the library
+    /// and select the new plan so the user sees it arrive (stay in the manager,
+    /// per spec frames 01–02 — the plan "lands here").
+    /// </summary>
+    public void SurfaceImported(string planId)
+    {
+        IsWalking = false;
+        Reload();
+        SelectedRow = Rows.FirstOrDefault(r => string.Equals(r.Id, planId, StringComparison.Ordinal));
+    }
+
+    private IReadOnlyDictionary<string, int> OnHandCounts()
+        => _onHand.QueryActiveCharacter().Counts;
+
+    private static string? DefaultPickPlanFile()
+    {
+        var dlg = new Microsoft.Win32.OpenFileDialog
+        {
+            Title = "Import leveling plan",
+            Filter = "Mithril plan (*.plan;*.json)|*.plan;*.json|All files (*.*)|*.*",
+            CheckFileExists = true,
+        };
+        return dlg.ShowDialog() == true ? dlg.FileName : null;
+    }
+
+    private static bool DefaultConfirmDelete(SavedPlanRowViewModel row)
+        => System.Windows.MessageBox.Show(
+               $"Delete the plan \"{row.Title}\"? This cannot be undone.",
+               "Delete plan", System.Windows.MessageBoxButton.OKCancel,
+               System.Windows.MessageBoxImage.Warning) == System.Windows.MessageBoxResult.OK;
+
+    private static void DispatchOnUi(Action action)
+    {
+        var d = System.Windows.Application.Current?.Dispatcher;
+        if (d is null || d.CheckAccess()) action();
+        else d.InvokeAsync(action);
+    }
+}

--- a/src/Celebrimbor.Module/ViewModels/SavedPlanRowViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/SavedPlanRowViewModel.cs
@@ -1,0 +1,105 @@
+using Mithril.Planning;
+
+namespace Celebrimbor.ViewModels;
+
+/// <summary>Resting status of a saved plan, as shown by the manager pill/glyph.</summary>
+public enum SavedPlanStatus
+{
+    NeverWalked,
+    InProgress,
+    Stale,
+    Done,
+    Hypothetical,
+}
+
+/// <summary>
+/// One row in the Plans manager (#228 PR-B/B1, frame 02). A read-only
+/// projection of a <see cref="SavedLevelingPlan"/> plus a manager-supplied
+/// <paramref name="isStale"/> flag (staleness needs the live character, which
+/// the row itself doesn't know). Telemetry-derived fields (crafts walked, xp
+/// banked) are intentionally absent — deferred with the craft-count tracker.
+/// </summary>
+public sealed class SavedPlanRowViewModel
+{
+    public SavedPlanRowViewModel(SavedLevelingPlan plan, bool isStale)
+    {
+        Plan = plan;
+        var phaseCount = plan.Phases.Count;
+        var done = phaseCount > 0 && plan.CurrentPhaseIndex >= phaseCount;
+
+        Status = plan.Character is null && !done ? SavedPlanStatus.Hypothetical
+            : done ? SavedPlanStatus.Done
+            : isStale ? SavedPlanStatus.Stale
+            : plan.CurrentPhaseIndex > 0 ? SavedPlanStatus.InProgress
+            : SavedPlanStatus.NeverWalked;
+
+        Title = $"{plan.Skill}  {plan.StartLevel}→{plan.GoalLevel}";
+
+        var span = phaseCount > 0
+            ? $"{plan.Phases[0].RecipeName} → {plan.Phases[^1].RecipeName} path · "
+            : "";
+        Subtitle = $"{span}{phaseCount} phases · {plan.TotalCrafts} predicted crafts";
+
+        CharacterLabel = plan.Character is { } c ? $"{c.Name} @ {c.Server}" : "hypothetical";
+
+        var completedPhases = Math.Min(Math.Max(plan.CurrentPhaseIndex, 0), phaseCount);
+        PhaseText = $"{completedPhases} / {phaseCount}";
+        ProgressFraction = phaseCount == 0 ? 0d : (double)completedPhases / phaseCount;
+
+        AgeText = Humanize(DateTimeOffset.Now - plan.CreatedAt);
+        Glyph = Status switch
+        {
+            SavedPlanStatus.InProgress => "▸",   // ▸
+            SavedPlanStatus.Stale => "⚠",        // ⚠
+            SavedPlanStatus.Done => "✓",         // ✓
+            _ => "○",                            // ○
+        };
+    }
+
+    public SavedLevelingPlan Plan { get; }
+    public string Id => Plan.Id;
+    public SavedPlanStatus Status { get; }
+    public string Title { get; }
+    public string Subtitle { get; }
+    public string CharacterLabel { get; }
+    public bool IsHypothetical => Plan.Character is null;
+    public string PhaseText { get; }
+    public double ProgressFraction { get; }
+    public string AgeText { get; }
+    public string Glyph { get; }
+
+    /// <summary>Does this row pass the active manager filter chip?</summary>
+    public bool MatchesFilter(PlanFilter filter) => filter switch
+    {
+        PlanFilter.InProgress => Status == SavedPlanStatus.InProgress,
+        PlanFilter.Stale => Status == SavedPlanStatus.Stale,
+        PlanFilter.Done => Status == SavedPlanStatus.Done,
+        _ => true,
+    };
+
+    /// <summary>Free-text search over skill, character and phase recipe names.</summary>
+    public bool MatchesSearch(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return true;
+        if (Title.Contains(query, StringComparison.OrdinalIgnoreCase)) return true;
+        if (CharacterLabel.Contains(query, StringComparison.OrdinalIgnoreCase)) return true;
+        return Plan.Phases.Any(p => p.RecipeName.Contains(query, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string Humanize(TimeSpan age)
+    {
+        if (age < TimeSpan.FromMinutes(1)) return "just now";
+        if (age < TimeSpan.FromHours(1)) return $"{(int)age.TotalMinutes}m ago";
+        if (age < TimeSpan.FromDays(1)) return $"{(int)age.TotalHours}h ago";
+        return $"{(int)age.TotalDays}d ago";
+    }
+}
+
+/// <summary>Manager filter chips (frame 02). "All" is the unfiltered default.</summary>
+public enum PlanFilter
+{
+    All,
+    InProgress,
+    Stale,
+    Done,
+}

--- a/src/Celebrimbor.Module/ViewModels/SourcingRowViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/SourcingRowViewModel.cs
@@ -1,0 +1,54 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Planning;
+
+namespace Celebrimbor.ViewModels;
+
+/// <summary>
+/// One ingredient of the walker's current phase with a tri-state sourcing
+/// toggle (#228 PR-B/B1, frame 03). The mode is persisted on the plan
+/// (<see cref="SavedLevelingPlan.Sourcing"/>) and consumed by the next
+/// re-plan — toggling here changes future regeneration, not the current
+/// predicted crafts. v1 covers item ingredients only; keyword slots are not
+/// individually sourced.
+/// </summary>
+public sealed partial class SourcingRowViewModel : ObservableObject
+{
+    private readonly Action<string, SourcingMode> _onModeChanged;
+
+    public SourcingRowViewModel(
+        string itemInternalName,
+        string displayName,
+        int need,
+        SourcingMode mode,
+        Action<string, SourcingMode> onModeChanged)
+    {
+        ItemInternalName = itemInternalName;
+        DisplayName = displayName;
+        Need = need;
+        _mode = mode;
+        _onModeChanged = onModeChanged;
+    }
+
+    public string ItemInternalName { get; }
+    public string DisplayName { get; }
+    public int Need { get; }
+
+    [ObservableProperty]
+    private SourcingMode _mode;
+
+    public bool IsCraft => Mode == SourcingMode.Craft;
+    public bool IsSupply => Mode == SourcingMode.SupplyExternally;
+    public bool IsIgnore => Mode == SourcingMode.Ignore;
+
+    partial void OnModeChanged(SourcingMode value)
+    {
+        OnPropertyChanged(nameof(IsCraft));
+        OnPropertyChanged(nameof(IsSupply));
+        OnPropertyChanged(nameof(IsIgnore));
+        _onModeChanged(ItemInternalName, value);
+    }
+
+    [RelayCommand]
+    private void SetMode(SourcingMode mode) => Mode = mode;
+}

--- a/src/Celebrimbor.Module/Views/CelebrimborShellView.xaml
+++ b/src/Celebrimbor.Module/Views/CelebrimborShellView.xaml
@@ -15,7 +15,10 @@
     </UserControl.Resources>
 
     <DockPanel>
-        <!-- Shell header with module title + wizard indicator -->
+        <!-- Shell header: module identity · crafting wizard breadcrumb · area pivot.
+             The Pick→Shop wizard and Plans are *peer areas* (not wizard steps):
+             the breadcrumb only shows in the crafting area; the pivot switches
+             between the two. -->
         <Border DockPanel.Dock="Top" Padding="12,10" Background="#FF1F1F1F" BorderBrush="#22FFFFFF" BorderThickness="0,0,0,1">
             <Grid>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
@@ -25,7 +28,21 @@
                                FontFamily="{DynamicResource AppHeaderFontFamily}" FontSize="{DynamicResource AppFontSizeLarge}" FontWeight="SemiBold"
                                Foreground="#FFD4A847" VerticalAlignment="Center"/>
                 </StackPanel>
-                <views:WizardStepIndicator HorizontalAlignment="Center"/>
+
+                <views:WizardStepIndicator HorizontalAlignment="Center"
+                                           Visibility="{Binding IsCraftingArea, Converter={StaticResource BoolToVis}}"/>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button Command="{Binding GoToCraftingCommand}" Cursor="Hand"
+                            BorderThickness="0" Background="Transparent" Padding="10,4"
+                            Foreground="{Binding IsCraftingArea, Converter={StaticResource AreaAccent}}"
+                            Content="Crafting"/>
+                    <Border Width="1" Height="14" Background="#33FFFFFF" Margin="6,0"/>
+                    <Button Command="{Binding GoToPlansCommand}" Cursor="Hand"
+                            BorderThickness="0" Background="Transparent" Padding="10,4"
+                            Foreground="{Binding IsPlansArea, Converter={StaticResource AreaAccent}}"
+                            Content="Plans"/>
+                </StackPanel>
             </Grid>
         </Border>
 
@@ -34,6 +51,8 @@
                                     Visibility="{Binding DataContext.CurrentView, ElementName=ShellRoot, Converter={StaticResource PickerVisibility}}"/>
             <views:ShoppingListView DataContext="{Binding Shopping}"
                                     Visibility="{Binding DataContext.CurrentView, ElementName=ShellRoot, Converter={StaticResource ShoppingVisibility}}"/>
+            <views:PlansView DataContext="{Binding Plans}"
+                             Visibility="{Binding DataContext.CurrentView, ElementName=ShellRoot, Converter={StaticResource PlansVisibility}}"/>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/src/Celebrimbor.Module/Views/Converters.cs
+++ b/src/Celebrimbor.Module/Views/Converters.cs
@@ -51,10 +51,9 @@ public sealed class ViewModeToVisibilityConverter : IValueConverter
     public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not CelebrimborViewMode mode) return Visibility.Collapsed;
-        var targetMode = string.Equals(Target, "Shopping", StringComparison.OrdinalIgnoreCase)
-            ? CelebrimborViewMode.Shopping
-            : CelebrimborViewMode.Picker;
-        return mode == targetMode ? Visibility.Visible : Visibility.Collapsed;
+        return Enum.TryParse<CelebrimborViewMode>(Target, ignoreCase: true, out var targetMode)
+            && mode == targetMode
+            ? Visibility.Visible : Visibility.Collapsed;
     }
 
     public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
@@ -71,11 +70,63 @@ public sealed class ViewModeToAccentBrushConverter : IValueConverter
     public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not CelebrimborViewMode mode) return Inactive;
-        var targetMode = string.Equals(Target, "Shopping", StringComparison.OrdinalIgnoreCase)
-            ? CelebrimborViewMode.Shopping
-            : CelebrimborViewMode.Picker;
-        return mode == targetMode ? Active : Inactive;
+        return Enum.TryParse<CelebrimborViewMode>(Target, ignoreCase: true, out var targetMode)
+            && mode == targetMode
+            ? Active : Inactive;
     }
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>Header pivot accent: gold when the area is active, dim otherwise.</summary>
+public sealed class BoolToAccentBrushConverter : IValueConverter
+{
+    private static readonly SolidColorBrush Active = (SolidColorBrush)new BrushConverter().ConvertFromString("#FFD4A847")!;
+    private static readonly SolidColorBrush Inactive = (SolidColorBrush)new BrushConverter().ConvertFromString("#88FFFFFF")!;
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b && b ? Active : Inactive;
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>Manager glyph / pill colour by plan status (#228 PR-B/B1 frame 02).</summary>
+public sealed class PlanStatusToBrushConverter : IValueConverter
+{
+    private static readonly SolidColorBrush Run = (SolidColorBrush)new BrushConverter().ConvertFromString("#FF4FB3A5")!;   // teal — progress
+    private static readonly SolidColorBrush Warn = (SolidColorBrush)new BrushConverter().ConvertFromString("#FFC9A24A")!;  // stale
+    private static readonly SolidColorBrush Ok = (SolidColorBrush)new BrushConverter().ConvertFromString("#FF7BA876")!;    // done
+    private static readonly SolidColorBrush Idle = (SolidColorBrush)new BrushConverter().ConvertFromString("#FF7A7A7A")!;
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value switch
+        {
+            SavedPlanStatus.InProgress => Run,
+            SavedPlanStatus.Stale => Warn,
+            SavedPlanStatus.Done => Ok,
+            _ => Idle,
+        };
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>Walker rail marker / text colour by phase position (#228 PR-B/B1 frame 03).</summary>
+public sealed class PhaseRailStateToBrushConverter : IValueConverter
+{
+    private static readonly SolidColorBrush Done = (SolidColorBrush)new BrushConverter().ConvertFromString("#FF7BA876")!;
+    private static readonly SolidColorBrush Current = (SolidColorBrush)new BrushConverter().ConvertFromString("#FF4FB3A5")!;
+    private static readonly SolidColorBrush Upcoming = (SolidColorBrush)new BrushConverter().ConvertFromString("#FF5A5A5A")!;
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value switch
+        {
+            PhaseRailState.Done => Done,
+            PhaseRailState.Current => Current,
+            _ => Upcoming,
+        };
 
     public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/src/Celebrimbor.Module/Views/PlansView.xaml
+++ b/src/Celebrimbor.Module/Views/PlansView.xaml
@@ -1,0 +1,514 @@
+<UserControl x:Class="Celebrimbor.Views.PlansView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Celebrimbor.ViewModels"
+             xmlns:planning="clr-namespace:Mithril.Planning;assembly=Mithril.Planning"
+             mc:Ignorable="d"
+             Background="#FF1A1A1A">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <Style x:Key="PlanActionButton" TargetType="Button">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="Foreground" Value="#FFB0B0B0"/>
+                <Setter Property="BorderBrush" Value="#22FFFFFF"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Padding" Value="9,3"/>
+                <Setter Property="Margin" Value="4,0,0,0"/>
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="FontSize" Value="{DynamicResource AppFontSizeHint}"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="2"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="#26FFFFFF"/>
+                        <Setter Property="Foreground" Value="#FFE6E6E6"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                        <Setter Property="Opacity" Value="0.4"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="PrimaryActionButton" TargetType="Button" BasedOn="{StaticResource PlanActionButton}">
+                <Setter Property="Background" Value="#FF4FB3A5"/>
+                <Setter Property="Foreground" Value="#FF0F1A18"/>
+                <Setter Property="BorderBrush" Value="#FF4FB3A5"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="#FF5BC2B3"/>
+                        <Setter Property="Foreground" Value="#FF0F1A18"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                        <Setter Property="Opacity" Value="0.4"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <!-- Tri-state segment. Tag is bound to the row's Is{Mode} bool; the
+                 active segment gets surface fill + accent text (frame 03). -->
+            <Style x:Key="SegButton" TargetType="Button" BasedOn="{StaticResource PlanActionButton}">
+                <Setter Property="Margin" Value="0"/>
+                <Setter Property="MinWidth" Value="58"/>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Tag, RelativeSource={RelativeSource Self}}" Value="True">
+                        <Setter Property="Background" Value="#FF2A2A2A"/>
+                        <Setter Property="Foreground" Value="#FF4FB3A5"/>
+                        <Setter Property="BorderBrush" Value="#FF4FB3A5"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <!-- ════════════ MANAGER ════════════ -->
+        <Grid Visibility="{Binding IsWalking, Converter={StaticResource InvBoolToVis}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Toolbar: search + filter chips -->
+            <Grid Grid.Row="0" Margin="16,12,16,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Border Grid.Column="0" Background="#FF171717" BorderBrush="#22FFFFFF" BorderThickness="1"
+                        CornerRadius="2" Padding="8,4" MaxWidth="340" HorizontalAlignment="Left">
+                    <TextBox Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             Background="Transparent" BorderThickness="0" Foreground="#FFB0B0B0"
+                             FontSize="{DynamicResource AppFontSizeHint}"
+                             d:Text="Filter plans by skill, character, recipe…"/>
+                </Border>
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <ItemsControl>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><StackPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <Button Style="{StaticResource PlanActionButton}"
+                                Command="{Binding SetFilterCommand}" CommandParameter="{x:Static vm:PlanFilter.All}">
+                            <TextBlock><Run Text="All "/><Run Text="{Binding AllCount, Mode=OneWay}"/></TextBlock>
+                        </Button>
+                        <Button Style="{StaticResource PlanActionButton}"
+                                Command="{Binding SetFilterCommand}" CommandParameter="{x:Static vm:PlanFilter.InProgress}">
+                            <TextBlock><Run Text="In progress "/><Run Text="{Binding InProgressCount, Mode=OneWay}"/></TextBlock>
+                        </Button>
+                        <Button Style="{StaticResource PlanActionButton}"
+                                Command="{Binding SetFilterCommand}" CommandParameter="{x:Static vm:PlanFilter.Stale}">
+                            <TextBlock><Run Text="Stale "/><Run Text="{Binding StaleCount, Mode=OneWay}"/></TextBlock>
+                        </Button>
+                        <Button Style="{StaticResource PlanActionButton}"
+                                Command="{Binding SetFilterCommand}" CommandParameter="{x:Static vm:PlanFilter.Done}">
+                            <TextBlock><Run Text="Done "/><Run Text="{Binding DoneCount, Mode=OneWay}"/></TextBlock>
+                        </Button>
+                    </ItemsControl>
+                </StackPanel>
+            </Grid>
+
+            <!-- Empty state -->
+            <StackPanel Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" MaxWidth="420"
+                        Visibility="{Binding IsEmpty, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="No plans in your library" FontWeight="SemiBold"
+                           FontSize="{DynamicResource AppFontSizeLarge}" Foreground="#FFB0B0B0"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                <TextBlock TextWrapping="Wrap" TextAlignment="Center" Foreground="#FF7A7A7A"
+                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,16"
+                           Text="Celebrimbor walks plans you've received. Generate one from Elrond, the skill advisor — for the active character or a hypothetical — and it will land here."/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <Button Style="{StaticResource PrimaryActionButton}" Padding="12,5"
+                            Command="{Binding OpenPlanSourceCommand}" Content="Open Elrond"/>
+                    <Button Style="{StaticResource PlanActionButton}" Padding="12,5"
+                            Command="{Binding ImportPlanFromFileCommand}" Content="Import .plan…"/>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Library list -->
+            <ListBox Grid.Row="1" Margin="8,0,8,8" Background="Transparent" BorderThickness="0"
+                     ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                     HorizontalContentAlignment="Stretch"
+                     Visibility="{Binding IsEmpty, Converter={StaticResource InvBoolToVis}}">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="Padding" Value="0"/>
+                        <Setter Property="Margin" Value="0,1"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListBoxItem">
+                                    <Border x:Name="rowBorder" Background="{TemplateBinding Background}"
+                                            BorderThickness="2,0,0,0" BorderBrush="Transparent" Padding="14,8">
+                                        <ContentPresenter/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="rowBorder" Property="Background" Value="#FF262626"/>
+                                        </Trigger>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="rowBorder" Property="Background" Value="#FF222222"/>
+                                            <Setter TargetName="rowBorder" Property="BorderBrush" Value="#FF4FB3A5"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="22"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="160"/>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition Width="80"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0" Text="{Binding Glyph}" VerticalAlignment="Center"
+                                       Foreground="{Binding Status, Converter={StaticResource PlanStatusBrush}}"/>
+
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="6,0">
+                                <TextBlock Text="{Binding Title}" Foreground="#FFE6E6E6"
+                                           FontSize="{DynamicResource AppFontSizeNormal}"/>
+                                <TextBlock Text="{Binding Subtitle}" Foreground="#FF7A7A7A"
+                                           FontSize="{DynamicResource AppFontSizeSmall}"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="2" Text="{Binding CharacterLabel}" VerticalAlignment="Center"
+                                       Foreground="#FFB0B0B0" FontSize="{DynamicResource AppFontSizeHint}"/>
+
+                            <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding PhaseText}" Foreground="#FFB0B0B0"
+                                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,8,0"/>
+                                <ProgressBar Width="44" Height="4" Minimum="0" Maximum="1"
+                                             Value="{Binding ProgressFraction, Mode=OneWay}"
+                                             Background="#FF2A2A2A" Foreground="#FF4FB3A5" BorderThickness="0"/>
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="4" Text="{Binding AgeText}" VerticalAlignment="Center"
+                                       Foreground="#FF5A5A5A" FontSize="{DynamicResource AppFontSizeSmall}"/>
+
+                            <StackPanel Grid.Column="5" Orientation="Horizontal" VerticalAlignment="Center">
+                                <Button Style="{StaticResource PrimaryActionButton}" Content="Walk"
+                                        Command="{Binding DataContext.OpenWalkerCommand,
+                                                  RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding}"/>
+                                <Button Style="{StaticResource PlanActionButton}" Content="Re-plan"
+                                        Command="{Binding DataContext.ReplanCommand,
+                                                  RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding}"/>
+                                <Button Style="{StaticResource PlanActionButton}" Content="Delete"
+                                        Command="{Binding DataContext.DeleteCommand,
+                                                  RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding}"/>
+                            </StackPanel>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Grid>
+
+        <!-- ════════════ WALKER ════════════ -->
+        <Grid DataContext="{Binding Walker}"
+              Visibility="{Binding DataContext.IsWalking,
+                           RelativeSource={RelativeSource AncestorType=UserControl},
+                           Converter={StaticResource BoolToVis}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Stale banner -->
+            <Border Grid.Row="0" Background="#1FC9A24A" BorderBrush="#4DC9A24A" BorderThickness="0,0,0,1"
+                    Padding="22,10" Visibility="{Binding IsStale, Converter={StaticResource BoolToVis}}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock Text="The live character outpaced this plan." Foreground="#FFC9A24A"
+                                   FontWeight="SemiBold" FontSize="{DynamicResource AppFontSizeHint}"/>
+                        <TextBlock Text="{Binding StaleSummary}" Foreground="#FF7A7A7A"
+                                   FontSize="{DynamicResource AppFontSizeSmall}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Style="{StaticResource PlanActionButton}" Content="Walk anyway"
+                                Command="{Binding DismissStaleCommand}"/>
+                        <Button Style="{StaticResource PrimaryActionButton}" Content="Refresh &amp; re-plan"
+                                Command="{Binding RefreshAndReplanCommand}"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- Header -->
+            <Border Grid.Row="1" Padding="22,12" BorderBrush="#14FFFFFF" BorderThickness="0,0,0,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0">
+                        <TextBlock FontSize="{DynamicResource AppFontSizeSmall}" Foreground="#FF5A5A5A">
+                            <Run Text="{Binding Skill, Mode=OneWay}"/><Run Text=" · "/>
+                            <Run Text="{Binding CharacterLabel, Mode=OneWay}"/><Run Text=" · "/>
+                            <Run Text="{Binding GoalLabel, Mode=OneWay}"/>
+                        </TextBlock>
+                        <TextBlock Text="{Binding DetailTitle}" Foreground="#FFE6E6E6"
+                                   FontSize="{DynamicResource AppFontSizeLarge}" FontWeight="SemiBold"
+                                   Visibility="{Binding HasCurrentPhase, Converter={StaticResource BoolToVis}}"/>
+                        <TextBlock Text="Plan complete" Foreground="#FF7BA876"
+                                   FontSize="{DynamicResource AppFontSizeLarge}" FontWeight="SemiBold"
+                                   Visibility="{Binding IsPlanComplete, Converter={StaticResource BoolToVis}}"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" Style="{StaticResource PlanActionButton}" Content="↩ Library"
+                            VerticalAlignment="Top" Command="{Binding BackToLibraryCommand}"/>
+                </Grid>
+            </Border>
+
+            <!-- Three columns: rail · detail · sourcing -->
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="340"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="280"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Rail -->
+                <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto"
+                              BorderBrush="#14FFFFFF" BorderThickness="0,0,1,0">
+                    <ItemsControl ItemsSource="{Binding Rail}" Margin="0,8">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <!-- Phase -->
+                                    <Border Padding="18,10" Margin="0,1"
+                                            Visibility="{Binding IsUnlock, Converter={StaticResource InvBoolToVis}}">
+                                        <StackPanel>
+                                            <StackPanel Orientation="Horizontal">
+                                                <Ellipse Width="9" Height="9" Margin="0,0,8,0" VerticalAlignment="Center"
+                                                         Fill="{Binding State, Converter={StaticResource PhaseRailBrush}}"/>
+                                                <TextBlock Text="{Binding RecipeName}" Foreground="#FFE6E6E6"
+                                                           FontSize="{DynamicResource AppFontSizeHint}"/>
+                                            </StackPanel>
+                                            <TextBlock Margin="17,2,0,0" Foreground="#FF5A5A5A"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}">
+                                                <Run Text="{Binding LevelRange, Mode=OneWay}"/><Run Text="   "/>
+                                                <Run Text="{Binding Meta, Mode=OneWay}"/>
+                                            </TextBlock>
+                                            <TextBlock Text="first-time bonus" Margin="17,1,0,0" Foreground="#FF4FB3A5"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}"
+                                                       Visibility="{Binding UsesFirstTimeBonus, Converter={StaticResource BoolToVis}}"/>
+                                            <StackPanel Orientation="Horizontal" Margin="17,5,0,0"
+                                                        Visibility="{Binding ShowMiniProgress, Converter={StaticResource BoolToVis}}">
+                                                <TextBlock Foreground="#FFB0B0B0" FontSize="{DynamicResource AppFontSizeSmall}"
+                                                           Margin="0,0,8,0">
+                                                    <Run Text="{Binding MiniOnHand, Mode=OneWay}"/><Run Text=" / "/>
+                                                    <Run Text="{Binding MiniThreshold, Mode=OneWay}"/>
+                                                </TextBlock>
+                                                <ProgressBar Width="120" Height="3" Minimum="0" Maximum="1"
+                                                             Value="{Binding MiniFraction, Mode=OneWay}"
+                                                             Background="#FF262626" Foreground="#FF4FB3A5" BorderThickness="0"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Border>
+                                    <!-- Unlock callout -->
+                                    <Border Margin="42,2,18,2" Padding="8,6"
+                                            Background="#0DC9A24A" BorderBrush="#73C9A24A" BorderThickness="2,0,0,0"
+                                            Visibility="{Binding IsUnlock, Converter={StaticResource BoolToVis}}">
+                                        <StackPanel>
+                                            <TextBlock Foreground="#FFC9A24A" FontWeight="SemiBold"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}">
+                                                <Run Text="Unlocks at L"/><Run Text="{Binding UnlockAtLevel, Mode=OneWay}"/>
+                                            </TextBlock>
+                                            <TextBlock Foreground="#FFB0B0B0" FontSize="{DynamicResource AppFontSizeSmall}">
+                                                <Run Text="{Binding RecipeName, Mode=OneWay}"/><Run Text=" · "/>
+                                                <Run Text="{Binding UnlockXp, Mode=OneWay}"/><Run Text=" xp/craft"/>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding UnlockReason}" Foreground="#FF5A5A5A"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}" TextWrapping="Wrap"/>
+                                            <TextBlock Text="already known on live character" Foreground="#FFC9A24A"
+                                                       FontSize="{DynamicResource AppFontSizeSmall}" FontStyle="Italic"
+                                                       Visibility="{Binding AlreadyKnown, Converter={StaticResource BoolToVis}}"/>
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <!-- Center detail -->
+                <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="22,18">
+                        <!-- Current phase -->
+                        <StackPanel Visibility="{Binding HasCurrentPhase, Converter={StaticResource BoolToVis}}">
+                            <WrapPanel>
+                                <TextBlock Foreground="#FF7A7A7A" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,16,4">
+                                    <Run Text="{Binding DetailLevels, Mode=OneWay}"/>
+                                </TextBlock>
+                                <TextBlock Foreground="#FF7A7A7A" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,16,4">
+                                    <Run Text="predicted crafts: "/><Run Text="{Binding DetailPredictedCrafts, Mode=OneWay}"/>
+                                </TextBlock>
+                                <TextBlock Foreground="#FF7A7A7A" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,16,4">
+                                    <Run Text="xp / craft: "/><Run Text="{Binding DetailXpPerCraft, Mode=OneWay}"/>
+                                </TextBlock>
+                                <TextBlock Foreground="#FF7A7A7A" FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,16,4">
+                                    <Run Text="reuse-intermediate: "/><Run Text="{Binding DetailReuseXp, Mode=OneWay}"/>
+                                </TextBlock>
+                                <TextBlock Text="first-time bonus active" Foreground="#FF4FB3A5"
+                                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,16,4"
+                                           Visibility="{Binding DetailUsesFirstTimeBonus, Converter={StaticResource BoolToVis}}"/>
+                            </WrapPanel>
+
+                            <Border Margin="0,14,0,0" Padding="14,12" Background="#FF1F1F1F"
+                                    BorderBrush="#22FFFFFF" BorderThickness="1" CornerRadius="2">
+                                <StackPanel>
+                                    <Grid Margin="0,0,0,8">
+                                        <TextBlock Text="Phase completion · on hand" Foreground="#FF7A7A7A"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                        <TextBlock HorizontalAlignment="Right" Foreground="#FFE6E6E6"
+                                                   FontSize="{DynamicResource AppFontSizeLarge}">
+                                            <Run Text="{Binding PredicateOnHand, Mode=OneWay}"
+                                                 Foreground="#FF4FB3A5"/><Run Text=" / "/>
+                                            <Run Text="{Binding PredicateThreshold, Mode=OneWay}"/>
+                                        </TextBlock>
+                                    </Grid>
+                                    <ProgressBar Height="6" Minimum="0" Maximum="1"
+                                                 Value="{Binding PredicateFraction, Mode=OneWay}"
+                                                 Background="#FF262626" Foreground="#FF4FB3A5" BorderThickness="0"/>
+                                    <TextBlock Margin="0,10,0,0" Foreground="#FF7A7A7A" TextWrapping="Wrap"
+                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                               Text="Phase advances when on-hand of the recipe's output ≥ the produced threshold — crafted, bought or dropped."/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Plan-complete terminal -->
+                        <Border Visibility="{Binding IsPlanComplete, Converter={StaticResource BoolToVis}}"
+                                Padding="22,24" Background="#FF1F1F1F" BorderBrush="#22FFFFFF"
+                                BorderThickness="1" CornerRadius="2">
+                            <StackPanel HorizontalAlignment="Center">
+                                <TextBlock Foreground="#FF7BA876" FontWeight="SemiBold"
+                                           FontSize="{DynamicResource AppFontSizeLarge}"
+                                           HorizontalAlignment="Center" Margin="0,0,0,6">
+                                    <Run Text="{Binding Skill, Mode=OneWay}"/><Run Text=" goal reached"/>
+                                </TextBlock>
+                                <TextBlock Foreground="#FF7A7A7A" TextWrapping="Wrap" TextAlignment="Center"
+                                           FontSize="{DynamicResource AppFontSizeHint}" MaxWidth="380"
+                                           Text="The plan reached its goal level — nothing more to walk. Re-plan from here for a new goal, or open another plan from the library."/>
+                                <TextBlock Foreground="#FF5A5A5A" HorizontalAlignment="Center" Margin="0,10,0,0"
+                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                    <Run Text="created "/><Run Text="{Binding CreatedAgeText, Mode=OneWay}"/>
+                                </TextBlock>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,14,0,0">
+                                    <Button Style="{StaticResource PlanActionButton}" Content="Re-plan"
+                                            Command="{Binding ReplanCommand}"/>
+                                    <Button Style="{StaticResource PlanActionButton}" Content="↩ Back to library"
+                                            Command="{Binding BackToLibraryCommand}"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- Sourcing -->
+                <Grid Grid.Column="2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Padding="16,10" BorderBrush="#14FFFFFF" BorderThickness="1,0,0,1">
+                        <TextBlock Text="SOURCING" Foreground="#FFE6E6E6" FontWeight="SemiBold"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"
+                                  BorderBrush="#14FFFFFF" BorderThickness="1,0,0,0">
+                        <ItemsControl ItemsSource="{Binding SourcingRows}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Padding="16,7" BorderBrush="#14FFFFFF" BorderThickness="0,0,0,1">
+                                        <StackPanel>
+                                            <Grid Margin="0,0,0,5">
+                                                <TextBlock Text="{Binding DisplayName}" Foreground="#FFE6E6E6"
+                                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock HorizontalAlignment="Right" Foreground="#FF5A5A5A"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}">
+                                                    <Run Text="×"/><Run Text="{Binding Need, Mode=OneWay}"/>
+                                                </TextBlock>
+                                            </Grid>
+                                            <UniformGrid Columns="3">
+                                                <Button Style="{StaticResource SegButton}" Content="Craft"
+                                                        Command="{Binding SetModeCommand}"
+                                                        CommandParameter="{x:Static planning:SourcingMode.Craft}"
+                                                        Tag="{Binding IsCraft}"/>
+                                                <Button Style="{StaticResource SegButton}" Content="Supply"
+                                                        Command="{Binding SetModeCommand}"
+                                                        CommandParameter="{x:Static planning:SourcingMode.SupplyExternally}"
+                                                        Tag="{Binding IsSupply}"/>
+                                                <Button Style="{StaticResource SegButton}" Content="Ignore"
+                                                        Command="{Binding SetModeCommand}"
+                                                        CommandParameter="{x:Static planning:SourcingMode.Ignore}"
+                                                        Tag="{Binding IsIgnore}"/>
+                                            </UniformGrid>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </Grid>
+
+            <!-- Footer -->
+            <Border Grid.Row="3" Background="#FF181818" BorderBrush="#22FFFFFF" BorderThickness="0,1,0,0"
+                    Padding="22,0" Height="46">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Foreground="#FFB0B0B0"
+                               FontSize="{DynamicResource AppFontSizeHint}">
+                        <Run Text="{Binding PositionText, Mode=OneWay}"/><Run Text="   ·   "/>
+                        <Run Text="{Binding RemainingText, Mode=OneWay}"/>
+                    </TextBlock>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Style="{StaticResource PlanActionButton}" Content="Re-plan"
+                                Command="{Binding ReplanCommand}"
+                                Visibility="{Binding HasCurrentPhase, Converter={StaticResource BoolToVis}}"/>
+                        <Button Style="{StaticResource PlanActionButton}" Content="Advance phase"
+                                Command="{Binding AdvancePhaseCommand}"
+                                Visibility="{Binding HasCurrentPhase, Converter={StaticResource BoolToVis}}"/>
+                        <Button Style="{StaticResource PrimaryActionButton}" Content="Send to craft list"
+                                Command="{Binding SendPhaseToCraftListCommand}"
+                                Visibility="{Binding HasCurrentPhase, Converter={StaticResource BoolToVis}}"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Celebrimbor.Module/Views/PlansView.xaml.cs
+++ b/src/Celebrimbor.Module/Views/PlansView.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows.Controls;
+
+namespace Celebrimbor.Views;
+
+public partial class PlansView : UserControl
+{
+    public PlansView() => InitializeComponent();
+}

--- a/src/Celebrimbor.Module/Views/Resources.xaml
+++ b/src/Celebrimbor.Module/Views/Resources.xaml
@@ -9,11 +9,16 @@
     <views:ZeroToGhostBrushConverter x:Key="ZeroToGhost"/>
     <views:ViewModeToVisibilityConverter x:Key="PickerVisibility" Target="Picker"/>
     <views:ViewModeToVisibilityConverter x:Key="ShoppingVisibility" Target="Shopping"/>
+    <views:ViewModeToVisibilityConverter x:Key="PlansVisibility" Target="Plans"/>
     <views:ViewModeToAccentBrushConverter x:Key="PickerAccent" Target="Picker"/>
     <views:ViewModeToAccentBrushConverter x:Key="ShoppingAccent" Target="Shopping"/>
     <views:CountToVisibilityConverter x:Key="CountToVisibility"/>
     <views:CountToVisibilityConverter x:Key="CountToVisibilityInverted" Invert="True"/>
+    <views:BoolToAccentBrushConverter x:Key="AreaAccent"/>
+    <views:PlanStatusToBrushConverter x:Key="PlanStatusBrush"/>
+    <views:PhaseRailStateToBrushConverter x:Key="PhaseRailBrush"/>
     <wpf:BoolToVisibilityConverter x:Key="BoolToVis"/>
+    <wpf:InverseBoolToVisibilityConverter x:Key="InvBoolToVis"/>
 
     <!-- Shared rich recipe card template.
          Consumers bind to anything exposing Name, IconId, Skill, SkillLevelReq,

--- a/src/Mithril.Planning/SavedLevelingPlanLibrary.cs
+++ b/src/Mithril.Planning/SavedLevelingPlanLibrary.cs
@@ -23,4 +23,7 @@ public sealed class SavedLevelingPlanLibrary : IVersionedState<SavedLevelingPlan
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
 [JsonSerializable(typeof(SavedLevelingPlanLibrary))]
+// A single plan is the share / hand-off unit (Elrond → Celebrimbor #228 PR-B/B2,
+// plan share/import #384) — same canonical context as the persisted library.
+[JsonSerializable(typeof(SavedLevelingPlan))]
 public partial class SavedLevelingPlanJsonContext : JsonSerializerContext;

--- a/src/Mithril.Shared/Modules/ISavedLevelingPlanImportTarget.cs
+++ b/src/Mithril.Shared/Modules/ISavedLevelingPlanImportTarget.cs
@@ -1,0 +1,29 @@
+namespace Mithril.Shared.Modules;
+
+/// <summary>
+/// Optional target that receives a leveling-plan artifact and adds it to the
+/// plan library. Implemented by Celebrimbor (#228 PR-B/B1) to persist the plan,
+/// activate its tab and bring the Plans area to the foreground.
+///
+/// <para>The plan is passed as its <b>canonical persisted JSON</b> (the same
+/// shape the plan library writes — <c>SavedLevelingPlanLibrary</c>'s
+/// source-generated context), not as a typed object: <c>Mithril.Planning</c>
+/// depends on <c>Mithril.Shared</c>, so the shared layer cannot reference the
+/// plan type without a cycle. Producers (Elrond's "Generate leveling plan",
+/// #228 PR-B/B2) serialize the <c>SavedLevelingPlan</c> they built; the same
+/// wire serves plan share/import (#384). Mirrors
+/// <see cref="ICraftListImportTarget.ImportFromLinkPayload"/>: a single string
+/// payload, all errors logged and swallowed — callers (module hand-off,
+/// OS/file activation) must not throw.</para>
+/// </summary>
+public interface ISavedLevelingPlanImportTarget
+{
+    /// <summary>
+    /// Deserializes <paramref name="planJson"/> (one <c>SavedLevelingPlan</c> in
+    /// its persisted JSON form), upserts it into the plan library by id, and
+    /// surfaces the Plans area. <paramref name="source"/> is a short provenance
+    /// label for diagnostics (e.g. "Elrond", "Imported file"). Invalid or empty
+    /// JSON is logged and dropped.
+    /// </summary>
+    void ImportPlan(string planJson, string source);
+}

--- a/tests/Celebrimbor.Tests/PlanWalkerViewModelTests.cs
+++ b/tests/Celebrimbor.Tests/PlanWalkerViewModelTests.cs
@@ -1,0 +1,186 @@
+using Celebrimbor.Services;
+using Celebrimbor.ViewModels;
+using FluentAssertions;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+using Xunit;
+
+namespace Celebrimbor.Tests;
+
+/// <summary>
+/// #228 PR-B/B1: the walker's projection of a <see cref="SavedLevelingPlan"/>
+/// (rail / detail / predicate / sourcing) and its actions. Inventory-driven
+/// only — craft-count-telemetry frames are deferred.
+/// </summary>
+public class PlanWalkerViewModelTests
+{
+    private static FakeReferenceData Data() => new(
+        [FakeReferenceData.Item(1, "Bar"), FakeReferenceData.Item(2, "Plate"), FakeReferenceData.Item(3, "Ore")],
+        [
+            FakeReferenceData.Recipe("ForgeBar", "Smithing", 0,
+                [FakeReferenceData.ItemIngredient(3, 4)], [FakeReferenceData.Result(1, 1)]),
+            FakeReferenceData.Recipe("ForgePlate", "Smithing", 0, [], [FakeReferenceData.Result(2, 2)]),
+        ]);
+
+    private static (PlanWalkerViewModel Vm, LevelingPlanStore Store) Walker(
+        FakeReferenceData data, IActiveCharacterService active)
+    {
+        var store = new LevelingPlanStore(new InMemoryPlanLibraryStore());
+        var exec = PlanFixtures.Executor(data, active);
+        var onHand = new OnHandInventoryQuery(active, data);
+        var craft = new RecordingCraftListImportTarget();
+        var vm = new PlanWalkerViewModel(store, exec, onHand, data, craft);
+        return (vm, store);
+    }
+
+    [Fact]
+    public void Load_BuildsRail_InterleavingPhasesAndUnlocks_WithStates()
+    {
+        var (vm, _) = Walker(Data(), new FakeActiveCharacter());
+        var plan = PlanFixtures.Plan("Smithing", 1, 5, cursor: 0,
+            [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3), PlanFixtures.Phase(1, "ForgePlate", 3, 3, 5)],
+            unlocks: [new PersistedSkillUnlock { AtLevel = 2, RecipeInternalName = "ForgePlate", RecipeName = "Forge Plate", XpPerCraftAtUnlock = 90, Reason = "Reaches Smithing 2" }]);
+
+        vm.Load(plan);
+
+        vm.Rail.Should().HaveCount(3, because: "2 phases + 1 unlock interstitial");
+        vm.Rail[0].IsUnlock.Should().BeFalse();
+        vm.Rail[0].State.Should().Be(PhaseRailState.Current);
+        vm.Rail[1].IsUnlock.Should().BeTrue();
+        vm.Rail[1].UnlockAtLevel.Should().Be(2);
+        vm.Rail[1].AlreadyKnown.Should().BeFalse();
+        vm.Rail[2].State.Should().Be(PhaseRailState.Upcoming);
+    }
+
+    [Fact]
+    public void Load_ProjectsCurrentPhaseDetailAndPredicate()
+    {
+        var (vm, _) = Walker(Data(), new FakeActiveCharacter());
+        vm.Load(PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)]));
+
+        vm.HasCurrentPhase.Should().BeTrue();
+        vm.DetailTitle.Should().Be("ForgeBar");
+        vm.PredicateThreshold.Should().Be(5, because: "5 predicted crafts × stack-of-1 output");
+        vm.PredicateOnHand.Should().Be(0);
+        vm.PredicateFraction.Should().Be(0d);
+        vm.PredicateComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Load_BuildsSourcingRows_FromItemIngredients()
+    {
+        var (vm, _) = Walker(Data(), new FakeActiveCharacter());
+        vm.Load(PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)]));
+
+        vm.SourcingRows.Should().ContainSingle();
+        var row = vm.SourcingRows[0];
+        row.ItemInternalName.Should().Be("Ore");
+        row.Need.Should().Be(20, because: "stack 4 × 5 predicted crafts");
+        row.IsCraft.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SourcingToggle_PersistsModeOntoPlan()
+    {
+        var (vm, store) = Walker(Data(), new FakeActiveCharacter());
+        var plan = PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)]);
+        store.Upsert(plan);
+        vm.Load(plan);
+
+        vm.SourcingRows[0].Mode = SourcingMode.SupplyExternally;
+
+        store.Get(plan.Id)!.Sourcing.Should().ContainSingle()
+            .Which.Mode.Should().Be(SourcingMode.SupplyExternally);
+    }
+
+    [Fact]
+    public void SendPhaseToCraftList_HandsCurrentRecipeAtPredictedCount()
+    {
+        var data = Data();
+        var active = new FakeActiveCharacter();
+        var store = new LevelingPlanStore(new InMemoryPlanLibraryStore());
+        var craft = new RecordingCraftListImportTarget();
+        var vm = new PlanWalkerViewModel(store, PlanFixtures.Executor(data, active),
+            new OnHandInventoryQuery(active, data), data, craft);
+        vm.Load(PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)]));
+
+        vm.SendPhaseToCraftListCommand.Execute(null);
+
+        craft.Calls.Should().ContainSingle();
+        craft.Calls[0].Recipes.Should().ContainSingle()
+            .Which.Should().Be(new Mithril.Shared.Modules.CraftListImportEntry("ForgeBar", 5));
+    }
+
+    [Fact]
+    public void AdvancePhase_MovesPastSatisfiedNonLastPhase()
+    {
+        var data = Data();
+        // Storage holds 5 Bar (phase 0 output) but no Plate ⇒ phase 0 trips, phase 1 cold.
+        var active = new FakeActiveCharacter(storage: StorageReportFactory.With((1, 5)));
+        var (vm, store) = Walker(data, active);
+        var plan = PlanFixtures.Plan("Smithing", 1, 5, cursor: 0,
+            [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3), PlanFixtures.Phase(1, "ForgePlate", 3, 3, 5)]);
+        store.Upsert(plan);
+        vm.Load(plan);
+
+        vm.PredicateComplete.Should().BeTrue(because: "5 Bar ≥ 5 threshold");
+        vm.IsPlanComplete.Should().BeFalse(because: "phase 1 is still ahead");
+        vm.AdvancePhaseCommand.Execute(null);
+
+        store.Get(plan.Id)!.CurrentPhaseIndex.Should().Be(1);
+        vm.HasCurrentPhase.Should().BeTrue();
+        vm.DetailTitle.Should().Be("ForgePlate");
+        vm.IsPlanComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Recompute_AutoFinalizesTerminalSentinel_WhenLastPhaseSatisfied()
+    {
+        var data = Data();
+        // Storage holds 6 Plate (phase 1 output, stack-of-2 × 3 crafts) ⇒ last phase trips.
+        var active = new FakeActiveCharacter(storage: StorageReportFactory.With((2, 6)));
+        var (vm, store) = Walker(data, active);
+        var plan = PlanFixtures.Plan("Smithing", 1, 5, cursor: 1,
+            [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3), PlanFixtures.Phase(1, "ForgePlate", 3, 3, 5)]);
+        store.Upsert(plan);
+
+        vm.Load(plan);
+
+        vm.IsPlanComplete.Should().BeTrue();
+        vm.HasCurrentPhase.Should().BeFalse();
+        store.Get(plan.Id)!.CurrentPhaseIndex.Should()
+            .Be(2, because: "the last phase being satisfied finalizes the cursor to Phases.Count");
+    }
+
+    [Fact]
+    public void TerminalPlan_RendersComplete_WithoutCurrentPhase()
+    {
+        var (vm, _) = Walker(Data(), new FakeActiveCharacter());
+        vm.Load(PlanFixtures.Plan("Smithing", 1, 5, cursor: 1, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 5)]));
+
+        vm.IsPlanComplete.Should().BeTrue();
+        vm.HasCurrentPhase.Should().BeFalse();
+        vm.SourcingRows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StaleBanner_ShowsWhenLiveCharacterDiverged_AndDismisses()
+    {
+        var snap = new CharacterSnapshot("Borg", "Alpha", DateTimeOffset.Now,
+            new Dictionary<string, CharacterSkill> { ["Smithing"] = new(20, 0, 0, 100) },
+            new Dictionary<string, int>(), new Dictionary<string, string>());
+        var active = new FakeActiveCharacter(active: snap);
+        var (vm, _) = Walker(Data(), active);
+
+        // Plan claims Borg@Alpha but embeds no skills ⇒ live diverged ⇒ stale.
+        var plan = PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)],
+            character: new PlanCharacterRef { Name = "Borg", Server = "Alpha" });
+        vm.Load(plan);
+
+        vm.IsStale.Should().BeTrue();
+        vm.StaleSummary.Should().NotBeNullOrEmpty();
+
+        vm.DismissStaleCommand.Execute(null);
+        vm.IsStale.Should().BeFalse(because: "\"Walk anyway\" dismisses the warning for the session");
+    }
+}

--- a/tests/Celebrimbor.Tests/PlansTestSupport.cs
+++ b/tests/Celebrimbor.Tests/PlansTestSupport.cs
@@ -1,0 +1,112 @@
+using Celebrimbor.Services;
+using Mithril.Leveling;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+using Mithril.Shared.Crafting;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Settings;
+using Mithril.Shared.Storage;
+
+namespace Celebrimbor.Tests;
+
+/// <summary>Shared builders for #228 PR-B/B1 manager + walker VM tests.</summary>
+internal static class PlanFixtures
+{
+    public static PlanExecutor Executor(FakeReferenceData data, IActiveCharacterService active)
+        => new(data, new CrossSkillPlanner(data, new LevelingMath(data), new RecipeExpander(data)), active);
+
+    public static PersistedPlanPhase Phase(
+        int index, string recipe, int crafts, int lvlStart, int lvlEnd, bool firstTime = false)
+        => new()
+        {
+            PhaseIndex = index,
+            RecipeInternalName = recipe,
+            RecipeName = recipe,
+            PredictedCrafts = crafts,
+            XpPerCraft = 100,
+            LevelAtStart = lvlStart,
+            LevelAtEnd = lvlEnd,
+            UsesFirstTimeBonus = firstTime,
+        };
+
+    public static SavedLevelingPlan Plan(
+        string skill, int start, int goal, int cursor,
+        IEnumerable<PersistedPlanPhase> phases,
+        PlanCharacterRef? character = null,
+        IEnumerable<PersistedSkillUnlock>? unlocks = null)
+        => new()
+        {
+            Skill = skill,
+            StartLevel = start,
+            GoalLevel = goal,
+            CurrentPhaseIndex = cursor,
+            TotalCrafts = phases.Sum(p => p.PredictedCrafts),
+            Phases = phases.ToList(),
+            Unlocks = unlocks?.ToList() ?? [],
+            Character = character,
+        };
+}
+
+/// <summary>In-memory plan-library backing store for #228 PR-B/B1 VM tests.</summary>
+internal sealed class InMemoryPlanLibraryStore : ISettingsStore<SavedLevelingPlanLibrary>
+{
+    private SavedLevelingPlanLibrary _current;
+    public InMemoryPlanLibraryStore(SavedLevelingPlanLibrary? seed = null) => _current = seed ?? new();
+    public int SaveCount { get; private set; }
+    public string FilePath => "(memory)";
+    public SavedLevelingPlanLibrary Load() => _current;
+    public Task<SavedLevelingPlanLibrary> LoadAsync(CancellationToken ct = default) => Task.FromResult(_current);
+    public Task SaveAsync(SavedLevelingPlanLibrary v, CancellationToken ct = default) { Save(v); return Task.CompletedTask; }
+    public void Save(SavedLevelingPlanLibrary v) { _current = v; SaveCount++; }
+}
+
+/// <summary>Configurable <see cref="IActiveCharacterService"/> double.</summary>
+internal sealed class FakeActiveCharacter : IActiveCharacterService
+{
+    public FakeActiveCharacter(CharacterSnapshot? active = null, StorageReport? storage = null)
+    {
+        ActiveCharacter = active;
+        ActiveStorageContents = storage;
+        Characters = active is null ? [] : [active];
+    }
+
+    public IReadOnlyList<CharacterSnapshot> Characters { get; set; }
+    public IReadOnlyList<ReportFileInfo> StorageReports { get; } = [];
+    public string? ActiveCharacterName => ActiveCharacter?.Name;
+    public string? ActiveServer => ActiveCharacter?.Server;
+    public CharacterSnapshot? ActiveCharacter { get; }
+    public ReportFileInfo? ActiveStorageReport => null;
+    public StorageReport? ActiveStorageContents { get; }
+    public void SetActiveCharacter(string name, string server) { }
+    public void Refresh() { }
+    public event EventHandler? ActiveCharacterChanged { add { } remove { } }
+    public event EventHandler? CharacterExportsChanged { add { } remove { } }
+    public event EventHandler? StorageReportsChanged { add { } remove { } }
+    public void Dispose() { }
+}
+
+/// <summary>Captures craft-list hand-offs so the walker's send-to-craft-list is observable.</summary>
+internal sealed class RecordingCraftListImportTarget : ICraftListImportTarget
+{
+    public List<(IReadOnlyList<CraftListImportEntry> Recipes, string Source)> Calls { get; } = [];
+    public void ImportFromLinkPayload(string base64UrlPayload) { }
+    public void ImportRecipes(IReadOnlyList<CraftListImportEntry> recipes, string source)
+        => Calls.Add((recipes, source));
+}
+
+internal static class StorageReportFactory
+{
+    /// <summary>Storage report with the given (item TypeID, stack count) holdings.</summary>
+    public static StorageReport With(params (int TypeId, int Count)[] items)
+        => new("Borg", "Alpha", "t", "r", 1,
+            items.Select(i => new StorageItem(
+                i.TypeId, "x", i.Count, 0m, "Vault", null, null, null,
+                false, false, null, null, null, null, null, null, null, null, null)).ToList());
+}
+
+/// <summary>Records plan-import provenance / IDs surfaced to the manager.</summary>
+internal sealed class RecordingPlanImportActivator : IModuleActivator
+{
+    public List<string> Activated { get; } = [];
+    public bool Activate(string moduleId) { Activated.Add(moduleId); return true; }
+}

--- a/tests/Celebrimbor.Tests/PlansViewModelTests.cs
+++ b/tests/Celebrimbor.Tests/PlansViewModelTests.cs
@@ -1,0 +1,140 @@
+using Celebrimbor.Services;
+using Celebrimbor.ViewModels;
+using FluentAssertions;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+using Xunit;
+
+namespace Celebrimbor.Tests;
+
+/// <summary>
+/// #228 PR-B/B1: the Plans manager — library projection, filter chips, search,
+/// staleness, and the row actions (open walker / re-plan / delete / import).
+/// </summary>
+public class PlansViewModelTests
+{
+    private static FakeReferenceData Data() => new(
+        [FakeReferenceData.Item(1, "Bar")],
+        [FakeReferenceData.Recipe("ForgeBar", "Smithing", 0, [], [FakeReferenceData.Result(1, 1)])]);
+
+    private static PlansViewModel Manager(
+        LevelingPlanStore store, IActiveCharacterService active,
+        Func<SavedPlanRowViewModel, bool>? confirm = null, Func<string?>? pick = null)
+    {
+        var data = Data();
+        var exec = PlanFixtures.Executor(data, active);
+        var onHand = new OnHandInventoryQuery(active, data);
+        var walker = new PlanWalkerViewModel(store, exec, onHand, data, new RecordingCraftListImportTarget());
+        return new PlansViewModel(store, exec, onHand, active, walker,
+            activator: null, pickPlanFile: pick, confirmDelete: confirm);
+    }
+
+    private static LevelingPlanStore Seeded(params SavedLevelingPlan[] plans)
+    {
+        var store = new LevelingPlanStore(new InMemoryPlanLibraryStore());
+        foreach (var p in plans) store.Upsert(p);
+        return store;
+    }
+
+    [Fact]
+    public void Reload_ProjectsRows_AndChipCounts()
+    {
+        var inProgress = PlanFixtures.Plan("Smithing", 1, 9, cursor: 1,
+            [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 5), PlanFixtures.Phase(1, "ForgeBar", 4, 5, 9)],
+            character: new PlanCharacterRef { Name = "Borg", Server = "Alpha" });
+        var done = PlanFixtures.Plan("Cooking", 1, 5, cursor: 1, [PlanFixtures.Phase(0, "ForgeBar", 3, 1, 5)]);
+        var fresh = PlanFixtures.Plan("Tailoring", 1, 4, cursor: 0, [PlanFixtures.Phase(0, "ForgeBar", 2, 1, 4)],
+            character: new PlanCharacterRef { Name = "Borg", Server = "Alpha" });
+
+        var vm = Manager(Seeded(inProgress, done, fresh), new FakeActiveCharacter());
+
+        vm.IsEmpty.Should().BeFalse();
+        vm.AllCount.Should().Be(3);
+        vm.InProgressCount.Should().Be(1);
+        vm.DoneCount.Should().Be(1);
+        vm.Rows.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Filter_AndSearch_NarrowTheVisibleRows()
+    {
+        var smithing = PlanFixtures.Plan("Smithing", 1, 9, 1, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+        var cooking = PlanFixtures.Plan("Cooking", 1, 5, 1, [PlanFixtures.Phase(0, "ForgeBar", 3, 1, 5)]);
+        var vm = Manager(Seeded(smithing, cooking), new FakeActiveCharacter());
+
+        vm.SetFilterCommand.Execute(PlanFilter.Done);
+        vm.Rows.Should().OnlyContain(r => r.Status == SavedPlanStatus.Done);
+
+        vm.SetFilterCommand.Execute(PlanFilter.All);
+        vm.SearchText = "cook";
+        vm.Rows.Should().ContainSingle().Which.Title.Should().Contain("Cooking");
+    }
+
+    [Fact]
+    public void Delete_RespectsConfirmation()
+    {
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+        var store = Seeded(plan);
+
+        var deny = Manager(store, new FakeActiveCharacter(), confirm: _ => false);
+        deny.DeleteCommand.Execute(deny.Rows[0]);
+        store.All().Should().ContainSingle(because: "declined confirmation is a no-op");
+
+        var allow = Manager(store, new FakeActiveCharacter(), confirm: _ => true);
+        allow.DeleteCommand.Execute(allow.Rows[0]);
+        store.All().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OpenWalker_EntersWalkingState_WithLoadedPlan()
+    {
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+        var vm = Manager(Seeded(plan), new FakeActiveCharacter());
+
+        vm.OpenWalkerCommand.Execute(vm.Rows[0]);
+
+        vm.IsWalking.Should().BeTrue();
+        vm.Walker.Skill.Should().Be("Smithing");
+    }
+
+    [Fact]
+    public void Walker_BackRequested_ReturnsToManager()
+    {
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+        var vm = Manager(Seeded(plan), new FakeActiveCharacter());
+        vm.OpenWalkerCommand.Execute(vm.Rows[0]);
+
+        vm.Walker.BackToLibraryCommand.Execute(null);
+
+        vm.IsWalking.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SurfaceImported_RefreshesAndSelects_StayingInManager()
+    {
+        var store = Seeded();
+        var vm = Manager(store, new FakeActiveCharacter());
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+        store.Upsert(plan);
+
+        vm.SurfaceImported(plan.Id);
+
+        vm.IsWalking.Should().BeFalse();
+        vm.SelectedRow!.Id.Should().Be(plan.Id);
+    }
+
+    [Fact]
+    public void StalePlan_IsFlagged_WhenLiveCharacterDiverged()
+    {
+        var snap = new CharacterSnapshot("Borg", "Alpha", DateTimeOffset.Now,
+            new Dictionary<string, CharacterSkill> { ["Smithing"] = new(20, 0, 0, 100) },
+            new Dictionary<string, int>(), new Dictionary<string, string>());
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)],
+            character: new PlanCharacterRef { Name = "Borg", Server = "Alpha" });
+
+        var vm = Manager(Seeded(plan), new FakeActiveCharacter(active: snap));
+
+        vm.StaleCount.Should().Be(1);
+        vm.Rows[0].Status.Should().Be(SavedPlanStatus.Stale);
+    }
+}

--- a/tests/Celebrimbor.Tests/SavedLevelingPlanImportTargetTests.cs
+++ b/tests/Celebrimbor.Tests/SavedLevelingPlanImportTargetTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Celebrimbor.Services;
+using Celebrimbor.ViewModels;
+using FluentAssertions;
+using Mithril.Planning;
+using Xunit;
+
+namespace Celebrimbor.Tests;
+
+/// <summary>
+/// #228 PR-B/B1: the cross-module hand-off target. Valid plan JSON is upserted
+/// and surfaced; malformed / empty / phase-less payloads are dropped (callers
+/// are activation handlers that must not throw).
+/// </summary>
+public class SavedLevelingPlanImportTargetTests
+{
+    private static FakeReferenceData Data() => new(
+        [FakeReferenceData.Item(1, "Bar")],
+        [FakeReferenceData.Recipe("ForgeBar", "Smithing", 0, [], [FakeReferenceData.Result(1, 1)])]);
+
+    private static (SavedLevelingPlanImportTarget Target, LevelingPlanStore Store,
+                    PlansViewModel Plans, RecordingPlanImportActivator Activator) Build()
+    {
+        var store = new LevelingPlanStore(new InMemoryPlanLibraryStore());
+        var data = Data();
+        var active = new FakeActiveCharacter();
+        var exec = PlanFixtures.Executor(data, active);
+        var onHand = new OnHandInventoryQuery(active, data);
+        var walker = new PlanWalkerViewModel(store, exec, onHand, data, new RecordingCraftListImportTarget());
+        var plans = new PlansViewModel(store, exec, onHand, active, walker);
+        var activator = new RecordingPlanImportActivator();
+        return (new SavedLevelingPlanImportTarget(store, plans, activator), store, plans, activator);
+    }
+
+    private static string Json(SavedLevelingPlan plan)
+        => JsonSerializer.Serialize(plan, SavedLevelingPlanJsonContext.Default.SavedLevelingPlan);
+
+    [Fact]
+    public void ImportPlan_ValidJson_UpsertsActivatesAndSurfaces()
+    {
+        var (target, store, plans, activator) = Build();
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+
+        target.ImportPlan(Json(plan), "Elrond");
+
+        store.Get(plan.Id).Should().NotBeNull();
+        activator.Activated.Should().ContainSingle().Which.Should().Be("celebrimbor");
+        plans.SelectedRow!.Id.Should().Be(plan.Id);
+    }
+
+    [Fact]
+    public void ImportPlan_SameId_ReplacesNotDuplicates()
+    {
+        var (target, store, _, _) = Build();
+        var plan = PlanFixtures.Plan("Smithing", 1, 9, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+        target.ImportPlan(Json(plan), "Elrond");
+
+        plan.GoalLevel = 50;
+        target.ImportPlan(Json(plan), "Elrond");
+
+        store.All().Should().ContainSingle().Which.GoalLevel.Should().Be(50);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{ not json")]
+    public void ImportPlan_InvalidOrEmpty_Dropped(string payload)
+    {
+        var (target, store, _, activator) = Build();
+        target.ImportPlan(payload, "Imported file");
+        store.All().Should().BeEmpty();
+        activator.Activated.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ImportPlan_PhaselessPlan_Dropped()
+    {
+        var (target, store, _, _) = Build();
+        var empty = PlanFixtures.Plan("Smithing", 1, 9, 0, []);
+        target.ImportPlan(Json(empty), "Elrond");
+        store.All().Should().BeEmpty(because: "a plan with no phases is not walkable");
+    }
+}


### PR DESCRIPTION
Closes the last interactive piece of the #224–228 leveling chain: **#228 PR-B/B1**.
Builds on the merged PR-A foundation (#369: `SavedLevelingPlan`, `LevelingPlanStore`,
`PlanExecutor`). Design specs vendored separately in #386 (docs-only).

## Charter split
Elrond authors/generates the plan (PR-B/B2, next); Celebrimbor **receives,
manages and walks** it — "receives a computed plan, does not compute it".

## What's here
- **`ISavedLevelingPlanImportTarget`** (`Mithril.Shared.Modules`) — in-process
  hand-off mirroring #224's `ICraftListImportTarget`. Takes the **canonical
  persisted JSON**, not a typed object: `Mithril.Planning → Mithril.Shared` is
  one-way, so the shared layer can't name `SavedLevelingPlan` without a cycle.
  The same wire is exactly what plan share/import (#384) needs.
- **`SavedLevelingPlanImportTarget`** (Celebrimbor) — deserialize → store
  upsert → activate module → surface in Plans. Errors logged + swallowed.
- **Plans as a peer area, not a wizard step.** Celebrimbor is a 2-step
  Pick→Shop *wizard* (not a tab strip). Plans is independent (no craft-list
  gating; data flows Plans→craft-list, not forward). A header pivot
  `Crafting | Plans` switches areas; the wizard chrome is untouched. See the
  reconciliation note below.
- **Manager** (`PlansViewModel`): library rows, filter chips
  (All/InProgress/Stale/Done) + counts, search, stale-vs-live-character flag
  (`IsInitialStateStaleAgainst`), open-walker / re-plan / delete(confirm) /
  import-from-file; empty-state CTA → Elrond.
- **Walker** (`PlanWalkerViewModel`): phase rail with unlock-callout
  interleave, inventory-vs-threshold predicate, per-ingredient tri-state
  sourcing (persists onto the plan → next re-plan), send-phase-to-craft-list
  (reuses #224's `ICraftListImportTarget`), stale-refresh banner,
  plan-complete terminal. Recompute auto-finalizes the terminal sentinel
  (`cursor == Phases.Count`) so manager Done matches a satisfied last phase.

## Scope (agreed with owner)
Inventory-driven only. The three craft-count-telemetry frames (drift "output
ran short", 2 s auto-advance countdown, walked/xp-banked stats) are deferred —
they need a Player.log craft tracker the PR-A foundation doesn't provide.
**Filed: #389.**

## Reconciliation (for #386 / B2)
The vendored spec frames Celebrimbor as a flat `Picker·Shopping·Plans` tab
strip. That model is wrong: Celebrimbor is a sequential wizard. This PR
implements Plans as a **peer area** with a header pivot; B2 (Elrond) authors
the plan in its own UI and hands off via `ISavedLevelingPlanImportTarget`.
Controls / binds / states from the spec are honored as-is.

## Verification
- `dotnet build Mithril.slnx` green.
- Celebrimbor.Tests **+22 → 85**; Planning 14 / Leveling 12 / Elrond 14 /
  Shared 1025 green.
- 12-module shell boot → `=== startup done ===`; `ValidateOnBuild=true` walks
  the new constructor graph (PlansVM → Walker → import targets) — no DI cycle
  (the #365-class hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
