### PR TITLE
refactor(favor): converge slim NpcService.MinFavorTier to typed FavorTier? (closes #385)

### DIFF
--- a/docs/agent-plans/2026-05-16-smaug-385-minfavortier-retype.md
+++ b/docs/agent-plans/2026-05-16-smaug-385-minfavortier-retype.md
@@ -194,10 +194,9 @@ the json-versioning convention — out of #385 scope. #385 therefore:
 - changes nothing in the calibration path,
 - adds a **characterization test** pinning the current raw-token passthrough
   (so a future migration is a deliberate, test-visible change, not a silent one),
-- files a follow-up issue for "canonicalise calibration favor token at ingest
-  behind a `SchemaVersion` bump"; this doc + that issue are the recorded
-  rationale per the Acceptance "if anything stays `string`, record the
-  rationale" clause.
+- filed follow-up **#397** ("canonicalise calibration favor token at ingest
+  behind a `SchemaVersion` bump"); this doc + #397 are the recorded rationale
+  per the Acceptance "if anything stays `string`, record the rationale" clause.
 
 ## Testing
 

--- a/docs/agent-plans/2026-05-16-smaug-385-minfavortier-retype.md
+++ b/docs/agent-plans/2026-05-16-smaug-385-minfavortier-retype.md
@@ -60,6 +60,11 @@ for junk), **not** a throwing parse. After the retype the comparison is a direct
 enum `<` / `>=` and the table above must still hold (verify `Unknown = int.MinValue`
 keeps "junk = not gated"; `null` MinFavorTier keeps "no gate").
 
+**Display parity corollary** (Approach step 5): wherever `MinFavorTier` drives a
+*shown requirement* (`ResolveFavorRequirement`), `null` **and** `Unknown` both
+render as *no requirement line*. The displayed requirement must never assert a
+gate the logic doesn't enforce.
+
 ## Approach
 
 **Push the parse into the projection; compare typed everywhere downstream.**
@@ -90,6 +95,33 @@ keeps "junk = not gated"; `null` MinFavorTier keeps "no gate").
      [[favortier-extensions-using-static-not-dead]] — `.DisplayName()`/`.ToToken()`
      are extension calls that still need the namespace/`using static` under the
      alias pattern; do not blindly delete).
+5. **Cross-project consumer (NOT just Smaug).** The slim
+   `NpcService.MinFavorTier` has one consumer outside Smaug that the retype
+   hard-breaks under warnings-as-errors:
+   [`IngredientSourcesViewModel.ResolveFavorRequirement`](../../src/Mithril.Shared.Wpf/IngredientSourcesViewModel.cs#L199-L216)
+   (`Mithril.Shared.Wpf`). Lines 212-213 do `string.IsNullOrEmpty(svc.MinFavorTier)`
+   (now a type error) + `$"Requires {svc.MinFavorTier} or higher"`. Fix:
+   - **Aliases, NOT a namespace import.** This file references POCO-vs-slim
+     `NpcService`/`NpcPreference` in `<see cref>` doc comments (lines 162-166);
+     a blanket `using Mithril.Reference.Models.Npcs;` creates CS0104 /
+     ambiguous-cref errors under warnings-as-errors (the
+     [[favortier-extensions-using-static-not-dead]] collision). Mirror the Smaug
+     pattern instead:
+     ```csharp
+     using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
+     using static Mithril.Reference.Models.Npcs.FavorTierExtensions;
+     ```
+   - Body (212-213) →
+     ```csharp
+     if (svc.MinFavorTier is not { } tier || tier == FavorTier.Unknown) return null;
+     return $"Requires {tier.DisplayName()} or higher";
+     ```
+   - **Decision (display ⇔ gate parity):** collapse `Unknown` into the same
+     "no requirement shown" branch as `null`. The gate logic treats `Unknown`
+     as *not gated*; printing "Requires Unknown or higher" would assert a
+     requirement the gate doesn't enforce — exactly the display/logic divergence
+     #385 exists to kill. Real-token behaviour is unchanged; junk shifts from
+     "Requires &lt;junk&gt; or higher" to no line (strictly more correct).
 4. **Display layer — keep `string?`, convert at the boundary** (mirrors how #387
    handled `PlayerFavorTier`). The three Smaug service records
    ([SellPlannerService.cs:32](../../src/Smaug.Module/State/SellPlannerService.cs#L32),
@@ -114,8 +146,10 @@ keeps "junk = not gated"; `null` MinFavorTier keeps "no gate").
 - [src/Smaug.Module/Domain/VendorCapResolver.cs](../../src/Smaug.Module/Domain/VendorCapResolver.cs#L44) — typed gate.
 - [src/Smaug.Module/State/SellPlannerService.cs](../../src/Smaug.Module/State/SellPlannerService.cs#L102-L119) — typed gate + estimate + `MinFavorTier:` display conversion.
 - [src/Smaug.Module/State/StorageSellbackService.cs](../../src/Smaug.Module/State/StorageSellbackService.cs#L146) — `MinFavorTier:` display conversion.
-- [src/Smaug.Module/State/VendorCatalogService.cs](../../src/Smaug.Module/State/VendorCatalogService.cs#L105) — `MinFavorTier:` display conversion.
-- Any other `MinFavorTier` consumer surfaced by the audit grep below.
+- [src/Smaug.Module/State/VendorCatalogService.cs](../../src/Smaug.Module/State/VendorCatalogService.cs#L105) — `MinFavorTier:` display conversion (note: `storeService?.MinFavorTier?.DisplayName()` — null-conditional already there).
+- [src/Mithril.Shared.Wpf/IngredientSourcesViewModel.cs](../../src/Mithril.Shared.Wpf/IngredientSourcesViewModel.cs#L199-L216) — cross-project consumer; alias-not-namespace + `Unknown`-suppression per Approach step 5.
+- [src/Mithril.Reference/Models/Npcs/FavorTier.cs](../../src/Mithril.Reference/Models/Npcs/FavorTier.cs#L26) — stale doc comment ("`NpcService.MinFavorTier` remains `string?`") becomes false; update it in the same PR.
+- Audit grep confirmed the above is the *complete* consumer set of the slim `NpcService.MinFavorTier`. Silmarillion's `MinFavorTier` carriers are fed from the **POCO** `s.Favor`/`p.Favor`, not the slim record — see Out of scope.
 
 ## Calibration — explicitly NOT migrated (token-at-rest)
 
@@ -137,6 +171,34 @@ that finding and change nothing. If a versioned migration is ever wanted, it
 must be an explicit `SchemaVersion` bump (see the settings-migration /
 json-versioning conventions), never silent.
 
+### Audit outcome (traced — decision recorded, no code change)
+
+The `favorTier` arg to `RecordObservation` is **not** a `.ToToken()`-canonicalised
+value. Chain:
+[`RecordObservation(…, _context.ActiveFavorTier!, …)`](../../src/Smaug.Module/State/VendorIngestionService.cs#L91)
+← `VendorSellContext.ActiveFavorTier` (`string?`,
+[VendorSellContext.cs:14/42](../../src/Smaug.Module/State/VendorSellContext.cs#L14))
+← `VendorScreenOpened.FavorTier` ← the **raw regex capture group** at
+[VendorLogParser.cs:61](../../src/Smaug.Module/Parsing/VendorLogParser.cs#L61)
+(`m.Groups[2].Value` from `ProcessVendorScreen(entityId, FavorTier, …)`),
+never round-tripped through `Parse`/`ToToken`.
+
+**Decision: document + defer; no #385 code change.** In practice the value is
+canonical because `FavorTier`'s tokens are modelled directly on PG's emitted
+tier names, so the empirically-observed key shape is already correct. The
+defensive risk (PG emits an unrecognised spelling → it bakes verbatim into a
+mis-keyed `AbsoluteKey`/`RatioKey`) is real but cannot be fixed inside #385:
+canonicalising at ingest *changes the persisted key shape*, which is a versioned
+calibration-data migration and **must** be an explicit `SchemaVersion` bump per
+the json-versioning convention — out of #385 scope. #385 therefore:
+- changes nothing in the calibration path,
+- adds a **characterization test** pinning the current raw-token passthrough
+  (so a future migration is a deliberate, test-visible change, not a silent one),
+- files a follow-up issue for "canonicalise calibration favor token at ingest
+  behind a `SchemaVersion` bump"; this doc + that issue are the recorded
+  rationale per the Acceptance "if anything stays `string`, record the
+  rationale" clause.
+
 ## Testing
 
 TDD. The behavioural-equivalence table is the spec — pin it.
@@ -154,9 +216,13 @@ TDD. The behavioural-equivalence table is the spec — pin it.
   safety net), per TDD-for-refactor.
 - **SellPlanner accessibility**: a test that `isAccessible` is unchanged across
   the retype for null / real / junk `MinFavorTier`.
-- Calibration: if the `RecordObservation` caller is found to pass a non-canonical
-  token, add a regression test that the persisted key uses the canonical token;
-  otherwise no calibration test change.
+- **`ResolveFavorRequirement`** (`tests/Mithril.Shared.Tests`, Wpf VM suite):
+  `null MinFavorTier → null`; real tier → `"Requires <DisplayName> or higher"`;
+  junk/`Unknown` → `null` (display ⇔ gate parity, Approach step 5).
+- **Calibration characterization test**: pin the *current* raw-token passthrough
+  into the persisted key (audit found the caller passes the raw log token, not
+  `.ToToken()`). This is a guard so the deferred canonicalisation migration is
+  test-visible, not a behaviour change in #385.
 - Full `dotnet test Mithril.slnx` green; `grep -rn "MinFavorTier" src --include=*.cs`
   shows no remaining `string`-typed *comparison* (only display-record `string`
   carriers + the projection).
@@ -170,6 +236,13 @@ TDD. The behavioural-equivalence table is the spec — pin it.
   stays at rest; audit-only).
 - `StoreCapIncrease.Tier` (already typed since #373) and `PlayerFavorTier`
   (already handled in #387).
+- **Silmarillion's `MinFavorTier` — do not touch.**
+  `NpcsTabViewModel.cs:223/451` + `NpcServiceRow`/`NpcPreferenceRow` carry
+  `string? MinFavorTier` fed from the **POCO** `s.Favor`/`p.Favor`, not the
+  slim `Mithril.Shared.Reference.NpcService`, so the retype does not reach them.
+  In particular `NpcsTabViewModel.cs:223` has a deliberate
+  `Despised → null` special-case — **must not** be "converged" into the
+  projection; its semantics differ from the gate's null/Unknown rules.
 
 ## Acceptance
 

--- a/src/Mithril.Reference/Models/Npcs/FavorTier.cs
+++ b/src/Mithril.Reference/Models/Npcs/FavorTier.cs
@@ -23,8 +23,9 @@ namespace Mithril.Reference.Models.Npcs;
 /// <para>
 /// Canonical type for the whole solution (#368/#370): Smaug and Arwen previously
 /// maintained local string-based ladders — both now converge here (Smaug #370 Task 3,
-/// Arwen Task 2). <c>NpcService.MinFavorTier</c> remains <c>string?</c> (field retype
-/// deferred to #385); parse at the boundary via <see cref="Parse"/>.
+/// Arwen Task 2). The slim <c>NpcService.MinFavorTier</c> is <c>FavorTier?</c> as of
+/// #385, parsed once at the <c>ReferenceDataService</c> projection via <see cref="Parse"/>
+/// (junk → <see cref="Unknown"/>); downstream comparisons are typed.
 /// </para>
 /// </remarks>
 public enum FavorTier

--- a/src/Mithril.Shared.Wpf/IngredientSourcesViewModel.cs
+++ b/src/Mithril.Shared.Wpf/IngredientSourcesViewModel.cs
@@ -1,5 +1,10 @@
 using Mithril.Shared.Reference;
 using Mithril.Shared.Storage;
+// Aliased, NOT `using Mithril.Reference.Models.Npcs;` — that namespace also
+// declares NpcService/NpcPreference, colliding CS0104 with the slim records
+// this file references in <see cref> doc comments (#385).
+using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
+using static Mithril.Reference.Models.Npcs.FavorTierExtensions;
 
 namespace Mithril.Shared.Wpf;
 
@@ -209,8 +214,12 @@ public sealed record IngredientSourcesViewModel(
         foreach (var svc in npc.Services)
         {
             if (!string.Equals(svc.Type, serviceType, StringComparison.Ordinal)) continue;
-            if (string.IsNullOrEmpty(svc.MinFavorTier)) return null;
-            return $"Requires {svc.MinFavorTier} or higher";
+            // #385 display ⇔ gate parity: null = no gate; Unknown = the gate's
+            // "not gated" sentinel (junk token). Neither asserts a requirement —
+            // showing "Requires Unknown or higher" would claim a gate the logic
+            // does not enforce.
+            if (svc.MinFavorTier is not { } tier || tier == FavorTier.Unknown) return null;
+            return $"Requires {tier.DisplayName()} or higher";
         }
         return null;
     }

--- a/src/Mithril.Shared/Reference/NpcEntry.cs
+++ b/src/Mithril.Shared/Reference/NpcEntry.cs
@@ -1,6 +1,9 @@
-// Only StoreCapIncrease is pulled from the Reference models — aliased to avoid
-// colliding with this file's own slim NpcService record.
+// StoreCapIncrease and FavorTier are pulled from the Reference models — aliased
+// (NOT a blanket `using Mithril.Reference.Models.Npcs;`) because that namespace
+// also declares NpcService/NpcPreference, which would collide CS0104 with this
+// file's own slim records.
 using StoreCapIncrease = Mithril.Reference.Models.Npcs.StoreCapIncrease;
+using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
 
 namespace Mithril.Shared.Reference;
 
@@ -36,5 +39,5 @@ public sealed record NpcPreference(
 /// </summary>
 public sealed record NpcService(
     string Type,
-    string? MinFavorTier,
+    FavorTier? MinFavorTier,
     IReadOnlyList<StoreCapIncrease> CapIncreases);

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -23,6 +23,8 @@ using PocoNpcService = Mithril.Reference.Models.Npcs.NpcService;
 using PocoNpcStoreService = Mithril.Reference.Models.Npcs.StoreService;
 using StoreCapIncrease = Mithril.Reference.Models.Npcs.StoreCapIncrease;
 using StoreCapIncreaseParser = Mithril.Reference.Models.Npcs.StoreCapIncreaseParser;
+using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
+using FavorTierExtensions = Mithril.Reference.Models.Npcs.FavorTierExtensions;
 using PocoPower = Mithril.Reference.Models.Misc.PowerProfile;
 using DirectedGoal = Mithril.Reference.Models.Misc.DirectedGoal;
 using AbilityKeyword = Mithril.Reference.Models.Misc.AbilityKeyword;
@@ -1109,7 +1111,10 @@ public sealed class ReferenceDataService : IReferenceDataService
                 .Where(s => !string.IsNullOrEmpty(s.Type))
                 .Select(s => new NpcService(
                     s.Type,
-                    s.Favor,
+                    // #385: parse the favor gate ONCE here. null Favor → null (no gate);
+                    // any non-null Favor → Parse (junk → FavorTier.Unknown, NOT null —
+                    // the gate math owns "not gated", not a coincidental null).
+                    s.Favor is { } f ? FavorTierExtensions.Parse(f) : (FavorTier?)null,
                     s is PocoNpcStoreService store ? StoreCapIncreaseParser.ParseRequiringGold(store.CapIncreases) : (IReadOnlyList<StoreCapIncrease>)[]))
                 .ToList();
 

--- a/src/Smaug.Module/Domain/VendorCapResolver.cs
+++ b/src/Smaug.Module/Domain/VendorCapResolver.cs
@@ -1,6 +1,5 @@
 using Mithril.Shared.Reference;
 using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
-using static Mithril.Reference.Models.Npcs.FavorTierExtensions;
 
 namespace Smaug.Domain;
 
@@ -39,9 +38,11 @@ public static class VendorCapResolver
     {
         if (store.CapIncreases.Count == 0) return null;
 
-        // Gate on MinFavorTier first.
+        // Gate on MinFavorTier first. MinFavorTier is parsed once at the projection
+        // (#385); a junk token is FavorTier.Unknown (int.MinValue) so currentTier is
+        // never < it — junk stays "not gated", exactly as before the retype.
         var currentTier = playerFavorTier;
-        if (store.MinFavorTier is { } minTier && currentTier < Parse(minTier)) return null;
+        if (store.MinFavorTier is { } req && currentTier < req) return null;
 
         int? best = null;
         foreach (var cap in store.CapIncreases)

--- a/src/Smaug.Module/State/SellPlannerService.cs
+++ b/src/Smaug.Module/State/SellPlannerService.cs
@@ -99,13 +99,15 @@ public sealed class SellPlannerService
             if (!VendorAcceptsItem(store, itemKeywords)) continue;
 
             var playerTier = _favorLookup?.GetFavorTier(npcKey);
+            // MinFavorTier is FavorTier? (parsed once at the projection, #385). The
+            // `is null` short-circuit keeps a null gate "accessible"; .Value is safe
+            // past it. Junk → Unknown (int.MinValue) so any tier >= it ⇒ accessible.
             var isAccessible = store.MinFavorTier is null ||
-                               (playerTier ?? FavorTier.Neutral) >= Parse(store.MinFavorTier);
+                               (playerTier ?? FavorTier.Neutral) >= store.MinFavorTier.Value;
 
             // Use the player's known tier for the estimate when we have it; otherwise fall back
             // to the vendor's requirement so users see some number for tier-gated vendors.
-            var estimateTier = playerTier
-                ?? (store.MinFavorTier is { } m ? Parse(m) : FavorTier.Neutral);
+            var estimateTier = playerTier ?? store.MinFavorTier ?? FavorTier.Neutral;
             var estimate = _calibration.EstimateSellPrice(
                 npcKey,
                 item.InternalName,
@@ -116,7 +118,7 @@ public sealed class SellPlannerService
                 NpcKey: npcKey,
                 NpcName: npc.Name,
                 Area: string.IsNullOrEmpty(npc.Area) ? "(Unknown Area)" : npc.Area,
-                MinFavorTier: store.MinFavorTier,
+                MinFavorTier: store.MinFavorTier?.DisplayName(),
                 PlayerFavorTier: playerTier?.DisplayName(),
                 IsAccessible: isAccessible,
                 Estimate: estimate));

--- a/src/Smaug.Module/State/StorageSellbackService.cs
+++ b/src/Smaug.Module/State/StorageSellbackService.cs
@@ -143,7 +143,7 @@ public sealed class StorageSellbackService
                 NpcKey: npcKey,
                 NpcName: npc.Name,
                 Area: string.IsNullOrEmpty(npc.Area) ? "(Unknown Area)" : npc.Area,
-                MinFavorTier: store.MinFavorTier,
+                MinFavorTier: store.MinFavorTier?.DisplayName(),
                 PlayerFavorTier: playerTier?.DisplayName(),
                 Items: buyableItems));
         }

--- a/src/Smaug.Module/State/VendorCatalogService.cs
+++ b/src/Smaug.Module/State/VendorCatalogService.cs
@@ -102,7 +102,7 @@ public sealed class VendorCatalogService
                     NpcKey: src.Npc,
                     NpcName: npc?.Name ?? src.Npc.Replace("NPC_", ""),
                     Area: npc?.Area ?? "",
-                    MinFavorTier: storeService?.MinFavorTier,
+                    MinFavorTier: storeService?.MinFavorTier?.DisplayName(),
                     PlayerFavorTier: playerTier?.DisplayName(),
                     EffectiveMaxGold: maxGold,
                     IsAcceptable: acceptable));

--- a/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
+++ b/tests/Mithril.Shared.Tests/ReferenceDataServiceTests.cs
@@ -851,6 +851,34 @@ public class ReferenceDataServiceTests : IDisposable
     }
 
     [Fact]
+    public void Npcs_projection_parses_service_MinFavorTier_to_FavorTier()
+    {
+        // #385: the slim NpcService.MinFavorTier is FavorTier?, parsed once at the
+        // projection. null Favor → null; a real token → that tier; junk → Unknown
+        // (NOT null — the gate math, not a coincidental null, is the not-gated rule).
+        File.WriteAllText(Path.Combine(_bundledDir, "items.json"), "{}");
+        File.WriteAllText(Path.Combine(_bundledDir, "items.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+        File.WriteAllText(Path.Combine(_bundledDir, "npcs.json"), """
+            {
+              "NPC_Real": { "Name": "Real", "Services": [ { "Type": "Store", "Favor": "Friends" } ] },
+              "NPC_Null": { "Name": "Null", "Services": [ { "Type": "Store" } ] },
+              "NPC_Junk": { "Name": "Junk", "Services": [ { "Type": "Store", "Favor": "totally-not-a-tier" } ] }
+            }
+            """);
+        File.WriteAllText(Path.Combine(_bundledDir, "npcs.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        svc.Npcs["NPC_Real"].Services.Single().MinFavorTier
+            .Should().Be(Mithril.Reference.Models.Npcs.FavorTier.Friends);
+        svc.Npcs["NPC_Null"].Services.Single().MinFavorTier
+            .Should().BeNull("absent Favor projects to a null gate");
+        svc.Npcs["NPC_Junk"].Services.Single().MinFavorTier
+            .Should().Be(Mithril.Reference.Models.Npcs.FavorTier.Unknown,
+                "an unrecognised token is Unknown, not null — the gate math owns 'not gated'");
+    }
+
+    [Fact]
     public void GetSnapshot_UnknownKey_Throws()
     {
         WriteBundled("""{}""", version: "v100");

--- a/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/IngredientSourcesViewModelTests.cs
@@ -5,6 +5,7 @@ using Mithril.Shared.Reference;
 using Mithril.Shared.Storage;
 using Mithril.Shared.Wpf;
 using Xunit;
+using FavorTier = Mithril.Reference.Models.Npcs.FavorTier;
 
 namespace Mithril.Shared.Tests.Wpf;
 
@@ -126,8 +127,8 @@ public class IngredientSourcesViewModelTests
     [Fact]
     public void Vendor_source_surfaces_Store_service_MinFavorTier_as_Requirement()
     {
-        // Hulon's Store service is gated on "Liked" favor; we should expose that.
-        var store = new NpcService(Type: "Store", MinFavorTier: "Liked", CapIncreases: []);
+        // Hulon's Store service is gated on Comfortable favor; we should expose that.
+        var store = new NpcService(Type: "Store", MinFavorTier: FavorTier.Comfortable, CapIncreases: []);
         var npc = new NpcEntry("NPC_Hulon", "Hulon", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store]);
         var refData = new StubRefData(
             sources: new() { ["IronBar"] = [new ItemSource("Vendor", "NPC_Hulon", null)] },
@@ -136,16 +137,34 @@ public class IngredientSourcesViewModelTests
         var vm = IngredientSourcesViewModel.Build(
             new IngredientSourcesInput("Iron Bar", null, "IronBar", []), refData);
 
-        vm.Sources.Single().Requirement.Should().Be("Requires Liked or higher");
+        vm.Sources.Single().Requirement.Should().Be("Requires Comfortable or higher");
+    }
+
+    [Fact]
+    public void Vendor_source_with_unparseable_MinFavorTier_emits_no_Requirement()
+    {
+        // #385 display ⇔ gate parity: FavorTier.Unknown is the gate's "not gated"
+        // sentinel (junk tokens project to it). The shown requirement must agree —
+        // no "Requires Unknown or higher" line.
+        var store = new NpcService(Type: "Store", MinFavorTier: FavorTier.Unknown, CapIncreases: []);
+        var npc = new NpcEntry("NPC_Hulon", "Hulon", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store]);
+        var refData = new StubRefData(
+            sources: new() { ["IronBar"] = [new ItemSource("Vendor", "NPC_Hulon", null)] },
+            npcs: new() { ["NPC_Hulon"] = npc });
+
+        var vm = IngredientSourcesViewModel.Build(
+            new IngredientSourcesInput("Iron Bar", null, "IronBar", []), refData);
+
+        vm.Sources.Single().Requirement.Should().BeNull();
     }
 
     [Fact]
     public void Barter_source_uses_Barter_service_for_Requirement_lookup()
     {
-        // Same NPC has a Store at Neutral and a Barter at "Loved" — only the Barter gate
-        // applies for a Barter source. Confirms the service-type routing isn't conflated.
+        // Same NPC has an ungated Store and a Barter gated at BestFriends — only the
+        // Barter gate applies for a Barter source. Confirms service-type routing isn't conflated.
         var store = new NpcService("Store", MinFavorTier: null, CapIncreases: []);
-        var barter = new NpcService("Barter", MinFavorTier: "Loved", CapIncreases: []);
+        var barter = new NpcService("Barter", MinFavorTier: FavorTier.BestFriends, CapIncreases: []);
         var npc = new NpcEntry("NPC_Velkort", "Velkort", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store, barter]);
         var refData = new StubRefData(
             sources: new() { ["RareIngot"] = [new ItemSource("Barter", "NPC_Velkort", null)] },
@@ -154,7 +173,7 @@ public class IngredientSourcesViewModelTests
         var vm = IngredientSourcesViewModel.Build(
             new IngredientSourcesInput("Rare Ingot", null, "RareIngot", []), refData);
 
-        vm.Sources.Single().Requirement.Should().Be("Requires Loved or higher");
+        vm.Sources.Single().Requirement.Should().Be("Requires Best Friends or higher");
     }
 
     [Fact]
@@ -301,7 +320,7 @@ public class IngredientSourcesViewModelTests
     {
         // NpcGift gating lives on per-preference RequiredFavorTier, not per-NPC.
         // The Sources tab line should not claim a vendor-style favor gate for gifts.
-        var store = new NpcService("Store", MinFavorTier: "Liked", CapIncreases: []);
+        var store = new NpcService("Store", MinFavorTier: FavorTier.Comfortable, CapIncreases: []);
         var npc = new NpcEntry("NPC_Marna", "Marna", "Serbule", Preferences: [], ItemGiftTiers: [], Services: [store]);
         var refData = new StubRefData(
             sources: new() { ["GiftedItem"] = [new ItemSource("NpcGift", "NPC_Marna", null)] },

--- a/tests/Smaug.Tests/PriceCalibrationTests.cs
+++ b/tests/Smaug.Tests/PriceCalibrationTests.cs
@@ -28,6 +28,22 @@ public sealed class PriceCalibrationTests
     }
 
     [Fact]
+    public void AbsoluteKey_uses_the_favor_token_verbatim_not_canonicalised()
+    {
+        // #385 calibration audit guard. The favor token reaching the persisted
+        // key is the RAW VendorScreenOpened token (VendorLogParser.cs), never
+        // round-tripped through FavorTierExtensions.Parse/.ToToken. #385 keeps
+        // it that way (canonicalising = a key-shape change ⇒ SchemaVersion bump,
+        // out of scope). This pins the raw passthrough so a future migration is
+        // a deliberate, test-visible change — not a silent one.
+        var key = PriceCalibrationService.AbsoluteKey(
+            "NPC_A", "BottleOfWater", "totally-not-a-tier", "Under5");
+
+        key.Should().Be("NPC_A|BottleOfWater|totally-not-a-tier|Under5",
+            "the junk token is keyed verbatim, NOT normalised to 'Unknown'");
+    }
+
+    [Fact]
     public void RatioRates_UseKeywordBucket()
     {
         var obs = new List<PriceObservation>

--- a/tests/Smaug.Tests/VendorCapResolverTests.cs
+++ b/tests/Smaug.Tests/VendorCapResolverTests.cs
@@ -35,6 +35,57 @@ public sealed class VendorCapResolverTests
         result.Should().Be(500);
     }
 
+    // #385 behavioural-equivalence table — the MinFavorTier gate. These pin the
+    // exact null / real-tier / junk semantics so the string→FavorTier? retype is
+    // a provable no-op (green both before and after; the post-retype change is only
+    // the input literal's type, never the assertion). A matching Neutral cap at 500
+    // is present in every row so "not gated" surfaces as 500 and "gated" as null.
+
+    [Fact]
+    public void Gate_NullMinFavorTier_IsNotGated()
+    {
+        var store = new NpcService("Store", MinFavorTier: null,
+            CapIncreases: new[] { new StoreCapIncrease(FavorTier.Neutral, 500, []) });
+
+        VendorCapResolver.ResolveMaxGold(store, FavorTier.Neutral, new HashSet<string>(), 0)
+            .Should().Be(500, "a null MinFavorTier means no favor gate");
+    }
+
+    [Fact]
+    public void Gate_RealTierAbovePlayer_Blocks()
+    {
+        // Comfortable (+100) is above a Neutral player → gated, even though the
+        // Neutral cap row would otherwise match.
+        var store = new NpcService("Store", MinFavorTier: FavorTier.Comfortable,
+            CapIncreases: new[] { new StoreCapIncrease(FavorTier.Neutral, 500, []) });
+
+        VendorCapResolver.ResolveMaxGold(store, FavorTier.Neutral, new HashSet<string>(), 0)
+            .Should().BeNull("the player's tier is below the gate");
+    }
+
+    [Fact]
+    public void Gate_RealTierAtOrBelowPlayer_Admits()
+    {
+        var store = new NpcService("Store", MinFavorTier: FavorTier.Neutral,
+            CapIncreases: new[] { new StoreCapIncrease(FavorTier.Neutral, 500, []) });
+
+        VendorCapResolver.ResolveMaxGold(store, FavorTier.Neutral, new HashSet<string>(), 0)
+            .Should().Be(500, "the player meets the gate exactly");
+    }
+
+    [Fact]
+    public void Gate_UnparseableMinFavorTier_IsNotGated()
+    {
+        // The subtle row: Unknown (= int.MinValue, what a junk token projects to) is
+        // never > any real tier, so the gate never blocks. The projection test pins
+        // junk-string → Unknown; this pins Unknown → not-gated.
+        var store = new NpcService("Store", MinFavorTier: FavorTier.Unknown,
+            CapIncreases: new[] { new StoreCapIncrease(FavorTier.Neutral, 500, []) });
+
+        VendorCapResolver.ResolveMaxGold(store, FavorTier.Neutral, new HashSet<string>(), 0)
+            .Should().Be(500, "Unknown is the not-gated sentinel, never blocks");
+    }
+
     // The upper side of the same boundary must stay excluded: Comfortable is favor +100,
     // ABOVE Neutral, so a Neutral-favor player must NOT receive a Comfortable-tier cap.
     [Fact]


### PR DESCRIPTION
Closes #385. Converges the last string-typed favor seam deliberately left out of #387.

## What

`Mithril.Shared.Reference.NpcService.MinFavorTier`: `string?` → `FavorTier?`, parsed **once** at the `ReferenceDataService` projection (`Favor` absent → `null`; junk token → `FavorTier.Unknown`). Downstream comparisons are now direct enum compares — the two Smaug boundary `Parse()` calls (`VendorCapResolver`, `SellPlannerService`) are gone. Display records/VMs/XAML stay `string`, converted via `.DisplayName()` at construction (a label wants a string, not a type).

## Behavioural equivalence (the spec)

The null / real-tier / junk gate table is pinned by `VendorCapResolverTests.Gate_*` — written and **green against pre-#385 code**, still green after the retype (refactor safety net). A projection test pins `null→null` / `"Friends"→Friends` / `junk→Unknown`. TDD throughout: the one genuine behaviour change (`ResolveFavorRequirement` junk → no requirement line) was fail-first.

## Handoff-review concerns, resolved

- **Cross-project consumer** `IngredientSourcesViewModel.ResolveFavorRequirement` (`Mithril.Shared.Wpf`) — the grep-surfaced, build-breaking consumer the plan didn't name. Retyped via **aliases, not a namespace import** (a blanket `using` collides CS0104 with the slim records in its doc-comment crefs). `Unknown` collapses into the `null` "no requirement shown" branch so the displayed requirement never asserts a gate the logic doesn't enforce (display ⇔ gate parity).
- **`NpcEntry.cs`** uses a `FavorTier` alias for the same CS0104 reason — the plan's blanket-`using` step 1 would self-collide with its own record declarations.
- **Calibration** — traced: `PriceCalibrationService` receives the raw `VendorScreenOpened` token (never `.ToToken()`). Kept token-at-rest by design; canonicalising = a persisted-key-shape change needing a `SchemaVersion` bump → out of scope. Pinned by a characterization test; deferred to **#397**.
- **Silmarillion** `MinFavorTier` left untouched (POCO-fed; its `Despised→null` special-case must not be unified).

## Verification

- Full solution: **0 warnings / 0 errors**.
- `dotnet test Mithril.slnx`: **all green, 19 assemblies** (incl. Silmarillion 455/455, Arwen 83/83 — other slim-`NpcService` consumers unaffected).
- Audit grep: no `string`-typed favor *comparison* remains in Smaug logic; only display-carrier `string` (converted via `.DisplayName()`) + persisted calibration tokens (audit-only, #397).

## Commits

Carries the original handoff doc, the review-concern refinements to it, and the implementation in one PR (per the agreed single-PR path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
