### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 6/8 — StorageVault grammar migration

### DIFF
--- a/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
@@ -104,6 +104,61 @@ public sealed class StorageVaultDetailViewModel
             || HasItemKeywordTags
             || HasRequirementLines
             || HasQuestRequirements;
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // Legacy chip/row/string members above stay (the existing tests + the
+        // detail-pane contract); these are the grammar-tier carriers the view
+        // binds. StorageVault is the view that exercises TWO Phase-4
+        // carry-forwards by name:
+        //   • #3 — polymorphic Capacity is ONE FactTable in three layouts:
+        //     the favor-tier table = Grid, a flat count / script-atomic range =
+        //     Scalar, the rare event-gated set = more Grid rows (NOT three
+        //     bespoke controls). The gold slot count is the NAMED G-b
+        //     "StorageVault slots" violation → dropped (FactTable is inert).
+        //   • #4 — the ItemKeyword tags are the explicitly-named forbidden
+        //     "inert grey Fact pill" the availability corollary says Phase 5
+        //     MUST correct, not preserve → tag-form Set-ref on the blue
+        //     chassis, IsActionable=false (the filter is not wired; these are
+        //     keyword tags, not navigable entities).
+        // Cross-links: Area / operator-NPC / quest-completed are 1:1 entity
+        // refs ⇒ Link. EnvelopeKey was an inert mono footer (matrix T14) ⇒
+        // storage-only inert ROW (PlayerTitle's path).
+
+        AreaLink = AreaChip is null ? null : LinkVm.From(AreaChip);
+        OperatorNpcLink = OperatorNpcChip is null ? null : LinkVm.From(OperatorNpcChip);
+        QuestRequirementLinks = QuestRequirementChips.Select(LinkVm.From).ToList();
+
+        // Carry-forward #3 — ONE polymorphic FactTable. Favor table ⇒ Grid;
+        // else a flat count / script-atomic range ⇒ Scalar; empty ⇒ StripText
+        // "" so the shared Style self-hides. The gold slot count is dropped
+        // (FactTable is inert per G-b — the NAMED "StorageVault slots" G-b fix).
+        CapacityFact =
+            HasCapacityTable
+                ? FactTableVm.Grid(CapacityRows
+                    .Select(r => new FactPair(r.Tier, r.Slots.ToString())).ToList())
+            : HasFlatSlots
+                ? FactTableVm.Scalar($"{FlatSlots} slots")
+            : ScriptAtomicRange is { } sar
+                ? FactTableVm.Scalar(sar)
+                : FactTableVm.Strip(Array.Empty<FactPair>());
+
+        // Rare event-gated overrides: "just more Grid rows" (carry-forward #3),
+        // kept under its own distinct Structure label. Empty Grid ⇒ self-hide.
+        EventLevelsFact = FactTableVm.Grid(EventLevelRows
+            .Select(r => new FactPair(r.Tier, r.Slots.ToString())).ToList());
+
+        // Carry-forward #4 — the NAMED grey-pill correction. Tag-form Set-ref,
+        // IsActionable=false (the keyword filter is not wired; per the
+        // availability corollary it still renders on the FULL blue chassis and
+        // is NEVER a degraded inert grey Fact pill). No Activate command — the
+        // grammar specifies a safe no-op for an un-wired Set-ref.
+        ItemKeywordSetRefs = ItemKeywordTags
+            .Select(t => new SetRefVm(t, MatchCount: null, IsActionable: false))
+            .ToList();
+
+        Footer = string.IsNullOrEmpty(EnvelopeKey)
+            ? FactFooterVm.None()
+            : FactFooterVm.Of(new FactFooterId("ROW", EnvelopeKey, copyable: false));
     }
 
     public StorageVaultListRow Row { get; }
@@ -183,6 +238,49 @@ public sealed class StorageVaultDetailViewModel
     public bool HasQuestRequirements { get; }
 
     public bool HasAccessRequirements { get; }
+
+    // ── Phase 5 grammar-primitive carriers ──────────────────────────────────
+
+    /// <summary>Parent-area cross-link as <see cref="LinkVm"/> (inline Prose Link
+    /// behind the Structure "Area:" prefix). Null when no area.</summary>
+    public LinkVm? AreaLink { get; }
+
+    /// <summary>Operator-NPC cross-link as <see cref="LinkVm"/> (inline Prose
+    /// Link behind the Structure "Operator:" prefix). Null for a transfer chest.</summary>
+    public LinkVm? OperatorNpcLink { get; }
+
+    /// <summary>Quest-completed requirements as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> QuestRequirementLinks { get; }
+
+    /// <summary>
+    /// Carry-forward #3: the polymorphic Capacity as ONE <see cref="FactTableVm"/>
+    /// — favor-tier table ⇒ <see cref="FactTableLayout.Grid"/>, flat count /
+    /// script-atomic range ⇒ <see cref="FactTableLayout.Scalar"/>, empty ⇒
+    /// self-hiding. Inert (G-b): the legacy gold slot count is dropped.
+    /// </summary>
+    public FactTableVm CapacityFact { get; }
+
+    /// <summary>The rare event-gated overrides as a separate <see cref="FactTableVm"/>
+    /// Grid ("just more Grid rows" — carry-forward #3), kept under its own
+    /// Structure label. Empty ⇒ self-hides.</summary>
+    public FactTableVm EventLevelsFact { get; }
+
+    /// <summary>
+    /// Carry-forward #4 — the explicitly-named correction. The ItemKeyword tags
+    /// as tag-form Set-references (<see cref="SetRefVm.IsActionable"/> = false:
+    /// the keyword filter is not wired). Per the availability corollary they
+    /// render on the FULL blue Set-ref chassis and MUST NOT degrade to the
+    /// forbidden inert grey Fact pill (today's behaviour Phase 5 corrects).
+    /// </summary>
+    public IReadOnlyList<SetRefVm> ItemKeywordSetRefs { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14 / G-a · ratified E5). The EnvelopeKey
+    /// was already an inert-mono footer (matrix T14) — a display/storage-only
+    /// key ⇒ the inert <c>ROW</c> cell (PlayerTitle's path), not a copyable
+    /// <c>KEY</c>. <see cref="FactFooterVm.None"/> if keyless.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     // ── Helpers ──
 

--- a/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml
@@ -4,7 +4,6 @@
              xmlns:local="clr-namespace:Silmarillion.Views"
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -17,178 +16,142 @@
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- One capacity row: favor tier (or event key) — mono slot count (gold). -->
-            <DataTemplate DataType="{x:Type vm:StorageVaultCapacityRow}">
-                <Grid Margin="0,0,0,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Text="{Binding Tier}"
-                               Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                    <TextBlock Grid.Column="1" Text="{Binding Slots}"
-                               FontFamily="{DynamicResource AppMonoFontFamily}"
-                               Foreground="#FFD4A847"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               Margin="12,0,0,0"/>
-                </Grid>
+            <!-- One inline Link, prose-density (the pilot inline-ref idiom). -->
+            <DataTemplate x:Key="InlineLinkTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="Prose"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
             </DataTemplate>
-
-            <!-- Plain item-keyword tag (NOT navigable — these are keyword tags, not entities). -->
-            <DataTemplate x:Key="ItemKeywordTagTemplate">
-                <Border Background="#FF2A2A2A" CornerRadius="3" Padding="6,2" Margin="0,0,4,4">
-                    <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeSmall}"/>
-                </Border>
+            <!-- One Link, list-density (canonical pilot enumeration pattern). -->
+            <DataTemplate x:Key="EntityLinkListTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="List" Margin="0,0,0,3"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
             </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
+    <!-- Phase-5 fan-out · view 6 (StorageVault) — a consistency-diff against the
+         merged Recipe pilot, NOT fresh design. This view exercises TWO Phase-4
+         carry-forwards by name:
+           • #3 — the polymorphic Capacity is ONE FactTable in three layouts
+             (favor table = Grid, flat count / script-atomic range = Scalar,
+             event-gated = more Grid rows), NOT three bespoke controls. The gold
+             slot count is the NAMED G-b "StorageVault slots" violation —
+             dropped (FactTable is inert).
+           • #4 — the ItemKeyword tags are the explicitly-named forbidden
+             "inert grey Fact pill" the availability corollary says Phase 5
+             MUST correct, not preserve → tag-form Set-ref on the blue chassis,
+             IsActionable=false (the filter is not wired).
+
+         Footer (matrix #14 / G-a · ratified E5): the inert DockPanel.Bottom
+         mono TextBlock (matrix T14 — already non-copyable) becomes
+         <c:FactFooter/> at the foot; storage-only ⇒ inert ROW. Host retained. -->
     <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Footer: envelope key (mono, bottom-right) — per detail-view convention. -->
-            <TextBlock DockPanel.Dock="Bottom" Text="{Binding EnvelopeKey}"
-                       Foreground="#88FFFFFF"
-                       FontFamily="{DynamicResource AppMonoFontFamily}"
-                       FontSize="{DynamicResource AppFontSizeSmall}"
-                       Margin="0,8,0,0" HorizontalAlignment="Right"
-                       VerticalAlignment="Bottom"/>
-
             <StackPanel>
-                <!-- ─── Header ─── -->
+                <!-- Header — Fact-title (inline gold/header-font/XLarge dropped, G-b). -->
                 <StackPanel Margin="0,0,0,10">
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" TextWrapping="Wrap"/>
+                               Style="{StaticResource FactTitleStyle}"/>
                 </StackPanel>
 
-                <!-- ─── Metadata row ─── -->
+                <!-- Metadata: Account-wide flag → inert Fact (the T15 colored
+                     badge box dropped). Area / Operator → Structure inline
+                     prefix (E1) + Prose Link. -->
                 <WrapPanel Margin="0,0,0,10">
-                    <!-- Account-wide badge: rendered only when true (noise-filter default). -->
-                    <Border Background="#332E7DD2" BorderBrush="#662E7DD2" BorderThickness="1"
-                            CornerRadius="3" Padding="6,2" Margin="0,0,6,4"
-                            Visibility="{Binding IsAccountWide, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Account-wide" Foreground="#FF9CC3EA"
-                                   FontSize="{DynamicResource AppFontSizeSmall}"/>
-                    </Border>
-
-                    <StackPanel Orientation="Horizontal" Margin="0,0,6,4"
-                                Visibility="{Binding HasArea, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Area: " Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
-                        <ContentControl Content="{Binding AreaChip}">
-                            <ContentControl.Resources>
-                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
-                                </DataTemplate>
-                            </ContentControl.Resources>
-                        </ContentControl>
+                    <TextBlock Text="Account-wide" Style="{StaticResource FactBodyStyle}"
+                               Margin="0,0,12,4"
+                               Visibility="{Binding IsAccountWide, Converter={StaticResource BoolToVis}}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,12,4" VerticalAlignment="Center"
+                                Visibility="{Binding AreaLink, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="Area:" Style="{StaticResource StructureInlinePrefixStyle}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl Content="{Binding AreaLink}"
+                                        ContentTemplate="{StaticResource InlineLinkTemplate}"
+                                        VerticalAlignment="Center"/>
                     </StackPanel>
-
-                    <StackPanel Orientation="Horizontal" Margin="0,0,6,4"
-                                Visibility="{Binding HasOperatorNpc, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Operator: " Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
-                        <ContentControl Content="{Binding OperatorNpcChip}">
-                            <ContentControl.Resources>
-                                <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
-                                </DataTemplate>
-                            </ContentControl.Resources>
-                        </ContentControl>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,12,4" VerticalAlignment="Center"
+                                Visibility="{Binding OperatorNpcLink, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="Operator:" Style="{StaticResource StructureInlinePrefixStyle}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl Content="{Binding OperatorNpcLink}"
+                                        ContentTemplate="{StaticResource InlineLinkTemplate}"
+                                        VerticalAlignment="Center"/>
                     </StackPanel>
                 </WrapPanel>
 
-                <!-- ─── Capacity ─── -->
+                <!-- Capacity — carry-forward #3: ONE polymorphic FactTable
+                     (Grid favor table / Scalar flat-or-range; self-hides empty).
+                     Event-gated overrides = more Grid rows under their own
+                     Structure group label. -->
                 <StackPanel Margin="0,0,0,10">
-                    <TextBlock Text="Capacity" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-
-                    <!-- Favor-scaled: ordered favor-tier table. -->
-                    <ItemsControl ItemsSource="{Binding CapacityRows}"
-                                  Visibility="{Binding HasCapacityTable, Converter={StaticResource BoolToVis}}"/>
-
-                    <!-- Flat slot count. -->
-                    <TextBlock Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               Visibility="{Binding HasFlatSlots, Converter={StaticResource BoolToVis}}">
-                        <Run Text="{Binding FlatSlots, Mode=OneWay}"/><Run Text=" slots"/>
-                    </TextBlock>
-
-                    <!-- Dynamic / script-atomic range. -->
-                    <TextBlock Text="{Binding ScriptAtomicRange}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               Margin="0,2,0,0"
-                               Visibility="{Binding HasScriptAtomicRange, Converter={StaticResource NullOrEmptyToVis}}"/>
-
-                    <!-- Rare event-gated overrides. -->
+                    <TextBlock Text="Capacity" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <c:FactTable DataContext="{Binding CapacityFact}"
+                                 HorizontalAlignment="Left"/>
                     <StackPanel Margin="0,6,0,0"
                                 Visibility="{Binding HasEventLevels, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Event-gated capacity" Foreground="#88FFFFFF"
-                                   FontStyle="Italic"
-                                   FontSize="{DynamicResource AppFontSizeSmall}"
-                                   Margin="0,0,0,2"/>
-                        <ItemsControl ItemsSource="{Binding EventLevelRows}"/>
+                        <TextBlock Text="Event-gated capacity"
+                                   Style="{StaticResource StructureGroupHeaderStyle}" Margin="0,0,0,2"/>
+                        <c:FactTable DataContext="{Binding EventLevelsFact}"
+                                     HorizontalAlignment="Left"/>
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ─── Access requirements ─── -->
+                <!-- Access requirements -->
                 <StackPanel Visibility="{Binding HasAccessRequirements, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="Access requirements" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Access requirements" Style="{StaticResource StructureSectionLabelStyle}"/>
 
                     <TextBlock Text="{Binding RequirementDescription}"
-                               Foreground="#CCFFFFFF" FontStyle="Italic"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               TextWrapping="Wrap" Margin="0,0,0,4"
+                               Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
+                               Margin="0,0,0,4"
                                Visibility="{Binding RequirementDescription, Converter={StaticResource NullOrEmptyToVis}}"/>
 
-                    <ItemsControl ItemsSource="{Binding ItemKeywordTags}"
-                                  ItemTemplate="{StaticResource ItemKeywordTagTemplate}"
+                    <!-- Carry-forward #4: the keyword tags as tag-form
+                         Set-references (blue chassis, IsActionable=false — the
+                         filter is not wired). NOT the old inert grey pill. -->
+                    <ItemsControl ItemsSource="{Binding ItemKeywordSetRefs}"
                                   Margin="0,0,0,4"
                                   Visibility="{Binding HasItemKeywordTags, Converter={StaticResource BoolToVis}}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <c:SetRef Margin="0,0,4,4"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <!-- Quest-completed requirements → 1:1 navigable Quest chips. -->
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4"
+                    <!-- Quest-completed requirements → 1:1 Quest Links. -->
+                    <StackPanel Margin="0,0,0,4"
                                 Visibility="{Binding HasQuestRequirements, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="Completed: " Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
-                        <ItemsControl ItemsSource="{Binding QuestRequirementChips}">
+                        <TextBlock Text="Completed:" Style="{StaticResource StructureInlinePrefixStyle}"
+                                   Margin="0,0,0,2"/>
+                        <ItemsControl ItemsSource="{Binding QuestRequirementLinks}"
+                                      ItemTemplate="{StaticResource EntityLinkListTemplate}">
                             <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                                <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:StorageVaultDetailView}}}"/>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </StackPanel>
 
-                    <!-- Non-quest polymorphic requirements as human labels (incl. the
-                         graceful "(unrecognised requirement)" degrade). -->
+                    <!-- Non-quest polymorphic requirements as inert Fact lines
+                         (incl. the graceful "(unrecognised requirement)" degrade). -->
                     <ItemsControl ItemsSource="{Binding RequirementLines}"
                                   Visibility="{Binding HasRequirementLines, Converter={StaticResource BoolToVis}}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding}" Style="{StaticResource FactBodyStyle}"
+                                           Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). Storage-only
+                     EnvelopeKey ⇒ inert ROW. None() self-hides at 0 ids. -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
@@ -5,6 +5,7 @@ using Mithril.Reference.Models.Npcs;
 using Mithril.Reference.Models.Quests;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
 using Silmarillion.Navigation;
 using Silmarillion.ViewModels;
 using Xunit;
@@ -272,6 +273,91 @@ public sealed class StorageVaultDetailViewModelTests
         nav.Current.Should().NotBeNull("clicking the Area chip should drive navigation");
         nav.Current!.Kind.Should().Be(EntityKind.Area);
         nav.Current.InternalName.Should().Be("AreaSerbule");
+    }
+
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void CapacityFact_FavorTable_IsOneInertGrid_NoGold()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "NPC_X", new StorageVaultPoco
+        {
+            NpcFriendlyName = "X",
+            Levels = new Dictionary<string, int> { ["Neutral"] = 16, ["SoulMates"] = 64 },
+        });
+
+        // Carry-forward #3: the favor table is ONE FactTable Grid (label→value);
+        // FactTableVm carries no brush, so the named G-b "StorageVault slots"
+        // gold cannot be expressed by construction.
+        vm.CapacityFact.Layout.Should().Be(FactTableLayout.Grid);
+        vm.CapacityFact.Pairs.Select(p => p.Label)
+            .Should().Equal(vm.CapacityRows.Select(r => r.Tier));
+        vm.CapacityFact.Pairs.Select(p => p.Value)
+            .Should().Equal(vm.CapacityRows.Select(r => r.Slots.ToString()));
+    }
+
+    [Fact]
+    public void CapacityFact_FlatAndRange_AreScalar_EmptySelfHides()
+    {
+        var refData = new FakeReferenceData();
+        Build(refData, "Chest32", new StorageVaultPoco { NpcFriendlyName = "C", NumSlots = 32 })
+            .CapacityFact.Should().BeEquivalentTo(FactTableVm.Scalar("32 slots"));
+
+        var range = Build(refData, "CommunityChest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "CC",
+            NumSlotsScriptAtomic = "atomic", NumSlotsScriptAtomicMinValue = 1, NumSlotsScriptAtomicMaxValue = 150,
+        });
+        range.CapacityFact.Layout.Should().Be(FactTableLayout.Scalar);
+        range.CapacityFact.Pairs.Single().Value.Should().Be("Dynamic: 1–150 slots");
+
+        // No capacity of any shape ⇒ StripText "" so the shared Style self-hides.
+        var none = Build(refData, "*AccountStorage_Empty", new StorageVaultPoco { NpcFriendlyName = "E", NumSlots = 0 });
+        none.CapacityFact.StripText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItemKeywordTags_AreTagFormSetRefs_OnTheBlueChassis_NeverGreyPills()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "Chest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "C",
+            RequiredItemKeywords = ["Fish", "CookingIngredient"],
+        });
+
+        // Carry-forward #4 (the explicitly-named correction): tag-form Set-refs
+        // (no count/arrow), IsActionable=false (filter unwired) — still on the
+        // FULL blue chassis, never the forbidden inert grey Fact pill.
+        vm.ItemKeywordSetRefs.Select(s => s.Label).Should().Equal("Fish", "CookingIngredient");
+        vm.ItemKeywordSetRefs.Should().OnlyContain(s => !s.IsSummaryForm && !s.IsActionable);
+        vm.ItemKeywordSetRefs.Should().OnlyContain(s =>
+            SetRef.ResolveClick(s) == SetRefClickAction.Unavailable);
+    }
+
+    [Fact]
+    public void QuestRequirementLinks_ProjectChips_AndFooterIsInertStorageRow()
+    {
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "NPC_CynthiaRolfe", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Cynthia",
+            Requirements = new StorageRequirement[]
+            {
+                new StorageQuestCompletedRequirement { Quest = "SomeQuest" },
+            },
+        });
+
+        vm.QuestRequirementLinks.Select(l => l.DisplayName)
+            .Should().Equal(vm.QuestRequirementChips.Select(c => c.DisplayName));
+
+        // EnvelopeKey was an inert mono footer (matrix T14) ⇒ storage-only ROW.
+        vm.Footer.Ids.Should().ContainSingle();
+        vm.Footer.Ids[0].LabelTag.Should().Be("ROW");
+        vm.Footer.Ids[0].Value.Should().Be("NPC_CynthiaRolfe");
+        vm.Footer.Ids[0].Copyable.Should().BeFalse();
+        FactFooter.ResolveCellClick(vm.Footer.Ids[0]).Should().Be(FactFooterCellAction.Inert);
     }
 
     private static StorageVaultDetailViewModel Build(


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 6 of 8: StorageVault

Sixth fan-out view. A consistency-diff against the merged Recipe pilot, not fresh design. **StorageVault is the view that exercises two Phase-4 carry-forwards by name.**

### The two named carry-forwards

**Carry-forward #3 — one polymorphic Capacity primitive.** The favor-tier table, the flat slot count, the script-atomic range, and the rare event-gated set are now **one `FactTable`** in three layouts — `Grid` (favor table / event-gated) and `Scalar` (flat count / `"Dynamic lo–hi"` range) — not three bespoke controls (the anti-fork mandate). The legacy **gold slot count** is the explicitly-named G-b *"StorageVault slots"* violation; `FactTableVm` carries **no brush**, so the gold cannot be expressed by construction (inert by design). Empty ⇒ self-hides.

**Carry-forward #4 — the named grey-pill correction.** The `ItemKeyword` tags were *exactly* the "inert grey Fact pill" the availability corollary calls the forbidden inverted-affordance lie: *"today's StorageVault keyword tags are exactly that degrade and Phase 5 must correct it, not preserve it."* They are now tag-form Set-references on the **full blue chassis** with `IsActionable=false` (the keyword filter is not wired) — never a grey pill. This is the textbook availability-corollary case the grammar was written to fix.

### Other elements

| Element | Treatment |
|---|---|
| Title | `FactTitleStyle` (G-b) |
| Account-wide (T15 colored badge box) | inert Fact text |
| Area / Operator | Structure inline prefix (E1) + Prose `Link` |
| Quest-completed requirements | `Link` enumeration `Density="List"` |
| RequirementDescription / RequirementLines | `FactBodyStyle` |
| Section / sub labels | `StructureSectionLabelStyle` / `StructureGroupHeaderStyle` / inline prefix |
| Footer | inert `DockPanel.Bottom` mono (matrix **T14**) → `<c:FactFooter/>`, storage-only **inert `ROW`** |

### Anti-goals respected

- One view per PR; `git status` = only `StorageVaultDetailView.xaml` + its VM + its tests.
- No primitive / `Resources.xaml` / other-view edits. Now-unused `xmlns:icon` removed (this file's scope).
- Legacy chip/row/string members retained — existing StorageVault detail tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **487/487** (existing StorageVault detail tests + 4 new: favor `Grid` no-gold-by-construction, flat/range `Scalar` + empty self-hide, keyword tag-form-on-blue-chassis (never grey pill), quest `Link` + inert-`ROW` footer)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`

Boot smoke deferred to the consolidated integration pass before Phase 6 (per-view full build compiles BAML + lints resources).

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot** — esp. (a) carry-forward #3: the polymorphic Capacity collapsed to one `FactTable` (Grid/Scalar), gold gone by construction; (b) carry-forward #4: the named keyword-tag grey-pill corrected to blue-chassis tag-form Set-ref. These are the two carry-forwards the Phase-4 dispatch flagged for Phase-5 to *decide and correct*; this PR is where they land.

Tracked in #404 · Phase 5 fan-out **6 of 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
