### PR TITLE
fix(planning): gate CrossSkillPlanner on Recipe.OtherRequirements (AlwaysFail / RecipeUsed / RecipeKnown)

### DIFF
--- a/docs/planner-recipe-field-consumption.md
+++ b/docs/planner-recipe-field-consumption.md
@@ -1,0 +1,78 @@
+# Planner · Recipe field consumption
+
+> **A different axis from [silmarillion-field-coverage.md](silmarillion-field-coverage.md).**
+> That doc asks *which `Recipe` properties reach the user in the reference
+> browser*. This one asks *which `Recipe` properties `CrossSkillPlanner`
+> consumes when it generates a leveling plan* — i.e. which fields, if ignored,
+> make the planner schedule **impossible or mis-counted crafts**.
+
+## Why this is its own axis
+
+The two axes are independent and a field can sit differently on each. The
+canonical example: `MaxUses` is **surfaced** in Silmarillion (it has a chip) yet
+was a **planner bug** — the planner ground recipes past their per-character cap.
+The display-coverage doc would never have caught it because, by its axis, the
+field was fine. So planner-consumption needs recording on its own, once, or the
+next planner-relevant recipe field gets silently ignored the same way.
+
+A `Recipe` property is **planner-relevant** iff ignoring it changes the *set or
+count of crafts* a viable plan would schedule. Cosmetic / time-cyclical /
+currency fields are not — see "Correctly ignored".
+
+## Respected — the planner gates/counts on these
+
+| Field | How `CrossSkillPlanner` uses it |
+|---|---|
+| `Skill` + `SkillLevelReq` | `IsAvailable`: recipe ineligible until the gating skill ≥ req. |
+| `PrereqRecipe` | `IsAvailable`: ineligible until the prereq recipe is in `completed`. |
+| `RewardSkill` / `RewardSkillXp` / `RewardSkillXpFirstTime` / drop-off | XP math (`LevelingMath`) — phase sizing + first-time-bonus ordering. |
+| `Ingredients` | `RecipeExpander` / `SourcingPolicy` — intermediate-reuse credit + sub-DAG pruning. |
+| `MaxUses` | Per-character lifetime cap. `RemainingUses` against the run's `completions` (history + this run); filters `available` and clamps the grind. (#396) |
+| `OtherRequirements` → `AlwaysFail` | `IsAvailable` hard-exclude — `ImproveProphesied*` can never succeed; never schedule despite large advertised XP. |
+| `OtherRequirements` → `RecipeKnown` | `IsAvailable` gate — same shape as `PrereqRecipe`, against `completed`/`history.IsKnown`. |
+| `OtherRequirements` → `RecipeUsed` | Per-character craft cap (the WeatherWitching litany; self-referential `RecipeUsed{self, n}` ⇒ `n+1` crafts). Folded into `RemainingCraftBudget` alongside `MaxUses`. |
+
+## Deliberate punt — user-asserted, NOT auto-gated
+
+`OtherRequirements` kinds that are genuine **non-skill, non-recipe-state**
+unlocks: `PetCount`, `HasHands`, `HasEffectKeyword`, `EquipmentSlotEmpty`,
+`Appearance`, `EntityPhysicalState`, `EntitiesNear`, `InGraveyard`,
+`DruidEventState`, `IsLycanthrope`, `HasGuildHall` (~42 recipes, ≤19 each).
+
+These match the `AssertedUnlocks` philosophy (`PlanInputs.cs`: *"the planner does
+NOT pursue favor/quests/lorebooks itself — non-skill unlocks are user-asserted"*).
+The planner does **not** read them; a user who knows they'll satisfy the
+condition plans as normal. **Known limitation:** `AssertedUnlocks` is keyed by
+recipe `InternalName`, so it cannot actually *express* most of these
+(pet count, body form, equipped-slot, world event). This is accepted: these
+gates are rare, situational, and outside the planner's "skill grind path"
+remit. Do not file "increase coverage" issues against this list; if a future
+audit re-flags it, point here.
+
+## Correctly ignored — not planner-relevant
+
+| Field(s) | Why ignored |
+|---|---|
+| `OtherRequirements` → `TimeOfDay`, `Weather`, `MoonPhase`, `FullMoon` | Time/RNG-cyclical. The plan is a **time-stateless craft-count** projection by design (`SkillState` is stateless in time); these don't change the count. |
+| `OtherRequirements` → `IsHardcore` | Character-mode flag; trivially rare; not a grind-path gate. |
+| `ResetTimeInSeconds`, `SharesResetTimerWith` | Cooldown duration/grouping. Time-stateless design — pacing, not count. (Silmarillion *display* gap is the separate #342.) |
+| `Costs` | Currency/item cost to perform the recipe. Doesn't change XP or craft count; sourcing is modelled via `Ingredients`, not `Costs`. |
+| `RequiredAttributeNonZero` | 1 recipe in the bundled corpus; negligible; treat as the Bucket-B punt class if it ever matters. |
+| VFX / animation / `ItemMenu*` / `SortSkill` / `Particle` / engine flags | Never affects the plan. |
+
+## Acting on this doc
+
+- A **new `RecipeRequirement` subtype** (parser emits `UnknownRecipeRequirement`)
+  or a new planner-relevant `Recipe` field ⇒ decide its row here *before*
+  assuming the planner handles it. Default assumption for an unhandled gate is
+  "bug" until classified, given the `MaxUses` precedent.
+- The "deliberate punt" / "correctly ignored" rows are settled decisions — do
+  not re-open them as planner bugs.
+
+## History
+
+- **2026-05-16** — Created alongside the `OtherRequirements` planner fix
+  (`AlwaysFail` exclude · `RecipeKnown` gate · `RecipeUsed` cap). Recipe-field
+  prevalence and the kind taxonomy came from a full-corpus audit of bundled
+  `recipes.json` (v470, 4427 recipes). Builds on the `MaxUses` fix (#396);
+  `RecipeUsed` shares its `RemainingCraftBudget` path.

--- a/src/Mithril.Planning/CrossSkillPlanner.cs
+++ b/src/Mithril.Planning/CrossSkillPlanner.cs
@@ -135,10 +135,11 @@ public sealed class CrossSkillPlanner
                     return (recipe: r, baseXp, reuse, effXp: baseXp + reuse);
                 })
                 .Where(x => x.effXp > 0 || unusedBonuses.Contains(x.recipe.Key))
-                // Respect the recipe's per-character lifetime cap (Recipe.MaxUses):
-                // a recipe exhausted by prior history or earlier phases this run is
-                // no longer craftable, so it can't be a grind OR a bonus source.
-                .Where(x => RemainingUses(x.recipe, completions) > 0)
+                // Respect per-character craft caps — Recipe.MaxUses and the
+                // OtherRequirements RecipeUsed gate — against prior history +
+                // this run. A recipe with no budget left can't be a grind OR a
+                // bonus source. (AlwaysFail / RecipeKnown gates live in IsAvailable.)
+                .Where(x => RemainingCraftBudget(x.recipe, completions) > 0)
                 .ToList();
 
             if (available.Count == 0) break;
@@ -184,10 +185,10 @@ public sealed class CrossSkillPlanner
             var needed = xpForLevel - xp;
             var crafts = (int)Math.Ceiling((double)needed / best.effXp);
             if (crafts < 1) crafts = 1;
-            // Never schedule a recipe past its lifetime cap; if that's short of
-            // the level, the loop re-picks the next-best recipe next iteration
-            // (this recipe is now exhausted ⇒ filtered out of `available`).
-            var remaining = RemainingUses(best.recipe, completions);
+            // Never schedule a recipe past its craft budget (MaxUses + RecipeUsed);
+            // if that's short of the level, the loop re-picks the next-best recipe
+            // next iteration (this recipe is now exhausted ⇒ filtered out).
+            var remaining = RemainingCraftBudget(best.recipe, completions);
             if (crafts > remaining) crafts = remaining;
 
             xp += (long)crafts * best.effXp;
@@ -263,6 +264,25 @@ public sealed class CrossSkillPlanner
 
         if (recipe.SkillLevelReq > gatingLevel) return false;
         if (!string.IsNullOrEmpty(recipe.PrereqRecipe) && !completed.Contains(recipe.PrereqRecipe!)) return false;
+
+        // OtherRequirements gates the planner can resolve from data it already
+        // has. RecipeUsed (per-character craft cap) is dynamic ⇒ enforced in the
+        // RemainingCraftBudget path, not here. Non-skill gates (pet/form/buff/
+        // location/event) are a deliberate punt to AssertedUnlocks — see
+        // docs/planner-recipe-field-consumption.md.
+        if (recipe.OtherRequirements is { } reqs)
+        {
+            foreach (var req in reqs)
+            {
+                // Can never succeed (the ImproveProphesied* recipes) — must never
+                // be scheduled despite advertising large XP.
+                if (req is AlwaysFailRequirement) return false;
+                // "Recipe X must be known" — same shape as the PrereqRecipe gate.
+                if (req is RecipeKnownRequirement { Recipe: { } needed }
+                    && !completed.Contains(needed) && !history.IsKnown(needed))
+                    return false;
+            }
+        }
 
         return history.IsKnown(name) || asserted.IsAsserted(name) || recipe.SkillLevelReq > 0;
     }
@@ -354,6 +374,34 @@ public sealed class CrossSkillPlanner
         => recipe.MaxUses is int max
             ? Math.Max(0, max - (completions.TryGetValue(recipe.InternalName ?? "", out var c) ? c : 0))
             : int.MaxValue;
+
+    /// <summary>
+    /// Craft allowance from the <c>OtherRequirements</c> <see cref="RecipeUsedRequirement"/>
+    /// gates: each says "the referenced recipe must have been used ≤ MaxTimesUsed".
+    /// Self-referential ones (the WeatherWitching litany — recipe X requires
+    /// <c>RecipeUsed{X, n}</c>) are a per-character cap of <c>n + 1</c> crafts;
+    /// cross-referential ones are a static gate (0 once the other recipe is over
+    /// its cap, unbounded otherwise — this recipe doesn't increment it). Min over
+    /// all such gates; no gate ⇒ unbounded.
+    /// </summary>
+    private static int OtherReqUsesRemaining(Recipe recipe, IReadOnlyDictionary<string, int> completions)
+    {
+        if (recipe.OtherRequirements is not { } reqs) return int.MaxValue;
+        var budget = int.MaxValue;
+        foreach (var r in reqs)
+        {
+            if (r is not RecipeUsedRequirement { Recipe: { } target } used) continue;
+            var max = used.MaxTimesUsed ?? 0;
+            var done = completions.TryGetValue(target, out var c) ? c : 0;
+            budget = Math.Min(budget, Math.Max(0, max + 1 - done));
+        }
+        return budget;
+    }
+
+    /// <summary>The min of every per-character craft cap that applies (MaxUses +
+    /// RecipeUsed). Zero ⇒ the recipe is exhausted and must be skipped.</summary>
+    private static int RemainingCraftBudget(Recipe recipe, IReadOnlyDictionary<string, int> completions)
+        => Math.Min(RemainingUses(recipe, completions), OtherReqUsesRemaining(recipe, completions));
 
     /// <summary>
     /// Merge consecutive non-bonus steps for the same recipe into one phase, then

--- a/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
+++ b/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
@@ -234,6 +234,83 @@ public class CrossSkillPlannerTests
         plan.FinalState.LevelOf(Skill).Should().Be(4);
     }
 
+    // ── OtherRequirements gates ──────────────────────────────────────────
+
+    [Fact]
+    public void OtherRequirements_AlwaysFail_RecipeNeverScheduled()
+    {
+        // AlwaysFail recipe advertises the highest XP but can never succeed
+        // (the ImproveProphesied* family) — it must never be picked.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Idol").AddItem(2, "Plank")
+            .AddRecipe("ImproveProphesiedIdol", Skill, xp: 1000, produces: (1, 1), skillLevelReq: 1,
+                otherRequirements: [new AlwaysFailRequirement()])
+            .AddRecipe("CarvePlank", Skill, xp: 40, produces: (2, 1), skillLevelReq: 1);
+
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 4), State(1), RecipeHistory.Empty)!;
+
+        plan.Phases.Should().NotContain(p => p.RecipeInternalName == "ImproveProphesiedIdol",
+            because: "an AlwaysFail recipe can never succeed regardless of XP");
+        plan.Phases.Should().OnlyContain(p => p.RecipeInternalName == "CarvePlank");
+        plan.FinalState.LevelOf(Skill).Should().Be(4);
+    }
+
+    [Fact]
+    public void OtherRequirements_RecipeUsed_SelfReferentialCap_IsHonoured()
+    {
+        // WeatherWitching shape: the recipe requires itself used ≤0 times ⇒
+        // craftable exactly once per character, then the planner must switch.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Sun").AddItem(2, "Twig")
+            .AddRecipe("SongOfTheSun", Skill, xp: 100, produces: (1, 1), skillLevelReq: 1,
+                otherRequirements: [new RecipeUsedRequirement { Recipe = "SongOfTheSun", MaxTimesUsed = 0 }])
+            .AddRecipe("SnapTwig", Skill, xp: 40, produces: (2, 1), skillLevelReq: 1);
+
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 5), State(1), RecipeHistory.Empty)!;
+
+        plan.Phases.Where(p => p.RecipeInternalName == "SongOfTheSun").Sum(p => p.PredictedCrafts)
+            .Should().Be(1, because: "RecipeUsed{self, 0} ⇒ exactly one craft ever");
+        plan.Phases.Should().Contain(p => p.RecipeInternalName == "SnapTwig");
+        plan.FinalState.LevelOf(Skill).Should().Be(5);
+    }
+
+    [Fact]
+    public void OtherRequirements_RecipeUsed_PriorHistoryCountsAgainstTheCap()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Sun").AddItem(2, "Twig")
+            .AddRecipe("SongOfTheSun", Skill, xp: 100, produces: (1, 1), skillLevelReq: 1,
+                otherRequirements: [new RecipeUsedRequirement { Recipe = "SongOfTheSun", MaxTimesUsed = 0 }])
+            .AddRecipe("SnapTwig", Skill, xp: 40, produces: (2, 1), skillLevelReq: 1);
+
+        var history = new RecipeHistory(new Dictionary<string, int> { ["SongOfTheSun"] = 1 });
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 4), State(1), history)!;
+
+        plan.Phases.Should().NotContain(p => p.RecipeInternalName == "SongOfTheSun",
+            because: "cap 0+1=1 already spent by history");
+        plan.Phases.Should().OnlyContain(p => p.RecipeInternalName == "SnapTwig");
+    }
+
+    [Fact]
+    public void OtherRequirements_RecipeKnown_GatesUntilTheReferencedRecipeIsKnown()
+    {
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Augury").AddItem(2, "Note")
+            .AddRecipe("Augury2", Skill, xp: 100, produces: (1, 1), skillLevelReq: 1,
+                otherRequirements: [new RecipeKnownRequirement { Recipe = "Augury1" }])
+            .AddRecipe("Scribble", Skill, xp: 40, produces: (2, 1), skillLevelReq: 1);
+
+        // Augury1 unknown ⇒ Augury2 gated out; plan falls back to Scribble.
+        var gated = Planner(data).Plan(new SkillTarget(Skill, 4), State(1), RecipeHistory.Empty)!;
+        gated.Phases.Should().OnlyContain(p => p.RecipeInternalName == "Scribble");
+
+        // Augury1 known ⇒ Augury2 available and (higher XP) preferred.
+        var known = new RecipeHistory(new Dictionary<string, int> { ["Augury1"] = 1 });
+        var ok = Planner(data).Plan(new SkillTarget(Skill, 4), State(1), known)!;
+        ok.Phases.Should().Contain(p => p.RecipeInternalName == "Augury2",
+            because: "the RecipeKnown gate is satisfied once Augury1 is known");
+    }
+
     // ── Minimal IReferenceDataService fake ───────────────────────────────
 
     private sealed class FakeRef : IReferenceDataService
@@ -271,7 +348,7 @@ public class CrossSkillPlannerTests
             string internalName, string rewardSkill, int xp,
             (long id, int stack) produces,
             int firstTime = 0, int skillLevelReq = 0, (long id, int stack)? ingredients = null,
-            int? maxUses = null)
+            int? maxUses = null, IReadOnlyList<RecipeRequirement>? otherRequirements = null)
         {
             var r = new Recipe
             {
@@ -284,6 +361,7 @@ public class CrossSkillPlannerTests
                 RewardSkillXp = xp,
                 RewardSkillXpFirstTime = firstTime,
                 MaxUses = maxUses,
+                OtherRequirements = otherRequirements,
                 Ingredients = ingredients is { } ing
                     ? [new RecipeItemIngredient { ItemCode = ing.id, StackSize = ing.stack }]
                     : [],


### PR DESCRIPTION
**Stacked on #396** (base = `fix/planner-respect-maxuses`; GitHub auto-retargets
to `main` when #396 merges). `RecipeUsed` reuses #396's `RemainingCraftBudget`
path — splitting them would duplicate that helper and guarantee a conflict.

A read-only agent audit of the bundled corpus (v470, 4427 recipes) found
`CrossSkillPlanner` ignored **every** `Recipe.OtherRequirements` gate (90
recipes). Three kinds are genuine over-scheduling bugs (49 recipes) — the same
class as the `MaxUses` fix:

- **`AlwaysFail` (36 — all `ImproveProphesied*`)**: can *never* succeed yet
  advertise `FirstTime 1360` XP; the planner picked them as top grind
  candidates → impossible phases. Now hard-excluded in `IsAvailable`.
- **`RecipeUsed` (13 — all WeatherWitching, self-referential `{self, n}`)**: a
  per-character cap of `n+1` crafts, identical to `MaxUses`. Folded into
  `RemainingCraftBudget` (= min of MaxUses + RecipeUsed allowance, vs history +
  this run).
- **`RecipeKnown` (3 — Augury chain)**: "recipe X must be known" — same shape
  as the `PrereqRecipe` gate; checked vs `completed` / `history.IsKnown`.

Everything else (`PetCount`/`HasHands`/`HasEffectKeyword`/form/location/event
≈42; `TimeOfDay`/`Weather`/`MoonPhase`/`FullMoon`/`IsHardcore` ≈8; `Costs`;
reset-timers) is a **deliberate, documented punt** — non-skill unlocks
consistent with the `AssertedUnlocks` philosophy, plus time-cyclical gates
irrelevant to a time-stateless craft-count plan.

New **`docs/planner-recipe-field-consumption.md`** records this once, as an
axis distinct from `silmarillion-field-coverage.md` (display): that doc lists
`MaxUses` as *surfaced* and so would never have caught the planner bugs —
planner-consumption needed its own ledger.

Also serves as the post-merge re-verify for the simultaneous #395 + #396 merge: full `Mithril.slnx` suite (every project, incl. Shell.Tests) green on the rebased tree.

### Verification
- `dotnet build Mithril.slnx` green.
- Mithril.Planning.Tests **+4 → 20** (AlwaysFail never scheduled · RecipeUsed
  self-cap · RecipeUsed prior-history counts · RecipeKnown gate both ways);
  Celebrimbor 87 / Elrond 53 / Shared green.
- 12-module shell boot → `=== startup done ===`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
