### PR TITLE
feat(silmarillion): surface recipe OtherRequirements, Costs, reset-timer (closes #342)

### DIFF
--- a/docs/agent-plans/2026-05-16-silmarillion-404-visual-grammar.md
+++ b/docs/agent-plans/2026-05-16-silmarillion-404-visual-grammar.md
@@ -1,0 +1,175 @@
+# Silmarillion #404 — fact / control / link visual grammar: audit → standard → migrate
+
+**Tracked in:** #404
+
+> **For the owning agent.** This is a *program* plan, not a single-PR task. You
+> own it end to end across multiple PRs and several human/design decision gates.
+> Your job between gates is to produce the artifact that *unblocks* the gate, then
+> stop and present — not to push past a gate on your own judgement. The two
+> guardrails in "Anti-goals" are load-bearing: violating either reproduces the
+> exact debt this issue exists to pay down.
+
+## Context
+
+A design critique ([chip-critique](https://api.anthropic.com/v1/design/h/pLUeHE3xm41GCSG3irbBcQ?open_file=explorations%2Fchip-critique.html))
+found the shared `EntityChip` ([Mithril.Shared.Wpf](../../src/Mithril.Shared.Wpf))
+renders navigable references with the same bordered/surface-filled box as the
+header **stat badges** (`Skill N`, `MaxUses`, cooldown), and breaks prose in
+`{prefix} [chip]` rows. Root cause is the **absence of a visual grammar**
+separating three (probably four) semantically different things; the chip
+collision is one symptom. The debt accumulated because every detail surface made
+a locally-reasonable rendering choice with no system to conform to (six chip
+corrections in [#400](https://github.com/moumantai-gg/mithril/pull/400) alone).
+
+This plan is the **presentation axis only**. The *coverage* axis ("what data is
+shown / omitted / why") is a separate, already-tracked concern owned by
+[docs/silmarillion-field-coverage.md](../silmarillion-field-coverage.md) — Recipe
+VERIFIED, the other eight an audit baseline. Do not re-open it.
+
+## Ownership model & decision gates
+
+Agent owns: every audit, classification, inventory, migration PR, and the
+guardrail. Agent does **not** own: the per-tier *visual* design (pigment,
+glyph, spacing, hover) — that is the designer's call, informed by your artifacts.
+
+| Gate | Blocks on | Agent deliverable that unblocks it |
+|---|---|---|
+| **G1** tier set ratified | design + maintainer | Phase 0 strawman tier definitions |
+| **G2** grammar covers reality | design + maintainer | Phase 1+2 treatment×tier matrix |
+| **G3** target treatments chosen | **designer** | Phase 3 gap list + harness-ready specimens |
+| **G4** each migration PR | maintainer review | Phase 5 per-area PR, consistency-checked |
+
+At G1–G3 you produce the artifact and **present + stop**. Do not start the next
+phase until the gate clears (record the clearance in #404).
+
+## Phase 0 — Strawman the tiers (top-down, before any audit)
+
+Derive the tier set from *semantics*, not from current code. Starting strawman
+(refine, don't discard without cause):
+
+- **Fact** — passive data the user reads. Stat badges, counts, mono footers.
+- **Control** — user actuates it. Buttons, inputs, the query box.
+- **Link** — navigable reference to another entity. `EntityChip` today.
+- **Set-affordance** — "go see a set of N", not one entity. The recipe
+  keyword-slot "view all N →" popup; `ItemSourceChip`'s navigable↔plain degrade.
+  This tier is the most likely to be missing/contested — treat it as a first-
+  class hypothesis to validate in Phase 1, not an afterthought.
+
+Deliverable: a short tier-definition section appended to #404 (definition +
+1-line "you know it's this tier when…" test each). **Gate G1.**
+
+## Phase 1 — Pilot on Recipe (depth, not breadth)
+
+Recipe detail is already coverage-VERIFIED and is the freshest surface. Classify
+**every rendered element** in [RecipeDetailView.xaml](../../src/Silmarillion.Module/Views/RecipeDetailView.xaml)
++ [RecipeDetailViewModel.cs](../../src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs)
+(title, icon, stat badges, flavor, requirement rows incl. the new
+`RecipeRequirementRow` dual-shape, shared-cooldown row, cost lines, sources,
+ingredient/produced/keyword-slot chips, effects stub, footer) into:
+
+`element → intended tier → current treatment → delta`
+
+Output: a `treatment × tier` matrix for Recipe. The off-diagonal cells are the
+Recipe migration backlog; "fits no tier" cells are grammar gaps. Expect the
+set-affordance tier and the prose-vs-list link question to surface here.
+
+## Phase 2 — Sweep the other eight (breadth, validate not discover)
+
+Detail views: `Glob src/Silmarillion.Module/Views/*DetailView.xaml`
+(Quest, StorageVault, Npc, Area, Effect, Lorebook, PlayerTitle, Ability — Item
+has no detail pane by design, confirm against the coverage doc). For each, you
+are **not** re-discovering from scratch — you are checking "does the
+Recipe-derived tier set + treatment inventory hold here; what new edge cases
+appear." Extend the single shared matrix; do not write nine independent reports.
+
+Deliverable: one consolidated `treatment × tier` matrix across all views +
+an enumerated list of (a) distinct current treatments, (b) grammar-gap cells.
+**Gate G2** — present the matrix; confirm the tier set survives contact with all
+nine views before anything is standardized.
+
+## Phase 3 — Resolve grammar gaps, then ratify targets
+
+For every "fits no tier" cell: either extend the grammar (new tier / sub-rule)
+or argue it into an existing tier — explicitly, in writing. **No pixel target is
+chosen until every gap is closed**, or migration will improvise into the gaps
+(the original failure mode).
+
+Then, in the design-system preview harness (the bundle the critique came
+from *is* that harness — `mithril-design-system/.../preview/`), produce
+specimen artboards for each tier so the designer can choose the visual target.
+Carry the engineering constraints into the specimens, do not re-decide them:
+
+- Link tier: **V2** (small lead-icon + gold name, no box) is the agreed
+  engineering position. **V5 (prose/list dual-form) is rejected** — its
+  call-site render-context flag is the optional-context footgun this codebase
+  is repeatedly bitten by (compiles green, ships wrong on the next surface;
+  permanent reviewer ambiguity). Present V2; only re-open V5 if the designer
+  raises it, and if so attach this rejection rationale.
+- Fact tier: must read **inert** (borderless label:value or mono) so it cannot
+  be confused with link/control. This is half the grammar, not "orthogonal."
+- Avoid V1 (no icon → loses NPC/item/recipe type recognition) and V3 (dotted
+  underline = Windows tooltip-trigger mis-affordance).
+
+Deliverable: closed gap list + harness specimens. **Gate G3** — designer picks
+the per-tier visual target. Record the chosen targets in #404 and as a "visual
+grammar" section in the design system / a `docs/` reference.
+
+## Phase 4 — Encode the standard as a shared primitive
+
+Land the chosen treatments as **shared, named WPF styles/controls** in
+`Mithril.Shared.Wpf` (one per tier), not per-view copies. The link tier replaces
+`EntityChip`'s internals; the fact tier replaces the ad-hoc per-view stat-badge
+borders. Call sites express *which tier*, never raw pixels — that is what makes
+the grammar enforceable instead of advisory. No behavior change, no view
+migrated yet; this PR is the primitive + its tests + harness parity.
+
+## Phase 5 — Migrate, one area per PR, consistency-gated
+
+Recipe first (pilot → proves the primitive on the surface you know best), then
+one PR per remaining detail view. Each PR's **acceptance bar is cross-tab
+consistency**, verified explicitly against the matrix — *not* per-tab judgement.
+Per-tab judgement is precisely how the debt accumulated; the bar is the point.
+Keep `dotnet test tests/Silmarillion.Tests` green each PR; spot-verify the live
+view per the project's "tests green ≠ shipped" memory.
+
+## Phase 6 — Guardrail so it can't re-rot
+
+Add a cheap conformance check: a test (or analyzer) that fails when a detail
+view introduces a raw bordered/box style for an entity reference instead of the
+shared link primitive — i.e., the next surface *cannot* improvise. Update
+[docs/silmarillion-field-coverage.md](../silmarillion-field-coverage.md)'s
+visual-debt note to "resolved" with a pointer to the grammar reference.
+
+## Anti-goals (violating these reproduces the debt)
+
+1. **Do not re-audit "what is shown."** Presentation only. Coverage is settled
+   and separately tracked; re-flagging it re-opens decided questions.
+2. **Do not let the audit define the standard.** Semantics define the tiers
+   (top-down, Phase 0/G1); the audit *validates coverage of* the tiers and
+   *scopes the migration*. "Catalog current treatments → average them into a
+   standard" anchors the target to the mess and is explicitly forbidden.
+3. **Do not migrate before all grammar gaps are closed** (Phase 3). A migration
+   into an undefined cell is a new improvisation.
+4. **Do not make the visual call.** That is the designer's at G3. You supply
+   classification, constraints, and specimens — decision support, not the
+   decision.
+
+## Acceptance (program-level)
+
+Every entity reference and every stat fact across all nine detail views renders
+through a shared tier primitive; fact/control/link/set-affordance are mutually
+unmistakable; the conformance guardrail is in place; #404's visual-debt note is
+closed. The proof is not "it looks better" — it is "no surface can render an
+entity reference as a box again without the build telling it no."
+
+## Starting coordinates
+
+- Detail views: `src/Silmarillion.Module/Views/*DetailView.xaml` (+ matching
+  `*DetailViewModel.cs`).
+- Shared chip: `EntityChip` in `src/Mithril.Shared.Wpf` (consumed by every tab).
+- Stat badges: inline `Border`s in each `*DetailView.xaml` header (grep
+  `NullOrEmptyToVis` / `stat`-style chips; Recipe's are the
+  `SkillRequirementChip`/`MaxUsesChip`/`CooldownChip` `Border`s).
+- Coverage axis (read, do not modify in audit phases):
+  [docs/silmarillion-field-coverage.md](../silmarillion-field-coverage.md).
+- Critique + harness: the Mithril design-system bundle the critique link serves.

--- a/docs/planner-recipe-field-consumption.md
+++ b/docs/planner-recipe-field-consumption.md
@@ -42,7 +42,23 @@ unlocks: `PetCount`, `HasHands`, `HasEffectKeyword`, `EquipmentSlotEmpty`,
 These match the `AssertedUnlocks` philosophy (`PlanInputs.cs`: *"the planner does
 NOT pursue favor/quests/lorebooks itself — non-skill unlocks are user-asserted"*).
 The planner does **not** read them; a user who knows they'll satisfy the
-condition plans as normal. **Known limitation:** `AssertedUnlocks` is keyed by
+condition plans as normal.
+
+> **Load-bearing dependency — the punt is only sound if the gate is *visible*
+> somewhere.** The user-asserted contract assumes the user *knows* the condition
+> exists. That knowledge has to come from somewhere, and the planner isn't it. So
+> every row in this section (and in "Correctly ignored" below) is implicitly a
+> requirement on the **Silmarillion recipe detail**: if neither the planner nor
+> the browser shows `Weather`/`PetCount`/cooldown, the user is told nothing,
+> anywhere — the same silent-trap shape as the `MaxUses` bug, one layer up.
+> Resolved 2026-05-16: `OtherRequirements` (typed lines + recipe cross-link
+> chips), `Costs`, and the reset-timer now render in the recipe detail
+> (`RecipeRequirementProjector` + `RecipeDetailViewModel`; closes #342). Keep the
+> two in lockstep: a new planner-punted gate **must** get a
+> `RecipeRequirementProjector` arm, or it regresses this contract. The display
+> axis is tracked in [silmarillion-field-coverage.md](silmarillion-field-coverage.md).
+
+**Known limitation:** `AssertedUnlocks` is keyed by
 recipe `InternalName`, so it cannot actually *express* most of these
 (pet count, body form, equipped-slot, world event). This is accepted: these
 gates are rare, situational, and outside the planner's "skill grind path"
@@ -71,6 +87,12 @@ audit re-flags it, point here.
 
 ## History
 
+- **2026-05-16** — Recorded the **display dependency**: the "deliberate punt" /
+  "correctly ignored" rows are only defensible if Silmarillion surfaces the gate.
+  Resolved the blind spot — `OtherRequirements`/`Costs`/reset-timer now render in
+  the recipe detail (`RecipeRequirementProjector`, closes #342). The planner's
+  consumption is unchanged; this closes the *visibility* half so the user-asserted
+  contract is verifiable.
 - **2026-05-16** — Created alongside the `OtherRequirements` planner fix
   (`AlwaysFail` exclude · `RecipeKnown` gate · `RecipeUsed` cap). Recipe-field
   prevalence and the kind taxonomy came from a full-corpus audit of bundled

--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -50,7 +50,11 @@ The one entity audited against source directly
 `Skill`+`SkillLevelReq` (chip, skill resolved to display name), `MaxUses` (chip),
 `Ingredients` (item chips), keyword-slot ingredients (provenance popup, #318),
 `ResultItems`/`ProtoResultItems`→"Produces", `ResultEffects` (plain-text stub, #214),
-recipe sources ("Taught by", from `sources_recipes.json`).
+recipe sources ("Taught by", from `sources_recipes.json`), `OtherRequirements`
+(typed "Requirements" lines + `RecipeKnown`/cross-recipe-`RecipeUsed` cross-link
+chips, via `RecipeRequirementProjector`; #342), `Costs` ("Cost" lines; #342),
+`ResetTimeInSeconds` (cooldown chip beside `MaxUses`) + `SharesResetTimerWith`
+(resolved "Shares its cooldown with …" note; #342).
 
 **Deliberate omissions** (taxonomy classes 1–4): `Key`, `UsageAnimation`,
 `UsageAnimationEnd`, `UsageDelay`, `UsageDelayMessage`, `ActionLabel`, `Particle`,
@@ -65,27 +69,28 @@ against the bundled `recipes.json` (v470, 4427 entries) on 2026-05-16 — the ga
 | Property | Recipes carrying it | Why it matters | Precedent |
 |---|---|---|---|
 | **`PrereqRecipe`** | **2004 (~45%)** | Prerequisite-recipe chain — a primary crafting-progression axis | Navigable cross-link shape already exists (`EntityRef` → same Recipes tab); identical to how `Ingredients`/`Produces` chips work |
-| `OtherRequirements` | 90 (~2%) | Polymorphic recipe gating (who/what can run it) | Quest & StorageVault render their `Requirements` as typed rows |
-| `ResetTimeInSeconds` | 51 (~1.2%) | Cooldown duration | We render the *cap* half (`MaxUsesChip`, 91 recipes ≈ same prevalence); the *cooldown* half is conspicuously absent |
-| `SharesResetTimerWith` | 21 (~0.5%) | Shared-cooldown grouping | Pairs with the above |
-| `Costs` | 55 (~1.2%) | Currency/item cost to perform the recipe | No equivalent rendered anywhere; standalone |
 
-**This is two findings, not one:**
+`OtherRequirements` (90, ~2%), `ResetTimeInSeconds` (51, ~1.2%),
+`SharesResetTimerWith` (21, ~0.5%), and `Costs` (55, ~1.2%) **were** in this table
+and are **now surfaced** (see "Surfaced" above) — resolved 2026-05-16, #342.
 
-1. **`PrereqRecipe` — broad, structural, high-value.** ~45% of all recipes have a
-   prerequisite the browser shows nowhere. It is a *navigable cross-link* (recipe →
-   prerequisite recipe), which is precisely what Silmarillion's chip model is built for
-   — the same shape as the already-shipped ingredient/produces chips, just an unwired
-   edge. This is the priority and stands alone as an issue.
-2. **`OtherRequirements` + `Costs` + reset-timer pair — long-tail completeness.**
-   1–2% each. Worth a single "recipe-detail completeness" pass for parity with how we
-   treat Quest/StorageVault requirements and our own `MaxUsesChip`, but low-traffic and
-   clearly secondary to (1). The reset-timer omission is the sharpest of these because
-   the *consistency* break is measurable: comparable prevalence to `MaxUses`, which we
-   do surface.
+**Remaining gap — `PrereqRecipe`, broad, structural, high-value.** ~45% of all
+recipes have a prerequisite the browser shows nowhere. It is a *navigable
+cross-link* (recipe → prerequisite recipe), precisely what Silmarillion's chip
+model is built for — the same shape as the shipped ingredient/produces chips, just
+an unwired edge. This is the priority and stands alone.
 
-**Tracked in:** #341 (`PrereqRecipe` cross-link — priority) · #342 (completeness
-trio: `OtherRequirements` + `Costs` + reset-timer — lower-priority).
+> **Why the trio was resolved ahead of its "long-tail" priority.** It wasn't just
+> Quest/StorageVault parity. These exact fields are the ones `CrossSkillPlanner`
+> *deliberately punts on* (see
+> [planner-recipe-field-consumption.md](planner-recipe-field-consumption.md)). The
+> planner's punt is justified by a "user-asserted" contract — the user is assumed
+> to know the gate exists. If the browser also hides it, that knowledge has no
+> source: a silent trap, the `MaxUses`-bug shape one layer up. Surfacing them here
+> is the *load-bearing complement* to the planner punt, not cosmetic completeness.
+
+**Tracked in:** #341 (`PrereqRecipe` cross-link — priority, open) · #342
+(`OtherRequirements` + `Costs` + reset-timer — **resolved 2026-05-16**).
 
 ---
 
@@ -124,14 +129,24 @@ trio: `OtherRequirements` + `Costs` + reset-timer — lower-priority).
 
 - **`PrereqRecipe` cross-link** (#341) — the priority. ~45% of recipes affected; a
   navigable edge in Silmarillion's existing chip model.
-- **Recipe-detail completeness pass** (#342) — `OtherRequirements` + `Costs` +
-  reset-timer; long-tail (1–2% each) but a parity/consistency fix. Do after #341.
+- **Recipe-detail completeness pass** (#342) — **done 2026-05-16.**
+  `OtherRequirements` + `Costs` + reset-timer now render. This was the
+  load-bearing complement to the `CrossSkillPlanner` punt, not just
+  Quest/StorageVault parity — keep it in lockstep: a new planner-punted
+  `RecipeRequirement` arm must also get a `RecipeRequirementProjector` arm.
 - Quest narrative prose is a *judgement call*, not a clear gap — decide before filing.
 - Everything else unsurfaced is deliberate; do not file "increase coverage" issues
   against it. If a future audit re-flags class 1–4 properties, point it here.
 
 ## History
 
+- **2026-05-16** — #342 resolved: `OtherRequirements` (typed lines + recipe
+  cross-link chips, `RecipeRequirementProjector`), `Costs`, and reset-timer
+  surfaced in the recipe detail. Reframed from "long-tail completeness" to the
+  *load-bearing complement* to the `CrossSkillPlanner` deliberate punt — the
+  display axis and the planner-consumption axis are now coupled by an explicit
+  lockstep rule in both this doc and
+  [planner-recipe-field-consumption.md](planner-recipe-field-consumption.md).
 - **2026-05-16** — Recipe candidate gaps quantified against bundled `recipes.json`
   (v470). Reframed from one combined issue to two: `PrereqRecipe` (~45%, broad,
   cross-linkable — priority) vs. a long-tail completeness trio (1–2% each). Grounding

--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -52,7 +52,10 @@ The one entity audited against source directly
 `ResultItems`/`ProtoResultItems`→"Produces", `ResultEffects` (plain-text stub, #214),
 recipe sources ("Taught by", from `sources_recipes.json`), `OtherRequirements`
 (typed "Requirements" lines + `RecipeKnown`/cross-recipe-`RecipeUsed` cross-link
-chips, via `RecipeRequirementProjector`; #342), `Costs` ("Cost" lines; #342),
+chips, via `RecipeRequirementProjector`; `PetTypeTag` resolved through
+`strings_all["npc_<tag>_Name"]` per the id→display-name convention — pets are
+NPC/monster entities, "SummonedBakingBread" → "Rising Dough", not camel-split;
+#342), `Costs` ("Cost" lines; #342),
 `ResetTimeInSeconds` (cooldown chip beside `MaxUses`) + `SharesResetTimerWith`
 (resolved "Shares its cooldown with …" note; #342).
 

--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -51,8 +51,10 @@ The one entity audited against source directly
 `Ingredients` (item chips), keyword-slot ingredients (provenance popup, #318),
 `ResultItems`/`ProtoResultItems`→"Produces", `ResultEffects` (plain-text stub, #214),
 recipe sources ("Taught by", from `sources_recipes.json`), `OtherRequirements`
-(typed "Requirements" lines + `RecipeKnown`/cross-recipe-`RecipeUsed` cross-link
-chips, via `RecipeRequirementProjector`; `PetTypeTag` resolved through
+(one "Requirements" list of dual-shape rows — prose, or "{prefix} [inline chip]"
+for `RecipeKnown`/cross-recipe-`RecipeUsed` — in authored order, the Quest
+dual-shape idiom so cross-links read in the prose flow not as an orphaned pill
+cluster; via `RecipeRequirementProjector`; `PetTypeTag` resolved through
 `strings_all["npc_<tag>_Name"]` per the id→display-name convention — pets are
 NPC/monster entities, "SummonedBakingBread" → "Rising Dough", not camel-split;
 #342), `Costs` ("Cost" lines; #342),

--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -144,6 +144,17 @@ an unwired edge. This is the priority and stands alone.
 - Everything else unsurfaced is deliberate; do not file "increase coverage" issues
   against it. If a future audit re-flags class 1–4 properties, point it here.
 
+### Known visual debt (axis: presentation, not coverage)
+
+- **`EntityChip` collides with the stat badges** (#404). A design critique found
+  the shared bordered/icon chip is visually identical to the header stat badges
+  (`Skill N`, `MaxUses`, cooldown) and breaks prose in `{prefix} [chip]` rows.
+  This is a *coverage-complete, presentation-wrong* state: #342's fields are all
+  surfaced, the chip *styling* is the debt. Recommendation (V5 hybrid: inline
+  gold link in prose, ghost pill in lists) + an orthogonal stat-badge restyle is
+  a design-system change, deliberately **out of #342/#400 scope** — tracked in
+  #404. Don't re-flag the recipe-detail chips as a coverage gap; they're not.
+
 ## History
 
 - **2026-05-16** — #342 resolved: `OtherRequirements` (typed lines + recipe

--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -57,7 +57,8 @@ chips, via `RecipeRequirementProjector`; `PetTypeTag` resolved through
 NPC/monster entities, "SummonedBakingBread" → "Rising Dough", not camel-split;
 #342), `Costs` ("Cost" lines; #342),
 `ResetTimeInSeconds` (cooldown chip beside `MaxUses`) + `SharesResetTimerWith`
-(resolved "Shares its cooldown with …" note; #342).
+(navigable recipe→recipe cross-link chip — every corpus value 19/19 is a real
+recipe `InternalName` — labelled "Shares cooldown with", not prose; #342).
 
 **Deliberate omissions** (taxonomy classes 1–4): `Key`, `UsageAnimation`,
 `UsageAnimationEnd`, `UsageDelay`, `UsageDelayMessage`, `ActionLabel`, `Particle`,

--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -146,14 +146,18 @@ an unwired edge. This is the priority and stands alone.
 
 ### Known visual debt (axis: presentation, not coverage)
 
-- **`EntityChip` collides with the stat badges** (#404). A design critique found
-  the shared bordered/icon chip is visually identical to the header stat badges
+- **No fact / control / link visual grammar** (#404). A design critique found
+  the shared `EntityChip` is visually identical to the header stat badges
   (`Skill N`, `MaxUses`, cooldown) and breaks prose in `{prefix} [chip]` rows.
-  This is a *coverage-complete, presentation-wrong* state: #342's fields are all
-  surfaced, the chip *styling* is the debt. Recommendation (V5 hybrid: inline
-  gold link in prose, ghost pill in lists) + an orthogonal stat-badge restyle is
-  a design-system change, deliberately **out of #342/#400 scope** — tracked in
-  #404. Don't re-flag the recipe-detail chips as a coverage gap; they're not.
+  Root cause is the *absence of a grammar* distinguishing passive facts from
+  controls from navigable links — the chip collision is one symptom. This is a
+  *coverage-complete, presentation-wrong* state: #342's fields are all surfaced,
+  the visual grammar is the debt. Agreed direction: grammar-first; link tier →
+  **V2** (small lead-icon + gold name, no box — V5's prose/list dual form
+  rejected as a call-site footgun); badge tier restyled to read inert (same
+  pass, not orthogonal). Design-system change, deliberately **out of #342/#400
+  scope** — tracked in #404. Don't re-flag the recipe-detail chips as a coverage
+  gap; they're not.
 
 ## History
 

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -43,7 +43,7 @@ public sealed class RecipeDetailViewModel
         IReadOnlyList<RecipeKeywordSlotVm>? keywordSlots = null,
         IReadOnlyList<string>? otherRequirementLines = null,
         IReadOnlyList<EntityChipVm>? recipeRequirementChips = null,
-        string? sharesResetTimerDisplayName = null)
+        EntityChipVm? sharedCooldownChip = null)
     {
         Recipe = recipe;
         Ingredients = ingredients;
@@ -57,9 +57,7 @@ public sealed class RecipeDetailViewModel
         RecipeRequirementChips = recipeRequirementChips ?? [];
         CostLines = BuildCostLines(recipe.Costs);
         CooldownChip = BuildCooldownChip(recipe.ResetTimeInSeconds);
-        SharedCooldownNote = string.IsNullOrEmpty(recipe.SharesResetTimerWith)
-            ? ""
-            : $"Shares its cooldown with {sharesResetTimerDisplayName ?? recipe.SharesResetTimerWith}";
+        SharedCooldownChip = sharedCooldownChip;
     }
 
     /// <summary>
@@ -175,11 +173,18 @@ public sealed class RecipeDetailViewModel
     public string CooldownChip { get; }
 
     /// <summary>
-    /// "Shares its cooldown with {recipe}" when <see cref="Recipe.SharesResetTimerWith"/>
-    /// is set (the referenced recipe resolved to its display name by the hosting tab);
-    /// empty string otherwise.
+    /// Navigable cross-link for <see cref="Recipe.SharesResetTimerWith"/> — every value
+    /// in the corpus (19/19) is a real recipe <c>InternalName</c>, so this is a recipe→
+    /// recipe edge of the same shape as <see cref="RecipeRequirementChips"/>, not prose.
+    /// Built by the hosting tab (resolves the name + <c>navigator.CanOpen</c>); null when
+    /// the field is absent. Kept distinct from <see cref="RecipeRequirementChips"/>
+    /// because a shared-cooldown grouping is not a requirement gate — the view labels it
+    /// "<see cref="SharedCooldownLabel"/>" so the two don't read as the same thing.
     /// </summary>
-    public string SharedCooldownNote { get; }
+    public EntityChipVm? SharedCooldownChip { get; }
+
+    /// <summary>Prefix shown before <see cref="SharedCooldownChip"/>.</summary>
+    public string SharedCooldownLabel => "Shares cooldown with";
 
     private static IReadOnlyList<string> BuildCostLines(IReadOnlyList<RecipeCost>? costs)
     {

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -40,7 +40,10 @@ public sealed class RecipeDetailViewModel
         ICommand? openEntityCommand = null,
         string? skillDisplayName = null,
         IReadOnlyList<ItemSourceChipVm>? sources = null,
-        IReadOnlyList<RecipeKeywordSlotVm>? keywordSlots = null)
+        IReadOnlyList<RecipeKeywordSlotVm>? keywordSlots = null,
+        IReadOnlyList<string>? otherRequirementLines = null,
+        IReadOnlyList<EntityChipVm>? recipeRequirementChips = null,
+        string? sharesResetTimerDisplayName = null)
     {
         Recipe = recipe;
         Ingredients = ingredients;
@@ -50,6 +53,13 @@ public sealed class RecipeDetailViewModel
         SkillDisplayName = skillDisplayName ?? recipe.Skill;
         Sources = sources;
         KeywordSlots = keywordSlots ?? [];
+        OtherRequirementLines = otherRequirementLines ?? [];
+        RecipeRequirementChips = recipeRequirementChips ?? [];
+        CostLines = BuildCostLines(recipe.Costs);
+        CooldownChip = BuildCooldownChip(recipe.ResetTimeInSeconds);
+        SharedCooldownNote = string.IsNullOrEmpty(recipe.SharesResetTimerWith)
+            ? ""
+            : $"Shares its cooldown with {sharesResetTimerDisplayName ?? recipe.SharesResetTimerWith}";
     }
 
     /// <summary>
@@ -128,6 +138,85 @@ public sealed class RecipeDetailViewModel
     /// <c>Sources</c> shape used by <see cref="ItemDetailViewModel"/>.
     /// </summary>
     public IReadOnlyList<ItemSourceChipVm>? Sources { get; }
+
+    /// <summary>
+    /// Plain readable lines for the non-navigable <see cref="Recipe.OtherRequirements"/>
+    /// gates — the time/RNG-cyclical and user-asserted unlocks the planner deliberately
+    /// punts on (<c>docs/planner-recipe-field-consumption.md</c>). Empty when the recipe
+    /// has none; the view hides the section on a zero count. Built by
+    /// <see cref="RecipeRequirementProjector"/> in <see cref="RecipesTabViewModel"/>.
+    /// </summary>
+    public IReadOnlyList<string> OtherRequirementLines { get; }
+
+    /// <summary>
+    /// 1:1 navigable chips for the recipe-referencing requirement kinds
+    /// (<c>RecipeKnown</c> / cross-recipe <c>RecipeUsed</c>) — real cross-links into the
+    /// same Recipes tab, same shape as <see cref="Ingredients"/>/<see cref="ProducedItems"/>.
+    /// A self-referential <c>RecipeUsed</c> (per-character craft cap) is folded into
+    /// <see cref="OtherRequirementLines"/> instead, not a dead self-chip.
+    /// </summary>
+    public IReadOnlyList<EntityChipVm> RecipeRequirementChips { get; }
+
+    /// <summary>
+    /// Currency cost lines from <see cref="Recipe.Costs"/> (e.g. "1,500 Councils"). The
+    /// planner ignores <c>Costs</c> by design (it doesn't change XP or craft count) — so
+    /// the browser is the only surface that can tell the player a recipe costs money.
+    /// Empty when absent.
+    /// </summary>
+    public IReadOnlyList<string> CostLines { get; }
+
+    /// <summary>
+    /// Reuse-cooldown chip (e.g. "Reuse every 1h 30m") from
+    /// <see cref="Recipe.ResetTimeInSeconds"/>. Sits beside <see cref="MaxUsesChip"/>:
+    /// the planner is time-stateless so it surfaces the cap half but not this — closing
+    /// the consistency break called out in <c>docs/silmarillion-field-coverage.md</c>.
+    /// Empty string when absent (view hides on empty, string-only NullOrEmptyToVis).
+    /// </summary>
+    public string CooldownChip { get; }
+
+    /// <summary>
+    /// "Shares its cooldown with {recipe}" when <see cref="Recipe.SharesResetTimerWith"/>
+    /// is set (the referenced recipe resolved to its display name by the hosting tab);
+    /// empty string otherwise.
+    /// </summary>
+    public string SharedCooldownNote { get; }
+
+    private static IReadOnlyList<string> BuildCostLines(IReadOnlyList<RecipeCost>? costs)
+    {
+        if (costs is null || costs.Count == 0) return [];
+        var lines = new List<string>(costs.Count);
+        foreach (var c in costs)
+        {
+            if (c.Price <= 0) continue;
+            lines.Add($"{c.Price:N0} {FriendlyCurrency(c.Currency)}");
+        }
+        return lines;
+    }
+
+    // Recipe Costs currencies in the bundled corpus are exotic crafting currencies
+    // (FaeEnergy, CombatWisdom, GlamourCredits, GuildCredits) — never Councils/Cera.
+    // Camel-split the token so it reads "Fae Energy" not the raw id, per the
+    // skill-key→display-name convention. Single-token names ("Cera") pass through.
+    private static string FriendlyCurrency(string? currency) =>
+        string.IsNullOrEmpty(currency)
+            ? "currency"
+            : System.Text.RegularExpressions.Regex.Replace(currency, "(?<=[a-z])([A-Z])", " $1");
+
+    /// <summary>Seconds → compact "1d 2h", "1h 30m", "45m", "30s" (largest two units).</summary>
+    private static string BuildCooldownChip(int? resetSeconds)
+    {
+        if (resetSeconds is not { } secs || secs <= 0) return "";
+        var d = secs / 86400;
+        var h = secs % 86400 / 3600;
+        var m = secs % 3600 / 60;
+        var s = secs % 60;
+        var parts = new List<string>(2);
+        if (d > 0) parts.Add($"{d}d");
+        if (h > 0) parts.Add($"{h}h");
+        if (m > 0 && parts.Count < 2) parts.Add($"{m}m");
+        if (s > 0 && parts.Count < 2) parts.Add($"{s}s");
+        return $"Reuse every {string.Join(" ", parts)}";
+    }
 }
 
 /// <summary>

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -41,8 +41,7 @@ public sealed class RecipeDetailViewModel
         string? skillDisplayName = null,
         IReadOnlyList<ItemSourceChipVm>? sources = null,
         IReadOnlyList<RecipeKeywordSlotVm>? keywordSlots = null,
-        IReadOnlyList<string>? otherRequirementLines = null,
-        IReadOnlyList<EntityChipVm>? recipeRequirementChips = null,
+        IReadOnlyList<RecipeRequirementRow>? requirements = null,
         EntityChipVm? sharedCooldownChip = null)
     {
         Recipe = recipe;
@@ -53,11 +52,18 @@ public sealed class RecipeDetailViewModel
         SkillDisplayName = skillDisplayName ?? recipe.Skill;
         Sources = sources;
         KeywordSlots = keywordSlots ?? [];
-        OtherRequirementLines = otherRequirementLines ?? [];
-        RecipeRequirementChips = recipeRequirementChips ?? [];
+        Requirements = requirements ?? [];
         CostLines = BuildCostLines(recipe.Costs);
         CooldownChip = BuildCooldownChip(recipe.ResetTimeInSeconds);
-        SharedCooldownChip = sharedCooldownChip;
+        // Shared-cooldown is a recipe→recipe edge too, but not a requirement gate — render
+        // it through the same row template (prefix + inline chip) so it reads consistently
+        // with the requirement chip rows instead of as a separate visual register.
+        SharedCooldownRow = sharedCooldownChip is null
+            ? null
+            : new RecipeRequirementRow(
+                $"Shares cooldown with {sharedCooldownChip.DisplayName}",
+                "Shares cooldown with",
+                sharedCooldownChip);
     }
 
     /// <summary>
@@ -138,22 +144,15 @@ public sealed class RecipeDetailViewModel
     public IReadOnlyList<ItemSourceChipVm>? Sources { get; }
 
     /// <summary>
-    /// Plain readable lines for the non-navigable <see cref="Recipe.OtherRequirements"/>
-    /// gates — the time/RNG-cyclical and user-asserted unlocks the planner deliberately
-    /// punts on (<c>docs/planner-recipe-field-consumption.md</c>). Empty when the recipe
-    /// has none; the view hides the section on a zero count. Built by
-    /// <see cref="RecipeRequirementProjector"/> in <see cref="RecipesTabViewModel"/>.
+    /// Ordered <see cref="Recipe.OtherRequirements"/> rows — each either prose or a
+    /// sentence with an inline navigable chip (the Quest dual-shape idiom), in authored
+    /// order so cross-links read in the same flow as the prose gates rather than as an
+    /// orphaned pill cluster. Covers the time/RNG-cyclical and user-asserted unlocks the
+    /// planner deliberately punts on (<c>docs/planner-recipe-field-consumption.md</c>).
+    /// Empty when the recipe has none; the view hides the section on a zero count. Built
+    /// by <see cref="RecipeRequirementProjector"/> in <see cref="RecipesTabViewModel"/>.
     /// </summary>
-    public IReadOnlyList<string> OtherRequirementLines { get; }
-
-    /// <summary>
-    /// 1:1 navigable chips for the recipe-referencing requirement kinds
-    /// (<c>RecipeKnown</c> / cross-recipe <c>RecipeUsed</c>) — real cross-links into the
-    /// same Recipes tab, same shape as <see cref="Ingredients"/>/<see cref="ProducedItems"/>.
-    /// A self-referential <c>RecipeUsed</c> (per-character craft cap) is folded into
-    /// <see cref="OtherRequirementLines"/> instead, not a dead self-chip.
-    /// </summary>
-    public IReadOnlyList<EntityChipVm> RecipeRequirementChips { get; }
+    public IReadOnlyList<RecipeRequirementRow> Requirements { get; }
 
     /// <summary>
     /// Currency cost lines from <see cref="Recipe.Costs"/> (e.g. "1,500 Councils"). The
@@ -173,18 +172,14 @@ public sealed class RecipeDetailViewModel
     public string CooldownChip { get; }
 
     /// <summary>
-    /// Navigable cross-link for <see cref="Recipe.SharesResetTimerWith"/> — every value
-    /// in the corpus (19/19) is a real recipe <c>InternalName</c>, so this is a recipe→
-    /// recipe edge of the same shape as <see cref="RecipeRequirementChips"/>, not prose.
-    /// Built by the hosting tab (resolves the name + <c>navigator.CanOpen</c>); null when
-    /// the field is absent. Kept distinct from <see cref="RecipeRequirementChips"/>
-    /// because a shared-cooldown grouping is not a requirement gate — the view labels it
-    /// "<see cref="SharedCooldownLabel"/>" so the two don't read as the same thing.
+    /// Navigable cross-link row for <see cref="Recipe.SharesResetTimerWith"/> — every
+    /// value in the corpus (19/19) is a real recipe <c>InternalName</c>, so this is a
+    /// recipe→recipe edge, not prose. Same <see cref="RecipeRequirementRow"/> shape as
+    /// <see cref="Requirements"/> so it renders through the identical prefix+inline-chip
+    /// template, but exposed separately and labelled "Shares cooldown with" because a
+    /// shared-cooldown grouping is not a requirement gate. Null when the field is absent.
     /// </summary>
-    public EntityChipVm? SharedCooldownChip { get; }
-
-    /// <summary>Prefix shown before <see cref="SharedCooldownChip"/>.</summary>
-    public string SharedCooldownLabel => "Shares cooldown with";
+    public RecipeRequirementRow? SharedCooldownRow { get; }
 
     private static IReadOnlyList<string> BuildCostLines(IReadOnlyList<RecipeCost>? costs)
     {

--- a/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
@@ -39,7 +39,8 @@ public static class RecipeRequirementProjector
         IReadOnlyList<RecipeRequirement>? requirements,
         string? ownerInternalName,
         IReferenceNavigator navigator,
-        IEntityNameResolver resolver)
+        IEntityNameResolver resolver,
+        IReadOnlyDictionary<string, string> strings)
     {
         if (requirements is null || requirements.Count == 0)
             return (Array.Empty<string>(), Array.Empty<EntityChipVm>());
@@ -136,7 +137,7 @@ public static class RecipeRequirementProjector
                     break;
 
                 case PetCountRecipeRequirement p:
-                    lines.Add(DescribePetCount(p));
+                    lines.Add(DescribePetCount(p, strings));
                     break;
 
                 case HasEffectKeywordRecipeRequirement h when !string.IsNullOrEmpty(h.Keyword):
@@ -195,12 +196,26 @@ public static class RecipeRequirementProjector
     /// Phrase a pet-count gate. <c>MinCount</c>/<c>MaxCount</c> are bounds, not a required
     /// quantity — the corpus only carries upper bounds (<c>SummonedBakingBread</c> ≤4,
     /// <c>StorageCrateDruid</c> ≤0), so "Requires N …" would be doubly wrong (it's a cap,
-    /// and N=0 means *none allowed*). The word "pet" is appended only when the humanised
-    /// tag doesn't already end in it, killing the "… Cow Pet pets" redundancy.
+    /// and N=0 means *none allowed*). The word "pet" is appended only when the resolved
+    /// kind doesn't already end in it, killing the "… Cow Pet pets" redundancy.
+    /// <para>
+    /// A <c>PetTypeTag</c> is an NPC/monster entity in PG's data model, so its real
+    /// in-game name lives in <c>strings_all</c> under <c>npc_&lt;tag&gt;_Name</c>
+    /// ("SummonedBakingBread" → "Rising Dough"). Resolve through there per the
+    /// id→display-name convention; <see cref="Humanise"/> is only the fallback when the
+    /// tag has no string entry (these aren't in <c>npcs.json</c>, so the
+    /// <see cref="IEntityNameResolver"/>'s NPC path can't help).
+    /// </para>
     /// </summary>
-    private static string DescribePetCount(PetCountRecipeRequirement p)
+    private static string DescribePetCount(PetCountRecipeRequirement p, IReadOnlyDictionary<string, string> strings)
     {
-        var kind = string.IsNullOrEmpty(p.PetTypeTag) ? "pet" : Humanise(p.PetTypeTag!);
+        string kind;
+        if (string.IsNullOrEmpty(p.PetTypeTag))
+            kind = "pet";
+        else if (strings.TryGetValue($"npc_{p.PetTypeTag}_Name", out var resolved) && !string.IsNullOrEmpty(resolved))
+            kind = resolved;
+        else
+            kind = Humanise(p.PetTypeTag!);
         var kindIsPetNoun =
             kind.EndsWith("pet", StringComparison.OrdinalIgnoreCase)
             || kind.EndsWith("pets", StringComparison.OrdinalIgnoreCase);

--- a/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
@@ -136,17 +136,8 @@ public static class RecipeRequirementProjector
                     break;
 
                 case PetCountRecipeRequirement p:
-                {
-                    var kind = string.IsNullOrEmpty(p.PetTypeTag) ? "" : $" {Humanise(p.PetTypeTag!)}";
-                    if (p.MinCount is { } mn && p.MaxCount is { } mx && mn != mx)
-                        lines.Add($"Requires {mn}–{mx}{kind} pets.");
-                    else
-                    {
-                        var n = p.MinCount ?? p.MaxCount ?? 1;
-                        lines.Add($"Requires {n}{kind} pet{(n == 1 ? "" : "s")}.");
-                    }
+                    lines.Add(DescribePetCount(p));
                     break;
-                }
 
                 case HasEffectKeywordRecipeRequirement h when !string.IsNullOrEmpty(h.Keyword):
                     lines.Add(h.MinCount is > 1
@@ -198,6 +189,38 @@ public static class RecipeRequirementProjector
         }
 
         return (lines, chips);
+    }
+
+    /// <summary>
+    /// Phrase a pet-count gate. <c>MinCount</c>/<c>MaxCount</c> are bounds, not a required
+    /// quantity — the corpus only carries upper bounds (<c>SummonedBakingBread</c> ≤4,
+    /// <c>StorageCrateDruid</c> ≤0), so "Requires N …" would be doubly wrong (it's a cap,
+    /// and N=0 means *none allowed*). The word "pet" is appended only when the humanised
+    /// tag doesn't already end in it, killing the "… Cow Pet pets" redundancy.
+    /// </summary>
+    private static string DescribePetCount(PetCountRecipeRequirement p)
+    {
+        var kind = string.IsNullOrEmpty(p.PetTypeTag) ? "pet" : Humanise(p.PetTypeTag!);
+        var kindIsPetNoun =
+            kind.EndsWith("pet", StringComparison.OrdinalIgnoreCase)
+            || kind.EndsWith("pets", StringComparison.OrdinalIgnoreCase);
+        string Noun(int n) => kindIsPetNoun ? kind : $"{kind} pet{(n == 1 ? "" : "s")}";
+
+        var min = p.MinCount;
+        var max = p.MaxCount;
+
+        // Max 0 with no floor ⇒ the pet is disallowed entirely.
+        if (max is 0 && min is null or 0)
+            return $"Must not own any {kind}.";
+
+        return (min, max) switch
+        {
+            ({ } a, { } b) when a == b => $"Requires exactly {a} {Noun(a)}.",
+            ({ } a, { } b) => $"Requires {a}–{b} {Noun(b)}.",
+            ({ } a, null) => $"Requires at least {a} {Noun(a)}.",
+            (null, { } b) => $"Requires at most {b} {Noun(b)}.",
+            _ => kindIsPetNoun ? $"Requires a {kind}." : $"Requires a {kind} pet.",
+        };
     }
 
     /// <summary>

--- a/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
@@ -29,13 +29,16 @@ namespace Silmarillion.ViewModels;
 public static class RecipeRequirementProjector
 {
     /// <summary>
-    /// Project <paramref name="requirements"/> into (plain readable lines, navigable
-    /// recipe-cross-link chips). <paramref name="ownerInternalName"/> is the recipe these
-    /// requirements belong to — used to recognise a self-referential <c>RecipeUsed</c>
-    /// (the per-character craft cap, the WeatherWitching litany) and render it as a
-    /// count line rather than a dead self-chip.
+    /// Project <paramref name="requirements"/> into an ordered list of display rows.
+    /// Each row is <em>either</em> prose <em>or</em> a sentence with an inline navigable
+    /// chip (<see cref="RecipeRequirementRow.Prefix"/> + <see cref="RecipeRequirementRow.Chip"/>) —
+    /// the Quest dual-shape idiom. Authored order is preserved so chip rows read in the
+    /// same flow as prose ones rather than as an orphaned trailing pill cluster.
+    /// <paramref name="ownerInternalName"/> identifies the owning recipe so a
+    /// self-referential <c>RecipeUsed</c> (per-character craft cap, the WeatherWitching
+    /// litany) renders as a count line rather than a dead self-chip.
     /// </summary>
-    public static (IReadOnlyList<string> Lines, IReadOnlyList<EntityChipVm> RecipeChips) Build(
+    public static IReadOnlyList<RecipeRequirementRow> Build(
         IReadOnlyList<RecipeRequirement>? requirements,
         string? ownerInternalName,
         IReferenceNavigator navigator,
@@ -43,19 +46,20 @@ public static class RecipeRequirementProjector
         IReadOnlyDictionary<string, string> strings)
     {
         if (requirements is null || requirements.Count == 0)
-            return (Array.Empty<string>(), Array.Empty<EntityChipVm>());
+            return Array.Empty<RecipeRequirementRow>();
 
-        var lines = new List<string>();
-        var chips = new List<EntityChipVm>();
+        var rows = new List<RecipeRequirementRow>();
 
-        EntityChipVm RecipeChip(string internalName)
+        RecipeRequirementRow ChipRow(string prefix, string internalName)
         {
             var reference = EntityRef.Recipe(internalName);
-            return new EntityChipVm(
+            var chip = new EntityChipVm(
                 DisplayName: resolver.Resolve(reference),
                 IconId: 0,
                 Reference: reference,
                 IsNavigable: navigator.CanOpen(reference));
+            // Text is the accessible / fallback rendering; the view prefers Prefix+Chip.
+            return new RecipeRequirementRow($"{prefix} {chip.DisplayName}", prefix, chip);
         }
 
         foreach (var req in requirements)
@@ -65,11 +69,11 @@ public static class RecipeRequirementProjector
                 case AlwaysFailRequirement:
                     // The planner's hard-exclude case (ImproveProphesied* etc.) — the recipe
                     // can never succeed despite any advertised XP. Say so plainly.
-                    lines.Add("This recipe can never be completed (unavailable placeholder).");
+                    rows.Add(new("This recipe can never be completed (unavailable placeholder)."));
                     break;
 
                 case RecipeKnownRequirement r when !string.IsNullOrEmpty(r.Recipe):
-                    chips.Add(RecipeChip(r.Recipe!));
+                    rows.Add(ChipRow("Requires recipe:", r.Recipe!));
                     break;
 
                 case RecipeUsedRequirement u when !string.IsNullOrEmpty(u.Recipe):
@@ -78,97 +82,97 @@ public static class RecipeRequirementProjector
                         // Self-referential RecipeUsed{self, n} ⇒ a per-character lifetime
                         // cap of n+1 crafts (the planner folds this into RemainingCraftBudget
                         // alongside MaxUses). A self-chip would be a dead loop, so render the
-                        // cap as a line instead.
-                        lines.Add(u.MaxTimesUsed is { } n
+                        // cap as prose instead.
+                        rows.Add(new(u.MaxTimesUsed is { } n
                             ? $"Limited to {n + 1} craft{(n + 1 == 1 ? "" : "s")} per character."
-                            : "Limited per-character craft count.");
+                            : "Limited per-character craft count."));
                     }
                     else
                     {
-                        chips.Add(RecipeChip(u.Recipe!));
+                        rows.Add(ChipRow("Requires having crafted:", u.Recipe!));
                     }
                     break;
 
                 case WeatherRequirement w:
-                    lines.Add(w.ClearSky switch
+                    rows.Add(new(w.ClearSky switch
                     {
                         true => "Only when the sky is clear.",
                         false => "Only when the weather is overcast.",
                         null => "Weather-dependent.",
-                    });
+                    }));
                     break;
 
                 case MoonPhaseRecipeRequirement m when !string.IsNullOrEmpty(m.MoonPhase):
-                    lines.Add($"Only during the {Humanise(m.MoonPhase!).ToLowerInvariant()} moon.");
+                    rows.Add(new($"Only during the {Humanise(m.MoonPhase!).ToLowerInvariant()} moon."));
                     break;
 
                 case FullMoonRecipeRequirement:
-                    lines.Add("Only during the full moon.");
+                    rows.Add(new("Only during the full moon."));
                     break;
 
                 case TimeOfDayRecipeRequirement t:
-                    lines.Add((t.MinHour, t.MaxHour) switch
+                    rows.Add(new((t.MinHour, t.MaxHour) switch
                     {
                         ({ } lo, { } hi) => $"Only between {lo:00}:00 and {hi:00}:00 in-game time.",
                         ({ } lo, null) => $"Only after {lo:00}:00 in-game time.",
                         (null, { } hi) => $"Only before {hi:00}:00 in-game time.",
                         _ => "Time-of-day dependent.",
-                    });
+                    }));
                     break;
 
                 case IsHardcoreRequirement:
-                    lines.Add("Hardcore characters only.");
+                    rows.Add(new("Hardcore characters only."));
                     break;
 
                 case IsLycanthropeRequirement:
-                    lines.Add("Werewolf characters only.");
+                    rows.Add(new("Werewolf characters only."));
                     break;
 
                 case HasHandsRequirement:
-                    lines.Add("Requires hands (not available in animal form).");
+                    rows.Add(new("Requires hands (not available in animal form)."));
                     break;
 
                 case HasGuildHallRequirement:
-                    lines.Add("Requires a guild hall.");
+                    rows.Add(new("Requires a guild hall."));
                     break;
 
                 case InGraveyardRequirement:
-                    lines.Add("Must be in a graveyard.");
+                    rows.Add(new("Must be in a graveyard."));
                     break;
 
                 case PetCountRecipeRequirement p:
-                    lines.Add(DescribePetCount(p, strings));
+                    rows.Add(new(DescribePetCount(p, strings)));
                     break;
 
                 case HasEffectKeywordRecipeRequirement h when !string.IsNullOrEmpty(h.Keyword):
-                    lines.Add(h.MinCount is > 1
+                    rows.Add(new(h.MinCount is > 1
                         ? $"Requires the effect “{Humanise(h.Keyword!)}” ×{h.MinCount}."
-                        : $"Requires the effect “{Humanise(h.Keyword!)}”.");
+                        : $"Requires the effect “{Humanise(h.Keyword!)}”."));
                     break;
 
                 case EquipmentSlotEmptyRecipeRequirement e when !string.IsNullOrEmpty(e.Slot):
-                    lines.Add($"The {Humanise(e.Slot!).ToLowerInvariant()} equipment slot must be empty.");
+                    rows.Add(new($"The {Humanise(e.Slot!).ToLowerInvariant()} equipment slot must be empty."));
                     break;
 
                 case AppearanceRecipeRequirement a when !string.IsNullOrEmpty(a.Appearance):
-                    lines.Add($"Requires appearance: {Humanise(a.Appearance!)}.");
+                    rows.Add(new($"Requires appearance: {Humanise(a.Appearance!)}."));
                     break;
 
                 case EntityPhysicalStateRecipeRequirement s when s.AllowedStates is { Count: > 0 }:
-                    lines.Add($"Requires physical state: {string.Join(", ", s.AllowedStates!)}.");
+                    rows.Add(new($"Requires physical state: {string.Join(", ", s.AllowedStates!)}."));
                     break;
 
                 case DruidEventStateRequirement d when d.DisallowedStates is { Count: > 0 }:
-                    lines.Add($"Not available during druid event: {string.Join(", ", d.DisallowedStates!)}.");
+                    rows.Add(new($"Not available during druid event: {string.Join(", ", d.DisallowedStates!)}."));
                     break;
 
                 case EntitiesNearRequirement n:
                     if (!string.IsNullOrEmpty(n.ErrorMsg))
-                        lines.Add(n.ErrorMsg!);
+                        rows.Add(new(n.ErrorMsg!));
                     else
                     {
                         var what = string.IsNullOrEmpty(n.EntityTypeTag) ? "entities" : Humanise(n.EntityTypeTag!);
-                        lines.Add($"Requires {n.MinCount ?? 1} {what} nearby.");
+                        rows.Add(new($"Requires {n.MinCount ?? 1} {what} nearby."));
                     }
                     break;
 
@@ -176,20 +180,20 @@ public static class RecipeRequirementProjector
                     // Graceful degrade for a future PG-added discriminator — surface it so
                     // it's diagnosable, behind a clearly-noise-filtered label (never blank,
                     // never a crash). Same contract as StorageVault's unknown handling.
-                    lines.Add(string.IsNullOrEmpty(u.DiscriminatorValue)
+                    rows.Add(new(string.IsNullOrEmpty(u.DiscriminatorValue)
                         ? "(unrecognised requirement)"
-                        : $"(unrecognised requirement: {u.DiscriminatorValue})");
+                        : $"(unrecognised requirement: {u.DiscriminatorValue})"));
                     break;
 
                 default:
                     // A known subclass with an empty payload (defensive — RecipeKnown /
                     // RecipeUsed with no Recipe, MoonPhase with no phase). Skip silently
-                    // rather than emit a blank line.
+                    // rather than emit a blank row.
                     break;
             }
         }
 
-        return (lines, chips);
+        return rows;
     }
 
     /// <summary>
@@ -268,3 +272,19 @@ public static class RecipeRequirementProjector
         return sb.ToString().Trim();
     }
 }
+
+/// <summary>
+/// One projected recipe-requirement row. Two render shapes, chosen at projection time
+/// (the Quest dual-shape idiom — see <c>QuestRequirementDisplay</c>):
+/// <list type="bullet">
+///   <item><description><b>Prose row:</b> <see cref="Text"/> set, <see cref="Chip"/> null.
+///   A plain sentence ("Only during the full moon.").</description></item>
+///   <item><description><b>Chip row:</b> <see cref="Prefix"/> + <see cref="Chip"/> set.
+///   Renders as "{Prefix} [chip]" with the recipe as an inline navigable
+///   <see cref="EntityChipVm"/> — so a cross-link reads in the same flow as the prose
+///   rows instead of as an orphaned pill.</description></item>
+/// </list>
+/// <see cref="Text"/> is always populated as the accessible / fallback rendering; the
+/// view prefers <see cref="Prefix"/>/<see cref="Chip"/> when <see cref="Chip"/> is set.
+/// </summary>
+public sealed record RecipeRequirementRow(string Text, string? Prefix = null, EntityChipVm? Chip = null);

--- a/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeRequirementProjector.cs
@@ -1,0 +1,232 @@
+using System.Text;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Projects a recipe's polymorphic <see cref="Recipe.OtherRequirements"/> to the
+/// player-facing rows used by <see cref="RecipeDetailViewModel"/>.
+/// <para>
+/// This is the <em>display</em> half of the parity the planner deliberately punts on:
+/// <c>docs/planner-recipe-field-consumption.md</c> records that <c>CrossSkillPlanner</c>
+/// does not auto-gate on the user-asserted unlocks (<c>PetCount</c>, <c>HasHands</c>, …)
+/// nor on the time/RNG-cyclical gates (<c>Weather</c>, <c>MoonPhase</c>, …). That punt is
+/// only sound if the player can <em>see</em> the gate somewhere — so the gates the planner
+/// won't pursue are exactly the ones this projector must surface.
+/// </para>
+/// <para>
+/// Shape mirrors <c>StorageVaultDetailViewModel.BuildRequirements</c> — a flat
+/// <see cref="string"/> line list for the (mostly non-navigable) gates plus a separate
+/// 1:1 <see cref="EntityChipVm"/> list for the recipe-referencing kinds
+/// (<c>RecipeKnown</c> / cross-recipe <c>RecipeUsed</c>) which are real cross-links into
+/// the same Recipes tab. The heavier intent-bucketing <c>QuestDetailProjector</c> uses is
+/// deliberately not copied: the recipe requirement set is tiny (≤19 per recipe across
+/// ~42 recipes) and homogeneous enough that a flat list reads fine.
+/// </para>
+/// </summary>
+public static class RecipeRequirementProjector
+{
+    /// <summary>
+    /// Project <paramref name="requirements"/> into (plain readable lines, navigable
+    /// recipe-cross-link chips). <paramref name="ownerInternalName"/> is the recipe these
+    /// requirements belong to — used to recognise a self-referential <c>RecipeUsed</c>
+    /// (the per-character craft cap, the WeatherWitching litany) and render it as a
+    /// count line rather than a dead self-chip.
+    /// </summary>
+    public static (IReadOnlyList<string> Lines, IReadOnlyList<EntityChipVm> RecipeChips) Build(
+        IReadOnlyList<RecipeRequirement>? requirements,
+        string? ownerInternalName,
+        IReferenceNavigator navigator,
+        IEntityNameResolver resolver)
+    {
+        if (requirements is null || requirements.Count == 0)
+            return (Array.Empty<string>(), Array.Empty<EntityChipVm>());
+
+        var lines = new List<string>();
+        var chips = new List<EntityChipVm>();
+
+        EntityChipVm RecipeChip(string internalName)
+        {
+            var reference = EntityRef.Recipe(internalName);
+            return new EntityChipVm(
+                DisplayName: resolver.Resolve(reference),
+                IconId: 0,
+                Reference: reference,
+                IsNavigable: navigator.CanOpen(reference));
+        }
+
+        foreach (var req in requirements)
+        {
+            switch (req)
+            {
+                case AlwaysFailRequirement:
+                    // The planner's hard-exclude case (ImproveProphesied* etc.) — the recipe
+                    // can never succeed despite any advertised XP. Say so plainly.
+                    lines.Add("This recipe can never be completed (unavailable placeholder).");
+                    break;
+
+                case RecipeKnownRequirement r when !string.IsNullOrEmpty(r.Recipe):
+                    chips.Add(RecipeChip(r.Recipe!));
+                    break;
+
+                case RecipeUsedRequirement u when !string.IsNullOrEmpty(u.Recipe):
+                    if (string.Equals(u.Recipe, ownerInternalName, StringComparison.Ordinal))
+                    {
+                        // Self-referential RecipeUsed{self, n} ⇒ a per-character lifetime
+                        // cap of n+1 crafts (the planner folds this into RemainingCraftBudget
+                        // alongside MaxUses). A self-chip would be a dead loop, so render the
+                        // cap as a line instead.
+                        lines.Add(u.MaxTimesUsed is { } n
+                            ? $"Limited to {n + 1} craft{(n + 1 == 1 ? "" : "s")} per character."
+                            : "Limited per-character craft count.");
+                    }
+                    else
+                    {
+                        chips.Add(RecipeChip(u.Recipe!));
+                    }
+                    break;
+
+                case WeatherRequirement w:
+                    lines.Add(w.ClearSky switch
+                    {
+                        true => "Only when the sky is clear.",
+                        false => "Only when the weather is overcast.",
+                        null => "Weather-dependent.",
+                    });
+                    break;
+
+                case MoonPhaseRecipeRequirement m when !string.IsNullOrEmpty(m.MoonPhase):
+                    lines.Add($"Only during the {Humanise(m.MoonPhase!).ToLowerInvariant()} moon.");
+                    break;
+
+                case FullMoonRecipeRequirement:
+                    lines.Add("Only during the full moon.");
+                    break;
+
+                case TimeOfDayRecipeRequirement t:
+                    lines.Add((t.MinHour, t.MaxHour) switch
+                    {
+                        ({ } lo, { } hi) => $"Only between {lo:00}:00 and {hi:00}:00 in-game time.",
+                        ({ } lo, null) => $"Only after {lo:00}:00 in-game time.",
+                        (null, { } hi) => $"Only before {hi:00}:00 in-game time.",
+                        _ => "Time-of-day dependent.",
+                    });
+                    break;
+
+                case IsHardcoreRequirement:
+                    lines.Add("Hardcore characters only.");
+                    break;
+
+                case IsLycanthropeRequirement:
+                    lines.Add("Werewolf characters only.");
+                    break;
+
+                case HasHandsRequirement:
+                    lines.Add("Requires hands (not available in animal form).");
+                    break;
+
+                case HasGuildHallRequirement:
+                    lines.Add("Requires a guild hall.");
+                    break;
+
+                case InGraveyardRequirement:
+                    lines.Add("Must be in a graveyard.");
+                    break;
+
+                case PetCountRecipeRequirement p:
+                {
+                    var kind = string.IsNullOrEmpty(p.PetTypeTag) ? "" : $" {Humanise(p.PetTypeTag!)}";
+                    if (p.MinCount is { } mn && p.MaxCount is { } mx && mn != mx)
+                        lines.Add($"Requires {mn}–{mx}{kind} pets.");
+                    else
+                    {
+                        var n = p.MinCount ?? p.MaxCount ?? 1;
+                        lines.Add($"Requires {n}{kind} pet{(n == 1 ? "" : "s")}.");
+                    }
+                    break;
+                }
+
+                case HasEffectKeywordRecipeRequirement h when !string.IsNullOrEmpty(h.Keyword):
+                    lines.Add(h.MinCount is > 1
+                        ? $"Requires the effect “{Humanise(h.Keyword!)}” ×{h.MinCount}."
+                        : $"Requires the effect “{Humanise(h.Keyword!)}”.");
+                    break;
+
+                case EquipmentSlotEmptyRecipeRequirement e when !string.IsNullOrEmpty(e.Slot):
+                    lines.Add($"The {Humanise(e.Slot!).ToLowerInvariant()} equipment slot must be empty.");
+                    break;
+
+                case AppearanceRecipeRequirement a when !string.IsNullOrEmpty(a.Appearance):
+                    lines.Add($"Requires appearance: {Humanise(a.Appearance!)}.");
+                    break;
+
+                case EntityPhysicalStateRecipeRequirement s when s.AllowedStates is { Count: > 0 }:
+                    lines.Add($"Requires physical state: {string.Join(", ", s.AllowedStates!)}.");
+                    break;
+
+                case DruidEventStateRequirement d when d.DisallowedStates is { Count: > 0 }:
+                    lines.Add($"Not available during druid event: {string.Join(", ", d.DisallowedStates!)}.");
+                    break;
+
+                case EntitiesNearRequirement n:
+                    if (!string.IsNullOrEmpty(n.ErrorMsg))
+                        lines.Add(n.ErrorMsg!);
+                    else
+                    {
+                        var what = string.IsNullOrEmpty(n.EntityTypeTag) ? "entities" : Humanise(n.EntityTypeTag!);
+                        lines.Add($"Requires {n.MinCount ?? 1} {what} nearby.");
+                    }
+                    break;
+
+                case UnknownRecipeRequirement u:
+                    // Graceful degrade for a future PG-added discriminator — surface it so
+                    // it's diagnosable, behind a clearly-noise-filtered label (never blank,
+                    // never a crash). Same contract as StorageVault's unknown handling.
+                    lines.Add(string.IsNullOrEmpty(u.DiscriminatorValue)
+                        ? "(unrecognised requirement)"
+                        : $"(unrecognised requirement: {u.DiscriminatorValue})");
+                    break;
+
+                default:
+                    // A known subclass with an empty payload (defensive — RecipeKnown /
+                    // RecipeUsed with no Recipe, MoonPhase with no phase). Skip silently
+                    // rather than emit a blank line.
+                    break;
+            }
+        }
+
+        return (lines, chips);
+    }
+
+    /// <summary>
+    /// Insert spaces at CamelCase / underscore word boundaries so a raw identifier reads
+    /// as a phrase ("WaningCrescent" → "Waning Crescent", "Main_Hand" → "Main Hand").
+    /// Matches the <c>QuestDetailProjector.SplitCamelCase</c> contract; kept local so the
+    /// two projectors stay independent (the cross-domain split noted on
+    /// <see cref="RecipeRequirement"/>).
+    /// </summary>
+    private static string Humanise(string input)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+        if (input.Length < 2) return input;
+        var sb = new StringBuilder(input.Length + 4);
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+            if (c == '_')
+            {
+                if (sb.Length > 0 && sb[sb.Length - 1] != ' ') sb.Append(' ');
+                continue;
+            }
+            if (i > 0 && char.IsUpper(c) && !char.IsUpper(input[i - 1])
+                && sb.Length > 0 && sb[sb.Length - 1] != ' ')
+            {
+                sb.Append(' ');
+            }
+            sb.Append(c);
+        }
+        return sb.ToString().Trim();
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -96,7 +96,7 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
         var sources = BuildSourceChips(recipe);
         var keywordSlots = BuildKeywordSlots(recipe);
         var (reqLines, reqChips) = RecipeRequirementProjector.Build(
-            recipe.OtherRequirements, recipe.InternalName, _navigator, _nameResolver);
+            recipe.OtherRequirements, recipe.InternalName, _navigator, _nameResolver, _refData.Strings);
         var sharesResetWith = string.IsNullOrEmpty(recipe.SharesResetTimerWith)
             ? null
             : _nameResolver.Resolve(EntityRef.Recipe(recipe.SharesResetTimerWith!));

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -95,8 +95,14 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
         var effects = recipe.ResultEffects ?? Array.Empty<string>();
         var sources = BuildSourceChips(recipe);
         var keywordSlots = BuildKeywordSlots(recipe);
+        var (reqLines, reqChips) = RecipeRequirementProjector.Build(
+            recipe.OtherRequirements, recipe.InternalName, _navigator, _nameResolver);
+        var sharesResetWith = string.IsNullOrEmpty(recipe.SharesResetTimerWith)
+            ? null
+            : _nameResolver.Resolve(EntityRef.Recipe(recipe.SharesResetTimerWith!));
         DetailViewModel = new RecipeDetailViewModel(
-            recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName, sources, keywordSlots);
+            recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName, sources, keywordSlots,
+            reqLines, reqChips, sharesResetWith);
     }
 
     private void OnFileUpdated(object? sender, string fileKey)

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -95,12 +95,12 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
         var effects = recipe.ResultEffects ?? Array.Empty<string>();
         var sources = BuildSourceChips(recipe);
         var keywordSlots = BuildKeywordSlots(recipe);
-        var (reqLines, reqChips) = RecipeRequirementProjector.Build(
+        var requirements = RecipeRequirementProjector.Build(
             recipe.OtherRequirements, recipe.InternalName, _navigator, _nameResolver, _refData.Strings);
         var sharedCooldownChip = BuildSharedCooldownChip(recipe);
         DetailViewModel = new RecipeDetailViewModel(
             recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName, sources, keywordSlots,
-            reqLines, reqChips, sharedCooldownChip);
+            requirements, sharedCooldownChip);
     }
 
     private void OnFileUpdated(object? sender, string fileKey)

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -97,12 +97,10 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
         var keywordSlots = BuildKeywordSlots(recipe);
         var (reqLines, reqChips) = RecipeRequirementProjector.Build(
             recipe.OtherRequirements, recipe.InternalName, _navigator, _nameResolver, _refData.Strings);
-        var sharesResetWith = string.IsNullOrEmpty(recipe.SharesResetTimerWith)
-            ? null
-            : _nameResolver.Resolve(EntityRef.Recipe(recipe.SharesResetTimerWith!));
+        var sharedCooldownChip = BuildSharedCooldownChip(recipe);
         DetailViewModel = new RecipeDetailViewModel(
             recipe, ingredients, produced, effects, _openEntityCommand, value.SkillDisplayName, sources, keywordSlots,
-            reqLines, reqChips, sharesResetWith);
+            reqLines, reqChips, sharedCooldownChip);
     }
 
     private void OnFileUpdated(object? sender, string fileKey)
@@ -127,6 +125,27 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
                 SelectedRow = resolved;
             }
         });
+    }
+
+    /// <summary>
+    /// Build the navigable chip for <c>SharesResetTimerWith</c>. Every corpus value is a
+    /// real recipe <see cref="Recipe.InternalName"/> (19/19), so this is a recipe→recipe
+    /// cross-link — same construction as the ingredient/produced chips. Null when absent;
+    /// degrades to a non-navigable pill when the Recipes tab can't open (mirrors the
+    /// <see cref="RecipeRequirementProjector"/> chips' degrade contract).
+    /// </summary>
+    private EntityChipVm? BuildSharedCooldownChip(Recipe recipe)
+    {
+        if (string.IsNullOrEmpty(recipe.SharesResetTimerWith)) return null;
+        var reference = EntityRef.Recipe(recipe.SharesResetTimerWith!);
+        var iconId = _refData.RecipesByInternalName.TryGetValue(recipe.SharesResetTimerWith!, out var target)
+            ? target.IconId
+            : 0;
+        return new EntityChipVm(
+            DisplayName: _nameResolver.Resolve(reference),
+            IconId: iconId,
+            Reference: reference,
+            IsNavigable: _navigator.CanOpen(reference));
     }
 
     private IReadOnlyList<RecipeListRow> BuildAllRecipes(IReferenceDataService refData) =>

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -51,6 +51,15 @@
                     <TextBlock Text="{Binding MaxUsesChip}" Foreground="#CCFFFFFF"
                                FontSize="{DynamicResource AppFontSizeHint}"/>
                 </Border>
+                <!-- Reuse cooldown. The planner is time-stateless and surfaces the cap
+                     (MaxUses) but not this — the browser is the only place a player learns
+                     a recipe is on a timer. Mirrors MaxUsesChip's self-hide on empty. -->
+                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
+                        CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Margin="0,0,6,0"
+                        Visibility="{Binding CooldownChip, Converter={StaticResource NullOrEmptyToVis}}">
+                    <TextBlock Text="{Binding CooldownChip}" Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"/>
+                </Border>
             </WrapPanel>
 
             <!-- Description (FormattedText parses any inline <i>/<b> markup). -->
@@ -58,6 +67,76 @@
                        FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
                        MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                        Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
+
+            <!-- Requirements: the polymorphic OtherRequirements gates. Plain readable
+                 lines for the time/RNG-cyclical + user-asserted unlocks the planner
+                 deliberately punts on (docs/planner-recipe-field-consumption.md — this
+                 section is the display half that makes that punt sound), plus 1:1
+                 navigable chips for the recipe-referencing kinds (RecipeKnown /
+                 cross-recipe RecipeUsed), plus the shared-cooldown note. Whole section
+                 self-hides when the recipe carries none of the three. -->
+            <StackPanel Margin="0,0,0,10">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding OtherRequirementLines.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding RecipeRequirementChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding SharedCooldownNote, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBlock Text="Requirements" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                <ItemsControl ItemsSource="{Binding OtherRequirementLines}"
+                              Visibility="{Binding OtherRequirementLines.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+                <TextBlock Text="{Binding SharedCooldownNote}" Foreground="#CCFFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           TextWrapping="Wrap" Margin="0,0,0,2"
+                           Visibility="{Binding SharedCooldownNote, Converter={StaticResource NullOrEmptyToVis}}"/>
+                <ItemsControl ItemsSource="{Binding RecipeRequirementChips}" Margin="0,4,0,0"
+                              Visibility="{Binding RecipeRequirementChips.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- Cost: currency to perform the recipe. The planner ignores Costs by
+                 design (no XP/count impact) so the browser is the only surface for it. -->
+            <StackPanel Margin="0,0,0,10"
+                        Visibility="{Binding CostLines.Count, Converter={StaticResource PositiveIntToVis}}">
+                <TextBlock Text="Cost" FontWeight="SemiBold" Foreground="#88FFFFFF"
+                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                <ItemsControl ItemsSource="{Binding CostLines}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
 
             <!-- Taught by (sources_recipes.json projection). Renders as ItemSourceChip:
                  navigable chip when the source's EntityReference resolves to a tabbed kind

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -4,6 +4,7 @@
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -14,6 +15,46 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- One projected requirement row. Dual-shape, mirroring QuestDetailView:
+                   - Chip set: "{Prefix} [chip]" — the recipe is an inline navigable
+                     EntityChip (degrades to a plain pill when the Recipes tab isn't
+                     open). Used for RecipeKnown / cross-recipe RecipeUsed and the
+                     shared-cooldown grouping.
+                   - Otherwise: plain Text (cyclical / user-asserted gates).
+                 Switching is on Chip (object) via NullToVis — NOT the string-only
+                 NullOrEmptyToVis, which silently collapses an EntityChipVm binding. -->
+            <DataTemplate DataType="{x:Type vm:RecipeRequirementRow}">
+                <Grid Margin="0,0,0,3">
+                    <StackPanel Orientation="Horizontal"
+                                Visibility="{Binding Chip, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="{Binding Prefix}" Foreground="#CCFFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl Content="{Binding Chip}">
+                            <ContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.ContentTemplate>
+                        </ContentControl>
+                    </StackPanel>
+                    <TextBlock Text="{Binding Text}" Foreground="#CCFFFFFF"
+                               FontSize="{DynamicResource AppFontSizeHint}"
+                               TextWrapping="Wrap" VerticalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Chip, Converter={StaticResource NullToVis}}" Value="Visible">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -68,27 +109,24 @@
                        MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                        Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
-            <!-- Requirements: the polymorphic OtherRequirements gates. Plain readable
-                 lines for the time/RNG-cyclical + user-asserted unlocks the planner
-                 deliberately punts on (docs/planner-recipe-field-consumption.md — this
-                 section is the display half that makes that punt sound), plus 1:1
-                 navigable chips for the recipe-referencing kinds (RecipeKnown /
-                 cross-recipe RecipeUsed), plus the shared-cooldown cross-link chip.
-                 Whole section self-hides when the recipe carries none of the three. -->
+            <!-- Requirements: the polymorphic OtherRequirements gates + the
+                 shared-cooldown grouping, all rendered through one RecipeRequirementRow
+                 template (prose, or "{Prefix} [inline chip]"), in authored order — so
+                 recipe cross-links read in the same flow as the prose gates instead of
+                 as an orphaned trailing pill cluster. This section is the display half
+                 that makes the planner's deliberate punt sound
+                 (docs/planner-recipe-field-consumption.md). Self-hides when the recipe
+                 carries neither requirements nor a shared-cooldown edge. -->
             <StackPanel Margin="0,0,0,10">
                 <StackPanel.Style>
                     <Style TargetType="StackPanel">
                         <Setter Property="Visibility" Value="Collapsed"/>
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding OtherRequirementLines.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                            <DataTrigger Binding="{Binding Requirements.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                 <Setter Property="Visibility" Value="Visible"/>
                             </DataTrigger>
-                            <DataTrigger Binding="{Binding RecipeRequirementChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
-                                <Setter Property="Visibility" Value="Visible"/>
-                            </DataTrigger>
-                            <!-- NullToVis (not NullOrEmptyToVis — that's string-only and
-                                 silently collapses an object binding). -->
-                            <DataTrigger Binding="{Binding SharedCooldownChip, Converter={StaticResource NullToVis}}" Value="Visible">
+                            <!-- NullToVis (object) — NOT the string-only NullOrEmptyToVis. -->
+                            <DataTrigger Binding="{Binding SharedCooldownRow, Converter={StaticResource NullToVis}}" Value="Visible">
                                 <Setter Property="Visibility" Value="Visible"/>
                             </DataTrigger>
                         </Style.Triggers>
@@ -96,46 +134,16 @@
                 </StackPanel.Style>
                 <TextBlock Text="Requirements" FontWeight="SemiBold" Foreground="#88FFFFFF"
                            FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding OtherRequirementLines}"
-                              Visibility="{Binding OtherRequirementLines.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-                <ItemsControl ItemsSource="{Binding RecipeRequirementChips}" Margin="0,4,0,0"
-                              Visibility="{Binding RecipeRequirementChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-                <!-- Shared-cooldown grouping. A recipe→recipe edge (every corpus value is
-                     a real recipe InternalName), so it's a navigable chip, not prose —
-                     but labelled distinctly from the requirement chips above because a
-                     cooldown grouping isn't a gate. Mirrors QuestDetailView's
-                     giver/turn-in prefix+chip pattern; StackPanel collapses on a null
-                     chip so the ContentControl template never instantiates dead. -->
-                <StackPanel Orientation="Horizontal" Margin="0,6,0,0"
-                            Visibility="{Binding SharedCooldownChip, Converter={StaticResource NullToVis}}">
-                    <TextBlock Text="{Binding SharedCooldownLabel}" Foreground="#88FFFFFF"
-                               FontWeight="SemiBold" FontSize="{DynamicResource AppFontSizeHint}"
-                               VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <ContentControl Content="{Binding SharedCooldownChip}">
-                        <ContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
-                            </DataTemplate>
-                        </ContentControl.ContentTemplate>
-                    </ContentControl>
-                </StackPanel>
+                <!-- No ItemTemplate: the implicit DataType-keyed RecipeRequirementRow
+                     template in Resources renders each row (prose vs prefix+chip). -->
+                <ItemsControl ItemsSource="{Binding Requirements}"
+                              Visibility="{Binding Requirements.Count, Converter={StaticResource PositiveIntToVis}}"/>
+                <!-- Shared-cooldown: same RecipeRequirementRow shape/template, exposed
+                     separately and labelled "Shares cooldown with" — a cooldown grouping
+                     isn't a requirement gate. ContentControl picks up the implicit
+                     template; collapses on a null row so it never instantiates dead. -->
+                <ContentControl Content="{Binding SharedCooldownRow}"
+                                Visibility="{Binding SharedCooldownRow, Converter={StaticResource NullToVis}}"/>
             </StackPanel>
 
             <!-- Cost: currency to perform the recipe. The planner ignores Costs by

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -73,8 +73,8 @@
                  deliberately punts on (docs/planner-recipe-field-consumption.md — this
                  section is the display half that makes that punt sound), plus 1:1
                  navigable chips for the recipe-referencing kinds (RecipeKnown /
-                 cross-recipe RecipeUsed), plus the shared-cooldown note. Whole section
-                 self-hides when the recipe carries none of the three. -->
+                 cross-recipe RecipeUsed), plus the shared-cooldown cross-link chip.
+                 Whole section self-hides when the recipe carries none of the three. -->
             <StackPanel Margin="0,0,0,10">
                 <StackPanel.Style>
                     <Style TargetType="StackPanel">
@@ -86,7 +86,9 @@
                             <DataTrigger Binding="{Binding RecipeRequirementChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                 <Setter Property="Visibility" Value="Visible"/>
                             </DataTrigger>
-                            <DataTrigger Binding="{Binding SharedCooldownNote, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                            <!-- NullToVis (not NullOrEmptyToVis — that's string-only and
+                                 silently collapses an object binding). -->
+                            <DataTrigger Binding="{Binding SharedCooldownChip, Converter={StaticResource NullToVis}}" Value="Visible">
                                 <Setter Property="Visibility" Value="Visible"/>
                             </DataTrigger>
                         </Style.Triggers>
@@ -104,10 +106,6 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <TextBlock Text="{Binding SharedCooldownNote}" Foreground="#CCFFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}"
-                           TextWrapping="Wrap" Margin="0,0,0,2"
-                           Visibility="{Binding SharedCooldownNote, Converter={StaticResource NullOrEmptyToVis}}"/>
                 <ItemsControl ItemsSource="{Binding RecipeRequirementChips}" Margin="0,4,0,0"
                               Visibility="{Binding RecipeRequirementChips.Count, Converter={StaticResource PositiveIntToVis}}">
                     <ItemsControl.ItemsPanel>
@@ -119,6 +117,25 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+                <!-- Shared-cooldown grouping. A recipe→recipe edge (every corpus value is
+                     a real recipe InternalName), so it's a navigable chip, not prose —
+                     but labelled distinctly from the requirement chips above because a
+                     cooldown grouping isn't a gate. Mirrors QuestDetailView's
+                     giver/turn-in prefix+chip pattern; StackPanel collapses on a null
+                     chip so the ContentControl template never instantiates dead. -->
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0"
+                            Visibility="{Binding SharedCooldownChip, Converter={StaticResource NullToVis}}">
+                    <TextBlock Text="{Binding SharedCooldownLabel}" Foreground="#88FFFFFF"
+                               FontWeight="SemiBold" FontSize="{DynamicResource AppFontSizeHint}"
+                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <ContentControl Content="{Binding SharedCooldownChip}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
+                </StackPanel>
             </StackPanel>
 
             <!-- Cost: currency to perform the recipe. The planner ignores Costs by

--- a/tests/Silmarillion.Tests/ViewModels/RecipeDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeDetailViewModelTests.cs
@@ -15,7 +15,10 @@ public sealed class RecipeDetailViewModelTests
         int skillLevel = 12,
         string? description = null,
         IReadOnlyList<string>? resultEffects = null,
-        int? maxUses = null) => new()
+        int? maxUses = null,
+        IReadOnlyList<RecipeCost>? costs = null,
+        int? resetTimeInSeconds = null,
+        string? sharesResetTimerWith = null) => new()
     {
         Key = "recipe_1",
         InternalName = internalName,
@@ -27,6 +30,9 @@ public sealed class RecipeDetailViewModelTests
         Ingredients = [],
         ResultEffects = resultEffects,
         MaxUses = maxUses,
+        Costs = costs,
+        ResetTimeInSeconds = resetTimeInSeconds,
+        SharesResetTimerWith = sharesResetTimerWith,
     };
 
     [Fact]
@@ -135,5 +141,74 @@ public sealed class RecipeDetailViewModelTests
             resultEffectsText: []);
 
         vm.MaxUsesChip.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData(0, "")]
+    [InlineData(45, "Reuse every 45s")]
+    [InlineData(90, "Reuse every 1m 30s")]
+    [InlineData(5400, "Reuse every 1h 30m")]
+    [InlineData(180000, "Reuse every 2d 2h")]
+    public void CooldownChip_FormatsResetTime_OrEmptyWhenAbsent(int? resetSeconds, string expected)
+    {
+        // The planner is time-stateless: it surfaces the MaxUses cap but never the
+        // cooldown. The browser is the only place this reaches the player (#342).
+        var vm = new RecipeDetailViewModel(
+            SampleRecipe(resetTimeInSeconds: resetSeconds), [], [], []);
+
+        vm.CooldownChip.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SharedCooldownNote_UsesResolvedDisplayName_WhenProvided()
+    {
+        var vm = new RecipeDetailViewModel(
+            SampleRecipe(sharesResetTimerWith: "MakeRouxInternal"), [], [], [],
+            sharesResetTimerDisplayName: "Make Roux");
+
+        vm.SharedCooldownNote.Should().Be("Shares its cooldown with Make Roux");
+    }
+
+    [Fact]
+    public void SharedCooldownNote_FallsBackToInternalName_AndIsEmptyWhenAbsent()
+    {
+        new RecipeDetailViewModel(SampleRecipe(sharesResetTimerWith: "MakeRouxInternal"), [], [], [])
+            .SharedCooldownNote.Should().Be("Shares its cooldown with MakeRouxInternal");
+
+        new RecipeDetailViewModel(SampleRecipe(), [], [], [])
+            .SharedCooldownNote.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CostLines_FormatCurrencyAndSkipNonPositive_OrEmptyWhenAbsent()
+    {
+        new RecipeDetailViewModel(SampleRecipe(), [], [], []).CostLines.Should().BeEmpty();
+
+        var vm = new RecipeDetailViewModel(
+            SampleRecipe(costs: new[]
+            {
+                new RecipeCost { Currency = "FaeEnergy", Price = 1500 },     // camel-split
+                new RecipeCost { Currency = "CombatWisdom", Price = 0 },      // skipped (≤0)
+                new RecipeCost { Currency = null, Price = 25 },
+            }),
+            [], [], []);
+
+        vm.CostLines.Should().Equal("1,500 Fae Energy", "25 currency");
+    }
+
+    [Fact]
+    public void RequirementCollections_DefaultEmpty_AndPassThroughWhenProvided()
+    {
+        new RecipeDetailViewModel(SampleRecipe(), [], [], []).OtherRequirementLines.Should().BeEmpty();
+
+        var chips = new[] { new EntityChipVm("Make Roux", 0, EntityRef.Recipe("MakeRoux"), true) };
+        var vm = new RecipeDetailViewModel(
+            SampleRecipe(), [], [], [],
+            otherRequirementLines: new[] { "Only during the full moon." },
+            recipeRequirementChips: chips);
+
+        vm.OtherRequirementLines.Should().ContainSingle().Which.Should().Be("Only during the full moon.");
+        vm.RecipeRequirementChips.Should().BeEquivalentTo(chips);
     }
 }

--- a/tests/Silmarillion.Tests/ViewModels/RecipeDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeDetailViewModelTests.cs
@@ -161,10 +161,11 @@ public sealed class RecipeDetailViewModelTests
     }
 
     [Fact]
-    public void SharedCooldownChip_IsANavigableRecipeCrossLink_WhenProvided()
+    public void SharedCooldownRow_IsANavigableChipRow_WithDistinctPrefix_WhenProvided()
     {
         // SharesResetTimerWith is a recipe→recipe edge (19/19 corpus values are real
-        // recipe InternalNames) — it must be a navigable chip, not dead prose.
+        // recipe InternalNames) — a chip row, not dead prose, but labelled distinctly
+        // from the requirement gates (a cooldown grouping isn't a gate).
         var chip = new EntityChipVm("Make Roux", IconId: 7,
             Reference: EntityRef.Recipe("MakeRouxInternal"), IsNavigable: true);
 
@@ -172,17 +173,18 @@ public sealed class RecipeDetailViewModelTests
             SampleRecipe(sharesResetTimerWith: "MakeRouxInternal"), [], [], [],
             sharedCooldownChip: chip);
 
-        vm.SharedCooldownChip.Should().BeSameAs(chip);
-        vm.SharedCooldownChip!.Reference!.Kind.Should().Be(EntityKind.Recipe);
-        vm.SharedCooldownChip.IsNavigable.Should().BeTrue();
-        vm.SharedCooldownLabel.Should().Be("Shares cooldown with");
+        vm.SharedCooldownRow.Should().NotBeNull();
+        vm.SharedCooldownRow!.Chip.Should().BeSameAs(chip);
+        vm.SharedCooldownRow.Chip!.Reference!.Kind.Should().Be(EntityKind.Recipe);
+        vm.SharedCooldownRow.Prefix.Should().Be("Shares cooldown with");
+        vm.SharedCooldownRow.Text.Should().Be("Shares cooldown with Make Roux");
     }
 
     [Fact]
-    public void SharedCooldownChip_IsNullWhenAbsent()
+    public void SharedCooldownRow_IsNullWhenAbsent()
     {
         new RecipeDetailViewModel(SampleRecipe(), [], [], [])
-            .SharedCooldownChip.Should().BeNull();
+            .SharedCooldownRow.Should().BeNull();
     }
 
     [Fact]
@@ -203,17 +205,18 @@ public sealed class RecipeDetailViewModelTests
     }
 
     [Fact]
-    public void RequirementCollections_DefaultEmpty_AndPassThroughWhenProvided()
+    public void Requirements_DefaultEmpty_AndPassThroughWhenProvided()
     {
-        new RecipeDetailViewModel(SampleRecipe(), [], [], []).OtherRequirementLines.Should().BeEmpty();
+        new RecipeDetailViewModel(SampleRecipe(), [], [], []).Requirements.Should().BeEmpty();
 
-        var chips = new[] { new EntityChipVm("Make Roux", 0, EntityRef.Recipe("MakeRoux"), true) };
-        var vm = new RecipeDetailViewModel(
-            SampleRecipe(), [], [], [],
-            otherRequirementLines: new[] { "Only during the full moon." },
-            recipeRequirementChips: chips);
+        var rows = new[]
+        {
+            new RecipeRequirementRow("Only during the full moon."),
+            new RecipeRequirementRow("Requires recipe: Make Roux", "Requires recipe:",
+                new EntityChipVm("Make Roux", 0, EntityRef.Recipe("MakeRoux"), true)),
+        };
+        var vm = new RecipeDetailViewModel(SampleRecipe(), [], [], [], requirements: rows);
 
-        vm.OtherRequirementLines.Should().ContainSingle().Which.Should().Be("Only during the full moon.");
-        vm.RecipeRequirementChips.Should().BeEquivalentTo(chips);
+        vm.Requirements.Should().BeEquivalentTo(rows, o => o.WithStrictOrdering());
     }
 }

--- a/tests/Silmarillion.Tests/ViewModels/RecipeDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeDetailViewModelTests.cs
@@ -161,23 +161,28 @@ public sealed class RecipeDetailViewModelTests
     }
 
     [Fact]
-    public void SharedCooldownNote_UsesResolvedDisplayName_WhenProvided()
+    public void SharedCooldownChip_IsANavigableRecipeCrossLink_WhenProvided()
     {
+        // SharesResetTimerWith is a recipe→recipe edge (19/19 corpus values are real
+        // recipe InternalNames) — it must be a navigable chip, not dead prose.
+        var chip = new EntityChipVm("Make Roux", IconId: 7,
+            Reference: EntityRef.Recipe("MakeRouxInternal"), IsNavigable: true);
+
         var vm = new RecipeDetailViewModel(
             SampleRecipe(sharesResetTimerWith: "MakeRouxInternal"), [], [], [],
-            sharesResetTimerDisplayName: "Make Roux");
+            sharedCooldownChip: chip);
 
-        vm.SharedCooldownNote.Should().Be("Shares its cooldown with Make Roux");
+        vm.SharedCooldownChip.Should().BeSameAs(chip);
+        vm.SharedCooldownChip!.Reference!.Kind.Should().Be(EntityKind.Recipe);
+        vm.SharedCooldownChip.IsNavigable.Should().BeTrue();
+        vm.SharedCooldownLabel.Should().Be("Shares cooldown with");
     }
 
     [Fact]
-    public void SharedCooldownNote_FallsBackToInternalName_AndIsEmptyWhenAbsent()
+    public void SharedCooldownChip_IsNullWhenAbsent()
     {
-        new RecipeDetailViewModel(SampleRecipe(sharesResetTimerWith: "MakeRouxInternal"), [], [], [])
-            .SharedCooldownNote.Should().Be("Shares its cooldown with MakeRouxInternal");
-
         new RecipeDetailViewModel(SampleRecipe(), [], [], [])
-            .SharedCooldownNote.Should().BeEmpty();
+            .SharedCooldownChip.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
@@ -59,6 +59,7 @@ public sealed class RecipeRequirementProjectorTests
             new WeatherRequirement { T = "Weather", ClearSky = true },
             new TimeOfDayRecipeRequirement { T = "TimeOfDay", MinHour = 20, MaxHour = 4 },
             new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "CowPet", MinCount = 2, MaxCount = 2 },
+            new HasEffectKeywordRecipeRequirement { T = "HasEffectKeyword", Keyword = "Sandstorm" },
             new HasHandsRequirement { T = "HasHands" },
             new IsLycanthropeRequirement { T = "IsLycanthrope" },
             new HasGuildHallRequirement { T = "HasGuildHall" },
@@ -72,10 +73,31 @@ public sealed class RecipeRequirementProjectorTests
             "Only during the waning crescent moon.",
             "Only when the sky is clear.",
             "Only between 20:00 and 04:00 in-game time.",
-            "Requires 2 Cow Pet pets.",
+            "Requires exactly 2 Cow Pet.",                 // tag already a pet-noun ⇒ no "pets" suffix
+            "Requires the effect “Sandstorm”.",
             "Requires hands (not available in animal form).",
             "Werewolf characters only.",
             "Requires a guild hall.");
+    }
+
+    [Fact]
+    public void PetCount_TreatsMinMaxAsBounds_NotARequiredQuantity()
+    {
+        var (nav, resolver) = Deps();
+        // The only two shapes in the bundled corpus, plus a floor-only and a non-pet-noun.
+        var reqs = new RecipeRequirement[]
+        {
+            new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "SummonedBakingBread", MaxCount = 4 },
+            new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "StorageCrateDruid", MaxCount = 0 },
+            new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "Wolf", MinCount = 2 },
+        };
+
+        var (lines, _) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver);
+
+        lines.Should().Equal(
+            "Requires at most 4 Summoned Baking Bread pets.",   // cap, not "requires 4"
+            "Must not own any Storage Crate Druid.",            // Max 0 ⇒ disallowed, not "0 pets"
+            "Requires at least 2 Wolf pets.");                  // "pet" appended (tag isn't a pet-noun)
     }
 
     [Fact]

--- a/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
@@ -39,11 +39,15 @@ public sealed class RecipeRequirementProjectorTests
         public string Resolve(EntityRef reference) => reference.InternalName;
     }
 
+    /// <summary>No strings_all entries ⇒ tag projection falls back to Humanise.</summary>
+    private static readonly IReadOnlyDictionary<string, string> NoStrings =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
     [Fact]
     public void EmptyOrNull_YieldsNoLinesOrChips()
     {
         var (nav, resolver) = Deps();
-        var (lines, chips) = RecipeRequirementProjector.Build(null, "Self", nav, resolver);
+        var (lines, chips) = RecipeRequirementProjector.Build(null, "Self", nav, resolver, NoStrings);
         lines.Should().BeEmpty();
         chips.Should().BeEmpty();
     }
@@ -65,7 +69,7 @@ public sealed class RecipeRequirementProjectorTests
             new HasGuildHallRequirement { T = "HasGuildHall" },
         };
 
-        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver);
+        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
 
         chips.Should().BeEmpty();
         lines.Should().Equal(
@@ -92,12 +96,37 @@ public sealed class RecipeRequirementProjectorTests
             new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "Wolf", MinCount = 2 },
         };
 
-        var (lines, _) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver);
+        var (lines, _) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
 
         lines.Should().Equal(
             "Requires at most 4 Summoned Baking Bread pets.",   // cap, not "requires 4"
             "Must not own any Storage Crate Druid.",            // Max 0 ⇒ disallowed, not "0 pets"
             "Requires at least 2 Wolf pets.");                  // "pet" appended (tag isn't a pet-noun)
+    }
+
+    [Fact]
+    public void PetTypeTag_ResolvesThroughStringsAll_NotCamelSplit()
+    {
+        var (nav, resolver) = Deps();
+        // PG models pet types as NPC/monster entities — the real in-game name lives in
+        // strings_all under npc_<tag>_Name. Camel-splitting "SummonedBakingBread" to
+        // "Summoned Baking Bread" fabricates a label the game never shows ("Rising Dough").
+        var strings = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["npc_SummonedBakingBread_Name"] = "Rising Dough",
+            ["npc_StorageCrateDruid_Name"] = "Druidic Storage Crate",
+        };
+        var reqs = new RecipeRequirement[]
+        {
+            new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "SummonedBakingBread", MaxCount = 4 },
+            new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "StorageCrateDruid", MaxCount = 0 },
+        };
+
+        var (lines, _) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, strings);
+
+        lines.Should().Equal(
+            "Requires at most 4 Rising Dough pets.",
+            "Must not own any Druidic Storage Crate.");
     }
 
     [Fact]
@@ -110,7 +139,7 @@ public sealed class RecipeRequirementProjectorTests
             new RecipeUsedRequirement { T = "RecipeUsed", Recipe = "OtherRecipe", MaxTimesUsed = 3 },
         };
 
-        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "MakeStew", nav, resolver);
+        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "MakeStew", nav, resolver, NoStrings);
 
         lines.Should().BeEmpty();
         chips.Should().HaveCount(2);
@@ -127,7 +156,7 @@ public sealed class RecipeRequirementProjectorTests
             new RecipeUsedRequirement { T = "RecipeUsed", Recipe = "WeatherWitchRitual", MaxTimesUsed = 4 },
         };
 
-        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "WeatherWitchRitual", nav, resolver);
+        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "WeatherWitchRitual", nav, resolver, NoStrings);
 
         chips.Should().BeEmpty();
         lines.Should().ContainSingle().Which.Should().Be("Limited to 5 crafts per character.");
@@ -138,7 +167,7 @@ public sealed class RecipeRequirementProjectorTests
     {
         var (nav, resolver) = Deps();
         var (lines, _) = RecipeRequirementProjector.Build(
-            new RecipeRequirement[] { new AlwaysFailRequirement { T = "AlwaysFail" } }, "Self", nav, resolver);
+            new RecipeRequirement[] { new AlwaysFailRequirement { T = "AlwaysFail" } }, "Self", nav, resolver, NoStrings);
         lines.Should().ContainSingle().Which.Should().Contain("never be completed");
     }
 
@@ -148,7 +177,7 @@ public sealed class RecipeRequirementProjectorTests
         var (nav, resolver) = Deps();
         var (lines, _) = RecipeRequirementProjector.Build(
             new RecipeRequirement[] { new UnknownRecipeRequirement { T = "Brand_New", DiscriminatorValue = "Brand_New" } },
-            "Self", nav, resolver);
+            "Self", nav, resolver, NoStrings);
         lines.Should().ContainSingle().Which.Should().Be("(unrecognised requirement: Brand_New)");
     }
 
@@ -158,7 +187,7 @@ public sealed class RecipeRequirementProjectorTests
         var (nav, resolver) = Deps(recipesTabbed: false);
         var (_, chips) = RecipeRequirementProjector.Build(
             new RecipeRequirement[] { new RecipeKnownRequirement { T = "RecipeKnown", Recipe = "MakeRoux" } },
-            "Self", nav, resolver);
+            "Self", nav, resolver, NoStrings);
         chips.Should().ContainSingle().Which.IsNavigable.Should().BeFalse();
     }
 }

--- a/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
@@ -11,7 +11,8 @@ namespace Silmarillion.Tests.ViewModels;
 /// Covers the requirement projection that closes the planner-punt ↔ Silmarillion-display
 /// blind spot: the gates <c>CrossSkillPlanner</c> deliberately does not pursue
 /// (<c>docs/planner-recipe-field-consumption.md</c>) must be visible here, or the
-/// user-asserted contract is unverifiable. Synthetic fixtures verify projection shape.
+/// user-asserted contract is unverifiable. Rows are the Quest dual-shape: prose, or a
+/// "{Prefix} [chip]" sentence with an inline navigable chip.
 /// </summary>
 public sealed class RecipeRequirementProjectorTests
 {
@@ -43,17 +44,18 @@ public sealed class RecipeRequirementProjectorTests
     private static readonly IReadOnlyDictionary<string, string> NoStrings =
         new Dictionary<string, string>(StringComparer.Ordinal);
 
+    private static IReadOnlyList<string> Texts(IEnumerable<RecipeRequirementRow> rows) =>
+        rows.Select(r => r.Text).ToList();
+
     [Fact]
-    public void EmptyOrNull_YieldsNoLinesOrChips()
+    public void EmptyOrNull_YieldsNoRows()
     {
         var (nav, resolver) = Deps();
-        var (lines, chips) = RecipeRequirementProjector.Build(null, "Self", nav, resolver, NoStrings);
-        lines.Should().BeEmpty();
-        chips.Should().BeEmpty();
+        RecipeRequirementProjector.Build(null, "Self", nav, resolver, NoStrings).Should().BeEmpty();
     }
 
     [Fact]
-    public void CyclicalAndUserAssertedGates_RenderAsReadableLines()
+    public void CyclicalAndUserAssertedGates_RenderAsProseRows()
     {
         var (nav, resolver) = Deps();
         var reqs = new RecipeRequirement[]
@@ -69,10 +71,10 @@ public sealed class RecipeRequirementProjectorTests
             new HasGuildHallRequirement { T = "HasGuildHall" },
         };
 
-        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
+        var rows = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
 
-        chips.Should().BeEmpty();
-        lines.Should().Equal(
+        rows.Should().OnlyContain(r => r.Chip == null && r.Prefix == null);
+        Texts(rows).Should().Equal(
             "Only during the full moon.",
             "Only during the waning crescent moon.",
             "Only when the sky is clear.",
@@ -85,10 +87,33 @@ public sealed class RecipeRequirementProjectorTests
     }
 
     [Fact]
+    public void ProseAndChipRows_StayInterleavedInAuthoredOrder()
+    {
+        // The whole point of the row model: a cross-link chip reads in the same flow as
+        // the prose gates around it, not as a trailing orphaned cluster.
+        var (nav, resolver) = Deps();
+        var reqs = new RecipeRequirement[]
+        {
+            new FullMoonRecipeRequirement { T = "FullMoon" },
+            new RecipeKnownRequirement { T = "RecipeKnown", Recipe = "Augury1" },
+            new HasGuildHallRequirement { T = "HasGuildHall" },
+        };
+
+        var rows = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
+
+        rows.Should().HaveCount(3);
+        rows[0].Chip.Should().BeNull();
+        rows[0].Text.Should().Be("Only during the full moon.");
+        rows[1].Chip.Should().NotBeNull();                         // chip sits *between* prose rows
+        rows[1].Prefix.Should().Be("Requires recipe:");
+        rows[2].Chip.Should().BeNull();
+        rows[2].Text.Should().Be("Requires a guild hall.");
+    }
+
+    [Fact]
     public void PetCount_TreatsMinMaxAsBounds_NotARequiredQuantity()
     {
         var (nav, resolver) = Deps();
-        // The only two shapes in the bundled corpus, plus a floor-only and a non-pet-noun.
         var reqs = new RecipeRequirement[]
         {
             new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "SummonedBakingBread", MaxCount = 4 },
@@ -96,9 +121,9 @@ public sealed class RecipeRequirementProjectorTests
             new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "Wolf", MinCount = 2 },
         };
 
-        var (lines, _) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
+        var rows = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, NoStrings);
 
-        lines.Should().Equal(
+        Texts(rows).Should().Equal(
             "Requires at most 4 Summoned Baking Bread pets.",   // cap, not "requires 4"
             "Must not own any Storage Crate Druid.",            // Max 0 ⇒ disallowed, not "0 pets"
             "Requires at least 2 Wolf pets.");                  // "pet" appended (tag isn't a pet-noun)
@@ -108,9 +133,6 @@ public sealed class RecipeRequirementProjectorTests
     public void PetTypeTag_ResolvesThroughStringsAll_NotCamelSplit()
     {
         var (nav, resolver) = Deps();
-        // PG models pet types as NPC/monster entities — the real in-game name lives in
-        // strings_all under npc_<tag>_Name. Camel-splitting "SummonedBakingBread" to
-        // "Summoned Baking Bread" fabricates a label the game never shows ("Rising Dough").
         var strings = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["npc_SummonedBakingBread_Name"] = "Rising Dough",
@@ -122,15 +144,15 @@ public sealed class RecipeRequirementProjectorTests
             new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "StorageCrateDruid", MaxCount = 0 },
         };
 
-        var (lines, _) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, strings);
+        var rows = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver, strings);
 
-        lines.Should().Equal(
+        Texts(rows).Should().Equal(
             "Requires at most 4 Rising Dough pets.",
             "Must not own any Druidic Storage Crate.");
     }
 
     [Fact]
-    public void RecipeKnown_AndCrossRecipeUsed_BecomeNavigableChips()
+    public void RecipeKnown_AndCrossRecipeUsed_BecomeNavigableChipRows_WithPrefixes()
     {
         var (nav, resolver) = Deps();
         var reqs = new RecipeRequirement[]
@@ -139,16 +161,18 @@ public sealed class RecipeRequirementProjectorTests
             new RecipeUsedRequirement { T = "RecipeUsed", Recipe = "OtherRecipe", MaxTimesUsed = 3 },
         };
 
-        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "MakeStew", nav, resolver, NoStrings);
+        var rows = RecipeRequirementProjector.Build(reqs, "MakeStew", nav, resolver, NoStrings);
 
-        lines.Should().BeEmpty();
-        chips.Should().HaveCount(2);
-        chips[0].Reference!.Kind.Should().Be(EntityKind.Recipe);
-        chips.Should().OnlyContain(c => c.IsNavigable);
+        rows.Should().HaveCount(2);
+        rows.Should().OnlyContain(r => r.Chip != null && r.Chip!.IsNavigable
+                                       && r.Chip.Reference!.Kind == EntityKind.Recipe);
+        rows[0].Prefix.Should().Be("Requires recipe:");
+        rows[0].Text.Should().Be("Requires recipe: MakeRoux");          // prose fallback = prefix + name
+        rows[1].Prefix.Should().Be("Requires having crafted:");
     }
 
     [Fact]
-    public void SelfReferentialRecipeUsed_IsACraftCapLine_NotADeadSelfChip()
+    public void SelfReferentialRecipeUsed_IsACraftCapProseRow_NotADeadSelfChip()
     {
         var (nav, resolver) = Deps();
         var reqs = new RecipeRequirement[]
@@ -156,38 +180,38 @@ public sealed class RecipeRequirementProjectorTests
             new RecipeUsedRequirement { T = "RecipeUsed", Recipe = "WeatherWitchRitual", MaxTimesUsed = 4 },
         };
 
-        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "WeatherWitchRitual", nav, resolver, NoStrings);
+        var rows = RecipeRequirementProjector.Build(reqs, "WeatherWitchRitual", nav, resolver, NoStrings);
 
-        chips.Should().BeEmpty();
-        lines.Should().ContainSingle().Which.Should().Be("Limited to 5 crafts per character.");
+        rows.Should().ContainSingle().Which.Chip.Should().BeNull();
+        rows.Single().Text.Should().Be("Limited to 5 crafts per character.");
     }
 
     [Fact]
     public void AlwaysFail_SaysItCanNeverBeCompleted()
     {
         var (nav, resolver) = Deps();
-        var (lines, _) = RecipeRequirementProjector.Build(
+        var rows = RecipeRequirementProjector.Build(
             new RecipeRequirement[] { new AlwaysFailRequirement { T = "AlwaysFail" } }, "Self", nav, resolver, NoStrings);
-        lines.Should().ContainSingle().Which.Should().Contain("never be completed");
+        rows.Should().ContainSingle().Which.Text.Should().Contain("never be completed");
     }
 
     [Fact]
     public void UnknownRequirement_DegradesGracefullyWithDiscriminator()
     {
         var (nav, resolver) = Deps();
-        var (lines, _) = RecipeRequirementProjector.Build(
+        var rows = RecipeRequirementProjector.Build(
             new RecipeRequirement[] { new UnknownRecipeRequirement { T = "Brand_New", DiscriminatorValue = "Brand_New" } },
             "Self", nav, resolver, NoStrings);
-        lines.Should().ContainSingle().Which.Should().Be("(unrecognised requirement: Brand_New)");
+        rows.Should().ContainSingle().Which.Text.Should().Be("(unrecognised requirement: Brand_New)");
     }
 
     [Fact]
-    public void RecipeChips_DegradeToNonNavigable_WhenRecipesTabAbsent()
+    public void ChipRow_DegradesToNonNavigable_WhenRecipesTabAbsent()
     {
         var (nav, resolver) = Deps(recipesTabbed: false);
-        var (_, chips) = RecipeRequirementProjector.Build(
+        var rows = RecipeRequirementProjector.Build(
             new RecipeRequirement[] { new RecipeKnownRequirement { T = "RecipeKnown", Recipe = "MakeRoux" } },
             "Self", nav, resolver, NoStrings);
-        chips.Should().ContainSingle().Which.IsNavigable.Should().BeFalse();
+        rows.Should().ContainSingle().Which.Chip!.IsNavigable.Should().BeFalse();
     }
 }

--- a/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipeRequirementProjectorTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+/// <summary>
+/// Covers the requirement projection that closes the planner-punt ↔ Silmarillion-display
+/// blind spot: the gates <c>CrossSkillPlanner</c> deliberately does not pursue
+/// (<c>docs/planner-recipe-field-consumption.md</c>) must be visible here, or the
+/// user-asserted contract is unverifiable. Synthetic fixtures verify projection shape.
+/// </summary>
+public sealed class RecipeRequirementProjectorTests
+{
+    private static (IReferenceNavigator Nav, IEntityNameResolver Resolver) Deps(bool recipesTabbed = true)
+    {
+        var targets = recipesTabbed
+            ? new[] { (IReferenceKindTarget)new RecipeTarget() }
+            : Array.Empty<IReferenceKindTarget>();
+        return (new SilmarillionReferenceNavigator(targets), new InternalNameResolver());
+    }
+
+    /// <summary>Minimal Recipe-kind target so <c>navigator.CanOpen(Recipe)</c> is true.</summary>
+    private sealed class RecipeTarget : IReferenceKindTarget
+    {
+        public EntityKind Kind => EntityKind.Recipe;
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => true;
+    }
+
+    /// <summary>Resolver that echoes the internal name — chip display assertions only
+    /// care that the reference/navigability is wired, not the friendly string.</summary>
+    private sealed class InternalNameResolver : IEntityNameResolver
+    {
+        public string Resolve(EntityRef reference) => reference.InternalName;
+    }
+
+    [Fact]
+    public void EmptyOrNull_YieldsNoLinesOrChips()
+    {
+        var (nav, resolver) = Deps();
+        var (lines, chips) = RecipeRequirementProjector.Build(null, "Self", nav, resolver);
+        lines.Should().BeEmpty();
+        chips.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CyclicalAndUserAssertedGates_RenderAsReadableLines()
+    {
+        var (nav, resolver) = Deps();
+        var reqs = new RecipeRequirement[]
+        {
+            new FullMoonRecipeRequirement { T = "FullMoon" },
+            new MoonPhaseRecipeRequirement { T = "MoonPhase", MoonPhase = "WaningCrescent" },
+            new WeatherRequirement { T = "Weather", ClearSky = true },
+            new TimeOfDayRecipeRequirement { T = "TimeOfDay", MinHour = 20, MaxHour = 4 },
+            new PetCountRecipeRequirement { T = "PetCount", PetTypeTag = "CowPet", MinCount = 2, MaxCount = 2 },
+            new HasHandsRequirement { T = "HasHands" },
+            new IsLycanthropeRequirement { T = "IsLycanthrope" },
+            new HasGuildHallRequirement { T = "HasGuildHall" },
+        };
+
+        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "Self", nav, resolver);
+
+        chips.Should().BeEmpty();
+        lines.Should().Equal(
+            "Only during the full moon.",
+            "Only during the waning crescent moon.",
+            "Only when the sky is clear.",
+            "Only between 20:00 and 04:00 in-game time.",
+            "Requires 2 Cow Pet pets.",
+            "Requires hands (not available in animal form).",
+            "Werewolf characters only.",
+            "Requires a guild hall.");
+    }
+
+    [Fact]
+    public void RecipeKnown_AndCrossRecipeUsed_BecomeNavigableChips()
+    {
+        var (nav, resolver) = Deps();
+        var reqs = new RecipeRequirement[]
+        {
+            new RecipeKnownRequirement { T = "RecipeKnown", Recipe = "MakeRoux" },
+            new RecipeUsedRequirement { T = "RecipeUsed", Recipe = "OtherRecipe", MaxTimesUsed = 3 },
+        };
+
+        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "MakeStew", nav, resolver);
+
+        lines.Should().BeEmpty();
+        chips.Should().HaveCount(2);
+        chips[0].Reference!.Kind.Should().Be(EntityKind.Recipe);
+        chips.Should().OnlyContain(c => c.IsNavigable);
+    }
+
+    [Fact]
+    public void SelfReferentialRecipeUsed_IsACraftCapLine_NotADeadSelfChip()
+    {
+        var (nav, resolver) = Deps();
+        var reqs = new RecipeRequirement[]
+        {
+            new RecipeUsedRequirement { T = "RecipeUsed", Recipe = "WeatherWitchRitual", MaxTimesUsed = 4 },
+        };
+
+        var (lines, chips) = RecipeRequirementProjector.Build(reqs, "WeatherWitchRitual", nav, resolver);
+
+        chips.Should().BeEmpty();
+        lines.Should().ContainSingle().Which.Should().Be("Limited to 5 crafts per character.");
+    }
+
+    [Fact]
+    public void AlwaysFail_SaysItCanNeverBeCompleted()
+    {
+        var (nav, resolver) = Deps();
+        var (lines, _) = RecipeRequirementProjector.Build(
+            new RecipeRequirement[] { new AlwaysFailRequirement { T = "AlwaysFail" } }, "Self", nav, resolver);
+        lines.Should().ContainSingle().Which.Should().Contain("never be completed");
+    }
+
+    [Fact]
+    public void UnknownRequirement_DegradesGracefullyWithDiscriminator()
+    {
+        var (nav, resolver) = Deps();
+        var (lines, _) = RecipeRequirementProjector.Build(
+            new RecipeRequirement[] { new UnknownRecipeRequirement { T = "Brand_New", DiscriminatorValue = "Brand_New" } },
+            "Self", nav, resolver);
+        lines.Should().ContainSingle().Which.Should().Be("(unrecognised requirement: Brand_New)");
+    }
+
+    [Fact]
+    public void RecipeChips_DegradeToNonNavigable_WhenRecipesTabAbsent()
+    {
+        var (nav, resolver) = Deps(recipesTabbed: false);
+        var (_, chips) = RecipeRequirementProjector.Build(
+            new RecipeRequirement[] { new RecipeKnownRequirement { T = "RecipeKnown", Recipe = "MakeRoux" } },
+            "Self", nav, resolver);
+        chips.Should().ContainSingle().Which.IsNavigable.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Closes #342.

## Why

`docs/planner-recipe-field-consumption.md` records the `Recipe` fields `CrossSkillPlanner` deliberately doesn't act on — the user-asserted unlocks (`PetCount`, `HasHands`, …), time/RNG-cyclical gates (`Weather`, `MoonPhase`, …), the reset-timer, and `Costs`. That punt is justified by a *user-asserted contract*: the user is assumed to know the gate exists. But none of these were surfaced in Silmarillion either — so the knowledge had **no source anywhere**. That's the `MaxUses`-bug shape (planner ignores it, browser hides it, user is silently trapped), one layer up.

This makes #342 the **load-bearing complement** to the planner punt, not just Quest/StorageVault parity.

## What

- **New `RecipeRequirementProjector`** — projects all 19 `RecipeRequirement` subclasses. Mirrors `StorageVaultDetailViewModel`'s `(lines, chips)` split (the recipe set is tiny and homogeneous; Quest's intent-bucketing would be overkill). Plain readable lines for the cyclical/user-asserted gates; navigable Recipe chips for `RecipeKnown` / cross-recipe `RecipeUsed`; self-referential `RecipeUsed` → craft-cap line (no dead self-chip); `UnknownRecipeRequirement` degrades to a noise-filtered line.
- **`RecipeDetailViewModel`** gains `OtherRequirementLines`, `RecipeRequirementChips`, `CostLines`, `CooldownChip` (beside `MaxUsesChip`), `SharedCooldownNote` (referenced recipe resolved to display name). New ctor params are optional — additive.
- **`RecipeDetailView.xaml`** — new self-hiding "Requirements" / "Cost" sections + a reuse-cooldown chip.
- Currency names camel-split per the id→display-name convention (real recipe `Costs` use `FaeEnergy`/`CombatWisdom`/`GlamourCredits`/`GuildCredits`, never `Councils`/`Cera`).

## Real-data validation

Audited the bundled `recipes.json` rather than trusting synthetic fixtures. Confirmed every field shape and caught two things tests wouldn't: `EntitiesNear` carries a player-facing `ErrorMsg` (surfaced verbatim), and the real currency vocabulary (drove the camel-split fix). Prevalence matches the doc exactly: `OtherRequirements` ~90, `ResetTimeInSeconds` 51, `SharesResetTimerWith` 21, `Costs` 55.

## Docs

Recorded the **planner-punt ↔ Silmarillion-display lockstep rule** in both `planner-recipe-field-consumption.md` and `silmarillion-field-coverage.md`: a new planner-punted `RecipeRequirement` arm **must** also get a `RecipeRequirementProjector` arm, or it regresses this contract. #341 (`PrereqRecipe`) is correctly out of scope — the planner *consumes* it, so it's not a blind spot on this axis.

## Tests

28 new/extended (`RecipeRequirementProjectorTests` + `RecipeDetailViewModelTests`). Full Silmarillion suite **472/472 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
