### PR TITLE
fix(planning): respect Recipe.MaxUses (per-character lifetime cap) in CrossSkillPlanner

### DIFF
--- a/src/Mithril.Planning/CrossSkillPlanner.cs
+++ b/src/Mithril.Planning/CrossSkillPlanner.cs
@@ -135,6 +135,10 @@ public sealed class CrossSkillPlanner
                     return (recipe: r, baseXp, reuse, effXp: baseXp + reuse);
                 })
                 .Where(x => x.effXp > 0 || unusedBonuses.Contains(x.recipe.Key))
+                // Respect the recipe's per-character lifetime cap (Recipe.MaxUses):
+                // a recipe exhausted by prior history or earlier phases this run is
+                // no longer craftable, so it can't be a grind OR a bonus source.
+                .Where(x => RemainingUses(x.recipe, completions) > 0)
                 .ToList();
 
             if (available.Count == 0) break;
@@ -180,6 +184,11 @@ public sealed class CrossSkillPlanner
             var needed = xpForLevel - xp;
             var crafts = (int)Math.Ceiling((double)needed / best.effXp);
             if (crafts < 1) crafts = 1;
+            // Never schedule a recipe past its lifetime cap; if that's short of
+            // the level, the loop re-picks the next-best recipe next iteration
+            // (this recipe is now exhausted ⇒ filtered out of `available`).
+            var remaining = RemainingUses(best.recipe, completions);
+            if (crafts > remaining) crafts = remaining;
 
             xp += (long)crafts * best.effXp;
             completed.Add(best.recipe.InternalName!);
@@ -333,6 +342,18 @@ public sealed class CrossSkillPlanner
 
     private static void Bump(IDictionary<string, int> map, string key, int by)
         => map[key] = map.TryGetValue(key, out var v) ? v + by : by;
+
+    /// <summary>
+    /// How many more times this recipe may be crafted given its per-character
+    /// lifetime cap (<see cref="Recipe.MaxUses"/> — Research recipes:
+    /// WeatherWitching / FireMagic / IceMagic, often <c>1</c>). <paramref name="completions"/>
+    /// is seeded from <see cref="RecipeHistory"/> and bumped per scheduled
+    /// craft, so it already holds prior + this-run uses. No cap ⇒ unbounded.
+    /// </summary>
+    private static int RemainingUses(Recipe recipe, IReadOnlyDictionary<string, int> completions)
+        => recipe.MaxUses is int max
+            ? Math.Max(0, max - (completions.TryGetValue(recipe.InternalName ?? "", out var c) ? c : 0))
+            : int.MaxValue;
 
     /// <summary>
     /// Merge consecutive non-bonus steps for the same recipe into one phase, then

--- a/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
+++ b/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
@@ -194,6 +194,46 @@ public class CrossSkillPlannerTests
         widgetPhase.PredictedCrafts.Should().Be(7);
     }
 
+    // ── Recipe.MaxUses (per-character lifetime cap) ──────────────────────
+
+    [Fact]
+    public void MaxUses_CapsGrind_ThenSwitchesToNextBestRecipe()
+    {
+        // Capped recipe is the highest XP but usable only twice ever; the
+        // planner must grind it ≤2× then fall through to the uncapped one.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Rune").AddItem(2, "Brick")
+            .AddRecipe("ScribeRune", Skill, xp: 100, produces: (1, 1), skillLevelReq: 1, maxUses: 2)
+            .AddRecipe("LayBrick", Skill, xp: 40, produces: (2, 1), skillLevelReq: 1);
+
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 5), State(1), RecipeHistory.Empty)!;
+
+        plan.Phases.Where(p => p.RecipeInternalName == "ScribeRune").Sum(p => p.PredictedCrafts)
+            .Should().Be(2, because: "MaxUses=2 is a hard per-character lifetime cap");
+        plan.Phases.Should().Contain(p => p.RecipeInternalName == "LayBrick",
+            because: "the planner switches to the uncapped recipe once the cap is hit");
+        plan.FinalState.LevelOf(Skill).Should().Be(5, because: "the goal is still reached via the fallback");
+    }
+
+    [Fact]
+    public void MaxUses_PriorHistoryCountsAgainstTheCap()
+    {
+        // ScribeRune already crafted twice on this character ⇒ cap exhausted;
+        // it must not appear in the plan at all.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Rune").AddItem(2, "Brick")
+            .AddRecipe("ScribeRune", Skill, xp: 100, produces: (1, 1), skillLevelReq: 1, maxUses: 2)
+            .AddRecipe("LayBrick", Skill, xp: 40, produces: (2, 1), skillLevelReq: 1);
+
+        var history = new RecipeHistory(new Dictionary<string, int> { ["ScribeRune"] = 2 });
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 4), State(1), history)!;
+
+        plan.Phases.Should().NotContain(p => p.RecipeInternalName == "ScribeRune",
+            because: "history completions count toward MaxUses — the cap is already spent");
+        plan.Phases.Should().OnlyContain(p => p.RecipeInternalName == "LayBrick");
+        plan.FinalState.LevelOf(Skill).Should().Be(4);
+    }
+
     // ── Minimal IReferenceDataService fake ───────────────────────────────
 
     private sealed class FakeRef : IReferenceDataService
@@ -230,7 +270,8 @@ public class CrossSkillPlannerTests
         public FakeRef AddRecipe(
             string internalName, string rewardSkill, int xp,
             (long id, int stack) produces,
-            int firstTime = 0, int skillLevelReq = 0, (long id, int stack)? ingredients = null)
+            int firstTime = 0, int skillLevelReq = 0, (long id, int stack)? ingredients = null,
+            int? maxUses = null)
         {
             var r = new Recipe
             {
@@ -242,6 +283,7 @@ public class CrossSkillPlannerTests
                 RewardSkill = rewardSkill,
                 RewardSkillXp = xp,
                 RewardSkillXpFirstTime = firstTime,
+                MaxUses = maxUses,
                 Ingredients = ingredients is { } ing
                     ? [new RecipeItemIngredient { ItemCode = ing.id, StackSize = ing.stack }]
                     : [],


### PR DESCRIPTION
`CrossSkillPlanner` picked the best effective-XP recipe and ground it for as
many crafts as the level target needed, **never reading `Recipe.MaxUses`** —
the per-character lifetime cap on Research recipes (WeatherWitching /
FireMagic / IceMagic, frequently `MaxUses == 1`; ~91 recipes). A generated
plan could schedule e.g. 142 crafts of a recipe the character may legally
craft twice. Pre-existing #227 engine gap (the now-removed `LevelingSimulator`
didn't honour it either), surfaced by B2 making the plan user-facing/walkable.

The run-scoped `completions` map is seeded from `RecipeHistory` and bumped per
scheduled craft, so it already holds prior + this-run uses — exactly what the
cap limits.

- `RemainingUses(recipe, completions)` = `MaxUses − used` (∞ when uncapped).
- Exhausted recipes (prior history **or** earlier phases this run) are filtered
  out of `available` → ineligible as both a grind target and a
  first-time-bonus source.
- The grind count is clamped to `RemainingUses`; if that falls short of the
  level, the loop re-picks the next-best recipe next iteration. Progress is
  still guaranteed (`crafts ≥ 1`); a genuinely unreachable goal already
  degrades to "no viable path" (`null`).

### Tests
Mithril.Planning.Tests **+2 → 16**: cap → switch-to-next-best, and prior
history counting against the cap. Celebrimbor 87 / Elrond 53 / Shared green.

### Verification
- Own branch off fresh `main` (`5b587e0`); engine-only change (no DI).
- `dotnet build Mithril.slnx` green; 12-module shell boot → `=== startup done ===`.

Independent of #395 (themed Confirm dialog). Touches only
`CrossSkillPlanner.cs` + its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
