### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 3/8 — Area grammar migration

### DIFF
--- a/src/Silmarillion.Module/ViewModels/AreaDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/AreaDetailViewModel.cs
@@ -98,6 +98,42 @@ public sealed partial class AreaDetailViewModel : ObservableObject
         ShowLandmarksPopupCommand = new RelayCommand(
             () => ProvenancePopupOpener(LandmarksPopup!, OpenEntityCommand),
             () => LandmarksPopup is not null);
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // Legacy chip/popup/command members above stay (the existing tests +
+        // the detail-pane contract); these are the grammar-tier carriers the
+        // view binds. #404 Phase-2: Area carries the NPC Link enumeration, TWO
+        // Set-references (the two "View all N →" ghost-gold buttons), Fact
+        // landmark rows, and a copyable-KEY footer.
+
+        // NPC cross-links (matrix #6/#10 — entity enumeration). The capped chip
+        // cluster becomes the unified Link list via the ratified adapter; the
+        // view renders it Density="List" (own line per entry — the canonical
+        // pilot enumeration pattern, exactly Ingredients/Produces/Sources).
+        NpcLinks = NpcChips.Select(LinkVm.From).ToList();
+
+        // The two "View all N →" ghost-gold action buttons (matrix T7 — #404
+        // Phase-2 "Area ×2") become the shared Set-reference summary-form
+        // ("{set} · N matches →"), actionable via the EXISTING popup commands
+        // (no command rewiring). Gold→blue is the ratified G-b correction. Null
+        // when the popup is null (section hides). SlotOrdinal null: a single
+        // positionally-inert drawer, not the recipe keyword-slot stacking case.
+        NpcsSetRef = NpcsPopup is null
+            ? null
+            : new SetRefVm("NPCs in this area", MatchCount: NpcsTotal, IsActionable: true);
+        LandmarksSetRef = LandmarksPopup is null
+            ? null
+            : new SetRefVm("Landmarks in this area", MatchCount: LandmarksTotal, IsActionable: true);
+
+        // Footer id (matrix #14 / G-a · ratified E5). The Area key
+        // (e.g. "AreaSerbule") IS a cross-entity reference key — NPCs, lorebooks
+        // and quests resolve an area by it — so per E5 rule 2 it is the
+        // copyable `KEY` (the pilot's FactFooterVm.Key path), NOT PlayerTitle's
+        // inert envelope ROW. None() when somehow keyless so the strip
+        // self-hides.
+        Footer = string.IsNullOrEmpty(InternalName)
+            ? FactFooterVm.None()
+            : FactFooterVm.Key(InternalName);
     }
 
     public AreaEntry Area { get; }
@@ -152,6 +188,21 @@ public sealed partial class AreaDetailViewModel : ObservableObject
     /// <summary>True when at least one NPC chip rendered (drives the section header visibility).</summary>
     public bool HasNpcs => NpcChips.Count > 0;
 
+    /// <summary>
+    /// NPC cross-links as the unified <see cref="LinkVm"/> (matrix #6/#10). The
+    /// view renders these <c>Density="List"</c> — the canonical pilot
+    /// enumeration pattern. Projection of <see cref="NpcChips"/> (same cap).
+    /// </summary>
+    public IReadOnlyList<LinkVm> NpcLinks { get; }
+
+    /// <summary>
+    /// The "NPCs in this area" drawer as the shared Set-reference summary-form
+    /// (matrix T7): <c>"NPCs in this area · N matches →"</c>, actionable — its
+    /// reveal is <see cref="ShowNpcsPopupCommand"/>. Replaces the ghost-gold
+    /// "View all N →" button; gold→blue per ratified G-b. Null when no NPCs.
+    /// </summary>
+    public SetRefVm? NpcsSetRef { get; }
+
     // ── Landmarks in this area (#311 fold-in) ──────────────────────────────────
 
     /// <summary>
@@ -189,6 +240,23 @@ public sealed partial class AreaDetailViewModel : ObservableObject
 
     /// <summary>True when at least one landmark group rendered (drives the section header visibility).</summary>
     public bool HasLandmarks => LandmarkGroups.Count > 0;
+
+    /// <summary>
+    /// The "Landmarks in this area" drawer as the shared Set-reference
+    /// summary-form (matrix T7): <c>"Landmarks in this area · N matches →"</c>,
+    /// actionable — its reveal is <see cref="ShowLandmarksPopupCommand"/>.
+    /// Replaces the ghost-gold "View all N →" button (gold→blue, ratified G-b).
+    /// Null when the area has no landmarks.
+    /// </summary>
+    public SetRefVm? LandmarksSetRef { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14, G-a · ratified E5). The Area key is
+    /// a cross-entity reference key (other entities resolve an area by it) ⇒ the
+    /// copyable <c>KEY</c> (the pilot path), not an inert envelope <c>ROW</c>.
+    /// <see cref="FactFooterVm.None"/> (self-hides) if somehow keyless.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/src/Silmarillion.Module/Views/AreaDetailView.xaml
+++ b/src/Silmarillion.Module/Views/AreaDetailView.xaml
@@ -4,7 +4,6 @@
              xmlns:local="clr-namespace:Silmarillion.Views"
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -18,10 +17,18 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!-- ── Per-type landmark row templates ──
-                 Mixed font runs (Combo/Loc in mono, Desc italic) are achieved through separate
-                 Run elements bound to the row's pre-formatted *Display properties (which return
-                 empty string when the underlying field is null — Run can't carry Visibility, so
-                 the empty-string idiom is the WPF-friendly way to collapse missing pieces). -->
+                 #404 Phase-2 classified these as ✅ on-diagonal Fact (T2 "plain
+                 inline text any weight/shade" + "mono flags"): mixed Run fonts
+                 (Desc italic, Loc/Combo mono) are legitimate inert Fact
+                 presentation — FactBodyStyle would break the deliberate
+                 mono/italic the same way the pilot left its mono ResultEffects
+                 stub inline. So these templates are NOT restyled wholesale
+                 (that would be fresh design — anti-goal #1). The ONE required
+                 change is the ratified G-b fix: the MeditationPillar Combo Run
+                 dropped its gold #FFD4A847 (the named "Area combo" gold-in-Fact
+                 violation — gold now means Link XOR title; a Fact value is
+                 never gold). It stays mono (mono ≠ gold) and inherits the row's
+                 plain Fact pigment. -->
             <!-- Portal: bold Name — italic Desc · mono Loc. -->
             <DataTemplate DataType="{x:Type vm:AreaLandmarkPortalRow}">
                 <TextBlock Margin="0,0,0,2" TextWrapping="Wrap"
@@ -35,15 +42,14 @@
                 </TextBlock>
             </DataTemplate>
 
-            <!-- MeditationPillar: bold Name · Combo: mono (gold) · mono Loc. -->
+            <!-- MeditationPillar: bold Name · Combo mono (G-b: gold dropped) · mono Loc. -->
             <DataTemplate DataType="{x:Type vm:AreaLandmarkPillarRow}">
                 <TextBlock Margin="0,0,0,2" TextWrapping="Wrap"
                            Foreground="#CCFFFFFF"
                            FontSize="{DynamicResource AppFontSizeHint}">
                     <Run Text="{Binding Name, Mode=OneWay}" FontWeight="SemiBold"/>
                     <Run Text="{Binding ComboDisplay, Mode=OneWay}"
-                         FontFamily="{DynamicResource AppMonoFontFamily}"
-                         Foreground="#FFD4A847"/>
+                         FontFamily="{DynamicResource AppMonoFontFamily}"/>
                     <Run Text="{Binding LocDisplay, Mode=OneWay}"
                          FontFamily="{DynamicResource AppMonoFontFamily}"
                          Foreground="#88FFFFFF"/>
@@ -62,130 +68,118 @@
                 </TextBlock>
             </DataTemplate>
 
-            <!-- One landmark group: heading + per-row layout (delegated to the row's DataTemplate). -->
+            <!-- One landmark group: Structure group header + per-row layout
+                 (delegated to the row's DataTemplate). The heading is a
+                 Structure group header (matrix T3 → Structure) — migrated to
+                 the shared StructureGroupHeaderStyle (the G4-ratified
+                 UPPERCASE+tracked treatment; zero call-site work). -->
             <DataTemplate DataType="{x:Type vm:AreaLandmarkGroup}">
                 <StackPanel Margin="0,0,0,8">
-                    <TextBlock Text="{Binding Heading}" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               FontWeight="SemiBold" Margin="0,0,0,4"/>
+                    <TextBlock Text="{Binding Heading}"
+                               Style="{StaticResource StructureGroupHeaderStyle}"
+                               Margin="0,0,0,4"/>
                     <!-- In-pane preview cluster only. The full landmark set (and any
                          high-cardinality area — the ~547-row #259 precedent) is reachable
                          through the shared virtualizing ProvenancePopupWindow via the
-                         "View all N →" affordance below; there is no separate
-                         non-virtualized list path for the full set (#311 fold-in). -->
+                         Set-reference below; there is no separate non-virtualized
+                         list path for the full set (#311 fold-in). -->
                     <ItemsControl ItemsSource="{Binding Rows}"/>
                 </StackPanel>
             </DataTemplate>
-
-            <!-- Shared "View all N →" affordance (ghost fill, ListFilter glyph) — reads as
-                 "go see the full set", not "open an entity". Mirrors the surface-1
-                 ItemDetailView affordance; opens the shared provenance popup (#318). -->
-            <Style x:Key="ViewAllButtonStyle" TargetType="Button">
-                <Setter Property="Margin" Value="0,4,0,0"/>
-                <Setter Property="Padding" Value="6,2"/>
-                <Setter Property="HorizontalAlignment" Value="Left"/>
-                <Setter Property="Cursor" Value="Hand"/>
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="BorderBrush" Value="#66D4A847"/>
-                <Setter Property="BorderThickness" Value="1"/>
-                <Setter Property="Foreground" Value="#FFD4A847"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Border Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="3" Padding="{TemplateBinding Padding}">
-                                <StackPanel Orientation="Horizontal">
-                                    <icon:PackIconLucide Kind="ListFilter" Width="12" Height="12"
-                                                         Foreground="{TemplateBinding Foreground}"
-                                                         Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                    <ContentPresenter VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-                <Style.Triggers>
-                    <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#22D4A847"/>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterText="{Binding InternalName}">
+    <!-- Phase-5 fan-out · view 3 (Area) — a consistency-diff against the merged
+         Recipe pilot, NOT fresh design. #404 Phase-2 element classification:
+         the NPC chip cluster is a Link enumeration; the two "View all N →"
+         ghost-gold buttons are Set-references (Phase-2 "Area ×2"); landmark
+         rows are inert Fact (✅ on-diagonal — only the G-b Combo gold actioned);
+         the Area-key footer is a copyable cross-reference KEY.
+
+         Footer (matrix #14 / G-a · ratified E5): the pilot move — stop binding
+         DetailExportHost.FooterText, place <c:FactFooter/> at the foot of the
+         wrapped content (host retained unchanged). The Area key is a
+         cross-entity reference key ⇒ copyable KEY (not PlayerTitle's inert
+         envelope ROW). -->
+    <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Internal-name footer is owned by the wrapping DetailExportHost (FooterText). -->
-
             <StackPanel>
-                <!-- ─── Header: friendly name + optional short form ─── -->
+                <!-- ─── Header: Fact-title + short-form ───
+                     Matrix T4 → FactTitleStyle (inline gold/header-font/XLarge
+                     dropped, G-b). No title-glyph (no entity icon).
+                     ShortFriendlyName is a Fact (the area's short name) at quiet
+                     weight → FactBodyStyle; string-typed binding so
+                     NullOrEmptyToVis is correct. -->
                 <StackPanel Margin="0,0,0,10">
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847"/>
+                               Style="{StaticResource FactTitleStyle}"/>
                     <TextBlock Text="{Binding ShortFriendlyName}"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
+                               Style="{StaticResource FactBodyStyle}"
                                Margin="0,2,0,0"
                                Visibility="{Binding ShortFriendlyName, Converter={StaticResource NullOrEmptyToVis}}"/>
                 </StackPanel>
 
-                <!-- ─── NPCs in this area ─── -->
+                <!-- ─── NPCs in this area ───
+                     Section header: matrix T3 → StructureSectionLabelStyle
+                     (G4 UPPERCASE+tracked). NPC chips: matrix #6/#10 entity
+                     enumeration → the canonical pilot pattern — Density="List",
+                     vertical StackPanel, one Link per line (was a WrapPanel of
+                     EntityChip). "View all N →" ghost-gold button → the shared
+                     Set-reference summary-form via the existing command. -->
                 <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding HasNpcs, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="NPCs in this area" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding NpcChips}">
+                    <TextBlock Text="NPCs in this area"
+                               Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding NpcLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AreaDetailView}}}"/>
+                                <!-- G4-ratified: enumeration → Density="List" (canonical pattern). -->
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:AreaDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <!-- "View all N →" — opens the shared provenance popup (#318 slice 4,
-                         surface 4) fed IReferenceDataService.NpcsByAreaWithReason directly.
-                         Always visible whenever any NPC is in the area (independent of the
-                         chip cap). Replaces the retired NpcByArea synthetic-kind shortcut. -->
-                    <Button Style="{StaticResource ViewAllButtonStyle}"
-                            Command="{Binding ShowNpcsPopupCommand}"
-                            Visibility="{Binding NpcsPopup, Converter={StaticResource NullToVis}}">
-                        <TextBlock Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center">
-                            <Run Text="View all "/><Run Text="{Binding NpcsTotal, Mode=OneWay}"/><Run Text=" →"/>
-                        </TextBlock>
-                    </Button>
+                    <ContentControl Content="{Binding NpcsSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding NpcsSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowNpcsPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- ─── Landmarks in this area (#311 fold-in) ─── -->
+                <!-- ─── Landmarks in this area (#311 fold-in) ───
+                     Section header → StructureSectionLabelStyle. Per-group
+                     heading → StructureGroupHeaderStyle (in the group
+                     DataTemplate). "View all N →" → the shared Set-reference
+                     summary-form via the existing command. -->
                 <StackPanel
                             Visibility="{Binding HasLandmarks, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="Landmarks in this area" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Landmarks in this area"
+                               Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding LandmarkGroups}"/>
-                    <!-- "View all N →" — opens the shared virtualizing ProvenancePopupWindow
-                         (#311 fold-in). The full landmark set (and the ~547-row #259
-                         high-cardinality precedent) renders ONLY through the popup's
-                         recycling VirtualizingStackPanel — no separate non-virtualized
-                         list path remains. Sectioned by landmark Type (genuine provenance). -->
-                    <Button Style="{StaticResource ViewAllButtonStyle}"
-                            Command="{Binding ShowLandmarksPopupCommand}"
-                            Visibility="{Binding LandmarksPopup, Converter={StaticResource NullToVis}}">
-                        <TextBlock Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center">
-                            <Run Text="View all "/><Run Text="{Binding LandmarksTotal, Mode=OneWay}"/><Run Text=" →"/>
-                        </TextBlock>
-                    </Button>
+                    <ContentControl Content="{Binding LandmarksSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding LandmarksSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowLandmarksPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). The Area
+                     key is a cross-entity reference KEY ⇒ copyable.
+                     FactFooterVm.None() self-hides at 0 ids. -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/AreaDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/AreaDetailViewModelTests.cs
@@ -438,6 +438,88 @@ public sealed class AreaDetailViewModelTests
         popup.Sections.Single().Chips.Should().OnlyContain(c => !c.IsNavigable);
     }
 
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void NpcLinks_ProjectChips_PreservingOrderAndNavigability()
+    {
+        var stub = new StubReferenceData
+        {
+            NpcsByAreaMap =
+            {
+                ["AreaSerbule"] = new[]
+                {
+                    new NpcEntry("NPC_Norbert", "Norbert", "Serbule", [], [], []),
+                    new NpcEntry("NPC_Marna", "Marna", "Serbule", [], [], []),
+                },
+            },
+        };
+        var (vm, _) = Build(new AreaEntry("AreaSerbule", "Serbule", "Serbule"), stub);
+
+        vm.NpcLinks.Select(l => l.DisplayName)
+            .Should().Equal(vm.NpcChips.Select(c => c.DisplayName), "Link list mirrors the capped cluster");
+        vm.NpcLinks.Should().OnlyContain(l => l.Glyph == LinkGlyph.Npc, "Npc kind → npc glyph");
+        vm.NpcLinks.Should().OnlyContain(l => !l.IsNavigable, "adapter preserves the chips' navigability");
+    }
+
+    [Fact]
+    public void NpcsSetRef_IsActionableSummaryForm_CountEqualsTotal_OrNull()
+    {
+        var npcs = Enumerable.Range(1, 30)
+            .Select(i => new NpcEntry($"NPC_{i:000}", $"NPC {i:000}", "Serbule", [], [], []))
+            .ToArray();
+        var stub = new StubReferenceData { NpcsByAreaMap = { ["AreaSerbule"] = npcs } };
+        var (vm, _) = Build(new AreaEntry("AreaSerbule", "Serbule", "Serbule"), stub,
+            new SilmarillionSettings { UsedInChipCap = 12 });
+
+        vm.NpcsSetRef.Should().NotBeNull();
+        vm.NpcsSetRef!.MatchCount.Should().Be(30, "the Set-ref count is the index total, never the chip cap");
+        vm.NpcsSetRef.IsSummaryForm.Should().BeTrue();
+        vm.NpcsSetRef.IsActionable.Should().BeTrue();
+        vm.NpcsSetRef.DisplayText.Should().Be("NPCs in this area · 30 matches →");
+
+        var (empty, _) = Build(new AreaEntry("AreaSerbule", "Serbule", "Serbule"));
+        empty.NpcsSetRef.Should().BeNull("no NPCs ⇒ no Set-ref (section hides)");
+    }
+
+    [Fact]
+    public void LandmarksSetRef_IsActionableSummaryForm_OrNull()
+    {
+        var stub = new StubReferenceData
+        {
+            LandmarksMap =
+            {
+                ["AreaSerbule"] = new[]
+                {
+                    new PocoLandmark { Name = "P1", Type = "Portal", Loc = "x:0 y:0 z:0" },
+                    new PocoLandmark { Name = "P2", Type = "Portal", Loc = "x:1 y:1 z:1" },
+                },
+            },
+        };
+        var (vm, _) = Build(new AreaEntry("AreaSerbule", "Serbule", "Serbule"), stub);
+
+        vm.LandmarksSetRef.Should().NotBeNull();
+        vm.LandmarksSetRef!.DisplayText.Should().Be("Landmarks in this area · 2 matches →");
+        vm.LandmarksSetRef.IsActionable.Should().BeTrue();
+
+        var (empty, _) = Build(new AreaEntry("AreaSerbule", "Serbule", "Serbule"));
+        empty.LandmarksSetRef.Should().BeNull();
+    }
+
+    [Fact]
+    public void Footer_AreaKey_IsCopyableCrossReferenceKey()
+    {
+        var (vm, _) = Build(new AreaEntry("AreaSerbule", "Serbule Hills", "Serbule"));
+
+        // Contrast PlayerTitle's inert envelope ROW: the Area key is referenced
+        // by other entities ⇒ the copyable KEY (E5 rule 2 / the pilot path).
+        vm.Footer.Ids.Should().ContainSingle();
+        vm.Footer.Ids[0].LabelTag.Should().Be("KEY");
+        vm.Footer.Ids[0].Value.Should().Be("AreaSerbule");
+        vm.Footer.Ids[0].Copyable.Should().BeTrue();
+        FactFooter.ResolveCellClick(vm.Footer.Ids[0]).Should().Be(FactFooterCellAction.Copy);
+    }
+
     // ── Real-data sanity ──────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 3 of 8: Area

Third fan-out view. A **consistency-diff against the merged Recipe pilot, not fresh design**. Area exercises a Link *enumeration*, **two** Set-references (#404 Phase-2 "Area ×2"), the copyable-`KEY` footer, and the named **G-b "Area combo" gold** fix.

### Canonical pattern applied

| Element | #404 matrix | Treatment |
|---|---|---|
| Title | T4 bold-gold | → `FactTitleStyle` (G-b); no title-glyph |
| ShortFriendlyName | T2 Fact | → `FactBodyStyle` (quiet) |
| Section headers, landmark group heading | T3 Structure | → `StructureSectionLabelStyle` / `StructureGroupHeaderStyle` (G4 UPPERCASE+tracked) |
| NPC chip cluster | #6/#10 entity enumeration | Canonical pilot pattern: `Density="List"`, vertical `StackPanel`, one `Link` per line via `LinkVm.From` (was a `WrapPanel` of `EntityChip`) |
| **Both** `View all N →` ghost-gold buttons | **T7 Set-reference (Phase-2 "Area ×2")** | → shared `SetRef` summary-form `"<set> · N matches →"`, actionable via the **existing** popup commands. Bespoke local `ViewAllButtonStyle` + now-unused `xmlns:icon` removed (dead code in the migrated file's own scope). |
| Footer | #14 / G-a · ratified **E5** | `<c:FactFooter/>` at the foot (host retained); Area key = **copyable `KEY`** |

### Two substantive judgements

**1. The footer is a copyable `KEY` — the positive E5 case.** The Area key (`AreaSerbule`) *is* a cross-entity reference key: NPCs, lorebooks and quests resolve an area by it. Per ratified E5 rule 2 → `FactFooterVm.Key(...)` (copyable), the pilot path. This is the deliberate **contrast** to PlayerTitle's inert envelope `ROW` — together views 1+3 pin both sides of the E5 copyable-iff-cross-reference discriminator.

**2. Landmark rows are NOT restyled wholesale — only the G-b gold is actioned.** #404 Phase-2 marked the landmark rows ✅ **on-diagonal Fact** (T2 "plain inline text any weight/shade" + "mono flags"). Routing them through `FactBodyStyle` would destroy the deliberate mono (Loc/Combo coordinate readouts) and italic (Desc) — exactly the reasoning the pilot used to leave its mono `ResultEffects` stub inline. Wholesale restyle would be fresh design (anti-goal #1). The **one** required change is the ratified **G-b fix**: the `MeditationPillar` `Combo` Run dropped its gold `#FFD4A847` — the *named* "Area combo" gold-in-Fact violation called out on the #404 G-b evidence list. It stays mono (mono ≠ gold) and inherits the row's plain Fact pigment.

### Anti-goals respected

- One view per PR; `git status` = **only** `AreaDetailView.xaml` + its VM + its tests.
- No primitive / `Resources.xaml` / other-view edits. (The removed `ViewAllButtonStyle` was a *local* view resource, in this file's scope — not shared infra.)
- Grammar not re-opened — per-PR G4 consistency check vs the pilot.
- Legacy chip/popup/command members retained — the 18 existing VM tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **487/487** (18 existing Area + 4 new: `NpcLinks` projection, Npcs/Landmarks `SetRef` summary-form/null, copyable-`KEY` footer)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`

Boot smoke deferred to the consolidated integration pass before Phase 6 (pure restyle, no new code-behind / DI; the per-view full build compiles all BAML + lints resources).

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot** — esp. (a) the disciplined landmark-row decision (✅-Fact left as-is, only the named G-b Combo gold dropped) and (b) the copyable-`KEY` footer as the E5 positive case.

Tracked in #404 · Phase 5 fan-out **3 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
