### PR TITLE
feat(elrond): Generate leveling plan — #228 PR-B/B2 (chain complete)

### DIFF
--- a/src/Elrond.Module/Elrond.Module.csproj
+++ b/src/Elrond.Module/Elrond.Module.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mithril.Leveling\Mithril.Leveling.csproj" />
+    <ProjectReference Include="..\Mithril.Planning\Mithril.Planning.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
     <ProjectReference Include="..\Mithril.Shared.Wpf\Mithril.Shared.Wpf.csproj" />
   </ItemGroup>

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -4,6 +4,8 @@ using Elrond.Services;
 using Elrond.ViewModels;
 using Elrond.Views;
 using Mithril.Leveling.DependencyInjection;
+using Mithril.Planning;
+using Mithril.Planning.DependencyInjection;
 using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Modules;
 using MahApps.Metro.IconPacks;
@@ -32,8 +34,21 @@ public sealed class ElrondModule : IMithrilModule
         services.AddMithrilSettings<ElrondSettings>(settingsPath, ElrondSettingsJsonContext.Default.ElrondSettings);
 
         services.AddMithrilLeveling();
+        // #227 converged planner engine (CrossSkillPlanner + LevelingMath +
+        // RecipeExpander). All depend only on IReferenceDataService — no
+        // shell/module-activator edge. Powers B2 "Generate leveling plan".
+        services.AddMithrilPlanning();
         services.AddSingleton<SkillAdvisorEngine>();
         services.AddSingleton<LevelingSimulator>();
+
+        services.AddSingleton<GenerateLevelingPlanViewModel>(sp => new GenerateLevelingPlanViewModel(
+            sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
+            sp.GetRequiredService<CrossSkillPlanner>(),
+            // Deferred for the same reason as the craft-list accessor below:
+            // resolving Celebrimbor's ISavedLevelingPlanImportTarget eagerly
+            // closes a DI cycle (→ IModuleActivator → ShellViewModel → eager
+            // ActivateModule → back here). Resolved only on the Generate click.
+            () => sp.GetService<ISavedLevelingPlanImportTarget>()));
 
         services.AddSingleton<SkillAdvisorViewModel>(sp => new SkillAdvisorViewModel(
             sp.GetRequiredService<SkillAdvisorEngine>(),
@@ -41,6 +56,7 @@ public sealed class ElrondModule : IMithrilModule
             sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
             sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
             sp.GetRequiredService<ElrondSettings>(),
+            sp.GetRequiredService<GenerateLevelingPlanViewModel>(),
             // Deferred, NOT sp.GetService<ICraftListImportTarget>() eagerly: resolving it
             // at VM-construction time closes a DI cycle (→ Celebrimbor's
             // CraftListImportTarget → IModuleActivator → ShellViewModel → eager

--- a/src/Elrond.Module/Services/SnapshotPlanInput.cs
+++ b/src/Elrond.Module/Services/SnapshotPlanInput.cs
@@ -1,0 +1,32 @@
+using Mithril.Leveling;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+
+namespace Elrond.Services;
+
+/// <summary>
+/// Adapts a character export (<see cref="CharacterSnapshot"/>) into the
+/// <i>neutral</i> multi-skill planner inputs (#225: Mithril.Leveling takes a
+/// neutral <see cref="SkillState"/>/<see cref="RecipeHistory"/>; Elrond owns
+/// the snapshot→neutral projection so the planner stays character-agnostic).
+///
+/// <para>Mirrors Celebrimbor's <c>PlanExecutor.ToSkillState/ToRecipeHistory</c>
+/// by intent (Elrond must not depend on the executor module); the projection
+/// is a pure field copy so the two cannot diverge in behaviour.</para>
+/// </summary>
+internal static class SnapshotPlanInput
+{
+    public static SkillState ToSkillState(CharacterSnapshot s)
+        => new(s.Skills.ToDictionary(
+            kv => kv.Key,
+            kv => new SkillProgress(
+                kv.Value.Level, kv.Value.BonusLevels,
+                kv.Value.XpTowardNextLevel, kv.Value.XpNeededForNextLevel),
+            StringComparer.Ordinal));
+
+    public static RecipeHistory ToRecipeHistory(CharacterSnapshot s)
+        => new(new Dictionary<string, int>(s.RecipeCompletions, StringComparer.Ordinal));
+
+    public static PlanCharacterRef ToCharacterRef(CharacterSnapshot s)
+        => PlanCharacterRef.FromSnapshot(s);
+}

--- a/src/Elrond.Module/ViewModels/BoolToVisConverter.cs
+++ b/src/Elrond.Module/ViewModels/BoolToVisConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Elrond.ViewModels;
+
+/// <summary>Converts true to Visible, false to Collapsed. Pass ConverterParameter="invert" to flip.</summary>
+public sealed class BoolToVisConverter : IValueConverter
+{
+    public static readonly BoolToVisConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var on = value is true;
+        if (parameter is "invert") on = !on;
+        return on ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/Elrond.Module/ViewModels/GenerateLevelingPlanViewModel.cs
+++ b/src/Elrond.Module/ViewModels/GenerateLevelingPlanViewModel.cs
@@ -1,0 +1,217 @@
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Elrond.Services;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+using Mithril.Shared.Modules;
+
+namespace Elrond.ViewModels;
+
+/// <summary>
+/// "Generate leveling plan" (#228 PR-B/B2). Elrond authors the plan — it has
+/// the skill selector, goal and the live progression snapshot — using the
+/// converged shared <see cref="CrossSkillPlanner"/>, then hands a
+/// <see cref="SavedLevelingPlan"/> off to Celebrimbor (the executor) via the
+/// in-process <see cref="ISavedLevelingPlanImportTarget"/>. Charter-correct:
+/// Elrond generates, Celebrimbor receives/walks.
+///
+/// <para>Four states mirror the spec: empty (no skill), preview (skill+goal),
+/// no active character, and goal ≤ current (no-op). Advanced inputs (sourcing
+/// policy, asserted unlocks) are deferred — the planner defaults apply.</para>
+/// </summary>
+public sealed partial class GenerateLevelingPlanViewModel : ObservableObject
+{
+    private readonly IActiveCharacterService _activeChar;
+    private readonly CrossSkillPlanner _planner;
+
+    // Deferred resolution: resolving the import target at construction would
+    // close a DI cycle (→ Celebrimbor's target → IModuleActivator →
+    // ShellViewModel → eager ActivateModule → back to an Elrond VM) that MS.DI
+    // turns into a silent UI-thread deadlock. Resolve only on the Generate
+    // click — exact same pattern as SkillAdvisorViewModel's craft-list accessor.
+    private readonly Func<ISavedLevelingPlanImportTarget?>? _importAccessor;
+
+    private LevelingPlan? _preview;
+    private bool _userEdited;
+    private bool _seeding;
+
+    public GenerateLevelingPlanViewModel(
+        IActiveCharacterService activeChar,
+        CrossSkillPlanner planner,
+        Func<ISavedLevelingPlanImportTarget?>? importAccessor = null)
+    {
+        _activeChar = activeChar;
+        _planner = planner;
+        _importAccessor = importAccessor;
+
+        _activeChar.ActiveCharacterChanged += (_, _) => RefreshSnapshot();
+        _activeChar.CharacterExportsChanged += (_, _) => RefreshSnapshot();
+        RefreshSnapshot();
+    }
+
+    // ── Snapshot (embedded initial state) ────────────────────────────────
+    [ObservableProperty] private bool _hasActiveCharacter;
+    [ObservableProperty] private string _snapshotName = "";
+    [ObservableProperty] private string _snapshotServer = "";
+    [ObservableProperty] private string _snapshotRelTime = "";
+
+    // ── Target ───────────────────────────────────────────────────────────
+    [ObservableProperty] private IReadOnlyList<string> _availableSkills = [];
+    [ObservableProperty] private string? _selectedSkill;
+    [ObservableProperty] private int? _currentLevel;
+    [ObservableProperty] private int? _goalLevel;
+    [ObservableProperty] private bool _goalInvalid;
+
+    // ── Preview ──────────────────────────────────────────────────────────
+    [ObservableProperty] private bool _hasPreview;
+    [ObservableProperty] private bool _alreadyAtGoal;
+    [ObservableProperty] private int _previewPhases;
+    [ObservableProperty] private int _previewTotalCrafts;
+    [ObservableProperty] private int _previewStartLevel;
+    [ObservableProperty] private int _previewGoalLevel;
+    [ObservableProperty] private int _previewUnlocks;
+
+    public bool CanGenerate => _preview is { } p && !p.IsComplete && HasActiveCharacter;
+
+    /// <summary>Raised after a plan was generated and handed off (UI may navigate away).</summary>
+    public event EventHandler? PlanHandedOff;
+
+    /// <summary>
+    /// Prefill skill/goal from the advisor's current selection — continuity for
+    /// a user who was just analysing that skill. Ignored once the user has
+    /// edited the generate inputs themselves (seed, don't clobber).
+    /// </summary>
+    public void SeedFromAdvisor(string? skill, int? goalLevel)
+    {
+        if (_userEdited) return;
+        _seeding = true;
+        try
+        {
+            if (!string.IsNullOrEmpty(skill) && AvailableSkills.Contains(skill))
+                SelectedSkill = skill;
+            if (goalLevel is { } g)
+                GoalLevel = g;
+        }
+        finally { _seeding = false; }
+        Recompute();
+    }
+
+    partial void OnSelectedSkillChanged(string? value)
+    {
+        if (!_seeding) _userEdited = true;
+        Recompute();
+    }
+
+    partial void OnGoalLevelChanged(int? value)
+    {
+        if (!_seeding) _userEdited = true;
+        Recompute();
+    }
+
+    private void RefreshSnapshot()
+    {
+        var snap = _activeChar.ActiveCharacter;
+        HasActiveCharacter = snap is not null;
+        if (snap is null)
+        {
+            SnapshotName = SnapshotServer = SnapshotRelTime = "";
+            AvailableSkills = [];
+            Recompute();
+            return;
+        }
+        SnapshotName = snap.Name;
+        SnapshotServer = snap.Server;
+        SnapshotRelTime = HumanizeAge(DateTimeOffset.Now - snap.ExportedAt);
+        AvailableSkills = snap.Skills.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+        Recompute();
+    }
+
+    private void Recompute()
+    {
+        var snap = _activeChar.ActiveCharacter;
+        _preview = null;
+        HasPreview = false;
+        AlreadyAtGoal = false;
+        CurrentLevel = null;
+        GoalInvalid = false;
+
+        if (snap is null || string.IsNullOrEmpty(SelectedSkill))
+        {
+            NotifyGenerate();
+            return;
+        }
+
+        CurrentLevel = snap.Skills.TryGetValue(SelectedSkill, out var cs) ? cs.Level : null;
+
+        if (GoalLevel is not { } goal)
+        {
+            NotifyGenerate();
+            return;
+        }
+
+        if (CurrentLevel is { } cur && goal <= cur)
+        {
+            GoalInvalid = true;
+            AlreadyAtGoal = true;
+            NotifyGenerate();
+            return;
+        }
+
+        var plan = _planner.Plan(
+            new SkillTarget(SelectedSkill, goal),
+            SnapshotPlanInput.ToSkillState(snap),
+            SnapshotPlanInput.ToRecipeHistory(snap));
+
+        if (plan is null || plan.IsComplete)
+        {
+            NotifyGenerate();
+            return;
+        }
+
+        _preview = plan;
+        PreviewPhases = plan.Phases.Count;
+        PreviewTotalCrafts = plan.TotalCrafts;
+        PreviewStartLevel = plan.StartLevel;
+        PreviewGoalLevel = plan.GoalLevel;
+        PreviewUnlocks = plan.Unlocks.Count;
+        HasPreview = true;
+        NotifyGenerate();
+    }
+
+    private void NotifyGenerate()
+    {
+        OnPropertyChanged(nameof(CanGenerate));
+        GenerateCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGenerate))]
+    private void Generate()
+    {
+        var snap = _activeChar.ActiveCharacter;
+        if (snap is null || _preview is not { } plan || string.IsNullOrEmpty(SelectedSkill)
+            || GoalLevel is not { } goal)
+            return;
+
+        var target = new SkillTarget(SelectedSkill, goal);
+        var saved = SavedLevelingPlan.From(
+            plan,
+            target,
+            SnapshotPlanInput.ToSkillState(snap),
+            SnapshotPlanInput.ToRecipeHistory(snap),
+            SourcingPolicy.CraftEverything,
+            SnapshotPlanInput.ToCharacterRef(snap));
+
+        var json = JsonSerializer.Serialize(saved, SavedLevelingPlanJsonContext.Default.SavedLevelingPlan);
+        _importAccessor?.Invoke()?.ImportPlan(json, "Elrond");
+        PlanHandedOff?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static string HumanizeAge(TimeSpan age)
+    {
+        if (age < TimeSpan.FromMinutes(1)) return "just now";
+        if (age < TimeSpan.FromHours(1)) return $"{(int)age.TotalMinutes}m ago";
+        if (age < TimeSpan.FromDays(1)) return $"{(int)age.TotalHours}h ago";
+        return $"{(int)age.TotalDays}d ago";
+    }
+}

--- a/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
+++ b/src/Elrond.Module/ViewModels/SkillAdvisorViewModel.cs
@@ -70,12 +70,19 @@ public sealed partial class SkillAdvisorViewModel
 
     public ICollectionView RecipesView { get; }
 
+    /// <summary>
+    /// The "Generate leveling plan" surface (#228 PR-B/B2), hosted as a peer
+    /// tab. Seeded — but not clobbered — from the advisor's current skill/goal.
+    /// </summary>
+    public GenerateLevelingPlanViewModel GeneratePlan { get; }
+
     public SkillAdvisorViewModel(
         SkillAdvisorEngine engine,
         LevelingSimulator simulator,
         IActiveCharacterService characterData,
         IReferenceDataService referenceData,
         ElrondSettings settings,
+        GenerateLevelingPlanViewModel generatePlan,
         Func<ICraftListImportTarget?>? craftListImportAccessor = null)
     {
         _engine = engine;
@@ -83,6 +90,7 @@ public sealed partial class SkillAdvisorViewModel
         _activeChar = characterData;
         _referenceData = referenceData;
         _settings = settings;
+        GeneratePlan = generatePlan;
         _craftListImportAccessor = craftListImportAccessor;
 
         _goalLevel = settings.LastGoalLevel;
@@ -279,6 +287,7 @@ public sealed partial class SkillAdvisorViewModel
             _settings.LastSkill = value;
         UpdateSelectedSkillSummary(value);
         ResetSimulationStartState();
+        GeneratePlan?.SeedFromAdvisor(value, GoalLevel);
         Reanalyze();
     }
 
@@ -292,6 +301,7 @@ public sealed partial class SkillAdvisorViewModel
     {
         _settings.LastGoalLevel = value;
         SimulationResult = null;
+        GeneratePlan?.SeedFromAdvisor(SelectedSkill, value);
         Reanalyze();
     }
 

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -718,6 +718,159 @@
                             </Grid>
                         </DockPanel>
                     </TabItem>
+
+                    <!-- ── Plan tab (#228 PR-B/B2) ─────────────────────────── -->
+                    <TabItem Header="Plan">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,8,0,0"
+                                      DataContext="{Binding GeneratePlan}">
+                            <StackPanel MaxWidth="640" HorizontalAlignment="Left">
+                                <TextBlock Margin="0,0,0,4" FontWeight="SemiBold"
+                                           FontSize="{DynamicResource AppFontSizeLarge}"
+                                           Foreground="{StaticResource TextPrimaryBrush}"
+                                           Text="Generate leveling plan"/>
+                                <TextBlock Margin="0,0,0,12" TextWrapping="Wrap"
+                                           Foreground="{StaticResource TextSecondaryBrush}"
+                                           FontSize="{DynamicResource AppFontSizeHint}"
+                                           Text="Pick a target skill and goal. The active character's progression is captured into the plan as its initial state; Celebrimbor walks the resulting phases."/>
+
+                                <!-- Snapshot card (embedded initial state) -->
+                                <Border Background="{StaticResource BgSurfaceBrush}" BorderThickness="2,0,0,0"
+                                        BorderBrush="{StaticResource AccentBrush}" Padding="12,8" Margin="0,0,0,10"
+                                        Visibility="{Binding HasActiveCharacter, Converter={x:Static vm:BoolToVisConverter.Instance}}">
+                                    <StackPanel>
+                                        <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                                   Text="Initial state · embedded · read-only"/>
+                                        <TextBlock Margin="0,2,0,0" Foreground="{StaticResource TextPrimaryBrush}">
+                                            <Run Text="{Binding SnapshotName, Mode=OneWay}"/>
+                                            <Run Text=" @ " Foreground="{StaticResource TextSecondaryBrush}"/>
+                                            <Run Text="{Binding SnapshotServer, Mode=OneWay}" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                            <Run Text="  ·  exported " Foreground="{StaticResource TextSecondaryBrush}"/>
+                                            <Run Text="{Binding SnapshotRelTime, Mode=OneWay}" Foreground="{StaticResource TextSecondaryBrush}"/>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- No active character -->
+                                <Border Background="{StaticResource BgSurfaceBrush}" BorderThickness="1"
+                                        BorderBrush="#4DC9A24A" Padding="12,8" Margin="0,0,0,10"
+                                        Visibility="{Binding HasActiveCharacter, Converter={x:Static vm:BoolToVisConverter.Instance}, ConverterParameter=invert}">
+                                    <TextBlock TextWrapping="Wrap" Foreground="#FFC7A872"
+                                               Text="No active character. Export a character (in-game /charexport) and select it so the plan can capture its skills and recipes as the initial state."/>
+                                </Border>
+
+                                <!-- Target -->
+                                <Grid Margin="0,0,0,10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="110"/>
+                                        <ColumnDefinition Width="110"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Skill" Margin="0,0,8,3"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Current" Margin="8,0,8,3"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Goal (1–250)" Margin="8,0,0,3"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                    <ComboBox Grid.Row="1" Grid.Column="0" Margin="0,0,8,0"
+                                              IsEditable="True" IsTextSearchEnabled="True"
+                                              ItemsSource="{Binding AvailableSkills}"
+                                              Text="{Binding SelectedSkill, UpdateSourceTrigger=PropertyChanged}"
+                                              IsEnabled="{Binding HasActiveCharacter}"/>
+                                    <Border Grid.Row="1" Grid.Column="1" Margin="8,0,8,0"
+                                            Background="{StaticResource BgSurfaceBrush}"
+                                            BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
+                                            Padding="8,5">
+                                        <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
+                                                   Text="{Binding CurrentLevel, Mode=OneWay, TargetNullValue='—'}"/>
+                                    </Border>
+                                    <TextBox Grid.Row="1" Grid.Column="2" Margin="8,0,0,0"
+                                             IsEnabled="{Binding HasActiveCharacter}"
+                                             Text="{Binding GoalLevel, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"/>
+                                </Grid>
+
+                                <!-- Goal ≤ current (no-op) -->
+                                <Border Background="#14C7A872" BorderBrush="#4DC7A872" BorderThickness="1"
+                                        Padding="12,8" Margin="0,0,0,10"
+                                        Visibility="{Binding AlreadyAtGoal, Converter={x:Static vm:BoolToVisConverter.Instance}}">
+                                    <TextBlock TextWrapping="Wrap" Foreground="#FFC7A872">
+                                        <Run Text="Already at goal — the goal level is not above the current level ("/>
+                                        <Run Text="{Binding CurrentLevel, Mode=OneWay}"/>
+                                        <Run Text="). Raise the goal to generate a plan."/>
+                                    </TextBlock>
+                                </Border>
+
+                                <!-- Preview -->
+                                <Border Background="{StaticResource BgSurfaceBrush}"
+                                        BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"
+                                        Padding="14,10" Margin="0,0,0,12"
+                                        Visibility="{Binding HasPreview, Converter={x:Static vm:BoolToVisConverter.Instance}}">
+                                    <StackPanel>
+                                        <TextBlock Text="Plan preview" Margin="0,0,0,8"
+                                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                        <UniformGrid Columns="4">
+                                            <StackPanel Margin="0,0,12,0">
+                                                <TextBlock Text="Phases" Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                                <TextBlock Text="{Binding PreviewPhases, Mode=OneWay}"
+                                                           Foreground="{StaticResource TextPrimaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeLarge}"/>
+                                            </StackPanel>
+                                            <StackPanel Margin="0,0,12,0">
+                                                <TextBlock Text="Total crafts" Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                                <TextBlock Text="{Binding PreviewTotalCrafts, Mode=OneWay}"
+                                                           Foreground="{StaticResource TextPrimaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeLarge}"/>
+                                            </StackPanel>
+                                            <StackPanel Margin="0,0,12,0">
+                                                <TextBlock Text="Range" Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                                <TextBlock Foreground="{StaticResource TextPrimaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeLarge}">
+                                                    <Run Text="{Binding PreviewStartLevel, Mode=OneWay}"/>
+                                                    <Run Text="→"/>
+                                                    <Run Text="{Binding PreviewGoalLevel, Mode=OneWay}"/>
+                                                </TextBlock>
+                                            </StackPanel>
+                                            <StackPanel>
+                                                <TextBlock Text="Skill unlocks" Foreground="{StaticResource TextSecondaryBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                                <TextBlock Text="{Binding PreviewUnlocks, Mode=OneWay}"
+                                                           Foreground="{StaticResource AccentBrush}"
+                                                           FontSize="{DynamicResource AppFontSizeLarge}"/>
+                                            </StackPanel>
+                                        </UniformGrid>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- Action -->
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Padding="14,6" Command="{Binding GenerateCommand}"
+                                            Background="{StaticResource AccentBrush}" Foreground="#FF0E1B19"
+                                            BorderThickness="0">
+                                        <StackPanel Orientation="Horizontal">
+                                            <icon:PackIconLucide Kind="Send" Width="13" Height="13"
+                                                                 VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                            <TextBlock Text="Generate &amp; send to Celebrimbor" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Button>
+                                    <TextBlock Margin="12,0,0,0" VerticalAlignment="Center"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                               Text="Embeds the snapshot and hands the plan to Celebrimbor to execute."/>
+                                </StackPanel>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </TabItem>
                 </TabControl>
             </DockPanel>
         </Grid>

--- a/tests/Elrond.Tests/Elrond.Tests.csproj
+++ b/tests/Elrond.Tests/Elrond.Tests.csproj
@@ -13,6 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elrond.Module\Elrond.Module.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Planning\Mithril.Planning.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Reference\Mithril.Reference.csproj" />
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Elrond.Tests/GenerateLevelingPlanViewModelTests.cs
+++ b/tests/Elrond.Tests/GenerateLevelingPlanViewModelTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Elrond.ViewModels;
+using FluentAssertions;
+using Mithril.Leveling;
+using Mithril.Planning;
+using Mithril.Shared.Character;
+using Mithril.Shared.Crafting;
+using Mithril.Shared.Modules;
+using Xunit;
+
+namespace Elrond.Tests;
+
+/// <summary>
+/// #228 PR-B/B2: Elrond's "Generate leveling plan" surface — the four spec
+/// states (no character / empty / preview / goal ≤ current), seed-from-advisor
+/// continuity, and the serialized hand-off to Celebrimbor.
+/// </summary>
+public class GenerateLevelingPlanViewModelTests
+{
+    private const string Skill = "Smithing";
+
+    private static FakeRef Data() => new FakeRef()
+        .AddSkill(Skill).AddXpTable(100)
+        .AddItem(1, "Nail")
+        .AddRecipe("ForgeNail", Skill, xp: 50, produces: (1, 1));
+
+    private static CrossSkillPlanner Planner(FakeRef d)
+        => new(d, new LevelingMath(d), new RecipeExpander(d));
+
+    private static CharacterSnapshot Char(int level)
+        => new("Galadriel", "Eltibule", DateTimeOffset.Now.AddMinutes(-4),
+            new Dictionary<string, CharacterSkill> { [Skill] = new(level, 0, 0, 100) },
+            // ForgeNail known (completed once) so the planner has a grindable
+            // recipe — CrossSkillPlanner only grinds recipes in RecipeHistory.
+            new Dictionary<string, int> { ["ForgeNail"] = 1 },
+            new Dictionary<string, string>());
+
+    private static GenerateLevelingPlanViewModel Vm(
+        CharacterSnapshot? snap, FakeRef? data = null, RecordingPlanImportTarget? sink = null)
+    {
+        data ??= Data();
+        return new GenerateLevelingPlanViewModel(
+            new FakeActiveChar(snap), Planner(data),
+            sink is null ? null : () => sink);
+    }
+
+    [Fact]
+    public void NoActiveCharacter_DisablesAndExposesNoSkills()
+    {
+        var vm = Vm(snap: null);
+        vm.HasActiveCharacter.Should().BeFalse();
+        vm.AvailableSkills.Should().BeEmpty();
+        vm.CanGenerate.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_CharacterButNoSkill_NoPreview()
+    {
+        var vm = Vm(Char(12));
+        vm.HasActiveCharacter.Should().BeTrue();
+        vm.AvailableSkills.Should().ContainSingle().Which.Should().Be(Skill);
+        vm.HasPreview.Should().BeFalse();
+        vm.CanGenerate.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SkillAndGoal_ProducesPreview_AndEnablesGenerate()
+    {
+        var vm = Vm(Char(1));
+        vm.SelectedSkill = Skill;
+        vm.GoalLevel = 3;
+
+        vm.CurrentLevel.Should().Be(1);
+        vm.GoalInvalid.Should().BeFalse();
+        vm.HasPreview.Should().BeTrue();
+        vm.PreviewPhases.Should().BeGreaterThan(0);
+        vm.PreviewStartLevel.Should().Be(1);
+        vm.PreviewGoalLevel.Should().Be(3);
+        vm.CanGenerate.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GoalAtOrBelowCurrent_FlagsNoOp_NoPreview()
+    {
+        var vm = Vm(Char(5));
+        vm.SelectedSkill = Skill;
+        vm.GoalLevel = 5;
+
+        vm.GoalInvalid.Should().BeTrue();
+        vm.AlreadyAtGoal.Should().BeTrue();
+        vm.HasPreview.Should().BeFalse();
+        vm.CanGenerate.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Generate_HandsOffSerializedPlan_ToCelebrimbor()
+    {
+        var sink = new RecordingPlanImportTarget();
+        var vm = Vm(Char(1), sink: sink);
+        vm.SelectedSkill = Skill;
+        vm.GoalLevel = 3;
+
+        var handed = false;
+        vm.PlanHandedOff += (_, _) => handed = true;
+        vm.GenerateCommand.Execute(null);
+
+        handed.Should().BeTrue();
+        sink.Calls.Should().ContainSingle();
+        sink.Calls[0].Source.Should().Be("Elrond");
+
+        var plan = JsonSerializer.Deserialize(
+            sink.Calls[0].Json, SavedLevelingPlanJsonContext.Default.SavedLevelingPlan);
+        plan.Should().NotBeNull();
+        plan!.Skill.Should().Be(Skill);
+        plan.GoalLevel.Should().Be(3);
+        plan.Phases.Should().NotBeEmpty();
+        plan.Character!.Name.Should().Be("Galadriel");
+        plan.InitialSkills.Should().ContainKey(Skill);
+    }
+
+    [Fact]
+    public void SeedFromAdvisor_Prefills_ButDoesNotClobberUserEdits()
+    {
+        var vm = Vm(Char(1));
+
+        vm.SeedFromAdvisor(Skill, 5);
+        vm.SelectedSkill.Should().Be(Skill);
+        vm.GoalLevel.Should().Be(5);
+
+        // User changes the goal in the Plan tab → later advisor seeds are ignored.
+        vm.GoalLevel = 9;
+        vm.SeedFromAdvisor(Skill, 20);
+        vm.GoalLevel.Should().Be(9, because: "the user edited the generate inputs; seed must not clobber");
+    }
+
+    [Fact]
+    public void Generate_NoImportTarget_DoesNotThrow()
+    {
+        var vm = Vm(Char(1)); // sink null ⇒ accessor null
+        vm.SelectedSkill = Skill;
+        vm.GoalLevel = 3;
+
+        var act = () => vm.GenerateCommand.Execute(null);
+        act.Should().NotThrow(because: "the deferred accessor may resolve null if Celebrimbor isn't loaded");
+    }
+}

--- a/tests/Elrond.Tests/GeneratePlanTestSupport.cs
+++ b/tests/Elrond.Tests/GeneratePlanTestSupport.cs
@@ -1,0 +1,113 @@
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Character;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
+
+namespace Elrond.Tests;
+
+/// <summary>Configurable active-character double for #228 PR-B/B2 VM tests.</summary>
+internal sealed class FakeActiveChar : IActiveCharacterService
+{
+    public FakeActiveChar(CharacterSnapshot? active = null) => ActiveCharacter = active;
+    public IReadOnlyList<CharacterSnapshot> Characters => ActiveCharacter is null ? [] : [ActiveCharacter];
+    public IReadOnlyList<ReportFileInfo> StorageReports { get; } = [];
+    public string? ActiveCharacterName => ActiveCharacter?.Name;
+    public string? ActiveServer => ActiveCharacter?.Server;
+    public CharacterSnapshot? ActiveCharacter { get; }
+    public ReportFileInfo? ActiveStorageReport => null;
+    public StorageReport? ActiveStorageContents => null;
+    public void SetActiveCharacter(string name, string server) { }
+    public void Refresh() { }
+    public event EventHandler? ActiveCharacterChanged { add { } remove { } }
+    public event EventHandler? CharacterExportsChanged { add { } remove { } }
+    public event EventHandler? StorageReportsChanged { add { } remove { } }
+    public void Dispose() { }
+}
+
+/// <summary>Captures the plan JSON Elrond hands off so B2 serialization is observable.</summary>
+internal sealed class RecordingPlanImportTarget : ISavedLevelingPlanImportTarget
+{
+    public List<(string Json, string Source)> Calls { get; } = [];
+    public void ImportPlan(string planJson, string source) => Calls.Add((planJson, source));
+}
+
+/// <summary>Minimal fluent <see cref="IReferenceDataService"/> (mirrors the
+/// Mithril.Planning.Tests builder) — enough for <c>CrossSkillPlanner</c> to
+/// produce a real plan in B2 VM tests.</summary>
+internal sealed class FakeRef : IReferenceDataService
+{
+    private readonly Dictionary<long, Item> _items = new();
+    private readonly Dictionary<string, Item> _itemsByName = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Recipe> _recipes = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Recipe> _recipesByName = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, XpTableEntry> _xp = new(StringComparer.Ordinal);
+    private int _serial;
+
+    public FakeRef AddSkill(string key, string xpTable = "T")
+    {
+        _skills[key] = new SkillEntry(key, key, 0, false, xpTable, 0, [],
+            new Dictionary<string, SkillRewardEntry>());
+        return this;
+    }
+
+    public FakeRef AddXpTable(long perLevel, string name = "T", int levels = 50)
+    {
+        _xp[name] = new XpTableEntry(name, Enumerable.Repeat(perLevel, levels).ToList());
+        return this;
+    }
+
+    public FakeRef AddItem(long id, string internalName)
+    {
+        var it = new Item { Id = id, Name = internalName, InternalName = internalName };
+        _items[id] = it;
+        _itemsByName[internalName] = it;
+        return this;
+    }
+
+    public FakeRef AddRecipe(string internalName, string rewardSkill, int xp, (long id, int stack) produces)
+    {
+        var r = new Recipe
+        {
+            Key = $"recipe_{++_serial}",
+            Name = internalName,
+            InternalName = internalName,
+            Skill = rewardSkill,
+            SkillLevelReq = 0,
+            RewardSkill = rewardSkill,
+            RewardSkillXp = xp,
+            RewardSkillXpFirstTime = 0,
+            Ingredients = [],
+            ResultItems = [new RecipeResultItem { ItemCode = produces.id, StackSize = produces.stack }],
+        };
+        _recipes[r.Key] = r;
+        _recipesByName[internalName] = r;
+        return this;
+    }
+
+    public IReadOnlyList<string> Keys { get; } = ["skills", "xptables", "recipes", "items"];
+    public IReadOnlyDictionary<long, Item> Items => _items;
+    public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByName;
+    public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+    public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
+    public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _recipesByName;
+    public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
+    public IReadOnlyDictionary<string, XpTableEntry> XpTables => _xp;
+    public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+    public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+    public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+    public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+    public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+    public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public void BeginBackgroundRefresh() { }
+    public event EventHandler<string>? FileUpdated { add { } remove { } }
+}

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -5,7 +5,10 @@ using Elrond.Domain;
 using Elrond.Services;
 using Elrond.ViewModels;
 using FluentAssertions;
+using Mithril.Leveling;
+using Mithril.Planning;
 using Mithril.Shared.Character;
+using Mithril.Shared.Crafting;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Storage;
 using Xunit;
@@ -254,7 +257,8 @@ public class SkillAdvisorViewModelTests
         };
         var engine = new SkillAdvisorEngine(refData);
         var sim = new LevelingSimulator(refData, engine);
-        var vm = new SkillAdvisorViewModel(engine, sim, characterSvc, refData, settings);
+        var vm = new SkillAdvisorViewModel(engine, sim, characterSvc, refData, settings,
+            Gen(refData, characterSvc));
 
         vm.QueryText.Should().Be("ORDER BY EffectiveXp DESC, RecipeName");
         settings.ActiveSortKeys.Should().BeEmpty("legacy field cleared after migration");
@@ -330,11 +334,16 @@ public class SkillAdvisorViewModelTests
 
         var act = () => new SkillAdvisorViewModel(
             engine, sim, characterSvc, refData, new ElrondSettings(),
+            Gen(refData, characterSvc),
             () => throw new InvalidOperationException("import target resolved during construction"));
 
         act.Should().NotThrow(
             because: "the VM ctor must not resolve the import target — that edge is the #359 DI cycle");
     }
+
+    // #228 PR-B/B2: SkillAdvisorViewModel now hosts the Generate-plan child VM.
+    private static GenerateLevelingPlanViewModel Gen(IReferenceDataService refData, IActiveCharacterService chr)
+        => new(chr, new CrossSkillPlanner(refData, new LevelingMath(refData), new RecipeExpander(refData)));
 
     private static SkillAdvisorViewModel MakeVmWithImportTarget(
         out FakeRefData refData, out FakeCraftListImportTarget importTarget)
@@ -352,6 +361,7 @@ public class SkillAdvisorViewModelTests
         importTarget = new FakeCraftListImportTarget();
         var captured = importTarget;
         return new SkillAdvisorViewModel(engine, sim, characterSvc, refData, new ElrondSettings(),
+            Gen(refData, characterSvc),
             () => captured);
     }
 
@@ -388,7 +398,8 @@ public class SkillAdvisorViewModelTests
         var settings = new ElrondSettings();
         var engine = new SkillAdvisorEngine(refData);
         var simulator = new LevelingSimulator(refData, engine);
-        var vm = new SkillAdvisorViewModel(engine, simulator, characterSvc, refData, settings);
+        var vm = new SkillAdvisorViewModel(engine, simulator, characterSvc, refData, settings,
+            Gen(refData, characterSvc));
         return (vm, refData, characterSvc, settings);
     }
 


### PR DESCRIPTION
**Closes the #224–228 leveling chain.** Builds on B1 (#390, merged): Elrond
*authors* a plan; Celebrimbor *receives/walks* it via the in-process
`ISavedLevelingPlanImportTarget`. Charter-correct split — Elrond owns the
skill selector, goal and progression snapshot; Celebrimbor "receives a
computed plan, does not compute it".

## What's here
- **Elrond → Mithril.Planning** ProjectReference + `AddMithrilPlanning()`
  (the #226/#227 converged engine; `IReferenceDataService`-only — no
  shell/activator edge).
- **`SnapshotPlanInput`** — `CharacterSnapshot` → neutral
  `SkillState`/`RecipeHistory`/`PlanCharacterRef` (#225: Elrond owns the
  snapshot→neutral projection; pure field copy, mirrors `PlanExecutor` by
  intent without depending on the executor module).
- **`GenerateLevelingPlanViewModel`** — the spec's four states: no active
  character · empty (no skill) · preview (phases / total crafts / range /
  unlocks from a live `CrossSkillPlanner` recompute) · goal ≤ current (no-op).
  Advanced inputs (sourcing / asserted unlocks) deferred — planner defaults.
- **Hand-off** serializes via `SavedLevelingPlanJsonContext` →
  `ISavedLevelingPlanImportTarget.ImportPlan(json, "Elrond")`; Celebrimbor
  upserts + activates + surfaces the plan.
- **DI-cycle safety**: the import target is a deferred `Func<…?>` resolved
  only on the Generate click — never at construction — exactly mirroring the
  #366 craft-list-accessor fix (eager resolve → Celebrimbor → IModuleActivator
  → ShellViewModel → silent UI-thread deadlock). Regression-guarded by the
  existing ctor test, extended for the new param.
- New **"Plan" tab** in `SkillAdvisorView`, peer to Recipes/Simulation,
  **seeded but not clobbered** from the advisor's current skill/goal. The
  spec's "Plans → Elrond" tab-strip chrome is reconciled to Elrond's real
  tabbed UI (controls/binds/states honored).

## Supersedes Simulation (add-only here)
The Plan tab replaces Elrond's old greedy single-skill `LevelingSimulator`.
Per agreed sequencing this PR is **add-only** — a fast-follow (**#391**)
removes `LevelingSimulator` + the Simulation tab + its tests, so each PR stays
independently reviewable and no tested code is deleted in the feature PR.

## Verification
- `dotnet build Mithril.slnx` green.
- Elrond.Tests **+7 → 66**; Planning 14 / Celebrimbor 85 / Shared green.
- Post-merge re-verify done on fresh `main` (`ad6fd0e`) before building.
- 12-module shell boot → `=== startup done ===`; `ValidateOnBuild=true` walks
  the new `GenerateLevelingPlanViewModel` + `SkillAdvisorViewModel` ctor graph
  incl. the deferred accessor — no DI cycle (#365-class hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
