### PR TITLE
docs(silmarillion): TSys popup→tab ratified — charter + roadmap (#412)

### DIFF
--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -227,54 +227,50 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   Silmarillion's charter alone. Field-level scope:
   [silmarillion-field-coverage.md](silmarillion-field-coverage.md); tab scope:
   [silmarillion-roadmap.md](silmarillion-roadmap.md).
-- **In scope — owner-endorsed (2026-05-16):** Silmarillion should be able to show a
-  recipe's **possible TSys (treasure-system) rolls** in a popup — the same
-  `AugmentPoolPreview` pool surface Celebrimbor uses, fed by the shared
-  `ResultEffectsParser`. Silmarillion is the **master** view (full pool for any
-  browsed recipe); **Celebrimbor is the planning-narrowed slice** of that *same* data
-  (the pool for recipes in your craft plan). **Mechanic — verified against `recipes.json`, `items.json` &
-  `ResultEffectsParser` 2026-05-16 (owner was right; a first, too-narrow check was
-  wrong — see History):** two reference-data pieces combine.
-  1. *Base pool:* the `*E` *"(enchanted)"* recipe's `TSysCraftedEquipment(template)`
-     ResultEffect → `TryBuildCraftedEquipmentPool` → the crafted-equipment template's
-     `TSysProfile` → `IReferenceDataService.Profiles`. This is the full power pool for
-     that equipment template.
-  2. *Crystal scoping:* each `Crystal`-keyword item carries the enchantment family on
-     **its own item record** — `Item.Description` `"Associated Primary Skill: <Skill>"`
-     (+ optional Secondary) and `Item.DynamicCraftingSummary`
-     `"…create items that have <Skill> enchantments."` (e.g. `Moonstone` →
-     *Lycanthropy*; `LapisLazuli` → *Priest*; `Tsavorite` → *Ice Magic*). The crystal
-     slotted into the recipe selects the enchantment family/skill.
-  **Settled (owner, 2026-05-16):** crystals **do** influence enchanted crafts, and the
-  crystal→enchantment-family *association* is in CDN data (the crystal item's
-  `Description`/`DynamicCraftingSummary`, plus the template's `TSysProfile` pool). But
-  the **treasure-system *specifics* — how a roll actually resolves (probabilities, the
-  precise rolled power) — are not in CDN data at all.** That second fact is a
-  **data-availability ceiling, not a charter line**: no module can show roll resolution
-  from reference data because it isn't there (same class as Samwise's gardening-XP
-  absence), distinct from "calculation Silmarillion is barred from."
-  **Consequence:** Silmarillion *can* surface what's in the data — browse an enchanted
-  recipe → its `Crystal` slot → candidate crystals, and on each crystal show its
-  enchantment-family **text**. ⚠️ That text is **prose/category, frequently NOT a
-  resolvable `skills.json` entity**, and the data is **heterogeneous**: the only
-  consistent signal is `Item.DynamicCraftingSummary` (*"…<family> enchantments"*); a
-  `Description` `"Associated Primary Skill: <X>"` line exists on *some* crystals
-  (Moonstone, LapisLazuli, Tsavorite) but **not others** (Rubywall Crystal has none),
-  and the family term is often not a skill at all — *"survival-related"* has no
-  `Survival` skill. So treat it as **display text, not a guaranteed navigable Skill
-  cross-link** — it degrades to plain text per Silmarillion's existing
-  chip-degradation rule; don't promise a skill-entity link. It cannot show roll
-  *resolution* — not because that would be calculation, but because the data simply
-  doesn't carry it. Relates to #214.
+- **In scope — owner-ratified (2026-05-17; supersedes the 2026-05-16 "popup"
+  framing):** Silmarillion owns a dedicated **Treasure System tab** (**#412**) — a
+  browse/query surface over `tsysclientinfo` (the **Power** entity: skill-tagged,
+  tiered) + `tsysprofiles` (40 named **Profile** pools). PG's own term is "treasure
+  system"; the tab uses it (a reference browser mirrors source vocabulary). Recipe
+  detail (**#214**, rescoped) **deep-links into** this tab — the tab is the *single
+  render site* for TSys; recipe detail does **not** re-render the pool inline (no
+  divergence surface). Silmarillion is the **master** view; **Celebrimbor is the
+  planning-narrowed slice** of the *same* `ResultEffectsParser`/pool data (the pool
+  for recipes in your craft plan).
+  - *Data shape — verified v470 (`tsysclientinfo`/`tsysprofiles`, 2026-05-17):* both
+    sources are a faceted entity table + named-set table — **card-shaped and
+    crystal-free**. The earlier roadmap Bucket-D "calculator-shaped, not a Silmarillion
+    tab" verdict reasoned from the raw-JSON label, not the contents; **overturned**
+    (recorded in [silmarillion-roadmap.md](silmarillion-roadmap.md) + History below).
+  - *Pool/recipe linkage — verified `recipes.json`/`items.json`/`ResultEffectsParser`
+    2026-05-16:* the `*E` *"(enchanted)"* recipe's `TSysCraftedEquipment(template)`
+    ResultEffect → `TryBuildCraftedEquipmentPool` → the crafted-equipment template's
+    `Item.TSysProfile` → `IReferenceDataService.Profiles`. #214's deep-link prefills
+    the tab's query to that profile.
+  - *Crystal scoping is a recipe-crafting-path concern — **not part of the tab
+    browse**.* Retained because it is settled and still true *for enchanted crafting*:
+    each `Crystal`-keyword item carries the enchantment family on its own item record
+    (`Item.DynamicCraftingSummary` *"…<family> enchantments"*; an `Item.Description`
+    `"Associated Primary Skill: <X>"` line on *some* crystals — Moonstone, LapisLazuli,
+    Tsavorite — but **not** others like Rubywall, and the family term is often prose,
+    not a `skills.json` entity — *"survival-related"* has no `Survival` skill). It
+    degrades to display text per the chip-degradation rule; **the Treasure System tab
+    itself never touches crystals** (`tsysclientinfo`/`tsysprofiles` contain none).
+  - *Data-availability ceiling (unchanged, owner 2026-05-16):* roll **resolution** —
+    probabilities, the precise rolled power — is **not in CDN data at all** (same class
+    as Samwise's gardening-XP absence). The tab shows what the system is *composed of*,
+    never how a roll resolves. A data ceiling, not a charter bar. Relates to #214/#412.
 - **Does NOT own:**
   - **✅ confirmed** — *Computation/simulation.* It is a browser, not a calculator.
-    Calculators are Elrond/Celebrimbor; per the roadmap, TSys/power calc is explicitly
-    Celebrimbor's territory, "not a Silmarillion tab."
-    **Carve-out (owner-clarified 2026-05-16):** *displaying* parsed treasure-effect
-    previews via the shared `ResultEffectsParser` is browsing, not calculation — it is
-    within Silmarillion's charter and is exactly the intent of #214. "Does not
-    calculate" ≠ "cannot render parser output." Silmarillion not showing effects today
-    is a gap, not a prohibition.
+    Calculators are Elrond/Celebrimbor; TSys/power **roll calculation** (resolution
+    math — probabilities, the rolled power) stays Celebrimbor's territory.
+    **Updated 2026-05-17:** the roadmap's *"not a Silmarillion **tab**"* clause is
+    **overturned** — the *browse* surface (#412) is Silmarillion's; only the
+    *calculation* is Celebrimbor's. **Carve-out (owner 2026-05-16, realised 2026-05-17):**
+    *displaying* parsed treasure data / pools via the shared `ResultEffectsParser` and
+    browsing `tsysclientinfo`/`tsysprofiles` is browsing, not calculation — the
+    original #214 carve-out, now a dedicated tab (#412). "Does not calculate" ≠
+    "cannot render parser output or browse TSys data."
 - **Reference data:** effectively all sources (it is the browser), per the bucketing
   rule in the roadmap.
 
@@ -379,6 +375,21 @@ libraries; the charter follows the code:
 
 ## History
 
+- **2026-05-17** — **Silmarillion TSys: popup → tab (owner-ratified).** The
+  2026-05-16 "show possible TSys rolls in a *popup*" framing is superseded by a
+  dedicated **Treasure System tab** (#412). Verified v470: `tsysclientinfo` (Power
+  entity, skill-tagged, tiered) + `tsysprofiles` (40 Profile pools) are card-shaped
+  and **crystal-free** — the roadmap's Bucket-D "calculator-shaped, not a Silmarillion
+  tab" verdict reasoned from the raw-JSON label, not the contents, and is **overturned**
+  (roadmap doc updated in the same PR). #214 rescoped from "re-render pool inline" to
+  "deep-link into the tab" (single render site; no divergence surface). Only roll
+  *resolution* calculation stays Celebrimbor's; the *browse* is Silmarillion's.
+  Disambiguated a naming collision: `Create{Region}TreasureMap{Quality}` is the
+  **`TreasureCartography`** skill (buried-treasure maps, verified `recipe_21201` →
+  `RewardSkill: "TreasureCartography"`), an unrelated system — explicitly out of scope
+  for the TSys tab. Updated Silmarillion's *In scope* (popup→tab, v470 verification,
+  crystal scoped to the recipe-craft path only) and the *Computation* does-not-own line
+  (the "not a tab" clause overturned; calculation boundary retained).
 - **2026-05-16** — Final three modules charactered by owner, closing the set (all 12
   `*.Module` projects now covered): **Palantir** (debug module — browser over
   Mithril.GameState + badge tester; not player-facing), **Smaug** (NPC stores, inv/

--- a/docs/silmarillion-roadmap.md
+++ b/docs/silmarillion-roadmap.md
@@ -120,10 +120,19 @@ These would each require their own master-detail just to render a row count and 
 | `advancementtables` | Internal advancement mechanic |
 | `attributes` | Low-level effect-attribute primitives consumed by the Effects renderer |
 | `ai` | NPC behaviour trees; engine-side, not player-browsable |
-| `tsysclientinfo` | TSys augment metadata; calculator-shaped, not card-shaped |
-| `tsysprofiles` | TSys profile envelopes; same as above |
 
-`tsysclientinfo` / `tsysprofiles` could plausibly become a "Powers" surface in the future, but the natural shape is a calculator (Celebrimbor's territory), not a card browse. Out of scope for Silmarillion until Celebrimbor migrates per Step 5 of the reference-DB epic — and even then likely as a calculator pane embedded in Celebrimbor, not a Silmarillion tab.
+> **Reclassified 2026-05-17 — `tsysclientinfo` / `tsysprofiles` left Bucket D.**
+> Previously listed here as "calculator-shaped, not card-shaped… not a Silmarillion
+> tab." That verdict reasoned from the raw-JSON label, not the contents. Verified
+> v470: `tsysclientinfo` is a faceted **Power** entity table (skill-tagged, tiered,
+> slot/rarity-gated) and `tsysprofiles` is 40 named **Profile** pools (flat power-name
+> arrays) — card-shaped and **crystal-free**. The only calculator-shaped thing, roll
+> *resolution* (probabilities/precise rolled power), is absent from CDN data entirely
+> (data-availability ceiling, same class as item drop rates) — so it is out of scope
+> by *data*, not by shape. Owner-ratified as a dedicated **Treasure System tab**
+> (**#412**); recipe detail (#214, rescoped) deep-links into it. Only roll
+> *calculation* stays Celebrimbor's. See `module-charters.md` Silmarillion *In scope*
+> + its 2026-05-17 History entry for the full ruling.
 
 ## History
 
@@ -133,3 +142,4 @@ These would each require their own master-detail just to render a row count and 
 - **2026-05-14 → 05-15** — **Bucket B fully shipped.** NPCs #241 (PR #280), Quests #242 (#286), Abilities #243 (#293), Effects #244 (#298) on 05-14; Areas #245 (#310), Lorebooks #247 (#322), PlayerTitles #248 (#328), StorageVaults #249 (#329) on 05-15. Cross-link-dependency order (NPCs first to light up recipe-teacher links; Abilities before Effects). The #233 tab-style refactor (PR #272) and the #243 `ITabViewModel` refactor were the multi-tab enablers.
 - **2026-05-15** — **Plan deviation recorded:** `Landmark` did *not* become a sibling tab as the Areas/Landmarks section predicted. It folded into the Areas detail pane as a grouped provenance popup (#318 slice 4 surface 4, PR #324). Bucket B count unchanged (9 kinds, 8 tabs).
 - **2026-05-16** — Doc reframed from deferral plan to as-built record now that all Bucket B tabs shipped; [silmarillion-field-coverage.md](silmarillion-field-coverage.md) split off as the per-field axis. Bucket C "(when shipped)" markers resolved against source: `sources_abilities` and `lorebookinfo` fold-ins confirmed shipped; **`directedgoals` confirmed *not* built** (no module reference; Quests tab shipped without it) — and, by decision the same day, **consciously dropped** after inspecting the v470 data: it is the only Bucket C source with no foreign keys (self-contained prose hint cards), so Silmarillion's cross-link model has nothing to anchor. Recorded as a closed, evidence-backed decision in its Bucket C row.
+- **2026-05-17** — **`tsysclientinfo` / `tsysprofiles` left Bucket D → Treasure System tab (#412).** Owner-ratified reversal of the "calculator-shaped, not a Silmarillion tab" Bucket-D verdict, which had reasoned from the raw-JSON label rather than the contents. v470 inspection: `tsysclientinfo` is a faceted Power entity table (skill-tagged, tiered, slot/rarity-gated), `tsysprofiles` is 40 named Profile pools (flat power-name arrays) — card-shaped, crystal-free; only roll *resolution* is calculator-shaped and it is absent from CDN data entirely (data ceiling, not shape). #214 rescoped from inline pool render to a deep-link into the new tab (single render site). The companion naming collision — `Create{Region}TreasureMap{Quality}` is the `TreasureCartography` skill, a different system — was flagged out of scope on #214/#412. Charter (`module-charters.md`) updated in the same PR. Echoes the 2026-05-13 "deep-link to a tab with pre-filled query" kind-target precedent.


### PR DESCRIPTION
## What

Records the **2026-05-17 owner-ratified decision**: Silmarillion's TSys (treasure-system) surface moves from a recipe **popup** (2026-05-16 framing) to a dedicated **Treasure System tab** (#412), with recipe detail (#214, rescoped) deep-linking into it.

Docs only — no code. Filed issue #412 is the implementation.

## Why

The roadmap's Bucket-D verdict ("`tsysclientinfo`/`tsysprofiles` are calculator-shaped, not a Silmarillion tab") reasoned from the raw-JSON label, not the contents. Verified against v470:

- `tsysclientinfo` — faceted **Power** entity table (skill-tagged, tiered, slot/rarity-gated).
- `tsysprofiles` — 40 named **Profile** pools (flat power-name arrays).
- Both **card-shaped and crystal-free**. The only calculator-shaped thing — roll *resolution* (probabilities) — is absent from CDN data entirely (data-availability ceiling, same class as item drop rates), so it's out of scope by *data*, not by shape. Only roll *calculation* stays Celebrimbor's.

## Changes

- **`docs/module-charters.md`** — Silmarillion *In scope*: popup→tab (#412); v470 data-shape verification; crystal scoping confined to the recipe-craft path (the tab itself is crystal-free); data-availability ceiling retained. *Computation* does-not-own line: keeps the calculation boundary, drops the overturned "not a Silmarillion tab" clause. New 2026-05-17 History entry.
- **`docs/silmarillion-roadmap.md`** — `tsysclientinfo`/`tsysprofiles` removed from Bucket D ("never a tab") with a reclassification blockquote → #412; History entry.

## Related

- **#412** — Treasure System tab (the implementation this ratifies; under #203).
- **#214** — rescoped to deep-link into #412 (single render site; no inline pool re-render). Blocked on #412.
- Naming collision recorded out of scope: `Create{Region}TreasureMap{Quality}` is the `TreasureCartography` skill (verified `recipe_21201` → `RewardSkill: "TreasureCartography"`), an unrelated system — not part of the TSys tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
