### PR TITLE
fix(plans): resolve skill internalName → display name across the plan surfaces

### DIFF
--- a/src/Celebrimbor.Module/ViewModels/PlanWalkerViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/PlanWalkerViewModel.cs
@@ -108,7 +108,7 @@ public sealed partial class PlanWalkerViewModel : ObservableObject
         var walk = _executor.Evaluate(plan, onHand);
         var live = _executor.ResolveLiveSnapshot(plan.Character);
 
-        Skill = plan.Skill;
+        Skill = SkillDisplayName(plan.Skill);
         CharacterLabel = plan.Character is { } c ? $"{c.Name} @ {c.Server}" : "hypothetical";
         GoalLabel = $"Goal L{plan.GoalLevel}";
         var phaseCount = plan.Phases.Count;
@@ -129,7 +129,7 @@ public sealed partial class PlanWalkerViewModel : ObservableObject
         PhaseCountLabel = IsPlanComplete ? $"{phaseCount} / {phaseCount} complete" : $"{phaseCount} total";
 
         IsStale = !_staleDismissed && live is not null && plan.IsInitialStateStaleAgainst(live);
-        StaleSummary = IsStale ? BuildStaleSummary(plan, live!) : "";
+        StaleSummary = IsStale ? BuildStaleSummary(plan, live!, Skill) : "";
         CreatedAgeText = HumanizeAge(DateTimeOffset.Now - plan.CreatedAt);
 
         BuildRail(plan, walk, live);
@@ -246,7 +246,7 @@ public sealed partial class PlanWalkerViewModel : ObservableObject
         if (walk.CurrentPhase is not { } cur || string.IsNullOrEmpty(cur.RecipeInternalName)) return;
         _craftList.ImportRecipes(
             [new CraftListImportEntry(cur.RecipeInternalName, Math.Max(1, cur.PredictedCrafts))],
-            $"Leveling plan · {_plan.Skill}");
+            $"Leveling plan · {SkillDisplayName(_plan.Skill)}");
     }
 
     /// <summary>
@@ -294,18 +294,26 @@ public sealed partial class PlanWalkerViewModel : ObservableObject
     [RelayCommand]
     private void BackToLibrary() => BackRequested?.Invoke(this, EventArgs.Empty);
 
-    private static string BuildStaleSummary(SavedLevelingPlan plan, Mithril.Shared.Character.CharacterSnapshot live)
+    private static string BuildStaleSummary(SavedLevelingPlan plan, Mithril.Shared.Character.CharacterSnapshot live, string skillDisplay)
     {
         var newRecipes = live.RecipeCompletions.Keys
             .Count(k => !plan.InitialRecipeCompletions.ContainsKey(k));
         var skillNote = plan.InitialSkills.TryGetValue(plan.Skill, out var was)
             && live.Skills.TryGetValue(plan.Skill, out var now) && now.Level != was.Level
-            ? $"{plan.Skill} L{was.Level} → L{now.Level}"
-            : $"{plan.Skill} baseline unchanged";
+            ? $"{skillDisplay} L{was.Level} → L{now.Level}"
+            : $"{skillDisplay} baseline unchanged";
         return newRecipes > 0
             ? $"{skillNote} · {newRecipes} new recipe(s) since this plan was generated"
             : $"{skillNote} · progression changed since this plan was generated";
     }
+
+    /// <summary>
+    /// Resolve a skill's id-shaped key to its human display name (convention:
+    /// reverse-lookup internalName→display where reference data allows; the
+    /// model still stores the key). Falls back to the key when unknown.
+    /// </summary>
+    private string SkillDisplayName(string skillKey)
+        => _ref.Skills.TryGetValue(skillKey, out var e) ? e.DisplayName : skillKey;
 
     private static string HumanizeAge(TimeSpan age)
     {

--- a/src/Celebrimbor.Module/ViewModels/PlansViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/PlansViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using Mithril.Planning;
 using Mithril.Shared.Character;
 using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
 
 namespace Celebrimbor.ViewModels;
 
@@ -26,6 +27,7 @@ public sealed partial class PlansViewModel : ObservableObject
     private readonly PlanExecutor _executor;
     private readonly OnHandInventoryQuery _onHand;
     private readonly IActiveCharacterService _activeChar;
+    private readonly IReferenceDataService? _referenceData;
     private readonly IModuleActivator? _activator;
     private readonly Func<string?> _pickPlanFile;
     private readonly Func<SavedPlanRowViewModel, bool> _confirmDelete;
@@ -36,6 +38,7 @@ public sealed partial class PlansViewModel : ObservableObject
         OnHandInventoryQuery onHand,
         IActiveCharacterService activeChar,
         PlanWalkerViewModel walker,
+        IReferenceDataService? referenceData = null,
         IModuleActivator? activator = null,
         Func<string?>? pickPlanFile = null,
         Func<SavedPlanRowViewModel, bool>? confirmDelete = null)
@@ -44,6 +47,7 @@ public sealed partial class PlansViewModel : ObservableObject
         _executor = executor;
         _onHand = onHand;
         _activeChar = activeChar;
+        _referenceData = referenceData;
         _activator = activator;
         _pickPlanFile = pickPlanFile ?? DefaultPickPlanFile;
         _confirmDelete = confirmDelete ?? DefaultConfirmDelete;
@@ -96,7 +100,7 @@ public sealed partial class PlansViewModel : ObservableObject
         var live = _activeChar.ActiveCharacter;
         _allRows = _store.All()
             .OrderByDescending(p => p.CreatedAt)
-            .Select(p => new SavedPlanRowViewModel(p, IsStale(p, live)))
+            .Select(p => new SavedPlanRowViewModel(p, IsStale(p, live), SkillDisplay(p.Skill)))
             .ToList();
 
         AllCount = _allRows.Count;
@@ -126,6 +130,15 @@ public sealed partial class PlansViewModel : ObservableObject
 
     private static bool IsStale(SavedLevelingPlan plan, CharacterSnapshot? live)
         => live is not null && plan.IsInitialStateStaleAgainst(live);
+
+    /// <summary>
+    /// Resolve a skill's id-shaped key to its human display name (convention:
+    /// reverse-lookup internalName→display where reference data allows; the
+    /// persisted plan still stores the key). Falls back to the key.
+    /// </summary>
+    private string SkillDisplay(string skillKey)
+        => _referenceData is not null && _referenceData.Skills.TryGetValue(skillKey, out var e)
+            ? e.DisplayName : skillKey;
 
     [RelayCommand]
     private void SetFilter(PlanFilter filter) => ActiveFilter = filter;

--- a/src/Celebrimbor.Module/ViewModels/SavedPlanRowViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/SavedPlanRowViewModel.cs
@@ -21,7 +21,7 @@ public enum SavedPlanStatus
 /// </summary>
 public sealed class SavedPlanRowViewModel
 {
-    public SavedPlanRowViewModel(SavedLevelingPlan plan, bool isStale)
+    public SavedPlanRowViewModel(SavedLevelingPlan plan, bool isStale, string? skillDisplayName = null)
     {
         Plan = plan;
         var phaseCount = plan.Phases.Count;
@@ -33,7 +33,8 @@ public sealed class SavedPlanRowViewModel
             : plan.CurrentPhaseIndex > 0 ? SavedPlanStatus.InProgress
             : SavedPlanStatus.NeverWalked;
 
-        Title = $"{plan.Skill}  {plan.StartLevel}→{plan.GoalLevel}";
+        // Display the human skill name; the plan still stores the id-shaped key.
+        Title = $"{skillDisplayName ?? plan.Skill}  {plan.StartLevel}→{plan.GoalLevel}";
 
         var span = phaseCount > 0
             ? $"{plan.Phases[0].RecipeName} → {plan.Phases[^1].RecipeName} path · "
@@ -82,6 +83,8 @@ public sealed class SavedPlanRowViewModel
     {
         if (string.IsNullOrWhiteSpace(query)) return true;
         if (Title.Contains(query, StringComparison.OrdinalIgnoreCase)) return true;
+        // Also match the id-shaped key so deep-link / advanced users can still find it.
+        if (Plan.Skill.Contains(query, StringComparison.OrdinalIgnoreCase)) return true;
         if (CharacterLabel.Contains(query, StringComparison.OrdinalIgnoreCase)) return true;
         return Plan.Phases.Any(p => p.RecipeName.Contains(query, StringComparison.OrdinalIgnoreCase));
     }

--- a/src/Elrond.Module/ElrondModule.cs
+++ b/src/Elrond.Module/ElrondModule.cs
@@ -44,6 +44,7 @@ public sealed class ElrondModule : IMithrilModule
         services.AddSingleton<GenerateLevelingPlanViewModel>(sp => new GenerateLevelingPlanViewModel(
             sp.GetRequiredService<Mithril.Shared.Character.IActiveCharacterService>(),
             sp.GetRequiredService<CrossSkillPlanner>(),
+            sp.GetRequiredService<Mithril.Shared.Reference.IReferenceDataService>(),
             // Deferred for the same reason as the craft-list accessor below:
             // resolving Celebrimbor's ISavedLevelingPlanImportTarget eagerly
             // closes a DI cycle (→ IModuleActivator → ShellViewModel → eager

--- a/src/Elrond.Module/ViewModels/GenerateLevelingPlanViewModel.cs
+++ b/src/Elrond.Module/ViewModels/GenerateLevelingPlanViewModel.cs
@@ -5,6 +5,7 @@ using Elrond.Services;
 using Mithril.Planning;
 using Mithril.Shared.Character;
 using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
 
 namespace Elrond.ViewModels;
 
@@ -36,13 +37,17 @@ public sealed partial class GenerateLevelingPlanViewModel : ObservableObject
     private bool _userEdited;
     private bool _seeding;
 
+    private readonly IReferenceDataService _ref;
+
     public GenerateLevelingPlanViewModel(
         IActiveCharacterService activeChar,
         CrossSkillPlanner planner,
+        IReferenceDataService referenceData,
         Func<ISavedLevelingPlanImportTarget?>? importAccessor = null)
     {
         _activeChar = activeChar;
         _planner = planner;
+        _ref = referenceData;
         _importAccessor = importAccessor;
 
         _activeChar.ActiveCharacterChanged += (_, _) => RefreshSnapshot();
@@ -57,7 +62,11 @@ public sealed partial class GenerateLevelingPlanViewModel : ObservableObject
     [ObservableProperty] private string _snapshotRelTime = "";
 
     // ── Target ───────────────────────────────────────────────────────────
-    [ObservableProperty] private IReadOnlyList<string> _availableSkills = [];
+    /// <summary>A pickable skill: the id-shaped <see cref="Key"/> is the model
+    /// value; <see cref="DisplayName"/> is what the user sees/types.</summary>
+    public readonly record struct SkillChoice(string Key, string DisplayName);
+
+    [ObservableProperty] private IReadOnlyList<SkillChoice> _availableSkills = [];
     [ObservableProperty] private string? _selectedSkill;
     [ObservableProperty] private int? _currentLevel;
     [ObservableProperty] private int? _goalLevel;
@@ -88,7 +97,7 @@ public sealed partial class GenerateLevelingPlanViewModel : ObservableObject
         _seeding = true;
         try
         {
-            if (!string.IsNullOrEmpty(skill) && AvailableSkills.Contains(skill))
+            if (!string.IsNullOrEmpty(skill) && AvailableSkills.Any(c => c.Key == skill))
                 SelectedSkill = skill;
             if (goalLevel is { } g)
                 GoalLevel = g;
@@ -123,7 +132,13 @@ public sealed partial class GenerateLevelingPlanViewModel : ObservableObject
         SnapshotName = snap.Name;
         SnapshotServer = snap.Server;
         SnapshotRelTime = HumanizeAge(DateTimeOffset.Now - snap.ExportedAt);
-        AvailableSkills = snap.Skills.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToList();
+        // Resolve id-shaped keys → human display names (convention); the model
+        // (SelectedSkill / SkillTarget) still carries the key. Order by display.
+        AvailableSkills = snap.Skills.Keys
+            .Select(k => new SkillChoice(
+                k, _ref.Skills.TryGetValue(k, out var e) ? e.DisplayName : k))
+            .OrderBy(c => c.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
         Recompute();
     }
 

--- a/src/Elrond.Module/Views/SkillAdvisorView.xaml
+++ b/src/Elrond.Module/Views/SkillAdvisorView.xaml
@@ -779,11 +779,22 @@
                                     <TextBlock Grid.Row="0" Grid.Column="2" Text="Goal (1–250)" Margin="8,0,0,3"
                                                Foreground="{StaticResource TextSecondaryBrush}"
                                                FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                    <!-- Items carry {Key, DisplayName}; the user sees/searches
+                                         DisplayName, the model binds the id-shaped Key via
+                                         SelectedValue. ItemTemplate (not DisplayMemberPath) so the
+                                         selection box doesn't fall back to ToString(). -->
                                     <ComboBox Grid.Row="1" Grid.Column="0" Margin="0,0,8,0"
-                                              IsEditable="True" IsTextSearchEnabled="True"
+                                              IsTextSearchEnabled="True" TextSearch.TextPath="DisplayName"
                                               ItemsSource="{Binding AvailableSkills}"
-                                              Text="{Binding SelectedSkill, UpdateSourceTrigger=PropertyChanged}"
-                                              IsEnabled="{Binding HasActiveCharacter}"/>
+                                              SelectedValuePath="Key"
+                                              SelectedValue="{Binding SelectedSkill, UpdateSourceTrigger=PropertyChanged}"
+                                              IsEnabled="{Binding HasActiveCharacter}">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding DisplayName}"/>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
                                     <Border Grid.Row="1" Grid.Column="1" Margin="8,0,8,0"
                                             Background="{StaticResource BgSurfaceBrush}"
                                             BorderBrush="{StaticResource BorderSubtleBrush}" BorderThickness="1"

--- a/tests/Celebrimbor.Tests/FakeReferenceData.cs
+++ b/tests/Celebrimbor.Tests/FakeReferenceData.cs
@@ -45,7 +45,16 @@ internal sealed class FakeReferenceData : IReferenceDataService
     private readonly ItemKeywordIndex _keywordIndex;
     public IReadOnlyDictionary<string, Recipe> Recipes => _recipes;
     public IReadOnlyDictionary<string, Recipe> RecipesByInternalName => _recipesByName;
-    public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+    private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
+
+    /// <summary>Seed a skill key → display-name mapping (for the internalName→display convention).</summary>
+    public FakeReferenceData WithSkill(string key, string displayName)
+    {
+        _skills[key] = new SkillEntry(key, displayName, 0, false, "T", 0, [],
+            new Dictionary<string, SkillRewardEntry>());
+        return this;
+    }
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
     public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
     public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);

--- a/tests/Celebrimbor.Tests/PlanWalkerViewModelTests.cs
+++ b/tests/Celebrimbor.Tests/PlanWalkerViewModelTests.cs
@@ -183,4 +183,17 @@ public class PlanWalkerViewModelTests
         vm.DismissStaleCommand.Execute(null);
         vm.IsStale.Should().BeFalse(because: "\"Walk anyway\" dismisses the warning for the session");
     }
+
+    [Fact]
+    public void Skill_ResolvesIdKeyToDisplayName_FallingBackToKey()
+    {
+        var withDisplay = Data().WithSkill("Smithing", "Blacksmithing");
+        var (vm, _) = Walker(withDisplay, new FakeActiveCharacter());
+        vm.Load(PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)]));
+        vm.Skill.Should().Be("Blacksmithing", because: "the id-shaped key resolves to the human display name");
+
+        var (vm2, _) = Walker(Data(), new FakeActiveCharacter()); // no skill entry seeded
+        vm2.Load(PlanFixtures.Plan("Smithing", 1, 5, 0, [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 3)]));
+        vm2.Skill.Should().Be("Smithing", because: "unknown skill falls back to the key");
+    }
 }

--- a/tests/Celebrimbor.Tests/PlansViewModelTests.cs
+++ b/tests/Celebrimbor.Tests/PlansViewModelTests.cs
@@ -137,4 +137,17 @@ public class PlansViewModelTests
         vm.StaleCount.Should().Be(1);
         vm.Rows[0].Status.Should().Be(SavedPlanStatus.Stale);
     }
+
+    [Fact]
+    public void Row_TitleUsesSkillDisplayName_FallingBackToKey()
+    {
+        var plan = PlanFixtures.Plan("WeaponAugmentBrewing", 1, 9, 0,
+            [PlanFixtures.Phase(0, "ForgeBar", 5, 1, 9)]);
+
+        new SavedPlanRowViewModel(plan, isStale: false, "Weapon Augmentation")
+            .Title.Should().StartWith("Weapon Augmentation", because: "the row shows the human skill name");
+
+        new SavedPlanRowViewModel(plan, isStale: false, skillDisplayName: null)
+            .Title.Should().StartWith("WeaponAugmentBrewing", because: "no reference data ⇒ fall back to the key");
+    }
 }

--- a/tests/Elrond.Tests/GenerateLevelingPlanViewModelTests.cs
+++ b/tests/Elrond.Tests/GenerateLevelingPlanViewModelTests.cs
@@ -40,7 +40,7 @@ public class GenerateLevelingPlanViewModelTests
     {
         data ??= Data();
         return new GenerateLevelingPlanViewModel(
-            new FakeActiveChar(snap), Planner(data),
+            new FakeActiveChar(snap), Planner(data), data,
             sink is null ? null : () => sink);
     }
 
@@ -58,7 +58,7 @@ public class GenerateLevelingPlanViewModelTests
     {
         var vm = Vm(Char(12));
         vm.HasActiveCharacter.Should().BeTrue();
-        vm.AvailableSkills.Should().ContainSingle().Which.Should().Be(Skill);
+        vm.AvailableSkills.Should().ContainSingle().Which.Key.Should().Be(Skill);
         vm.HasPreview.Should().BeFalse();
         vm.CanGenerate.Should().BeFalse();
     }
@@ -131,6 +131,32 @@ public class GenerateLevelingPlanViewModelTests
         vm.GoalLevel = 9;
         vm.SeedFromAdvisor(Skill, 20);
         vm.GoalLevel.Should().Be(9, because: "the user edited the generate inputs; seed must not clobber");
+    }
+
+    [Fact]
+    public void SkillPicker_ShowsDisplayName_ButModelKeepsTheKey()
+    {
+        // id-shaped key vs human display — the convention this fix restores.
+        var data = new FakeRef()
+            .AddSkill("WeaponAugmentBrewing", displayName: "Weapon Augmentation").AddXpTable(100)
+            .AddItem(1, "Wax").AddRecipe("BrewWax", "WeaponAugmentBrewing", xp: 50, produces: (1, 1));
+        var snap = new CharacterSnapshot("Galadriel", "Eltibule", DateTimeOffset.Now,
+            new Dictionary<string, CharacterSkill> { ["WeaponAugmentBrewing"] = new(1, 0, 0, 100) },
+            new Dictionary<string, int> { ["BrewWax"] = 1 }, new Dictionary<string, string>());
+        var sink = new RecordingPlanImportTarget();
+        var vm = Vm(snap, data, sink);
+
+        vm.AvailableSkills.Should().ContainSingle();
+        vm.AvailableSkills[0].DisplayName.Should().Be("Weapon Augmentation");
+        vm.AvailableSkills[0].Key.Should().Be("WeaponAugmentBrewing");
+
+        vm.SeedFromAdvisor("WeaponAugmentBrewing", 3);
+        vm.SelectedSkill.Should().Be("WeaponAugmentBrewing", because: "the model binds the id-shaped key");
+
+        vm.GenerateCommand.Execute(null);
+        var plan = JsonSerializer.Deserialize(
+            sink.Calls[0].Json, SavedLevelingPlanJsonContext.Default.SavedLevelingPlan);
+        plan!.Skill.Should().Be("WeaponAugmentBrewing", because: "the persisted plan stores the key, not the display name");
     }
 
     [Fact]

--- a/tests/Elrond.Tests/GeneratePlanTestSupport.cs
+++ b/tests/Elrond.Tests/GeneratePlanTestSupport.cs
@@ -47,9 +47,9 @@ internal sealed class FakeRef : IReferenceDataService
     private readonly Dictionary<string, XpTableEntry> _xp = new(StringComparer.Ordinal);
     private int _serial;
 
-    public FakeRef AddSkill(string key, string xpTable = "T")
+    public FakeRef AddSkill(string key, string xpTable = "T", string? displayName = null)
     {
-        _skills[key] = new SkillEntry(key, key, 0, false, xpTable, 0, [],
+        _skills[key] = new SkillEntry(key, displayName ?? key, 0, false, xpTable, 0, [],
             new Dictionary<string, SkillRewardEntry>());
         return this;
     }

--- a/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
+++ b/tests/Elrond.Tests/SkillAdvisorViewModelTests.cs
@@ -343,7 +343,7 @@ public class SkillAdvisorViewModelTests
 
     // #228 PR-B/B2: SkillAdvisorViewModel now hosts the Generate-plan child VM.
     private static GenerateLevelingPlanViewModel Gen(IReferenceDataService refData, IActiveCharacterService chr)
-        => new(chr, new CrossSkillPlanner(refData, new LevelingMath(refData), new RecipeExpander(refData)));
+        => new(chr, new CrossSkillPlanner(refData, new LevelingMath(refData), new RecipeExpander(refData)), refData);
 
     private static SkillAdvisorViewModel MakeVmWithImportTarget(
         out FakeRefData refData, out FakeCraftListImportTarget importTarget)


### PR DESCRIPTION
**Convention fix on the merged #228 plan surfaces** (B1 #390 / B2 #392).

Those surfaces rendered the **id-shaped skill key** (e.g.
`WeaponAugmentBrewing`) instead of the human display name
("Weapon Augmentation"), breaking the established reverse-lookup convention —
Elrond's own `SkillAdvisorViewModel` already does
`_ref.Skills[key].DisplayName` with a key fallback. The persisted/model value
stays the key everywhere; only the *display* resolves.

### Fixed
- **`PlanWalkerViewModel`** — `Skill`, the stale-summary skill note, and the
  "Leveling plan · …" craft-list source label resolve via a
  `SkillDisplayName` helper (`_ref`-backed, key fallback).
- **`PlansViewModel` / `SavedPlanRowViewModel`** — `PlansViewModel` takes
  `IReferenceDataService` (optional, DI-injected, null-safe → key fallback)
  and passes the resolved display into the row; `Title` shows it. Free-text
  search still also matches the raw key (deep-link / advanced users).
- **`GenerateLevelingPlanViewModel`** (Elrond Plan tab) — the picker is now a
  `{Key, DisplayName}` list ordered by display. The ComboBox binds the
  display via `ItemTemplate` (not `DisplayMemberPath` — dodges the
  `SelectedValue`→`ToString()` quirk) with `SelectedValuePath=Key`, so
  `SelectedSkill` / `SkillTarget` / the serialized `SavedLevelingPlan` all
  keep the id-shaped key.

### Tests
+1 Elrond (picker shows display, model keeps key, persisted plan keeps key),
+2 Celebrimbor (walker resolve + key fallback; row title display + fallback);
`FakeReferenceData` gains a `WithSkill` seed. Elrond **67** / Celebrimbor
**87** / Planning 14 / Shared green.

### Verification
- Branched off fresh `main` (`fc1d99a`) after a green post-merge re-verify.
- `dotnet build Mithril.slnx` green; 12-module shell boot →
  `=== startup done ===`; `ValidateOnBuild=true` covers the new
  `IReferenceDataService` ctor edges — no DI cycle.

Independent of #393 (Simulation retirement) — different code paths, both off
`fc1d99a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
