### PR TITLE
fix(silmarillion): resolve QuestDetailProjector PetTypeTag via strings_all, not CamelCase-split (closes #405)

### DIFF
--- a/src/Silmarillion.Module/ViewModels/QuestDetailProjector.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestDetailProjector.cs
@@ -313,11 +313,17 @@ public static class QuestDetailProjector
 
             case PetCountRequirement p:
                 {
-                    var kind = SplitCamelCase(p.PetTypeTag);
+                    var kind = ResolvePetKind(p.PetTypeTag, refData);
+                    // Append "pet"/"pets" only when the resolved name isn't already a pet
+                    // noun, killing the "… Cow Pet pets" redundancy (recipe-side shape).
+                    var kindIsPetNoun =
+                        kind.EndsWith("pet", StringComparison.OrdinalIgnoreCase)
+                        || kind.EndsWith("pets", StringComparison.OrdinalIgnoreCase);
+                    string Noun(int n) => kindIsPetNoun ? kind : $"{kind} pet{(n == 1 ? "" : "s")}";
                     if (p.MinCount is { } mn && p.MaxCount is { } mx && mn != mx)
-                        return new QuestRequirementDisplay($"Owns {mn}–{mx} {kind} pets", null, false);
+                        return new QuestRequirementDisplay($"Owns {mn}–{mx} {Noun(mx)}", null, false);
                     var n = p.MinCount ?? p.MaxCount ?? 1;
-                    return new QuestRequirementDisplay($"Owns {n} {kind} pet{(n == 1 ? "" : "s")}", null, false);
+                    return new QuestRequirementDisplay($"Owns {n} {Noun(n)}", null, false);
                 }
 
             case OrRequirement or:
@@ -711,6 +717,44 @@ public static class QuestDetailProjector
             IsNavigable: navigator.CanOpen(reference),
             Prefix: prefix,
             ChipName: name);
+    }
+
+    /// <summary>
+    /// Resolve a <c>PetTypeTag</c> to its real in-game display name. PG models pet/summon
+    /// types as NPC/monster entities, so the name lives in <c>strings_all</c> under
+    /// <c>npc_&lt;tag&gt;_Name</c> ("SummonedBakingBread" → "Rising Dough"). These tags are
+    /// <em>not</em> in <c>npcs.json</c>, so <see cref="IEntityNameResolver"/>'s NPC path
+    /// can't reach them — consult <see cref="IReferenceDataService.Strings"/> directly (the
+    /// id→display-name convention; mirrors <c>RecipeRequirementProjector.DescribePetCount</c>
+    /// / PR #400). <see cref="SplitCamelCase"/> is the fallback when the key is absent.
+    /// <para>
+    /// <b>Per-tag audit — issue #405.</b> Only <c>PetTypeTag</c> resolves through
+    /// <c>strings_all</c>. Every other quest requirement tag that still falls back to
+    /// <see cref="SplitCamelCase"/> was checked against the bundled string table and has
+    /// <em>no</em> reliable, non-coincidental key — speculatively resolving them risks a
+    /// coincidental wrong label (the recipe-side rationale this mirrors):
+    /// <list type="bullet">
+    ///   <item><description><c>AppearanceRequirement.Appearance</c> ("Rabbit"): no
+    ///   <c>npc_Rabbit_Name</c> / <c>appearance_*</c> key exists; resolving via the rabbit
+    ///   monster would mislabel a player morph. Stays CamelCase-split.</description></item>
+    ///   <item><description><c>RaceRequirement</c> ("Fae"), <c>OtherHasTypeTagRequirement</c>
+    ///   ("Sentient"), <c>EquipmentSlotEmptyRequirement.Slot</c> ("Head"/"Chest"/…),
+    ///   <c>MoonPhaseRequirement</c>, <c>AreaEvent*Requirement</c>,
+    ///   <c>EquippedItemKeywordRequirement</c>, <c>HangOutCompletedRequirement</c>: no
+    ///   string-table key pattern; the CamelCase split already reads cleanly.</description></item>
+    /// </list>
+    /// (<c>HasEffectKeywordRequirement</c> is separately chip-anchored on
+    /// <see cref="EntityRef.EffectKeyword"/>; abilities get the future Abilities-tab
+    /// resolver.) Do not broaden this without repeating the audit.
+    /// </para>
+    /// </summary>
+    private static string ResolvePetKind(string? petTypeTag, IReferenceDataService refData)
+    {
+        if (string.IsNullOrEmpty(petTypeTag)) return "pet";
+        return refData.Strings.TryGetValue($"npc_{petTypeTag}_Name", out var resolved)
+               && !string.IsNullOrEmpty(resolved)
+            ? resolved!
+            : SplitCamelCase(petTypeTag);
     }
 
     /// <summary>

--- a/tests/Silmarillion.Tests/ViewModels/QuestDetailProjectorTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestDetailProjectorTests.cs
@@ -315,6 +315,74 @@ public sealed class QuestDetailProjectorTests
         groups[1].Label.Should().Be("Internal flags");
     }
 
+    [Fact]
+    public void PetCount_BucketedAsPets_ResolvesPetTypeTagThroughStringsAll_NotCamelSplit()
+    {
+        // Sibling of RecipeRequirementProjectorTests.PetTypeTag_ResolvesThroughStringsAll_NotCamelSplit.
+        // PG models pet/summon types as NPC entities → real name lives in strings_all under
+        // npc_<tag>_Name. "SummonedBakingBread" must read "Rising Dough", not the invented
+        // CamelCase split "Summoned Baking Bread".
+        var refData = new StubRefData();
+        refData.StringsMap["npc_SummonedBakingBread_Name"] = "Rising Dough";
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+
+        var groups = QuestDetailProjector.BuildRequirementGroups(
+            new QuestRequirement[]
+            {
+                new PetCountRequirement { T = "PetCount", PetTypeTag = "SummonedBakingBread", MaxCount = 4 },
+            },
+            refData, resolver, nav);
+
+        groups.Should().ContainSingle(g => g.Label == "Pets")
+            .Which.Requirements.Single().Text.Should().Be("Owns 4 Rising Dough pets");
+    }
+
+    [Fact]
+    public void PetCount_FallsBackToCamelSplit_WhenStringsAllKeyAbsent_AndDedupesPetNoun()
+    {
+        // No npc_<tag>_Name entry ⇒ CamelCase split (the fallback). A tag that already ends
+        // in a pet noun ("CowPet") must not double up into "Cow Pet pets" — same suffix
+        // dedup the recipe projector does.
+        var refData = new StubRefData();
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+
+        var groups = QuestDetailProjector.BuildRequirementGroups(
+            new QuestRequirement[]
+            {
+                new PetCountRequirement { T = "PetCount", PetTypeTag = "WolfPup", MinCount = 1 },
+                new PetCountRequirement { T = "PetCount", PetTypeTag = "CowPet", MinCount = 2, MaxCount = 3 },
+            },
+            refData, resolver, nav);
+
+        var reqs = groups.Should().ContainSingle(g => g.Label == "Pets").Which.Requirements;
+        reqs.Should().HaveCount(2);
+        reqs[0].Text.Should().Be("Owns 1 Wolf Pup pet");      // CamelCase split + singular noun appended
+        reqs[1].Text.Should().Be("Owns 2–3 Cow Pet");         // tag is already a pet-noun ⇒ no "pets" suffix
+    }
+
+    [Fact]
+    public void Appearance_StaysCamelSplit_DeliberatelyNotResolvedViaStringsAll()
+    {
+        // Audit guard (issue #405): the per-tag audit found AppearanceRequirement.Appearance
+        // has no reliable strings_all key. Even when a *coincidental* npc_<tag>_Name exists
+        // (the rabbit monster), the projector must NOT resolve through it — that would
+        // mislabel a player morph. Locks the scope-discipline decision so it isn't
+        // re-litigated by a future "make it consistent with PetTypeTag" change.
+        var refData = new StubRefData();
+        refData.StringsMap["npc_Rabbit_Name"] = "Rabbit (monster — wrong label)";
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var resolver = new ReferenceDataEntityNameResolver(refData);
+
+        var groups = QuestDetailProjector.BuildRequirementGroups(
+            new QuestRequirement[] { new AppearanceRequirement { T = "Appearance", Appearance = "Rabbit" } },
+            refData, resolver, nav);
+
+        groups.Should().ContainSingle(g => g.Label == "Identity / state")
+            .Which.Requirements.Single().Text.Should().Be("Appearance: Rabbit");
+    }
+
     // ─── Rewards ───────────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -620,6 +688,7 @@ public sealed class QuestDetailProjectorTests
         public Dictionary<string, Quest> QuestsByInternalNameMap { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, SkillEntry> Skills { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, AreaEntry> AreasMap { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, string> StringsMap { get; } = new(StringComparer.Ordinal);
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
@@ -638,7 +707,7 @@ public sealed class QuestDetailProjectorTests
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
         public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
         public IReadOnlyDictionary<string, Quest> QuestsByInternalName => QuestsByInternalNameMap;
-        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+        public IReadOnlyDictionary<string, string> Strings => StringsMap;
 
         public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
         public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;


### PR DESCRIPTION
Closes #405. Sibling of the recipe-side fix in PR #400 — same root cause (id→display-name convention violation), different projector.

## What

`QuestDetailProjector`'s `PetCountRequirement` arm CamelCase-split the raw `PetTypeTag` ("SummonedBakingBread" → "Summoned Baking Bread") instead of resolving the real in-game name. PG models pet/summon types as NPC entities, so the name lives in `strings_all` under `npc_<tag>_Name` ("SummonedBakingBread" → **"Rising Dough"**). These tags aren't in `npcs.json`, so `IEntityNameResolver`'s NPC path can't reach them — the projector now consults `IReferenceDataService.Strings` directly, falling back to `SplitCamelCase` when the key is absent. The recipe-side `"pet"/"pets"` suffix dedup is carried over so a resolved pet-noun name doesn't double up. No signature change (`refData` was already a parameter).

## Per-tag audit (issue's scope-discipline requirement)

Audited every quest-side requirement tag that falls back to `SplitCamelCase` against the bundled string table. **Only `PetTypeTag` resolves.** Recorded in the `ResolvePetKind` doc comment:

| Tag | Sample value | `strings_all` key? | Decision |
|---|---|---|---|
| `PetTypeTag` | SummonedBakingBread | `npc_<tag>_Name` ✓ | **Resolve** |
| `Appearance` | Rabbit | `npc_Rabbit_Name` / `appearance_*` — **none** | CamelCase (resolving = coincidental mislabel) |
| `Race` | Fae | none | CamelCase |
| `OtherHasTypeTag` | Sentient | none | CamelCase |
| `EquipmentSlotEmpty.Slot` | Head/Chest/… | none | CamelCase (already clean) |
| `MoonPhase` / `AreaEvent` / `EquippedItemKeyword` / `HangOut` | — | none | CamelCase |

The issue flagged `Appearance` as the most likely additional candidate — **disproven**: no `npc_Rabbit_Name` / `appearance_*` key exists.

## Tests (`tests/Silmarillion.Tests`)

Mirror the recipe-side tests:
- `PetCount_BucketedAsPets_ResolvesPetTypeTagThroughStringsAll_NotCamelSplit`
- `PetCount_FallsBackToCamelSplit_WhenStringsAllKeyAbsent_AndDedupesPetNoun`
- `Appearance_StaysCamelSplit_DeliberatelyNotResolvedViaStringsAll` — audit guard: even with a coincidental `npc_Rabbit_Name` present, `Appearance` must not resolve through it.

`dotnet test tests/Silmarillion.Tests` → **478 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
