### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 1/8 — PlayerTitle grammar migration

### DIFF
--- a/src/Silmarillion.Module/ViewModels/PlayerTitleDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/PlayerTitleDetailViewModel.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using Mithril.Shared.Wpf;
+
 namespace Silmarillion.ViewModels;
 
 /// <summary>
@@ -37,6 +40,48 @@ public sealed class PlayerTitleDetailViewModel
         AccountWide = row.AccountWide;
         SoulWide = row.SoulWide;
         IsObtainable = row.IsObtainable;
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // The legacy bool/string members above stay (the existing tests + the
+        // detail-pane contract); these are the grammar-tier carriers the view
+        // binds. Built here (not in the tab VM) because the VM already holds
+        // every source datum — the Phase-5 mapping is mechanical, not
+        // data-bearing. PlayerTitle is the #404-classified pure Fact+Structure+
+        // Control view (no Link/Set-reference at all), so the only carriers are
+        // an inert Fact strip and the Fact footer.
+
+        // Scope / obtainability strip (matrix T15 → inert Fact). The three
+        // legacy COLOURED semantic badge boxes (Account-wide green / Soul-wide
+        // indigo / not-obtainable red) collapse into ONE inert FactTable strip
+        // — value-only phrase segments, no box, no pigment (G-b: Fact is inert;
+        // the Strip Style carries the only pigment). This is the exact pilot
+        // stat-badge-box → strip collapse (RecipeDetailViewModel.StatStrip): a
+        // self-describing phrase keeps a null label, empties are skipped, and an
+        // all-false set yields StripText "" so the FactTable Style self-hides —
+        // the same self-elision the per-badge BoolToVis gave, with the accepted
+        // grammar trade-off that the semantic colours drop (consistency over
+        // fidelity is the ratified G4 acceptance bar).
+        var scope = new List<FactPair>(3);
+        if (AccountWide) scope.Add(new FactPair(null, "Account-wide"));
+        if (SoulWide) scope.Add(new FactPair(null, "Soul-wide"));
+        if (IsNotObtainable) scope.Add(new FactPair(null, "Not currently obtainable"));
+        ScopeStrip = FactTableVm.Strip(scope);
+
+        // Footer id (matrix #14 / G-a · ratified E5). PlayerTitle's POCO carries
+        // no InternalName — the "Title_NNNN" envelope key IS the only
+        // identifier. E5 rule 2: a footer is copyable IFF it is a cross-entity
+        // reference key (something else points at it). #248 established the
+        // Title_N envelope key has NO structured cross-reference (BestowTitle
+        // args live in a different namespace, nothing resolves through it), so
+        // it is a display/storage-only key ⇒ the INERT `ROW` cell, never the
+        // copyable `KEY`. This is deliberately NOT the pilot's
+        // FactFooterVm.Key(InternalName) copyable path — it is the
+        // EnvelopeKey-inert path the Recipe pilot never exercised, the first
+        // fan-out case that proves the E5 copyable-iff-cross-ref discriminator.
+        // None() when somehow keyless so the strip self-hides (G-a: hidden at 0).
+        Footer = string.IsNullOrEmpty(EnvelopeKey)
+            ? FactFooterVm.None()
+            : FactFooterVm.Of(new FactFooterId("ROW", EnvelopeKey, copyable: false));
     }
 
     public PlayerTitleListRow Row { get; }
@@ -50,8 +95,32 @@ public sealed class PlayerTitleDetailViewModel
     /// </summary>
     public string EnvelopeKey { get; }
 
-    /// <summary>Footer text — the bare envelope key (no divergent pair to render).</summary>
+    /// <summary>
+    /// Legacy footer text — the bare envelope key. Retained (the existing test +
+    /// the detail-pane contract); the view now binds <see cref="Footer"/> instead.
+    /// </summary>
     public string FooterText => EnvelopeKey;
+
+    /// <summary>
+    /// Inert scope/obtainability Fact strip (matrix T15 → Fact-inert). The three
+    /// legacy coloured semantic badge boxes collapse into one dot-separated
+    /// value-only <see cref="FactTableVm"/> strip (no box, no pigment — G-b).
+    /// Empty (all-false) ⇒ <see cref="FactTableVm.StripText"/> is "" so the
+    /// shared <c>FactTable</c> Style self-hides, exactly the per-badge
+    /// <c>BoolToVis</c> self-elision it replaces. Mirrors the pilot's
+    /// <c>RecipeDetailViewModel.StatStrip</c>.
+    /// </summary>
+    public FactTableVm ScopeStrip { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14, G-a · ratified E5). The
+    /// <c>Title_NNNN</c> envelope key is a display/storage-only key (#248: no
+    /// cross-entity reference resolves through it) ⇒ a single <b>inert</b>
+    /// <c>ROW</c> cell (<see cref="FactFooterId.Copyable"/> false), <em>not</em>
+    /// the pilot's copyable <c>KEY</c>. <see cref="FactFooterVm.None"/> (the
+    /// strip self-hides) if somehow keyless.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     /// <summary>"How to earn" prose, or null (italic placeholder shown instead).</summary>
     public string? Tooltip { get; }

--- a/src/Silmarillion.Module/Views/PlayerTitleDetailView.xaml
+++ b/src/Silmarillion.Module/Views/PlayerTitleDetailView.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -18,60 +17,60 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <wpf:DetailExportHost FooterText="{Binding FooterText}">
+    <!-- Phase-5 fan-out · view 1 (PlayerTitle) — a consistency-diff against the
+         merged Recipe pilot, NOT fresh design. #404 classified PlayerTitle as
+         the pure Fact+Structure+Control view (no Link / no Set-reference), so
+         every element here maps to an inert Fact or to Structure.
+
+         Footer (matrix #14 / G-a): exactly the pilot move — stop binding the
+         DetailExportHost FooterText and place <wpf:FactFooter/> at the bottom of
+         the wrapped content. The DetailExportHost wrapper is RETAINED unchanged
+         (export-camera affordance + snapshot wrapper — shared infra, not
+         edited); no host surgery, a purely per-view change. -->
+    <wpf:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Footer ("Title_NNNN") is owned by the wrapping DetailExportHost (FooterText). -->
-
             <StackPanel>
-                <!-- ─── Header: clean title ─── -->
+                <!-- ─── Header: Fact-title ───
+                     Matrix T4 → Fact-title. FactTitleStyle carries the
+                     Cambria/600/accent/×1.5em-wrap; the inline gold/header-font/
+                     XLarge are dropped (G-b: gold now means title XOR link, and
+                     the serif title is the title pattern). PlayerTitle has no
+                     entity icon, so there is NO title-glyph (correctly absent —
+                     not every Fact-title carries one). -->
                 <StackPanel Margin="0,0,0,10">
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" TextWrapping="Wrap"/>
+                               Style="{StaticResource FactTitleStyle}"/>
                 </StackPanel>
 
-                <!-- ─── Scope / obtainability badges ───
-                     Account-wide / Soul-wide only render when true (false/null
-                     default is noise). "Not currently obtainable" flags the
-                     Lint_* dev/non-earnable family without hiding it. -->
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                    <Border Background="#222E7D32" BorderBrush="#664CAF50" BorderThickness="1"
-                            CornerRadius="3" Padding="6,2" Margin="0,0,6,0"
-                            Visibility="{Binding AccountWide, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Account-wide" Foreground="#FF81C784"
-                                   FontSize="{DynamicResource AppFontSizeHint}"/>
-                    </Border>
-                    <Border Background="#22283593" BorderBrush="#665C6BC0" BorderThickness="1"
-                            CornerRadius="3" Padding="6,2" Margin="0,0,6,0"
-                            Visibility="{Binding SoulWide, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Soul-wide" Foreground="#FF9FA8DA"
-                                   FontSize="{DynamicResource AppFontSizeHint}"/>
-                    </Border>
-                    <Border Background="#22B71C1C" BorderBrush="#66E57373" BorderThickness="1"
-                            CornerRadius="3" Padding="6,2"
-                            Visibility="{Binding IsNotObtainable, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Not currently obtainable" Foreground="#FFE57373"
-                                   FontSize="{DynamicResource AppFontSizeHint}"/>
-                    </Border>
-                </StackPanel>
+                <!-- ─── Scope / obtainability ───
+                     Matrix T15 (coloured semantic badge box, ❌ off-diagonal) →
+                     ONE inert Fact strip. The pilot stat-badge-box → strip
+                     collapse, verbatim: value-only phrase segments, no box, no
+                     pigment (the FactTable Strip Style owns the only pigment).
+                     The VM skips false flags and yields StripText "" when all
+                     are false, so the shared FactTable Style self-hides — the
+                     same self-elision the three per-badge BoolToVis gave. -->
+                <wpf:FactTable DataContext="{Binding ScopeStrip}"
+                               HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
-                <!-- ─── How to earn ─── -->
+                <!-- ─── How to earn ───
+                     Matrix T2 → Fact body. Pilot description treatment: route
+                     through FactBodyStyle and drop the inline #EEFFFFFF / sizes /
+                     LineHeight (the style owns family·size·fg·wrap). FormattedText
+                     parses any inline <i>/<b> markup; the italic placeholder is
+                     the same Fact-body prose at quieter weight, kept inline-italic
+                     via BasedOn FactBodyStyle. -->
                 <Border Margin="0,0,0,10">
                     <Grid>
                         <TextBlock wpf:FormattedText.Text="{Binding Tooltip}"
-                                   Foreground="#EEFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeLarge}"
-                                   TextWrapping="Wrap" LineHeight="22"
+                                   Style="{StaticResource FactBodyStyle}"
                                    Visibility="{Binding HasTooltip, Converter={StaticResource BoolToVis}}"/>
-                        <TextBlock Text="No description of how this title is earned."
-                                   Foreground="#88FFFFFF" FontStyle="Italic"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   TextWrapping="Wrap">
+                        <TextBlock Text="No description of how this title is earned.">
                             <TextBlock.Style>
-                                <Style TargetType="TextBlock">
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource FactBodyStyle}">
+                                    <Setter Property="FontStyle" Value="Italic"/>
                                     <Setter Property="Visibility" Value="Visible"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding HasTooltip}" Value="True">
@@ -83,6 +82,13 @@
                         </TextBlock>
                     </Grid>
                 </Border>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). The
+                     Title_NNNN envelope key is storage-only (#248: nothing
+                     cross-references it) ⇒ an INERT `ROW` cell, never the
+                     pilot's copyable `KEY`. FactFooterVm.None() self-hides at 0
+                     ids. -->
+                <wpf:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/PlayerTitleDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/PlayerTitleDetailViewModelTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Mithril.Shared.Wpf;
 using Silmarillion.ViewModels;
 using Xunit;
 using PlayerTitlePoco = Mithril.Reference.Models.Misc.PlayerTitle;
@@ -122,6 +123,61 @@ public sealed class PlayerTitleDetailViewModelTests
                 n.Contains("Quest", System.StringComparison.OrdinalIgnoreCase)
                 || n.Contains("Popup", System.StringComparison.OrdinalIgnoreCase));
         vm.Should().NotBeNull();
+    }
+
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void ScopeStrip_SelfHides_WhenNoFlagsTrue()
+    {
+        var vm = Build("Title_1", new PlayerTitlePoco { Title = "<color=cyan>Plain</color>" });
+
+        // All-false ⇒ no segments ⇒ StripText "" so the shared FactTable Style
+        // collapses (the per-badge BoolToVis self-elision it replaces).
+        vm.ScopeStrip.Layout.Should().Be(FactTableLayout.Strip);
+        vm.ScopeStrip.Pairs.Should().BeEmpty();
+        vm.ScopeStrip.StripText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ScopeStrip_CollectsOnlyTrueFlags_AsValueOnlyPhraseSegments()
+    {
+        var vm = Build("Title_101", new PlayerTitlePoco
+        {
+            Title = "<color=white>Content Creator</color>",
+            AccountWide = true,
+            Keywords = new[] { "Lint_NotObtainable" }, // ⇒ IsNotObtainable
+        });
+
+        // Value-only (null label) phrase segments, false flags skipped (SoulWide
+        // absent), dot-joined by the shared Strip helper — no box, no pigment.
+        vm.ScopeStrip.Pairs.Should().BeEquivalentTo(new[]
+        {
+            new FactPair(null, "Account-wide"),
+            new FactPair(null, "Not currently obtainable"),
+        }, o => o.WithStrictOrdering());
+        vm.ScopeStrip.StripText.Should().Be("Account-wide · Not currently obtainable");
+    }
+
+    [Fact]
+    public void Footer_IsInertEnvelopeRowKey_NeverCopyable()
+    {
+        var vm = Build("Title_5018", new PlayerTitlePoco
+        {
+            Title = "<color=#00cc00>Warsmith</color>", Tooltip = "Earned by completing a quest.",
+        });
+
+        // E5: the Title_NNNN envelope key is storage-only (#248 — nothing
+        // cross-references it) ⇒ the INERT `ROW` cell, NOT the pilot's copyable
+        // `KEY`. This is the EnvelopeKey-inert path the Recipe pilot never
+        // exercised — the discriminator is the explicit Copyable bool.
+        vm.Footer.HasIds.Should().BeTrue();
+        vm.Footer.Ids.Should().ContainSingle();
+        var cell = vm.Footer.Ids[0];
+        cell.LabelTag.Should().Be("ROW");
+        cell.Value.Should().Be("Title_5018");
+        cell.Copyable.Should().BeFalse("an EnvelopeKey-style storage-only id is inert per ratified E5");
+        FactFooter.ResolveCellClick(cell).Should().Be(FactFooterCellAction.Inert);
     }
 
     private sealed class FakeRefData : Mithril.Shared.Reference.IReferenceDataService


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 1 of 8: PlayerTitle

First fan-out view. Per the [Phase 5 dispatch](https://github.com/moumantai-gg/mithril/blob/main/docs/agent-plans/2026-05-17-silmarillion-404-phase5-fanout.md) this is a **consistency-diff against the merged Recipe pilot, not fresh design**. #404 Phase-2 classified PlayerTitle as the **pure Fact + Structure + Control** view (no Link, no Set-reference), so every element maps to an inert Fact or to Structure.

### Canonical pattern applied (verbatim from the pilot)

| Element | #404 matrix | Treatment |
|---|---|---|
| Title | T4 bold-gold Fact-title | → `FactTitleStyle`; inline gold/header-font/XLarge dropped (G-b). **No title-glyph** — PlayerTitle has no entity icon (correctly absent). |
| Scope / obtainability badges | **T15 coloured semantic badge box (❌ off-diagonal)** | → one inert `FactTable` Strip of value-only phrase segments. Exact pilot stat-badge-box → strip collapse: false flags skipped; all-false ⇒ `StripText ""` so the shared Style self-hides (the per-badge `BoolToVis` self-elision it replaces). |
| "How to earn" prose + placeholder | T2 Fact body | → `FactBodyStyle`; inline fg/size/`LineHeight` dropped. Italic placeholder via `BasedOn FactBodyStyle`. |
| Footer (`Title_NNNN`) | #14 / G-a · ratified **E5** | Stop binding `DetailExportHost.FooterText`; place `<wpf:FactFooter/>` at the foot of the wrapped content (host retained unchanged — no surgery). |

### The one substantive judgement: the footer is an **inert `ROW`**, not a copyable `KEY`

This is the first fan-out case to exercise the **E5 copyable-iff-cross-reference discriminator** (the Recipe pilot only ever used the copyable `KEY` path). PlayerTitle's POCO carries no `InternalName` — the `Title_NNNN` envelope key is the only identifier. Per ratified E5 rule 2 a footer is copyable *iff* something cross-references it; **#248 established the `Title_N` envelope key has no structured cross-reference** (BestowTitle args live in a different namespace, nothing resolves through it). So it is a display/storage-only key ⇒ `FactFooterId("ROW", …, copyable: false)`, never `FactFooterVm.Key(...)`. The discriminator is the explicit `Copyable` bool, exactly as the primitive's G-a contract requires.

### Accepted grammar trade-off

The three scope badges lose their semantic colours (green/indigo/red) collapsing into one inert dot-separated strip. This is the ratified G4 acceptance bar (consistency over fidelity) — identical to the pilot's stat-badge-box collapse; Fact is inert per G-b.

### Anti-goals respected

- One view per PR; **only** `PlayerTitleDetailView.xaml` + its VM + its tests changed (`git diff --name-only origin/main...HEAD` clean).
- No primitive / `Resources.xaml` / legacy-control / other-view edits.
- Grammar not re-opened; this is a per-PR G4 consistency check vs the pilot.
- Legacy bool/string VM members (`DisplayName`, `FooterText`, `AccountWide`, …) retained per the pilot pattern — the 7 existing VM tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **486/486** (7 existing PlayerTitle + 3 new: `ScopeStrip` self-hide, `ScopeStrip` content, inert-`ROW` footer)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`
- Boot smoke — silmarillion module loaded, host started, creating App → resolving ShellWindow → **shell shown → startup done** (clean, no stall)

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot**, not fresh design. This PR sets the pattern the remaining 7 fan-out views copy — please confirm the pilot-application (esp. the E5 inert-`ROW` footer call) before the rest proceed.

Tracked in #404 · Phase 5 fan-out **1 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
