### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 2/8 — Lorebook grammar migration

### DIFF
--- a/src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/LorebookDetailViewModel.cs
@@ -83,6 +83,53 @@ public sealed class LorebookDetailViewModel
         ShowBestowingItemsPopupCommand = new RelayCommand(
             () => ProvenancePopupOpener(BestowingItemsPopup!, OpenEntityCommand),
             () => BestowingItemsPopup is not null);
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // Legacy chip/string/command members above stay (the existing tests +
+        // the detail-pane contract); these are the grammar-tier carriers the
+        // view binds. Built here — the VM already holds every source datum, the
+        // mapping is mechanical. #404 Phase-2: Lorebook has one inline Link
+        // (the folded-in area chip), one Set-reference (the "Bestowed by N →"
+        // ghost-gold button), and the E5 "carries BOTH identifiers" footer.
+
+        // Inline area Link (matrix #6 — "Found in: [area]"). The folded-in
+        // EntityChip becomes the unified Link via the ratified adapter; the
+        // view renders it Density="Prose" (inline in a sentence — exactly the
+        // pilot requirement-row idiom: Structure inline prefix + Prose Link).
+        AreaLink = AreaChip is null ? null : LinkVm.From(AreaChip);
+
+        // "Bestowed by N →" (matrix T7′ ghost-gold action button → Set-ref).
+        // The bespoke gold button becomes the shared Set-reference summary-form
+        // (MatchCount ⇒ "Bestowed by · N matches →"), actionable — its reveal is
+        // the existing ShowBestowingItemsPopupCommand. Gold→blue is the ratified
+        // G-b correction, not a regression. Null when nothing bestows it (the
+        // section hides). SlotOrdinal null: a single, positionally-inert ref —
+        // not the recipe keyword-slot stacking case.
+        BestowingItemsSetRef = BestowingItemsPopup is null
+            ? null
+            : new SetRefVm("Bestowed by", MatchCount: BestowingItemsTotal, IsActionable: true);
+
+        // Footer ids (matrix #14 / G-a · ratified E5). Lorebook is the E5
+        // "carries BOTH identifiers" case (rule 1: 0/1/2 ids). Order preserved
+        // verbatim from the legacy FooterSegments / "Book_101 / TheWastedWishes"
+        // pair: the "Book_N" envelope key is a display/storage-only key ⇒ the
+        // INERT `ROW` cell; the PascalCase InternalName is the cross-entity
+        // reference key other entities point at (recipes/items resolve a book by
+        // it) ⇒ the copyable `KEY` (E5 rule 2). The defensive equal case
+        // collapses to the single copyable KEY (mirrors the legacy
+        // FooterSegments single-segment collapse).
+        Footer = BuildFooter(EnvelopeKey, InternalName);
+    }
+
+    private static FactFooterVm BuildFooter(string envelopeKey, string internalName)
+    {
+        if (string.IsNullOrEmpty(internalName) && string.IsNullOrEmpty(envelopeKey))
+            return FactFooterVm.None();
+        if (string.Equals(envelopeKey, internalName, StringComparison.Ordinal))
+            return FactFooterVm.Key(internalName);
+        return FactFooterVm.Of(
+            new FactFooterId("ROW", envelopeKey, copyable: false),
+            new FactFooterId("KEY", internalName, copyable: true));
     }
 
     private static void ShowProvenancePopupWindow(ProvenancePopupViewModel vm, ICommand? chipClick) =>
@@ -128,6 +175,33 @@ public sealed class LorebookDetailViewModel
     /// <summary>Single area chip folded into the metadata strip (<c>Found in: [chip]</c>).</summary>
     public EntityChipVm? AreaChip { get; }
     public bool HasArea => AreaChip is not null;
+
+    /// <summary>
+    /// The folded-in area cross-link as the unified <see cref="LinkVm"/> (matrix
+    /// #6). Rendered <c>Density="Prose"</c> behind the Structure "Found in:"
+    /// inline prefix — the pilot inline-ref idiom. Null when no area (section
+    /// hides via <see cref="HasArea"/>).
+    /// </summary>
+    public LinkVm? AreaLink { get; }
+
+    /// <summary>
+    /// "Bestowed by N item(s)" as the shared Set-reference summary-form (matrix
+    /// T7′): <c>"Bestowed by · {N} matches →"</c>, actionable — its reveal is
+    /// <see cref="ShowBestowingItemsPopupCommand"/>. Replaces the bespoke
+    /// ghost-gold button; gold→blue is the ratified G-b correction. Null when
+    /// nothing bestows the book (section hides via <see cref="HasBestowingItems"/>).
+    /// </summary>
+    public SetRefVm? BestowingItemsSetRef { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14, G-a · ratified E5). The E5
+    /// "carries BOTH identifiers" case: <c>ROW</c> (the storage-only
+    /// <c>Book_N</c> envelope key, inert) · <c>KEY</c> (the cross-entity
+    /// reference <see cref="InternalName"/>, copyable), order preserved from the
+    /// legacy footer pair. Defensive equal case collapses to the single
+    /// copyable <c>KEY</c>.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     /// <summary>Body prose, or null for the 12 external-guide books (placeholder shown instead).</summary>
     public string? BodyText { get; }

--- a/src/Silmarillion.Module/Views/LorebookDetailView.xaml
+++ b/src/Silmarillion.Module/Views/LorebookDetailView.xaml
@@ -5,7 +5,6 @@
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -20,62 +19,82 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterSegments="{Binding FooterSegments}">
+    <!-- Phase-5 fan-out · view 2 (Lorebook) — a consistency-diff against the
+         merged Recipe pilot, NOT fresh design. #404 Phase-2 classified
+         Lorebook's elements: one inline Link (the folded-in area chip), one
+         Set-reference (the "Bestowed by N →" ghost-gold button), Fact body, and
+         the E5 "carries BOTH identifiers" footer.
+
+         Footer (matrix #14 / G-a · ratified E5): the pilot move — stop binding
+         DetailExportHost.FooterSegments and place <c:FactFooter/> at the foot
+         of the wrapped content. The host wrapper is RETAINED unchanged
+         (export-camera + snapshot — shared infra, not edited). Lorebook is the
+         2-identifier case: ROW (storage-only Book_N, inert) · KEY (cross-ref
+         InternalName, copyable). -->
+    <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Footer is owned by the wrapping DetailExportHost via FooterSegments (independent click-to-copy chips: envelope key + InternalName). -->
-
             <StackPanel>
-                <!-- ─── Header: title + category subtitle ─── -->
+                <!-- ─── Header: Fact-title + category subtitle ───
+                     Matrix T4 → FactTitleStyle (inline gold/header-font/XLarge
+                     dropped, G-b). No title-glyph: Lorebook has no entity icon.
+                     CategorySubtitle "from <category>" is a Fact (the book's
+                     category) at quiet weight → FactBodyStyle + italic (the
+                     pilot description treatment); string-typed binding so
+                     NullOrEmptyToVis is correct here. -->
                 <StackPanel Margin="0,0,0,10">
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" TextWrapping="Wrap"/>
+                               Style="{StaticResource FactTitleStyle}"/>
                     <TextBlock Text="{Binding CategorySubtitle}"
-                               Foreground="#88FFFFFF" FontStyle="Italic"
-                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
                                Margin="0,2,0,0"
                                Visibility="{Binding CategorySubtitle, Converter={StaticResource NullOrEmptyToVis}}"/>
                 </StackPanel>
 
-                <!-- ─── Metadata strip: location hint + folded-in area chip ─── -->
+                <!-- ─── Metadata strip: location hint + folded-in area Link ───
+                     LocationHint: Fact body (matrix T2) → FactBodyStyle +
+                     italic. "Found in: [area]" is the pilot inline-ref idiom:
+                     Structure inline prefix (E1 — auto-UPPERCASE+tracked by the
+                     shared StructureLabel behavior; keep the ':') + a
+                     Density="Prose" Link via the LinkVm adapter, ClickCommand
+                     wired exactly as the old chip. -->
                 <StackPanel Margin="0,0,0,10">
                     <TextBlock Text="{Binding LocationHint}"
-                               Foreground="#CCFFFFFF" FontStyle="Italic"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               TextWrapping="Wrap" Margin="0,0,0,4"
+                               Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
+                               Margin="0,0,0,4"
                                Visibility="{Binding HasLocationHint, Converter={StaticResource BoolToVis}}"/>
                     <StackPanel Orientation="Horizontal"
                                 Visibility="{Binding HasArea, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Found in: " Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
-                        <ContentControl Content="{Binding AreaChip}">
-                            <ContentControl.Resources>
-                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:LorebookDetailView}}}"/>
+                        <TextBlock Text="Found in:"
+                                   Style="{StaticResource StructureInlinePrefixStyle}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl Content="{Binding AreaLink}">
+                            <ContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <c:Link Density="Prose"
+                                            ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:LorebookDetailView}}}"/>
                                 </DataTemplate>
-                            </ContentControl.Resources>
+                            </ContentControl.ContentTemplate>
                         </ContentControl>
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ─── Body ─── -->
+                <!-- ─── Body ───
+                     Matrix T2 → FactBodyStyle (inline #EEFFFFFF / size /
+                     LineHeight dropped — the style owns them). FormattedText
+                     parses inline markup. The external-guide placeholder is the
+                     same Fact-body prose at quieter weight, kept inline-italic
+                     via BasedOn FactBodyStyle. -->
                 <Border Margin="0,0,0,10">
                     <Grid>
                         <TextBlock wpf:FormattedText.Text="{Binding BodyText}"
-                                   Foreground="#EEFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeLarge}"
-                                   TextWrapping="Wrap" LineHeight="22"
+                                   Style="{StaticResource FactBodyStyle}"
                                    Visibility="{Binding HasBody, Converter={StaticResource BoolToVis}}"/>
-                        <TextBlock Text="This book points to an external resource — see the in-game Volunteer Guide."
-                                   Foreground="#88FFFFFF" FontStyle="Italic"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   TextWrapping="Wrap">
+                        <TextBlock Text="This book points to an external resource — see the in-game Volunteer Guide.">
                             <TextBlock.Style>
-                                <Style TargetType="TextBlock">
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource FactBodyStyle}">
+                                    <Setter Property="FontStyle" Value="Italic"/>
                                     <Setter Property="Visibility" Value="Visible"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding HasBody}" Value="True">
@@ -89,46 +108,31 @@
                 </Border>
 
                 <!-- ─── Items that bestow this book (#318 popup-from-index) ───
-                     Single-reason 1:N. A one-line affordance opens the shared
-                     ProvenancePopupWindow fed ItemsBestowingLorebook[InternalName]
-                     directly (single flat section, no synthetic kind, no deep-link,
-                     no navigator history). Hidden entirely when nothing bestows it. -->
-                <Button HorizontalAlignment="Left" Cursor="Hand" Padding="6,2"
-                        Command="{Binding ShowBestowingItemsPopupCommand}"
-                        Visibility="{Binding HasBestowingItems, Converter={StaticResource BoolToVis}}">
-                    <Button.Style>
-                        <Style TargetType="Button">
-                            <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="BorderBrush" Value="#66D4A847"/>
-                            <Setter Property="BorderThickness" Value="1"/>
-                            <Setter Property="Foreground" Value="#FFD4A847"/>
-                            <Style.Triggers>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Background" Value="#22D4A847"/>
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Button.Style>
-                    <Button.Template>
-                        <ControlTemplate TargetType="Button">
-                            <Border Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="3" Padding="{TemplateBinding Padding}">
-                                <StackPanel Orientation="Horizontal">
-                                    <icon:PackIconLucide Kind="BookMarked" Width="12" Height="12"
-                                                         Foreground="{TemplateBinding Foreground}"
-                                                         Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                    <TextBlock Foreground="{TemplateBinding Foreground}"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
-                                               VerticalAlignment="Center">
-                                        <Run Text="Bestowed by "/><Run Text="{Binding BestowingItemsTotal, Mode=OneWay}"/><Run Text=" item(s) →"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Border>
-                        </ControlTemplate>
-                    </Button.Template>
-                </Button>
+                     Matrix T7′ ghost-gold action button → the shared
+                     Set-reference summary-form. The bespoke gold button +
+                     bespoke ControlTemplate collapse into <c:SetRef>:
+                     "Bestowed by · N matches →", actionable via the existing
+                     ShowBestowingItemsPopupCommand (no command rewiring). The
+                     pilot keyword-slot SetRef idiom verbatim: ContentControl
+                     hosts the SetRefVm, ActivateCommand resolves the command on
+                     the ContentControl's (view-model) DataContext. Gold→blue is
+                     the ratified G-b correction. Section hides via
+                     HasBestowingItems. -->
+                <ContentControl Content="{Binding BestowingItemsSetRef}"
+                                HorizontalAlignment="Left" Margin="0,0,0,4"
+                                Visibility="{Binding HasBestowingItems, Converter={StaticResource BoolToVis}}">
+                    <ContentControl.ContentTemplate>
+                        <DataTemplate>
+                            <c:SetRef ActivateCommand="{Binding DataContext.ShowBestowingItemsPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                        </DataTemplate>
+                    </ContentControl.ContentTemplate>
+                </ContentControl>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). 2 ids:
+                     ROW (storage-only Book_N, inert) · KEY (cross-ref
+                     InternalName, copyable). FactFooterVm collapses to one KEY
+                     in the defensive equal case; None() self-hides at 0. -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/LorebookDetailViewModelTests.cs
@@ -206,6 +206,110 @@ public sealed class LorebookDetailViewModelTests
             .Which.Reference.InternalName.Should().Be("Only");
     }
 
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void Footer_DivergentIds_AreInertRow_PlusCopyableKey_InOrder()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes",
+            Title = "The Wasted Wishes", Text = "x",
+        });
+        var vm = BuildDetail(refData, "TheWastedWishes");
+
+        // E5 "carries BOTH" case, order preserved from the legacy pair: the
+        // storage-only Book_N envelope key is the INERT ROW; the cross-entity
+        // reference InternalName is the copyable KEY.
+        vm.Footer.Ids.Should().HaveCount(2);
+        var row = vm.Footer.Ids[0];
+        row.LabelTag.Should().Be("ROW");
+        row.Value.Should().Be("Book_101");
+        row.Copyable.Should().BeFalse("the Book_N envelope key is storage-only (E5)");
+        var key = vm.Footer.Ids[1];
+        key.LabelTag.Should().Be("KEY");
+        key.Value.Should().Be("TheWastedWishes");
+        key.Copyable.Should().BeTrue("InternalName is the cross-entity reference key (E5)");
+        FactFooter.ResolveCellClick(row).Should().Be(FactFooterCellAction.Inert);
+        FactFooter.ResolveCellClick(key).Should().Be(FactFooterCellAction.Copy);
+    }
+
+    [Fact]
+    public void Footer_KeyEqualsName_CollapsesToSingleCopyableKey()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("SameName", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "SameName", Title = "Same", Text = "x",
+        });
+        var vm = BuildDetail(refData, "SameName");
+
+        vm.Footer.Ids.Should().ContainSingle();
+        vm.Footer.Ids[0].LabelTag.Should().Be("KEY");
+        vm.Footer.Ids[0].Value.Should().Be("SameName");
+        vm.Footer.Ids[0].Copyable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreaLink_ProjectsTheFoldedInAreaChip_AsAProseLink()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddArea(new AreaEntry("AreaSerbule", "Serbule", "Serbule"));
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "B", Title = "B",
+            Keywords = new[] { "AreaSerbule" }, Text = "x",
+        });
+        var vm = BuildDetail(refData, "B", areaKey: "AreaSerbule");
+
+        vm.AreaLink.Should().NotBeNull();
+        vm.AreaLink!.DisplayName.Should().Be("Serbule");
+        // Glyph proves the Area-kind → Link adapter mapping (GlyphFor).
+        vm.AreaLink.Glyph.Should().Be(LinkGlyph.Location, "Area kind maps to the location glyph");
+        vm.AreaLink.IsNavigable.Should().Be(vm.AreaChip!.IsNavigable, "adapter preserves navigability");
+    }
+
+    [Fact]
+    public void AreaLink_IsNull_WhenNoArea()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "B", Title = "B", Text = "x",
+        });
+        BuildDetail(refData, "B").AreaLink.Should().BeNull();
+    }
+
+    [Fact]
+    public void BestowingItemsSetRef_IsActionableSummaryForm_OrNull()
+    {
+        var refData = new FakeReferenceData();
+        refData.AddLorebook("Book_101", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "TheWastedWishes", Title = "The Wasted Wishes", Text = "x",
+        });
+        refData.SetBestowing("TheWastedWishes",
+            new Item { InternalName = "ItemA", Name = "Item A" },
+            new Item { InternalName = "ItemB", Name = "Item B" });
+        var vm = BuildDetail(refData, "TheWastedWishes");
+
+        vm.BestowingItemsSetRef.Should().NotBeNull();
+        vm.BestowingItemsSetRef!.Label.Should().Be("Bestowed by");
+        vm.BestowingItemsSetRef.MatchCount.Should().Be(2);
+        vm.BestowingItemsSetRef.IsSummaryForm.Should().BeTrue();
+        vm.BestowingItemsSetRef.IsActionable.Should().BeTrue();
+        vm.BestowingItemsSetRef.DisplayText.Should().Be("Bestowed by · 2 matches →");
+
+        // No bestowing items → no Set-ref (section hides).
+        var refData2 = new FakeReferenceData();
+        refData2.AddLorebook("Book_1", new LorebookPoco
+        {
+            Category = "Stories", InternalName = "Lonely", Title = "Lonely", Text = "x",
+        });
+        BuildDetail(refData2, "Lonely").BestowingItemsSetRef.Should().BeNull();
+    }
+
     // ── Real-data sanity walk (cookbook *Verification ladder* — load-bearing per #298) ──
 
     [Fact]


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 2 of 8: Lorebook

Second fan-out view. A **consistency-diff against the merged Recipe pilot, not fresh design**. Lorebook exercises three pilot idioms PlayerTitle didn't: an inline **Link**, a **Set-reference**, and the E5 **2-identifier footer**.

### Canonical pattern applied

| Element | #404 matrix | Treatment |
|---|---|---|
| Title | T4 bold-gold | → `FactTitleStyle` (gold dropped, G-b); no title-glyph (no entity icon) |
| CategorySubtitle / LocationHint | T2 Fact | → `FactBodyStyle` + italic (pilot description treatment) |
| `Found in: [area]` | E1 Structure prefix + **Link** | Pilot inline-ref idiom: `StructureInlinePrefixStyle` (auto-UPPERCASE+tracked) + `Density="Prose"` `Link` via `LinkVm.From(EntityChipVm)`, `ClickCommand` wired exactly as the old chip |
| `Bestowed by N item(s) →` | **T7′ ghost-gold action button → Set-reference** | Bespoke `Button`+`ControlTemplate` collapse into `<c:SetRef>` summary-form `"Bestowed by · N matches →"`, actionable via the **existing** `ShowBestowingItemsPopupCommand` (no command rewiring). Gold→blue per ratified G-b. |
| Body + external-guide placeholder | T2 Fact | → `FactBodyStyle`; placeholder via `BasedOn FactBodyStyle + Italic` |
| Footer | #14 / G-a · ratified **E5** | Stop binding `DetailExportHost.FooterSegments`; `<c:FactFooter/>` at the foot (host retained unchanged) |

### The substantive judgement: the E5 **2-identifier** footer

Lorebook is the ratified-E5 *"carries both identifiers"* case (rule 1: 0/1/2 ids). Mapping per E5 rule 2 (copyable iff cross-entity reference key):

- **`ROW`** — the `Book_N` envelope key: a display/storage-only dictionary key, nothing resolves through it → **inert** (`copyable: false`)
- **`KEY`** — the PascalCase `InternalName`: the cross-entity reference key (recipes/items resolve a book by it) → **copyable**

Order preserved verbatim from the legacy `FooterSegments` / `Book_101 / TheWastedWishes` pair. The defensive equal case collapses to the single copyable `KEY` (mirrors the legacy single-segment collapse). This complements PlayerTitle's single-inert-`ROW` case — together views 1+2 pin all three E5 footer shapes the pilot didn't exercise (single-inert, two-cell, equal-collapse).

### Anti-goals respected

- One view per PR; `git status` = **only** `LorebookDetailView.xaml` + its VM + its tests.
- No primitive / `Resources.xaml` / legacy-control / other-view edits.
- Grammar not re-opened — per-PR G4 consistency check vs the pilot.
- Legacy chip/string/command members (`AreaChip`, `FooterText`, `FooterSegments`, `BestowingItemsTotal`, `ShowBestowingItemsPopupCommand`, …) retained per the pilot pattern — the 9 existing VM tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **488/488** (9 existing Lorebook + 5 new: 2-id ROW+KEY order, equal-collapse, `AreaLink` adapter+navigability, `BestowingItemsSetRef` summary-form/null)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`

Boot smoke deferred to the consolidated integration pass before Phase 6 (per the orchestration note: pure restyle, no new code-behind / DI; the per-view full build compiles all BAML + lints resources).

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot** — esp. the E5 2-identifier `ROW`+`KEY` footer call and the bespoke-button→`SetRef` collapse.

Tracked in #404 · Phase 5 fan-out **2 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
