### PR TITLE
feat(silmarillion): #404 Phase 5 fan-out 8/8 — Quest grammar migration (fan-out complete)

### DIFF
--- a/src/Silmarillion.Module/ViewModels/QuestDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/QuestDetailViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
 using Mithril.Reference.Models.Quests;
 using Mithril.Shared.Reference;
@@ -65,6 +67,57 @@ public sealed class QuestDetailViewModel
         BadgesDisplay = BuildBadgesDisplay(IsCancellable, IsGuildQuest, IsWorkOrder, WorkOrderSkillDisplay);
 
         OpenEntityCommand = openEntityCommand;
+
+        // ── Phase 5 grammar-primitive projections ──────────────────────────────
+        // Legacy chip/group/string members above stay (the existing tests + the
+        // detail-pane contract); these are the grammar-tier carriers the view
+        // binds. Quest is the ORIGIN of the dual-shape row the Recipe pilot was
+        // modelled on ("Dual-shape, mirroring QuestDetailView"), so the
+        // QuestRequirementDisplay / QuestRewardDisplay rows wrap to LinkVm
+        // EXACTLY via the pilot's RecipeRequirementRowVm idiom (prose row ⇒
+        // Link null; chip row ⇒ Structure prefix + Prose Link). The
+        // *Display/*Group/*ObjectiveRow records live in their own files (out
+        // of this view's diff-guard scope) so they are WRAPPED, not edited —
+        // and the bespoke RequirementChipVmConverter the old XAML used to coerce
+        // a row → EntityChip is no longer referenced (the wrapper builds the
+        // LinkVm directly; the converter class is now dead — flagged as a
+        // follow-up cleanup, out of this PR's 3-file scope).
+        // #404 Phase-2: giver/turn-in + reward/pre-give/follow-up chips = 1:1
+        // refs = Link; the gold group labels + RepeatabilityChip (T11) + the
+        // named G-b "Quest favor line" = inert Fact (gold dropped); the
+        // dialogue Expander = Control (ratified E3 — correctly classified,
+        // left as-is); InternalName footer = a cross-entity reference key
+        // (follow-ups / NPCs / vaults resolve a quest by it) ⇒ copyable KEY.
+
+        GiverLink = GiverChip is null ? null : LinkVm.From(GiverChip);
+        TurnInLink = TurnInChip is null ? null : LinkVm.From(TurnInChip);
+
+        RewardItemLinks = RewardItemChips.Select(LinkVm.From).ToList();
+        RewardRecipeLinks = RewardRecipeChips.Select(LinkVm.From).ToList();
+        FollowUpQuestLinks = FollowUpQuestChips.Select(LinkVm.From).ToList();
+        PreGiveItemLinks = PreGiveItemChips.Select(LinkVm.From).ToList();
+        PreGiveRecipeLinks = PreGiveRecipeChips.Select(LinkVm.From).ToList();
+
+        RequirementGroupVms = RequirementGroups.Select(QuestRequirementGroupVm.From).ToList();
+        SustainRequirementGroupVms = SustainRequirementGroups.Select(QuestRequirementGroupVm.From).ToList();
+        RewardGroupVms = RewardGroups.Select(QuestRewardGroupVm.From).ToList();
+        ObjectiveRowVms = Objectives.Select(QuestObjectiveRowVm.From).ToList();
+
+        // Header Level / Location / Repeatability badge boxes collapse into ONE
+        // inert Fact strip (the pilot StatStrip pattern). RepeatabilityChip was
+        // the named G-b gold-tinted badge (T11) — gone by construction (no
+        // brush on FactTableVm). The precise cooldown the old hover tooltip
+        // recovered stays queryable via QuestListRow.ReuseMinutes (accepted
+        // fidelity trade-off — consistency over fidelity, the ratified G4 bar).
+        var hdr = new List<FactPair>(3);
+        if (Level is { } lvl) hdr.Add(new FactPair(null, $"Level {lvl}"));
+        if (!string.IsNullOrEmpty(LocationDisplay)) hdr.Add(new FactPair(null, LocationDisplay!));
+        if (!string.IsNullOrEmpty(RepeatabilityChip)) hdr.Add(new FactPair(null, RepeatabilityChip!));
+        HeaderStrip = FactTableVm.Strip(hdr);
+
+        Footer = string.IsNullOrEmpty(InternalName)
+            ? FactFooterVm.None()
+            : FactFooterVm.Key(InternalName);
     }
 
     public Quest Quest { get; }
@@ -147,6 +200,57 @@ public sealed class QuestDetailViewModel
     /// to the navigator.
     /// </summary>
     public ICommand? OpenEntityCommand { get; }
+
+    // ── Phase 5 grammar-primitive carriers ──────────────────────────────────
+
+    /// <summary>Quest giver NPC as an inline Prose <see cref="LinkVm"/> (behind
+    /// the Structure "Giver:" prefix). Null when none.</summary>
+    public LinkVm? GiverLink { get; }
+
+    /// <summary>Turn-in NPC as an inline Prose <see cref="LinkVm"/>. Null when none.</summary>
+    public LinkVm? TurnInLink { get; }
+
+    /// <summary>Reward-item cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> RewardItemLinks { get; }
+
+    /// <summary>Reward-recipe cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> RewardRecipeLinks { get; }
+
+    /// <summary>Follow-up quest cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> FollowUpQuestLinks { get; }
+
+    /// <summary>Pre-give item cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> PreGiveItemLinks { get; }
+
+    /// <summary>Pre-give recipe cross-links as <see cref="LinkVm"/> (Density="List").</summary>
+    public IReadOnlyList<LinkVm> PreGiveRecipeLinks { get; }
+
+    /// <summary>Requirement groups reshaped so each dual-shape row carries a
+    /// <see cref="LinkVm"/> (chip row) or null (prose row) — the pilot
+    /// <c>RecipeRequirementRowVm</c> idiom, applied to its origin.</summary>
+    public IReadOnlyList<QuestRequirementGroupVm> RequirementGroupVms { get; }
+
+    /// <summary>"Maintain to keep" requirement groups, same wrapped shape.</summary>
+    public IReadOnlyList<QuestRequirementGroupVm> SustainRequirementGroupVms { get; }
+
+    /// <summary>Reward groups reshaped to the dual-shape Link/prose row VM.</summary>
+    public IReadOnlyList<QuestRewardGroupVm> RewardGroupVms { get; }
+
+    /// <summary>Objective rows reshaped (nested requirement groups wrapped too).</summary>
+    public IReadOnlyList<QuestObjectiveRowVm> ObjectiveRowVms { get; }
+
+    /// <summary>Header Level / Location / Repeatability badge boxes collapsed to
+    /// ONE inert Fact strip (pilot StatStrip). The Repeatability box was the
+    /// named G-b T11 gold badge — gone by construction.</summary>
+    public FactTableVm HeaderStrip { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14 / G-a · ratified E5). The Quest
+    /// InternalName is a cross-entity reference key (follow-ups / NPCs / vaults
+    /// resolve a quest by it) ⇒ the copyable <c>KEY</c> (Area's path), not an
+    /// inert envelope <c>ROW</c>. <see cref="FactFooterVm.None"/> if keyless.
+    /// </summary>
+    public FactFooterVm Footer { get; }
 
     // ─── Builders ──────────────────────────────────────────────────────────────────────
 
@@ -277,4 +381,115 @@ public sealed class QuestDetailViewModel
 
     private static string ResolveSkillDisplay(IReferenceDataService refData, string skillKey) =>
         refData.Skills.TryGetValue(skillKey, out var s) && !string.IsNullOrEmpty(s.DisplayName) ? s.DisplayName : skillKey;
+}
+
+/// <summary>
+/// View-side reshape of a <see cref="QuestRequirementDisplay"/> — the dual shape
+/// the Recipe pilot's <c>RecipeRequirementRowVm</c> was modelled on, now applied
+/// to its origin. Chip row (<c>ChipName</c> + a resolvable <c>Reference</c>) ⇒
+/// Structure <see cref="Prefix"/> + a Prose <see cref="Link"/>; prose row ⇒
+/// <see cref="Link"/> null (the same object self-switch the legacy template did
+/// on <c>ChipName</c>). Wraps the record (its file is out of edit scope).
+/// </summary>
+public sealed class QuestRequirementRowVm
+{
+    private QuestRequirementRowVm(string text, string? prefix, LinkVm? link)
+    {
+        Text = text;
+        Prefix = prefix;
+        Link = link;
+    }
+
+    /// <summary>Accessible / fallback prose (used when <see cref="Link"/> is null).</summary>
+    public string Text { get; }
+
+    /// <summary>Inline field-label prefix shown before the <see cref="Link"/> (Structure tier).</summary>
+    public string? Prefix { get; }
+
+    /// <summary>The inline navigable cross-link, or null for a prose-only row.</summary>
+    public LinkVm? Link { get; }
+
+    public static QuestRequirementRowVm From(QuestRequirementDisplay d) =>
+        new(d.Text, d.Prefix,
+            !string.IsNullOrEmpty(d.ChipName) && d.Reference is { } r
+                ? new LinkVm(d.ChipName!, LinkVm.GlyphFor(r.Kind), d.Reference, d.IsNavigable)
+                : null);
+}
+
+/// <summary>A requirement group whose rows are the wrapped dual-shape VM.</summary>
+public sealed class QuestRequirementGroupVm
+{
+    private QuestRequirementGroupVm(string label, IReadOnlyList<QuestRequirementRowVm> requirements)
+    {
+        Label = label;
+        Requirements = requirements;
+    }
+
+    public string Label { get; }
+    public IReadOnlyList<QuestRequirementRowVm> Requirements { get; }
+
+    public static QuestRequirementGroupVm From(QuestRequirementGroup g) =>
+        new(g.Label, g.Requirements.Select(QuestRequirementRowVm.From).ToList());
+}
+
+/// <summary>View-side reshape of a <see cref="QuestRewardDisplay"/> — identical
+/// dual shape to <see cref="QuestRequirementRowVm"/>.</summary>
+public sealed class QuestRewardRowVm
+{
+    private QuestRewardRowVm(string text, string? prefix, LinkVm? link)
+    {
+        Text = text;
+        Prefix = prefix;
+        Link = link;
+    }
+
+    public string Text { get; }
+    public string? Prefix { get; }
+    public LinkVm? Link { get; }
+
+    public static QuestRewardRowVm From(QuestRewardDisplay d) =>
+        new(d.Text, d.Prefix,
+            !string.IsNullOrEmpty(d.ChipName) && d.Reference is { } r
+                ? new LinkVm(d.ChipName!, LinkVm.GlyphFor(r.Kind), d.Reference, d.IsNavigable)
+                : null);
+}
+
+/// <summary>A reward group whose rows are the wrapped dual-shape VM.</summary>
+public sealed class QuestRewardGroupVm
+{
+    private QuestRewardGroupVm(string label, IReadOnlyList<QuestRewardRowVm> rewards)
+    {
+        Label = label;
+        Rewards = rewards;
+    }
+
+    public string Label { get; }
+    public IReadOnlyList<QuestRewardRowVm> Rewards { get; }
+
+    public static QuestRewardGroupVm From(QuestRewardGroup g) =>
+        new(g.Label, g.Rewards.Select(QuestRewardRowVm.From).ToList());
+}
+
+/// <summary>View-side reshape of a <see cref="QuestObjectiveRow"/> — its nested
+/// requirement groups are recursively wrapped to the dual-shape VM.</summary>
+public sealed class QuestObjectiveRowVm
+{
+    private QuestObjectiveRowVm(
+        int index, string description, int? number,
+        IReadOnlyList<QuestRequirementGroupVm> nestedRequirements)
+    {
+        Index = index;
+        Description = description;
+        Number = number;
+        NestedRequirements = nestedRequirements;
+    }
+
+    public int Index { get; }
+    public string Description { get; }
+    public int? Number { get; }
+    public IReadOnlyList<QuestRequirementGroupVm> NestedRequirements { get; }
+
+    public static QuestObjectiveRowVm From(QuestObjectiveRow o) =>
+        new(o.Index, o.Description, o.Number,
+            o.NestedRequirements.Select(QuestRequirementGroupVm.From).ToList());
 }

--- a/src/Silmarillion.Module/Views/QuestDetailView.xaml
+++ b/src/Silmarillion.Module/Views/QuestDetailView.xaml
@@ -15,46 +15,44 @@
                 <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- Local converter declaration: keeps the resource scoped to this view (no
-                 cross-view merge of the module's Resources.xaml needed). -->
-            <vm:RequirementChipVmConverter x:Key="RequirementChipVmConverter"/>
+            <!-- The bespoke RequirementChipVmConverter is no longer referenced:
+                 the dual-shape rows wrap to a LinkVm in the VM (the pilot
+                 RecipeRequirementRowVm idiom) so no row→EntityChip coercion is
+                 needed. The converter class is now dead code — a follow-up
+                 cleanup, out of this view's 3-file diff-guard scope. -->
 
-            <!-- One projected requirement row. Two render paths chosen by the projector:
-                   - Prefix + ChipName set: "{Prefix} [chip:{ChipName}]" — the entity is a
-                     proper clickable EntityChip when IsNavigable is true; degrades to a
-                     plain pill when the kind isn't tabbed yet. Used for story prerequisites
-                     (Completed: Wolf: Hunt Deer), favor gates (Friends with Joeh (Serbule)),
-                     inventory gates (Has Skinning Knife), etc.
-                   - Otherwise: plain Text only (skill levels, time-of-day, identity, flags). -->
-            <DataTemplate DataType="{x:Type vm:QuestRequirementDisplay}">
+            <!-- One Link, list-density (canonical pilot enumeration pattern). -->
+            <DataTemplate x:Key="EntityLinkListTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="List" Margin="0,0,0,3"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
+            </DataTemplate>
+            <!-- One inline Prose Link (giver / turn-in). -->
+            <DataTemplate x:Key="InlineLinkTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="Prose"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
+            </DataTemplate>
+
+            <!-- The canonical dual-shape row (verbatim from the merged Recipe
+                 pilot, which itself was modelled on THIS view): chip row ⇒
+                 Structure inline prefix + Prose Link; prose row ⇒ inert Fact
+                 text. Switch is on Link (object) via NullToVis — never the
+                 string-only NullOrEmptyToVis. -->
+            <DataTemplate DataType="{x:Type vm:QuestRequirementRowVm}">
                 <Grid Margin="0,0,0,3">
-                    <!-- Chip-rendered path: Prefix + EntityChip. -->
-                    <StackPanel Orientation="Horizontal">
-                        <StackPanel.Style>
-                            <Style TargetType="StackPanel">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ChipName, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </StackPanel.Style>
-                        <TextBlock Text="{Binding Prefix}" Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
+                    <StackPanel Orientation="Horizontal"
+                                Visibility="{Binding Link, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="{Binding Prefix}"
+                                   Style="{StaticResource StructureInlinePrefixStyle}"
                                    VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"
-                                      DataContext="{Binding Converter={StaticResource RequirementChipVmConverter}}"/>
+                        <ContentControl Content="{Binding Link}"
+                                        ContentTemplate="{StaticResource InlineLinkTemplate}"/>
                     </StackPanel>
-                    <!-- Plain-text path: shown only when ChipName is empty. -->
-                    <TextBlock Text="{Binding Text}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               TextWrapping="Wrap" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Text}" VerticalAlignment="Center">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource FactBodyStyle}">
                                 <Setter Property="Visibility" Value="Visible"/>
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ChipName, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
+                                    <DataTrigger Binding="{Binding Link, Converter={StaticResource NullToVis}}" Value="Visible">
                                         <Setter Property="Visibility" Value="Collapsed"/>
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -64,90 +62,74 @@
                 </Grid>
             </DataTemplate>
 
-            <!-- One labelled requirement group (e.g. "Skill / ability gates"). Renders the
-                 group header + nested item rows. Empty groups don't reach the renderer — the
-                 projector culls them. -->
-            <DataTemplate DataType="{x:Type vm:QuestRequirementGroup}">
+            <DataTemplate DataType="{x:Type vm:QuestRewardRowVm}">
+                <Grid Margin="0,0,0,3">
+                    <StackPanel Orientation="Horizontal"
+                                Visibility="{Binding Link, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="{Binding Prefix}"
+                                   Style="{StaticResource StructureInlinePrefixStyle}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"
+                                   Visibility="{Binding Prefix, Converter={StaticResource NullOrEmptyToVis}}"/>
+                        <ContentControl Content="{Binding Link}"
+                                        ContentTemplate="{StaticResource InlineLinkTemplate}"/>
+                    </StackPanel>
+                    <TextBlock Text="{Binding Text}" VerticalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource FactBodyStyle}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Link, Converter={StaticResource NullToVis}}" Value="Visible">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </DataTemplate>
+
+            <!-- Group container: the Border is layout scaffolding (Phase-1: out
+                 of audit scope) — retained. The gold Label is the #404
+                 box-as-everything collision: dropped → StructureGroupHeaderStyle
+                 (G-b: Structure is never gold). -->
+            <DataTemplate DataType="{x:Type vm:QuestRequirementGroupVm}">
                 <Border Background="#FF1F1F1F" BorderBrush="#22FFFFFF" BorderThickness="1"
                         CornerRadius="3" Padding="8,6" Margin="0,0,0,4">
                     <StackPanel>
-                        <TextBlock Text="{Binding Label}" FontWeight="SemiBold"
-                                   Foreground="#FFD4A847"
-                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,3"/>
+                        <TextBlock Text="{Binding Label}"
+                                   Style="{StaticResource StructureGroupHeaderStyle}" Margin="0,0,0,3"/>
                         <ItemsControl ItemsSource="{Binding Requirements}"/>
                     </StackPanel>
                 </Border>
             </DataTemplate>
 
-            <!-- Reward row: prose path for value-shaped rewards (XP, currency), chip path for
-                 entity-shaped rewards (learned ability, taught recipe, lorebook, title). Same
-                 visibility-switch idiom as the requirement template. -->
-            <DataTemplate DataType="{x:Type vm:QuestRewardDisplay}">
-                <Grid Margin="0,0,0,3">
-                    <StackPanel Orientation="Horizontal">
-                        <StackPanel.Style>
-                            <Style TargetType="StackPanel">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ChipName, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </StackPanel.Style>
-                        <TextBlock Text="{Binding Prefix}" Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                   VerticalAlignment="Center" Margin="0,0,6,0"
-                                   Visibility="{Binding Prefix, Converter={StaticResource NullOrEmptyToVis}}"/>
-                        <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"
-                                      DataContext="{Binding Converter={StaticResource RequirementChipVmConverter}}"/>
-                    </StackPanel>
-                    <TextBlock Text="{Binding Text}" Foreground="#CCFFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               TextWrapping="Wrap" VerticalAlignment="Center">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Visibility" Value="Visible"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ChipName, Converter={StaticResource NullOrEmptyToVis}}" Value="Visible">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                </Grid>
-            </DataTemplate>
-
-            <DataTemplate DataType="{x:Type vm:QuestRewardGroup}">
+            <DataTemplate DataType="{x:Type vm:QuestRewardGroupVm}">
                 <Border Background="#FF1F1F1F" BorderBrush="#22FFFFFF" BorderThickness="1"
                         CornerRadius="3" Padding="8,6" Margin="0,0,0,4">
                     <StackPanel>
-                        <TextBlock Text="{Binding Label}" FontWeight="SemiBold"
-                                   Foreground="#FFD4A847"
-                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,3"/>
+                        <TextBlock Text="{Binding Label}"
+                                   Style="{StaticResource StructureGroupHeaderStyle}" Margin="0,0,0,3"/>
                         <ItemsControl ItemsSource="{Binding Rewards}"/>
                     </StackPanel>
                 </Border>
             </DataTemplate>
 
-            <DataTemplate DataType="{x:Type vm:QuestObjectiveRow}">
+            <DataTemplate DataType="{x:Type vm:QuestObjectiveRowVm}">
                 <Border Margin="0,0,0,6" Padding="8,4" Background="#FF1F1F1F"
                         BorderBrush="#22FFFFFF" BorderThickness="1" CornerRadius="3">
                     <StackPanel>
                         <DockPanel>
+                            <!-- Numbered-list ordinal marker (layout). The index
+                                 gold is dropped (G-b — a Fact value is never gold);
+                                 it reads as inert Fact in its marker box. -->
                             <Border DockPanel.Dock="Left" Background="#FF252525" CornerRadius="3"
                                     Padding="6,1" Margin="0,0,8,0" VerticalAlignment="Center">
-                                <TextBlock Text="{Binding Index}" Foreground="#FFD4A847"
-                                           FontSize="{DynamicResource AppFontSizeSmall}"/>
+                                <TextBlock Text="{Binding Index}" Style="{StaticResource FactBodyStyle}"/>
                             </Border>
-                            <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#FFFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"
-                                       TextWrapping="Wrap" VerticalAlignment="Center"/>
+                            <TextBlock c:FormattedText.Text="{Binding Description}"
+                                       Style="{StaticResource FactBodyStyle}" VerticalAlignment="Center"/>
                         </DockPanel>
-                        <TextBlock Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeSmall}"
-                                   Margin="32,2,0,0"
+                        <TextBlock Style="{StaticResource FactBodyStyle}" Margin="32,2,0,0"
                                    Visibility="{Binding Number, Converter={StaticResource NullOrEmptyToVis}}">
                             <Run Text="Repeat ×"/>
                             <Run Text="{Binding Number, Mode=OneWay}"/>
@@ -160,213 +142,146 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterText="{Binding InternalName}">
+    <!-- Phase-5 fan-out · view 8 of 8 (Quest — the dual-shape origin) — a
+         consistency-diff against the merged Recipe pilot, NOT fresh design.
+         The pilot's RecipeRequirementRowVm was modelled on THIS view's
+         dual-shape rows; the migration applies that exact wrapper back to its
+         source. #404 Phase-2: giver/turn-in + reward/pre-give/follow-up chips =
+         1:1 Link; gold group labels + RepeatabilityChip (T11) + the named G-b
+         "Quest favor line" = inert Fact (gold dropped); the dialogue Expander =
+         Control (ratified E3 — correctly classified, chrome left as-is).
+
+         Footer (matrix #14 / G-a · ratified E5): stop binding
+         DetailExportHost.FooterText, place <c:FactFooter/> at the foot (host
+         retained). InternalName is a cross-entity reference key ⇒ copyable KEY. -->
+    <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Internal-name footer is owned by the wrapping DetailExportHost (FooterText). -->
-
             <StackPanel>
-                <!-- Header: name + location chip + badges -->
+                <!-- Header: Fact-title + collapsed badge strip + badges line. -->
                 <StackPanel Margin="0,0,0,10">
-                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
-                               Foreground="#FFD4A847"
-                               FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                        <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
-                                CornerRadius="3" Padding="6,2"
-                                Visibility="{Binding Level, Converter={StaticResource NullOrEmptyToVis}}">
-                            <TextBlock Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}">
-                                <Run Text="Level "/>
-                                <Run Text="{Binding Level, Mode=OneWay}"/>
-                            </TextBlock>
-                        </Border>
-                        <Border Background="#FF252525" BorderBrush="#33FFFFFF" BorderThickness="1"
-                                CornerRadius="3" Padding="6,2" Margin="6,0,0,0"
-                                Visibility="{Binding LocationDisplay, Converter={StaticResource NullOrEmptyToVis}}">
-                            <TextBlock Text="{Binding LocationDisplay}" Foreground="#CCFFFFFF"
-                                       FontSize="{DynamicResource AppFontSizeHint}"/>
-                        </Border>
-                        <!-- Repeatability cadence. Gold-tinted to draw the eye — distinguishing
-                             a daily from a one-shot is the first piece of info a player wants. -->
-                        <Border Background="#FF2A2418" BorderBrush="#55D4A847" BorderThickness="1"
-                                CornerRadius="3" Padding="6,2" Margin="6,0,0,0"
-                                ToolTip="{Binding RepeatabilityDetail}"
-                                Visibility="{Binding RepeatabilityChip, Converter={StaticResource NullOrEmptyToVis}}">
-                            <TextBlock Text="{Binding RepeatabilityChip}" Foreground="#FFD4A847"
-                                       FontWeight="SemiBold"
-                                       FontSize="{DynamicResource AppFontSizeHint}"/>
-                        </Border>
-                    </StackPanel>
-                    <TextBlock Text="{Binding BadgesDisplay}" Foreground="#88FFFFFF" FontStyle="Italic"
-                               FontSize="{DynamicResource AppFontSizeSmall}" Margin="0,4,0,0"
+                    <TextBlock Text="{Binding DisplayName}"
+                               Style="{StaticResource FactTitleStyle}"/>
+                    <c:FactTable DataContext="{Binding HeaderStrip}"
+                                 HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                    <TextBlock Text="{Binding BadgesDisplay}"
+                               Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
+                               Margin="0,4,0,0"
                                Visibility="{Binding BadgesDisplay, Converter={StaticResource NullOrEmptyToVis}}"/>
                 </StackPanel>
 
-                <!-- Description sits high in the layout so it sets context before the player
-                     scans objectives / requirements. Embedded <i>/<b> markup parsed by the
-                     FormattedText attached property. -->
-                <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF"
-                           FontSize="{DynamicResource AppFontSize}" TextWrapping="Wrap"
+                <!-- Description -->
+                <TextBlock c:FormattedText.Text="{Binding Description}"
+                           Style="{StaticResource FactBodyStyle}"
                            MaxWidth="560" HorizontalAlignment="Left" Margin="0,0,0,10"
                            Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
 
-                <!-- Giver / turn-in NPCs. Two labelled chip slots — these typically refer to the
-                     same NPC for repeatable quests (giver = turn-in); render both regardless so the
-                     player can verify, and the chip degradation handles missing data. -->
+                <!-- Giver / Turn-in — Structure inline prefix + Prose Link. -->
                 <StackPanel Margin="0,0,0,10">
                     <StackPanel Orientation="Horizontal"
-                                Visibility="{Binding GiverChip, Converter={StaticResource NullToVis}}">
-                        <TextBlock Text="Giver:" Foreground="#88FFFFFF" FontWeight="SemiBold"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                Visibility="{Binding GiverLink, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="Giver:" Style="{StaticResource StructureInlinePrefixStyle}"
                                    VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <ContentControl Content="{Binding GiverChip}">
-                            <ContentControl.ContentTemplate>
-                                <DataTemplate>
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                                </DataTemplate>
-                            </ContentControl.ContentTemplate>
-                        </ContentControl>
+                        <ContentControl Content="{Binding GiverLink}"
+                                        ContentTemplate="{StaticResource InlineLinkTemplate}"
+                                        VerticalAlignment="Center"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,4,0,0"
-                                Visibility="{Binding TurnInChip, Converter={StaticResource NullToVis}}">
-                        <TextBlock Text="Turn in:" Foreground="#88FFFFFF" FontWeight="SemiBold"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                Visibility="{Binding TurnInLink, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="Turn in:" Style="{StaticResource StructureInlinePrefixStyle}"
                                    VerticalAlignment="Center" Margin="0,0,6,0"/>
-                        <ContentControl Content="{Binding TurnInChip}">
-                            <ContentControl.ContentTemplate>
-                                <DataTemplate>
-                                    <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                                </DataTemplate>
-                            </ContentControl.ContentTemplate>
-                        </ContentControl>
+                        <ContentControl Content="{Binding TurnInLink}"
+                                        ContentTemplate="{StaticResource InlineLinkTemplate}"
+                                        VerticalAlignment="Center"/>
                     </StackPanel>
                 </StackPanel>
 
                 <!-- Objectives -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding Objectives.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Objectives" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding Objectives}"/>
+                            Visibility="{Binding ObjectiveRowVms.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Objectives" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding ObjectiveRowVms}"/>
                 </StackPanel>
 
                 <!-- Requirements -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding RequirementGroups.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Requirements" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding RequirementGroups}"/>
+                            Visibility="{Binding RequirementGroupVms.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Requirements" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding RequirementGroupVms}"/>
                 </StackPanel>
 
-                <!-- Requirements to sustain — separately labelled so the player can tell apart
-                     "to bestow" from "to keep". Same shape, different label. -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding SustainRequirementGroups.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Maintain to keep quest" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding SustainRequirementGroups}"/>
+                            Visibility="{Binding SustainRequirementGroupVms.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Maintain to keep quest" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding SustainRequirementGroupVms}"/>
                 </StackPanel>
 
-                <!-- Rewards: items + recipes (clickable chips) + grouped value rewards + favor.
-                     Order matters — clickable cross-link rewards first, value rewards second. -->
+                <!-- Item / recipe rewards — Link enumerations. -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding RewardItemChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Item rewards" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding RewardItemChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding RewardItemLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Item rewards" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding RewardItemLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding RewardRecipeChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Recipe rewards" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding RewardRecipeChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding RewardRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Recipe rewards" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding RewardRecipeLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding RewardGroups.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <ItemsControl ItemsSource="{Binding RewardGroups}"/>
+                            Visibility="{Binding RewardGroupVms.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <ItemsControl ItemsSource="{Binding RewardGroupVms}"/>
                 </StackPanel>
 
-                <TextBlock Foreground="#FFD4A847" FontStyle="Italic"
-                           FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,10"
+                <!-- Favor reward — the NAMED G-b "Quest favor line": gold
+                     dropped → inert Fact (italic kept). -->
+                <TextBlock Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
+                           Margin="0,0,0,10"
                            Visibility="{Binding FavorRewardDisplay, Converter={StaticResource NullOrEmptyToVis}}"
                            Text="{Binding FavorRewardDisplay}"/>
 
-                <!-- Pre-give: items + recipes handed over when the quest is accepted. -->
+                <!-- Pre-give: items + recipes -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding PreGiveItemChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Given when accepted" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding PreGiveItemChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding PreGiveItemLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Given when accepted" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding PreGiveItemLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding PreGiveRecipeChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Recipes given when accepted" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding PreGiveRecipeChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding PreGiveRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Recipes given when accepted" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding PreGiveRecipeLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Follow-up quests — clickable from day one since they self-reference this tab. -->
+                <!-- Follow-up quests -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding FollowUpQuestChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Leads to" FontWeight="SemiBold" Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding FollowUpQuestChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:QuestDetailView}}}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            Visibility="{Binding FollowUpQuestLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Leads to" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding FollowUpQuestLinks}"
+                                  ItemTemplate="{StaticResource EntityLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- NPC dialogue (preface / midway / completion). Mostly flavor text — tucked
-                     into an Expander that defaults closed so it doesn't dominate the pane. PG's
-                     <i>Speaker:</i> dialogue markup is parsed by the FormattedText attached
-                     property. -->
+                <!-- NPC dialogue — ratified E3: in-place disclosure of
+                     non-entity prose = Control (correctly classified). The
+                     Expander chrome is left as-is (the canonical pattern
+                     defines no Expander treatment — restyling it would be fresh
+                     design); only the inner flavor prose moves to FactBody. -->
                 <Expander Header="Quest dialogue"
                           Foreground="#88FFFFFF" Background="Transparent"
                           BorderBrush="#22FFFFFF" BorderThickness="0,1,0,0"
@@ -374,20 +289,25 @@
                           IsExpanded="False"
                           Visibility="{Binding HasFlavorText, Converter={StaticResource BoolToVis}}">
                     <StackPanel Margin="0,6,0,0">
-                        <TextBlock c:FormattedText.Text="{Binding PrefaceFormatted}" Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeSmall}" TextWrapping="Wrap"
+                        <TextBlock c:FormattedText.Text="{Binding PrefaceFormatted}"
+                                   Style="{StaticResource FactBodyStyle}"
                                    MaxWidth="560" HorizontalAlignment="Left" Margin="0,0,0,8"
                                    Visibility="{Binding PrefaceFormatted, Converter={StaticResource NullOrEmptyToVis}}"/>
-                        <TextBlock c:FormattedText.Text="{Binding MidwayFormatted}" Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeSmall}" TextWrapping="Wrap"
+                        <TextBlock c:FormattedText.Text="{Binding MidwayFormatted}"
+                                   Style="{StaticResource FactBodyStyle}"
                                    MaxWidth="560" HorizontalAlignment="Left" Margin="0,0,0,8"
                                    Visibility="{Binding MidwayFormatted, Converter={StaticResource NullOrEmptyToVis}}"/>
-                        <TextBlock c:FormattedText.Text="{Binding SuccessFormatted}" Foreground="#CCFFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeSmall}" TextWrapping="Wrap"
+                        <TextBlock c:FormattedText.Text="{Binding SuccessFormatted}"
+                                   Style="{StaticResource FactBodyStyle}"
                                    MaxWidth="560" HorizontalAlignment="Left" Margin="0,0,0,8"
                                    Visibility="{Binding SuccessFormatted, Converter={StaticResource NullOrEmptyToVis}}"/>
                     </StackPanel>
                 </Expander>
+
+                <!-- Footer ID strip (matrix #14, G-a · ratified E5). Quest
+                     InternalName is a cross-entity reference KEY ⇒ copyable.
+                     FactFooterVm.None() self-hides at 0 ids. -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>
         </DockPanel>
     </Border>

--- a/tests/Silmarillion.Tests/ViewModels/QuestsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/QuestsTabViewModelTests.cs
@@ -4,6 +4,7 @@ using Mithril.Reference.Models.Npcs;
 using Mithril.Reference.Models.Quests;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
 using Silmarillion.Navigation;
 using Silmarillion.ViewModels;
 using Xunit;
@@ -230,6 +231,101 @@ public sealed class QuestsTabViewModelTests
         columns.Should().Contain("IsCancellable");
         columns.Should().Contain("FavorNpcDisplayName");
         columns.Should().Contain("DisplayedLocation");
+    }
+
+    // ── Phase 5 grammar-primitive projections ──────────────────────────────
+
+    [Fact]
+    public void HeaderStrip_CollapsesBadges_AndFooterIsCopyableKey()
+    {
+        var refData = new StubReferenceData
+        {
+            QuestsByInternalNameMap =
+            {
+                ["Q1"] = new Quest
+                {
+                    InternalName = "Q1", Name = "Quest One",
+                    Level = 25, DisplayedLocation = "Serbule", ReuseTime_Hours = 24,
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllQuests.Single();
+        var d = vm.DetailViewModel!;
+
+        // Level / Location / Repeatability badge boxes collapse into ONE inert
+        // Strip (value-only); the named G-b T11 Repeatability gold is gone by
+        // construction (FactTableVm has no brush).
+        d.HeaderStrip.Layout.Should().Be(FactTableLayout.Strip);
+        d.HeaderStrip.Pairs.Select(p => p.Value).Should().Equal("Level 25", "Serbule", "Daily");
+        d.HeaderStrip.Pairs.Should().OnlyContain(p => p.Label == null);
+
+        // Quest InternalName is a cross-entity reference key ⇒ copyable KEY.
+        d.Footer.Ids.Should().ContainSingle();
+        d.Footer.Ids[0].LabelTag.Should().Be("KEY");
+        d.Footer.Ids[0].Value.Should().Be("Q1");
+        d.Footer.Ids[0].Copyable.Should().BeTrue();
+        FactFooter.ResolveCellClick(d.Footer.Ids[0]).Should().Be(FactFooterCellAction.Copy);
+    }
+
+    [Fact]
+    public void LinkProjections_GiverAndRewardItems_MirrorLegacyChips()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByInternalNameMap = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+            QuestsByInternalNameMap =
+            {
+                ["Q1"] = new Quest
+                {
+                    InternalName = "Q1", Name = "Quest One", QuestNpc = "NPC_Joeh",
+                    Rewards_Items = new[] { new QuestItemRef { Item = "Apple", StackSize = 2 } },
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllQuests.Single();
+        var d = vm.DetailViewModel!;
+
+        d.GiverLink.Should().NotBeNull();
+        d.GiverLink!.DisplayName.Should().Be(d.GiverChip!.DisplayName);
+        d.GiverLink.Glyph.Should().Be(LinkGlyph.Npc);
+        d.GiverLink.IsNavigable.Should().Be(d.GiverChip.IsNavigable, "adapter preserves navigability");
+        d.RewardItemLinks.Select(l => l.DisplayName)
+            .Should().Equal(d.RewardItemChips.Select(c => c.DisplayName));
+    }
+
+    [Fact]
+    public void RequirementGroupVms_WrapGroups_PreservingProseRowsWithNullLink()
+    {
+        var refData = new StubReferenceData
+        {
+            QuestsByInternalNameMap =
+            {
+                ["Q1"] = new Quest
+                {
+                    InternalName = "Q1", Name = "Quest One",
+                    Requirements = new QuestRequirement[]
+                    {
+                        new MinSkillLevelRequirement { Skill = "Sword", Level = "10" },
+                    },
+                },
+            },
+        };
+        var vm = BuildVm(refData);
+        vm.SelectedRow = vm.AllQuests.Single();
+        var d = vm.DetailViewModel!;
+
+        // Wrapper count/labels mirror the legacy groups (the pilot
+        // RecipeRequirementRowVm idiom applied to its origin).
+        d.RequirementGroupVms.Select(g => g.Label)
+            .Should().Equal(d.RequirementGroups.Select(g => g.Label));
+        var rows = d.RequirementGroupVms.SelectMany(g => g.Requirements).ToList();
+        rows.Should().NotBeEmpty();
+        // A skill-level gate is a prose row ⇒ Link null, Text preserved verbatim.
+        rows.Should().OnlyContain(r => r.Link == null);
+        rows.Select(r => r.Text).Should().BeEquivalentTo(
+            d.RequirementGroups.SelectMany(g => g.Requirements).Select(x => x.Text));
     }
 
     private static QuestsTabViewModel BuildVm(StubReferenceData refData) =>


### PR DESCRIPTION
## #404 Phase 5 fan-out — view 8 of 8: Quest (the dual-shape origin) — **fan-out complete**

The eighth and **final** fan-out view. Uniquely, Quest is the **origin** the pilot's `RecipeRequirementRowVm` dual-shape was modelled on (pilot comment: *"Dual-shape, mirroring QuestDetailView"*). This migration applies that exact wrapper back to its source — the cleanest possible consistency-diff.

### Canonical pattern applied

| Element | #404 matrix | Treatment |
|---|---|---|
| Title | T4 | `FactTitleStyle` |
| Level / Location / **Repeatability** badge boxes | T1 + **named G-b T11** | collapse to one inert `FactTable` Strip; gold gone by construction |
| BadgesDisplay | T2 | `FactBodyStyle` italic |
| Giver / Turn-in | E1 + Link | Structure inline prefix + Prose `Link` |
| **QuestRequirementDisplay / QuestRewardDisplay dual-shape rows** | the pilot's source | wrapped **verbatim** via the `RecipeRequirementRowVm` idiom: chip row ⇒ Structure prefix + Prose `Link`; prose row ⇒ inert Fact (`Link` null, `NullToVis` object switch) |
| Group labels / objective index | gold ❌ | gold dropped → `StructureGroupHeaderStyle` / inert Fact (Borders kept as layout scaffolding) |
| Item / recipe / pre-give / follow-up rewards | enumeration | `Link` `Density="List"` |
| **FavorRewardDisplay** | **named G-b "Quest favor line"** | gold dropped → inert Fact (italic kept) |
| Quest-dialogue Expander | **ratified E3 → Control** | correctly classified; chrome left as-is (canonical pattern defines no Expander treatment — restyling = fresh design); inner prose → `FactBodyStyle` |
| Footer | #14 / G-a · ratified E5 | `<c:FactFooter/>`; InternalName = **copyable `KEY`** |

### Substantive judgements

1. **The dual-shape comes home.** The pilot was explicitly modelled on this view's requirement/reward rows. Wrapping them with the *same* `RecipeRequirementRowVm` shape (now `QuestRequirementRowVm` / `QuestRewardRowVm` / `*GroupVm` / `QuestObjectiveRowVm`) is the highest-confidence application in the whole fan-out — it closes the loop.
2. **Named G-b sites fixed.** Both Quest-specific G-b call-outs from the #404 evidence list — the Repeatability T11 badge and the "Quest favor line" — are corrected (gold gone by construction / dropped to inert Fact).
3. **E3 respected, not over-applied.** The dialogue Expander is ratified Control; the canonical pattern table has no Expander treatment, so the chrome is left as-is (restyling would be fresh design, anti-goal #1) — only the inner Fact prose migrates.
4. **Scope-disciplined dead code.** The bespoke `RequirementChipVmConverter` is no longer *referenced* (the wrapper builds `LinkVm` directly), but its `.cs` lives in a separate file outside this view's 3-file diff-guard scope, so it is **not deleted here** — flagged as a follow-up cleanup rather than breaching the scope guard.

### Anti-goals respected

- One view per PR; `git status` = only `QuestDetailView.xaml` + its VM + the Quest test file. No primitive / `Resources.xaml` / other-view edits; out-of-scope row records wrapped not edited.
- Legacy members retained — existing Quest tab + projector tests stay green.

### Verification

- Isolated build `src/Silmarillion.Module` — **0W/0E**
- `dotnet test tests/Silmarillion.Tests` — **486/486** (existing Quest tab + projector tests + 3 new: header-strip collapse + copyable-`KEY` footer, Giver/RewardItem Link projections, dual-shape `RequirementGroupVm` wrap preserving prose-row `Link`-null)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK (117 keys)`

### Fan-out status — COMPLETE

This is **8 of 8**. With PRs #415–#421 + this, every Silmarillion detail view is migrated to the shared grammar primitives. Next: a **consolidated boot smoke** across all eight (the per-view full builds already compiled every BAML + linted resources) and **Phase 6** (the conformance guardrail + flipping the visual-debt note in `docs/silmarillion-field-coverage.md`).

### G4 acceptance bar

Maintainer **consistency review vs the merged pilot** — esp. the dual-shape wrapper as the exact return of the pilot's own idiom to its source, and the two named G-b Quest fixes.

Tracked in #404 · Phase 5 fan-out **8 of 8 — complete**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
