### PR TITLE
feat(planning): opt-in LearnabilityPolicy for trainer/quest-gated recipes (#401)

### DIFF
--- a/docs/planner-recipe-field-consumption.md
+++ b/docs/planner-recipe-field-consumption.md
@@ -23,7 +23,7 @@ currency fields are not — see "Correctly ignored".
 
 | Field | How `CrossSkillPlanner` uses it |
 |---|---|
-| `Skill` + `SkillLevelReq` | `IsAvailable`: recipe ineligible until the gating skill ≥ req. |
+| `Skill` + `SkillLevelReq` | `IsAvailable`: recipe ineligible until the gating skill ≥ req. **Caveat:** once the gate is met, the planner *optimistically* treats the recipe as auto-learned (`SkillLevelReq > 0` ⇒ available). PG only auto-grants a minority of these — see "Learnability" below (#401). |
 | `PrereqRecipe` | `IsAvailable`: ineligible until the prereq recipe is in `completed`. |
 | `RewardSkill` / `RewardSkillXp` / `RewardSkillXpFirstTime` / drop-off | XP math (`LevelingMath`) — phase sizing + first-time-bonus ordering. |
 | `Ingredients` | `RecipeExpander` / `SourcingPolicy` — intermediate-reuse credit + sub-DAG pruning. |
@@ -48,6 +48,28 @@ recipe `InternalName`, so it cannot actually *express* most of these
 gates are rare, situational, and outside the planner's "skill grind path"
 remit. Do not file "increase coverage" issues against this list; if a future
 audit re-flags it, point here.
+
+## Learnability — `RecipeSources` (external, not a `Recipe` field) (#401)
+
+The `Recipe` model carries **no** "auto-learned on skill-up" flag. The only
+signal that separates an innate skill-up unlock from a trainer/quest-gated one
+lives in `sources_recipes.json` (`IReferenceDataService.RecipeSources` — the
+same index Silmarillion surfaces). As of v470, **~63% of `SkillLevelReq ≥ 1`
+recipes have a `Training` source** and 143 are `Quest`-gated, so the optimistic
+default schedules many recipes a fresh character can't actually craft yet.
+
+`LearnabilityPolicy` (`PlanInputs.cs`) is the opt-in fix:
+
+| Policy | Behavior |
+|---|---|
+| `AssumeAutoLearned` (**default**) | v1 behavior — any `SkillLevelReq > 0` recipe rides the auto-learn pass. No regression for existing callers. |
+| `RequireKnownForTrainerAndQuest` | A recipe with a `Training`/`Quest` `RecipeSource` no longer rides the pass — it must be `history.IsKnown` or `AssertedUnlocks`-asserted. Source-less skill-gated recipes still auto-learn. |
+
+Default stays optimistic deliberately: the user-facing surface to assert "I'll
+go train this" is #227. Strict mode is the engine half and becomes the sensible
+default once that surface ships. **Item-bestow learning**
+(`BestowRecipeIfNotKnown` item result-effects) is not in `sources_recipes` and
+is intentionally *not* treated as blocking — noted caveat, not an oversight.
 
 ## Correctly ignored — not planner-relevant
 
@@ -76,3 +98,6 @@ audit re-flags it, point here.
   prevalence and the kind taxonomy came from a full-corpus audit of bundled
   `recipes.json` (v470, 4427 recipes). Builds on the `MaxUses` fix (#396);
   `RecipeUsed` shares its `RemainingCraftBudget` path.
+- **2026-05-16** — Added `LearnabilityPolicy` (opt-in trainer/quest gating,
+  [#401](https://github.com/moumantai-gg/mithril/issues/401)). Engine companion
+  to the asserted-unlocks surface (#227); default behavior unchanged.

--- a/src/Mithril.Planning/CrossSkillPlanner.cs
+++ b/src/Mithril.Planning/CrossSkillPlanner.cs
@@ -48,10 +48,12 @@ public sealed class CrossSkillPlanner
         RecipeHistory history,
         IReadOnlyDictionary<string, int>? onHand = null,
         SourcingPolicy? sourcing = null,
-        AssertedUnlocks? asserted = null)
+        AssertedUnlocks? asserted = null,
+        LearnabilityPolicy? learnability = null)
     {
         sourcing ??= SourcingPolicy.CraftEverything;
         asserted ??= AssertedUnlocks.None;
+        learnability ??= LearnabilityPolicy.AssumeAutoLearned;
         onHand ??= new Dictionary<string, int>(StringComparer.Ordinal);
 
         var skill = target.Skill;
@@ -90,10 +92,12 @@ public sealed class CrossSkillPlanner
             {
                 if (history.CompletionCount(name) == 0) unusedBonuses.Add(r.Key);
             }
-            else if (asserted.IsAsserted(name) || r.SkillLevelReq > 0)
+            else if (asserted.IsAsserted(name) || AutoLearnableSkillGate(r, learnability))
             {
                 // Auto-considered: a skill-gated recipe's first craft still carries
-                // its one-shot bonus once we reach the gate.
+                // its one-shot bonus once we reach the gate — but only if it's
+                // actually schedulable under the learnability policy (a gated
+                // trainer/quest recipe we can't reach earns no phantom bonus).
                 unusedBonuses.Add(r.Key);
             }
         }
@@ -110,7 +114,7 @@ public sealed class CrossSkillPlanner
         // Seed: any skill-gated recipe already past its gate at the start level is
         // not an "unlock event" — only crossings *during* the plan are marked.
         foreach (var r in candidates)
-            if (IsAvailable(r, level, state, completed, history, asserted))
+            if (IsAvailable(r, level, state, completed, history, asserted, learnability))
                 unlockEmitted.Add(r.Key);
 
         var guard = 0;
@@ -121,17 +125,17 @@ public sealed class CrossSkillPlanner
                 xp -= xpForLevel;
                 level++;
                 if (level - 1 < xpAmounts.Count) xpForLevel = xpAmounts[level - 1];
-                EmitNewUnlocks(candidates, level, state, completed, history, asserted,
+                EmitNewUnlocks(candidates, level, state, completed, history, asserted, learnability,
                     unlockEmitted, unlocks, reuseCache);
                 continue;
             }
 
             var available = candidates
-                .Where(r => IsAvailable(r, level, state, completed, history, asserted))
+                .Where(r => IsAvailable(r, level, state, completed, history, asserted, learnability))
                 .Select(r =>
                 {
                     var baseXp = _math.EffectiveXpPerCraft(r, level);
-                    var reuse = IntermediateReuseXpPerCraft(r, level, state, completed, history, asserted, onHand, sourcing, reuseCache);
+                    var reuse = IntermediateReuseXpPerCraft(r, level, state, completed, history, asserted, learnability, onHand, sourcing, reuseCache);
                     return (recipe: r, baseXp, reuse, effXp: baseXp + reuse);
                 })
                 .Where(x => x.effXp > 0 || unusedBonuses.Contains(x.recipe.Key))
@@ -165,7 +169,7 @@ public sealed class CrossSkillPlanner
                     level++;
                     if (level - 1 < xpAmounts.Count) xpForLevel = xpAmounts[level - 1]; else break;
                 }
-                EmitNewUnlocks(candidates, level, state, completed, history, asserted,
+                EmitNewUnlocks(candidates, level, state, completed, history, asserted, learnability,
                     unlockEmitted, unlocks, reuseCache);
                 rawSteps.Add(new PlanPhase(0, bonus.recipe.Key, bonus.recipe.InternalName!,
                     bonus.recipe.Name ?? "", bonus.recipe.IconId, PredictedCrafts: 1,
@@ -200,7 +204,7 @@ public sealed class CrossSkillPlanner
                 level++;
                 if (level - 1 < xpAmounts.Count) xpForLevel = xpAmounts[level - 1]; else break;
             }
-            EmitNewUnlocks(candidates, level, state, completed, history, asserted,
+            EmitNewUnlocks(candidates, level, state, completed, history, asserted, learnability,
                 unlockEmitted, unlocks, reuseCache);
             rawSteps.Add(new PlanPhase(0, best.recipe.Key, best.recipe.InternalName!,
                 best.recipe.Name ?? "", best.recipe.IconId, PredictedCrafts: crafts,
@@ -248,11 +252,15 @@ public sealed class CrossSkillPlanner
     /// <summary>
     /// A recipe is grindable when its skill gate is met, its prereq is complete,
     /// and it's either known, user-asserted, or skill-gated (skill-source unlocks
-    /// are auto-considered — that's the planner's job vs. Elrond's sim).
+    /// are auto-considered — that's the planner's job vs. Elrond's sim). Under a
+    /// strict <paramref name="learnability"/> policy a skill-gated recipe that the
+    /// game actually trains/quest-gates (per <see cref="IReferenceDataService.RecipeSources"/>)
+    /// no longer rides the auto-learn pass — it must be known or asserted (#401).
     /// </summary>
     private bool IsAvailable(
         Recipe recipe, int targetSkillLevel, SkillState state,
-        ISet<string> completed, RecipeHistory history, AssertedUnlocks asserted)
+        ISet<string> completed, RecipeHistory history, AssertedUnlocks asserted,
+        LearnabilityPolicy learnability)
     {
         var name = recipe.InternalName ?? "";
         var gatingSkill = string.IsNullOrEmpty(recipe.Skill) ? null : recipe.Skill;
@@ -284,12 +292,46 @@ public sealed class CrossSkillPlanner
             }
         }
 
-        return history.IsKnown(name) || asserted.IsAsserted(name) || recipe.SkillLevelReq > 0;
+        return history.IsKnown(name) || asserted.IsAsserted(name)
+            || AutoLearnableSkillGate(recipe, learnability);
+    }
+
+    /// <summary>
+    /// True when a recipe's skill gate alone is enough to consider it learnable.
+    /// Optimistically that's any <c>SkillLevelReq &gt; 0</c>; under a strict
+    /// <see cref="LearnabilityPolicy"/> a recipe the game trains/quest-gates
+    /// (a <c>Training</c>/<c>Quest</c> <see cref="RecipeSource"/>) is excluded —
+    /// it has to be explicitly known or asserted instead (#401). Recipes with no
+    /// such source keep the auto-learn pass (genuine skill-up unlocks).
+    /// </summary>
+    private bool AutoLearnableSkillGate(Recipe recipe, LearnabilityPolicy learnability)
+    {
+        if (recipe.SkillLevelReq <= 0) return false;
+        if (!learnability.GateTrainerAndQuest) return true;
+        return !HasBlockingSource(recipe.InternalName ?? "");
+    }
+
+    /// <summary>
+    /// Does the game gate this recipe behind a trainer or a quest? Read from
+    /// <see cref="IReferenceDataService.RecipeSources"/> (the same index
+    /// Silmarillion surfaces). Item-bestow learning lives in item result-effects,
+    /// not <c>sources_recipes</c>, so it is intentionally not treated as blocking.
+    /// </summary>
+    private bool HasBlockingSource(string recipeInternalName)
+    {
+        if (string.IsNullOrEmpty(recipeInternalName)) return false;
+        if (!_ref.RecipeSources.TryGetValue(recipeInternalName, out var sources)) return false;
+        foreach (var s in sources)
+            if (string.Equals(s.Type, "Training", StringComparison.Ordinal)
+                || string.Equals(s.Type, "Quest", StringComparison.Ordinal))
+                return true;
+        return false;
     }
 
     private void EmitNewUnlocks(
         IReadOnlyList<Recipe> candidates, int level, SkillState state,
         ISet<string> completed, RecipeHistory history, AssertedUnlocks asserted,
+        LearnabilityPolicy learnability,
         ISet<string> unlockEmitted, List<SkillSourceUnlock> unlocks,
         Dictionary<(string, int), int> reuseCache)
     {
@@ -297,7 +339,7 @@ public sealed class CrossSkillPlanner
         {
             if (unlockEmitted.Contains(r.Key)) continue;
             if (r.SkillLevelReq <= 0) continue; // only skill-source unlocks are auto-marked
-            if (!IsAvailable(r, level, state, completed, history, asserted)) continue;
+            if (!IsAvailable(r, level, state, completed, history, asserted, learnability)) continue;
 
             unlockEmitted.Add(r.Key);
             unlocks.Add(new SkillSourceUnlock(
@@ -319,7 +361,7 @@ public sealed class CrossSkillPlanner
     /// </summary>
     private int IntermediateReuseXpPerCraft(
         Recipe recipe, int level, SkillState state, ISet<string> completed,
-        RecipeHistory history, AssertedUnlocks asserted,
+        RecipeHistory history, AssertedUnlocks asserted, LearnabilityPolicy learnability,
         IReadOnlyDictionary<string, int> onHand, SourcingPolicy sourcing,
         Dictionary<(string, int), int> cache)
     {
@@ -349,7 +391,7 @@ public sealed class CrossSkillPlanner
             if (qty <= 0) continue;
             if (!_expander.Producers.TryGetDefault(itemName, out var sub)) continue;
             if (!string.Equals(sub.RewardSkill, recipe.RewardSkill, StringComparison.Ordinal)) continue;
-            if (!IsAvailable(sub, level, state, completed, history, asserted)) continue;
+            if (!IsAvailable(sub, level, state, completed, history, asserted, learnability)) continue;
 
             var stack = Math.Max(1, _expander.OutputStackSize(sub, itemName));
             var subBatches = (int)Math.Ceiling(qty / stack);

--- a/src/Mithril.Planning/PlanInputs.cs
+++ b/src/Mithril.Planning/PlanInputs.cs
@@ -66,3 +66,34 @@ public sealed class AssertedUnlocks
     public bool IsAsserted(string recipeInternalName)
         => !string.IsNullOrEmpty(recipeInternalName) && _recipes.Contains(recipeInternalName);
 }
+
+/// <summary>
+/// Whether the planner trusts a skill-gated recipe to be auto-learned the moment
+/// its level gate is crossed. Most Project Gorgon leveling recipes are *not*
+/// auto-granted — they're trained at an NPC or unlocked by a quest (~63% of the
+/// skill-gated corpus as of v470). See #401.
+///
+/// <para><see cref="AssumeAutoLearned"/> is the v1 behavior and the default, so
+/// existing callers don't regress. <see cref="RequireKnownForTrainerAndQuest"/>
+/// makes a recipe carrying a <c>Training</c>/<c>Quest</c>
+/// <see cref="Mithril.Shared.Reference.RecipeSource"/> pass *only* when it's
+/// already known or user-asserted — it becomes the meaningful default once the
+/// assertion surface (#227) ships. Item-bestow learning isn't in
+/// <c>sources_recipes</c> and is deliberately not gated here.</para>
+/// </summary>
+public sealed class LearnabilityPolicy
+{
+    private LearnabilityPolicy(bool gateTrainerAndQuest) => GateTrainerAndQuest = gateTrainerAndQuest;
+
+    /// <summary>v1 / default: any <c>SkillLevelReq &gt; 0</c> recipe is assumed
+    /// learnable at its gate, regardless of how the game actually grants it.</summary>
+    public static LearnabilityPolicy AssumeAutoLearned { get; } = new(false);
+
+    /// <summary>Trainer/quest-gated recipes must be known or asserted; only
+    /// genuinely source-less skill-gated recipes keep the auto-learn free pass.</summary>
+    public static LearnabilityPolicy RequireKnownForTrainerAndQuest { get; } = new(true);
+
+    /// <summary>When true, a recipe with a <c>Training</c>/<c>Quest</c> source
+    /// does not satisfy availability on its skill gate alone.</summary>
+    public bool GateTrainerAndQuest { get; }
+}

--- a/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
+++ b/tests/Mithril.Planning.Tests/CrossSkillPlannerTests.cs
@@ -311,6 +311,69 @@ public class CrossSkillPlannerTests
             because: "the RecipeKnown gate is satisfied once Augury1 is known");
     }
 
+    // ── Learnability policy (trainer/quest gating, #401) ─────────────────
+
+    [Fact]
+    public void TrainerGatedRecipe_DefaultPolicy_StillAutoLearned_NoRegression()
+    {
+        // A skill-gated recipe the game trains at an NPC. Under the default
+        // (optimistic) policy the planner still assumes it's learned at the gate.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Blade")
+            .AddRecipe("ForgeBlade", Skill, xp: 50, skillLevelReq: 1, produces: (1, 1))
+            .AddRecipeSource("ForgeBlade", "Training", npc: "NPC_Smith");
+
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 3), State(1), RecipeHistory.Empty)!;
+
+        plan.Phases.Should().ContainSingle().Which.RecipeInternalName.Should().Be("ForgeBlade",
+            because: "default LearnabilityPolicy keeps the v1 auto-learn behavior");
+    }
+
+    [Fact]
+    public void TrainerOrQuestGatedRecipe_StrictPolicy_GatedUnlessKnownOrAsserted()
+    {
+        FakeRef Data() => new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Blade").AddItem(2, "Charmstone")
+            .AddRecipe("ForgeBlade", Skill, xp: 50, skillLevelReq: 1, produces: (1, 1))
+            .AddRecipeSource("ForgeBlade", "Training", npc: "NPC_Smith")
+            .AddRecipe("CutCharmstone", Skill, xp: 50, skillLevelReq: 1, produces: (2, 1))
+            .AddRecipeSource("CutCharmstone", "Quest");
+
+        var strict = LearnabilityPolicy.RequireKnownForTrainerAndQuest;
+
+        // Unknown + unasserted ⇒ both gated out ⇒ no viable path.
+        Planner(Data()).Plan(new SkillTarget(Skill, 3), State(1), RecipeHistory.Empty,
+            learnability: strict).Should().BeNull(
+            because: "strict policy refuses to assume trainer/quest recipes are auto-learned");
+
+        // Asserted ⇒ the escape hatch reinstates it.
+        var asserted = Planner(Data()).Plan(new SkillTarget(Skill, 3), State(1), RecipeHistory.Empty,
+            asserted: new AssertedUnlocks(["ForgeBlade"]), learnability: strict)!;
+        asserted.Phases.Should().OnlyContain(p => p.RecipeInternalName == "ForgeBlade");
+
+        // Already known ⇒ also fine.
+        var known = Planner(Data()).Plan(new SkillTarget(Skill, 3), State(1),
+            new RecipeHistory(new Dictionary<string, int> { ["CutCharmstone"] = 1 }),
+            learnability: strict)!;
+        known.Phases.Should().Contain(p => p.RecipeInternalName == "CutCharmstone");
+    }
+
+    [Fact]
+    public void SourcelessSkillGatedRecipe_StrictPolicy_StillAutoLearned()
+    {
+        // No Training/Quest source ⇒ a genuine skill-up unlock; even strict
+        // policy keeps the auto-learn pass for it.
+        var data = new FakeRef().AddSkill(Skill).AddXpTable(100)
+            .AddItem(1, "Ingot")
+            .AddRecipe("SmeltIngot", Skill, xp: 50, skillLevelReq: 1, produces: (1, 1));
+
+        var plan = Planner(data).Plan(new SkillTarget(Skill, 3), State(1), RecipeHistory.Empty,
+            learnability: LearnabilityPolicy.RequireKnownForTrainerAndQuest)!;
+
+        plan.Phases.Should().ContainSingle().Which.RecipeInternalName.Should().Be("SmeltIngot",
+            because: "source-less skill-gated recipes are genuine auto-learns");
+    }
+
     // ── Minimal IReferenceDataService fake ───────────────────────────────
 
     private sealed class FakeRef : IReferenceDataService
@@ -321,6 +384,7 @@ public class CrossSkillPlannerTests
         private readonly Dictionary<string, Recipe> _recipesByName = new(StringComparer.Ordinal);
         private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
         private readonly Dictionary<string, XpTableEntry> _xp = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, IReadOnlyList<RecipeSource>> _recipeSources = new(StringComparer.Ordinal);
         private int _serial;
 
         public FakeRef AddSkill(string key, string xpTable = "T")
@@ -372,6 +436,15 @@ public class CrossSkillPlannerTests
             return this;
         }
 
+        public FakeRef AddRecipeSource(string recipeInternalName, string type, string? npc = null)
+        {
+            if (_recipeSources.TryGetValue(recipeInternalName, out var existing))
+                ((List<RecipeSource>)existing).Add(new RecipeSource(type, npc, null));
+            else
+                _recipeSources[recipeInternalName] = new List<RecipeSource> { new(type, npc, null) };
+            return this;
+        }
+
         public IReadOnlyList<string> Keys { get; } = ["skills", "xptables", "recipes", "items"];
         public IReadOnlyDictionary<long, Item> Items => _items;
         public IReadOnlyDictionary<string, Item> ItemsByInternalName => _itemsByName;
@@ -383,6 +456,7 @@ public class CrossSkillPlannerTests
         public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
         public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
         public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, IReadOnlyList<RecipeSource>> RecipeSources => _recipeSources;
         public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
         public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();


### PR DESCRIPTION
Closes #401.

## Problem

`CrossSkillPlanner.IsAvailable` treated **any** `SkillLevelReq > 0` recipe as auto-learned the instant the level gate is crossed. The `Recipe` model has no auto-learn flag — the trainer/quest/innate distinction only exists in `sources_recipes.json`. Per PG v470, **~63% of skill-gated recipes have a `Training` source** and 143 are `Quest`-gated, so the planner could schedule recipes a fresh character has no way to craft, producing non-executable plans.

## Change

New `LearnabilityPolicy` plan input, mirroring the existing optional-input shape (`SourcingPolicy`, `AssertedUnlocks`):

| Policy | Behavior |
|---|---|
| `AssumeAutoLearned` (**default**) | v1 behavior — any `SkillLevelReq > 0` recipe rides the auto-learn pass. **No regression**, existing tests untouched. |
| `RequireKnownForTrainerAndQuest` | A recipe with a `Training`/`Quest` `RecipeSource` no longer rides the pass — must be `history.IsKnown` or `AssertedUnlocks`-asserted. Source-less skill-gated recipes still auto-learn. |

Threaded through `IsAvailable`, `EmitNewUnlocks`, the depth-1 reuse-credit path, **and** the first-time-bonus seeding (so availability and bonus accounting can't desync). Blocking-source lookup reads `IReferenceDataService.RecipeSources` — already held by the planner, no new plumbing.

## Scope / caveats

- Opt-in by design: the user-facing surface to assert "I'll train this" is #227. This is the **engine half**; strict mode becomes the sensible default once that surface ships.
- **Item-bestow learning** (`BestowRecipeIfNotKnown` item result-effects) isn't in `sources_recipes` and is intentionally **not** treated as blocking — documented caveat.

## Verification

- `dotnet test tests/Mithril.Planning.Tests` → **23/23 green** (20 existing unchanged + 3 new: default-still-scheduled, strict-gated-unless-known/asserted, source-less-still-auto-learned).
- `dotnet build Mithril.slnx` → **0 warnings, 0 errors** (warnings-as-errors).
- `docs/planner-recipe-field-consumption.md` gains a Learnability section + history entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
