### PR TITLE
feat(silmarillion): #404 Phase 5 Recipe pilot — complete (amend-1/2 + canonical pattern + G4 conformance)

### DIFF
--- a/docs/silmarillion-visual-grammar.md
+++ b/docs/silmarillion-visual-grammar.md
@@ -85,7 +85,7 @@ Net: gold now reads as **title** (serif, large, no glyph) or **link** (sans, bod
 
 The Link primitive **is** `<icon> <gold name>` plus:
 
-- **provenance suffix** *(optional)* — italic, `--fg-quaternary`, 10pt, trailing: *— from Distil Brine.* Renders when Link acts as ItemSourceChip; absent everywhere else.
+- **provenance suffix** *(optional)* — italic, `--fg-quaternary`, 10pt, trailing: *— from Distil Brine.* Renders when Link acts as ItemSourceChip; absent everywhere else. **Not for name discriminators** — strings that are part of the entity's canonical name (`(Enchanted)`, `(Max-Enchanted)`, Mk. N suffixes, variant parentheticals) stay inside the gold name span. Provenance is *where this thing came from*, not *which variant of it this is*.
 - **kind label** *(optional, rare)* — same slot: *— skill*, *— consumable*. Used when icon+name aren't enough.
 - **degrade flag** *(optional)* — changes hover only (see above).
 
@@ -123,7 +123,7 @@ EntityChip and ItemSourceChip both collapse into this primitive in Phase 4.
 |---|---|
 | **Role** | Navigate to another row in the master-detail. Subsumes EntityChip and ItemSourceChip. |
 | **Pigment** | Name: `--accent` `#D4A847`. Provenance suffix: `--fg-quaternary` italic. |
-| **Glyph** | Lucide, **12px**, **lead** (before name). Type-coded: `sparkles` (skill), `flask-conical` (recipe), `droplet`/`flask-round` (ingredient), `user-round` (NPC), `map-pin` (location), `package` (item), `sword` (combat ability). |
+| **Glyph** | **Hybrid icon family** *(G3 amendment 2026-05-17 — see decision log)*. Sprite (from CDN game art) when the entity is a tangible noun with established player-recognized art (items, recipes, NPCs, monsters); Lucide when the entity is abstract (skills, abilities, locations, keywords, factions). Both render at 12px lead position. One Link primitive, two glyph inputs (`sprite_url` preferred when present, `kind` drives Lucide fallback). |
 | **Shape · spacing** | No border. No surface at rest. 2px tap padding (`margin: 0 -2px`) so the tint hover-box fits visually. Inline with text baseline. |
 | **Hover** | 10% gold tint background (`rgba(212,168,71,0.10)`). |
 | **Degrade** | Rest = identical to shipped. Hover swaps nav-tint for neutral row-tint + trailing `⧉` copy glyph. Click copies the canonical name. |
@@ -194,6 +194,7 @@ log can't drift).
 | Phase 2 | [comment 4468177334](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4468177334) | Nine-view consolidated matrix + 16-treatment inventory. |
 | G2 | [comment 4468464536](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4468464536) | Inventory cleared; E1/E3/E4 ratified, E5/E6 scoped; G-a / G-b / G-c flagged open. |
 | **G3** | this document (2026-05-17) | **G-a / G-b / G-c closed; one visual target per tier ratified. Phase 4 unblocked.** |
+| **G3 amend** | [#404 comment 4469052562](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4469052562) (2026-05-17) | **Link lead element → hybrid icon family** (sprite for tangible nouns, Lucide fallback for abstract; both 12px). + provenance suffix ≠ name-discriminator. Surgical single-rule amendment; Phase-5 Recipe pilot G4 finding. Phase 4 Link primitive re-implemented + pilot re-run on PR #411. |
 
 ---
 

--- a/docs/silmarillion-visual-grammar.md
+++ b/docs/silmarillion-visual-grammar.md
@@ -123,8 +123,8 @@ EntityChip and ItemSourceChip both collapse into this primitive in Phase 4.
 |---|---|
 | **Role** | Navigate to another row in the master-detail. Subsumes EntityChip and ItemSourceChip. |
 | **Pigment** | Name: `--accent` `#D4A847`. Provenance suffix: `--fg-quaternary` italic. |
-| **Glyph** | **Hybrid icon family** *(G3 amendment 2026-05-17 — see decision log)*. Sprite (from CDN game art) when the entity is a tangible noun with established player-recognized art (items, recipes, NPCs, monsters); Lucide when the entity is abstract (skills, abilities, locations, keywords, factions). Both render at 12px lead position. One Link primitive, two glyph inputs (`sprite_url` preferred when present, `kind` drives Lucide fallback). |
-| **Shape · spacing** | No border. No surface at rest. 2px tap padding (`margin: 0 -2px`) so the tint hover-box fits visually. Inline with text baseline. |
+| **Glyph** | **Hybrid icon family — CDN sprite if `iconId` is set, Lucide otherwise** *(G3 amendments 2026-05-17 — see decision log)*. Sprites resolved as `https://cdn.projectgorgon.com/{version}/icons/icon_{iconId}.png`, rendered with `image-rendering: pixelated`. Tangible entities (items, recipes, NPCs, monsters) carry an `iconId`; abstract entities (skills, abilities, locations, keywords, factions) do not, and fall back to a kind-mapped Lucide glyph. **Sizes are em-relative, not px**, so they scale with the user's Appearance font-size slider: prose-density Link `1em` sprite / `0.75em` Lucide; list-density Link `1.5em` sprite / `1.125em` Lucide. One Link primitive, two inputs — `iconId` (drives family) and `density` (drives size); no entity-kind discriminator at the call site. |
+| **Shape · spacing** | No border. No surface at rest. 2px tap padding (`margin: 0 -2px`) so the tint hover-box fits visually. Inline with text baseline. **Two row modes:** `Density="Prose"` — inline in a sentence, single Link or short list; `Density="List"` — own line per entry, sprite scaled up to `1.5em`, line-height ~1.7. |
 | **Hover** | 10% gold tint background (`rgba(212,168,71,0.10)`). |
 | **Degrade** | Rest = identical to shipped. Hover swaps nav-tint for neutral row-tint + trailing `⧉` copy glyph. Click copies the canonical name. |
 | **Replaces** | EntityChip, ItemSourceChip. |
@@ -181,6 +181,29 @@ Set-reference also spans loud (toolbar filter chip) → quiet (inline keyword in
 
 ---
 
+## All sizes are em-relative, not px
+
+Mithril's Appearance settings give users a body-font picker and a base-size slider (~11–18pt). The Link primitive — and every tier in this spec — sizes itself in `em` relative to inherited font-size, so a user bumping body to 15pt gets sprites at 20px and Lucide at 15px without anything in the spec changing.
+
+**Exception: the title-glyph (entity icon next to the Fact-title) stays a fixed 40px.** It's an entity stamp, not a UI element subject to accessibility scaling. Pixel art at non-integer scale multiples looks bad; fixing the size keeps the sprite at integer-pixel render. No border, no surface fill when an image is present — the image just sits in the slot.
+
+| Element | Size | At 12pt default | At 15pt | At 18pt |
+|---|---|---|---|---|
+| Body | `1em` (defined by user) | 16px | 20px | 24px |
+| Title (Fact-title) | `1.5em` | 24px | 30px | 36px |
+| Title-glyph (entity icon) | **`40px` fixed** | 40px | 40px | 40px |
+| Link prose sprite | `1em` | 16px | 20px | 24px |
+| Link list sprite | `1.5em` | 24px | 30px | 36px |
+| Link prose Lucide | `0.75em` | 12px | 15px | 18px |
+| Link list Lucide | `1.125em` | 18px | ~22px | 27px |
+| Stat strip | `0.9em` | ~14px | ~18px | ~22px |
+| Footer ID | `0.78em` | ~12.5px | ~15.6px | ~18.7px |
+| Section / Structure label | `0.78em` (tracked) | ~12.5px | ~15.6px | ~18.7px |
+
+Phase 4 implements the Link primitive with `Density="Prose|List"` as its sole sizing input; the renderer multiplies inherited `FontSize` by the appropriate factor (a `FontSize × n` converter is the cleanest XAML approach).
+
+---
+
 ## Decision log
 
 Reconciled to the authoritative #404 thread (the bundle draft's speculative
@@ -194,7 +217,8 @@ log can't drift).
 | Phase 2 | [comment 4468177334](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4468177334) | Nine-view consolidated matrix + 16-treatment inventory. |
 | G2 | [comment 4468464536](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4468464536) | Inventory cleared; E1/E3/E4 ratified, E5/E6 scoped; G-a / G-b / G-c flagged open. |
 | **G3** | this document (2026-05-17) | **G-a / G-b / G-c closed; one visual target per tier ratified. Phase 4 unblocked.** |
-| **G3 amend** | [#404 comment 4469052562](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4469052562) (2026-05-17) | **Link lead element → hybrid icon family** (sprite for tangible nouns, Lucide fallback for abstract; both 12px). + provenance suffix ≠ name-discriminator. Surgical single-rule amendment; Phase-5 Recipe pilot G4 finding. Phase 4 Link primitive re-implemented + pilot re-run on PR #411. |
+| **G3 amend 1** | [#404 comment 4469052562](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4469052562) (2026-05-17) | **Link lead element → hybrid icon family** (sprite for tangible nouns, Lucide fallback for abstract). + provenance suffix ≠ name-discriminator. Surgical single-rule; Phase-5 Recipe pilot G4 finding. |
+| **G3 amend 2** | #404 (2026-05-17) | **System-wide em-relative sizing + Link `Density`** (Prose/List) + **new fixed-40px title-glyph** rule. Root-cause of the pilot's "sprites too small at 12px" finding (px ignored the Appearance accessibility slider). Scope expansion *consciously accepted by maintainer* — re-touches Link + FactTable + FactFooter + Structure + Fact-title (all Phase-4 primitives) + adds the title-glyph element. Supersedes amend-1's fixed-12px. Pilot re-run on PR #411. |
 
 ---
 

--- a/src/Mithril.Shared.Wpf/Converters.cs
+++ b/src/Mithril.Shared.Wpf/Converters.cs
@@ -108,6 +108,58 @@ public sealed class LinkGlyphToVisibilityConverter : IValueConverter
 }
 
 /// <summary>
+/// The G3-amend-2 "<c>FontSize × n</c>" converter — the single mechanism by which every
+/// Silmarillion grammar tier sizes itself in <em>em</em> (relative to inherited
+/// <c>FontSize</c>) rather than fixed px, so sizes track the Appearance base-size slider
+/// (<c>docs/silmarillion-visual-grammar.md</c> · "All sizes are em-relative, not px").
+/// <para>
+/// <c>value</c> is the inherited <c>FontSize</c> (a <see cref="double"/>, supplied via a
+/// <c>RelativeSource Self</c>/<c>AncestorType</c> binding to the element whose inherited
+/// font-size defines 1em); <c>parameter</c> is the factor (a <see cref="double"/>,
+/// parsed culture-<em>invariantly</em> so a XAML <c>ConverterParameter=1.125</c> is not
+/// mis-read under comma-decimal locales). Returns <c>value * factor</c>.
+/// </para>
+/// Null / non-numeric / non-positive inputs degrade to <see cref="double.NaN"/> ("size
+/// to content") rather than throwing — a missing inherited FontSize must never crash a
+/// detail pane.
+/// </summary>
+public sealed class FontSizeTimesConverter : IValueConverter
+{
+    /// <summary>
+    /// Pure size math, factored out so it is unit-testable without the converter /
+    /// visual tree. Returns <c>fontSize * factor</c>; <see cref="double.NaN"/> when
+    /// <paramref name="fontSize"/> is not a positive finite number.
+    /// </summary>
+    public static double Scale(double fontSize, double factor) =>
+        double.IsFinite(fontSize) && fontSize > 0 ? fontSize * factor : double.NaN;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        double fontSize = value switch
+        {
+            double d => d,
+            float f => f,
+            int i => i,
+            _ => double.NaN,
+        };
+
+        double factor = parameter switch
+        {
+            double d => d,
+            float f => f,
+            int i => i,
+            string s when double.TryParse(
+                s, NumberStyles.Float, CultureInfo.InvariantCulture, out var p) => p,
+            _ => double.NaN,
+        };
+
+        return double.IsFinite(factor) ? Scale(fontSize, factor) : double.NaN;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+
+/// <summary>
 /// Two-way converter between an enum value and <c>bool</c> for radio-button bindings.
 /// Usage: <c>IsChecked="{Binding Foo, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=SomeEnumValue}"</c>.
 /// </summary>

--- a/src/Mithril.Shared.Wpf/Converters.xaml
+++ b/src/Mithril.Shared.Wpf/Converters.xaml
@@ -11,4 +11,5 @@
     <c:CamelCaseSplitConverter x:Key="CamelCaseSplit"/>
     <c:LinkGlyphToLucideKindConverter x:Key="LinkGlyphToLucideKind"/>
     <c:LinkGlyphToVisibilityConverter x:Key="LinkGlyphToVis"/>
+    <c:FontSizeTimesConverter x:Key="FontSizeTimes"/>
 </ResourceDictionary>

--- a/src/Mithril.Shared.Wpf/Link.cs
+++ b/src/Mithril.Shared.Wpf/Link.cs
@@ -27,6 +27,48 @@ public enum LinkClickAction
 }
 
 /// <summary>
+/// What the lead element of a <see cref="Link"/> should render, decided purely from
+/// the bound <see cref="LinkVm"/>. The G3-amended hybrid icon family: a CDN sprite
+/// when present (preferred), else the type-coded Lucide fallback, else nothing.
+/// Factored out (mirroring <see cref="LinkClickAction"/> / <see cref="Link.ResolveClick"/>)
+/// so the sprite-vs-Lucide-vs-none branch is unit-testable without the visual tree.
+/// </summary>
+public enum LinkLeadKind
+{
+    /// <summary>No <see cref="LinkVm.IconId"/> and <see cref="LinkGlyph.None"/> — no lead element.</summary>
+    None,
+
+    /// <summary>Real CDN game-art sprite (<see cref="LinkVm.IconId"/> &gt; 0). Wins over Lucide.</summary>
+    Sprite,
+
+    /// <summary>No sprite; type-coded Lucide fallback (<see cref="LinkVm.Glyph"/> != None).</summary>
+    Lucide,
+}
+
+/// <summary>
+/// Discriminated result of <see cref="Link.ResolveLead(LinkVm)"/>. Exactly one of
+/// <see cref="IconId"/> (when <see cref="Kind"/> is <see cref="LinkLeadKind.Sprite"/>)
+/// or <see cref="LucideKind"/> (when <see cref="LinkLeadKind.Lucide"/>) is meaningful;
+/// <see cref="LinkLeadKind.None"/> carries neither.
+/// </summary>
+public readonly record struct LinkLead(
+    LinkLeadKind Kind,
+    int IconId,
+    PackIconLucideKind LucideKind)
+{
+    /// <summary>Sprite lead: render the CDN art for <paramref name="iconId"/>.</summary>
+    public static LinkLead Sprite(int iconId) =>
+        new(LinkLeadKind.Sprite, iconId, PackIconLucideKind.None);
+
+    /// <summary>Lucide fallback lead: render <paramref name="lucide"/>.</summary>
+    public static LinkLead Lucide(PackIconLucideKind lucide) =>
+        new(LinkLeadKind.Lucide, 0, lucide);
+
+    /// <summary>No lead element.</summary>
+    public static readonly LinkLead None = new(LinkLeadKind.None, 0, PackIconLucideKind.None);
+}
+
+/// <summary>
 /// The Phase-4 shared <b>Link</b> primitive (G3 visual grammar · "Link · navigates ·
 /// V2"). One templated control subsuming both <see cref="EntityChip"/> and
 /// <see cref="ItemSourceChip"/>; DataContext is a <see cref="LinkVm"/>.
@@ -118,6 +160,24 @@ public sealed class Link : Control
         if (vm is null) return LinkClickAction.None;
         if (vm.IsNavigable && vm.Reference is not null) return LinkClickAction.Navigate;
         return LinkClickAction.CopyName;
+    }
+
+    /// <summary>
+    /// Pure decision (G3 amendment 2026-05-17): given a (possibly null) bound VM, what
+    /// should the 12px lead element render? The hybrid icon family — a real CDN sprite
+    /// is <em>preferred</em> when present (<see cref="LinkVm.IconId"/> &gt; 0 ⇒
+    /// <see cref="LinkLead.Sprite"/>, beating any <see cref="LinkVm.Glyph"/>); else the
+    /// type-coded Lucide fallback (<see cref="LinkVm.Glyph"/> != <see cref="LinkGlyph.None"/>
+    /// ⇒ <see cref="LinkLead.Lucide"/>); else <see cref="LinkLead.None"/>. Mirrors
+    /// <see cref="ResolveClick"/> so it's unit-testable without the visual tree. Does
+    /// not touch the G-c degrade / pending behaviour — the amendment is lead-only.
+    /// </summary>
+    public static LinkLead ResolveLead(LinkVm? vm)
+    {
+        if (vm is null) return LinkLead.None;
+        if (vm.IconId > 0) return LinkLead.Sprite(vm.IconId);
+        if (vm.Glyph != LinkGlyph.None) return LinkLead.Lucide(ToLucideKind(vm.Glyph));
+        return LinkLead.None;
     }
 
     private Button? _button;

--- a/src/Mithril.Shared.Wpf/Link.cs
+++ b/src/Mithril.Shared.Wpf/Link.cs
@@ -117,6 +117,25 @@ public sealed class Link : Control
         typeof(Link),
         new PropertyMetadata(null));
 
+    /// <summary>
+    /// Row-density — the G3-amend-2 sole sizing input (<c>docs/silmarillion-visual-grammar.md</c>
+    /// · em size table). Drives <em>only</em> the lead element's em factor (see
+    /// <see cref="LeadFactor"/>); nothing else about the Link changes. Defaults to
+    /// <see cref="LinkDensity.Prose"/> so existing wrapped-chip call sites keep their
+    /// inline layout. The Style's lead-size triggers key off this DP.
+    /// </summary>
+    public LinkDensity Density
+    {
+        get => (LinkDensity)GetValue(DensityProperty);
+        set => SetValue(DensityProperty, value);
+    }
+
+    public static readonly DependencyProperty DensityProperty = DependencyProperty.Register(
+        nameof(Density),
+        typeof(LinkDensity),
+        typeof(Link),
+        new PropertyMetadata(LinkDensity.Prose));
+
     private static readonly DependencyPropertyKey CopiedKey =
         DependencyProperty.RegisterReadOnly(
             nameof(Copied), typeof(bool), typeof(Link),
@@ -179,6 +198,29 @@ public sealed class Link : Control
         if (vm.Glyph != LinkGlyph.None) return LinkLead.Lucide(ToLucideKind(vm.Glyph));
         return LinkLead.None;
     }
+
+    /// <summary>
+    /// Pure G3-amend-2 lead em-factor: the multiplier applied to the inherited
+    /// <c>FontSize</c> (via <see cref="FontSizeTimesConverter"/>) to size the lead
+    /// element, decided solely by <paramref name="density"/> × the lead family
+    /// (<paramref name="lead"/>). The exact ratified table
+    /// (<c>docs/silmarillion-visual-grammar.md</c> · "All sizes are em-relative"):
+    /// <list type="bullet">
+    ///   <item>Sprite — Prose <c>1.0</c>, List <c>1.5</c></item>
+    ///   <item>Lucide — Prose <c>0.75</c>, List <c>1.125</c></item>
+    /// </list>
+    /// <see cref="LinkLeadKind.None"/> has no lead element, so its factor is
+    /// irrelevant (returns <c>0</c>). Factored out (mirroring <see cref="ResolveLead"/> /
+    /// <see cref="ResolveClick"/>) so the density→size math is unit-testable without
+    /// the visual tree. <b>This supersedes the prior fixed-12px lead</b> (commit
+    /// <c>ec0a49e</c>): the lead is now em-relative, not a hard 12px.
+    /// </summary>
+    public static double LeadFactor(LinkDensity density, LinkLeadKind lead) => lead switch
+    {
+        LinkLeadKind.Sprite => density == LinkDensity.List ? 1.5 : 1.0,
+        LinkLeadKind.Lucide => density == LinkDensity.List ? 1.125 : 0.75,
+        _ => 0.0,
+    };
 
     private Button? _button;
 

--- a/src/Mithril.Shared.Wpf/LinkVm.cs
+++ b/src/Mithril.Shared.Wpf/LinkVm.cs
@@ -37,7 +37,13 @@ public enum LinkGlyph
 /// <see cref="From(ItemSourceChipVm)"/> adapters make that mechanical.
 /// </summary>
 /// <param name="DisplayName">The human-readable name (gold, body weight).</param>
-/// <param name="Glyph">The 12px lead glyph type-code; <see cref="LinkGlyph.None"/> for no glyph.</param>
+/// <param name="Glyph">
+/// The 12px lead Lucide <em>fallback</em> glyph type-code; <see cref="LinkGlyph.None"/>
+/// for no glyph. Per the G3 amendment (2026-05-17) the lead element is a <b>hybrid</b>:
+/// a real CDN sprite (<see cref="IconId"/> &gt; 0) is preferred when present; this
+/// type-coded Lucide is the fallback for abstract refs that have no sprite. Always
+/// set it — icon-less refs still need it.
+/// </param>
 /// <param name="Reference">
 /// The navigation target, passed to the host's <see cref="Link.ClickCommand"/> on a
 /// navigable click. Mirrors <see cref="EntityChipVm.Reference"/>'s type.
@@ -54,14 +60,30 @@ public enum LinkGlyph
 /// Optional, rare trailing kind disambiguator (e.g. <c>"skill"</c>) when icon+name
 /// aren't enough. Same trailing slot as <see cref="ProvenanceSuffix"/>.
 /// </param>
+/// <param name="IconId">
+/// Real CDN game-art sprite id (G3 amendment 2026-05-17). <c>&gt; 0</c> ⇒ the lead
+/// element renders this sprite via <see cref="IconImage"/> (preferred — tangible
+/// nouns: items, recipes, NPCs, monsters). <c>0</c> ⇒ no sprite; the lead falls back
+/// to the type-coded Lucide <see cref="Glyph"/> (abstract refs: skills, abilities,
+/// locations, keywords, factions). The sprite, when present, wins over
+/// <see cref="Glyph"/> — both render at the 12px lead position.
+/// </param>
 public sealed record LinkVm(
     string DisplayName,
     LinkGlyph Glyph,
     EntityRef? Reference,
     bool IsNavigable,
     string? ProvenanceSuffix = null,
-    string? KindLabel = null)
+    string? KindLabel = null,
+    int IconId = 0)
 {
+    /// <summary>
+    /// True when a real CDN sprite is present (<see cref="IconId"/> &gt; 0) and should
+    /// be the lead element. Drives the Style's mutually-exclusive sprite-vs-Lucide
+    /// switch object-safely (int&gt;0 → bool DataTrigger; the repo-preferred pattern
+    /// over a converter for an int predicate).
+    /// </summary>
+    public bool HasSprite => IconId > 0;
     /// <summary>
     /// Maps an <see cref="EntityRef"/>'s <see cref="EntityKind"/> to the Link lead-glyph
     /// type-code. Unknown / non-entity kinds (keyword-filter pivots, Effect envelopes,
@@ -82,27 +104,31 @@ public sealed record LinkVm(
     };
 
     /// <summary>
-    /// Adapts a legacy <see cref="EntityChipVm"/> into the unified Link VM. The glyph is
-    /// derived from <see cref="EntityChipVm.Reference"/>'s kind (the legacy
-    /// <c>IconId</c> is dropped — Link is glyph-coded, not icon-imaged, per the grammar).
+    /// Adapts a legacy <see cref="EntityChipVm"/> into the unified Link VM. Per the G3
+    /// amendment the chip's <see cref="EntityChipVm.IconId"/> rides through as the
+    /// preferred lead sprite; the kind-derived <see cref="LinkGlyph"/> is kept as the
+    /// Lucide fallback for icon-less (abstract) refs.
     /// </summary>
     public static LinkVm From(EntityChipVm chip) => new(
         chip.DisplayName,
         GlyphFor(chip.Reference.Kind),
         chip.Reference,
-        chip.IsNavigable);
+        chip.IsNavigable,
+        IconId: chip.IconId);
 
     /// <summary>
     /// Adapts a legacy <see cref="ItemSourceChipVm"/> into the unified Link VM.
     /// <see cref="ItemSourceChipVm.Detail"/> becomes the <see cref="ProvenanceSuffix"/>
-    /// (the ItemSourceChip "— from X" bit); the glyph is derived from the optional
-    /// <see cref="ItemSourceChipVm.EntityReference"/> kind (<see cref="LinkGlyph.None"/>
-    /// when the source maps to no entity).
+    /// (the ItemSourceChip "— from X" bit); the kind-derived <see cref="LinkGlyph"/>
+    /// (<see cref="LinkGlyph.None"/> when the source maps to no entity) is the Lucide
+    /// fallback. Per the G3 amendment <see cref="ItemSourceChipVm.IconId"/> (null ⇒ 0)
+    /// rides through as the preferred lead sprite.
     /// </summary>
     public static LinkVm From(ItemSourceChipVm chip) => new(
         chip.DisplayName,
         chip.EntityReference is { } r ? GlyphFor(r.Kind) : LinkGlyph.None,
         chip.EntityReference,
         chip.IsNavigable,
-        ProvenanceSuffix: string.IsNullOrEmpty(chip.Detail) ? null : chip.Detail);
+        ProvenanceSuffix: string.IsNullOrEmpty(chip.Detail) ? null : chip.Detail,
+        IconId: chip.IconId ?? 0);
 }

--- a/src/Mithril.Shared.Wpf/LinkVm.cs
+++ b/src/Mithril.Shared.Wpf/LinkVm.cs
@@ -21,6 +21,23 @@ public enum LinkGlyph
 }
 
 /// <summary>
+/// Row-density of a <see cref="Link"/> — the G3-amend-2 sole sizing input
+/// (<c>docs/silmarillion-visual-grammar.md</c> · "Link · navigates · V2", "Shape ·
+/// spacing", and the em size table). It selects the em factor the lead element scales
+/// by; <see cref="Prose"/> is the default (inline in a sentence, single Link or short
+/// list). <see cref="List"/> is own-line-per-entry — a layout-changing per-section
+/// design call, deliberately NOT applied by the Recipe pilot (left a G4 decision).
+/// </summary>
+public enum LinkDensity
+{
+    /// <summary>Inline in a sentence / short list. Sprite ×1.0em, Lucide ×0.75em.</summary>
+    Prose,
+
+    /// <summary>Own line per entry. Sprite ×1.5em, Lucide ×1.125em (line-height ~1.7).</summary>
+    List,
+}
+
+/// <summary>
 /// The unified data-carrier for the Phase-4 <see cref="Link"/> primitive — the single
 /// VM that subsumes both <see cref="EntityChipVm"/> (cross-entity navigation chip) and
 /// <see cref="ItemSourceChipVm"/> (item/recipe source row with a provenance suffix).

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1817,8 +1817,13 @@
          G3-amend-2: size = 0.78em (was the fixed AppFontSizeXSmall=9; only the
          SIZE changes). Same circular-Style-setter constraint as FactTitleStyle
          → 1em source is the NEAREST ANCESTOR's inherited (TextElement.FontSize)
-         via FindAncestor (skips Self → no cycle), ×0.78. The tracked-uppercase
-         WPF-limitation flag (below, unchanged) still stands — only SIZE moves. -->
+         via FindAncestor (skips Self → no cycle), ×0.78.
+         G4 (ratified): the tracked-UPPERCASE treatment (text-transform:uppercase
+         + letter-spacing ≈0.08em) is now applied — previously deferred because
+         WPF TextBlock has no native letter-spacing. c:StructureLabel.IsEnabled
+         rebuilds Inlines as upper-cased chars interleaved with a hair-space
+         spacer (em-relative → tracks the Appearance slider). Applied here so all
+         ~9 fan-out views inherit it with zero per-call-site work. -->
     <Style x:Key="StructureSectionLabelStyle" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize"
@@ -1826,6 +1831,7 @@
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
         <Setter Property="Margin"     Value="0,10,0,4"/>
+        <Setter Property="c:StructureLabel.IsEnabled" Value="True"/>
     </Style>
 
     <!-- Structure · inline field-label prefix (terminating ':' is the call
@@ -1839,9 +1845,16 @@
                 Value="{Binding Path=(TextElement.FontSize), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type FrameworkElement}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
+        <!-- G4: same tracked-UPPERCASE behavior as the section label. The
+             terminating ':' (call-site text, e.g. "Field:") is preserved
+             literally (ToUpperInvariant is a no-op on punctuation) and tracks
+             with the letters so the prefix reads as one tracked label. -->
+        <Setter Property="c:StructureLabel.IsEnabled" Value="True"/>
     </Style>
 
-    <!-- Structure · group header: dimmer (fg-quaternary), else as section label. -->
+    <!-- Structure · group header: dimmer (fg-quaternary), else as section label.
+         G4: inherits the tracked-UPPERCASE c:StructureLabel.IsEnabled setter via
+         BasedOn StructureSectionLabelStyle (only the pigment is overridden). -->
     <Style x:Key="StructureGroupHeaderStyle" TargetType="TextBlock"
            BasedOn="{StaticResource StructureSectionLabelStyle}">
         <Setter Property="Foreground" Value="{StaticResource TextQuaternaryBrush}"/>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1156,8 +1156,30 @@
                                         CornerRadius="{StaticResource GrammarRadiusMd}"
                                         Padding="2,0">
                                     <StackPanel Orientation="Horizontal">
-                                        <!-- 12px LEAD glyph. Collapsed for LinkGlyph.None. -->
-                                        <icon:PackIconLucide
+                                        <!-- 12px LEAD element · G3 hybrid icon family
+                                             (amendment 2026-05-17). Two mutually-
+                                             exclusive elements in the one lead slot:
+                                             a real CDN sprite (preferred when
+                                             IconId>0 / HasSprite) ELSE the type-coded
+                                             Lucide fallback. Both render 12×12.
+                                             Switch is HasSprite (LinkVm bool: int>0,
+                                             object-safe — no converter) via the
+                                             DataTriggers below. -->
+                                        <!-- Preferred: real game-art sprite. Collapsed
+                                             by default; the HasSprite=True trigger
+                                             reveals it (and hides the Lucide). IconImage
+                                             self-collapses internally if IconId<=0. -->
+                                        <c:IconImage x:Name="LeadSprite"
+                                            Width="12" Height="12"
+                                            Margin="0,0,4,0"
+                                            VerticalAlignment="Center"
+                                            IconId="{Binding IconId}"
+                                            Visibility="Collapsed"/>
+                                        <!-- Fallback: 12px LEAD Lucide. Collapsed for
+                                             LinkGlyph.None (LinkGlyphToVis); ALSO hidden
+                                             when a sprite is present (HasSprite=True
+                                             trigger). -->
+                                        <icon:PackIconLucide x:Name="LeadLucide"
                                             Width="12" Height="12"
                                             Margin="0,0,4,0"
                                             VerticalAlignment="Center"
@@ -1211,6 +1233,16 @@
                                     </StackPanel>
                                 </Border>
                                 <ControlTemplate.Triggers>
+                                    <!-- G3 hybrid lead switch: a real sprite present
+                                         (HasSprite = IconId>0) wins — reveal the sprite,
+                                         hide the Lucide fallback. When False, both
+                                         elements keep their default visibility (sprite
+                                         Collapsed; Lucide per LinkGlyphToVis), i.e. the
+                                         pre-amendment Lucide-only behaviour. -->
+                                    <DataTrigger Binding="{Binding HasSprite}" Value="True">
+                                        <Setter TargetName="LeadSprite" Property="Visibility" Value="Visible"/>
+                                        <Setter TargetName="LeadLucide" Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
                                     <!-- Navigable hover: 10% gold tint + Hand cursor. -->
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1156,40 +1156,56 @@
                                         CornerRadius="{StaticResource GrammarRadiusMd}"
                                         Padding="2,0">
                                     <StackPanel Orientation="Horizontal">
-                                        <!-- 12px LEAD element · G3 hybrid icon family
-                                             (amendment 2026-05-17). Two mutually-
-                                             exclusive elements in the one lead slot:
-                                             a real CDN sprite (preferred when
+                                        <!-- LEAD element · G3 hybrid icon family
+                                             (amend 1) + em-relative size (amend 2,
+                                             SUPERSEDES amend-1's fixed 12px). Two
+                                             mutually-exclusive elements in the one lead
+                                             slot: a real CDN sprite (preferred when
                                              IconId>0 / HasSprite) ELSE the type-coded
-                                             Lucide fallback. Both render 12×12.
-                                             Switch is HasSprite (LinkVm bool: int>0,
-                                             object-safe — no converter) via the
-                                             DataTriggers below. -->
+                                             Lucide fallback. Switch is HasSprite
+                                             (LinkVm bool: int>0, object-safe — no
+                                             converter) via the DataTriggers below.
+                                             SIZE: em-relative — Width/Height bind the
+                                             Link's INHERITED FontSize (AncestorType
+                                             c:Link) through FontSizeTimes with the
+                                             ratified per-family factor. Defaults are
+                                             the Prose factors (sprite ×1.0, Lucide
+                                             ×0.75); the Density=List trigger swaps to
+                                             the list factors (×1.5 / ×1.125). Mirrors
+                                             Link.LeadFactor (unit-tested). -->
                                         <!-- Preferred: real game-art sprite. Collapsed
                                              by default; the HasSprite=True trigger
                                              reveals it (and hides the Lucide). IconImage
-                                             self-collapses internally if IconId<=0. -->
+                                             self-collapses internally if IconId<=0.
+                                             NearestNeighbor = the WPF equivalent of the
+                                             grammar's image-rendering: pixelated, so
+                                             pixel-art stays crisp at any em scale. -->
                                         <c:IconImage x:Name="LeadSprite"
-                                            Width="12" Height="12"
+                                            Width="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.0}"
+                                            Height="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.0}"
+                                            RenderOptions.BitmapScalingMode="NearestNeighbor"
                                             Margin="0,0,4,0"
                                             VerticalAlignment="Center"
                                             IconId="{Binding IconId}"
                                             Visibility="Collapsed"/>
-                                        <!-- Fallback: 12px LEAD Lucide. Collapsed for
-                                             LinkGlyph.None (LinkGlyphToVis); ALSO hidden
-                                             when a sprite is present (HasSprite=True
-                                             trigger). -->
+                                        <!-- Fallback: em-relative LEAD Lucide. Collapsed
+                                             for LinkGlyph.None (LinkGlyphToVis); ALSO
+                                             hidden when a sprite is present
+                                             (HasSprite=True trigger). -->
                                         <icon:PackIconLucide x:Name="LeadLucide"
-                                            Width="12" Height="12"
+                                            Width="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.75}"
+                                            Height="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.75}"
                                             Margin="0,0,4,0"
                                             VerticalAlignment="Center"
                                             Foreground="{StaticResource AccentBrush}"
                                             Kind="{Binding Glyph, Converter={StaticResource LinkGlyphToLucideKind}}"
                                             Visibility="{Binding Glyph, Converter={StaticResource LinkGlyphToVis}}"/>
-                                        <!-- Name: gold, body weight, AppFontSize. -->
+                                        <!-- Name: gold, body weight, inherited (em)
+                                             FontSize — the text itself already scales
+                                             with the Appearance slider via inheritance;
+                                             no converter needed at 1em. -->
                                         <TextBlock Text="{Binding DisplayName}"
                                                    Foreground="{StaticResource AccentBrush}"
-                                                   FontSize="{DynamicResource AppFontSize}"
                                                    FontWeight="Normal"
                                                    VerticalAlignment="Center"/>
                                         <!-- Trailing ProvenanceSuffix: italic, quaternary,
@@ -1242,6 +1258,24 @@
                                     <DataTrigger Binding="{Binding HasSprite}" Value="True">
                                         <Setter TargetName="LeadSprite" Property="Visibility" Value="Visible"/>
                                         <Setter TargetName="LeadLucide" Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                    <!-- G3-amend-2 Density=List: swap the lead em
+                                         factors from the Prose defaults (sprite ×1.0,
+                                         Lucide ×0.75) to the list factors (×1.5 /
+                                         ×1.125). Density is a DP on the c:Link
+                                         ancestor (mirrors the Copied AncestorType
+                                         binding below); the size still binds the
+                                         Link's inherited FontSize so it stays
+                                         em-relative. Exactly Link.LeadFactor. -->
+                                    <DataTrigger Binding="{Binding Density, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}}" Value="List">
+                                        <Setter TargetName="LeadSprite" Property="Width"
+                                                Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.5}"/>
+                                        <Setter TargetName="LeadSprite" Property="Height"
+                                                Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.5}"/>
+                                        <Setter TargetName="LeadLucide" Property="Width"
+                                                Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.125}"/>
+                                        <Setter TargetName="LeadLucide" Property="Height"
+                                                Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.125}"/>
                                     </DataTrigger>
                                     <!-- Navigable hover: 10% gold tint + Hand cursor. -->
                                     <MultiDataTrigger>
@@ -1441,13 +1475,18 @@
                     <Grid x:Name="Root" Grid.IsSharedSizeScope="True">
                         <!-- STRIP: one TextBlock bound to the pure StripText
                              helper (separator injected between segments only). -->
+                        <!-- G3-amend-2: stat-strip text = 0.9em (was the fixed
+                             AppFontSizeHint=11). EM-SOURCE: the c:FactTable
+                             ancestor's inherited FontSize (FactTable sets no
+                             FontSize itself → no cycle, AncestorType not Self).
+                             ×0.9 via FontSizeTimes. -->
                         <TextBlock x:Name="StripView"
                                    Visibility="Collapsed"
                                    Text="{Binding StripText}"
                                    TextWrapping="Wrap"
                                    Foreground="{StaticResource TextPrimaryBrush}"
                                    FontFamily="{DynamicResource AppFontFamily}"
-                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                                   FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactTable}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.9}"/>
 
                         <!-- GRID: vertical 2-column, label left, value
                              right-aligned on a shared column. -->
@@ -1466,13 +1505,13 @@
                                                    Margin="0,0,16,0"
                                                    Foreground="{StaticResource TextTertiaryBrush}"
                                                    FontFamily="{DynamicResource AppFontFamily}"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                   FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactTable}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.9}"/>
                                         <TextBlock Grid.Column="1"
                                                    Text="{Binding Value}"
                                                    HorizontalAlignment="Right"
                                                    Foreground="{StaticResource TextPrimaryBrush}"
                                                    FontFamily="{DynamicResource AppFontFamily}"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                                                   FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactTable}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.9}"/>
                                     </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
@@ -1485,7 +1524,7 @@
                                    Text="{Binding Pairs[0].Value}"
                                    Foreground="{StaticResource TextPrimaryBrush}"
                                    FontFamily="{DynamicResource AppFontFamily}"
-                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                                   FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactTable}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.9}"/>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <!-- ONE trigger set selects the layout view. This IS the
@@ -1510,8 +1549,12 @@
                             <Setter TargetName="StripView" Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
                             <Setter TargetName="ScalarView" Property="FontFamily" Value="{DynamicResource AppMonoFontFamily}"/>
                             <Setter TargetName="ScalarView" Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
-                            <Setter TargetName="StripView" Property="FontSize" Value="{DynamicResource AppFontSizeSmall}"/>
-                            <Setter TargetName="ScalarView" Property="FontSize" Value="{DynamicResource AppFontSizeSmall}"/>
+                            <!-- G3-amend-2: footer-quiet weight = the Footer-ID
+                                 tier size, 0.78em (was the fixed AppFontSizeSmall=
+                                 10). Same em-source as the strip (c:FactTable
+                                 ancestor), ×0.78. -->
+                            <Setter TargetName="StripView" Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactTable}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"/>
+                            <Setter TargetName="ScalarView" Property="FontSize" Value="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactTable}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"/>
                         </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1600,23 +1643,35 @@
                                                          only; the first cell
                                                          suppresses it. Never part
                                                          of any copy payload. -->
+                                                    <!-- G3-amend-2: Footer-ID tier =
+                                                         0.78em (was fixed
+                                                         AppFontSizeSmall=10). The tiny
+                                                         KEY/ROW label is the same
+                                                         0.78em (grammar: "the tiny
+                                                         KEY/ROW label"), was
+                                                         AppFontSizeXSmall=9. EM-SOURCE:
+                                                         the c:FactFooter ancestor's
+                                                         inherited FontSize (FactFooter
+                                                         sets no FontSize → no cycle).
+                                                         Sep middot tracks the value
+                                                         size so it stays on-line. -->
                                                     <TextBlock x:Name="Sep"
                                                                Text="{x:Static c:FactFooterVm.CellSeparator}"
                                                                Foreground="{StaticResource TextQuaternaryBrush}"
-                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactFooter}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"
                                                                VerticalAlignment="Center"/>
-                                                    <!-- Tiny UPPERCASE tag. -->
+                                                    <!-- Tiny UPPERCASE KEY/ROW tag. -->
                                                     <TextBlock x:Name="Tag"
                                                                Text="{Binding LabelTag}"
                                                                Margin="0,0,4,0"
                                                                Foreground="{StaticResource TextQuaternaryBrush}"
-                                                               FontSize="{DynamicResource AppFontSizeXSmall}"
+                                                               FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactFooter}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"
                                                                VerticalAlignment="Center"/>
                                                     <!-- Mono value (tertiary). -->
                                                     <TextBlock Text="{Binding Value}"
                                                                Foreground="{StaticResource TextTertiaryBrush}"
                                                                FontFamily="{DynamicResource AppMonoFontFamily}"
-                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactFooter}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"
                                                                VerticalAlignment="Center"/>
                                                     <!-- Hover-revealed 11px Copy
                                                          glyph (copyable only).
@@ -1637,7 +1692,7 @@
                                                                Text="copied ✓"
                                                                Margin="4,0,0,0"
                                                                Foreground="{StaticResource TextTertiaryBrush}"
-                                                               FontSize="{DynamicResource AppFontSizeSmall}"
+                                                               FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType={x:Type c:FactFooter}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"
                                                                VerticalAlignment="Center"
                                                                Visibility="Collapsed"/>
                                                 </StackPanel>
@@ -1714,13 +1769,37 @@
          Phase 5 call site (pass already-upper text; tracking would need a
          custom behavior). Surfaced in the Phase 4 reconciliation flags. -->
 
-    <!-- Fact · title-loud: Cambria 18 / 600 / accent, one per pane. -->
+    <!-- Fact · title-loud: Cambria / 600 / accent, one per pane. G3-amend-2:
+         size is 1.5em (was the fixed AppFontSizeHeader=18, which equalled 1.5×
+         the AppFontSize=12 default — now it TRACKS the Appearance slider).
+         EM-SOURCE MECHANISM (documented per the dispatch): a Style setter cannot
+         RelativeSource Self FontSize without a circular self-reference (the
+         setter writes FontSize; reading Self.FontSize re-reads the written
+         value). So the 1em source is the NEAREST ANCESTOR's inherited
+         (TextElement.FontSize) via FindAncestor (FindAncestor skips Self → no
+         cycle); that ancestor carries the body em the title would otherwise
+         inherit. ×1.5 through FontSizeTimes. -->
     <Style x:Key="FactTitleStyle" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="{DynamicResource AppHeaderFontFamily}"/>
-        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeHeader}"/>
+        <Setter Property="FontSize"
+                Value="{Binding Path=(TextElement.FontSize), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type FrameworkElement}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=1.5}"/>
         <Setter Property="FontWeight" Value="SemiBold"/><!-- WPF SemiBold == weight 600 -->
         <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <!-- G3-amend-2 NEW: the title-glyph rule. The entity icon shown next to a
+         Fact-title is a FIXED 40px IconImage — an "entity stamp", explicitly
+         EXEMPT from accessibility (em) scaling (pixel art at non-integer scale
+         looks bad; 40px keeps an integer-pixel render). No border, no surface /
+         fill: the image just sits in the slot. NearestNeighbor = the WPF
+         equivalent of the grammar's image-rendering: pixelated. Opt-in x:Key'd
+         (TargetType IconImage) so only the explicitly-tagged header icon picks
+         it up; nothing else changes. -->
+    <Style x:Key="FactTitleGlyphStyle" TargetType="{x:Type c:IconImage}">
+        <Setter Property="Width"  Value="40"/>
+        <Setter Property="Height" Value="40"/>
+        <Setter Property="RenderOptions.BitmapScalingMode" Value="NearestNeighbor"/>
     </Style>
 
     <!-- Fact · body: Segoe UI 12 / fg-primary. -->
@@ -1731,11 +1810,17 @@
         <Setter Property="TextWrapping" Value="Wrap"/>
     </Style>
 
-    <!-- Structure · section label: fg-tertiary, SemiBold, ~9pt, 10px top gap.
-         Never gold, no glyph (enforced by being a bare TextBlock style). -->
+    <!-- Structure · section label: fg-tertiary, SemiBold, 10px top gap.
+         Never gold, no glyph (enforced by being a bare TextBlock style).
+         G3-amend-2: size = 0.78em (was the fixed AppFontSizeXSmall=9; only the
+         SIZE changes). Same circular-Style-setter constraint as FactTitleStyle
+         → 1em source is the NEAREST ANCESTOR's inherited (TextElement.FontSize)
+         via FindAncestor (skips Self → no cycle), ×0.78. The tracked-uppercase
+         WPF-limitation flag (below, unchanged) still stands — only SIZE moves. -->
     <Style x:Key="StructureSectionLabelStyle" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
-        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeXSmall}"/>
+        <Setter Property="FontSize"
+                Value="{Binding Path=(TextElement.FontSize), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type FrameworkElement}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
         <Setter Property="Margin"     Value="0,10,0,4"/>
@@ -1746,7 +1831,10 @@
          no top margin (it sits inline before a value). -->
     <Style x:Key="StructureInlinePrefixStyle" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
-        <Setter Property="FontSize"   Value="{DynamicResource AppFontSizeXSmall}"/>
+        <!-- G3-amend-2: 0.78em (was AppFontSizeXSmall=9). Same FindAncestor
+             em-source as StructureSectionLabelStyle (no Style-setter self-cycle). -->
+        <Setter Property="FontSize"
+                Value="{Binding Path=(TextElement.FontSize), RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type FrameworkElement}}, Converter={StaticResource FontSizeTimes}, ConverterParameter=0.78}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Foreground" Value="{StaticResource TextTertiaryBrush}"/>
     </Style>

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1359,34 +1359,36 @@
                             Background="Transparent" BorderThickness="0" Padding="0">
                         <Button.Template>
                             <ControlTemplate TargetType="Button">
-                                <!-- The chassis. Rest state is token-fixed and does
-                                     NOT vary with IsActionable (availability
-                                     corollary). Hover-only setters below. -->
-                                <Border x:Name="Chassis"
-                                        Background="{StaticResource SetRefIdleFillBrush}"
-                                        BorderBrush="{StaticResource SetRefBorderBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="{StaticResource GrammarRadiusSm}"
-                                        Padding="8,1">
-                                    <StackPanel Orientation="Horizontal">
-                                        <!-- Stacking ordinal prefix: small,
-                                             quaternary, leading. Hidden via the VM
-                                             bool HasOrdinal (object-safe; no
-                                             converter). -->
-                                        <TextBlock x:Name="OrdinalPrefix"
-                                                   Text="{Binding OrdinalText}"
-                                                   Margin="0,0,4,0"
-                                                   Foreground="{StaticResource TextQuaternaryBrush}"
-                                                   FontSize="{DynamicResource AppFontSizeXSmall}"
-                                                   VerticalAlignment="Center"/>
-                                        <!-- The shape-baked body: tag-form = bare
-                                             Label; summary-form = "{Label} · N →". -->
+                                <!-- Row = ordinal list-marker OUTSIDE the chassis
+                                     (dim mono, left gutter ~8px, ordered-list
+                                     style — ratified specimen) + the blue chip
+                                     box. The ordinal is NOT inside the rectangle. -->
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock x:Name="OrdinalPrefix"
+                                               Text="{Binding OrdinalText}"
+                                               Margin="0,0,8,0"
+                                               Foreground="{StaticResource TextQuaternaryBrush}"
+                                               FontFamily="{DynamicResource AppMonoFontFamily}"
+                                               FontSize="{DynamicResource AppFontSizeXSmall}"
+                                               VerticalAlignment="Center"/>
+                                    <!-- The chassis. Rest state is token-fixed and
+                                         does NOT vary with IsActionable
+                                         (availability corollary). Hover-only
+                                         setters below. Holds only the shape-baked
+                                         body: tag-form = bare Label; summary-form
+                                         = "{Label} · N matches →". -->
+                                    <Border x:Name="Chassis"
+                                            Background="{StaticResource SetRefIdleFillBrush}"
+                                            BorderBrush="{StaticResource SetRefBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="{StaticResource GrammarRadiusSm}"
+                                            Padding="8,1">
                                         <TextBlock Text="{Binding DisplayText}"
                                                    Foreground="{StaticResource SetRefTextBrush}"
                                                    FontSize="{DynamicResource AppFontSizeHint}"
                                                    VerticalAlignment="Center"/>
-                                    </StackPanel>
-                                </Border>
+                                    </Border>
+                                </StackPanel>
                                 <ControlTemplate.Triggers>
                                     <!-- Hide the ordinal prefix entirely when the VM
                                          carries no SlotOrdinal (positionally inert /

--- a/src/Mithril.Shared.Wpf/SetRefVm.cs
+++ b/src/Mithril.Shared.Wpf/SetRefVm.cs
@@ -78,7 +78,12 @@ public sealed record SetRefVm(
     /// string instead of re-deciding the shape in XAML.
     /// </summary>
     public string DisplayText =>
-        IsSummaryForm ? $"{Label} · {MatchCount} →" : Label;
+        IsSummaryForm
+            // Ratified summary-form (grammar doc "Crystal · 150 matches →"). The spec
+            // only exemplified the plural; "1 matches" reads as a bug, so the noun is
+            // count-aware — sensible reading of the spec, flagged not silently decided.
+            ? $"{Label} · {MatchCount} {(MatchCount == 1 ? "match" : "matches")} →"
+            : Label;
 
     /// <summary>The leading ordinal prefix glyph (e.g. <c>"1"</c>), or empty when none.</summary>
     public string OrdinalText => HasOrdinal ? SlotOrdinal!.Value.ToString() : string.Empty;

--- a/src/Mithril.Shared.Wpf/StructureLabelBehavior.cs
+++ b/src/Mithril.Shared.Wpf/StructureLabelBehavior.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+
+namespace Mithril.Shared.Wpf;
+
+/// <summary>
+/// Attached behavior that renders the <b>Structure</b> tier's ratified G4 typographic
+/// treatment — <c>text-transform: uppercase</c> + <c>letter-spacing ≈ 0.08em</c> — onto a
+/// <see cref="TextBlock"/>. G3's grammar fixed the Structure tier as "Tracked uppercase
+/// (letter-spacing 0.08em). 9–9.5pt. Weight 600"; the repo-side note in
+/// <c>docs/silmarillion-visual-grammar.md</c> deferred the *uppercasing + tracking* because
+/// WPF's <see cref="TextBlock"/> has <b>no native <c>letter-spacing</c></b>. G4 ratifies
+/// applying the treatment now; this behavior is that encoding.
+/// <para>
+/// <b>Why an attached behavior, applied via Style.</b> The three Structure styles
+/// (<c>StructureSectionLabelStyle</c>, <c>StructureInlinePrefixStyle</c>,
+/// <c>StructureGroupHeaderStyle</c>) are consumed by ~9 fan-out views whose TextBlocks set
+/// <see cref="TextBlock.Text"/> directly (literal or bound). A Style setter switches
+/// <see cref="IsEnabledProperty"/> on; the behavior then reads the block's own
+/// <see cref="TextBlock.Text"/>, rebuilds <see cref="TextBlock.Inlines"/> as the tracked
+/// upper-cased form, and keeps it in sync — so no call site changes (the Recipe pilot keeps
+/// working unchanged). Mirrors the <see cref="FormattedText"/> attached-property pattern.
+/// </para>
+/// <para>
+/// <b>Tracking technique (WPF has no letter-spacing).</b> The content is rebuilt as one
+/// <see cref="Run"/> per upper-cased character, interleaved with a thin spacer
+/// <see cref="Run"/> whose text is a single Unicode <c>HAIR SPACE</c> (<c>U+200A</c>). A
+/// hair space's intrinsic advance width is itself defined relative to the font em
+/// (~0.06–0.1em in the body fonts Mithril ships), so it scales automatically with the
+/// inherited <see cref="Control.FontSize"/> — i.e. it stays em-correct as the Appearance
+/// base-size slider moves, with <b>no</b> width binding or converter needed (consistent with
+/// the grammar's "all sizes are em-relative" rule). <b>Fidelity caveat:</b> this is a
+/// glyph-spacer approximation of true kerning-level tracking — it targets ≈0.08em but the
+/// exact advance is the font's hair-space metric, not a pixel-exact 0.08em. That is the
+/// expected, accepted trade-off for short uppercase labels (per the G4 dispatch); do not
+/// read it as pixel-exact tracking.
+/// </para>
+/// <para>
+/// <b>Punctuation.</b> A trailing <c>:</c> (the <c>StructureInlinePrefixStyle</c> idiom —
+/// <c>Field:</c>) is preserved literally: <see cref="char.ToUpperInvariant(char)"/> is a
+/// no-op on punctuation, and the terminating <c>:</c> still gets a *leading* hair-space so
+/// it tracks consistently with the letters before it (it reads as part of the same tracked
+/// label, not a tight-set afterthought). Empty / null / single-char text is safe (no spacer
+/// for &lt; 2 visible characters).
+/// </para>
+/// <para>
+/// Usage (applied through the Structure styles; not authored per call site):
+/// <code>
+/// &lt;Setter Property="c:StructureLabel.IsEnabled" Value="True"/&gt;
+/// </code>
+/// </para>
+/// </summary>
+public static class StructureLabel
+{
+    /// <summary>
+    /// Unicode <c>HAIR SPACE</c> (<c>U+200A</c>) — the inter-character spacer glyph. Chosen
+    /// because its advance is font-em-relative, so the rendered tracking scales with the
+    /// inherited <see cref="Control.FontSize"/> without an explicit width binding.
+    /// </summary>
+    public const char HairSpace = ' ';
+
+    /// <summary>
+    /// Switches the tracked-uppercase Structure treatment on for the attached
+    /// <see cref="TextBlock"/>. Set <c>True</c> by the Structure styles; the behavior then
+    /// owns <see cref="TextBlock.Inlines"/> for that block.
+    /// </summary>
+    public static readonly DependencyProperty IsEnabledProperty =
+        DependencyProperty.RegisterAttached(
+            "IsEnabled",
+            typeof(bool),
+            typeof(StructureLabel),
+            new PropertyMetadata(defaultValue: false, OnIsEnabledChanged));
+
+    public static bool GetIsEnabled(DependencyObject obj) => (bool)obj.GetValue(IsEnabledProperty);
+    public static void SetIsEnabled(DependencyObject obj, bool value) => obj.SetValue(IsEnabledProperty, value);
+
+    private static void OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not TextBlock textBlock) return;
+
+        // Detach first so a style re-application / toggle can't double-subscribe.
+        textBlock.Loaded -= OnTextBlockLoaded;
+        DependencyPropertyDescriptor
+            .FromProperty(TextBlock.TextProperty, typeof(TextBlock))
+            .RemoveValueChanged(textBlock, OnTrackedSourceChanged);
+        DependencyPropertyDescriptor
+            .FromProperty(TextBlock.FontSizeProperty, typeof(TextBlock))
+            .RemoveValueChanged(textBlock, OnTrackedSourceChanged);
+
+        if (e.NewValue is not true) return;
+
+        // Re-render on Text change AND on (inherited) FontSize change so the hair-space
+        // tracking stays em-correct when the Appearance slider moves the inherited size —
+        // mirrors how the rest of the grammar binds live to FontSize.
+        DependencyPropertyDescriptor
+            .FromProperty(TextBlock.TextProperty, typeof(TextBlock))
+            .AddValueChanged(textBlock, OnTrackedSourceChanged);
+        DependencyPropertyDescriptor
+            .FromProperty(TextBlock.FontSizeProperty, typeof(TextBlock))
+            .AddValueChanged(textBlock, OnTrackedSourceChanged);
+
+        // The em-source FontSize binding (FindAncestor in the Style) often resolves only
+        // once the element is in the visual tree, so render on Loaded too.
+        textBlock.Loaded += OnTextBlockLoaded;
+        Render(textBlock);
+    }
+
+    private static void OnTextBlockLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBlock tb) Render(tb);
+    }
+
+    private static void OnTrackedSourceChanged(object? sender, System.EventArgs e)
+    {
+        if (sender is TextBlock tb) Render(tb);
+    }
+
+    private static bool _rendering;
+
+    private static void Render(TextBlock textBlock)
+    {
+        // Reading Text after we've replaced Inlines yields the concatenated run text
+        // (which already includes hair-spaces) — guard against the resulting feedback loop.
+        if (_rendering) return;
+        _rendering = true;
+        try
+        {
+            var source = textBlock.Text ?? string.Empty;
+
+            // The concatenation of our own emitted runs (letters + hair-spaces). If Text
+            // already equals that, the visible label is unchanged — re-rendering would
+            // just re-tokenise our own output. Skip.
+            if (source.IndexOf(HairSpace) >= 0) return;
+
+            var inlines = BuildTrackedInlines(source);
+            textBlock.Inlines.Clear();
+            foreach (var inline in inlines)
+                textBlock.Inlines.Add(inline);
+        }
+        finally
+        {
+            _rendering = false;
+        }
+    }
+
+    /// <summary>
+    /// Pure transform: upper-cases <paramref name="text"/> (invariant culture) and
+    /// interleaves a <see cref="HairSpace"/> spacer <see cref="Run"/> between every adjacent
+    /// pair of characters, producing the tracked-uppercase <see cref="Inline"/> sequence the
+    /// behavior assigns to <see cref="TextBlock.Inlines"/>. Factored out (no visual tree) so
+    /// the upper-casing + spacing contract is unit-testable, exactly like
+    /// <see cref="FormattedText.BuildInlines"/>.
+    /// <para>
+    /// The spacer is em-correct by construction: a hair space's advance is defined relative
+    /// to the font em, so it scales with whatever <see cref="Control.FontSize"/> the runs
+    /// inherit — no per-call width math. Returns an empty list for null/empty input and a
+    /// single <see cref="Run"/> (no spacer) for a single-character label.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<Inline> BuildTrackedInlines(string? text)
+    {
+        var result = new List<Inline>();
+        if (string.IsNullOrEmpty(text)) return result;
+
+        var upper = text!.ToUpperInvariant();
+        for (var i = 0; i < upper.Length; i++)
+        {
+            if (i > 0)
+                result.Add(new Run(HairSpace.ToString()));
+            result.Add(new Run(upper[i].ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Pure <c>string → string</c> helper: the rendered text the tracked label produces
+    /// (upper-cased, hair-space between every adjacent character). Equivalent to
+    /// concatenating <see cref="BuildTrackedInlines"/>'s run text; provided for tests that
+    /// want to assert the transform without enumerating inlines.
+    /// </summary>
+    public static string TrackedText(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        var upper = text!.ToUpperInvariant();
+        if (upper.Length < 2) return upper;
+        return string.Join(HairSpace.ToString(), upper.ToCharArray());
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -177,6 +177,14 @@ public sealed class RecipeDetailViewModel
     public string? Description => Recipe.Description;
     public string? Skill => Recipe.Skill;
     public int SkillLevelReq => Recipe.SkillLevelReq;
+
+    /// <summary>
+    /// The recipe's own CDN icon. G3-amend-2: this is the <em>title-glyph</em> (the
+    /// entity icon next to the Fact-title) — the view renders it through the FIXED
+    /// 40px <c>FactTitleGlyphStyle</c> ("entity stamp", exempt from em/accessibility
+    /// scaling), not an em-scaled lead. The size lives entirely in the style; the VM
+    /// only supplies the id.
+    /// </summary>
     public int IconId => Recipe.IconId;
 
     /// <summary>

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -227,6 +227,19 @@ public sealed class RecipeDetailViewModel
     /// </summary>
     public IReadOnlyList<RecipeKeywordSlotVm> KeywordSlots { get; }
 
+    /// <summary>
+    /// Section-label text for the "Keyword ingredients" block. G4 Stacking
+    /// semantics (docs/silmarillion-visual-grammar.md · "Stacking semantics"):
+    /// when there are ≥2 positionally-material slots the label gets a slot-count
+    /// suffix (<c>"Keyword ingredients · 2 slots"</c>); 0/1 slot keeps the plain
+    /// label. The VM owns the text (count logic must NOT live in XAML) so the
+    /// view binds one string under <c>StructureSectionLabelStyle</c>.
+    /// </summary>
+    public string KeywordIngredientsLabel =>
+        KeywordSlots.Count >= 2
+            ? $"Keyword ingredients · {KeywordSlots.Count} slots"
+            : "Keyword ingredients";
+
     public IReadOnlyList<EntityChipVm> ProducedItems { get; }
 
     /// <summary>
@@ -337,7 +350,11 @@ public sealed class RecipeDetailViewModel
 /// </summary>
 public sealed class RecipeKeywordSlotVm
 {
-    public RecipeKeywordSlotVm(string label, ProvenancePopupViewModel popup, ICommand? chipClickCommand)
+    public RecipeKeywordSlotVm(
+        string label,
+        ProvenancePopupViewModel popup,
+        ICommand? chipClickCommand,
+        int? slotOrdinal = null)
     {
         Label = label;
         Popup = popup;
@@ -348,7 +365,22 @@ public sealed class RecipeKeywordSlotVm
         // becomes the shared Set-reference primitive. Summary-form (MatchCount
         // non-null ⇒ "{Label} · N →"), actionable (the reveal is wired to
         // ShowPopupCommand). Gold→blue is intentional per G-b, not a regression.
-        SetRef = new SetRefVm(Label, MatchCount: MatchCount, IsActionable: true);
+        //
+        // G4 Stacking semantics (docs/silmarillion-visual-grammar.md ·
+        // "Stacking semantics"): recipe keyword-ingredient slots are
+        // positionally MATERIAL — the grammar's own canonical example is
+        // "two 'any Crystal' slots where TSysCraftedEquipment references the
+        // actual crystal bound in each slot", so position is material for
+        // crafted-equipment recipes regardless of whether the constraints are
+        // identical. The builder therefore passes a 1-based slotOrdinal ONLY
+        // when the slot list has ≥2 entries; null (single/0 slot) ⇒ no prefix
+        // (positionally inert path — not exercised by the Recipe pilot since a
+        // recipe slot is never count-only). This SetRefVm population is the
+        // CANONICAL stacking pattern the 8 fan-out views copy: ordinal in the
+        // VM (SlotOrdinal), prefix rendered by the shared SetRef control —
+        // never re-decide the visual values per call site.
+        SetRef = new SetRefVm(
+            Label, MatchCount: MatchCount, IsActionable: true, SlotOrdinal: slotOrdinal);
     }
 
     /// <summary>Friendly slot description, e.g. "any Crystal" / "Main-Hand Item".</summary>
@@ -384,6 +416,13 @@ public sealed class RecipeKeywordSlotVm
     /// actionable — its reveal is <see cref="ShowPopupCommand"/>. Replaces the
     /// bespoke ghost-gold "view all N" Button; the gold→blue shift is the ratified
     /// G-b correction, not a regression.
+    /// <para>
+    /// G4 Stacking semantics: carries <see cref="SetRefVm.SlotOrdinal"/> = the
+    /// slot's 1-based position when the recipe has ≥2 keyword slots (positionally
+    /// material per the <c>TSysCraftedEquipment</c> canonical example), null
+    /// otherwise. The shared <c>SetRef</c> control renders the ordinal prefix; this
+    /// VM only populates it — the canonical stacking pattern the fan-out views copy.
+    /// </para>
     /// </summary>
     public SetRefVm SetRef { get; }
 }

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -83,9 +83,13 @@ public sealed class RecipeDetailViewModel
                 .ToList());
 
         // Link projections (matrix #6/#9/#10/#12). EntityChip/ItemSourceChip →
-        // LinkVm via the ratified adapters. Ingredients force LinkGlyph.Ingredient
-        // explicitly (reconciliation flag #3: the adapter can't infer Ingredient
-        // from EntityKind.Item — it would yield Item/package).
+        // LinkVm via the ratified adapters; the G3-amended adapters now carry the
+        // chip's IconId through as the preferred lead sprite. Ingredients still set
+        // LinkGlyph.Ingredient explicitly, but per the G3 amendment that glyph is now
+        // the Lucide *fallback* only: `with { Glyph = ... }` preserves the IconId from
+        // LinkVm.From(c), so a real ingredient sprite renders when present and the
+        // flask Lucide shows only for icon-less ingredients (reconciliation flag #3
+        // CLOSED — the adapter no longer needs to infer Ingredient when art exists).
         IngredientLinks = Ingredients
             .Select(c => LinkVm.From(c) with { Glyph = LinkGlyph.Ingredient })
             .ToList();
@@ -120,9 +124,11 @@ public sealed class RecipeDetailViewModel
 
     /// <summary>
     /// Ingredient cross-links as the unified <see cref="LinkVm"/> (matrix #10).
-    /// Glyph is forced to <see cref="LinkGlyph.Ingredient"/> (reconciliation flag
-    /// #3 — the kind-driven adapter yields <see cref="LinkGlyph.Item"/> for
-    /// <see cref="EntityKind.Item"/>; this list is semantically ingredients).
+    /// <see cref="LinkVm.Glyph"/> is set to <see cref="LinkGlyph.Ingredient"/> as the
+    /// Lucide <em>fallback</em>; per the G3 amendment the chip's
+    /// <see cref="LinkVm.IconId"/> sprite is preferred when present (reconciliation
+    /// flag #3 closed — a real ingredient sprite now shows; the flask Lucide is the
+    /// icon-less fallback only).
     /// </summary>
     public IReadOnlyList<LinkVm> IngredientLinks { get; }
 

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -72,15 +72,21 @@ public sealed class RecipeDetailViewModel
         // here (not in RecipesTabViewModel) because the VM already holds every
         // source datum — the Phase-5 mapping is mechanical, not data-bearing.
 
-        // Fact stat strip (matrix #3): one inert dot-separated value-only strip
-        // replacing the three bordered stat-badge boxes. Each segment is a
-        // value-only FactPair (null label) and empties are skipped, so the strip
-        // self-elides exactly like the old per-chip NullOrEmptyToVis did.
-        StatStrip = FactTableVm.Strip(
-            new[] { SkillRequirementChip, MaxUsesChip, CooldownChip }
-                .Where(s => !string.IsNullOrEmpty(s))
-                .Select(s => new FactPair(null, s))
-                .ToList());
+        // Fact stat strip (matrix #3) replacing the three bordered stat-badge
+        // boxes. Grammar ratifies the stat strip as label-value pairs (doc
+        // lines 105/169/247; weight-axis example "Skill **Alchemy 55**"), so
+        // the Skill stat carries its "Skill" label (renders "Skill
+        // Toolcrafting 98", matching the ratified specimen). MaxUses/Cooldown
+        // are self-describing phrase-form ("Limited to 2 uses", "Reuse every
+        // 1h 30m") — kept label-null; the grammar only exemplified the
+        // labelled Skill case, so phrase-stats-bare is a flagged sensible
+        // reading, and a fan-out consideration for views with other stats.
+        // Empties skipped → self-elides like the old per-chip NullOrEmptyToVis.
+        var stat = new List<FactPair>(3);
+        if (!string.IsNullOrEmpty(SkillRequirementChip)) stat.Add(new FactPair("Skill", SkillRequirementChip));
+        if (!string.IsNullOrEmpty(MaxUsesChip)) stat.Add(new FactPair(null, MaxUsesChip));
+        if (!string.IsNullOrEmpty(CooldownChip)) stat.Add(new FactPair(null, CooldownChip));
+        StatStrip = FactTableVm.Strip(stat);
 
         // Link projections (matrix #6/#9/#10/#12). EntityChip/ItemSourceChip →
         // LinkVm via the ratified adapters; the G3-amended adapters now carry the

--- a/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipeDetailViewModel.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Recipes;
@@ -64,7 +65,98 @@ public sealed class RecipeDetailViewModel
                 $"Shares cooldown with {sharedCooldownChip.DisplayName}",
                 "Shares cooldown with",
                 sharedCooldownChip);
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // The legacy string/chip members above stay (tests + planner-facing
+        // contract); these are the grammar-tier carriers the view binds. Built
+        // here (not in RecipesTabViewModel) because the VM already holds every
+        // source datum — the Phase-5 mapping is mechanical, not data-bearing.
+
+        // Fact stat strip (matrix #3): one inert dot-separated value-only strip
+        // replacing the three bordered stat-badge boxes. Each segment is a
+        // value-only FactPair (null label) and empties are skipped, so the strip
+        // self-elides exactly like the old per-chip NullOrEmptyToVis did.
+        StatStrip = FactTableVm.Strip(
+            new[] { SkillRequirementChip, MaxUsesChip, CooldownChip }
+                .Where(s => !string.IsNullOrEmpty(s))
+                .Select(s => new FactPair(null, s))
+                .ToList());
+
+        // Link projections (matrix #6/#9/#10/#12). EntityChip/ItemSourceChip →
+        // LinkVm via the ratified adapters. Ingredients force LinkGlyph.Ingredient
+        // explicitly (reconciliation flag #3: the adapter can't infer Ingredient
+        // from EntityKind.Item — it would yield Item/package).
+        IngredientLinks = Ingredients
+            .Select(c => LinkVm.From(c) with { Glyph = LinkGlyph.Ingredient })
+            .ToList();
+        ProducedItemLinks = ProducedItems.Select(LinkVm.From).ToList();
+        SourceLinks = Sources is null
+            ? []
+            : Sources.Select(LinkVm.From).ToList();
+
+        // Requirement rows: same prose-or-(prefix+link) dual shape, but the inline
+        // chip is now a LinkVm (matrix #6). The row record lives in a file outside
+        // this pilot's edit scope, so wrap it rather than extend it.
+        RequirementRows = Requirements.Select(RecipeRequirementRowVm.From).ToList();
+        SharedCooldownRowVm = SharedCooldownRow is null
+            ? null
+            : RecipeRequirementRowVm.From(SharedCooldownRow);
+
+        // Footer ID: InternalName is a cross-entity reference KEY ⇒ copyable
+        // (matrix #14, G-a). None() when absent so the strip self-hides.
+        Footer = string.IsNullOrEmpty(InternalName)
+            ? FactFooterVm.None()
+            : FactFooterVm.Key(InternalName);
     }
+
+    /// <summary>
+    /// Inert Fact stat strip (matrix #3) — the dot-separated value-only segments
+    /// (<see cref="SkillRequirementChip"/> · <see cref="MaxUsesChip"/> ·
+    /// <see cref="CooldownChip"/>, empties skipped) replacing the three legacy
+    /// bordered stat-badge boxes. G-b: no box, no gold; the
+    /// <c>FactTableLayout.Strip</c> Style carries the (inert) pigment.
+    /// </summary>
+    public FactTableVm StatStrip { get; }
+
+    /// <summary>
+    /// Ingredient cross-links as the unified <see cref="LinkVm"/> (matrix #10).
+    /// Glyph is forced to <see cref="LinkGlyph.Ingredient"/> (reconciliation flag
+    /// #3 — the kind-driven adapter yields <see cref="LinkGlyph.Item"/> for
+    /// <see cref="EntityKind.Item"/>; this list is semantically ingredients).
+    /// </summary>
+    public IReadOnlyList<LinkVm> IngredientLinks { get; }
+
+    /// <summary>Produced-item cross-links as <see cref="LinkVm"/> (matrix #12);
+    /// glyph derived from kind by the adapter (Item ⇒ package).</summary>
+    public IReadOnlyList<LinkVm> ProducedItemLinks { get; }
+
+    /// <summary>
+    /// "Taught by" source rows as <see cref="LinkVm"/> (matrix #9). The provenance
+    /// suffix rides from <see cref="ItemSourceChipVm.Detail"/>; glyph by kind.
+    /// Empty (never null) so the view's count-based section hide is uniform.
+    /// </summary>
+    public IReadOnlyList<LinkVm> SourceLinks { get; }
+
+    /// <summary>
+    /// <see cref="Requirements"/> reshaped so each row's inline chip is a
+    /// <see cref="LinkVm"/> (matrix #6). Wraps the underlying
+    /// <see cref="RecipeRequirementRow"/> (whose record lives outside this pilot's
+    /// edit scope) rather than mutating it.
+    /// </summary>
+    public IReadOnlyList<RecipeRequirementRowVm> RequirementRows { get; }
+
+    /// <summary>
+    /// <see cref="SharedCooldownRow"/> reshaped to the Link-carrying row VM
+    /// (matrix #7 — same template as the requirement rows). Null when absent.
+    /// </summary>
+    public RecipeRequirementRowVm? SharedCooldownRowVm { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14, G-a). <see cref="InternalName"/> is a
+    /// cross-entity reference KEY ⇒ a single copyable cell; <c>None()</c> (the
+    /// strip self-hides) when the recipe has no internal name.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     /// <summary>
     /// Human-readable skill name (resolved by the page VM via <c>IReferenceDataService.Skills</c>),
@@ -238,6 +330,11 @@ public sealed class RecipeKeywordSlotVm
         MatchCount = popup.TotalCount;
         ShowPopupCommand = new RelayCommand(
             () => RecipeDetailViewModel.ProvenancePopupOpener(popup, chipClickCommand));
+        // Matrix #11: the bespoke ghost-gold "{Label} — view all N →" Button
+        // becomes the shared Set-reference primitive. Summary-form (MatchCount
+        // non-null ⇒ "{Label} · N →"), actionable (the reveal is wired to
+        // ShowPopupCommand). Gold→blue is intentional per G-b, not a regression.
+        SetRef = new SetRefVm(Label, MatchCount: MatchCount, IsActionable: true);
     }
 
     /// <summary>Friendly slot description, e.g. "any Crystal" / "Main-Hand Item".</summary>
@@ -266,4 +363,55 @@ public sealed class RecipeKeywordSlotVm
     /// (#229 contract; mirrors the surface-1 <c>ItemDetailViewModel</c> command).
     /// </summary>
     public ICommand ShowPopupCommand { get; }
+
+    /// <summary>
+    /// The keyword slot as the shared Set-reference primitive (matrix #11): a
+    /// summary-form <see cref="SetRefVm"/> (<c>"{Label} · {MatchCount} →"</c>),
+    /// actionable — its reveal is <see cref="ShowPopupCommand"/>. Replaces the
+    /// bespoke ghost-gold "view all N" Button; the gold→blue shift is the ratified
+    /// G-b correction, not a regression.
+    /// </summary>
+    public SetRefVm SetRef { get; }
+}
+
+/// <summary>
+/// View-side reshape of a <see cref="RecipeRequirementRow"/> for the Phase-5
+/// grammar primitives: the prose-or-(prefix + inline chip) dual shape is
+/// preserved, but the inline chip is the unified <see cref="LinkVm"/> instead of
+/// the legacy <see cref="EntityChipVm"/> (matrix #6/#7). This wraps rather than
+/// extends the underlying record because <see cref="RecipeRequirementRow"/> is
+/// declared outside this pilot's edit scope (<c>RecipeRequirementProjector.cs</c>).
+/// <see cref="Link"/> is null for a prose-only row (drives the same NullToVis
+/// object self-switch the legacy template used on <c>Chip</c>).
+/// </summary>
+public sealed class RecipeRequirementRowVm
+{
+    private RecipeRequirementRowVm(string text, string? prefix, LinkVm? link)
+    {
+        Text = text;
+        Prefix = prefix;
+        Link = link;
+    }
+
+    /// <summary>Accessible / fallback prose rendering (used when <see cref="Link"/> is null).</summary>
+    public string Text { get; }
+
+    /// <summary>Inline field-label prefix shown before the <see cref="Link"/> (Structure tier).</summary>
+    public string? Prefix { get; }
+
+    /// <summary>
+    /// The inline navigable cross-link, or null for a prose-only row. Recipe→recipe
+    /// edges (RecipeKnown / RecipeUsed / shared-cooldown) are Recipe-kind, so the
+    /// adapter yields the recipe glyph by kind (matrix #6 — acceptable).
+    /// </summary>
+    public LinkVm? Link { get; }
+
+    /// <summary>
+    /// Adapts a legacy <see cref="RecipeRequirementRow"/>: a row carrying a
+    /// <see cref="RecipeRequirementRow.Chip"/> becomes a prefix + <see cref="LinkVm"/>
+    /// row (chip → <see cref="LinkVm.From(EntityChipVm)"/>); a prose row stays prose
+    /// (<see cref="Link"/> null).
+    /// </summary>
+    public static RecipeRequirementRowVm From(RecipeRequirementRow row) =>
+        new(row.Text, row.Prefix, row.Chip is null ? null : LinkVm.From(row.Chip));
 }

--- a/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/RecipesTabViewModel.cs
@@ -244,7 +244,13 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
         var ingredients = recipe.Ingredients;
         if (ingredients is null) return [];
 
-        var rows = new List<RecipeKeywordSlotVm>();
+        // Two-pass build so the G4 ≥2-slot ordinal gate keys off the FINAL count:
+        // skipped slots (empty keys / not-in-index) never reach the list, so the
+        // ordinal must be assigned after all skips are resolved — not from the raw
+        // ingredient position. Pass 1 collects the surviving (label, popup) inputs;
+        // pass 2 materializes the VMs, threading a 1-based SlotOrdinal only when ≥2
+        // slots survived (positionally material per the Stacking-semantics clause).
+        var inputs = new List<(string Label, ProvenancePopupViewModel Popup)>();
         foreach (var kwIng in ingredients.OfType<RecipeKeywordIngredient>())
         {
             if (kwIng.ItemKeys.Count == 0) continue;
@@ -281,7 +287,26 @@ public sealed partial class RecipesTabViewModel : ObservableObject, ITabViewMode
                     new(label, chips),
                 });
 
-            rows.Add(new RecipeKeywordSlotVm(label, popup, _openEntityCommand));
+            inputs.Add((label, popup));
+        }
+
+        // G4 Stacking semantics (docs/silmarillion-visual-grammar.md ·
+        // "Stacking semantics"): recipe keyword slots are positionally MATERIAL
+        // whenever there are ≥2 (the grammar's own TSysCraftedEquipment canonical
+        // example — slot position is material for crafted-equipment recipes
+        // regardless of whether the constraints are identical, so do NOT gate on
+        // "same constraint"; ≥2 ⇒ material). ≥2 ⇒ 1-based ordinal per slot; the
+        // single/0-slot case stays null (no prefix). The slot-count suffix on the
+        // section label is the VM's RecipeDetailViewModel.KeywordIngredientsLabel.
+        var material = inputs.Count >= 2;
+        var rows = new List<RecipeKeywordSlotVm>(inputs.Count);
+        for (var i = 0; i < inputs.Count; i++)
+        {
+            rows.Add(new RecipeKeywordSlotVm(
+                inputs[i].Label,
+                inputs[i].Popup,
+                _openEntityCommand,
+                slotOrdinal: material ? i + 1 : null));
         }
         return rows;
     }

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -33,7 +33,13 @@
                         <ContentControl Content="{Binding Link}">
                             <ContentControl.ContentTemplate>
                                 <DataTemplate>
-                                    <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                                    <!-- G3-amend-2: Density="Prose" (the DP default,
+                                         stated explicitly so the pilot's deliberate
+                                         choice is visible). Prose-vs-List per Recipe
+                                         section is a G4 design decision left at Prose
+                                         on purpose — NOT silently chosen here. -->
+                                    <c:Link Density="Prose"
+                                            ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                                 </DataTemplate>
                             </ContentControl.ContentTemplate>
                         </ContentControl>
@@ -70,8 +76,13 @@
             <!-- Header: icon + name. Internal name goes in the footer bottom-right per the
                  detail-view convention (matches ItemDetailView). -->
             <DockPanel Margin="0,0,0,10">
+                <!-- G3-amend-2: the recipe's own header icon IS the title-glyph
+                     → the FIXED 40px FactTitleGlyphStyle (was 48×48). An entity
+                     stamp: exempt from em/accessibility scaling, NearestNeighbor
+                     crisp, no border/fill. -->
                 <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                             Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
+                             Style="{StaticResource FactTitleGlyphStyle}"
+                             Margin="0,0,12,0" VerticalAlignment="Top"/>
                 <StackPanel VerticalAlignment="Center">
                     <!-- Matrix #1: Fact-title. The FactTitleStyle carries the
                          Cambria/600/accent/wrap; the inline gold/bold/size is dropped. -->
@@ -158,7 +169,10 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            <!-- G3-amend-2: Density="Prose" (DP default, explicit).
+                                 Prose↔List for this section is a deferred G4 call. -->
+                            <c:Link Density="Prose"
+                                    ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -174,7 +188,12 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            <!-- G3-amend-2: Density="Prose" (DP default, explicit).
+                                 Ingredients↔List (own-line, ×1.5) is a layout-
+                                 changing G4 design call — deliberately left Prose,
+                                 NOT silently chosen. -->
+                            <c:Link Density="Prose"
+                                    ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -223,7 +242,10 @@
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            <!-- G3-amend-2: Density="Prose" (DP default, explicit).
+                                 Produces↔List is a deferred G4 design call. -->
+                            <c:Link Density="Prose"
+                                    ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -209,7 +209,10 @@
                  popup is a flat list. -->
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding KeywordSlots.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Keyword ingredients" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <!-- G4 Stacking semantics: the slot-count suffix ("· N slots")
+                     lives in the VM (KeywordIngredientsLabel); XAML never owns
+                     the count logic. StructureSectionLabelStyle unchanged. -->
+                <TextBlock Text="{Binding KeywordIngredientsLabel}" Style="{StaticResource StructureSectionLabelStyle}"/>
                 <!-- Matrix #11: the bespoke ghost-gold "{Label} — view all N →"
                      Button becomes the shared Set-reference primitive (summary-form
                      "{Label} · N →", actionable). ActivateCommand → the existing

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -163,15 +163,19 @@
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding SourceLinks.Count, Converter={StaticResource PositiveIntToVis}}">
                 <TextBlock Text="Taught by" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <!-- CANONICAL ENUMERATION PATTERN (G4-ratified, copied by all fan-out
+                     views): a list of entity refs is Density="List" — sprite ×1.5em,
+                     one Link per line (vertical StackPanel), light row spacing for the
+                     grammar's ~1.7 line-height intent (exact 1.7 line-box doesn't map
+                     to icon+text rows; approximated, flagged). Inline-in-sentence refs
+                     (requirement rows) stay Prose. -->
                 <ItemsControl ItemsSource="{Binding SourceLinks}">
                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <!-- G3-amend-2: Density="Prose" (DP default, explicit).
-                                 Prose↔List for this section is a deferred G4 call. -->
-                            <c:Link Density="Prose"
+                            <c:Link Density="List" Margin="0,0,0,3"
                                     ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -184,15 +188,12 @@
                 <TextBlock Text="Ingredients" Style="{StaticResource StructureSectionLabelStyle}"/>
                 <ItemsControl ItemsSource="{Binding IngredientLinks}">
                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <!-- G3-amend-2: Density="Prose" (DP default, explicit).
-                                 Ingredients↔List (own-line, ×1.5) is a layout-
-                                 changing G4 design call — deliberately left Prose,
-                                 NOT silently chosen. -->
-                            <c:Link Density="Prose"
+                            <!-- G4-ratified: enumeration → Density="List" (canonical pattern). -->
+                            <c:Link Density="List" Margin="0,0,0,3"
                                     ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -238,13 +239,12 @@
                 <TextBlock Text="Produces" Style="{StaticResource StructureSectionLabelStyle}"/>
                 <ItemsControl ItemsSource="{Binding ProducedItemLinks}">
                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                        <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <!-- G3-amend-2: Density="Prose" (DP default, explicit).
-                                 Produces↔List is a deferred G4 design call. -->
-                            <c:Link Density="Prose"
+                            <!-- G4-ratified: enumeration → Density="List" (canonical pattern). -->
+                            <c:Link Density="List" Margin="0,0,0,3"
                                     ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/src/Silmarillion.Module/Views/RecipeDetailView.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailView.xaml
@@ -2,7 +2,6 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:local="clr-namespace:Silmarillion.Views"
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -24,29 +23,28 @@
                    - Otherwise: plain Text (cyclical / user-asserted gates).
                  Switching is on Chip (object) via NullToVis — NOT the string-only
                  NullOrEmptyToVis, which silently collapses an EntityChipVm binding. -->
-            <DataTemplate DataType="{x:Type vm:RecipeRequirementRow}">
+            <DataTemplate DataType="{x:Type vm:RecipeRequirementRowVm}">
                 <Grid Margin="0,0,0,3">
                     <StackPanel Orientation="Horizontal"
-                                Visibility="{Binding Chip, Converter={StaticResource NullToVis}}">
-                        <TextBlock Text="{Binding Prefix}" Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                Visibility="{Binding Link, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="{Binding Prefix}"
+                                   Style="{StaticResource StructureInlinePrefixStyle}"
                                    VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <ContentControl Content="{Binding Chip}">
+                        <ContentControl Content="{Binding Link}">
                             <ContentControl.ContentTemplate>
                                 <DataTemplate>
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                                    <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                                 </DataTemplate>
                             </ContentControl.ContentTemplate>
                         </ContentControl>
                     </StackPanel>
-                    <TextBlock Text="{Binding Text}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               TextWrapping="Wrap" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Text}"
+                               VerticalAlignment="Center">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource FactBodyStyle}">
                                 <Setter Property="Visibility" Value="Visible"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Chip, Converter={StaticResource NullToVis}}" Value="Visible">
+                                    <DataTrigger Binding="{Binding Link, Converter={StaticResource NullToVis}}" Value="Visible">
                                         <Setter Property="Visibility" Value="Collapsed"/>
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -58,11 +56,16 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterText="{Binding InternalName}">
+    <!-- Matrix #14 / G-a: the InternalName footer migrates from DetailExportHost's
+         FooterText to the shared FactFooter primitive (InternalName is a cross-entity
+         reference KEY ⇒ copyable). The DetailExportHost wrapper is RETAINED unchanged
+         for the export-camera affordance + snapshot wrapper (shared infra, not edited);
+         we simply stop binding FooterText and place <c:FactFooter/> at the bottom of
+         the wrapped content. No DetailExportHost surgery — purely a per-view change. -->
+    <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Internal-name footer is owned by the wrapping DetailExportHost (FooterText). -->
             <StackPanel>
             <!-- Header: icon + name. Internal name goes in the footer bottom-right per the
                  detail-view convention (matches ItemDetailView). -->
@@ -70,42 +73,25 @@
                 <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
                              Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
                 <StackPanel VerticalAlignment="Center">
-                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
-                               Foreground="#FFD4A847"
-                               FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                    <!-- Matrix #1: Fact-title. The FactTitleStyle carries the
+                         Cambria/600/accent/wrap; the inline gold/bold/size is dropped. -->
+                    <TextBlock Text="{Binding DisplayName}"
+                               Style="{StaticResource FactTitleStyle}"/>
                 </StackPanel>
             </DockPanel>
 
-            <!-- Recipe attribute chips: skill requirement + (Research-only) lifetime
-                 use cap. WrapPanel keeps them on one line and wraps if cramped. Each
-                 chip self-hides on an empty string via NullOrEmptyToVis. -->
-            <WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
-                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
-                        CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Margin="0,0,6,0"
-                        Visibility="{Binding SkillRequirementChip, Converter={StaticResource NullOrEmptyToVis}}">
-                    <TextBlock Text="{Binding SkillRequirementChip}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                </Border>
-                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
-                        CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Margin="0,0,6,0"
-                        Visibility="{Binding MaxUsesChip, Converter={StaticResource NullOrEmptyToVis}}">
-                    <TextBlock Text="{Binding MaxUsesChip}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                </Border>
-                <!-- Reuse cooldown. The planner is time-stateless and surfaces the cap
-                     (MaxUses) but not this — the browser is the only place a player learns
-                     a recipe is on a timer. Mirrors MaxUsesChip's self-hide on empty. -->
-                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
-                        CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Margin="0,0,6,0"
-                        Visibility="{Binding CooldownChip, Converter={StaticResource NullOrEmptyToVis}}">
-                    <TextBlock Text="{Binding CooldownChip}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                </Border>
-            </WrapPanel>
+            <!-- Matrix #3: one inert Fact stat strip (skill req · max uses ·
+                 cooldown, empties skipped, value-only segments) replacing the three
+                 bordered stat-badge boxes. No box, no gold (G-b) — the FactTable
+                 Strip Style carries the inert pigment. Self-hides when every
+                 segment is empty (StripText is "" ⇒ nothing renders). -->
+            <c:FactTable DataContext="{Binding StatStrip}" HorizontalAlignment="Left"
+                         Margin="0,0,0,10"/>
 
-            <!-- Description (FormattedText parses any inline <i>/<b> markup). -->
-            <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
-                       FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
+            <!-- Description (FormattedText parses any inline <i>/<b> markup).
+                 Matrix #4: FactBodyStyle + keep italic; drop the inline #CCFFFFFF. -->
+            <TextBlock c:FormattedText.Text="{Binding Description}" FontStyle="Italic"
+                       Style="{StaticResource FactBodyStyle}"
                        MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                        Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
@@ -122,42 +108,39 @@
                     <Style TargetType="StackPanel">
                         <Setter Property="Visibility" Value="Collapsed"/>
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding Requirements.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                            <DataTrigger Binding="{Binding RequirementRows.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                 <Setter Property="Visibility" Value="Visible"/>
                             </DataTrigger>
                             <!-- NullToVis (object) — NOT the string-only NullOrEmptyToVis. -->
-                            <DataTrigger Binding="{Binding SharedCooldownRow, Converter={StaticResource NullToVis}}" Value="Visible">
+                            <DataTrigger Binding="{Binding SharedCooldownRowVm, Converter={StaticResource NullToVis}}" Value="Visible">
                                 <Setter Property="Visibility" Value="Visible"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
                 </StackPanel.Style>
-                <TextBlock Text="Requirements" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <!-- No ItemTemplate: the implicit DataType-keyed RecipeRequirementRow
-                     template in Resources renders each row (prose vs prefix+chip). -->
-                <ItemsControl ItemsSource="{Binding Requirements}"
-                              Visibility="{Binding Requirements.Count, Converter={StaticResource PositiveIntToVis}}"/>
-                <!-- Shared-cooldown: same RecipeRequirementRow shape/template, exposed
+                <TextBlock Text="Requirements" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <!-- No ItemTemplate: the implicit DataType-keyed RecipeRequirementRowVm
+                     template in Resources renders each row (prose vs prefix+link). -->
+                <ItemsControl ItemsSource="{Binding RequirementRows}"
+                              Visibility="{Binding RequirementRows.Count, Converter={StaticResource PositiveIntToVis}}"/>
+                <!-- Shared-cooldown: same RecipeRequirementRowVm shape/template, exposed
                      separately and labelled "Shares cooldown with" — a cooldown grouping
                      isn't a requirement gate. ContentControl picks up the implicit
                      template; collapses on a null row so it never instantiates dead. -->
-                <ContentControl Content="{Binding SharedCooldownRow}"
-                                Visibility="{Binding SharedCooldownRow, Converter={StaticResource NullToVis}}"/>
+                <ContentControl Content="{Binding SharedCooldownRowVm}"
+                                Visibility="{Binding SharedCooldownRowVm, Converter={StaticResource NullToVis}}"/>
             </StackPanel>
 
             <!-- Cost: currency to perform the recipe. The planner ignores Costs by
                  design (no XP/count impact) so the browser is the only surface for it. -->
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding CostLines.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Cost" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                <TextBlock Text="Cost" Style="{StaticResource StructureSectionLabelStyle}"/>
                 <ItemsControl ItemsSource="{Binding CostLines}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" Margin="0,0,0,2"/>
+                            <TextBlock Text="{Binding}" Style="{StaticResource FactBodyStyle}"
+                                       Margin="0,0,0,2"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -167,16 +150,15 @@
                  navigable chip when the source's EntityReference resolves to a tabbed kind
                  (e.g. NPC trainers, post-#241), plain-text in a transparent frame otherwise. -->
             <StackPanel Margin="0,0,0,10"
-                        Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Taught by" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding Sources}">
+                        Visibility="{Binding SourceLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <TextBlock Text="Taught by" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <ItemsControl ItemsSource="{Binding SourceLinks}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <c:ItemSourceChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -184,16 +166,15 @@
 
             <!-- Ingredients -->
             <StackPanel Margin="0,0,0,10"
-                        Visibility="{Binding Ingredients.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Ingredients" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding Ingredients}">
+                        Visibility="{Binding IngredientLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <TextBlock Text="Ingredients" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <ItemsControl ItemsSource="{Binding IngredientLinks}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -208,50 +189,25 @@
                  popup is a flat list. -->
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding KeywordSlots.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Keyword ingredients" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                <TextBlock Text="Keyword ingredients" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <!-- Matrix #11: the bespoke ghost-gold "{Label} — view all N →"
+                     Button becomes the shared Set-reference primitive (summary-form
+                     "{Label} · N →", actionable). ActivateCommand → the existing
+                     ShowPopupCommand. Gold→blue is the ratified G-b correction. -->
                 <ItemsControl ItemsSource="{Binding KeywordSlots}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <!-- ActionChip-style affordance (ghost fill, ListFilter glyph):
-                                 reads as "go see the full set", not "open an entity".
-                                 Mirrors the surface-1 ItemDetailView "View all N →" button. -->
-                            <Button Margin="0,0,0,4" Padding="6,2"
-                                    HorizontalAlignment="Left" Cursor="Hand"
-                                    Command="{Binding ShowPopupCommand}">
-                                <Button.Style>
-                                    <Style TargetType="Button">
-                                        <Setter Property="Background" Value="Transparent"/>
-                                        <Setter Property="BorderBrush" Value="#66D4A847"/>
-                                        <Setter Property="BorderThickness" Value="1"/>
-                                        <Setter Property="Foreground" Value="#FFD4A847"/>
-                                        <Style.Triggers>
-                                            <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter Property="Background" Value="#22D4A847"/>
-                                            </Trigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Button.Style>
-                                <Button.Template>
-                                    <ControlTemplate TargetType="Button">
-                                        <Border Background="{TemplateBinding Background}"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{TemplateBinding BorderThickness}"
-                                                CornerRadius="3" Padding="{TemplateBinding Padding}">
-                                            <StackPanel Orientation="Horizontal">
-                                                <icon:PackIconLucide Kind="ListFilter" Width="12" Height="12"
-                                                                     Foreground="{TemplateBinding Foreground}"
-                                                                     Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                                <TextBlock Foreground="{TemplateBinding Foreground}"
-                                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                                           VerticalAlignment="Center">
-                                                    <Run Text="{Binding Label, Mode=OneWay}"/><Run Text=" — view all "/><Run Text="{Binding MatchCount, Mode=OneWay}"/><Run Text=" →"/>
-                                                </TextBlock>
-                                            </StackPanel>
-                                        </Border>
-                                    </ControlTemplate>
-                                </Button.Template>
-                            </Button>
+                            <!-- Slot VM stays the DataTemplate DataContext so the
+                                 per-slot ShowPopupCommand resolves; SetRef takes its
+                                 own SetRefVm DataContext, command via ContentControl. -->
+                            <ContentControl Content="{Binding SetRef}"
+                                            HorizontalAlignment="Left" Margin="0,0,0,4">
+                                <ContentControl.ContentTemplate>
+                                    <DataTemplate>
+                                        <c:SetRef ActivateCommand="{Binding DataContext.ShowPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                                    </DataTemplate>
+                                </ContentControl.ContentTemplate>
+                            </ContentControl>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -259,16 +215,15 @@
 
             <!-- Produces -->
             <StackPanel Margin="0,0,0,10"
-                        Visibility="{Binding ProducedItems.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Produces" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                <ItemsControl ItemsSource="{Binding ProducedItems}">
+                        Visibility="{Binding ProducedItemLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <TextBlock Text="Produces" Style="{StaticResource StructureSectionLabelStyle}"/>
+                <ItemsControl ItemsSource="{Binding ProducedItemLinks}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
+                            <c:Link ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:RecipeDetailView}}}"/>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -277,12 +232,14 @@
             <!-- Result effects (plain-text stub; TODO(stub:#214) brings rich chip rendering) -->
             <StackPanel Margin="0,0,0,10"
                         Visibility="{Binding ResultEffectsText.Count, Converter={StaticResource PositiveIntToVis}}">
-                <TextBlock Text="Effects" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                <TextBlock Text="Effects" Style="{StaticResource StructureSectionLabelStyle}"/>
                 <ItemsControl ItemsSource="{Binding ResultEffectsText}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <!-- TODO(stub:#214): rich chip templates -->
+                            <!-- TODO(stub:#214): rich chip templates. Matrix #13: this
+                                 mono stub's placement/restyle is #214-bound — out of
+                                 scope for the pilot. Left inline mono deliberately
+                                 (FactBodyStyle would break the mono-stub intent). -->
                             <TextBlock Text="{Binding}" Foreground="#AAFFFFFF"
                                        FontFamily="{DynamicResource AppMonoFontFamily}"
                                        FontSize="{DynamicResource AppFontSizeSmall}"
@@ -291,6 +248,10 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </StackPanel>
+
+            <!-- Footer ID strip (matrix #14, G-a): InternalName as a copyable KEY
+                 cell below the read-flow. FactFooterVm.None() self-hides at 0 ids. -->
+            <c:FactFooter DataContext="{Binding Footer}"/>
 
             </StackPanel>
         </DockPanel>

--- a/tests/Mithril.Shared.Tests/Wpf/FontSizeTimesConverterTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/FontSizeTimesConverterTests.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Pure-logic coverage for the G3-amend-2 <see cref="FontSizeTimesConverter"/> — the
+/// single "<c>FontSize × n</c>" mechanism every Silmarillion grammar tier sizes itself
+/// in em through (<c>docs/silmarillion-visual-grammar.md</c> · "All sizes are
+/// em-relative, not px"). Mirrors <see cref="LinkTests"/>'s no-UI-spin-up style.
+/// Covers value×factor, culture-invariant string-parameter parse, and the
+/// null / non-numeric / non-positive safety degrade (a missing inherited FontSize must
+/// never crash a detail pane).
+/// </summary>
+public sealed class FontSizeTimesConverterTests
+{
+    private static readonly FontSizeTimesConverter Sut = new();
+
+    private static object Convert(object value, object parameter, CultureInfo? culture = null)
+        => Sut.Convert(value, typeof(double), parameter, culture ?? CultureInfo.InvariantCulture);
+
+    // ── value × factor (the ratified per-tier factors) ──
+
+    [Theory]
+    [InlineData(12.0, "1.5", 18.0)]    // Fact-title / Link list sprite 1.5em @ 12pt
+    [InlineData(12.0, "1.0", 12.0)]    // Link prose sprite 1.0em
+    [InlineData(12.0, "0.75", 9.0)]    // Link prose Lucide 0.75em
+    [InlineData(12.0, "1.125", 13.5)]  // Link list Lucide 1.125em
+    [InlineData(12.0, "0.9", 10.8)]    // Stat strip 0.9em
+    [InlineData(12.0, "0.78", 9.36)]   // Footer ID / Structure 0.78em
+    [InlineData(15.0, "1.5", 22.5)]    // tracks the Appearance slider (15pt)
+    [InlineData(18.0, "0.75", 13.5)]   // and at 18pt
+    public void Convert_MultipliesFontSizeByFactor(
+        double fontSize, string factor, double expected)
+    {
+        Convert(fontSize, factor).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Convert_AcceptsNumericParameter_NotJustString()
+    {
+        Convert(12.0, 1.5).Should().Be(18.0);
+        Convert(12.0, 2).Should().Be(24.0);
+    }
+
+    [Fact]
+    public void Convert_AcceptsIntAndFloatValue()
+    {
+        Convert(12, "1.5").Should().Be(18.0);
+        Convert(12.0f, "0.5").Should().Be(6.0);
+    }
+
+    // ── culture-invariant parameter parse (the comma-decimal-locale footgun) ──
+
+    [Fact]
+    public void Convert_ParsesDottedParameter_UnderCommaDecimalCulture()
+    {
+        // de-DE uses ',' as the decimal separator. A XAML ConverterParameter=1.125
+        // must NOT be misread as 1125 under that UI culture.
+        var de = CultureInfo.GetCultureInfo("de-DE");
+        Convert(16.0, "1.125", de).Should().Be(18.0);
+    }
+
+    // ── null / non-numeric / non-positive safety (never throw) ──
+
+    [Fact]
+    public void Convert_NullValue_DegradesToNaN_NoThrow()
+    {
+        Convert(null!, "1.5").Should().Be(double.NaN);
+    }
+
+    [Fact]
+    public void Convert_NonNumericValue_DegradesToNaN()
+    {
+        Convert("not-a-size", "1.5").Should().Be(double.NaN);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-3.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Convert_NonPositiveOrNonFiniteFontSize_DegradesToNaN(double fontSize)
+    {
+        Convert(fontSize, "1.5").Should().Be(double.NaN);
+    }
+
+    [Fact]
+    public void Convert_NullOrUnparseableParameter_DegradesToNaN()
+    {
+        Convert(12.0, null!).Should().Be(double.NaN);
+        Convert(12.0, "xyz").Should().Be(double.NaN);
+    }
+
+    [Fact]
+    public void Scale_PureHelper_MatchesConvert()
+    {
+        FontSizeTimesConverter.Scale(12.0, 1.5).Should().Be(18.0);
+        FontSizeTimesConverter.Scale(0.0, 1.5).Should().Be(double.NaN);
+        FontSizeTimesConverter.Scale(double.NaN, 1.0).Should().Be(double.NaN);
+    }
+
+    [Fact]
+    public void ConvertBack_IsNotSupported()
+    {
+        var act = () => Sut.ConvertBack(18.0, typeof(double), "1.5", CultureInfo.InvariantCulture);
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
@@ -262,6 +262,52 @@ public sealed class LinkTests
         Link.ResolveLead(null).Should().Be(LinkLead.None);
     }
 
+    // ── Density DP default + lead em-factor (G3 amendment 2 · 2026-05-17) ──
+
+    [Fact]
+    public void Density_DefaultsToProse()
+    {
+        // The DP default — existing wrapped-chip call sites keep inline layout.
+        // (Pure metadata read; no visual tree needed.)
+        Link.DensityProperty.DefaultMetadata.DefaultValue
+            .Should().Be(LinkDensity.Prose);
+    }
+
+    [Theory]
+    // Sprite — Prose ×1.0, List ×1.5 (the ratified em size table).
+    [InlineData(LinkDensity.Prose, LinkLeadKind.Sprite, 1.0)]
+    [InlineData(LinkDensity.List, LinkLeadKind.Sprite, 1.5)]
+    // Lucide — Prose ×0.75, List ×1.125.
+    [InlineData(LinkDensity.Prose, LinkLeadKind.Lucide, 0.75)]
+    [InlineData(LinkDensity.List, LinkLeadKind.Lucide, 1.125)]
+    public void LeadFactor_MatchesRatifiedEmTable(
+        LinkDensity density, LinkLeadKind lead, double expected)
+    {
+        Link.LeadFactor(density, lead).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(LinkDensity.Prose)]
+    [InlineData(LinkDensity.List)]
+    public void LeadFactor_None_HasNoLead_FactorZero(LinkDensity density)
+    {
+        // LinkLeadKind.None renders no lead element → factor is irrelevant (0).
+        Link.LeadFactor(density, LinkLeadKind.None).Should().Be(0.0);
+    }
+
+    [Fact]
+    public void LeadFactor_ComposesWithResolveLead_SpriteWinsAtListSize()
+    {
+        // End-to-end: a tangible noun with real art at List density resolves to a
+        // Sprite lead sized ×1.5em — the supersession of ec0a49e's fixed 12px.
+        var vm = new LinkVm("Iron Sword", LinkGlyph.Item,
+            EntityRef.Item("IronSword"), IsNavigable: true, IconId: 42);
+
+        var lead = Link.ResolveLead(vm);
+        Link.LeadFactor(LinkDensity.List, lead.Kind).Should().Be(1.5);
+        Link.LeadFactor(LinkDensity.Prose, lead.Kind).Should().Be(1.0);
+    }
+
     [Fact]
     public void ResolveLead_IngredientGlyphOverride_StillShowsRealSprite()
     {

--- a/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
@@ -28,9 +28,25 @@ public sealed class LinkTests
         vm.DisplayName.Should().Be("Iron Sword");
         vm.Reference.Should().Be(EntityRef.Item("IronSword"));
         vm.IsNavigable.Should().BeTrue();
-        // Link is glyph-coded, not icon-imaged — IconId is intentionally dropped.
+        // G3 amendment: the chip's IconId rides through as the preferred lead sprite.
+        vm.IconId.Should().Be(42);
+        vm.HasSprite.Should().BeTrue();
         vm.ProvenanceSuffix.Should().BeNull();
         vm.KindLabel.Should().BeNull();
+    }
+
+    [Fact]
+    public void From_EntityChip_NoIcon_HasNoSprite()
+    {
+        var chip = new EntityChipVm("Alchemy", IconId: 0,
+            EntityRef.Skill("Alchemy"), IsNavigable: true);
+
+        var vm = LinkVm.From(chip);
+
+        vm.IconId.Should().Be(0);
+        vm.HasSprite.Should().BeFalse();
+        // Abstract ref → Lucide fallback retained.
+        vm.Glyph.Should().Be(LinkGlyph.Skill);
     }
 
     [Theory]
@@ -79,6 +95,22 @@ public sealed class LinkTests
         vm.Reference.Should().Be(EntityRef.Recipe("DistilBrine"));
         vm.Glyph.Should().Be(LinkGlyph.Recipe);
         vm.IsNavigable.Should().BeTrue();
+        // G3 amendment: ItemSourceChip.IconId (non-null) rides through.
+        vm.IconId.Should().Be(7);
+        vm.HasSprite.Should().BeTrue();
+    }
+
+    [Fact]
+    public void From_ItemSourceChip_NullIconId_NormalisedToZeroNoSprite()
+    {
+        var chip = new ItemSourceChipVm("X", Detail: null, IconId: null,
+            EntityReference: EntityRef.Npc("NPC_X"), IsNavigable: false);
+
+        var vm = LinkVm.From(chip);
+
+        vm.IconId.Should().Be(0);
+        vm.HasSprite.Should().BeFalse();
+        vm.Glyph.Should().Be(LinkGlyph.Npc);
     }
 
     [Fact]
@@ -182,5 +214,75 @@ public sealed class LinkTests
         Link.ResolveClick(navigable).Should().Be(LinkClickAction.Navigate);
         Link.ResolveClick(pending).Should().Be(LinkClickAction.CopyName);
         pending.ProvenanceSuffix.Should().Be("from Trader Joe");
+    }
+
+    // ── Lead decision: hybrid icon family (G3 amendment 2026-05-17) ──
+
+    [Fact]
+    public void ResolveLead_SpritePresent_RendersSprite_EvenWhenGlyphSet()
+    {
+        // Sprite wins over Lucide: a tangible noun with real CDN art shows the art,
+        // not the type-coded fallback glyph.
+        var vm = new LinkVm("Iron Sword", LinkGlyph.Item,
+            EntityRef.Item("IronSword"), IsNavigable: true, IconId: 42);
+
+        var lead = Link.ResolveLead(vm);
+
+        lead.Kind.Should().Be(LinkLeadKind.Sprite);
+        lead.IconId.Should().Be(42);
+        lead.LucideKind.Should().Be(PackIconLucideKind.None);
+    }
+
+    [Fact]
+    public void ResolveLead_NoSprite_GlyphSet_RendersLucideFallback()
+    {
+        // Abstract ref (skill) — no sprite → type-coded Lucide fallback.
+        var vm = new LinkVm("Alchemy", LinkGlyph.Skill,
+            EntityRef.Skill("Alchemy"), IsNavigable: true, IconId: 0);
+
+        var lead = Link.ResolveLead(vm);
+
+        lead.Kind.Should().Be(LinkLeadKind.Lucide);
+        lead.LucideKind.Should().Be(PackIconLucideKind.Sparkles);
+    }
+
+    [Fact]
+    public void ResolveLead_NoSprite_NoGlyph_RendersNone()
+    {
+        var vm = new LinkVm("Orphan", LinkGlyph.None,
+            Reference: null, IsNavigable: false, IconId: 0);
+
+        Link.ResolveLead(vm).Should().Be(LinkLead.None);
+        Link.ResolveLead(vm).Kind.Should().Be(LinkLeadKind.None);
+    }
+
+    [Fact]
+    public void ResolveLead_NullVm_RendersNone()
+    {
+        Link.ResolveLead(null).Should().Be(LinkLead.None);
+    }
+
+    [Fact]
+    public void ResolveLead_IngredientGlyphOverride_StillShowsRealSprite()
+    {
+        // Reconciliation flag #3 closure: the Recipe pilot forces
+        // Glyph = LinkGlyph.Ingredient, but a real ingredient sprite (IconId>0)
+        // must still win — the flask Lucide is the icon-less fallback only.
+        var withArt = LinkVm.From(
+            new EntityChipVm("Moonlit Brine", IconId: 99,
+                EntityRef.Item("MoonlitBrine"), IsNavigable: true))
+            with { Glyph = LinkGlyph.Ingredient };
+        var noArt = LinkVm.From(
+            new EntityChipVm("Generic Reagent", IconId: 0,
+                EntityRef.Item("GenericReagent"), IsNavigable: true))
+            with { Glyph = LinkGlyph.Ingredient };
+
+        var leadArt = Link.ResolveLead(withArt);
+        leadArt.Kind.Should().Be(LinkLeadKind.Sprite);
+        leadArt.IconId.Should().Be(99);
+
+        var leadFallback = Link.ResolveLead(noArt);
+        leadFallback.Kind.Should().Be(LinkLeadKind.Lucide);
+        leadFallback.LucideKind.Should().Be(PackIconLucideKind.FlaskRound);
     }
 }

--- a/tests/Mithril.Shared.Tests/Wpf/SetRefTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/SetRefTests.cs
@@ -23,7 +23,19 @@ public sealed class SetRefTests
         var vm = new SetRefVm("Crystal", MatchCount: 150);
 
         vm.IsSummaryForm.Should().BeTrue();
-        vm.DisplayText.Should().Be("Crystal · 150 →");
+        // Ratified summary-form text (grammar doc "Crystal · 150 matches →").
+        vm.DisplayText.Should().Be("Crystal · 150 matches →");
+    }
+
+    [Fact]
+    public void MatchCountOne_SummaryForm_UsesSingularNoun()
+    {
+        // The grammar exemplified only the plural; "1 matches" reads as a bug,
+        // so the noun is count-aware (sensible reading of the spec).
+        var vm = new SetRefVm("Main-Hand Item", MatchCount: 1);
+
+        vm.IsSummaryForm.Should().BeTrue();
+        vm.DisplayText.Should().Be("Main-Hand Item · 1 match →");
     }
 
     [Fact]
@@ -45,7 +57,7 @@ public sealed class SetRefTests
         var vm = new SetRefVm("Potion", MatchCount: 0);
 
         vm.IsSummaryForm.Should().BeTrue();
-        vm.DisplayText.Should().Be("Potion · 0 →");
+        vm.DisplayText.Should().Be("Potion · 0 matches →");
     }
 
     // ── Stacking ordinal prefix (Stacking semantics clause) ──
@@ -140,7 +152,7 @@ public sealed class SetRefTests
         var unwired = new SetRefVm("Crystal", MatchCount: 150, IsActionable: false, SlotOrdinal: 2);
 
         unwired.DisplayText.Should().Be(wired.DisplayText);
-        unwired.DisplayText.Should().Be("Crystal · 150 →");
+        unwired.DisplayText.Should().Be("Crystal · 150 matches →");
         unwired.OrdinalText.Should().Be(wired.OrdinalText);
     }
 }

--- a/tests/Mithril.Shared.Tests/Wpf/StructureLabelBehaviorTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/StructureLabelBehaviorTests.cs
@@ -1,0 +1,105 @@
+using System.Linq;
+using System.Windows.Documents;
+using FluentAssertions;
+using Mithril.Shared.Wpf;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Wpf;
+
+/// <summary>
+/// Pure-logic tests for the G4 Structure-tier tracked-uppercase transform. Mirrors
+/// <see cref="FormattedTextRendererTests"/>: asserts the
+/// <see cref="StructureLabel.BuildTrackedInlines"/> / <see cref="StructureLabel.TrackedText"/>
+/// contract without instantiating a TextBlock or touching the visual tree.
+/// </summary>
+public sealed class StructureLabelBehaviorTests
+{
+    private const char Hair = StructureLabel.HairSpace;
+
+    private static string Concat(System.Collections.Generic.IEnumerable<Inline> inlines) =>
+        string.Concat(inlines.OfType<Run>().Select(r => r.Text));
+
+    [Fact]
+    public void UpperCases_Invariant()
+    {
+        StructureLabel.TrackedText("Requirements")
+            .Replace(Hair.ToString(), "")
+            .Should().Be("REQUIREMENTS");
+
+        Concat(StructureLabel.BuildTrackedInlines("Ingredients"))
+            .Replace(Hair.ToString(), "")
+            .Should().Be("INGREDIENTS");
+    }
+
+    [Fact]
+    public void InsertsHairSpace_BetweenEveryAdjacentPair()
+    {
+        // "ABC" → A <hair> B <hair> C : 3 letter runs + 2 spacers = 5 inlines.
+        var inlines = StructureLabel.BuildTrackedInlines("abc");
+
+        inlines.Should().HaveCount(5);
+        inlines.OfType<Run>().Select(r => r.Text)
+            .Should().Equal("A", Hair.ToString(), "B", Hair.ToString(), "C");
+
+        StructureLabel.TrackedText("abc").Should().Be($"A{Hair}B{Hair}C");
+    }
+
+    [Fact]
+    public void Spacing_ScalesWithFontSize_BecauseHairSpaceIsEmRelative()
+    {
+        // The spacer is a hair space whose advance is defined relative to the font em, so
+        // tracking scales with whatever FontSize the runs inherit — there is no px width to
+        // assert. The contract under test: exactly one hair-space spacer per inter-character
+        // gap, so the *number* of em-relative spacers scales 1:1 with label length (and the
+        // rendered width therefore scales with the inherited FontSize the runs carry).
+        var spacerCount = StructureLabel.BuildTrackedInlines("Taught by")
+            .OfType<Run>()
+            .Count(r => r.Text == Hair.ToString());
+
+        // "Taught by" = 9 chars → 8 inter-character gaps → 8 em-relative spacers.
+        spacerCount.Should().Be("Taught by".Length - 1);
+    }
+
+    [Fact]
+    public void TrailingColon_IsPreserved_AndTracksLikeALetter()
+    {
+        // StructureInlinePrefixStyle idiom: "Field:" — the ':' is call-site text. It must
+        // survive (ToUpperInvariant is a no-op on punctuation) AND get a leading hair-space
+        // so it reads as part of the same tracked label, not a tight-set afterthought.
+        var tracked = StructureLabel.TrackedText("Skill:");
+
+        tracked.Should().Be($"S{Hair}K{Hair}I{Hair}L{Hair}L{Hair}:");
+        tracked.Replace(Hair.ToString(), "").Should().Be("SKILL:");
+
+        var inlines = StructureLabel.BuildTrackedInlines("Skill:");
+        inlines.OfType<Run>().Last().Text.Should().Be(":");
+        // The ':' is preceded by a spacer (tracks consistently with the letters).
+        inlines.OfType<Run>().Reverse().Skip(1).First().Text.Should().Be(Hair.ToString());
+    }
+
+    [Fact]
+    public void SingleCharacter_HasNoSpacer()
+    {
+        StructureLabel.BuildTrackedInlines("x").Should().ContainSingle()
+            .Which.As<Run>().Text.Should().Be("X");
+        StructureLabel.TrackedText("x").Should().Be("X");
+    }
+
+    [Fact]
+    public void NullOrEmpty_IsSafe()
+    {
+        StructureLabel.BuildTrackedInlines(null).Should().BeEmpty();
+        StructureLabel.BuildTrackedInlines("").Should().BeEmpty();
+        StructureLabel.TrackedText(null).Should().BeEmpty();
+        StructureLabel.TrackedText("").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TrackedText_EqualsConcatenatedInlineRunText()
+    {
+        // The string helper and the inline builder must agree (one is the other flattened).
+        const string sample = "Other Requirements:";
+        Concat(StructureLabel.BuildTrackedInlines(sample))
+            .Should().Be(StructureLabel.TrackedText(sample));
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/RecipesTabViewModelTests.cs
@@ -423,6 +423,202 @@ public sealed class RecipesTabViewModelTests
         }
     }
 
+    // ── G4 Stacking semantics (docs/silmarillion-visual-grammar.md ·
+    //    "Stacking semantics") ─────────────────────────────────────────────────
+    // Recipe keyword-ingredient slots are positionally MATERIAL whenever ≥2 (the
+    // grammar's own TSysCraftedEquipment canonical example). ≥2 ⇒ each slot's
+    // SetRefVm.SlotOrdinal = its 1-based position + the section label gets a
+    // "· N slots" suffix. 0/1 slot ⇒ null ordinal + plain label. The Recipe pilot
+    // does not exercise the positionally-inert (count-only) path.
+
+    [Fact]
+    public void KeywordSlots_TwoOrMore_AreMaterial_OrdinalsAndLabelSuffix()
+    {
+        // The grammar's canonical example: a crafted-equipment recipe with two
+        // "any Crystal" slots. Constraints are IDENTICAL — materiality must NOT
+        // be gated on "same constraint"; ≥2 slots ⇒ material per the clause.
+        var a = new Item { Id = 1, InternalName = "RoughCrystal", Name = "Rough Crystal" };
+        var b = new Item { Id = 2, InternalName = "FineCrystal", Name = "Fine Crystal" };
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "ForgeCrystalBlade",
+            Name = "Forge Crystal Blade",
+            Skill = "Blacksmithing",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], Desc = "Primary Crystal", StackSize = 1 },
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], Desc = "Secondary Crystal", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["r1"] = recipe },
+            KeywordSlotMatches =
+            {
+                ["Crystal"] = new[]
+                {
+                    new RecipeKeywordItemMatch(a, RecipeKeywordItemMatchReason.KeywordMatch),
+                    new RecipeKeywordItemMatch(b, RecipeKeywordItemMatchReason.KeywordMatch),
+                },
+            },
+        };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item), new FakeEntityNameResolver());
+
+        vm.SelectedRecipe = recipe;
+
+        var slots = vm.DetailViewModel!.KeywordSlots;
+        slots.Should().HaveCount(2);
+        // 1-based ordinals flow into the SetRefVm.
+        slots[0].SetRef.SlotOrdinal.Should().Be(1);
+        slots[1].SetRef.SlotOrdinal.Should().Be(2);
+        slots[0].SetRef.HasOrdinal.Should().BeTrue();
+        slots[0].SetRef.OrdinalText.Should().Be("1");
+        slots[1].SetRef.OrdinalText.Should().Be("2");
+        // Section-label suffix is VM-owned.
+        vm.DetailViewModel.KeywordIngredientsLabel.Should().Be("Keyword ingredients · 2 slots");
+    }
+
+    [Fact]
+    public void KeywordSlots_ThreeSlots_OrdinalsAreOneTwoThree_LabelSaysThreeSlots()
+    {
+        var item = new Item { Id = 1, InternalName = "Gem", Name = "Gem" };
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "TripleSocket",
+            Name = "Triple Socket",
+            Skill = "Jewelry",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["Gem"], Desc = "Slot A", StackSize = 1 },
+                new RecipeKeywordIngredient { ItemKeys = ["Gem"], Desc = "Slot B", StackSize = 1 },
+                new RecipeKeywordIngredient { ItemKeys = ["Gem"], Desc = "Slot C", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["r1"] = recipe },
+            KeywordSlotMatches =
+            {
+                ["Gem"] = new[] { new RecipeKeywordItemMatch(item, RecipeKeywordItemMatchReason.KeywordMatch) },
+            },
+        };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item), new FakeEntityNameResolver());
+
+        vm.SelectedRecipe = recipe;
+
+        var slots = vm.DetailViewModel!.KeywordSlots;
+        slots.Select(s => s.SetRef.SlotOrdinal).Should().Equal(1, 2, 3);
+        vm.DetailViewModel.KeywordIngredientsLabel.Should().Be("Keyword ingredients · 3 slots");
+    }
+
+    [Fact]
+    public void KeywordSlots_OrdinalGate_KeysOffSurvivingCount_NotRawIngredientPosition()
+    {
+        // A skipped slot (keys not in the index) must not consume an ordinal: the
+        // ≥2-material gate and the 1-based numbering key off the FINAL surviving
+        // list. Here 3 keyword ingredients are authored but one is not in the
+        // index → 2 survive → still material, ordinals 1,2 (no gap at the skip).
+        var item = new Item { Id = 1, InternalName = "Crystal", Name = "Crystal" };
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "GappedRecipe",
+            Name = "Gapped Recipe",
+            Skill = "Blacksmithing",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], Desc = "First", StackSize = 1 },
+                new RecipeKeywordIngredient { ItemKeys = ["MissingKw"], Desc = "Skipped", StackSize = 1 },
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], Desc = "Second", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["r1"] = recipe },
+            KeywordSlotMatches =
+            {
+                ["Crystal"] = new[] { new RecipeKeywordItemMatch(item, RecipeKeywordItemMatchReason.KeywordMatch) },
+                // "MissingKw" deliberately absent from the index ⇒ that slot is skipped.
+            },
+        };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item), new FakeEntityNameResolver());
+
+        vm.SelectedRecipe = recipe;
+
+        var slots = vm.DetailViewModel!.KeywordSlots;
+        slots.Should().HaveCount(2, because: "the not-in-index slot is skipped, never reaches the list");
+        slots.Select(s => s.Label).Should().Equal("First", "Second");
+        slots.Select(s => s.SetRef.SlotOrdinal).Should().Equal(1, 2);
+        vm.DetailViewModel.KeywordIngredientsLabel.Should().Be("Keyword ingredients · 2 slots");
+    }
+
+    [Fact]
+    public void KeywordSlots_SingleSlot_IsInert_NoOrdinal_PlainLabel()
+    {
+        // Exactly 1 surviving slot ⇒ positionally inert path: SlotOrdinal null,
+        // no prefix, the section label stays plain (no "· N slots" suffix).
+        var match = new Item { Id = 1, InternalName = "RoughCrystal", Name = "Rough Crystal" };
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "SingleCrystal",
+            Name = "Single Crystal",
+            Skill = "Enchanting",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeKeywordIngredient { ItemKeys = ["Crystal"], Desc = "Auxiliary Crystal", StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            RecipesByKey = { ["r1"] = recipe },
+            KeywordSlotMatches =
+            {
+                ["Crystal"] = new[] { new RecipeKeywordItemMatch(match, RecipeKeywordItemMatchReason.KeywordMatch) },
+            },
+        };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item), new FakeEntityNameResolver());
+
+        vm.SelectedRecipe = recipe;
+
+        var slot = vm.DetailViewModel!.KeywordSlots.Should().ContainSingle().Which;
+        slot.SetRef.SlotOrdinal.Should().BeNull();
+        slot.SetRef.HasOrdinal.Should().BeFalse();
+        slot.SetRef.OrdinalText.Should().BeEmpty();
+        vm.DetailViewModel.KeywordIngredientsLabel.Should().Be("Keyword ingredients");
+    }
+
+    [Fact]
+    public void KeywordSlots_NoSlots_PlainLabel_SectionHiddenUnchanged()
+    {
+        // 0 slots ⇒ no ordinals, plain label, and the empty list still drives the
+        // section hide in the view (KeywordSlots.Count == 0) — behaviour unchanged.
+        var recipe = new Recipe
+        {
+            Key = "r1",
+            InternalName = "NoKeywordRecipe",
+            Name = "No Keyword Recipe",
+            Skill = "Cooking",
+            Ingredients = new RecipeIngredient[]
+            {
+                new RecipeItemIngredient { ItemCode = 100, StackSize = 1 },
+            },
+        };
+        var refData = new StubReferenceData
+        {
+            ItemsByCode = { [100] = new Item { Id = 100, InternalName = "Tomato", Name = "Tomato" } },
+            RecipesByKey = { ["r1"] = recipe },
+        };
+        var vm = new RecipesTabViewModel(refData, NavFactory.WithKinds(EntityKind.Item), new FakeEntityNameResolver());
+
+        vm.SelectedRecipe = recipe;
+
+        vm.DetailViewModel!.KeywordSlots.Should().BeEmpty();
+        vm.DetailViewModel.KeywordIngredientsLabel.Should().Be("Keyword ingredients");
+    }
+
     [Fact]
     public void SourceChips_NpcTrainerSource_NotNavigable_UntilNpcKindShips()
     {


### PR DESCRIPTION
## Phase 5 Recipe pilot — COMPLETE (G3 amend-1/2 + canonical pattern + all G4 conformance)

The pilot proved the primitives and absorbed every flaw the G4 review surfaced **here, before any 9× fan-out** — exactly the gate's purpose. One reviewable unit; the 8 remaining views copy this verbatim.

**Journey (each caught on the pilot, fixed here):** type-glyph killed identity → **amend-1** hybrid icons → 12px too small → **amend-2** system-wide em-relative sizing + Link `Density` + 40px title-glyph → Prose ×1em still small for enumerations → **canonical pinned to "D · Context-aware"** (vertical-list, reaffirmed authoritative-source-corrected) → G4 detail review → **conformance fixes** (matches wording, ordinal outside chip, Skill stat-label, keyword-slot stacking ordinals + "· N slots") → **Structure UPPERCASE + 0.08em tracking** shared behavior.

**Canonical pattern (PINNED #404, all 8 fan-out views copy verbatim):**
- Inline entity refs (requirement rows) = `Density="Prose"`; entity **enumerations** (Ingredients/Produced/Sources) = `Density="List"` (own-line, sprite ×1.5em)
- Set-reference stacking: ordinals `1`/`2` as **left-gutter mono markers OUTSIDE the chip** + `Keyword ingredients · N slots` (recipe slots positionally material per `TSysCraftedEquipment` canonical example); summary text `Label · N matches →` (count-aware)
- Fact stat strip = label-value (`Skill Toolcrafting 98`); Structure labels = UPPERCASE + ~0.08em tracking (shared `StructureLabelBehavior`, em-scaling, inherited by all views, zero call-site work); fixed-40px title-glyph; em-relative sizing adapts live to the Appearance slider

Commits: `fe8a5f1` em/Density · `380682f` List canonical · `1ce61d6` stacking · `346cfdb` conformance · `abf6156` Structure casing.

## Verify

- `start.ps1 -Build`: `Build succeeded 0W/0E` · `XamlResourceLint: OK (117 keys)` · `Application started`
- `Mithril.Shared.Tests` **1137/1137** · `Silmarillion.Tests` **483/483**
- Guard vs `main`: bundled scope only — **SetRef-tier/other-views/EntityChip/ItemSourceChip untouched** (legacy controls still serve the other 8 views until their PRs)
- All conformance details grounded in the **current** `docs/silmarillion-visual-grammar.md` (the older Orcpick HTML export is non-authoritative — #404 correction recorded)

## Flagged fidelity notes (your awareness, accepted trade-offs)

- Structure tracking via hair-space ≈0.06–0.1em (font-metric-derived, em-scaling, font-independent) — not pixel-exact 0.08em; alternative is a heavier InlineUIContainer. Inline-prefix `:` tracks with its label.
- Sprite `NearestNeighbor` is crisp at integer scale, slightly soft at off-default Appearance sizes (pixelated vs adaptive inherently trade).

## G4 sign-off

em-binding ✓ (your live dynamic-resize check) · render/identity/legibility/stacking/conformance/casing ✓. **Awaiting your final sign-off / merge.** On merge: I fan out the 8 remaining detail views (one consistency-gated PR each, copying this pattern), then Phase 6 conformance guardrail. Coverage #407/#408 + #214 Effects-placement remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
