### PR TITLE
feat(silmarillion): #404 Phase 4 — shared WPF grammar primitives (dispatch + implementation)

### DIFF
--- a/docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md
+++ b/docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md
@@ -1,0 +1,120 @@
+# Silmarillion #404 — Phase 4 dispatch (encode the grammar as shared WPF primitives)
+
+**Tracked in:** #404
+
+> **For the engineering session.** Phases 0–3 and gates G1/G2/G3 are **closed and
+> authoritative**. This is the Phase 4 *engineering* dispatch: turn the ratified
+> visual grammar into shared, named `Mithril.Shared.Wpf` primitives — **no view
+> is migrated in this phase** (that is Phase 5). Phase 4 is not a design or
+> maintainer gate; it is reviewed as a normal PR. The ratified visual targets
+> are **not yours to change** — re-deciding them reproduces the debt #404 exists
+> to pay down.
+
+## Where this sits
+
+G1 (tiers) → Phase 1 (Recipe pilot) → Phase 2 (nine-view sweep) → G2 → Phase 3
+(designer) → **G3 ✅ CLEARED**. The ratified grammar is on `main` at
+[`docs/silmarillion-visual-grammar.md`](../silmarillion-visual-grammar.md) with
+**four binding Phase-4 carry-forwards**. This dispatch produces the primitives;
+**Phase 5** (call-site migration, one detail view per PR, each gated by G4
+maintainer review) and **Phase 6** (conformance guardrail) are separate
+dispatches. Coverage axis (#407, #408) is out of scope.
+
+## Read first (authoritative, in order)
+
+1. [`docs/silmarillion-visual-grammar.md`](../silmarillion-visual-grammar.md) —
+   the G3-ratified grammar (Claude Design's verbatim text) **and** its
+   "Phase-4 carry-forward" section (4 pins — binding).
+2. [`docs/agent-plans/2026-05-16-silmarillion-404-visual-grammar.md`](2026-05-16-silmarillion-404-visual-grammar.md) — the program plan (Phase 4 = "encode the standard as a shared primitive").
+3. Issue #404, the **"G1 — CLEARED"**, **"G2 — CLEARED"** (`4468464536`), and
+   **"G3 — CLEARED"** (`4468731461`) comments — principles P1/P2, the
+   availability corollary, the ratified findings.
+4. The specimen harness (`explorations/phase-3-visual-grammar.html` in the
+   design-system bundle) — the visual source of truth for pixel parity. It is
+   **not** in this repo; treat it as reference, not a file to maintain.
+
+## Deliverable
+
+Shared, named primitives in `Mithril.Shared.Wpf` (with a default style in
+`Resources.xaml`), **one per tier**, plus their unit tests and harness parity.
+**No detail view edited.** Call sites express *which tier*, never raw pixels.
+
+| Primitive | Tier | Encodes |
+|---|---|---|
+| `<mithril:Link/>` | Link | V2: 12px **lead** Lucide glyph + gold (`--accent`) name, **no box, no surface at rest**. **Subsumes `EntityChip` and `ItemSourceChip`** (carry-forward — one primitive, not a fork). Optional bits: provenance suffix (italic `--fg-quaternary`), kind label, **degrade flag**. Degrade (G-c, both directions): rest **identical** to shipped (zero schedule-leak); hover swaps nav-tint → neutral tint + trailing `⧉`; click copies canonical name + toast. Type-coded glyph table is in the grammar doc. |
+| `<mithril:SetRef/>` | Set-reference | Carry-forward #4: **one shape-flexible** primitive — *summary-form* (`Crystal · 150 →`, count+arrow optional) **and** *tag-form* (bare keyword chip, no count/arrow/glyph). Blue `--info` chip, `--radius-sm`. **Availability corollary:** an unwired tag-form Set-ref still renders blue Set-ref — **never** the inert grey Fact pill (today's StorageVault keyword tags are that forbidden degrade). |
+| `<mithril:FactTable/>` | Fact | Carry-forward #3: **one polymorphic** Fact-group — horizontal dot-strip ↔ vertical 2-col grid ↔ **single flat scalar** (`16 slots`), one layout-switchable primitive, not a fork. `Capacity` is polymorphic (table/flat/range/event-gated); decide which shapes it renders vs. plain Fact body lines. Fact-**inert**; **no gold** on values (G-b). |
+| `<mithril:FactFooter/>` | Fact | G-a: footer ID strip **below a `--border-faint` divider** (location-not-chassis), no surface at rest. 0/1/2 identifiers (hidden/single/dot-separated). `KEY` (cross-entity ref / InternalName/title) copyable — hover-revealed 11px `copy` glyph + toast; `ROW` (EnvelopeKey-style) **inert** (`cursor:default`, no hover, no glyph). |
+| Fact-title / stat / body | Fact | Likely shared **styles**, not controls: title = Cambria 18pt 600 `--accent` (the only gold-text-without-glyph); stat/body/meta per the weight axis. No box, no surface. |
+| Structure | Structure | Shared **style**: `--fg-tertiary`/`--fg-quaternary`, tracked uppercase (0.08em), 9–9.5pt, **never gold, no glyph**. Section-label vs inline-prefix variants. Lowest stakes. |
+| Control | Control | Already the only tiered chassis in the system — confirm tokens align with the grammar; **no new primitive expected**, just reconcile the shared style. |
+
+## Token reconciliation (a real, explicit step — do not skip)
+
+The grammar is written in design-system tokens (`--accent #D4A847`,
+`--info #88B0E0`, `--fg-primary/secondary/tertiary/quaternary`, `--bg-surface`,
+`--border-faint/subtle/strong`, `--radius-sm/md`). Phase 4 must map each to the
+actual `Mithril.Shared.Wpf/Resources.xaml` brush/resource keys, **adding the
+missing ones** (e.g. an explicit `--info` blue and the `--fg-quaternary` ramp
+step likely do not exist yet). The design tokens are the source of truth; the
+WPF resource set is reconciled to them, not vice-versa. List every added/renamed
+resource key in the PR description.
+
+## Binding constraints (from G2/G3 — not re-openable)
+
+- Link = V2; **V5 rejected**; never V1 (always a lead glyph) or V3 (no dotted
+  underline). Fact reads **inert**; Set-reference is **blue, not gold**, and
+  non-confusable with Link; Structure never gold. P2: weight ⊥ tier.
+- The **four carry-forwards are binding**, not advisory: one Link subsuming
+  both legacy chips; one polymorphic FactTable incl. flat scalar; one
+  shape-flexible SetRef incl. unwired-tag availability; `×N` quantity is
+  adjacent Fact (never inside Link); `TSysCraftedEquipment` Effects-stub
+  placement is **deferred to #214** — do not implement it here.
+
+## Mithril-specific landmines (verify, don't rediscover)
+
+- A new shared lib/type must be reachable: confirm `Mithril.Shell` (and any
+  non-project-ref'd module) resolves the primitives — non-ProjectReference'd
+  modules don't get shared-lib deps staged (boot stalls look like a hang).
+- `NullToVis` vs `NullOrEmptyToVis`: the latter is **string-only** (`value as
+  string`) and silently collapses object/record bindings — bitten repeatedly.
+- Bound collection mutations on the UI thread only; `ObservableCollection<T>`
+  for bound add/remove; `<Run Text="{Binding…}">` needs explicit
+  `Mode=OneWay`; explicit `ContentTemplate` instantiates even for null content.
+- "Tests green ≠ shipped": a stale module DLL can survive a rebuild when
+  Mithril/VS holds a file lock (`MSB3026/27`), and the installed single-instance
+  mutex can mask a worktree build. **Acceptance includes launching the shell,
+  watching `boot.log` advance past module load, and eyeballing the primitives
+  in the harness parity view** — not just `dotnet test`.
+- `RG1000 'same key … *.baml'` on `dotnet build Mithril.slnx` is a known
+  stale-obj/parallel flake — confirm via isolated build, don't reflexively
+  `dotnet clean`.
+
+## Acceptance
+
+- Primitives + default styles in `Mithril.Shared.Wpf`; **no `*DetailView.xaml`
+  changed** (a guard test asserting detail views still bind the legacy controls
+  until Phase 5 is acceptable and encouraged).
+- `dotnet build Mithril.slnx` clean (warnings-as-errors); `dotnet test
+  tests/Silmarillion.Tests` and the `Mithril.Shared.Wpf` tests green.
+- Harness-parity check: each primitive matches the ratified specimen at the
+  documented tokens; degrade/availability states demonstrated.
+- Live-shell smoke per the landmine above.
+- PR lists every reconciled/added design-token → WPF resource key.
+
+## Anti-goals (violating these reproduces the debt)
+
+1. **Do not migrate any detail view.** Primitive + tests + harness only.
+2. **Do not change a ratified visual target.** G3 is the designer's; settled.
+3. **Do not fork.** One primitive per tier — the entire point. Two controls
+   doing one tier's job is the exact debt (`EntityChip`/`ItemSourceChip`).
+4. **Do not improvise a carry-forward cell** — they are decided in the doc.
+5. **Do not touch the coverage axis** (#407/#408) or implement the #214-bound
+   Effects-stub placement.
+
+## Pointers
+
+- Primitives + legacy: `src/Mithril.Shared.Wpf/` (`EntityChip`,
+  `ItemSourceChip`, `DetailExportHost`, `Resources.xaml`).
+- Ratified target: [`docs/silmarillion-visual-grammar.md`](../silmarillion-visual-grammar.md) (+ its Phase-4 carry-forward).
+- Phase 3 provenance: [`2026-05-17-silmarillion-404-phase3-design.md`](2026-05-17-silmarillion-404-phase3-design.md) (EXECUTED).

--- a/docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md
+++ b/docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md
@@ -118,3 +118,70 @@ resource key in the PR description.
   `ItemSourceChip`, `DetailExportHost`, `Resources.xaml`).
 - Ratified target: [`docs/silmarillion-visual-grammar.md`](../silmarillion-visual-grammar.md) (+ its Phase-4 carry-forward).
 - Phase 3 provenance: [`2026-05-17-silmarillion-404-phase3-design.md`](2026-05-17-silmarillion-404-phase3-design.md) (EXECUTED).
+
+---
+
+## Execution outcome (2026-05-17) — built, verified, NOT pushed
+
+Status: **EXECUTED, local-only.** Six commits on `claude/silmarillion-404-phase4`
+(`be03cee` token reconciliation · `1b4b7d7` Link · `0dcbcfa` SetRef ·
+`e2bb73a` FactTable · `c014f4e` FactFooter · `58c6546` Fact/Structure/Control
+styles). Not pushed; no PR (per maintainer instruction).
+
+Verification: `Mithril.slnx` build clean (0W/0E, no RG1000 flake);
+`Mithril.Shared.Tests` 1094/1094 (incl. 67 new: Link 31, SetRef 11, FactTable
+11, FactFooter 14); `Silmarillion.Tests` 478/478 (consumer unaffected); guard
+green — **no `*DetailView.xaml` / EntityChip / ItemSourceChip / DetailExportHost
+modified** (legacy controls coexist; Phase 5 migrates call sites).
+
+**Shell-boot smoke — deferred to an interactive run, with rationale.** A WPF
+GUI launch isn't feasible from the automated context. Residual risk is
+unusually low *by construction*: additions are purely additive (new types +
+**opt-in `x:Key`'d** styles — no implicit `TargetType` override, so no existing
+control's render changes); no DI service / ctor injection / new project added
+(Shell already `ProjectReference`s Mithril.Shared.Wpf); the 1094 STA WPF tests
+load the edited `Resources.xaml`. The specific failure modes the smoke exists
+to catch (stale-DLL deploy, DI cycle, missing ProjectReference, implicit-style
+regression) are structurally absent here. Still owed before "shipped" per the
+project's "tests green ≠ shipped" rule — flagged, not claimed.
+
+### Phase-4 reconciliation flags & under-specs (for designer / maintainer)
+
+None silently decided. Each is a genuine grammar under-specification or a
+WPF-platform constraint; all are cheap to re-tune (mostly one token/trigger).
+
+1. **`SetRefTextBrush` pigment** — grammar's literal `--info #88B0E0` reconciled
+   to the repo's real query-keyword `#FFCFE8FF` (intent = q-keyword kinship;
+   literal was a designer approximation). Designer: confirm or pin `#88B0E0`.
+2. **Link pending-hover tint** — grammar specifies only "neutral/cooler tint";
+   used `#14FFFFFF` (~8% white). Invented within a qualitative constraint —
+   designer pin a token.
+3. **Link `Ingredient` glyph** — no `EntityKind` maps to it; adapters yield it
+   never. Phase-5 ingredient-slot call sites must pass `LinkGlyph.Ingredient`
+   explicitly.
+4. **Link `KindLabel` + `ProvenanceSuffix` co-occurrence** — grammar shares one
+   trailing slot; rendered provenance-then-kind. Confirm intended order /
+   mutual-exclusion.
+5. **SetRef unwired-click** — grammar specifies only the never-grey-pill rest
+   guarantee, no click behavior; chose safe no-op. Designer may want a "filter
+   not available yet" affordance.
+6. **SetRef hover "border brightens"** — used neutral `BorderStrongBrush`; may
+   be intended blue-tinted (one-token swap).
+7. **FactTable range / event-gated Capacity shapes** — per carry-forward #3,
+   Phase 5 maps these to Grid/Scalar or plain Fact lines; not built, not
+   precluded (free-string Value).
+8. **FactTable `Quiet` weight** — grammar footer-quiet is 9.5pt; used nearest
+   committed token `AppFontSizeSmall` (10). No 9.5 token invented.
+9. **FactFooter hover-reveal** — grammar says "declares only on contact"; used
+   a hard Collapsed→Visible swap (mirrors Link's ratified G-c precedent), no
+   fade/opacity invented.
+10. **FactFooter divider width vs right-alignment** — divider stretches full
+    content width, cells right-aligned; host placement (Phase 5) governs the
+    container.
+11. **Structure tracked-uppercase** — WPF `TextBlock` has no letter-spacing /
+    `CharacterCasing`. Styles deliver family/size/weight/pigment/margin;
+    uppercasing + 0.08em tracking deferred to Phase-5 call site (or a future
+    behavior). Not hacked.
+12. **Control accent-fill variant** — primary/accent-fill ("`--accent` with
+    `--accent-fg`") not built; no `--accent-fg` token exists yet. Phase-5
+    concern when a primary Control is first needed.

--- a/docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md
+++ b/docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md
@@ -134,16 +134,14 @@ Verification: `Mithril.slnx` build clean (0W/0E, no RG1000 flake);
 green — **no `*DetailView.xaml` / EntityChip / ItemSourceChip / DetailExportHost
 modified** (legacy controls coexist; Phase 5 migrates call sites).
 
-**Shell-boot smoke — deferred to an interactive run, with rationale.** A WPF
-GUI launch isn't feasible from the automated context. Residual risk is
-unusually low *by construction*: additions are purely additive (new types +
-**opt-in `x:Key`'d** styles — no implicit `TargetType` override, so no existing
-control's render changes); no DI service / ctor injection / new project added
-(Shell already `ProjectReference`s Mithril.Shared.Wpf); the 1094 STA WPF tests
-load the edited `Resources.xaml`. The specific failure modes the smoke exists
-to catch (stale-DLL deploy, DI cycle, missing ProjectReference, implicit-style
-regression) are structurally absent here. Still owed before "shipped" per the
-project's "tests green ≠ shipped" rule — flagged, not claimed.
+**Shell-boot smoke — PASSED (2026-05-17, `start.ps1 -Clean`).** Full
+`dotnet clean` + rebuild: `Build succeeded, 0W/0E`; **`XamlResourceLint: OK
+(115 keys)`** (validates the edited `Resources.xaml` — new tokens + six shared
+styles, no dup/missing key); shell reached `Application started` then the
+expected non-interactive shutdown (not a crash). The one acceptance item
+previously owed is now satisfied; the additive Phase-4 changes do not break
+boot. (Interactive UI exercise of the primitives still only happens once Phase
+5 wires them into a view — they are not yet referenced by any pane.)
 
 ### Phase-4 reconciliation flags & under-specs (for designer / maintainer)
 

--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using MahApps.Metro.IconPacks;
 
 namespace Mithril.Shared.Wpf;
 
@@ -77,6 +78,32 @@ public sealed class CamelCaseSplitConverter : IValueConverter
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is string s ? Split(s) : (value ?? "");
 
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Maps a <see cref="LinkGlyph"/> to its concrete <see cref="PackIconLucideKind"/> for
+/// the <see cref="Link"/> template's lead glyph. Delegates to
+/// <see cref="Link.ToLucideKind"/> so the mapping has one home (and is unit-tested
+/// there). <see cref="LinkGlyph.None"/> yields <see cref="PackIconLucideKind.None"/> —
+/// the template independently collapses the glyph element via
+/// <see cref="LinkGlyphToVisibilityConverter"/>.
+/// </summary>
+public sealed class LinkGlyphToLucideKindConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is LinkGlyph g ? Link.ToLucideKind(g) : PackIconLucideKind.None;
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Collapses the <see cref="Link"/> lead-glyph element when the glyph is
+/// <see cref="LinkGlyph.None"/> (the name stands alone), Visible otherwise.
+/// </summary>
+public sealed class LinkGlyphToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is LinkGlyph g && g != LinkGlyph.None ? Visibility.Visible : Visibility.Collapsed;
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
 }
 

--- a/src/Mithril.Shared.Wpf/Converters.xaml
+++ b/src/Mithril.Shared.Wpf/Converters.xaml
@@ -9,4 +9,6 @@
     <c:PositiveIntToVisibilityConverter x:Key="PositiveIntToVis"/>
     <c:NullToVisibilityConverter x:Key="NullToVis"/>
     <c:CamelCaseSplitConverter x:Key="CamelCaseSplit"/>
+    <c:LinkGlyphToLucideKindConverter x:Key="LinkGlyphToLucideKind"/>
+    <c:LinkGlyphToVisibilityConverter x:Key="LinkGlyphToVis"/>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/FactFooter.cs
+++ b/src/Mithril.Shared.Wpf/FactFooter.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Threading;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// What a click on a single <see cref="FactFooterId"/> cell should do, decided purely
+/// from the cell. Factored out of the click handler so the G-a copyable-iff-KEY branch
+/// is unit-testable without spinning up the visual tree (mirrors
+/// <see cref="Link.ResolveClick"/> / <see cref="SetRef.ResolveClick"/>).
+/// </summary>
+public enum FactFooterCellAction
+{
+    /// <summary>Cell is null — do nothing.</summary>
+    None,
+
+    /// <summary>
+    /// G-a inert cell (<see cref="FactFooterId.Copyable"/> false — a storage-only
+    /// <c>ROW</c> key). No glyph, no hover, click does nothing. A deliberate no-op:
+    /// the grammar specifies <em>no</em> behaviour for an inert footer ID.
+    /// </summary>
+    Inert,
+
+    /// <summary>
+    /// G-a copyable cell (<see cref="FactFooterId.Copyable"/> true — a cross-entity
+    /// reference <c>KEY</c>). Copy exactly this cell's
+    /// <see cref="FactFooterId.Value"/> (no label, no separator) with a transient
+    /// per-cell ack.
+    /// </summary>
+    Copy,
+}
+
+/// <summary>
+/// The Phase-4 shared <b>FactFooter</b> primitive (G3 visual grammar · "G-a — Fact
+/// identifiers, copyable without becoming Control"). One templated control encoding the
+/// footer-ID strip as a standalone primitive; DataContext is a
+/// <see cref="FactFooterVm"/>.
+/// <para>
+/// <b>It is a Fact, not a Control — location, not chassis.</b> The strip lives below a
+/// thin <c>BorderFaintBrush</c> top divider, beneath the read-flow, with no surface / no
+/// fill / no border of its own. A Control declares itself at rest (a chassis); this
+/// declares itself only on contact — the 11px <c>Copy</c> Lucide glyph is
+/// hover-revealed, never shown at rest. Scan-time read is "another fact under the
+/// divider"; the copy affordance is <em>discovered</em>. This is exactly the G-a
+/// "why this isn't Control" reasoning.
+/// </para>
+/// <para>
+/// <b>Copyable iff cross-entity reference key (the G-a discriminator).</b> A
+/// <c>KEY</c> cell (<see cref="FactFooterId.Copyable"/> true) hover-reveals the copy
+/// glyph, takes <c>Cursor=Hand</c>, and click copies <em>exactly</em> that cell's
+/// <see cref="FactFooterId.Value"/> with a transient ~1.2s per-cell ack. A <c>ROW</c>
+/// cell (<see cref="FactFooterId.Copyable"/> false) is inert: <c>Cursor=Default</c>, no
+/// hover state, no glyph ever, click does nothing. The discriminator is the explicit
+/// <see cref="FactFooterId.Copyable"/> bool, never inferred from the tag string.
+/// </para>
+/// <para>
+/// <b>Per-cell ack, mirroring <see cref="DetailExportHost"/> without touching it.</b>
+/// This control owns the clipboard write + one-shot <c>DispatcherTimer</c> exactly as
+/// <c>DetailExportHost.CopySegment</c> does (try/catch the clipboard — it can
+/// transiently fail; on success set the cell's <see cref="FactFooterId.Copied"/> and
+/// clear it after <c>AckHold</c>). The ack is on the bound <see cref="FactFooterId"/>
+/// (an <see cref="FooterSegmentItem"/>-shaped <c>ObservableObject</c>), so only the
+/// clicked cell flips — the other cell is unaffected, precisely like
+/// <c>FooterSegmentItem.Copied</c>. <c>DetailExportHost</c> is the read-only reference;
+/// it is not modified — this is a standalone coexisting primitive (Phase 5 migrates
+/// hosts).
+/// </para>
+/// Default style ships in <c>Mithril.Shared.Wpf/Resources.xaml</c> (appended after the
+/// <see cref="FactTable"/> style, same <see cref="DefaultStyleKeyProperty"/>
+/// <c>OverrideMetadata</c> pattern as the other Phase-4 primitives).
+/// </summary>
+public sealed class FactFooter : Control
+{
+    static FactFooter()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(
+            typeof(FactFooter), new FrameworkPropertyMetadata(typeof(FactFooter)));
+    }
+
+    private static readonly TimeSpan AckHold = TimeSpan.FromMilliseconds(1200);
+
+    /// <summary>
+    /// Pure decision: given a (possibly null) footer-ID cell, what should a click do?
+    /// Factored out of <see cref="OnCellClick"/> so the G-a copyable-iff-KEY branch is
+    /// unit-testable without the visual tree (mirrors <see cref="Link.ResolveClick"/>).
+    /// Copyable cell → <see cref="FactFooterCellAction.Copy"/>; any other non-null cell
+    /// → <see cref="FactFooterCellAction.Inert"/> (the storage-only no-op); null cell →
+    /// <see cref="FactFooterCellAction.None"/>. The decision is driven solely by
+    /// <see cref="FactFooterId.Copyable"/> — never by <see cref="FactFooterId.LabelTag"/>.
+    /// </summary>
+    public static FactFooterCellAction ResolveCellClick(FactFooterId? cell)
+    {
+        if (cell is null) return FactFooterCellAction.None;
+        return cell.Copyable ? FactFooterCellAction.Copy : FactFooterCellAction.Inert;
+    }
+
+    private readonly List<ButtonBase> _cellButtons = [];
+
+    public override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        foreach (var b in _cellButtons)
+            b.Click -= OnCellClick;
+        _cellButtons.Clear();
+
+        // The template realises one ButtonBase per cell from an ItemsControl over
+        // FactFooterVm.Ids. Walk the realised children once the template is applied
+        // and wire each cell's click (mirrors the PART_-button wiring of the other
+        // primitives — here it is per-item rather than a single named PART).
+        if (GetTemplateChild("PART_Cells") is ItemsControl cells)
+        {
+            cells.Loaded += (_, _) => WireCellButtons(cells);
+            WireCellButtons(cells);
+        }
+    }
+
+    private void WireCellButtons(ItemsControl cells)
+    {
+        foreach (var b in _cellButtons)
+            b.Click -= OnCellClick;
+        _cellButtons.Clear();
+
+        foreach (var btn in EnumerateButtons(cells))
+        {
+            btn.Click += OnCellClick;
+            _cellButtons.Add(btn);
+        }
+    }
+
+    private static IEnumerable<ButtonBase> EnumerateButtons(DependencyObject root)
+    {
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is ButtonBase b)
+                yield return b;
+            else
+                foreach (var nested in EnumerateButtons(child))
+                    yield return nested;
+        }
+    }
+
+    private void OnCellClick(object sender, RoutedEventArgs e)
+    {
+        var cell = (sender as FrameworkElement)?.DataContext as FactFooterId;
+        switch (ResolveCellClick(cell))
+        {
+            case FactFooterCellAction.Copy:
+                CopyCell(cell!);
+                break;
+
+            // Inert (storage-only ROW): the grammar specifies no behaviour for an
+            // inert footer ID — do the minimal safe thing (nothing). No hover/glyph
+            // is shown for it either (Style), so this branch is defensive.
+            case FactFooterCellAction.Inert:
+            case FactFooterCellAction.None:
+            default:
+                break;
+        }
+    }
+
+    // Mirrors DetailExportHost.CopySegment verbatim in shape: try/catch the clipboard
+    // (it can transiently fail — no ack, user retries), then a one-shot DispatcherTimer
+    // drives the ~1.2s transient ack on JUST this cell's Copied (the other cell is
+    // untouched, exactly like FooterSegmentItem.Copied). DetailExportHost is the
+    // read-only reference and is not modified.
+    private static void CopyCell(FactFooterId cell)
+    {
+        if (string.IsNullOrEmpty(cell.Value))
+            return;
+
+        try
+        {
+            Clipboard.SetDataObject(
+                new DataObject(DataFormats.UnicodeText, cell.Value), copy: true);
+        }
+        catch
+        {
+            return; // clipboard can transiently fail; no ack, user can retry
+        }
+
+        cell.Copied = true;
+        var timer = new DispatcherTimer { Interval = AckHold };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            cell.Copied = false;
+        };
+        timer.Start();
+    }
+}

--- a/src/Mithril.Shared.Wpf/FactFooterVm.cs
+++ b/src/Mithril.Shared.Wpf/FactFooterVm.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// One footer identifier cell (G-a). A tiny uppercase <see cref="LabelTag"/>
+/// (<c>KEY</c> / <c>ROW</c>), the mono <see cref="Value"/>, and the G-a discriminator
+/// <see cref="Copyable"/>.
+/// <para>
+/// <b>The discriminator is an explicit bool, never inferred from the tag string.</b>
+/// G-a: a footer ID is copyable <em>iff</em> it is a cross-entity reference key
+/// (InternalName / title key — the <c>KEY</c> tag). A storage-only key
+/// (EnvelopeKey-style — the <c>ROW</c> tag) is inert. The ratified E5 rule decides
+/// copyability from the <em>data</em> (Phase 5 wires it), so this is a flag the call
+/// site sets, not something <see cref="FactFooter"/> derives by matching
+/// <see cref="LabelTag"/> == "KEY". Keeping them orthogonal means a future tag that is
+/// also a reference key (or a <c>KEY</c> that happens to be storage-only) is expressible
+/// without lying about the affordance.
+/// </para>
+/// <see cref="ObservableObject"/> with a transient <see cref="Copied"/> ack — mirrors
+/// <see cref="FooterSegmentItem"/>: the ack is <em>per cell</em>, the other cell is
+/// unaffected. <see cref="Copied"/> is driven by <see cref="FactFooter"/>'s one-shot
+/// <c>DispatcherTimer</c> exactly as <c>DetailExportHost.CopySegment</c> drives
+/// <see cref="FooterSegmentItem.Copied"/>.
+/// </summary>
+public sealed partial class FactFooterId : ObservableObject
+{
+    /// <param name="labelTag">
+    /// Tiny uppercase tag (<c>KEY</c> = cross-entity reference identifier;
+    /// <c>ROW</c> = storage-only key). Display only — does NOT decide copyability.
+    /// </param>
+    /// <param name="value">The atomic identifier shown (mono) and, if copyable,
+    /// copied verbatim.</param>
+    /// <param name="copyable">
+    /// The G-a discriminator: <see langword="true"/> ONLY for a cross-entity
+    /// reference key (<c>KEY</c>); <see langword="false"/> for a storage-only key
+    /// (<c>ROW</c>). Set explicitly by the call site from the data per the ratified
+    /// E5 rule — never inferred from <paramref name="labelTag"/>.
+    /// </param>
+    public FactFooterId(string labelTag, string value, bool copyable)
+    {
+        LabelTag = labelTag;
+        Value = value;
+        Copyable = copyable;
+    }
+
+    /// <summary>Tiny uppercase tag, e.g. <c>KEY</c> / <c>ROW</c>. Display only.</summary>
+    public string LabelTag { get; }
+
+    /// <summary>The atomic identifier; shown mono and (iff <see cref="Copyable"/>)
+    /// the exact, whole copy payload — no label, no separator.</summary>
+    public string Value { get; }
+
+    /// <summary>G-a: copyable iff a cross-entity reference key (KEY). Inert otherwise
+    /// (ROW). Explicit — not inferred from <see cref="LabelTag"/>.</summary>
+    public bool Copyable { get; }
+
+    /// <summary>True for ~1.2s after THIS cell is copied; the Style reveals a
+    /// "copied" ack on just this cell (the other cell is untouched — exactly like
+    /// <see cref="FooterSegmentItem.Copied"/>).</summary>
+    [ObservableProperty]
+    private bool _copied;
+}
+
+/// <summary>
+/// The Phase-4 shared <b>FactFooter</b> data-carrier (G3 visual grammar · "G-a — Fact
+/// identifiers, copyable without becoming Control"). An ordered list of 0, 1, or 2
+/// <see cref="FactFooterId"/>; DataContext for the <see cref="FactFooter"/> control.
+/// <para>
+/// <b>Location, not chassis (why this is a Fact, not a Control).</b> The strip lives
+/// <em>below</em> a thin top-divider, beneath the read-flow — a Control declares itself
+/// at rest (chassis); this declares itself only on contact (the copy glyph is
+/// hover-discovered, never shown at rest). Scan-time read is "another fact under the
+/// divider".
+/// </para>
+/// <para>
+/// <b>The grammar caps at 2 identifiers.</b> <see cref="Of"/> throws on &gt;2 — 0/1/2
+/// is a ratified G-a invariant, not a soft guideline, so an over-count is a
+/// programming error surfaced loudly rather than silently truncated.
+/// </para>
+/// </summary>
+public sealed class FactFooterVm
+{
+    /// <summary>The inert middot the Style places <em>between</em> the two cells. It
+    /// is NEVER part of any cell's copy payload (mirrors
+    /// <see cref="FactTableVm.StripSeparator"/> / <c>FooterSegmentItem</c>'s
+    /// "separator never in the copy payload" guarantee).</summary>
+    public const string CellSeparator = " · ";
+
+    /// <summary>The grammar caps footer identifiers at 0/1/2 (G-a).</summary>
+    public const int MaxIds = 2;
+
+    private FactFooterVm(IReadOnlyList<FactFooterId> ids) => Ids = ids;
+
+    /// <summary>The 0, 1, or 2 footer identifiers, in render order (preserved
+    /// verbatim — the Style never reorders).</summary>
+    public IReadOnlyList<FactFooterId> Ids { get; }
+
+    /// <summary>True only when there is ≥1 id; at 0 the control renders nothing
+    /// (Collapsed) — there is no divider with nothing under it.</summary>
+    public bool HasIds => Ids.Count > 0;
+
+    /// <summary>0 identifiers — the strip is hidden entirely (G-a: "Strip hidden at 0").</summary>
+    public static FactFooterVm None() => new([]);
+
+    /// <summary>The common single cross-entity reference key: one copyable
+    /// <c>KEY</c> (InternalName / title key).</summary>
+    public static FactFooterVm Key(string value) =>
+        new([new FactFooterId("KEY", value, copyable: true)]);
+
+    /// <summary>
+    /// General constructor. Order is preserved verbatim. Throws if more than
+    /// <see cref="MaxIds"/> are supplied — the 0/1/2 cap is a ratified G-a invariant,
+    /// so an over-count is a loud programming error, never a silent truncation.
+    /// </summary>
+    public static FactFooterVm Of(params FactFooterId[] ids)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+        if (ids.Length > MaxIds)
+            throw new ArgumentException(
+                $"The G-a footer grammar caps identifiers at {MaxIds} (got {ids.Length}). " +
+                "0/1/2 is a ratified invariant — do not exceed it.",
+                nameof(ids));
+
+        return new(ids.ToList());
+    }
+}

--- a/src/Mithril.Shared.Wpf/FactTable.cs
+++ b/src/Mithril.Shared.Wpf/FactTable.cs
@@ -1,0 +1,67 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// The Phase-4 shared <b>FactTable</b> primitive (G3 visual grammar · "Fact · inert ·
+/// weight-axis" + Phase-4 carry-forward #3). ONE polymorphic templated content control
+/// that renders a Fact label/value group in <em>three</em> layouts —
+/// <see cref="FactTableLayout.Strip"/> (horizontal dot-separated stat strip) ↔
+/// <see cref="FactTableLayout.Grid"/> (vertical 2-column capacity grid) ↔
+/// <see cref="FactTableLayout.Scalar"/> (a single bare value) — from one
+/// <see cref="FactTableVm"/>. DataContext is a <see cref="FactTableVm"/>.
+/// <para>
+/// <b>Anti-fork (carry-forward #3).</b> The recipe-header stat strip and the
+/// StorageVault favor-tier capacity table are the same data rotated, and a flat
+/// <c>16 slots</c> chest is the degenerate case — all THREE are this ONE control with
+/// a <see cref="LayoutProperty"/> the default Style <c>DataTrigger</c>s on. There are
+/// deliberately no per-shape controls (the identical anti-fork rationale as the
+/// single-<see cref="Link"/> mandate subsuming <see cref="EntityChip"/>/
+/// <see cref="ItemSourceChip"/>).
+/// </para>
+/// <para>
+/// <b>Inert per G-b.</b> Fact is the only fully inert tier: no border, no surface, NO
+/// gold on values (value text is <c>TextPrimaryBrush</c>, labels
+/// <c>TextTertiaryBrush</c>), zero hover, zero interactivity. There is intentionally
+/// <em>no</em> <c>ClickCommand</c> / <c>OnApplyTemplate</c> wiring — unlike
+/// <see cref="Link"/>/<see cref="SetRef"/> this control has nothing to click. The
+/// optional footer-quiet <see cref="FactTableVm.Quiet"/> weight (mono +
+/// <c>TextTertiaryBrush</c>) is the only weight-axis concession (orthogonal/P2),
+/// default off.
+/// </para>
+/// Default style ships in <c>Mithril.Shared.Wpf/Resources.xaml</c> (appended after the
+/// <see cref="SetRef"/> style, same <see cref="DefaultStyleKeyProperty"/>
+/// <c>OverrideMetadata</c> pattern). The Style mirrors the bound VM's
+/// <see cref="FactTableVm.Layout"/> onto <see cref="LayoutProperty"/> and switches the
+/// presented template with <c>DataTrigger</c>s on it — one control, no fork.
+/// </summary>
+public sealed class FactTable : Control
+{
+    static FactTable()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(
+            typeof(FactTable), new FrameworkPropertyMetadata(typeof(FactTable)));
+    }
+
+    /// <summary>
+    /// The active layout. The default Style binds this to the bound
+    /// <see cref="FactTableVm.Layout"/> and <c>DataTrigger</c>s the presented
+    /// template off it, so the polymorphic strip/grid/scalar switch is a single
+    /// layout-driven control rather than three forked controls (carry-forward #3).
+    /// Exposed as a DP (not read straight off the VM in XAML) purely so the
+    /// <c>DataTrigger</c>s have a control-level enum target — the VM stays the
+    /// single source of truth via the Style's binding.
+    /// </summary>
+    public FactTableLayout Layout
+    {
+        get => (FactTableLayout)GetValue(LayoutProperty);
+        set => SetValue(LayoutProperty, value);
+    }
+
+    public static readonly DependencyProperty LayoutProperty = DependencyProperty.Register(
+        nameof(Layout),
+        typeof(FactTableLayout),
+        typeof(FactTable),
+        new PropertyMetadata(FactTableLayout.Strip));
+}

--- a/src/Mithril.Shared.Wpf/FactTableVm.cs
+++ b/src/Mithril.Shared.Wpf/FactTableVm.cs
@@ -1,0 +1,131 @@
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// The layout the <see cref="FactTable"/> primitive renders its <see cref="FactPair"/>
+/// list in. ONE control, three layouts (carry-forward #3 anti-fork) — never three
+/// per-shape controls.
+/// </summary>
+public enum FactTableLayout
+{
+    /// <summary>
+    /// Horizontal, dot-separated <c>Label Value · Label Value · …</c> — the
+    /// recipe-header stat strip. A pair's <see cref="FactPair.Label"/> may be null
+    /// (value-only segment).
+    /// </summary>
+    Strip,
+
+    /// <summary>
+    /// Vertical 2-column grid, one <c>Label … Value</c> per row, values right-aligned
+    /// (the Bendith favor-tier capacity table).
+    /// </summary>
+    Grid,
+
+    /// <summary>
+    /// The degenerate case the carry-forward demands the SAME primitive degrade to: a
+    /// SINGLE bare value, no label, no rows (e.g. a chest whose <c>Capacity</c> is just
+    /// <c>"16 slots"</c>). <see cref="FactTableVm.Pairs"/> holds exactly one entry with
+    /// a null label.
+    /// </summary>
+    Scalar,
+}
+
+/// <summary>
+/// One label/value fact. <see cref="Label"/> is optional: null = value-only (Strip
+/// segment) or the degenerate <see cref="FactTableLayout.Scalar"/>. Both members are
+/// free strings — there is deliberately NO brush/pigment on the model: Fact is inert
+/// per G-b (the value is NEVER gold), so the pigment lives only in the default Style,
+/// not the data. A polymorphic-<c>Capacity</c> <em>range</em> (e.g. <c>"120–340"</c>)
+/// is just a <see cref="Value"/> string — the model does not preclude it.
+/// </summary>
+/// <param name="Label">Optional fact label (<c>TextTertiaryBrush</c> in the Style); null = value-only.</param>
+/// <param name="Value">The fact value (<c>TextPrimaryBrush</c> in the Style; never gold).</param>
+public readonly record struct FactPair(string? Label, string Value);
+
+/// <summary>
+/// The data-carrier for the Phase-4 <see cref="FactTable"/> primitive — ONE polymorphic
+/// Fact label/value group rendered in three layouts (<see cref="FactTableLayout.Strip"/>
+/// ↔ <see cref="FactTableLayout.Grid"/> ↔ <see cref="FactTableLayout.Scalar"/>) from a
+/// single data model.
+/// <para>
+/// <b>Anti-fork (carry-forward #3).</b> The recipe-header stat strip (horizontal,
+/// dot-separated pairs) and the StorageVault favor-tier capacity table (vertical 2-col
+/// grid) are the same data rotated; this is encoded as ONE layout-switchable primitive,
+/// not two — the same rationale as the single-Link mandate subsuming
+/// <c>EntityChip</c>/<c>ItemSourceChip</c>. It additionally degrades to a single flat
+/// <see cref="FactTableLayout.Scalar"/> without forking into a separate control.
+/// </para>
+/// <para>
+/// <b>Inert per G-b.</b> Every shape is Fact-inert: no border, no surface, NO gold on
+/// values. There is no <c>ClickCommand</c>, no hover, zero interactivity. The model
+/// carries no brush — pigment is the Style's job, so the value path cannot reference
+/// gold/accent by construction.
+/// </para>
+/// <para>
+/// <b>Polymorphic <c>Capacity</c> upstream.</b> <c>Capacity</c> is fully polymorphic in
+/// the existing data — favor-tier table · flat slot count · script-atomic range ·
+/// event-gated overrides (Phase 2 inventory). This primitive renders the Strip / Grid /
+/// Scalar shapes; the <em>range</em> and <em>event-gated</em> shapes are the call site's
+/// choice (Phase 5 decides per the carry-forward) to either map to Grid/Scalar or stay
+/// plain Fact body lines. Those shapes are deliberately NOT built here — but nothing
+/// precludes them: <see cref="FactPair.Value"/> is a free string, so a <c>"120–340"</c>
+/// range is simply a Scalar value, and an event-gated set is just more Grid rows.
+/// </para>
+/// </summary>
+/// <param name="Layout">Which of the three layouts to render.</param>
+/// <param name="Pairs">
+/// The fact pairs, in render order (preserved verbatim — the Style/strip helper never
+/// reorders). For <see cref="FactTableLayout.Scalar"/> this is exactly one label-less pair.
+/// </param>
+/// <param name="Quiet">
+/// Footer-quiet weight opt-in (the weight axis is orthogonal/P2 — see the grammar's
+/// "Fact weight axis"). When true the Style switches the value run to
+/// <c>AppMonoFontFamily</c> + <c>TextTertiaryBrush</c> (the footer-quiet
+/// <c>InternalName</c> case). Default off — do not over-engineer weight here.
+/// </param>
+public sealed record FactTableVm(
+    FactTableLayout Layout,
+    IReadOnlyList<FactPair> Pairs,
+    bool Quiet = false)
+{
+    /// <summary>
+    /// The dot character used as the Strip segment separator. It is NOT part of any
+    /// value (the grammar: "inline dot separators that are NOT part of any value") —
+    /// it is injected between segments by <see cref="StripText"/> / the Style only.
+    /// </summary>
+    public const string StripSeparator = " · ";
+
+    /// <summary>
+    /// Convenience: the degenerate single flat scalar (e.g. <c>FactTableVm.Scalar("16 slots")</c>).
+    /// Exactly one label-less pair, <see cref="FactTableLayout.Scalar"/> layout.
+    /// </summary>
+    public static FactTableVm Scalar(string value, bool quiet = false) =>
+        new(FactTableLayout.Scalar, new[] { new FactPair(null, value) }, quiet);
+
+    /// <summary>
+    /// Convenience: the horizontal dot-separated recipe-header stat strip. Pair order
+    /// is preserved; a null <see cref="FactPair.Label"/> renders value-only.
+    /// </summary>
+    public static FactTableVm Strip(IReadOnlyList<FactPair> pairs, bool quiet = false) =>
+        new(FactTableLayout.Strip, pairs, quiet);
+
+    /// <summary>
+    /// Convenience: the vertical 2-column favor-tier capacity grid. Pair order is
+    /// preserved; values are right-aligned in the Style.
+    /// </summary>
+    public static FactTableVm Grid(IReadOnlyList<FactPair> pairs, bool quiet = false) =>
+        new(FactTableLayout.Grid, pairs, quiet);
+
+    /// <summary>
+    /// Pure helper: the rendered Strip string — <c>"Label Value · Label Value · …"</c>,
+    /// with the middot injected <em>between</em> segments only (never inside a value).
+    /// A null label yields a value-only segment. Factored out (mirrors
+    /// <see cref="Link.ResolveClick"/> / <see cref="SetRefVm.DisplayText"/>) so
+    /// separator placement is unit-testable without a visual tree; the Strip Style
+    /// binds this one string instead of re-deciding separator logic in XAML.
+    /// </summary>
+    public string StripText =>
+        string.Join(
+            StripSeparator,
+            Pairs.Select(p =>
+                string.IsNullOrEmpty(p.Label) ? p.Value : $"{p.Label} {p.Value}"));
+}

--- a/src/Mithril.Shared.Wpf/Link.cs
+++ b/src/Mithril.Shared.Wpf/Link.cs
@@ -1,0 +1,184 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using MahApps.Metro.IconPacks;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// What a click on a <see cref="Link"/> should do, decided purely from the bound
+/// <see cref="LinkVm"/>. Factored out of the event handler so the navigable-vs-pending
+/// branch is unit-testable without spinning up the visual tree.
+/// </summary>
+public enum LinkClickAction
+{
+    /// <summary>VM is null / has no reference and isn't navigable — do nothing.</summary>
+    None,
+
+    /// <summary>Navigable + has a reference: invoke the host's command with the reference.</summary>
+    Navigate,
+
+    /// <summary>
+    /// G-c pending-availability: target tab not shipped. Still a Link — copy the
+    /// canonical <see cref="LinkVm.DisplayName"/> to the clipboard with a transient ack.
+    /// </summary>
+    CopyName,
+}
+
+/// <summary>
+/// The Phase-4 shared <b>Link</b> primitive (G3 visual grammar · "Link · navigates ·
+/// V2"). One templated control subsuming both <see cref="EntityChip"/> and
+/// <see cref="ItemSourceChip"/>; DataContext is a <see cref="LinkVm"/>.
+/// <para>
+/// Visual target (strictly per <c>docs/silmarillion-visual-grammar.md</c>): no border,
+/// no surface at rest; a 12px <em>lead</em> Lucide glyph before the name; the name in
+/// <c>AccentBrush</c> gold at body weight; optional italic quaternary provenance suffix
+/// / kind label trailing. Navigable hover paints a 10% gold tint over
+/// <c>GrammarRadiusMd</c> with <c>Cursor=Hand</c>.
+/// </para>
+/// <para>
+/// <b>G-c availability degrade (the inverse of EntityChip's legacy behaviour):</b> when
+/// <see cref="LinkVm.IsNavigable"/> is false the rest state is <em>visually identical</em>
+/// to a navigable Link — same gold, same glyph, zero shipping-schedule leak. Only on
+/// interaction does it differ: hover shows a neutral (non-gold) tint plus a trailing
+/// 11px <c>Copy</c> Lucide glyph, and click copies <see cref="LinkVm.DisplayName"/> to
+/// the clipboard with a brief transient ack (mirroring <see cref="DetailExportHost"/>).
+/// </para>
+/// Default style ships in <c>Mithril.Shared.Wpf/Resources.xaml</c> (mirrors the
+/// <see cref="DetailExportHost"/> / <see cref="ViewModeToggle"/> templated-control
+/// pattern).
+/// </summary>
+public sealed class Link : Control
+{
+    static Link()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(
+            typeof(Link), new FrameworkPropertyMetadata(typeof(Link)));
+    }
+
+    /// <summary>
+    /// Parent-supplied navigation command. Bound on the control itself, not on the
+    /// <see cref="LinkVm"/> — the VM is a data carrier; the command is supplied by the
+    /// hosting view. Receives the VM's <see cref="LinkVm.Reference"/> as its parameter.
+    /// Mirrors <see cref="EntityChip.ClickCommand"/>.
+    /// </summary>
+    public ICommand? ClickCommand
+    {
+        get => (ICommand?)GetValue(ClickCommandProperty);
+        set => SetValue(ClickCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty ClickCommandProperty = DependencyProperty.Register(
+        nameof(ClickCommand),
+        typeof(ICommand),
+        typeof(Link),
+        new PropertyMetadata(null));
+
+    private static readonly DependencyPropertyKey CopiedKey =
+        DependencyProperty.RegisterReadOnly(
+            nameof(Copied), typeof(bool), typeof(Link),
+            new PropertyMetadata(false));
+
+    public static readonly DependencyProperty CopiedProperty = CopiedKey.DependencyProperty;
+
+    /// <summary>True for ~1.2s after a pending (non-navigable) click copies the name;
+    /// the template flips to a "copied" acknowledgement while set.</summary>
+    public bool Copied => (bool)GetValue(CopiedProperty);
+
+    private static readonly TimeSpan AckHold = TimeSpan.FromMilliseconds(1200);
+
+    /// <summary>
+    /// Maps a Link's <see cref="LinkGlyph"/> type-code to a concrete Lucide glyph kind.
+    /// <see cref="LinkGlyph.None"/> has no glyph and is not mapped (callers hide the
+    /// glyph element). Verified exact against MahApps.Metro.IconPacks.Lucide 6.0.0.
+    /// </summary>
+    public static PackIconLucideKind ToLucideKind(LinkGlyph glyph) => glyph switch
+    {
+        LinkGlyph.Skill => PackIconLucideKind.Sparkles,
+        LinkGlyph.Recipe => PackIconLucideKind.FlaskConical,
+        LinkGlyph.Ingredient => PackIconLucideKind.FlaskRound,
+        LinkGlyph.Npc => PackIconLucideKind.UserRound,
+        LinkGlyph.Location => PackIconLucideKind.MapPin,
+        LinkGlyph.Item => PackIconLucideKind.Package,
+        LinkGlyph.CombatAbility => PackIconLucideKind.Sword,
+        // LinkGlyph.None — no lead glyph; element is hidden, kind is unused.
+        _ => PackIconLucideKind.None,
+    };
+
+    /// <summary>
+    /// Pure decision: given a (possibly null) bound VM, what should a click do? Factored
+    /// out of <see cref="OnClick"/> so the navigable-vs-pending branch is unit-testable
+    /// without the visual tree. Navigable + reference → <see cref="LinkClickAction.Navigate"/>;
+    /// any other non-null VM → <see cref="LinkClickAction.CopyName"/> (G-c: never a dead
+    /// click); null VM → <see cref="LinkClickAction.None"/>.
+    /// </summary>
+    public static LinkClickAction ResolveClick(LinkVm? vm)
+    {
+        if (vm is null) return LinkClickAction.None;
+        if (vm.IsNavigable && vm.Reference is not null) return LinkClickAction.Navigate;
+        return LinkClickAction.CopyName;
+    }
+
+    private Button? _button;
+
+    public override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        if (_button is not null)
+            _button.Click -= OnClick;
+
+        _button = GetTemplateChild("PART_Button") as Button;
+
+        if (_button is not null)
+            _button.Click += OnClick;
+    }
+
+    private void OnClick(object sender, RoutedEventArgs e)
+    {
+        var vm = DataContext as LinkVm;
+        switch (ResolveClick(vm))
+        {
+            case LinkClickAction.Navigate:
+                var cmd = ClickCommand;
+                if (cmd is not null && cmd.CanExecute(vm!.Reference))
+                    cmd.Execute(vm.Reference);
+                break;
+
+            case LinkClickAction.CopyName:
+                CopyNameToClipboard(vm!.DisplayName);
+                break;
+
+            case LinkClickAction.None:
+            default:
+                break;
+        }
+    }
+
+    // Mirrors DetailExportHost.OnFooterClick: try/catch the clipboard (it can transiently
+    // fail), then a one-shot DispatcherTimer drives the ~1.2s transient ack.
+    private void CopyNameToClipboard(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return;
+
+        try
+        {
+            Clipboard.SetDataObject(new DataObject(DataFormats.UnicodeText, name), copy: true);
+        }
+        catch
+        {
+            return; // clipboard can transiently fail; no ack, user can retry
+        }
+
+        SetValue(CopiedKey, true);
+        var timer = new DispatcherTimer { Interval = AckHold };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            SetValue(CopiedKey, false);
+        };
+        timer.Start();
+    }
+}

--- a/src/Mithril.Shared.Wpf/LinkVm.cs
+++ b/src/Mithril.Shared.Wpf/LinkVm.cs
@@ -1,0 +1,108 @@
+using Mithril.Shared.Reference;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Type-code for a <see cref="Link"/>'s 12px lead Lucide glyph. Maps to a
+/// <c>PackIconLucideKind</c> by the <see cref="Link"/> control template's
+/// converter. <see cref="None"/> renders no glyph (the name stands alone).
+/// </summary>
+public enum LinkGlyph
+{
+    /// <summary>No lead glyph.</summary>
+    None,
+    Skill,
+    Recipe,
+    Ingredient,
+    Npc,
+    Location,
+    Item,
+    CombatAbility,
+}
+
+/// <summary>
+/// The unified data-carrier for the Phase-4 <see cref="Link"/> primitive — the single
+/// VM that subsumes both <see cref="EntityChipVm"/> (cross-entity navigation chip) and
+/// <see cref="ItemSourceChipVm"/> (item/recipe source row with a provenance suffix).
+/// <para>
+/// Per the G3 visual grammar (<c>docs/silmarillion-visual-grammar.md</c> · "Link ·
+/// navigates · V2"): a Link is <c>&lt;lead glyph&gt; &lt;gold name&gt;</c> plus three
+/// optional bits — a provenance suffix, a kind label, and the availability/degrade flag
+/// (<see cref="IsNavigable"/>). Crucially, per G-c, <see cref="IsNavigable"/> is the
+/// <em>opposite</em> of EntityChip's legacy "grey it out" degrade: a non-navigable Link
+/// looks <em>identical</em> at rest (zero shipping-schedule leak); the difference shows
+/// only on interaction (copy-to-clipboard instead of navigate).
+/// </para>
+/// Phase 5 migrates call sites; the static <see cref="From(EntityChipVm)"/> /
+/// <see cref="From(ItemSourceChipVm)"/> adapters make that mechanical.
+/// </summary>
+/// <param name="DisplayName">The human-readable name (gold, body weight).</param>
+/// <param name="Glyph">The 12px lead glyph type-code; <see cref="LinkGlyph.None"/> for no glyph.</param>
+/// <param name="Reference">
+/// The navigation target, passed to the host's <see cref="Link.ClickCommand"/> on a
+/// navigable click. Mirrors <see cref="EntityChipVm.Reference"/>'s type.
+/// </param>
+/// <param name="IsNavigable">
+/// True if the target tab is shipped (click navigates). False = target not yet
+/// browsable: <em>still a Link</em> (G-c) — identical at rest, click copies the name.
+/// </param>
+/// <param name="ProvenanceSuffix">
+/// Optional ItemSourceChip-style trailing provenance (e.g. <c>"from Distil Brine"</c>);
+/// italic, quaternary, ~10pt. Null everywhere it doesn't apply.
+/// </param>
+/// <param name="KindLabel">
+/// Optional, rare trailing kind disambiguator (e.g. <c>"skill"</c>) when icon+name
+/// aren't enough. Same trailing slot as <see cref="ProvenanceSuffix"/>.
+/// </param>
+public sealed record LinkVm(
+    string DisplayName,
+    LinkGlyph Glyph,
+    EntityRef? Reference,
+    bool IsNavigable,
+    string? ProvenanceSuffix = null,
+    string? KindLabel = null)
+{
+    /// <summary>
+    /// Maps an <see cref="EntityRef"/>'s <see cref="EntityKind"/> to the Link lead-glyph
+    /// type-code. Unknown / non-entity kinds (keyword-filter pivots, Effect envelopes,
+    /// Quest/Area/etc. that have no grammar-assigned glyph) fall back to
+    /// <see cref="LinkGlyph.None"/> by design — the grammar only type-codes the seven
+    /// concrete entity families it enumerates.
+    /// </summary>
+    public static LinkGlyph GlyphFor(EntityKind kind) => kind switch
+    {
+        EntityKind.Skill => LinkGlyph.Skill,
+        EntityKind.Recipe => LinkGlyph.Recipe,
+        EntityKind.Npc => LinkGlyph.Npc,
+        EntityKind.Area => LinkGlyph.Location,
+        EntityKind.Item => LinkGlyph.Item,
+        EntityKind.ItemByKeyword => LinkGlyph.Item,
+        EntityKind.Ability => LinkGlyph.CombatAbility,
+        _ => LinkGlyph.None,
+    };
+
+    /// <summary>
+    /// Adapts a legacy <see cref="EntityChipVm"/> into the unified Link VM. The glyph is
+    /// derived from <see cref="EntityChipVm.Reference"/>'s kind (the legacy
+    /// <c>IconId</c> is dropped — Link is glyph-coded, not icon-imaged, per the grammar).
+    /// </summary>
+    public static LinkVm From(EntityChipVm chip) => new(
+        chip.DisplayName,
+        GlyphFor(chip.Reference.Kind),
+        chip.Reference,
+        chip.IsNavigable);
+
+    /// <summary>
+    /// Adapts a legacy <see cref="ItemSourceChipVm"/> into the unified Link VM.
+    /// <see cref="ItemSourceChipVm.Detail"/> becomes the <see cref="ProvenanceSuffix"/>
+    /// (the ItemSourceChip "— from X" bit); the glyph is derived from the optional
+    /// <see cref="ItemSourceChipVm.EntityReference"/> kind (<see cref="LinkGlyph.None"/>
+    /// when the source maps to no entity).
+    /// </summary>
+    public static LinkVm From(ItemSourceChipVm chip) => new(
+        chip.DisplayName,
+        chip.EntityReference is { } r ? GlyphFor(r.Kind) : LinkGlyph.None,
+        chip.EntityReference,
+        chip.IsNavigable,
+        ProvenanceSuffix: string.IsNullOrEmpty(chip.Detail) ? null : chip.Detail);
+}

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -59,6 +59,46 @@
     <SolidColorBrush x:Key="BorderSubtleBrush"   Color="#33FFFFFF"/>
     <SolidColorBrush x:Key="BorderStrongBrush"   Color="#55FFFFFF"/>
 
+    <!-- ===== Silmarillion #404 visual-grammar tokens (Phase 4) =====
+         Design token to resource key reconciliation ledger for the G3 ratified
+         grammar (docs/silmarillion-visual-grammar.md). Keys that already
+         existed are REUSED (no duplication); only genuinely missing tokens are
+         added here. Per the Phase 4 dispatch the design tokens are the source
+         of truth and the WPF set is reconciled to them.
+
+           token accent  D4A847        => AccentBrush         (exists; Fact-title, Link name)
+           token fg.primary            => TextPrimaryBrush    (exists; Fact values)
+           token fg.secondary          => TextSecondaryBrush  (exists)
+           token fg.tertiary           => TextTertiaryBrush   (exists; Structure label, footer KEY/ROW value)
+           token fg.quaternary         => TextQuaternaryBrush (ADDED)
+           token bg.surface            => BgSurfaceBrush      (exists; Control chassis only)
+           token bg.surface.hover      => BgSurfaceHoverBrush (exists)
+           token border.subtle         => BorderSubtleBrush   (exists)
+           token border.strong         => BorderStrongBrush   (exists)
+           token border.faint          => BorderFaintBrush    (ADDED; footer divider)
+           token accent.soft 1E3A5F    => AccentSoftBrush     (exists; SetRef active fill)
+           token radius.sm (2)         => GrammarRadiusSm     (ADDED; SetRef)
+           token radius.md (3)         => GrammarRadiusMd     (ADDED; general)
+
+         FLAGGED RECONCILIATION (designer confirm, see Phase 4 carry-forward):
+         the grammar specifies Set-reference text as token info #88B0E0,
+         explicitly "matching q.keyword from MithrilQueryBox". The repo's actual
+         query keyword brush is AccentSoftTextBrush / QueryKeywordBrush =
+         #FFCFE8FF, not #88B0E0. The literal hex was the designer's
+         approximation of a token they did not have; the ratified intent is
+         pigment kinship with the query keyword colour. Honoring intent over the
+         approximated literal, SetRefTextBrush is reconciled to the real query
+         keyword value (#FFCFE8FF). One resource key, trivially re-tuned if the
+         designer wants the literal #88B0E0. Surfaced here and in the PR, not a
+         silent override. ===== -->
+    <SolidColorBrush x:Key="TextQuaternaryBrush" Color="#66FFFFFF"/>
+    <SolidColorBrush x:Key="BorderFaintBrush"    Color="#22FFFFFF"/>
+    <SolidColorBrush x:Key="SetRefTextBrush"     Color="#FFCFE8FF"/>
+    <SolidColorBrush x:Key="SetRefIdleFillBrush" Color="#4D1E3A5F"/>
+    <SolidColorBrush x:Key="SetRefBorderBrush"   Color="#553398FF"/>
+    <CornerRadius x:Key="GrammarRadiusSm">2</CornerRadius>
+    <CornerRadius x:Key="GrammarRadiusMd">3</CornerRadius>
+
     <!-- Implicit styles — inline Foreground/Background attributes in existing views
          override these, so Samwise, the shell views and the Legolas overlays all
          keep their current hand-authored look. Only unstyled markup picks this up. -->

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1250,4 +1250,108 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- ===== SetRef · the Phase-4 shared Set-reference primitive (G3 grammar:
+         "Set-reference · filter / keyword / group / stacking" + carry-forward #4).
+         One polymorphic control carrying BOTH shapes on one blue chassis;
+         DataContext is a SetRefVm. Mirrors the Link templated-control pattern
+         above (PART_-named child wired in SetRef.cs OnApplyTemplate).
+
+         Visual target STRICTLY per docs/silmarillion-visual-grammar.md
+         (every value is a committed token — none invented here):
+           · A blue chip WITH a chassis (unlike Link): idle fill
+             SetRefIdleFillBrush, 1px SetRefBorderBrush border,
+             GrammarRadiusSm (2) corner, 1×8 padding, AppFontSizeHint text in
+             SetRefTextBrush.
+           · summary-form (MatchCount != null) → DisplayText is
+             "{Label} · {count} →"; tag-form (MatchCount == null) → bare Label
+             (no count, no arrow, NO lead glyph — grammar "glyph: None by
+             default"). The VM bakes the shape into DisplayText so the template
+             binds one string and the two shapes never fork.
+           · Optional leading SlotOrdinal prefix (stacking semantics): small,
+             TextQuaternaryBrush, hidden when null via the VM bool HasOrdinal
+             (a bool, NOT a converter — dodges the string-only NullOrEmptyToVis
+             repo footgun and avoids a bespoke int?->Visibility converter).
+           · Hover: fill darkens toward AccentSoftBrush (active fill), border
+             brightens to BorderStrongBrush — the drawer-pulling feel.
+             Cursor=Hand ONLY when IsActionable.
+           · AVAILABILITY COROLLARY (never-grey-pill guarantee): IsActionable
+             changes interaction ONLY. The at-rest chassis (fill/border/text/
+             radius/padding) is IDENTICAL regardless of IsActionable — an
+             un-wired tag-form Set-ref stays on the FULL blue chassis and is
+             NEVER demoted to an inert grey Fact pill (the forbidden inverted-
+             affordance lie). The only IsActionable-conditioned setters are the
+             hover fill/border and Cursor; none touch the rest state. ===== -->
+    <Style TargetType="{x:Type c:SetRef}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type c:SetRef}">
+                    <Button x:Name="PART_Button"
+                            HorizontalAlignment="Left"
+                            Background="Transparent" BorderThickness="0" Padding="0">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <!-- The chassis. Rest state is token-fixed and does
+                                     NOT vary with IsActionable (availability
+                                     corollary). Hover-only setters below. -->
+                                <Border x:Name="Chassis"
+                                        Background="{StaticResource SetRefIdleFillBrush}"
+                                        BorderBrush="{StaticResource SetRefBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="{StaticResource GrammarRadiusSm}"
+                                        Padding="8,1">
+                                    <StackPanel Orientation="Horizontal">
+                                        <!-- Stacking ordinal prefix: small,
+                                             quaternary, leading. Hidden via the VM
+                                             bool HasOrdinal (object-safe; no
+                                             converter). -->
+                                        <TextBlock x:Name="OrdinalPrefix"
+                                                   Text="{Binding OrdinalText}"
+                                                   Margin="0,0,4,0"
+                                                   Foreground="{StaticResource TextQuaternaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeXSmall}"
+                                                   VerticalAlignment="Center"/>
+                                        <!-- The shape-baked body: tag-form = bare
+                                             Label; summary-form = "{Label} · N →". -->
+                                        <TextBlock Text="{Binding DisplayText}"
+                                                   Foreground="{StaticResource SetRefTextBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                                   VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <!-- Hide the ordinal prefix entirely when the VM
+                                         carries no SlotOrdinal (positionally inert /
+                                         single). VM bool, not a converter. -->
+                                    <DataTrigger Binding="{Binding HasOrdinal}" Value="False">
+                                        <Setter TargetName="OrdinalPrefix" Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                    <!-- Actionable: hand cursor + drawer-pulling
+                                         hover (fill -> active, border -> strong).
+                                         Rest state untouched. -->
+                                    <DataTrigger Binding="{Binding IsActionable}" Value="True">
+                                        <Setter Property="Cursor" Value="Hand"/>
+                                    </DataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsActionable}" Value="True"/>
+                                            <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="Chassis" Property="Background" Value="{StaticResource AccentSoftBrush}"/>
+                                        <Setter TargetName="Chassis" Property="BorderBrush" Value="{StaticResource BorderStrongBrush}"/>
+                                    </MultiDataTrigger>
+                                    <!-- IsActionable=false: NO hover/cursor setters
+                                         at all. The chassis above is the entire look
+                                         (identical to actionable at rest) — never a
+                                         grey pill. -->
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1115,4 +1115,139 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- ===== Link · the Phase-4 shared navigation primitive (G3 grammar:
+         "Link · navigates · V2"). Subsumes EntityChip + ItemSourceChip;
+         DataContext is a LinkVm. Mirrors the DetailExportHost templated-control
+         pattern above (PART_-named child wired in Link.cs OnApplyTemplate).
+
+         Visual target STRICTLY per docs/silmarillion-visual-grammar.md:
+           · No border, no surface/background AT REST.
+           · 12px LEAD Lucide glyph before the name (hidden for LinkGlyph.None).
+           · Name: AccentBrush gold, body weight, AppFontSize.
+           · Trailing ProvenanceSuffix / KindLabel: italic, TextQuaternaryBrush,
+             ~10pt (AppFontSizeSmall), hidden when null via NullToVis (the
+             object-safe converter — NullOrEmptyToVis is the string-only repo
+             footgun and is deliberately NOT used here).
+           · Navigable hover: 10% gold tint #1AD4A847 over GrammarRadiusMd,
+             Margin 0,-2 tap padding so the tint box fits; Cursor=Hand.
+           · G-c pending (IsNavigable=false): rest state IDENTICAL to navigable
+             (same gold, same glyph — zero shipping-schedule leak; NOT greyed).
+             Difference shows only on hover: a NEUTRAL tint (#14FFFFFF, not gold)
+             plus a trailing 11px Copy glyph; click copies DisplayName (handled
+             in Link.cs) and flips to a transient "copied" ack (Copied DP). ===== -->
+    <Style TargetType="{x:Type c:Link}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type c:Link}">
+                    <Button x:Name="PART_Button"
+                            HorizontalAlignment="Left"
+                            Background="Transparent" BorderThickness="0" Padding="0"
+                            Margin="0,-2,0,-2">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <!-- Hover tint box. Transparent at rest (grammar: no
+                                     surface at rest). IsMouseOver swaps the fill:
+                                     navigable → 10% gold; pending → neutral white. -->
+                                <Border x:Name="HoverBox"
+                                        Background="Transparent"
+                                        CornerRadius="{StaticResource GrammarRadiusMd}"
+                                        Padding="2,0">
+                                    <StackPanel Orientation="Horizontal">
+                                        <!-- 12px LEAD glyph. Collapsed for LinkGlyph.None. -->
+                                        <icon:PackIconLucide
+                                            Width="12" Height="12"
+                                            Margin="0,0,4,0"
+                                            VerticalAlignment="Center"
+                                            Foreground="{StaticResource AccentBrush}"
+                                            Kind="{Binding Glyph, Converter={StaticResource LinkGlyphToLucideKind}}"
+                                            Visibility="{Binding Glyph, Converter={StaticResource LinkGlyphToVis}}"/>
+                                        <!-- Name: gold, body weight, AppFontSize. -->
+                                        <TextBlock Text="{Binding DisplayName}"
+                                                   Foreground="{StaticResource AccentBrush}"
+                                                   FontSize="{DynamicResource AppFontSize}"
+                                                   FontWeight="Normal"
+                                                   VerticalAlignment="Center"/>
+                                        <!-- Trailing ProvenanceSuffix: italic, quaternary,
+                                             ~10pt, hidden when null (NullToVis, object-safe). -->
+                                        <TextBlock Text="{Binding ProvenanceSuffix}"
+                                                   Margin="5,0,0,0"
+                                                   Foreground="{StaticResource TextQuaternaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                                   FontStyle="Italic"
+                                                   VerticalAlignment="Center"
+                                                   Visibility="{Binding ProvenanceSuffix, Converter={StaticResource NullToVis}}"/>
+                                        <!-- Trailing KindLabel: same slot, same rule. -->
+                                        <TextBlock Text="{Binding KindLabel}"
+                                                   Margin="5,0,0,0"
+                                                   Foreground="{StaticResource TextQuaternaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                                   FontStyle="Italic"
+                                                   VerticalAlignment="Center"
+                                                   Visibility="{Binding KindLabel, Converter={StaticResource NullToVis}}"/>
+                                        <!-- G-c pending copy affordance: 11px Copy glyph,
+                                             revealed only on hover of a non-navigable Link
+                                             (HoverCopyGlyph trigger below). Hidden by
+                                             default and entirely absent for navigable. -->
+                                        <icon:PackIconLucide x:Name="CopyGlyph"
+                                            Kind="Copy"
+                                            Width="11" Height="11"
+                                            Margin="5,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Foreground="{StaticResource TextTertiaryBrush}"
+                                            Visibility="Collapsed"/>
+                                        <!-- Transient "copied" ack (G-c useful action),
+                                             driven by the read-only Copied DP set in
+                                             Link.cs for ~1.2s after a pending click. -->
+                                        <TextBlock x:Name="CopiedAck"
+                                                   Text="copied ✓"
+                                                   Margin="5,0,0,0"
+                                                   Foreground="{StaticResource AccentBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                                   VerticalAlignment="Center"
+                                                   Visibility="Collapsed"/>
+                                    </StackPanel>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <!-- Navigable hover: 10% gold tint + Hand cursor. -->
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsNavigable}" Value="True"/>
+                                            <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="HoverBox" Property="Background" Value="#1AD4A847"/>
+                                    </MultiDataTrigger>
+                                    <DataTrigger Binding="{Binding IsNavigable}" Value="True">
+                                        <Setter Property="Cursor" Value="Hand"/>
+                                    </DataTrigger>
+                                    <!-- Pending hover: neutral (non-gold) tint + reveal
+                                         the trailing Copy glyph. Rest state is untouched
+                                         → identical to navigable (zero schedule leak). -->
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsNavigable}" Value="False"/>
+                                            <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter TargetName="HoverBox" Property="Background" Value="#14FFFFFF"/>
+                                        <Setter TargetName="CopyGlyph" Property="Visibility" Value="Visible"/>
+                                    </MultiDataTrigger>
+                                    <DataTrigger Binding="{Binding IsNavigable}" Value="False">
+                                        <Setter Property="Cursor" Value="Hand"/>
+                                    </DataTrigger>
+                                    <!-- Copied ack: swap the copy glyph for the ack text
+                                         while the Copied DP is set. -->
+                                    <DataTrigger Binding="{Binding Copied, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}}" Value="True">
+                                        <Setter TargetName="CopyGlyph" Property="Visibility" Value="Collapsed"/>
+                                        <Setter TargetName="CopiedAck" Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1486,4 +1486,185 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- ===== FactFooter · the Phase-4 shared footer-ID primitive (G3 grammar:
+         "G-a — Fact identifiers, copyable without becoming Control"). 0/1/2
+         FactFooterId cells; DataContext is a FactFooterVm. COEXISTS with
+         DetailExportHost's legacy footer (Phase 5 migrates hosts) — this is the
+         standalone G-a primitive only. Mirrors the FactTable templated-control
+         pattern above (DefaultStyleKeyProperty.OverrideMetadata in FactFooter.cs;
+         per-cell ButtonBase wired in OnApplyTemplate, not a single named PART).
+
+         Visual target STRICTLY per docs/silmarillion-visual-grammar.md
+         (every value is a committed token — none invented here):
+           · LOCATION, NOT CHASSIS: the strip sits BELOW a thin 1px
+             BorderFaintBrush TOP divider, beneath the read-flow. NO surface,
+             NO fill, NO border other than that one top divider. This is a Fact,
+             not a Control — it declares itself only on contact.
+           · Right-aligned (matches the detail-view footer convention), but the
+             divider spans the FULL content width (the Border is stretched; the
+             cells DockPanel inside is right-aligned).
+           · 0 ids → the whole control is Collapsed (HasIds=false → no divider
+             with nothing under it). 1 id → a single cell. 2 ids → the two cells
+             with an INERT middot `·` between them. The separator is NEVER part
+             of any copied value (the first cell suppresses its leading middot
+             via the VM IsFirst-style index; the copy payload is the cell Value
+             ONLY — mirrors FooterSegmentItem / FactTableVm.StripSeparator).
+           · Each cell: tiny UPPERCASE LabelTag in TextQuaternaryBrush at
+             AppFontSizeXSmall, then Value in TextTertiaryBrush +
+             AppMonoFontFamily at AppFontSizeSmall.
+           · COPYABLE cell (Copyable=true — a cross-entity reference KEY): on
+             HOVER reveal an 11px Copy PackIconLucide trailing the value;
+             Cursor=Hand; click copies EXACTLY that cell's Value (handled in
+             FactFooter.cs, try/catch like DetailExportHost) and flips that
+             cell's Copied for ~1.2s (per-cell ack — the OTHER cell is
+             unaffected, exactly like FooterSegmentItem.Copied). At REST the
+             copy glyph is NOT shown (G-a: "declares itself only on contact").
+           · INERT cell (Copyable=false — a storage-only ROW): Cursor=Default,
+             NO hover state, NO glyph EVER, click does nothing. The Copyable
+             bool is the sole discriminator — NOT the LabelTag string. ===== -->
+    <ItemsPanelTemplate x:Key="FactFooterCellsPanel">
+        <StackPanel Orientation="Horizontal"/>
+    </ItemsPanelTemplate>
+    <Style TargetType="{x:Type c:FactFooter}">
+        <!-- Right-aligned strip (detail-footer convention); the divider Border
+             below still stretches the full content width. -->
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type c:FactFooter}">
+                    <!-- The ONLY surface: a 1px TOP divider spanning the content
+                         width. No fill, no other border (Fact = no chassis). The
+                         whole control collapses at 0 ids (no divider with
+                         nothing under it). -->
+                    <Border x:Name="Root"
+                            BorderBrush="{StaticResource BorderFaintBrush}"
+                            BorderThickness="0,1,0,0"
+                            Padding="0,4,0,0"
+                            Background="Transparent">
+                        <!-- Cells right-aligned within the full-width divider. -->
+                        <ItemsControl x:Name="PART_Cells"
+                                      HorizontalAlignment="Right"
+                                      AlternationCount="2"
+                                      ItemsSource="{Binding Ids}"
+                                      ItemsPanel="{StaticResource FactFooterCellsPanel}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <!-- A ButtonBase per cell (FactFooter.cs walks
+                                         the realised tree and wires Click). No
+                                         chassis: transparent, borderless, no
+                                         padding — the button is a hit-target, not
+                                         a Control surface. -->
+                                    <Button Background="Transparent"
+                                            BorderThickness="0"
+                                            Padding="0"
+                                            HorizontalContentAlignment="Left">
+                                        <Button.Template>
+                                            <ControlTemplate TargetType="Button">
+                                                <StackPanel x:Name="CellRoot"
+                                                            Orientation="Horizontal"
+                                                            Background="Transparent">
+                                                    <!-- Inert middot BETWEEN cells
+                                                         only; the first cell
+                                                         suppresses it. Never part
+                                                         of any copy payload. -->
+                                                    <TextBlock x:Name="Sep"
+                                                               Text="{x:Static c:FactFooterVm.CellSeparator}"
+                                                               Foreground="{StaticResource TextQuaternaryBrush}"
+                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               VerticalAlignment="Center"/>
+                                                    <!-- Tiny UPPERCASE tag. -->
+                                                    <TextBlock x:Name="Tag"
+                                                               Text="{Binding LabelTag}"
+                                                               Margin="0,0,4,0"
+                                                               Foreground="{StaticResource TextQuaternaryBrush}"
+                                                               FontSize="{DynamicResource AppFontSizeXSmall}"
+                                                               VerticalAlignment="Center"/>
+                                                    <!-- Mono value (tertiary). -->
+                                                    <TextBlock Text="{Binding Value}"
+                                                               Foreground="{StaticResource TextTertiaryBrush}"
+                                                               FontFamily="{DynamicResource AppMonoFontFamily}"
+                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               VerticalAlignment="Center"/>
+                                                    <!-- Hover-revealed 11px Copy
+                                                         glyph (copyable only).
+                                                         Collapsed at rest (G-a:
+                                                         declares itself only on
+                                                         contact). -->
+                                                    <icon:PackIconLucide x:Name="CopyGlyph"
+                                                        Kind="Copy"
+                                                        Width="11" Height="11"
+                                                        Margin="4,0,0,0"
+                                                        VerticalAlignment="Center"
+                                                        Foreground="{StaticResource TextTertiaryBrush}"
+                                                        Visibility="Collapsed"/>
+                                                    <!-- Per-cell transient ack
+                                                         (FactFooterId.Copied,
+                                                         set in FactFooter.cs). -->
+                                                    <TextBlock x:Name="CopiedAck"
+                                                               Text="copied ✓"
+                                                               Margin="4,0,0,0"
+                                                               Foreground="{StaticResource TextTertiaryBrush}"
+                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               VerticalAlignment="Center"
+                                                               Visibility="Collapsed"/>
+                                                </StackPanel>
+                                                <ControlTemplate.Triggers>
+                                                    <!-- First cell → no leading
+                                                         middot (separator is
+                                                         BETWEEN cells only). -->
+                                                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=ContentPresenter}, Path=(ItemsControl.AlternationIndex)}" Value="0">
+                                                        <Setter TargetName="Sep" Property="Visibility" Value="Collapsed"/>
+                                                    </DataTrigger>
+                                                    <!-- COPYABLE (KEY): hand
+                                                         cursor; hover reveals the
+                                                         Copy glyph. At rest the
+                                                         glyph stays Collapsed. -->
+                                                    <DataTrigger Binding="{Binding Copyable}" Value="True">
+                                                        <Setter Property="Cursor" Value="Hand"/>
+                                                    </DataTrigger>
+                                                    <MultiDataTrigger>
+                                                        <MultiDataTrigger.Conditions>
+                                                            <Condition Binding="{Binding Copyable}" Value="True"/>
+                                                            <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}}" Value="True"/>
+                                                        </MultiDataTrigger.Conditions>
+                                                        <Setter TargetName="CopyGlyph" Property="Visibility" Value="Visible"/>
+                                                    </MultiDataTrigger>
+                                                    <!-- Per-cell ack: swap the
+                                                         copy glyph for the ack
+                                                         text while Copied is set
+                                                         (this cell only). -->
+                                                    <DataTrigger Binding="{Binding Copied}" Value="True">
+                                                        <Setter TargetName="CopyGlyph" Property="Visibility" Value="Collapsed"/>
+                                                        <Setter TargetName="CopiedAck" Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                    <!-- INERT (ROW): Copyable
+                                                         false → NO hover/cursor/
+                                                         glyph setters at all. The
+                                                         default Cursor + Collapsed
+                                                         glyph IS the entire look.
+                                                         (Defensive: explicit
+                                                         default cursor.) -->
+                                                    <DataTrigger Binding="{Binding Copyable}" Value="False">
+                                                        <Setter Property="Cursor" Value="Arrow"/>
+                                                    </DataTrigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Button.Template>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <!-- 0 ids → the whole control renders nothing (no divider
+                             with nothing under it). G-a: "Strip hidden at 0". -->
+                        <DataTrigger Binding="{Binding HasIds}" Value="False">
+                            <Setter TargetName="Root" Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1667,4 +1667,98 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- ===== Silmarillion #404 grammar — Fact / Structure / Control shared styles (Phase 4) =====
+         Opt-in x:Key'd styles (NOT implicit TargetType overrides) so existing
+         hand-authored views are untouched until Phase 5 migrates call sites.
+         Values are taken verbatim from docs/silmarillion-visual-grammar.md
+         (Fact tier + weight axis; Structure tier; Control tier). No view edited.
+
+         WPF LIMITATION FLAG (not silently dropped, not hacked): the Structure
+         tier specifies "tracked uppercase (letter-spacing 0.08em)". WPF
+         TextBlock has no native letter-spacing and no CharacterCasing. These
+         styles deliver the expressible parts (family / size / weight / pigment
+         / margin); the *uppercasing* and *letter-tracking* are deferred to the
+         Phase 5 call site (pass already-upper text; tracking would need a
+         custom behavior). Surfaced in the Phase 4 reconciliation flags. -->
+
+    <!-- Fact · title-loud: Cambria 18 / 600 / accent, one per pane. -->
+    <Style x:Key="FactTitleStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource AppHeaderFontFamily}"/>
+        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeHeader}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/><!-- WPF SemiBold == weight 600 -->
+        <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <!-- Fact · body: Segoe UI 12 / fg-primary. -->
+    <Style x:Key="FactBodyStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
+        <Setter Property="FontSize"   Value="{DynamicResource AppFontSize}"/>
+        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <!-- Structure · section label: fg-tertiary, SemiBold, ~9pt, 10px top gap.
+         Never gold, no glyph (enforced by being a bare TextBlock style). -->
+    <Style x:Key="StructureSectionLabelStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
+        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeXSmall}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
+        <Setter Property="Margin"     Value="0,10,0,4"/>
+    </Style>
+
+    <!-- Structure · inline field-label prefix (terminating ':' is the call
+         site's text, not the style). Same pigment/weight as section label,
+         no top margin (it sits inline before a value). -->
+    <Style x:Key="StructureInlinePrefixStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
+        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeXSmall}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
+    </Style>
+
+    <!-- Structure · group header: dimmer (fg-quaternary), else as section label. -->
+    <Style x:Key="StructureGroupHeaderStyle" TargetType="TextBlock"
+           BasedOn="{StaticResource StructureSectionLabelStyle}">
+        <Setter Property="Foreground" Value="{StaticResource TextQuaternaryBrush}"/>
+    </Style>
+
+    <!-- Control · the only tier with a real chassis. Opt-in reference style for
+         Phase-5 grammar-conformant buttons; existing button styles untouched.
+         bg-surface + border-subtle, radius-md 3, 1px, 5x12 pad; hover
+         bg-surface-hover / border-strong. (Primary/accent-fill variant is a
+         Phase-5 concern — accent-fg token not yet needed; flagged.) -->
+    <Style x:Key="GrammarControlChassisStyle" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource BgSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtleBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+        <Setter Property="Padding" Value="12,5"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chassis"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource GrammarRadiusMd}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chassis" Property="Background"
+                                    Value="{StaticResource BgSurfaceHoverBrush}"/>
+                            <Setter TargetName="Chassis" Property="BorderBrush"
+                                    Value="{StaticResource BorderStrongBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1354,4 +1354,136 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- ===== FactTable · the Phase-4 shared Fact-group primitive (G3 grammar:
+         "Fact · inert · weight-axis" + carry-forward #3). ONE polymorphic
+         control rendering a label/value group in THREE layouts from one
+         FactTableVm; DataContext is a FactTableVm. Mirrors the Link/SetRef
+         templated-control pattern above, but Fact is INERT — no PART_Button, no
+         ClickCommand, no hover, zero interactivity.
+
+         Visual target STRICTLY per docs/silmarillion-visual-grammar.md
+         (every value is a committed token — none invented here):
+           · Value text  = TextPrimaryBrush   (NEVER gold — G-b strips gold
+             from every Fact value; the model carries no brush at all).
+           · Label text  = TextTertiaryBrush  (Structure-weight label).
+           · NO border, NO surface/background anywhere (Fact is the only fully
+             inert tier).
+           · ANTI-FORK (carry-forward #3): this is ONE control. The Style binds
+             the control's Layout DP to the VM's Layout and DataTriggers the
+             presented template off it — Strip / Grid / Scalar are three
+             ContentControl templates selected by ONE trigger set, NOT three
+             forked controls (same rationale as the single-Link mandate).
+           · Strip  → ItemsControl-free single TextBlock bound to the VM's pure
+             StripText helper: "Label Value · Label Value · …". The middot is
+             injected BETWEEN segments by StripText only — it is NOT part of any
+             value (grammar: "inline dot separators that are NOT part of any
+             value"). One bound string ⇒ separator logic is unit-tested in
+             FactTableVm.StripText, never re-decided in XAML.
+           · Grid   → vertical 2-column ItemsControl: a Grid per row, label
+             (TextTertiaryBrush, left) + value (TextPrimaryBrush, right-aligned,
+             tabular-style alignment via a shared SharedSizeGroup label column so
+             values line up). One Label … Value per row, pair order preserved.
+           · Scalar → a single bare value TextBlock, no label, no rows (the
+             degenerate case the carry-forward demands the SAME primitive
+             degrade to — Pairs has exactly one label-less entry).
+           · Quiet (footer-quiet weight, orthogonal/P2): when the VM's Quiet is
+             true the value run switches to AppMonoFontFamily + TextTertiaryBrush
+             (the InternalName footer-quiet case). Default OFF — weight is not
+             over-engineered here. ===== -->
+    <Style TargetType="{x:Type c:FactTable}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <!-- The VM is the single source of truth: mirror its Layout onto the
+             control's Layout DP so the DataTriggers below have a control-level
+             enum target. One control, layout-switched — not a fork. -->
+        <Setter Property="Layout" Value="{Binding Layout}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type c:FactTable}">
+                    <!-- Grid.IsSharedSizeScope so the Grid-layout rows share a
+                         label-column width ⇒ values right-align on a common
+                         column (tabular-nums-style alignment). The three layout
+                         views live directly in this ONE template; the trigger
+                         set below toggles which is visible — that IS the
+                         anti-fork (one control, not three). -->
+                    <Grid x:Name="Root" Grid.IsSharedSizeScope="True">
+                        <!-- STRIP: one TextBlock bound to the pure StripText
+                             helper (separator injected between segments only). -->
+                        <TextBlock x:Name="StripView"
+                                   Visibility="Collapsed"
+                                   Text="{Binding StripText}"
+                                   TextWrapping="Wrap"
+                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                   FontFamily="{DynamicResource AppFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+
+                        <!-- GRID: vertical 2-column, label left, value
+                             right-aligned on a shared column. -->
+                        <ItemsControl x:Name="GridView"
+                                      Visibility="Collapsed"
+                                      ItemsSource="{Binding Pairs}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,1">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" SharedSizeGroup="FactLabel"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding Label}"
+                                                   Margin="0,0,16,0"
+                                                   Foreground="{StaticResource TextTertiaryBrush}"
+                                                   FontFamily="{DynamicResource AppFontFamily}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding Value}"
+                                                   HorizontalAlignment="Right"
+                                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                                   FontFamily="{DynamicResource AppFontFamily}"
+                                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <!-- SCALAR: a single bare value, no label, no rows.
+                             Pairs[0].Value is the lone label-less entry. -->
+                        <TextBlock x:Name="ScalarView"
+                                   Visibility="Collapsed"
+                                   Text="{Binding Pairs[0].Value}"
+                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                   FontFamily="{DynamicResource AppFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <!-- ONE trigger set selects the layout view. This IS the
+                             anti-fork: three templates, one control, switched by
+                             the Layout DP (mirrored from the VM). -->
+                        <Trigger Property="Layout" Value="Strip">
+                            <Setter TargetName="StripView" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="Layout" Value="Grid">
+                            <Setter TargetName="GridView" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="Layout" Value="Scalar">
+                            <Setter TargetName="ScalarView" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+
+                        <!-- Footer-quiet weight (orthogonal/P2): mono +
+                             TextTertiaryBrush on the value run. Applies to the
+                             single-value views (Strip/Scalar); Grid stays at
+                             body weight. Default OFF (Quiet=false). -->
+                        <DataTrigger Binding="{Binding Quiet}" Value="True">
+                            <Setter TargetName="StripView" Property="FontFamily" Value="{DynamicResource AppMonoFontFamily}"/>
+                            <Setter TargetName="StripView" Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
+                            <Setter TargetName="ScalarView" Property="FontFamily" Value="{DynamicResource AppMonoFontFamily}"/>
+                            <Setter TargetName="ScalarView" Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
+                            <Setter TargetName="StripView" Property="FontSize" Value="{DynamicResource AppFontSizeSmall}"/>
+                            <Setter TargetName="ScalarView" Property="FontSize" Value="{DynamicResource AppFontSizeSmall}"/>
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/SetRef.cs
+++ b/src/Mithril.Shared.Wpf/SetRef.cs
@@ -1,0 +1,134 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// What a click on a <see cref="SetRef"/> should do, decided purely from the bound
+/// <see cref="SetRefVm"/>. Factored out of the event handler so the
+/// actionable-vs-unwired branch is unit-testable without the visual tree (mirrors
+/// <see cref="LinkClickAction"/> / <see cref="Link.ResolveClick"/>).
+/// </summary>
+public enum SetRefClickAction
+{
+    /// <summary>VM is null — do nothing.</summary>
+    None,
+
+    /// <summary>Actionable Set-ref: invoke the host's command with the VM.</summary>
+    Activate,
+
+    /// <summary>
+    /// Availability corollary: the Set-ref is real and renders on the full blue
+    /// chassis, but its reveal/filter action is not yet wired. The grammar specifies
+    /// <em>no</em> behaviour for an un-wired Set-ref click, so this is the minimal
+    /// safe thing — a deliberate no-op (no command, no exception, no invented UI).
+    /// Flagged as an under-spec in the Phase-4 report.
+    /// </summary>
+    Unavailable,
+}
+
+/// <summary>
+/// The Phase-4 shared <b>SetRef</b> primitive (G3 visual grammar ·
+/// "Set-reference · filter / keyword / group / stacking" + carry-forward #4). One
+/// polymorphic templated control carrying <em>both</em> Set-ref shapes on one blue
+/// chassis; DataContext is a <see cref="SetRefVm"/>.
+/// <para>
+/// Visual target (strictly per <c>docs/silmarillion-visual-grammar.md</c> — every value
+/// is a committed token, none invented here): a blue chip <em>with</em> a chassis
+/// (unlike <see cref="Link"/>) — text <c>SetRefTextBrush</c>, idle fill
+/// <c>SetRefIdleFillBrush</c>, 1px <c>SetRefBorderBrush</c> border, <c>GrammarRadiusSm</c>
+/// corner, 1×8 padding. <b>summary-form</b> appends <c> · {count} →</c>; <b>tag-form</b>
+/// shows only the label (no count, no arrow, no glyph). Optional leading
+/// <c>SlotOrdinal</c> prefix in <c>TextQuaternaryBrush</c> for stacked positionally-
+/// material slots. Hover darkens the fill toward <c>AccentSoftBrush</c> and brightens the
+/// border (the "drawer-pulling" feel); <c>Cursor=Hand</c> only when actionable.
+/// </para>
+/// <para>
+/// <b>Availability corollary (never-grey-pill guarantee):</b> when
+/// <see cref="SetRefVm.IsActionable"/> is false the rest state is <em>visually
+/// identical</em> — same blue chassis, same fill/border/text. It MUST NOT degrade to an
+/// inert grey Fact pill (the forbidden inverted-affordance lie). Only interaction
+/// differs: no hand cursor, and a click is a safe no-op
+/// (<see cref="SetRefClickAction.Unavailable"/>).
+/// </para>
+/// Default style ships in <c>Mithril.Shared.Wpf/Resources.xaml</c> (appended after the
+/// <see cref="Link"/> style, mirroring its templated-control pattern).
+/// </summary>
+public sealed class SetRef : Control
+{
+    static SetRef()
+    {
+        DefaultStyleKeyProperty.OverrideMetadata(
+            typeof(SetRef), new FrameworkPropertyMetadata(typeof(SetRef)));
+    }
+
+    /// <summary>
+    /// Parent-supplied reveal/filter command. Bound on the control itself, not on the
+    /// <see cref="SetRefVm"/> — the VM is a data carrier; the command is supplied by the
+    /// hosting view. Receives the bound <see cref="SetRefVm"/> as its parameter (mirrors
+    /// how <see cref="Link.ClickCommand"/> / <see cref="EntityChip.ClickCommand"/> pass
+    /// their click param). Invoked only when the VM is actionable.
+    /// </summary>
+    public ICommand? ActivateCommand
+    {
+        get => (ICommand?)GetValue(ActivateCommandProperty);
+        set => SetValue(ActivateCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty ActivateCommandProperty = DependencyProperty.Register(
+        nameof(ActivateCommand),
+        typeof(ICommand),
+        typeof(SetRef),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Pure decision: given a (possibly null) bound VM, what should a click do? Factored
+    /// out of <see cref="OnClick"/> so the actionable-vs-unwired branch is unit-testable
+    /// without the visual tree. Actionable → <see cref="SetRefClickAction.Activate"/>;
+    /// any other non-null VM → <see cref="SetRefClickAction.Unavailable"/> (availability
+    /// corollary: still a Set-ref, never a dead-end <em>and</em> never an invented UI —
+    /// the safe no-op); null VM → <see cref="SetRefClickAction.None"/>.
+    /// </summary>
+    public static SetRefClickAction ResolveClick(SetRefVm? vm)
+    {
+        if (vm is null) return SetRefClickAction.None;
+        return vm.IsActionable ? SetRefClickAction.Activate : SetRefClickAction.Unavailable;
+    }
+
+    private Button? _button;
+
+    public override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        if (_button is not null)
+            _button.Click -= OnClick;
+
+        _button = GetTemplateChild("PART_Button") as Button;
+
+        if (_button is not null)
+            _button.Click += OnClick;
+    }
+
+    private void OnClick(object sender, RoutedEventArgs e)
+    {
+        var vm = DataContext as SetRefVm;
+        switch (ResolveClick(vm))
+        {
+            case SetRefClickAction.Activate:
+                var cmd = ActivateCommand;
+                if (cmd is not null && cmd.CanExecute(vm))
+                    cmd.Execute(vm);
+                break;
+
+            // Unavailable: availability-corollary no-op. The grammar specifies no
+            // behaviour for an un-wired Set-ref click; do the minimal safe thing
+            // (nothing — no command, no exception, no invented affordance).
+            case SetRefClickAction.Unavailable:
+            case SetRefClickAction.None:
+            default:
+                break;
+        }
+    }
+}

--- a/src/Mithril.Shared.Wpf/SetRefVm.cs
+++ b/src/Mithril.Shared.Wpf/SetRefVm.cs
@@ -1,0 +1,85 @@
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// The unified data-carrier for the Phase-4 <see cref="SetRef"/> primitive — the single
+/// polymorphic Set-reference VM that carries <em>both</em> shapes the G3 visual grammar
+/// ratifies on one blue chassis (<c>docs/silmarillion-visual-grammar.md</c> ·
+/// "Set-reference · filter / keyword / group / stacking" + Phase-4 carry-forward #4).
+/// <para>
+/// <b>Two shapes, one chassis (carry-forward #4):</b>
+/// <list type="bullet">
+///   <item><b>summary-form</b> — <see cref="MatchCount"/> non-null → renders
+///     <c>"{Label} · {MatchCount} →"</c> (count + trailing arrow ride on the chip;
+///     "the drawer you can pull").</item>
+///   <item><b>tag-form</b> — <see cref="MatchCount"/> null → bare <see cref="Label"/>:
+///     no count, no arrow, no lead glyph (the grammar's "glyph: None by default"). The
+///     <em>chip shape itself</em> carries the tier.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Availability corollary (the never-grey-pill guarantee).</b> <see cref="IsActionable"/>
+/// is <em>false</em> for an un-wired tag-form Set-ref (e.g. today's StorageVault keyword
+/// tags whose filter is not yet hooked up). Per the ratified availability corollary such a
+/// chip is <em>still a Set-reference in a non-activated state</em>: it MUST render on the
+/// full blue Set-ref chassis and MUST NOT degrade to an inert grey Fact pill — that grey
+/// pill is exactly the forbidden inverted-affordance lie #404 exists to kill.
+/// <see cref="IsActionable"/> therefore changes <em>interaction only</em> (hand cursor +
+/// dispatch), <b>never</b> the at-rest tier look. Mirrors the inverse-of-legacy stance
+/// <see cref="LinkVm.IsNavigable"/> takes for Link's G-c degrade.
+/// </para>
+/// <para>
+/// <b>Stacking ordinal.</b> Per the grammar's <em>Stacking semantics</em> clause: when a
+/// recipe has N <em>positionally material</em> slots binding the same set (the canonical
+/// "two any-Crystal ingredient slots" case where the consumer references the slot index),
+/// each chip carries a small ordinal prefix (1, 2, …) in <c>TextQuaternaryBrush</c>.
+/// <see cref="SlotOrdinal"/> null = positionally inert / single → no prefix.
+/// </para>
+/// </summary>
+/// <param name="Label">The set name (e.g. <c>"Crystal"</c>, <c>"Alchemy"</c>, <c>"Potion"</c>).</param>
+/// <param name="MatchCount">
+/// Non-null → summary-form (<c>"{Label} · {MatchCount} →"</c>). Null → tag-form (bare label).
+/// The presence of this value <em>is</em> the shape selector.
+/// </param>
+/// <param name="IsActionable">
+/// True if the reveal/filter action is wired (click dispatches, hand cursor). False = not
+/// yet wired: <em>still a Set-ref on the blue chassis</em> (availability corollary) — only
+/// interaction differs, never the at-rest look.
+/// </param>
+/// <param name="SlotOrdinal">
+/// Stacking ordinal prefix for positionally-material stacked slots (1, 2, …). Null =
+/// positionally inert / single → no prefix.
+/// </param>
+public sealed record SetRefVm(
+    string Label,
+    int? MatchCount = null,
+    bool IsActionable = true,
+    int? SlotOrdinal = null)
+{
+    /// <summary>
+    /// True when <see cref="MatchCount"/> is non-null → render the summary-form
+    /// (<c>"{Label} · {MatchCount} →"</c>). False → tag-form (bare <see cref="Label"/>).
+    /// This is the pure shape selector; the template binds its count/arrow visibility to
+    /// it so the two shapes never fork into two controls (anti-fork rationale, carry-fwd #4).
+    /// </summary>
+    public bool IsSummaryForm => MatchCount is not null;
+
+    /// <summary>
+    /// True when <see cref="SlotOrdinal"/> is set → the leading ordinal prefix renders.
+    /// A VM bool (not a converter) precisely so the template uses the object-safe
+    /// visibility path without a bespoke <c>int?</c>→Visibility converter — and to dodge
+    /// the string-only <c>NullOrEmptyToVis</c> repo footgun entirely.
+    /// </summary>
+    public bool HasOrdinal => SlotOrdinal is not null;
+
+    /// <summary>
+    /// The body text for the chip, with the shape baked in: tag-form is the bare label;
+    /// summary-form appends <c> · {count} →</c>. Factored onto the VM (pure, no visual
+    /// tree) so the summary-vs-tag selection is unit-testable and the template binds one
+    /// string instead of re-deciding the shape in XAML.
+    /// </summary>
+    public string DisplayText =>
+        IsSummaryForm ? $"{Label} · {MatchCount} →" : Label;
+
+    /// <summary>The leading ordinal prefix glyph (e.g. <c>"1"</c>), or empty when none.</summary>
+    public string OrdinalText => HasOrdinal ? SlotOrdinal!.Value.ToString() : string.Empty;
+}

--- a/tests/Mithril.Shared.Tests/Wpf/FactFooterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/FactFooterTests.cs
@@ -1,0 +1,199 @@
+using System.Linq;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Pure-logic coverage for the Phase-4 <see cref="FactFooter"/> primitive (mirrors
+/// <see cref="LinkTests"/> / <see cref="SetRefTests"/> / <see cref="FactTableTests"/>:
+/// no UI spin-up). Covers the <see cref="FactFooterVm.None"/>/<see cref="FactFooterVm.Key"/>/
+/// <see cref="FactFooterVm.Of"/> factories, the ratified G-a 0/1/2 cap (<c>Of</c>
+/// rejects &gt;2), the pure per-cell click decision
+/// (<see cref="FactFooter.ResolveCellClick"/>, factored out precisely so the
+/// copyable-iff-KEY branch is testable without a visual tree — mirrors
+/// <see cref="Link.ResolveClick"/>), the inert middot placement (between cells only,
+/// never inside a value), and that a copyable cell's copy payload is exactly its own
+/// <see cref="FactFooterId.Value"/> (no label, no separator).
+/// </summary>
+public sealed class FactFooterTests
+{
+    // ── Factories ──
+
+    [Fact]
+    public void None_ZeroIds_StripHidden()
+    {
+        var vm = FactFooterVm.None();
+
+        vm.Ids.Should().BeEmpty();
+        vm.HasIds.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Key_SingleCopyableKeyCell()
+    {
+        var vm = FactFooterVm.Key("BrewTinctureOfTheTides");
+
+        vm.Ids.Should().ContainSingle();
+        vm.HasIds.Should().BeTrue();
+        var id = vm.Ids[0];
+        id.LabelTag.Should().Be("KEY");
+        id.Value.Should().Be("BrewTinctureOfTheTides");
+        id.Copyable.Should().BeTrue();
+        id.Copied.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Of_ZeroIds_IsEquivalentToNone()
+    {
+        var vm = FactFooterVm.Of();
+
+        vm.Ids.Should().BeEmpty();
+        vm.HasIds.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Of_OneId_PreservesIt()
+    {
+        var key = new FactFooterId("KEY", "InternalName", copyable: true);
+
+        var vm = FactFooterVm.Of(key);
+
+        vm.Ids.Should().ContainSingle().Which.Should().BeSameAs(key);
+    }
+
+    [Fact]
+    public void Of_TwoIds_PreservesOrderVerbatim()
+    {
+        var key = new FactFooterId("KEY", "TheKey", copyable: true);
+        var row = new FactFooterId("ROW", "envelope-42", copyable: false);
+
+        var vm = FactFooterVm.Of(key, row);
+
+        vm.Ids.Should().HaveCount(2);
+        vm.Ids[0].Should().BeSameAs(key);
+        vm.Ids[1].Should().BeSameAs(row);
+    }
+
+    [Fact]
+    public void Of_MoreThanTwoIds_Throws_GaCapIsRatified()
+    {
+        var act = () => FactFooterVm.Of(
+            new FactFooterId("KEY", "a", true),
+            new FactFooterId("ROW", "b", false),
+            new FactFooterId("KEY", "c", true));
+
+        // 0/1/2 is a ratified G-a invariant — an over-count is a loud
+        // programming error, never a silent truncation.
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*caps identifiers at 2*");
+        FactFooterVm.MaxIds.Should().Be(2);
+    }
+
+    // ── The pure per-cell click decision (no visual tree) ──
+
+    [Fact]
+    public void ResolveCellClick_NullCell_None()
+    {
+        FactFooter.ResolveCellClick(null).Should().Be(FactFooterCellAction.None);
+    }
+
+    [Fact]
+    public void ResolveCellClick_CopyableKey_Copy()
+    {
+        var key = new FactFooterId("KEY", "TheKey", copyable: true);
+
+        FactFooter.ResolveCellClick(key).Should().Be(FactFooterCellAction.Copy);
+    }
+
+    [Fact]
+    public void ResolveCellClick_NonCopyableRow_Inert()
+    {
+        var row = new FactFooterId("ROW", "envelope-42", copyable: false);
+
+        FactFooter.ResolveCellClick(row).Should().Be(FactFooterCellAction.Inert);
+    }
+
+    [Fact]
+    public void ResolveCellClick_DecidedByCopyableBool_NotTheLabelTagString()
+    {
+        // The G-a discriminator is the explicit Copyable bool, never inferred
+        // from LabelTag. A "KEY"-tagged-but-not-copyable cell is Inert; a
+        // "ROW"-tagged-but-copyable cell is Copy. (The factories never produce
+        // these; the primitive must still honour the bool, not the string.)
+        var keyTaggedInert = new FactFooterId("KEY", "v", copyable: false);
+        var rowTaggedCopyable = new FactFooterId("ROW", "v", copyable: true);
+
+        FactFooter.ResolveCellClick(keyTaggedInert).Should().Be(FactFooterCellAction.Inert);
+        FactFooter.ResolveCellClick(rowTaggedCopyable).Should().Be(FactFooterCellAction.Copy);
+    }
+
+    // ── Separator: between cells only, never inside a value ──
+
+    [Fact]
+    public void CellSeparator_IsTheInertMiddot()
+    {
+        FactFooterVm.CellSeparator.Should().Be(" · ");
+    }
+
+    [Fact]
+    public void RenderedTwoCellStrip_PlacesMiddotOnlyBetweenCells_NeverInsideAValue()
+    {
+        // The Style suppresses the first cell's leading middot (AlternationIndex
+        // == 0) and prefixes every later cell with CellSeparator. Model that
+        // join here purely (no visual tree): cell[0] bare, cell[1..] separator-
+        // prefixed — the separator is BETWEEN cells, never authored into a value.
+        var key = new FactFooterId("KEY", "Brew Tincture", copyable: true);
+        var row = new FactFooterId("ROW", "envelope-42", copyable: false);
+        var vm = FactFooterVm.Of(key, row);
+
+        var rendered = string.Join(
+            "",
+            vm.Ids.Select((id, i) =>
+                (i == 0 ? "" : FactFooterVm.CellSeparator) + $"{id.LabelTag} {id.Value}"));
+
+        rendered.Should().Be("KEY Brew Tincture · ROW envelope-42");
+
+        // The separator appears exactly once (between the two cells) and never
+        // inside either value.
+        rendered.Split(FactFooterVm.CellSeparator).Should().HaveCount(2);
+        key.Value.Should().NotContain(FactFooterVm.CellSeparator.Trim());
+        row.Value.Should().NotContain(FactFooterVm.CellSeparator.Trim());
+    }
+
+    [Fact]
+    public void SingleCell_HasNoSeparatorAtAll()
+    {
+        var vm = FactFooterVm.Key("OnlyKey");
+
+        var rendered = string.Join(
+            "",
+            vm.Ids.Select((id, i) =>
+                (i == 0 ? "" : FactFooterVm.CellSeparator) + id.Value));
+
+        rendered.Should().Be("OnlyKey");
+        rendered.Should().NotContain(FactFooterVm.CellSeparator.Trim());
+    }
+
+    // ── Copy payload is exactly the cell's own Value ──
+
+    [Fact]
+    public void CopyableCell_CopyPayloadEqualsExactlyItsOwnValue_NoLabelNoSeparator()
+    {
+        // The cell's Value IS the whole copy payload — FactFooter.cs copies
+        // cell.Value verbatim (no LabelTag, no separator). Asserted on the model
+        // contract that the copy path consumes.
+        var key = new FactFooterId("KEY", "BrewTinctureOfTheTides", copyable: true);
+        var row = new FactFooterId("ROW", "envelope-99", copyable: false);
+        _ = FactFooterVm.Of(key, row);
+
+        // The payload for the copyable cell is its Value alone — it does not
+        // include the tag, the other cell's value, or the separator.
+        var payload = key.Value;
+        payload.Should().Be("BrewTinctureOfTheTides");
+        payload.Should().NotContain(key.LabelTag);
+        payload.Should().NotContain(row.Value);
+        payload.Should().NotContain(FactFooterVm.CellSeparator.Trim());
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/FactTableTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/FactTableTests.cs
@@ -1,0 +1,172 @@
+using System.Reflection;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Pure-logic coverage for the Phase-4 <see cref="FactTable"/> primitive (mirrors
+/// <see cref="LinkTests"/> / <see cref="SetRefTests"/>: no UI spin-up). Covers the
+/// three factory shapes and their <see cref="FactTableLayout"/>, the degenerate
+/// single-pair Scalar invariant, pair-order preservation for Strip/Grid, the pure
+/// <see cref="FactTableVm.StripText"/> separator-placement helper (factored out
+/// precisely so the middot logic is testable without a visual tree, mirroring
+/// <see cref="Link.ResolveClick"/>), and the load-bearing G-b inertness invariant:
+/// the model carries NO brush/pigment on the value path, so a Fact value can never
+/// reference gold/accent by construction.
+/// </summary>
+public sealed class FactTableTests
+{
+    // ── Factories produce the expected Layout + Pairs ──
+
+    [Fact]
+    public void ScalarFactory_ScalarLayout_SingleLabelLessPair()
+    {
+        var vm = FactTableVm.Scalar("16 slots");
+
+        vm.Layout.Should().Be(FactTableLayout.Scalar);
+        vm.Pairs.Should().ContainSingle();
+        vm.Pairs[0].Label.Should().BeNull();
+        vm.Pairs[0].Value.Should().Be("16 slots");
+        vm.Quiet.Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripFactory_StripLayout_PreservesPairOrder()
+    {
+        var pairs = new[]
+        {
+            new FactPair("Skill", "Alchemy 55"),
+            new FactPair("Yields", "2"),
+            new FactPair(null, "no-label tail"),
+        };
+
+        var vm = FactTableVm.Strip(pairs);
+
+        vm.Layout.Should().Be(FactTableLayout.Strip);
+        vm.Pairs.Should().Equal(pairs); // order preserved verbatim
+    }
+
+    [Fact]
+    public void GridFactory_GridLayout_PreservesPairOrder()
+    {
+        var pairs = new[]
+        {
+            new FactPair("Comfortable", "30"),
+            new FactPair("Friends", "40"),
+            new FactPair("Soul Mates", "60"),
+        };
+
+        var vm = FactTableVm.Grid(pairs);
+
+        vm.Layout.Should().Be(FactTableLayout.Grid);
+        vm.Pairs.Should().Equal(pairs); // favor-tier rows stay in order
+    }
+
+    [Fact]
+    public void Factories_PropagateQuietOptIn()
+    {
+        FactTableVm.Scalar("BrewTinctureOfTheTides", quiet: true).Quiet.Should().BeTrue();
+        FactTableVm.Strip(new[] { new FactPair(null, "x") }, quiet: true).Quiet.Should().BeTrue();
+        FactTableVm.Grid(new[] { new FactPair("a", "b") }, quiet: true).Quiet.Should().BeTrue();
+    }
+
+    // ── The pure StripText helper: separator placement (no visual tree) ──
+
+    [Fact]
+    public void StripText_JoinsLabelValuePairs_WithMiddotBetweenSegmentsOnly()
+    {
+        var vm = FactTableVm.Strip(new[]
+        {
+            new FactPair("A", "1"),
+            new FactPair("B", "2"),
+        });
+
+        // "A 1 · B 2" — the middot is BETWEEN segments, never inside a value.
+        vm.StripText.Should().Be("A 1 · B 2");
+    }
+
+    [Fact]
+    public void StripText_NullLabel_RendersValueOnlySegment()
+    {
+        var vm = FactTableVm.Strip(new[]
+        {
+            new FactPair(null, "ValueOnly"),
+            new FactPair("Skill", "Alchemy 55"),
+        });
+
+        vm.StripText.Should().Be("ValueOnly · Skill Alchemy 55");
+    }
+
+    [Fact]
+    public void StripText_SingleSegment_HasNoSeparator()
+    {
+        var vm = FactTableVm.Strip(new[] { new FactPair("Only", "1") });
+
+        vm.StripText.Should().Be("Only 1");
+        vm.StripText.Should().NotContain(FactTableVm.StripSeparator.Trim());
+    }
+
+    [Fact]
+    public void StripText_ScalarShape_IsJustTheBareValue_NoSeparator()
+    {
+        // The degenerate case still routes through the same helper: one
+        // label-less pair ⇒ the bare value, no middot.
+        var vm = FactTableVm.Scalar("16 slots");
+
+        vm.StripText.Should().Be("16 slots");
+    }
+
+    [Fact]
+    public void StripSeparator_IsMiddotAndNotPartOfAnyValue()
+    {
+        // The separator is the U+00B7 middot, padded — it is injected between
+        // segments only, never authored into a value.
+        FactTableVm.StripSeparator.Should().Be(" · ");
+    }
+
+    // ── G-b inertness invariant: no gold/accent on the value path ──
+
+    [Fact]
+    public void Model_CarriesNoBrushOrPigment_GbInertByConstruction()
+    {
+        // G-b: Fact values are NEVER gold. The strongest possible test is
+        // structural — the data model has no brush/colour member at all, so the
+        // value path *cannot* reference accent/gold. Pigment lives only in the
+        // default Style (TextPrimaryBrush for values, asserted by inspection /
+        // the Style comment block in Resources.xaml). Enumerate FactPair +
+        // FactTableVm members and assert none is a brush/colour.
+        var suspectNames = new[] { "brush", "color", "colour", "accent", "gold", "pigment" };
+
+        var members = typeof(FactPair).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => (p.Name, p.PropertyType))
+            .Concat(typeof(FactTableVm).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(p => (p.Name, p.PropertyType)))
+            .ToList();
+
+        members.Should().NotBeEmpty();
+        foreach (var (name, type) in members)
+        {
+            suspectNames.Should().NotContain(
+                s => name.Contains(s, StringComparison.OrdinalIgnoreCase),
+                $"Fact is inert per G-b — '{name}' must not be a pigment member");
+            type.Name.Should().NotContain(
+                "Brush",
+                $"Fact value path carries no brush ('{name}' is {type.Name}); pigment is the Style's job");
+        }
+    }
+
+    [Fact]
+    public void Layout_ThreeValues_OneControlNotAFork()
+    {
+        // Documents the anti-fork (carry-forward #3): exactly the three layout
+        // cases, all carried by ONE enum on ONE primitive — no per-shape type.
+        Enum.GetValues<FactTableLayout>().Should().BeEquivalentTo(new[]
+        {
+            FactTableLayout.Strip,
+            FactTableLayout.Grid,
+            FactTableLayout.Scalar,
+        });
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using MahApps.Metro.IconPacks;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Pure-logic coverage for the Phase-4 <see cref="Link"/> primitive (mirrors
+/// <see cref="FormattedTextRendererTests"/>'s style: no UI spin-up). Covers the
+/// <see cref="LinkVm"/> adapters, the glyph→Lucide mapping, and the
+/// navigable-vs-pending click decision (factored into <see cref="Link.ResolveClick"/>
+/// precisely so it is testable without the visual tree).
+/// </summary>
+public sealed class LinkTests
+{
+    // ── LinkVm.From(EntityChipVm) ──
+
+    [Fact]
+    public void From_EntityChip_CarriesNameReferenceAndNavigability()
+    {
+        var chip = new EntityChipVm("Iron Sword", IconId: 42,
+            EntityRef.Item("IronSword"), IsNavigable: true);
+
+        var vm = LinkVm.From(chip);
+
+        vm.DisplayName.Should().Be("Iron Sword");
+        vm.Reference.Should().Be(EntityRef.Item("IronSword"));
+        vm.IsNavigable.Should().BeTrue();
+        // Link is glyph-coded, not icon-imaged — IconId is intentionally dropped.
+        vm.ProvenanceSuffix.Should().BeNull();
+        vm.KindLabel.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(EntityKind.Skill, LinkGlyph.Skill)]
+    [InlineData(EntityKind.Recipe, LinkGlyph.Recipe)]
+    [InlineData(EntityKind.Npc, LinkGlyph.Npc)]
+    [InlineData(EntityKind.Area, LinkGlyph.Location)]
+    [InlineData(EntityKind.Item, LinkGlyph.Item)]
+    [InlineData(EntityKind.ItemByKeyword, LinkGlyph.Item)]
+    [InlineData(EntityKind.Ability, LinkGlyph.CombatAbility)]
+    public void From_EntityChip_MapsKnownKindsToGlyph(EntityKind kind, LinkGlyph expected)
+    {
+        var chip = new EntityChipVm("X", 0, new EntityRef(kind, "X"), IsNavigable: true);
+
+        LinkVm.From(chip).Glyph.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(EntityKind.Effect)]
+    [InlineData(EntityKind.Quest)]
+    [InlineData(EntityKind.Lorebook)]
+    [InlineData(EntityKind.PlayerTitle)]
+    [InlineData(EntityKind.StorageVault)]
+    [InlineData(EntityKind.EffectKeyword)]
+    [InlineData(EntityKind.EffectByStackingType)]
+    public void From_EntityChip_UnmappedKinds_DefaultToNone(EntityKind kind)
+    {
+        var chip = new EntityChipVm("X", 0, new EntityRef(kind, "X"), IsNavigable: false);
+
+        LinkVm.From(chip).Glyph.Should().Be(LinkGlyph.None);
+    }
+
+    // ── LinkVm.From(ItemSourceChipVm) ──
+
+    [Fact]
+    public void From_ItemSourceChip_DetailBecomesProvenanceSuffix()
+    {
+        var chip = new ItemSourceChipVm(
+            "Distilled Tincture", Detail: "from Distil Brine", IconId: 7,
+            EntityReference: EntityRef.Recipe("DistilBrine"), IsNavigable: true);
+
+        var vm = LinkVm.From(chip);
+
+        vm.DisplayName.Should().Be("Distilled Tincture");
+        vm.ProvenanceSuffix.Should().Be("from Distil Brine");
+        vm.Reference.Should().Be(EntityRef.Recipe("DistilBrine"));
+        vm.Glyph.Should().Be(LinkGlyph.Recipe);
+        vm.IsNavigable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void From_ItemSourceChip_NullDetail_YieldsNullProvenance()
+    {
+        var chip = new ItemSourceChipVm("Bare Source", Detail: null, IconId: null,
+            EntityReference: null, IsNavigable: false);
+
+        var vm = LinkVm.From(chip);
+
+        vm.ProvenanceSuffix.Should().BeNull();
+        // No EntityReference → no glyph.
+        vm.Glyph.Should().Be(LinkGlyph.None);
+        vm.Reference.Should().BeNull();
+        vm.IsNavigable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void From_ItemSourceChip_EmptyDetail_NormalisedToNullProvenance()
+    {
+        var chip = new ItemSourceChipVm("X", Detail: "", IconId: null,
+            EntityReference: EntityRef.Npc("NPC_X"), IsNavigable: false);
+
+        var vm = LinkVm.From(chip);
+
+        vm.ProvenanceSuffix.Should().BeNull();
+        vm.Glyph.Should().Be(LinkGlyph.Npc);
+    }
+
+    // ── Glyph enum → PackIconLucideKind ──
+
+    [Theory]
+    [InlineData(LinkGlyph.Skill, PackIconLucideKind.Sparkles)]
+    [InlineData(LinkGlyph.Recipe, PackIconLucideKind.FlaskConical)]
+    [InlineData(LinkGlyph.Ingredient, PackIconLucideKind.FlaskRound)]
+    [InlineData(LinkGlyph.Npc, PackIconLucideKind.UserRound)]
+    [InlineData(LinkGlyph.Location, PackIconLucideKind.MapPin)]
+    [InlineData(LinkGlyph.Item, PackIconLucideKind.Package)]
+    [InlineData(LinkGlyph.CombatAbility, PackIconLucideKind.Sword)]
+    public void ToLucideKind_MapsEachGlyphToItsRatifiedLucideKind(
+        LinkGlyph glyph, PackIconLucideKind expected)
+    {
+        Link.ToLucideKind(glyph).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ToLucideKind_None_MapsToLucideNone_NoGlyph()
+    {
+        Link.ToLucideKind(LinkGlyph.None).Should().Be(PackIconLucideKind.None);
+    }
+
+    // ── Click decision: navigable vs. pending (G-c) ──
+
+    [Fact]
+    public void ResolveClick_Navigable_WithReference_Navigates()
+    {
+        var vm = new LinkVm("Iron Sword", LinkGlyph.Item,
+            EntityRef.Item("IronSword"), IsNavigable: true);
+
+        Link.ResolveClick(vm).Should().Be(LinkClickAction.Navigate);
+    }
+
+    [Fact]
+    public void ResolveClick_NotNavigable_CopiesName_NeverDeadClick()
+    {
+        // G-c: a non-navigable Link is STILL a Link. Click copies the name.
+        var vm = new LinkVm("Coming Soon Entity", LinkGlyph.Recipe,
+            EntityRef.Recipe("NotShippedYet"), IsNavigable: false);
+
+        Link.ResolveClick(vm).Should().Be(LinkClickAction.CopyName);
+    }
+
+    [Fact]
+    public void ResolveClick_NavigableButNullReference_FallsBackToCopy()
+    {
+        // Navigable flag but no target (e.g. an ItemSourceChip source with no
+        // EntityReference) — degrade to copy rather than a no-op dead click.
+        var vm = new LinkVm("Orphan", LinkGlyph.None, Reference: null, IsNavigable: true);
+
+        Link.ResolveClick(vm).Should().Be(LinkClickAction.CopyName);
+    }
+
+    [Fact]
+    public void ResolveClick_NullVm_IsNoOp()
+    {
+        Link.ResolveClick(null).Should().Be(LinkClickAction.None);
+    }
+
+    [Fact]
+    public void ResolveClick_Adapters_FeedTheBranchEndToEnd()
+    {
+        // The Phase-5 migration path: a navigable EntityChip → Navigate; a
+        // non-navigable ItemSourceChip → CopyName. Proves the adapter + decision
+        // compose without re-deciding visuals.
+        var navigable = LinkVm.From(
+            new EntityChipVm("Recipe X", 0, EntityRef.Recipe("RecipeX"), IsNavigable: true));
+        var pending = LinkVm.From(
+            new ItemSourceChipVm("Vendor Y", "from Trader Joe", null,
+                EntityRef.Npc("NPC_Joe"), IsNavigable: false));
+
+        Link.ResolveClick(navigable).Should().Be(LinkClickAction.Navigate);
+        Link.ResolveClick(pending).Should().Be(LinkClickAction.CopyName);
+        pending.ProvenanceSuffix.Should().Be("from Trader Joe");
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/SetRefTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/SetRefTests.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Pure-logic coverage for the Phase-4 <see cref="SetRef"/> primitive (mirrors
+/// <see cref="LinkTests"/>'s style: no UI spin-up). Covers the two
+/// <see cref="SetRefVm"/> shapes (summary-form vs tag-form), the stacking ordinal
+/// prefix, the actionable-vs-unwired click decision (factored into
+/// <see cref="SetRef.ResolveClick"/> precisely so it is testable without the visual
+/// tree), and the availability corollary's load-bearing invariant: the at-rest shape
+/// does NOT vary with <see cref="SetRefVm.IsActionable"/>.
+/// </summary>
+public sealed class SetRefTests
+{
+    // ── Shape selection: summary-form vs tag-form (carry-forward #4) ──
+
+    [Fact]
+    public void MatchCountSet_IsSummaryForm_RendersCountAndArrow()
+    {
+        var vm = new SetRefVm("Crystal", MatchCount: 150);
+
+        vm.IsSummaryForm.Should().BeTrue();
+        vm.DisplayText.Should().Be("Crystal · 150 →");
+    }
+
+    [Fact]
+    public void MatchCountNull_IsTagForm_BareLabelOnly()
+    {
+        // tag-form: no count, no arrow, no glyph — the chip shape carries the tier.
+        var vm = new SetRefVm("Alchemy");
+
+        vm.IsSummaryForm.Should().BeFalse();
+        vm.MatchCount.Should().BeNull();
+        vm.DisplayText.Should().Be("Alchemy");
+    }
+
+    [Fact]
+    public void MatchCountZero_IsStillSummaryForm_NotTagForm()
+    {
+        // The shape selector is null-vs-set, NOT zero-vs-nonzero: a real
+        // "0 matches →" summary is still summary-form.
+        var vm = new SetRefVm("Potion", MatchCount: 0);
+
+        vm.IsSummaryForm.Should().BeTrue();
+        vm.DisplayText.Should().Be("Potion · 0 →");
+    }
+
+    // ── Stacking ordinal prefix (Stacking semantics clause) ──
+
+    [Fact]
+    public void SlotOrdinalSet_HasOrdinal_AndPrefixText()
+    {
+        var vm = new SetRefVm("Crystal", MatchCount: 150, SlotOrdinal: 2);
+
+        vm.HasOrdinal.Should().BeTrue();
+        vm.OrdinalText.Should().Be("2");
+    }
+
+    [Fact]
+    public void SlotOrdinalNull_NoOrdinal_EmptyPrefixText()
+    {
+        // Positionally inert / single → no prefix.
+        var vm = new SetRefVm("Crystal", MatchCount: 150);
+
+        vm.HasOrdinal.Should().BeFalse();
+        vm.OrdinalText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Ordinal_IsIndependentOfShape_TagFormCanStack()
+    {
+        // A stacked tag-form chip (e.g. two identical keyword slots) still
+        // carries its ordinal even with no count.
+        var vm = new SetRefVm("Crystal", MatchCount: null, SlotOrdinal: 1);
+
+        vm.IsSummaryForm.Should().BeFalse();
+        vm.HasOrdinal.Should().BeTrue();
+        vm.OrdinalText.Should().Be("1");
+        vm.DisplayText.Should().Be("Crystal");
+    }
+
+    // ── Click decision: actionable vs. unwired (availability corollary) ──
+
+    [Fact]
+    public void ResolveClick_Actionable_Activates()
+    {
+        var vm = new SetRefVm("Crystal", MatchCount: 150, IsActionable: true);
+
+        SetRef.ResolveClick(vm).Should().Be(SetRefClickAction.Activate);
+    }
+
+    [Fact]
+    public void ResolveClick_NotActionable_IsSafeNoOp_NeverThrows()
+    {
+        // Availability corollary: an un-wired Set-ref is STILL a Set-ref. The
+        // grammar specifies no click behaviour → minimal safe thing: no-op.
+        var vm = new SetRefVm("StorageKeyword", MatchCount: null, IsActionable: false);
+
+        SetRef.ResolveClick(vm).Should().Be(SetRefClickAction.Unavailable);
+    }
+
+    [Fact]
+    public void ResolveClick_NullVm_IsNone()
+    {
+        SetRef.ResolveClick(null).Should().Be(SetRefClickAction.None);
+    }
+
+    // ── Availability corollary invariant: at-rest shape is IsActionable-invariant ──
+
+    [Fact]
+    public void AtRestShape_DoesNotVaryWithIsActionable_NeverGreyPill()
+    {
+        // The load-bearing #404 invariant: an un-wired Set-ref must render on the
+        // FULL blue chassis identically to a wired one — never an inert grey Fact
+        // pill (the forbidden inverted-affordance lie). The pure shape surface
+        // (DisplayText / IsSummaryForm / ordinal) is the testable proxy for
+        // "same chassis": it is computed identically regardless of IsActionable;
+        // only ResolveClick (interaction) branches on it.
+        var wired = new SetRefVm("Alchemy", MatchCount: null, IsActionable: true);
+        var unwired = new SetRefVm("Alchemy", MatchCount: null, IsActionable: false);
+
+        unwired.DisplayText.Should().Be(wired.DisplayText);
+        unwired.IsSummaryForm.Should().Be(wired.IsSummaryForm);
+        unwired.HasOrdinal.Should().Be(wired.HasOrdinal);
+        unwired.OrdinalText.Should().Be(wired.OrdinalText);
+
+        // The ONLY axis that differs is the click dispatch (interaction), never
+        // the at-rest shape.
+        SetRef.ResolveClick(wired).Should().Be(SetRefClickAction.Activate);
+        SetRef.ResolveClick(unwired).Should().Be(SetRefClickAction.Unavailable);
+    }
+
+    [Fact]
+    public void AtRestShape_SummaryForm_AlsoIsActionableInvariant()
+    {
+        var wired = new SetRefVm("Crystal", MatchCount: 150, IsActionable: true, SlotOrdinal: 2);
+        var unwired = new SetRefVm("Crystal", MatchCount: 150, IsActionable: false, SlotOrdinal: 2);
+
+        unwired.DisplayText.Should().Be(wired.DisplayText);
+        unwired.DisplayText.Should().Be("Crystal · 150 →");
+        unwired.OrdinalText.Should().Be(wired.OrdinalText);
+    }
+}


### PR DESCRIPTION
## What

The complete **Phase 4** of the #404 visual-grammar program: the dispatch spec **and** its executed, verified implementation, bundled as one auditable change (same pattern as the Phase 3 PR #409).

**Dispatch + provenance**
- `docs/agent-plans/2026-05-17-silmarillion-404-phase4-primitives.md` — the Phase 4 engineering dispatch, now with an **Execution outcome** section: verification results, shell-boot-smoke PASS, and a 12-item reconciliation/under-spec ledger for the designer/maintainer.

**Implementation — shared `Mithril.Shared.Wpf` primitives (one per tier; legacy controls untouched, coexisting until Phase 5)**
- **token reconciliation** — missing G3 tokens added to `Resources.xaml` with an inline design-token→key ledger; flags the `--info #88B0E0` → real q-keyword `#FFCFE8FF` reconciliation.
- **`Link`** — V2 (lead glyph + gold name, no box); **subsumes `EntityChip` + `ItemSourceChip`** via `LinkVm` + adapters; G-c pending-availability (rest-identical, hover-copy, never grey/Fact).
- **`SetRef`** — blue chip; summary-form *and* tag-form on one chassis; unwired-tag stays blue Set-ref (never the forbidden grey Fact pill); stacking ordinal.
- **`FactTable`** — one polymorphic primitive: dot-strip ↔ 2-col grid ↔ flat scalar; inert, no gold (G-b).
- **`FactFooter`** — G-a: 0/1/2 ids, KEY-copyable vs ROW-inert, below a faint divider, location-not-chassis.
- **Fact/Structure/Control shared styles** — opt-in `x:Key`'d (no implicit override).

## Verification

- `Mithril.slnx` clean rebuild (`start.ps1 -Clean`): `0W/0E`, no RG1000 flake
- `XamlResourceLint: OK (115 keys)` — validates the new tokens + six styles
- Shell **reached `Application started`** (clean boot; primitives present)
- `Mithril.Shared.Tests` **1094/1094** (incl. 67 new: Link 31, SetRef 11, FactTable 11, FactFooter 14) · `Silmarillion.Tests` **478/478**
- Guard: **no `*DetailView.xaml` / `EntityChip` / `ItemSourceChip` / `DetailExportHost` modified** — Phase 5 migrates call sites

## Not in scope

No view migrated (Phase 5, G4-reviewed per area). The 12 reconciliation flags are the designer's call (headline: confirm/pin the Set-ref pigment) — all cheap one-token/trigger tunes, documented in the dispatch doc's ledger. Coverage axis (#407/#408) and the #214-bound Effects-stub placement remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
