### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 4/8 — Effect grammar migration

### DIFF
--- a/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/EffectDetailViewModel.cs
@@ -80,6 +80,118 @@ public sealed class EffectDetailViewModel
         ShowRequiredByAbilitiesPopupCommand = new RelayCommand(
             () => ProvenancePopupOpener(RequiredByAbilitiesPopup!, OpenEntityCommand),
             () => RequiredByAbilitiesPopup is not null);
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // Legacy chip/string/command members above stay (the existing tab tests
+        // + the detail-pane contract); these are the grammar-tier carriers the
+        // view binds. #404 Phase-2 / ratified E4 classification for Effect:
+        //   • keyword chips + StackingType chip = SET-REFERENCE, not Link
+        //     (activation scopes the Effects tab to a set of N — E4 RATIFIED,
+        //     "Phase 5 must NOT migrate these into Link");
+        //   • the "View all N →" RequiredBy ghost-gold button = Set-ref
+        //     summary-form (matrix T7);
+        //   • the RequiredBy ability chips = 1:1 entity refs = Link enumeration;
+        //   • Duration / Display-mode = inert label-value Fact (→ FactTable);
+        //   • the ProcsFromAbilityKeyword bordered non-nav tags = the forbidden
+        //     inverted-affordance "grey Fact pill" the availability corollary
+        //     says Phase 5 MUST correct, not preserve → tag-form Set-ref
+        //     (IsActionable=false, still the blue chassis);
+        //   • the inert-mono EnvelopeKey footer (matrix T14) = storage-only ⇒
+        //     the inert `ROW` cell (E5), exactly PlayerTitle's path.
+
+        // Keyword chips → tag-form Set-ref (no count/arrow; the chip shape
+        // carries the tier). Actionable iff the keyword-filter target is wired
+        // (navigable); the per-chip Activate bridges Set-ref's VM-param click to
+        // the host OpenEntityCommand(reference) — the pilot RecipeKeywordSlotVm
+        // "SetRefVm + own command" idiom. Non-navigable ⇒ IsActionable=false:
+        // availability corollary (blue chassis, safe no-op), never a grey pill.
+        KeywordSetRefs = KeywordChips.Select(BuildFilterSetRef).ToList();
+
+        // StackingType → summary-form Set-ref ("{type} · {peers} matches →").
+        // The legacy chip baked the peer count into its DisplayName ("Food
+        // (325)"); the grammar puts the count on the chip via MatchCount.
+        StackingTypeSetRef = BuildStackingTypeSetRef(
+            effect, StackingTypeChip, OpenEntityCommand);
+
+        // "Procs from abilities with keyword" tags: reverse-direction
+        // ability-keyword tags with no wired surface (VM doc: "navigation is
+        // deferred"). Carry-forward #4 / availability corollary: this is the
+        // forbidden inert-bordered-box "grey pill" lie — Phase 5 corrects it to
+        // a tag-form Set-ref on the blue chassis, IsActionable=false (unwired),
+        // NOT preserved as a Fact box.
+        ProcsFromAbilityKeywordSetRefs = ProcsFromAbilityKeywordRows
+            .Select(r => new EffectFilterSetRefVm(
+                new SetRefVm(r.Tag, MatchCount: null, IsActionable: false), null))
+            .ToList();
+
+        // RequiredBy ability chips → unified Link enumeration (Density="List").
+        RequiredByAbilityLinks = RequiredByAbilityChips.Select(LinkVm.From).ToList();
+
+        // "View all N →" RequiredBy ghost-gold button → Set-ref summary-form,
+        // actionable via the EXISTING ShowRequiredByAbilitiesPopupCommand
+        // (parameterless — SetRef passes the VM, RelayCommand ignores it). Null
+        // when no ability relates (section hides). Gold→blue per ratified G-b.
+        RequiredByAbilitiesSetRef = RequiredByAbilitiesPopup is null
+            ? null
+            : new SetRefVm("Required by abilities",
+                MatchCount: RequiredByAbilitiesTotal, IsActionable: true);
+
+        // Duration / Display-mode → ONE inert Fact strip (label-value pairs,
+        // empties skipped; StripText "" ⇒ the shared Style self-hides) —
+        // exactly the pilot StatStrip pattern. StackingType is NOT in here: it
+        // is a Set-ref, not a Fact (kept separate, same visual band).
+        var meta = new List<FactPair>(2);
+        if (!string.IsNullOrEmpty(DurationLabel)) meta.Add(new FactPair("Duration", DurationLabel!));
+        if (!string.IsNullOrEmpty(DisplayMode)) meta.Add(new FactPair("Display mode", DisplayMode!));
+        MetadataStrip = FactTableVm.Strip(meta);
+
+        // Footer (matrix #14 / G-a · ratified E5). The EnvelopeKey was already
+        // an inert mono footer (matrix T14, not click-to-copy) — the author's
+        // data judgement that it is a display/storage-only key. Its grammar
+        // form is the inert `ROW` cell (copyable:false), exactly PlayerTitle's
+        // path — NOT the copyable `KEY`. None() self-hides if keyless.
+        Footer = string.IsNullOrEmpty(EnvelopeKey)
+            ? FactFooterVm.None()
+            : FactFooterVm.Of(new FactFooterId("ROW", EnvelopeKey, copyable: false));
+    }
+
+    private EffectFilterSetRefVm BuildFilterSetRef(EntityChipVm chip)
+    {
+        var wired = chip.IsNavigable && OpenEntityCommand is not null;
+        var activate = wired
+            ? new RelayCommand(() => OpenEntityCommand!.Execute(chip.Reference))
+            : null;
+        // Tag-form (MatchCount null — bare keyword, no count/arrow). IsActionable
+        // mirrors LinkVm.IsNavigable's inverse-of-legacy stance: unwired ⇒ blue
+        // chassis + no-op (availability corollary), never a degraded grey pill.
+        return new EffectFilterSetRefVm(
+            new SetRefVm(chip.DisplayName, MatchCount: null, IsActionable: wired),
+            activate);
+    }
+
+    private static EffectFilterSetRefVm? BuildStackingTypeSetRef(
+        PocoEffect effect, EntityChipVm? legacyChip, ICommand? openEntityCommand)
+    {
+        if (legacyChip is null || string.IsNullOrEmpty(effect.StackingType)) return null;
+        // Recover the peer count the legacy chip baked into "Type (N)" — the
+        // single source of truth is the same DisplayName the tests assert, so
+        // the Set-ref count can't diverge from the legacy chip.
+        var open = legacyChip.DisplayName.LastIndexOf('(');
+        var close = legacyChip.DisplayName.LastIndexOf(')');
+        int? count = open >= 0 && close > open
+            && int.TryParse(
+                legacyChip.DisplayName.AsSpan(open + 1, close - open - 1),
+                out var n)
+            ? n
+            : null;
+        var wired = legacyChip.IsNavigable && openEntityCommand is not null;
+        var activate = wired
+            ? new RelayCommand(() => openEntityCommand!.Execute(legacyChip.Reference))
+            : null;
+        // Summary-form: count rides on the chip ("{type} · N matches →").
+        return new EffectFilterSetRefVm(
+            new SetRefVm(effect.StackingType!, MatchCount: count, IsActionable: wired),
+            activate);
     }
 
     private static void ShowProvenancePopupWindow(ProvenancePopupViewModel vm, ICommand? chipClick) =>
@@ -155,6 +267,67 @@ public sealed class EffectDetailViewModel
     public string? SpewText { get; }
 
     public ICommand? OpenEntityCommand { get; }
+
+    // ── Phase 5 grammar-primitive carriers ──────────────────────────────────
+
+    /// <summary>
+    /// Keyword chips as tag-form Set-references (ratified E4 — keyword chips are
+    /// Set-reference, not Link). Each carries its own Activate command bridging
+    /// the shared <c>SetRef</c>'s VM-param click to <see cref="OpenEntityCommand"/>;
+    /// non-navigable ⇒ <see cref="SetRefVm.IsActionable"/> false (availability
+    /// corollary — blue chassis, safe no-op, never a grey Fact pill).
+    /// </summary>
+    public IReadOnlyList<EffectFilterSetRefVm> KeywordSetRefs { get; }
+
+    /// <summary>
+    /// The StackingType as a summary-form Set-reference
+    /// (<c>"{type} · {peers} matches →"</c>; ratified E4). The count is recovered
+    /// from <see cref="StackingTypeChip"/>'s <c>"Type (N)"</c> DisplayName so it
+    /// cannot diverge from the legacy chip the tests assert. Null when there is
+    /// no StackingType / no peers (the row hides), exactly like the legacy chip.
+    /// </summary>
+    public EffectFilterSetRefVm? StackingTypeSetRef { get; }
+
+    /// <summary>
+    /// "Procs from abilities with keyword" tags as tag-form Set-references with
+    /// <see cref="SetRefVm.IsActionable"/> = false (the reverse-direction filter
+    /// is not wired). Carry-forward #4 / availability corollary: this replaces
+    /// the forbidden inert-bordered-box "grey pill" — still the blue Set-ref
+    /// chassis, NOT a Fact box (Phase 5 must correct, not preserve).
+    /// </summary>
+    public IReadOnlyList<EffectFilterSetRefVm> ProcsFromAbilityKeywordSetRefs { get; }
+
+    /// <summary>
+    /// RequiredBy ability cross-links as the unified <see cref="LinkVm"/>
+    /// (matrix #6/#10). The view renders these <c>Density="List"</c> — the
+    /// canonical pilot enumeration pattern. Projection of
+    /// <see cref="RequiredByAbilityChips"/> (same cap).
+    /// </summary>
+    public IReadOnlyList<LinkVm> RequiredByAbilityLinks { get; }
+
+    /// <summary>
+    /// The "View all N →" RequiredBy drawer as a summary-form Set-reference
+    /// (matrix T7): <c>"Required by abilities · N matches →"</c>, actionable via
+    /// <see cref="ShowRequiredByAbilitiesPopupCommand"/>. Null when no ability
+    /// relates (section hides). Gold→blue per ratified G-b.
+    /// </summary>
+    public SetRefVm? RequiredByAbilitiesSetRef { get; }
+
+    /// <summary>
+    /// Duration / Display-mode as one inert Fact strip (label-value pairs,
+    /// empties skipped; empty ⇒ <see cref="FactTableVm.StripText"/> "" so the
+    /// shared <c>FactTable</c> Style self-hides). Mirrors the pilot StatStrip;
+    /// StackingType is deliberately NOT here (it is a Set-ref, not a Fact).
+    /// </summary>
+    public FactTableVm MetadataStrip { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14 / G-a · ratified E5). The EnvelopeKey
+    /// was already an inert-mono footer (matrix T14) — a display/storage-only
+    /// key ⇒ the inert <c>ROW</c> cell (PlayerTitle's path), not a copyable
+    /// <c>KEY</c>. <see cref="FactFooterVm.None"/> (self-hides) if keyless.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -463,3 +636,31 @@ public sealed record EffectConditionalSpecialValueRow(string Display, IReadOnlyL
 /// navigation is deferred to a follow-up.
 /// </summary>
 public sealed record EffectProcsFromAbilityKeywordRow(string Tag);
+
+/// <summary>
+/// A Set-reference carrier (the pilot <c>RecipeKeywordSlotVm</c> idiom): the
+/// <see cref="SetRefVm"/> the shared <c>SetRef</c> binds, plus the per-chip
+/// <see cref="Activate"/> command that bridges <c>SetRef.ActivateCommand</c>
+/// (which passes the <see cref="SetRefVm"/>) to the host's
+/// <c>OpenEntityCommand(reference)</c>. <see cref="Activate"/> is null for an
+/// unwired tag (availability corollary — the chip still renders on the blue
+/// chassis; the click is a safe no-op).
+/// </summary>
+public sealed class EffectFilterSetRefVm
+{
+    public EffectFilterSetRefVm(SetRefVm setRef, System.Windows.Input.ICommand? activate)
+    {
+        SetRef = setRef;
+        Activate = activate;
+    }
+
+    /// <summary>The data carrier the shared <c>SetRef</c> control binds.</summary>
+    public SetRefVm SetRef { get; }
+
+    /// <summary>
+    /// Parameterless reveal/filter command wired to <c>SetRef.ActivateCommand</c>
+    /// (it ignores the passed <see cref="SetRefVm"/> and invokes the host
+    /// <c>OpenEntityCommand</c> with the captured reference). Null when unwired.
+    /// </summary>
+    public System.Windows.Input.ICommand? Activate { get; }
+}

--- a/src/Silmarillion.Module/Views/EffectDetailView.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailView.xaml
@@ -4,7 +4,6 @@
              xmlns:local="clr-namespace:Silmarillion.Views"
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -17,241 +16,207 @@
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- Conditional sub-table rows (DoT layered by ability + tooltip special-value). -->
+            <!-- Conditional sub-table rows: #404 Phase-2 ✅ Fact (T2 plain
+                 text). Routed to FactBodyStyle (the inline #CCFFFFFF / hint
+                 size dropped — the style owns family·size·fg·wrap). The
+                 ProcsFromAbilityKeyword bordered-box DataTemplate is REMOVED:
+                 those tags are now tag-form Set-references (carry-forward #4 /
+                 availability corollary — the forbidden grey-pill is corrected,
+                 not preserved). -->
             <DataTemplate DataType="{x:Type vm:EffectConditionalDotRow}">
-                <TextBlock Text="{Binding Display}" Foreground="#CCFFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}"
-                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                <TextBlock Text="{Binding Display}" Style="{StaticResource FactBodyStyle}"
+                           Margin="0,0,0,2"/>
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:EffectConditionalSpecialValueRow}">
-                <TextBlock Text="{Binding Display}" Foreground="#CCFFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}"
-                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                <TextBlock Text="{Binding Display}" Style="{StaticResource FactBodyStyle}"
+                           Margin="0,0,0,2"/>
             </DataTemplate>
-            <DataTemplate DataType="{x:Type vm:EffectProcsFromAbilityKeywordRow}">
-                <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
-                        CornerRadius="3" Padding="6,2" Margin="0,0,4,3">
-                    <TextBlock Text="{Binding Tag}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeSmall}"/>
-                </Border>
+
+            <!-- One Set-reference chip: the pilot keyword-slot idiom. The item
+                 DataContext is an EffectFilterSetRefVm (SetRef + per-chip
+                 Activate); SetRef binds the SetRefVm, its ActivateCommand
+                 bridges to the captured OpenEntityCommand(reference). Unwired
+                 (Activate null / IsActionable false) ⇒ availability-corollary
+                 no-op on the same blue chassis (never a grey Fact pill). -->
+            <DataTemplate x:Key="FilterSetRefTemplate" DataType="{x:Type vm:EffectFilterSetRefVm}">
+                <ContentControl Content="{Binding SetRef}" Margin="0,0,4,4">
+                    <ContentControl.ContentTemplate>
+                        <DataTemplate>
+                            <c:SetRef ActivateCommand="{Binding DataContext.Activate, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                        </DataTemplate>
+                    </ContentControl.ContentTemplate>
+                </ContentControl>
             </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
+    <!-- Phase-5 fan-out · view 4 (Effect) — a consistency-diff against the
+         merged Recipe pilot, NOT fresh design. #404 Phase-2 / ratified E4:
+         keyword chips + StackingType chip are Set-reference (not Link —
+         "Phase 5 must NOT migrate these into Link"); the RequiredBy ability
+         chips are a Link enumeration; the "View all N →" + StackingType count
+         are Set-ref summary-form; Duration/Display-mode are inert label-value
+         Fact; the ProcsFromAbilityKeyword bordered tags are the availability-
+         corollary grey-pill that Phase 5 corrects to tag-form Set-ref; the
+         inert-mono EnvelopeKey footer (matrix T14) is a storage-only inert ROW.
+
+         Footer (matrix #14 / G-a · ratified E5): the pilot move — the inert
+         DockPanel.Bottom mono TextBlock becomes <c:FactFooter/> at the foot of
+         the wrapped content (host retained unchanged). -->
     <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Footer: envelope key (mono, bottom-right) — per the detail-view convention. -->
-            <TextBlock DockPanel.Dock="Bottom" Text="{Binding EnvelopeKey}"
-                       Foreground="#88FFFFFF"
-                       FontFamily="{DynamicResource AppMonoFontFamily}"
-                       FontSize="{DynamicResource AppFontSizeSmall}"
-                       Margin="0,8,0,0" HorizontalAlignment="Right"
-                       VerticalAlignment="Bottom"/>
-
             <StackPanel>
-                <!-- ─── 1. Header: icon + name ─── -->
+                <!-- ─── 1. Header: title-glyph + Fact-title ───
+                     Icon → the fixed-40px FactTitleGlyphStyle (entity stamp;
+                     keep the optional-icon Visibility). Title → FactTitleStyle
+                     (inline gold/header-font/XLarge dropped, G-b). -->
                 <DockPanel Margin="0,0,0,10">
                     <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                 Width="40" Height="40" Margin="0,0,10,0"
-                                 VerticalAlignment="Top"
+                                 Style="{StaticResource FactTitleGlyphStyle}"
+                                 Margin="0,0,10,0" VerticalAlignment="Top"
                                  Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
                     <StackPanel VerticalAlignment="Center">
                         <TextBlock Text="{Binding DisplayName}"
-                                   FontFamily="{DynamicResource AppHeaderFontFamily}"
-                                   FontSize="{DynamicResource AppFontSizeXLarge}"
-                                   Foreground="#FFD4A847"/>
+                                   Style="{StaticResource FactTitleStyle}"/>
                     </StackPanel>
                 </DockPanel>
 
-                <!-- ─── 2. Description ─── -->
+                <!-- ─── 2. Description ─── Matrix T2 → FactBodyStyle. -->
                 <TextBlock c:FormattedText.Text="{Binding Description}"
-                           Foreground="#CCFFFFFF"
-                           FontSize="{DynamicResource AppFontSizeHint}"
-                           TextWrapping="Wrap" Margin="0,0,0,10"
+                           Style="{StaticResource FactBodyStyle}"
+                           Margin="0,0,0,10"
                            Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
-                <!-- ─── 3. Metadata strip: duration / stacking-type chip / display mode.
-                       The stacking-type row carries the navigation affordance (clicking the chip
-                       filters the Effects tab to peers in the same stacking group); the chip
-                       label includes a peer-count suffix so the group's size is visible at glance
-                       time. Per the design folded in from the separate 'Stacks with' section
-                       (#259's keyword-collapse precedent). -->
+                <!-- ─── 3. Metadata: inert Fact strip (Duration · Display mode)
+                       + the StackingType Set-reference (E4 — a filter to peers,
+                       NOT a Link). The FactTable self-hides when both are
+                       empty; the StackingType row hides when null. -->
                 <StackPanel Margin="0,0,0,10">
-                    <StackPanel.Style>
-                        <Style TargetType="StackPanel">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding DurationLabel, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding StackingTypeChip, Converter={StaticResource NullToVis}}" Value="Visible">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </StackPanel.Style>
-                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                               Margin="0,0,0,2"
-                               Visibility="{Binding DurationLabel, Converter={StaticResource NullOrEmptyToVis}}">
-                        <Run Text="Duration: " Foreground="#88FFFFFF"/>
-                        <Run Text="{Binding DurationLabel, Mode=OneWay}"/>
-                    </TextBlock>
+                    <c:FactTable DataContext="{Binding MetadataStrip}"
+                                 HorizontalAlignment="Left" Margin="0,0,0,4"/>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,2"
-                                Visibility="{Binding StackingTypeChip, Converter={StaticResource NullToVis}}">
-                        <TextBlock Text="Stacking type: " Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center"/>
-                        <ContentControl Content="{Binding StackingTypeChip}" VerticalAlignment="Center">
-                            <ContentControl.Resources>
-                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                                Visibility="{Binding StackingTypeSetRef, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="Stacking type:"
+                                   Style="{StaticResource StructureInlinePrefixStyle}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl DataContext="{Binding StackingTypeSetRef}"
+                                        Content="{Binding SetRef}" VerticalAlignment="Center">
+                            <ContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <c:SetRef ActivateCommand="{Binding DataContext.Activate, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
                                 </DataTemplate>
-                            </ContentControl.Resources>
+                            </ContentControl.ContentTemplate>
                         </ContentControl>
                     </StackPanel>
-                    <TextBlock Foreground="#CCFFFFFF" FontSize="{DynamicResource AppFontSizeHint}"
-                               Margin="0,0,0,2"
-                               Visibility="{Binding DisplayMode, Converter={StaticResource NullOrEmptyToVis}}">
-                        <Run Text="Display mode: " Foreground="#88FFFFFF"/>
-                        <Run Text="{Binding DisplayMode, Mode=OneWay}"/>
-                    </TextBlock>
                 </StackPanel>
 
-                <!-- ─── 4. Keywords ─── -->
+                <!-- ─── 4. Keywords ─── Section label → Structure. Keyword
+                       chips → tag-form Set-references (ratified E4), in a
+                       wrap row (the grammar's t-set-row flex container). -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding KeywordChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Keywords" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding KeywordChips}">
+                            Visibility="{Binding KeywordSetRefs.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Keywords" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding KeywordSetRefs}"
+                                  ItemTemplate="{StaticResource FilterSetRefTemplate}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- ─── 5. Conditional rules (DoTs + Special values) ─── -->
+                <!-- ─── 5. Conditional rules ─── Section label → Structure;
+                       the two sub-labels → Structure group headers; rows are
+                       Fact (FactBodyStyle, via the DataType templates). -->
                 <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding HasConditionalRuleRows, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="Conditional rules" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Conditional rules" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <StackPanel Margin="0,0,0,4"
                                 Visibility="{Binding ConditionalDotRows.Count, Converter={StaticResource PositiveIntToVis}}">
-                        <TextBlock Text="DoT effects layered on by abilities" Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,2"/>
+                        <TextBlock Text="DoT effects layered on by abilities"
+                                   Style="{StaticResource StructureGroupHeaderStyle}" Margin="0,0,0,2"/>
                         <ItemsControl ItemsSource="{Binding ConditionalDotRows}"/>
                     </StackPanel>
                     <StackPanel
                                 Visibility="{Binding ConditionalSpecialValueRows.Count, Converter={StaticResource PositiveIntToVis}}">
-                        <TextBlock Text="Tooltip values surfaced by abilities" Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,2"/>
+                        <TextBlock Text="Tooltip values surfaced by abilities"
+                                   Style="{StaticResource StructureGroupHeaderStyle}" Margin="0,0,0,2"/>
                         <ItemsControl ItemsSource="{Binding ConditionalSpecialValueRows}"/>
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ─── 6. (was 'Stacks with' — folded into Section 3's StackingType chip
-                       since the standalone section was redundant once the metadata strip's
-                       row carried the navigation affordance directly.) ─── -->
-
-                <!-- ─── 7. Required by abilities ─── -->
+                <!-- ─── 7. Required by abilities ─── Section label →
+                       Structure; ability chips → Link enumeration
+                       (Density="List", canonical pilot pattern); "View all
+                       N →" ghost-gold button → Set-ref summary-form via the
+                       existing popup command (gold→blue, ratified G-b). -->
                 <StackPanel Margin="0,0,0,10">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
                             <Setter Property="Visibility" Value="Collapsed"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding RequiredByAbilityChips.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding RequiredByAbilityLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </StackPanel.Style>
-                    <TextBlock Text="Required by abilities" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding RequiredByAbilityChips}">
+                    <TextBlock Text="Required by abilities" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding RequiredByAbilityLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
+                                <!-- G4-ratified: enumeration → Density="List" (canonical pattern). -->
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:EffectDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <!-- "View all N →" — opens the shared provenance popup fed the index
-                         directly (#318). No longer a synthetic-kind deep link: the popup
-                         renders membership AND provenance with no second derivation.
-                         Always visible whenever any ability relates (independent of the
-                         chip cap), styled like ActionChip (ghost fill, ListFilter glyph)
-                         so it reads as "go see the full set", not "open an entity". -->
-                    <Button Margin="0,4,0,0" Padding="6,2"
-                            HorizontalAlignment="Left" Cursor="Hand"
-                            Command="{Binding ShowRequiredByAbilitiesPopupCommand}"
-                            Visibility="{Binding RequiredByAbilitiesPopup, Converter={StaticResource NullToVis}}">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Setter Property="Background" Value="Transparent"/>
-                                <Setter Property="BorderBrush" Value="#66D4A847"/>
-                                <Setter Property="BorderThickness" Value="1"/>
-                                <Setter Property="Foreground" Value="#FFD4A847"/>
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="Background" Value="#22D4A847"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="3" Padding="{TemplateBinding Padding}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <icon:PackIconLucide Kind="ListFilter" Width="12" Height="12"
-                                                             Foreground="{TemplateBinding Foreground}"
-                                                             Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                        <TextBlock Foreground="{TemplateBinding Foreground}"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   VerticalAlignment="Center">
-                                            <Run Text="View all "/><Run Text="{Binding RequiredByAbilitiesTotal, Mode=OneWay}"/><Run Text=" →"/>
-                                        </TextBlock>
-                                    </StackPanel>
-                                </Border>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
+                    <ContentControl Content="{Binding RequiredByAbilitiesSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding RequiredByAbilitiesSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowRequiredByAbilitiesPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- ─── 8. Procs from abilities with keyword ─── -->
+                <!-- ─── 8. Procs from abilities with keyword ─── Section
+                       label → Structure. The bordered non-nav tags become
+                       tag-form Set-references with IsActionable=false
+                       (availability corollary — blue chassis, the reverse
+                       filter is simply not wired yet; NOT a Fact box). -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding ProcsFromAbilityKeywordRows.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Procs from abilities with keyword" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding ProcsFromAbilityKeywordRows}">
+                            Visibility="{Binding ProcsFromAbilityKeywordSetRefs.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Procs from abilities with keyword" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding ProcsFromAbilityKeywordSetRefs}"
+                                  ItemTemplate="{StaticResource FilterSetRefTemplate}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- ─── 9. Spew text — combat float text shown on effect application/refresh ─── -->
+                <!-- ─── 9. Spew text — combat float text ───
+                       Quiet Fact flavor → FactBodyStyle + italic (inline
+                       #88/small dropped — the style owns pigment). -->
                 <TextBlock Margin="0,0,0,10"
-                           Foreground="#88FFFFFF" FontStyle="Italic"
-                           FontSize="{DynamicResource AppFontSizeSmall}"
-                           TextWrapping="Wrap"
+                           Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
                            Visibility="{Binding SpewText, Converter={StaticResource NullOrEmptyToVis}}">
                     <Run Text="Combat float text: "/>
                     <Run Text="{Binding SpewText, Mode=OneWay}"/>
                 </TextBlock>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). The
+                     EnvelopeKey was already an inert mono footer (matrix T14)
+                     ⇒ a storage-only inert ROW (PlayerTitle's path), not a
+                     copyable KEY. FactFooterVm.None() self-hides at 0 ids. -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/EffectsTabViewModelTests.cs
@@ -490,6 +490,187 @@ public sealed class EffectsTabViewModelTests
         vm.DetailViewModel!.RequiredByAbilityChips.Should().HaveCount(2);
     }
 
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void KeywordSetRefs_AreTagForm_ActionableMirrorsNavigability()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "X", Keywords = ["FrostShard"] },
+            },
+        };
+        // EffectKeyword target registered ⇒ navigable ⇒ the filter is wired.
+        var vm = new EffectsTabViewModel(
+            refData, NavFactory.WithKinds(EntityKind.EffectKeyword),
+            new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings());
+        vm.SelectedRow = vm.AllEffects.Single();
+        var d = vm.DetailViewModel!;
+
+        d.KeywordSetRefs.Should().ContainSingle();
+        var k = d.KeywordSetRefs[0];
+        k.SetRef.Label.Should().Be("FrostShard");
+        k.SetRef.IsSummaryForm.Should().BeFalse("keyword chips are tag-form (no count/arrow)");
+        k.SetRef.MatchCount.Should().BeNull();
+        k.SetRef.IsActionable.Should().BeTrue("EffectKeyword target registered ⇒ filter wired");
+        k.Activate.Should().NotBeNull();
+
+        // Unwired: no EffectKeyword target ⇒ availability corollary (still a
+        // tag-form Set-ref, IsActionable=false, no command — NOT a Fact pill).
+        var unwired = BuildVm(refData);
+        unwired.SelectedRow = unwired.AllEffects.Single();
+        var ku = unwired.DetailViewModel!.KeywordSetRefs[0];
+        ku.SetRef.IsActionable.Should().BeFalse();
+        ku.Activate.Should().BeNull();
+        SetRef.ResolveClick(ku.SetRef).Should().Be(SetRefClickAction.Unavailable);
+    }
+
+    [Fact]
+    public void StackingTypeSetRef_IsSummaryForm_CountMatchesLegacyChip()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "A", StackingType = "Food" },
+            },
+            EffectsByStackingTypeMap =
+            {
+                ["Food"] = new[]
+                {
+                    new PocoEffect { InternalName = "effect_1" },
+                    new PocoEffect { InternalName = "effect_2" },
+                    new PocoEffect { InternalName = "effect_3" },
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_1");
+        var d = vm.DetailViewModel!;
+
+        // Legacy chip still "Food (2)" (2 peers excluding self); the Set-ref
+        // count is recovered from it so the two can't diverge.
+        d.StackingTypeChip!.DisplayName.Should().Be("Food (2)");
+        d.StackingTypeSetRef.Should().NotBeNull();
+        d.StackingTypeSetRef!.SetRef.Label.Should().Be("Food");
+        d.StackingTypeSetRef.SetRef.MatchCount.Should().Be(2);
+        d.StackingTypeSetRef.SetRef.IsSummaryForm.Should().BeTrue();
+        d.StackingTypeSetRef.SetRef.DisplayText.Should().Be("Food · 2 matches →");
+
+        // No StackingType ⇒ no Set-ref (row hides), exactly like the chip.
+        var noStack = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_9"] = new PocoEffect { InternalName = "effect_9", Name = "Z" } },
+        };
+        var vm2 = BuildVm(noStack);
+        vm2.SelectedRow = vm2.AllEffects.Single();
+        vm2.DetailViewModel!.StackingTypeSetRef.Should().BeNull();
+    }
+
+    [Fact]
+    public void ProcsFromAbilityKeyword_AreUnwiredTagFormSetRefs_NotFactPills()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect
+                {
+                    InternalName = "effect_1", Name = "X", AbilityKeywords = ["FireSpell", "NiceAttack"],
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.Single();
+        var d = vm.DetailViewModel!;
+
+        d.ProcsFromAbilityKeywordSetRefs.Select(s => s.SetRef.Label)
+            .Should().Equal("FireSpell", "NiceAttack");
+        d.ProcsFromAbilityKeywordSetRefs.Should().OnlyContain(s =>
+            !s.SetRef.IsSummaryForm && !s.SetRef.IsActionable && s.Activate == null,
+            "availability corollary: unwired tag-form Set-ref on the blue chassis, never a Fact box");
+    }
+
+    [Fact]
+    public void RequiredByAbilityLinks_AndSetRef_ProjectChipsAndPopupAffordance()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect { InternalName = "effect_1", Name = "X", Keywords = ["K"] },
+            },
+            AbilitiesByEffectKeywordMap =
+            {
+                ["K"] = new[]
+                {
+                    new Ability { InternalName = "AbilA", Name = "Ability A", Skill = "S", Level = 1 },
+                    new Ability { InternalName = "AbilB", Name = "Ability B", Skill = "S", Level = 2 },
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.Single();
+        var d = vm.DetailViewModel!;
+
+        d.RequiredByAbilityLinks.Select(l => l.DisplayName)
+            .Should().Equal(d.RequiredByAbilityChips.Select(c => c.DisplayName));
+        d.RequiredByAbilityLinks.Should().OnlyContain(l => l.Glyph == LinkGlyph.CombatAbility);
+        d.RequiredByAbilitiesSetRef.Should().NotBeNull();
+        d.RequiredByAbilitiesSetRef!.IsSummaryForm.Should().BeTrue();
+        d.RequiredByAbilitiesSetRef.IsActionable.Should().BeTrue();
+        d.RequiredByAbilitiesSetRef.DisplayText.Should().Be("Required by abilities · 2 matches →");
+    }
+
+    [Fact]
+    public void MetadataStrip_IsLabelValueFact_SelfHidingWhenEmpty()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey =
+            {
+                ["effect_1"] = new PocoEffect
+                {
+                    InternalName = "effect_1", Name = "A", Duration = "30", DisplayMode = "Curse",
+                },
+                ["effect_2"] = new PocoEffect { InternalName = "effect_2", Name = "B" },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_1");
+        var d = vm.DetailViewModel!;
+
+        d.MetadataStrip.Layout.Should().Be(FactTableLayout.Strip);
+        d.MetadataStrip.Pairs.Should().BeEquivalentTo(new[]
+        {
+            new FactPair("Duration", "30 seconds"),
+            new FactPair("Display mode", "Curse"),
+        }, o => o.WithStrictOrdering());
+
+        vm.SelectedRow = vm.AllEffects.First(r => r.EnvelopeKey == "effect_2");
+        vm.DetailViewModel!.MetadataStrip.StripText.Should().BeEmpty("no duration/mode ⇒ strip self-hides");
+    }
+
+    [Fact]
+    public void Footer_EnvelopeKey_IsInertStorageRow_NotCopyable()
+    {
+        var refData = new StubReferenceData
+        {
+            EffectsByKey = { ["effect_10003"] = new PocoEffect { InternalName = "effect_10003", Name = "Sticky!" } },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllEffects.Single();
+
+        var f = vm.DetailViewModel!.Footer;
+        f.Ids.Should().ContainSingle();
+        f.Ids[0].LabelTag.Should().Be("ROW");
+        f.Ids[0].Value.Should().Be("effect_10003");
+        f.Ids[0].Copyable.Should().BeFalse("the effect EnvelopeKey was already an inert mono footer (matrix T14)");
+        FactFooter.ResolveCellClick(f.Ids[0]).Should().Be(FactFooterCellAction.Inert);
+    }
+
     private static EffectsTabViewModel BuildVm(StubReferenceData refData) =>
         new EffectsTabViewModel(
             refData,


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 4 of 8: Effect

Fourth and **richest** fan-out view. A consistency-diff against the merged Recipe pilot, not fresh design. Effect is where ratified **E4** (keyword/stacking chips are Set-reference, *not* Link) and the **availability corollary** (carry-forward #4) both bite.

### Canonical pattern applied

| Element | #404 matrix | Treatment |
|---|---|---|
| Header icon / title | title-glyph / T4 | `FactTitleGlyphStyle` (fixed-40px, optional-icon Visibility kept) / `FactTitleStyle` |
| Description | T2 | `FactBodyStyle` |
| **Keyword chips** | **ratified E4 → Set-reference** | tag-form `SetRef` (no count/arrow). `IsActionable` mirrors navigability; per-chip `Activate` bridges `SetRef`'s VM-param click → host `OpenEntityCommand(reference)` (pilot `RecipeKeywordSlotVm` idiom). Unwired ⇒ availability corollary. |
| **StackingType chip** | **ratified E4 → Set-reference** | summary-form `SetRef` `"{type} · N matches →"`; count **recovered from the legacy chip's `"Type (N)"` DisplayName** so they cannot diverge |
| ProcsFromAbilityKeyword bordered tags | T1-as-Fact ❌ / carry-forward #4 | The forbidden inverted-affordance grey-pill the availability corollary says Phase 5 **must correct, not preserve** → tag-form `SetRef` `IsActionable=false` (blue chassis; reverse filter just isn't wired). Bordered-box template removed. |
| RequiredBy ability chips | #6/#10 enumeration | `Link` `Density="List"` (canonical pilot pattern) |
| `View all N →` button | T7 | `SetRef` summary-form via the **existing** popup command (gold→blue, G-b) |
| Duration / Display-mode | label-value Fact | ONE inert `FactTable` Strip (empties skipped, self-hiding) — pilot StatStrip. **StackingType deliberately NOT in the strip** (it's a Set-ref, not a Fact) |
| Conditional-rule rows / sub-labels | T2 / T3 | `FactBodyStyle` / `StructureGroupHeaderStyle`; section labels `StructureSectionLabelStyle` |
| Footer | #14 / G-a · ratified **E5** | inert `DockPanel.Bottom` mono (matrix **T14, already non-copyable**) → `<c:FactFooter/>`; EnvelopeKey = storage-only **inert `ROW`** (PlayerTitle's path) |

### Substantive judgements

1. **E4 is the headline.** Keyword + StackingType chips are Set-reference, not Link — the single biggest Phase-2 finding, ratified, "Phase 5 must not migrate these into Link." Done: tag-form (keywords) and summary-form (StackingType) on the blue chassis.
2. **The availability corollary, applied for real.** `ProcsFromAbilityKeyword` was a bordered non-nav box — exactly the "inverted-affordance grey pill" carry-forward #4 says must be *corrected*. It is now a tag-form `SetRef` with `IsActionable=false` (blue chassis, safe no-op), **not** preserved as a Fact box.
3. **Count parity without divergence.** The StackingType Set-ref count is parsed back out of the legacy chip's `"Type (N)"` DisplayName (the same value the existing tests assert), so the grammar surface and the legacy contract share one source of truth.
4. **Footer is inert `ROW`.** The EffectKeyword EnvelopeKey was *already* an inert mono footer (matrix T14, deliberately non-copyable) — its grammar form is the inert `ROW`, consistent with E5 being data-governed and with PlayerTitle.

### Anti-goals respected

- One view per PR; `git status` = only `EffectDetailView.xaml` + its VM + the Effect test file (no separate detail-test file exists — the detail VM is tested through `EffectsTabViewModelTests`).
- No primitive / `Resources.xaml` / other-view edits. Now-unused local `xmlns:icon` removed (this file's own scope).
- Grammar not re-opened; legacy chip/string/command members retained — existing Effect tab tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **489/489** (existing Effect tab tests + 6 new: keyword tag-form & actionable-vs-availability-corollary, StackingType summary-form/count-parity, Procs unwired tag-form, RequiredBy Link+SetRef, MetadataStrip self-hide, inert-`ROW` footer)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`

Boot smoke deferred to the consolidated integration pass before Phase 6 (this view introduces a new VM↔command bridge — `EffectFilterSetRefVm` — so it is a priority candidate for the integration eyeball; the per-view full build compiles its BAML + lints resources).

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot** — esp. (a) the E4 keyword/stacking → Set-ref split, (b) the availability-corollary correction of the Procs grey-pill, (c) the StackingType count-parity mechanism, (d) the `EffectFilterSetRefVm` VM↔command bridge (the one genuinely new mechanic vs prior views — modelled on the pilot's `RecipeKeywordSlotVm`).

Tracked in #404 · Phase 5 fan-out **4 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
