### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 5/8 — Npc grammar migration

### DIFF
--- a/src/Silmarillion.Module/ViewModels/NpcDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcDetailViewModel.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Npcs;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
@@ -43,6 +46,61 @@ public sealed class NpcDetailViewModel
         GiftSentimentTiers = giftSentimentTiers;
         AreaChip = areaChip;
         OpenEntityCommand = openEntityCommand;
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // Legacy chip/row members above stay (the existing tab tests + the
+        // detail-pane contract); these are the grammar-tier carriers the view
+        // binds. #404 Phase-2 classification for Npc:
+        //   • Area chip = 1:1 ref = inline Prose Link;
+        //   • Teaches/Sells/Quests chip clusters = 1:1 entity enumerations =
+        //     Link Density="List";
+        //   • Store-cap ItemKeyword detail chips = keyword filters ⇒
+        //     Set-reference (ratified E4 — NOT Link);
+        //   • the gold service-Type label = the named G-b "Npc service type"
+        //     gold-in-Fact violation (dropped);
+        //   • NPC InternalName footer = a cross-entity reference key (areas /
+        //     quests resolve an NPC by it) ⇒ copyable KEY (Area's path).
+        // NpcServiceRow / NpcServiceDetailLine are records in their own files
+        // (outside this view's diff-guard scope), so they are WRAPPED here, not
+        // edited — exactly the pilot's RecipeRequirementRow→RecipeRequirementRowVm
+        // approach.
+
+        AreaLink = AreaChip is null ? null : LinkVm.From(AreaChip);
+        TaughtRecipeLinks = TaughtRecipes.Select(LinkVm.From).ToList();
+        TaughtAbilityLinks = TaughtAbilities.Select(LinkVm.From).ToList();
+        SoldItemLinks = SoldItems.Select(LinkVm.From).ToList();
+        QuestLinks = Quests.Select(LinkVm.From).ToList();
+
+        ServiceRowVms = Services
+            .Select(s => new NpcServiceRowVm(
+                s.Type,
+                s.MinFavorTier,
+                s.Details
+                    .Select(d => new NpcServiceDetailLineVm(
+                        d.Text,
+                        d.Chips.Select(BuildFilterSetRef).ToList()))
+                    .ToList()))
+            .ToList();
+
+        Footer = string.IsNullOrEmpty(InternalName)
+            ? FactFooterVm.None()
+            : FactFooterVm.Key(InternalName);
+    }
+
+    private NpcFilterSetRefVm BuildFilterSetRef(EntityChipVm chip)
+    {
+        // Store-cap keyword chips filter the Items tab ⇒ tag-form Set-ref
+        // (ratified E4). Actionable iff the filter target is wired (navigable +
+        // a host command); the per-chip Activate bridges SetRef's VM-param
+        // click to OpenEntityCommand(reference) — the pilot RecipeKeywordSlotVm
+        // idiom. Unwired ⇒ availability corollary (blue chassis, safe no-op).
+        var wired = chip.IsNavigable && OpenEntityCommand is not null;
+        var activate = wired
+            ? new RelayCommand(() => OpenEntityCommand!.Execute(chip.Reference))
+            : null;
+        return new NpcFilterSetRefVm(
+            new SetRefVm(chip.DisplayName, MatchCount: null, IsActionable: wired),
+            activate);
     }
 
     public Npc Npc { get; }
@@ -71,10 +129,102 @@ public sealed class NpcDetailViewModel
     /// <summary>Comma-joined list of <see cref="GiftSentimentTiers"/> for the XAML <c>Run</c>.</summary>
     public string GiftSentimentTiersDisplay => string.Join(", ", GiftSentimentTiers);
 
+    // ── Phase 5 grammar-primitive carriers ──────────────────────────────────
+
+    /// <summary>Home-area cross-link as the unified <see cref="LinkVm"/> (inline
+    /// Prose Link behind the Structure "Area:" prefix). Null when no area.</summary>
+    public LinkVm? AreaLink { get; }
+
+    /// <summary>Taught-recipe cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> TaughtRecipeLinks { get; }
+
+    /// <summary>Taught-ability cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> TaughtAbilityLinks { get; }
+
+    /// <summary>Sold-item cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> SoldItemLinks { get; }
+
+    /// <summary>Quest cross-links as <see cref="LinkVm"/> (Density="List"; G-c
+    /// degrade keeps them identical at rest until the Quests tab ships).</summary>
+    public IReadOnlyList<LinkVm> QuestLinks { get; }
+
+    /// <summary>
+    /// Services wrapped for the grammar: the gold Type label is dropped (named
+    /// G-b "Npc service type" violation), the favor pill de-boxed, and each
+    /// detail line's Store-cap ItemKeyword chips become tag-form Set-references
+    /// (ratified E4). Wraps <see cref="NpcServiceRow"/> (out of edit scope).
+    /// </summary>
+    public IReadOnlyList<NpcServiceRowVm> ServiceRowVms { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14 / G-a · ratified E5). The NPC
+    /// InternalName is a cross-entity reference key (areas / quests resolve an
+    /// NPC by it) ⇒ the copyable <c>KEY</c> (Area's path), not an inert
+    /// envelope <c>ROW</c>. <see cref="FactFooterVm.None"/> if keyless.
+    /// </summary>
+    public FactFooterVm Footer { get; }
+
     /// <summary>
     /// Command invoked when the user clicks a cross-link chip (taught recipe / sold item).
     /// Receives the chip's <see cref="Mithril.Shared.Reference.EntityRef"/>. Wired by
     /// <see cref="NpcsTabViewModel"/> to the navigator.
     /// </summary>
     public ICommand? OpenEntityCommand { get; }
+}
+
+/// <summary>
+/// View-side grammar wrapper of a <see cref="NpcServiceRow"/> (which lives in
+/// its own file, outside this view's edit scope — wrapped, not mutated, exactly
+/// like the pilot's <c>RecipeRequirementRowVm</c>). The view styles
+/// <see cref="Type"/> as a Structure group header (the named G-b
+/// "Npc service type" gold dropped) and <see cref="MinFavorTier"/> as inert
+/// Fact (the bordered pill de-boxed).
+/// </summary>
+public sealed class NpcServiceRowVm
+{
+    public NpcServiceRowVm(string type, string? minFavorTier, IReadOnlyList<NpcServiceDetailLineVm> details)
+    {
+        Type = type;
+        MinFavorTier = minFavorTier;
+        Details = details;
+    }
+
+    public string Type { get; }
+    public string? MinFavorTier { get; }
+    public bool HasMinFavorTier => !string.IsNullOrEmpty(MinFavorTier);
+    public IReadOnlyList<NpcServiceDetailLineVm> Details { get; }
+}
+
+/// <summary>One service detail line: prose <see cref="Text"/> (inert Fact) plus
+/// the Store-cap keyword chips reshaped to tag-form Set-references (E4).</summary>
+public sealed class NpcServiceDetailLineVm
+{
+    public NpcServiceDetailLineVm(string text, IReadOnlyList<NpcFilterSetRefVm> setRefs)
+    {
+        Text = text;
+        SetRefs = setRefs;
+    }
+
+    public string Text { get; }
+    public IReadOnlyList<NpcFilterSetRefVm> SetRefs { get; }
+}
+
+/// <summary>
+/// A Set-reference carrier (the pilot <c>RecipeKeywordSlotVm</c> idiom): the
+/// <see cref="SetRefVm"/> the shared <c>SetRef</c> binds plus the per-chip
+/// <see cref="Activate"/> bridging <c>SetRef.ActivateCommand</c> (which passes
+/// the VM) to the host <c>OpenEntityCommand(reference)</c>.
+/// <see cref="Activate"/> is null for an unwired tag (availability corollary —
+/// still the blue chassis; the click is a safe no-op).
+/// </summary>
+public sealed class NpcFilterSetRefVm
+{
+    public NpcFilterSetRefVm(SetRefVm setRef, ICommand? activate)
+    {
+        SetRef = setRef;
+        Activate = activate;
+    }
+
+    public SetRefVm SetRef { get; }
+    public ICommand? Activate { get; }
 }

--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:local="clr-namespace:Silmarillion.Views"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -14,36 +14,67 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- One Set-reference chip (the pilot keyword-slot idiom). Item
+                 DataContext is an NpcFilterSetRefVm (SetRef + per-chip
+                 Activate); unwired (Activate null / IsActionable false) ⇒
+                 availability-corollary no-op on the blue chassis. -->
+            <DataTemplate x:Key="FilterSetRefTemplate" DataType="{x:Type vm:NpcFilterSetRefVm}">
+                <ContentControl Content="{Binding SetRef}" Margin="0,0,4,4">
+                    <ContentControl.ContentTemplate>
+                        <DataTemplate>
+                            <c:SetRef ActivateCommand="{Binding DataContext.Activate, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                        </DataTemplate>
+                    </ContentControl.ContentTemplate>
+                </ContentControl>
+            </DataTemplate>
+
+            <!-- One Link, list-density (canonical pilot enumeration pattern). -->
+            <DataTemplate x:Key="EntityLinkListTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="List" Margin="0,0,0,3"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterText="{Binding InternalName}">
+    <!-- Phase-5 fan-out · view 5 (Npc) — a consistency-diff against the merged
+         Recipe pilot, NOT fresh design. #404 Phase-2: the Area chip is an
+         inline Link; Teaches/Sells/Quests are Link enumerations; the Store-cap
+         ItemKeyword detail chips are Set-references (ratified E4 — keyword
+         filters, NOT Link); the gold service-Type label is the named G-b
+         "Npc service type" violation; the NPC InternalName footer is a
+         cross-entity reference key (copyable KEY). The service card Border is
+         layout scaffolding (Phase-1: out of audit scope) — retained.
+
+         Footer (matrix #14 / G-a · ratified E5): the pilot move — stop binding
+         DetailExportHost.FooterText, place <c:FactFooter/> at the foot (host
+         retained unchanged). -->
+    <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Internal-name footer is owned by the wrapping DetailExportHost (FooterText). -->
             <StackPanel>
-                <!-- Header: name + area + position -->
+                <!-- Header: Fact-title + Area Link + position ───
+                     Title T4 → FactTitleStyle (bold/gold/size dropped, G-b).
+                     "Area:" → Structure inline prefix (E1); AreaChip → Prose
+                     Link. Pos is a quiet mono coordinate Fact (#404 ✅ T2
+                     "mono flags"; no gold violation) — left as-is. -->
                 <StackPanel Margin="0,0,0,10">
-                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
-                               Foreground="#FFD4A847"
-                               FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding DisplayName}"
+                               Style="{StaticResource FactTitleStyle}"/>
                     <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                        <!-- Area chip: navigable EntityChip into the Areas tab. NullToVis (NOT
-                             NullOrEmptyToVis) because the binding is object-typed; the latter
-                             tests `value as string` and silently collapses chip references —
-                             bitten twice already (PR #298, PR #302). -->
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
-                                    Visibility="{Binding AreaChip, Converter={StaticResource NullToVis}}">
-                            <TextBlock Text="Area: " Foreground="#88FFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       VerticalAlignment="Center"/>
-                            <ContentControl Content="{Binding AreaChip}" VerticalAlignment="Center">
-                                <ContentControl.Resources>
-                                    <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                        <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
+                                    Visibility="{Binding AreaLink, Converter={StaticResource NullToVis}}">
+                            <TextBlock Text="Area:"
+                                       Style="{StaticResource StructureInlinePrefixStyle}"
+                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <ContentControl Content="{Binding AreaLink}" VerticalAlignment="Center">
+                                <ContentControl.ContentTemplate>
+                                    <DataTemplate>
+                                        <c:Link Density="Prose"
+                                                ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
                                     </DataTemplate>
-                                </ContentControl.Resources>
+                                </ContentControl.ContentTemplate>
                             </ContentControl>
                         </StackPanel>
                         <TextBlock Text="{Binding Pos}" Foreground="#88FFFFFF"
@@ -54,52 +85,42 @@
                     </StackPanel>
                 </StackPanel>
 
-                <!-- Services -->
+                <!-- Services — section label → Structure. The card Border is
+                     layout scaffolding (kept). Type → StructureGroupHeaderStyle
+                     (the named G-b "Npc service type" gold dropped). Favor →
+                     inert Fact (de-boxed). Detail text → FactBody; Store-cap
+                     ItemKeyword chips → tag-form Set-references (E4). -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding Services.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Services" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding Services}">
+                            Visibility="{Binding ServiceRowVms.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Services" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding ServiceRowVms}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border Background="#FF222222" BorderBrush="#22FFFFFF" BorderThickness="1"
                                         CornerRadius="3" Padding="8,6" Margin="0,0,0,4">
                                     <StackPanel>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="{Binding Type}" FontWeight="SemiBold"
-                                                       Foreground="#FFD4A847"
-                                                       FontSize="{DynamicResource AppFontSizeHint}"/>
-                                            <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1"
-                                                    CornerRadius="3" Padding="5,1" Margin="8,0,0,0"
-                                                    Visibility="{Binding MinFavorTier, Converter={StaticResource NullOrEmptyToVis}}">
-                                                <TextBlock Foreground="#CCFFFFFF"
-                                                           FontSize="{DynamicResource AppFontSizeSmall}">
-                                                    <Run Text="Favor: "/>
-                                                    <Run Text="{Binding MinFavorTier, Mode=OneWay}"/>
-                                                </TextBlock>
-                                            </Border>
+                                            <TextBlock Text="{Binding Type}"
+                                                       Style="{StaticResource StructureGroupHeaderStyle}"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBlock Style="{StaticResource FactBodyStyle}"
+                                                       VerticalAlignment="Center" Margin="8,0,0,0"
+                                                       Visibility="{Binding HasMinFavorTier, Converter={StaticResource BoolToVis}}">
+                                                <Run Text="Favor: "/><Run Text="{Binding MinFavorTier, Mode=OneWay}"/>
+                                            </TextBlock>
                                         </StackPanel>
                                         <ItemsControl ItemsSource="{Binding Details}" Margin="0,4,0,0"
                                                       Visibility="{Binding Details.Count, Converter={StaticResource PositiveIntToVis}}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
                                                     <StackPanel Margin="0,0,0,1">
-                                                        <TextBlock Text="{Binding Text}" Foreground="#CCFFFFFF"
-                                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                                   TextWrapping="Wrap"/>
-                                                        <!-- Per-line chip strip — Store cap rows surface their keyword tuple
-                                                             as ItemKeyword chips (filter the Items tab on click). Hidden when
-                                                             the line carries no chips (every non-Store row). -->
-                                                        <ItemsControl ItemsSource="{Binding Chips}" Margin="0,2,0,0"
-                                                                      Visibility="{Binding Chips.Count, Converter={StaticResource PositiveIntToVis}}">
+                                                        <TextBlock Text="{Binding Text}" Style="{StaticResource FactBodyStyle}"/>
+                                                        <ItemsControl ItemsSource="{Binding SetRefs}" Margin="0,2,0,0"
+                                                                      ItemTemplate="{StaticResource FilterSetRefTemplate}"
+                                                                      Visibility="{Binding SetRefs.Count, Converter={StaticResource PositiveIntToVis}}">
                                                             <ItemsControl.ItemsPanel>
                                                                 <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                                                             </ItemsControl.ItemsPanel>
-                                                            <ItemsControl.ItemTemplate>
-                                                                <DataTemplate>
-                                                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
-                                                                </DataTemplate>
-                                                            </ItemsControl.ItemTemplate>
                                                         </ItemsControl>
                                                     </StackPanel>
                                                 </DataTemplate>
@@ -112,117 +133,82 @@
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Teaches recipes -->
+                <!-- Teaches recipes — Link enumeration (Density="List"). -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding TaughtRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Teaches recipes" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding TaughtRecipes}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding TaughtRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Teaches recipes" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding TaughtRecipeLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- Teaches abilities -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding TaughtAbilities.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Teaches abilities" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding TaughtAbilities}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding TaughtAbilityLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Teaches abilities" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding TaughtAbilityLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- Sells items -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding SoldItems.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Sells items" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding SoldItems}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding SoldItemLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Sells items" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding SoldItemLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Quests this NPC gives, turns in, or anchors favor for. Routes through
-                     QuestsByGiverNpc — chips become navigable once the Quests tab ships. -->
+                <!-- Quests this NPC gives, turns in, or anchors favor for. -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding Quests.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Quests" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding Quests}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:NpcDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding QuestLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Quests" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding QuestLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Gift preferences -->
+                <!-- Gift preferences — section label → Structure. The Desire
+                     gold-boxed pill is the #404 box-as-everything collision:
+                     de-boxed + gold dropped (G-b) → inert Fact prose. -->
                 <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding Preferences.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Gift preferences" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Gift preferences" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding Preferences}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <DockPanel Margin="0,0,0,3">
-                                    <Border DockPanel.Dock="Left" Background="#FF252525" BorderBrush="#33FFFFFF"
-                                            BorderThickness="1" CornerRadius="3" Padding="5,1" Margin="0,0,6,0"
-                                            VerticalAlignment="Center">
-                                        <TextBlock Text="{Binding Desire}" Foreground="#FFD4A847"
-                                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
-                                    </Border>
-                                    <TextBlock Foreground="#CCFFFFFF"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
-                                               TextWrapping="Wrap" VerticalAlignment="Center">
-                                        <Run Text="{Binding DisplayName, Mode=OneWay}"/>
-                                        <Run Text=" ("/><Run Text="{Binding Pref, Mode=OneWay, StringFormat={}{0:+0.#;-0.#}}"/><Run Text="×)"/>
-                                    </TextBlock>
-                                </DockPanel>
+                                <TextBlock Style="{StaticResource FactBodyStyle}" Margin="0,0,0,3">
+                                    <Run Text="{Binding Desire, Mode=OneWay}" FontWeight="SemiBold"/>
+                                    <Run Text=" — "/>
+                                    <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                    <Run Text=" ("/><Run Text="{Binding Pref, Mode=OneWay, StringFormat={}{0:+0.#;-0.#}}"/><Run Text="×)"/>
+                                </TextBlock>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <!-- Gift sentiment tiers (Friends, BestFriends, ...) — the thresholds at which
-                         this NPC accepts gifts. Rendered as a comma-joined plain line below the
-                         preference rows. -->
-                    <TextBlock Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeSmall}"
-                               Margin="0,4,0,0" TextWrapping="Wrap"
+                    <TextBlock Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
+                               Margin="0,4,0,0"
                                Visibility="{Binding GiftSentimentTiers.Count, Converter={StaticResource PositiveIntToVis}}">
-                        <Run Text="Accepts gifts at: " FontStyle="Italic"/>
+                        <Run Text="Accepts gifts at: "/>
                         <Run Text="{Binding GiftSentimentTiersDisplay, Mode=OneWay}"/>
                     </TextBlock>
                 </StackPanel>
 
-                <!-- Description (FormattedText parses any inline <i>/<b> markup). -->
-                <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF" FontStyle="Italic"
-                           FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
+                <!-- Description (FormattedText parses inline <i>/<b>). -->
+                <TextBlock c:FormattedText.Text="{Binding Description}"
+                           Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
                            MaxWidth="460" HorizontalAlignment="Left" Margin="0,0,0,10"
                            Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). The NPC
+                     InternalName is a cross-entity reference KEY ⇒ copyable.
+                     FactFooterVm.None() self-hides at 0 ids. -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -4,6 +4,7 @@ using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Npcs;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
 using Mithril.Shared.Wpf.Query;
 using Mithril.TestSupport;
 using Silmarillion.Navigation;
@@ -958,6 +959,100 @@ public sealed class NpcsTabViewModelTests
             new NpcStoreServicePoco { Type = "Store", CapIncreases = capIncreases },
         },
     };
+
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void AreaLink_AndCrossLinkLinks_ProjectLegacyChips()
+    {
+        var recipe = new Recipe { Key = "r1", InternalName = "BakeBread", Name = "Bake Bread", IconId = 7 };
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple", IconId = 3 };
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh", AreaName = "AreaSerbule", AreaFriendlyName = "Serbule" } },
+            RecipesTaughtByNpcMap = { ["NPC_Joeh"] = new[] { recipe } },
+            ItemsSoldByNpcMap = { ["NPC_Joeh"] = new[] { apple } },
+        };
+        var vm = new NpcsTabViewModel(
+            refData, NavFactory.WithKinds(EntityKind.Area, EntityKind.Recipe, EntityKind.Item),
+            new ReferenceDataEntityNameResolver(refData));
+        vm.SelectedRow = vm.AllNpcs.Single();
+        var d = vm.DetailViewModel!;
+
+        d.AreaLink.Should().NotBeNull();
+        d.AreaLink!.DisplayName.Should().Be(d.AreaChip!.DisplayName);
+        d.AreaLink.Glyph.Should().Be(LinkGlyph.Location);
+        d.TaughtRecipeLinks.Select(l => l.DisplayName)
+            .Should().Equal(d.TaughtRecipes.Select(c => c.DisplayName));
+        d.TaughtRecipeLinks.Should().OnlyContain(l => l.Glyph == LinkGlyph.Recipe);
+        d.SoldItemLinks.Select(l => l.DisplayName)
+            .Should().Equal(d.SoldItems.Select(c => c.DisplayName));
+        d.AreaLink.IsNavigable.Should().Be(d.AreaChip.IsNavigable, "adapter preserves navigability");
+    }
+
+    [Fact]
+    public void ServiceRowVms_StoreCapKeywords_BecomeTagFormSetRefs_ActionableMirrorsNavigability()
+    {
+        var npc = new Npc
+        {
+            Name = "Joeh",
+            Services = new NpcServicePoco[]
+            {
+                new NpcStoreServicePoco
+                {
+                    Type = "Store",
+                    CapIncreases = ["Despised:10000:Food,Potion", "Comfortable:50000:"],
+                },
+            },
+        };
+        var refData = new StubReferenceData { NpcsByKey = { ["NPC_Joeh"] = npc } };
+
+        // Wired: ItemByKeyword target registered ⇒ navigable ⇒ actionable Set-ref.
+        var vm = new NpcsTabViewModel(
+            refData, NavFactory.WithKinds(EntityKind.ItemByKeyword),
+            new ReferenceDataEntityNameResolver(refData));
+        vm.SelectedRow = vm.AllNpcs.Single();
+        var store = vm.DetailViewModel!.ServiceRowVms.Single();
+
+        store.Type.Should().Be("Store");
+        var line0 = store.Details[0];
+        line0.SetRefs.Select(s => s.SetRef.Label).Should().Equal("Food", "Potion");
+        line0.SetRefs.Should().OnlyContain(s =>
+            !s.SetRef.IsSummaryForm && s.SetRef.IsActionable && s.Activate != null,
+            "Store-cap keyword chips are actionable tag-form Set-refs (ratified E4)");
+        store.Details[1].SetRefs.Should().BeEmpty("the empty-keyword row carries no chips");
+
+        // Unwired: no ItemByKeyword target ⇒ availability corollary (tag-form
+        // Set-ref, IsActionable=false, no command — NOT a Fact box).
+        var vmU = new NpcsTabViewModel(
+            refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+        vmU.SelectedRow = vmU.AllNpcs.Single();
+        var u = vmU.DetailViewModel!.ServiceRowVms.Single().Details[0].SetRefs[0];
+        u.SetRef.IsActionable.Should().BeFalse();
+        u.Activate.Should().BeNull();
+        SetRef.ResolveClick(u.SetRef).Should().Be(SetRefClickAction.Unavailable);
+    }
+
+    [Fact]
+    public void Footer_NpcInternalName_IsCopyableCrossReferenceKey()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+        };
+        var vm = new NpcsTabViewModel(
+            refData, new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+        vm.SelectedRow = vm.AllNpcs.Single();
+
+        var f = vm.DetailViewModel!.Footer;
+        f.Ids.Should().ContainSingle();
+        f.Ids[0].LabelTag.Should().Be("KEY");
+        f.Ids[0].Value.Should().Be("NPC_Joeh");
+        f.Ids[0].Copyable.Should().BeTrue("the NPC InternalName is a cross-entity reference key");
+        FactFooter.ResolveCellClick(f.Ids[0]).Should().Be(FactFooterCellAction.Copy);
+    }
 
     private sealed class StubReferenceData : IReferenceDataService
     {


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 5 of 8: Npc

Fifth fan-out view. A consistency-diff against the merged Recipe pilot, not fresh design.

### Canonical pattern applied

| Element | #404 matrix | Treatment |
|---|---|---|
| Title | T4 | `FactTitleStyle` (G-b); no title-glyph |
| `Area: [chip]` | E1 + Link | Structure inline prefix + `Density="Prose"` `Link` |
| Pos | ✅ T2 "mono flags" | left as-is (quiet mono-coordinate Fact, no gold violation) |
| Teaches recipes/abilities · Sells items · Quests | #6/#10 enumeration | `Link` `Density="List"` (canonical pilot pattern) |
| Section headers | T3 | `StructureSectionLabelStyle` |
| **Service `Type`** | **named G-b "Npc service type" gold** | dropped → `StructureGroupHeaderStyle` (card group header) |
| Service `Favor:` pill | bordered Fact | de-boxed → inert Fact |
| Store-cap ItemKeyword detail chips | **ratified E4 → Set-reference** | tag-form `SetRef`; per-chip `Activate` bridge; unwired ⇒ availability corollary |
| Gift-preference `Desire` gold pill | T1/T11 box-as-everything | de-boxed + gold dropped → inert Fact prose |
| Footer | #14 / G-a · ratified **E5** | `<c:FactFooter/>`; NPC InternalName = **copyable `KEY`** |

### Substantive judgements

1. **Named G-b violation fixed.** The gold service-`Type` label is one of the four explicitly-named "Fact gold values" on the #404 G-b evidence list ("StorageVault slots, Area combo, **Npc service type**, Quest favor"). Gold dropped; it now reads as the card's Structure group header.
2. **Out-of-scope records wrapped, not edited.** `NpcServiceRow` / `NpcServiceDetailLine` / `NpcPreferenceRow` live in their own files (outside this view's diff-guard scope). Following the pilot's `RecipeRequirementRow → RecipeRequirementRowVm` precedent, they are **wrapped** (`NpcServiceRowVm` / `NpcServiceDetailLineVm` / `NpcFilterSetRefVm`) in the view's own VM file — never mutated.
3. **E4 again.** Store-cap keyword chips filter the Items tab → tag-form Set-reference (not Link), with the same `EffectFilterSetRefVm`-style per-chip command bridge and availability-corollary handling proven on Effect.
4. **Service card Border retained.** It is a Structure grouping container = pure layout scaffolding, which Phase-1 explicitly placed *out of audit scope*. Restyling it would be fresh design (E2 was a flag, not a ratified canonical-pattern change). Only its **contents** were migrated.
5. **Copyable `KEY` footer.** NPC InternalName is a cross-entity reference key (areas/quests resolve an NPC by it) → `FactFooterVm.Key` (Area's path), contrasting PlayerTitle's inert `ROW`.

### Anti-goals respected

- One view per PR; `git status` = only `NpcDetailView.xaml` + its VM + the Npc test file.
- No primitive / `Resources.xaml` / other-view edits; out-of-scope row records wrapped not edited. Now-unused `xmlns:icon` removed (this file's scope).
- Legacy members retained — existing Npc tab tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **486/486** (existing Npc tab tests + 3 new: Area/cross-link Link projections, Store-cap keyword tag-form SetRef actionable-vs-availability-corollary, copyable-`KEY` footer)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`

Boot smoke deferred to the consolidated integration pass before Phase 6 (pure restyle + VM wrappers; per-view full build compiles BAML + lints resources).

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot** — esp. (a) the named G-b service-Type fix, (b) the wrap-not-edit handling of the out-of-scope service/preference records, (c) the service card Border left as out-of-audit-scope layout.

Tracked in #404 · Phase 5 fan-out **5 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
