### PR TITLE
fix(dialogs): themed chrome for Confirm() instead of a raw MessageBox

### DIFF
--- a/src/Celebrimbor.Module/ViewModels/PlansViewModel.cs
+++ b/src/Celebrimbor.Module/ViewModels/PlansViewModel.cs
@@ -8,6 +8,7 @@ using Mithril.Planning;
 using Mithril.Shared.Character;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Dialogs;
 
 namespace Celebrimbor.ViewModels;
 
@@ -30,6 +31,7 @@ public sealed partial class PlansViewModel : ObservableObject
     private readonly IReferenceDataService? _referenceData;
     private readonly IModuleActivator? _activator;
     private readonly Func<string?> _pickPlanFile;
+    private readonly IDialogService? _dialogService;
     private readonly Func<SavedPlanRowViewModel, bool> _confirmDelete;
 
     public PlansViewModel(
@@ -40,6 +42,7 @@ public sealed partial class PlansViewModel : ObservableObject
         PlanWalkerViewModel walker,
         IReferenceDataService? referenceData = null,
         IModuleActivator? activator = null,
+        IDialogService? dialogService = null,
         Func<string?>? pickPlanFile = null,
         Func<SavedPlanRowViewModel, bool>? confirmDelete = null)
     {
@@ -49,6 +52,7 @@ public sealed partial class PlansViewModel : ObservableObject
         _activeChar = activeChar;
         _referenceData = referenceData;
         _activator = activator;
+        _dialogService = dialogService;
         _pickPlanFile = pickPlanFile ?? DefaultPickPlanFile;
         _confirmDelete = confirmDelete ?? DefaultConfirmDelete;
         Walker = walker;
@@ -225,11 +229,10 @@ public sealed partial class PlansViewModel : ObservableObject
         return dlg.ShowDialog() == true ? dlg.FileName : null;
     }
 
-    private static bool DefaultConfirmDelete(SavedPlanRowViewModel row)
-        => System.Windows.MessageBox.Show(
-               $"Delete the plan \"{row.Title}\"? This cannot be undone.",
-               "Delete plan", System.Windows.MessageBoxButton.OKCancel,
-               System.Windows.MessageBoxImage.Warning) == System.Windows.MessageBoxResult.OK;
+    private bool DefaultConfirmDelete(SavedPlanRowViewModel row)
+        => (_dialogService ?? new DialogService()).Confirm(
+               "Delete plan",
+               $"Delete the plan \"{row.Title}\"? This cannot be undone.");
 
     private static void DispatchOnUi(Action action)
     {

--- a/src/Mithril.Shared.Wpf/Dialogs/ConfirmDialogView.xaml
+++ b/src/Mithril.Shared.Wpf/Dialogs/ConfirmDialogView.xaml
@@ -1,0 +1,13 @@
+<UserControl x:Class="Mithril.Shared.Wpf.Dialogs.ConfirmDialogView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <TextBlock Text="{Binding Message}"
+               Foreground="#FFD8D8D8"
+               FontSize="13"
+               TextWrapping="Wrap"
+               LineHeight="19"
+               Margin="4,2,4,6"/>
+</UserControl>

--- a/src/Mithril.Shared.Wpf/Dialogs/ConfirmDialogView.xaml.cs
+++ b/src/Mithril.Shared.Wpf/Dialogs/ConfirmDialogView.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows.Controls;
+
+namespace Mithril.Shared.Wpf.Dialogs;
+
+public partial class ConfirmDialogView : UserControl
+{
+    public ConfirmDialogView() => InitializeComponent();
+}

--- a/src/Mithril.Shared.Wpf/Dialogs/ConfirmDialogViewModel.cs
+++ b/src/Mithril.Shared.Wpf/Dialogs/ConfirmDialogViewModel.cs
@@ -1,0 +1,26 @@
+namespace Mithril.Shared.Wpf.Dialogs;
+
+/// <summary>
+/// View model for the themed yes/no confirmation rendered through
+/// <see cref="DialogWindow"/> (the app's custom chrome) instead of a raw
+/// <c>MessageBox</c>. Primary = confirm, secondary = cancel; the window's
+/// default <see cref="DialogViewModelBase.OnPrimaryAction"/> (returns true)
+/// is exactly the "Yes ⇒ true" semantics <see cref="IDialogService.Confirm"/>
+/// needs.
+/// </summary>
+public sealed class ConfirmDialogViewModel : DialogViewModelBase
+{
+    public ConfirmDialogViewModel(string title, string message,
+        string primaryButtonText = "Yes", string secondaryButtonText = "Cancel")
+    {
+        Title = title;
+        Message = message;
+        PrimaryButtonText = primaryButtonText;
+        SecondaryButtonText = secondaryButtonText;
+    }
+
+    public override string Title { get; }
+    public string Message { get; }
+    public override string PrimaryButtonText { get; }
+    public override string? SecondaryButtonText { get; }
+}

--- a/src/Mithril.Shared.Wpf/Dialogs/DialogService.cs
+++ b/src/Mithril.Shared.Wpf/Dialogs/DialogService.cs
@@ -14,14 +14,7 @@ public sealed class DialogService : IDialogService
     }
 
     public bool Confirm(string title, string message)
-    {
-        var result = MessageBox.Show(
-            Application.Current.MainWindow,
-            message,
-            title,
-            MessageBoxButton.YesNo,
-            MessageBoxImage.Warning,
-            MessageBoxResult.No);
-        return result == MessageBoxResult.Yes;
-    }
+        // Themed chrome (DialogWindow) — consistent with the rest of the app
+        // rather than a raw OS MessageBox. Primary ⇒ true; secondary / X ⇒ false.
+        => ShowDialog(new ConfirmDialogViewModel(title, message), new ConfirmDialogView()) == true;
 }


### PR DESCRIPTION
The custom-chrome dialog infra (`DialogWindow` + `DialogViewModelBase` —
themed title bar, primary/secondary buttons, app palette) already existed,
but the shared `IDialogService.Confirm` bypassed it for a raw OS
`MessageBox`. Every `Confirm()` caller (Arwen / Gandalf / Legolas / Pippin,
and the #228 B1 plan-delete) popped a Windows-chrome box that clashes with
the dark theme.

- **`ConfirmDialogViewModel : DialogViewModelBase`** + minimal
  `ConfirmDialogView` (message body; the window supplies the framed title +
  Yes/Cancel). The window's default `OnPrimaryAction()` (true) is exactly the
  "Yes ⇒ true" contract; secondary / X ⇒ false.
- **`DialogService.Confirm`** now renders through the existing `DialogWindow`
  path (same as `ShowDialog`) — modal, owner = MainWindow, returns `bool`.
  Behaviour preserved; chrome consistent app-wide.
- **Celebrimbor `PlansViewModel`** routes delete-confirm through the injected
  `IDialogService` instead of a private raw-`MessageBox` seam; the
  `Func<…,bool>` test seam is unchanged so the VM stays headless-testable.

**Intentionally app-wide** — every `IDialogService.Confirm` caller now gets
the themed dialog. **Left alone:** `Program.cs` crash handler (must stay raw
— DI/app may be down) and the standalone `MessageBox` sites in
`RecipePickerViewModel` / `GandalfSettingsViewModel` (pre-existing, separate
scope).

### Verification
- Branched off fresh `main` (`5b587e0`) after a green post-merge re-verify
  (the #393+#394 merged tree was full-suite + boot verified).
- `dotnet build Mithril.slnx` green; Celebrimbor 87 / Elrond 53 / Planning 14
  / Shared 1025 green; 12-module shell boot → `=== startup done ===`;
  `ValidateOnBuild=true` covers the new `IDialogService` edge into
  `PlansViewModel` — no DI cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
