### PR TITLE
feat(silmarillion): #404 Phase 6 — grammar conformance guardrail + flip visual-debt note (merge after #415–#422)

### DIFF
--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -144,20 +144,33 @@ an unwired edge. This is the priority and stands alone.
 - Everything else unsurfaced is deliberate; do not file "increase coverage" issues
   against it. If a future audit re-flags class 1–4 properties, point it here.
 
-### Known visual debt (axis: presentation, not coverage)
+### Visual grammar (#404) — RESOLVED
 
-- **No fact / control / link visual grammar** (#404). A design critique found
-  the shared `EntityChip` is visually identical to the header stat badges
-  (`Skill N`, `MaxUses`, cooldown) and breaks prose in `{prefix} [chip]` rows.
-  Root cause is the *absence of a grammar* distinguishing passive facts from
-  controls from navigable links — the chip collision is one symptom. This is a
-  *coverage-complete, presentation-wrong* state: #342's fields are all surfaced,
-  the visual grammar is the debt. Agreed direction: grammar-first; link tier →
-  **V2** (small lead-icon + gold name, no box — V5's prose/list dual form
-  rejected as a call-site footgun); badge tier restyled to read inert (same
-  pass, not orthogonal). Design-system change, deliberately **out of #342/#400
-  scope** — tracked in #404. Don't re-flag the recipe-detail chips as a coverage
-  gap; they're not.
+- **No fact / control / link visual grammar** (#404) — **RESOLVED 2026-05-17.**
+  The original debt: the shared `EntityChip` was visually identical to the
+  header stat badges (`Skill N`, `MaxUses`, cooldown) and broke prose in
+  `{prefix} [chip]` rows; root cause was the *absence of a grammar*
+  distinguishing passive facts from controls from navigable links (a
+  *coverage-complete, presentation-wrong* state — #342's fields were all
+  surfaced; the grammar was the debt).
+
+  Closed by the #404 program: the ratified five-tier grammar
+  (Fact · Control · Link · Set-reference · Structure) is encoded as shared WPF
+  primitives (`Link` / `SetRef` / `FactTable` / `FactFooter` + the Structure
+  styles — Phase 4) and **every** Silmarillion detail view is migrated to them
+  (Phase 5: the Recipe pilot + the eight-view fan-out — PlayerTitle, Lorebook,
+  Area, Effect, Npc, StorageVault, Ability, Quest). The link tier is the V2
+  form (small lead-icon + gold name, no box); stat badges read inert via
+  `FactTable`; keyword/stacking chips are Set-reference (ratified E4); the
+  footer is the G-a/E5 `FactFooter`. The full grammar +
+  amendments + decision log: [`docs/silmarillion-visual-grammar.md`](silmarillion-visual-grammar.md).
+
+  A Phase-6 conformance guardrail
+  (`DetailViewGrammarConformanceTests`) fails the build if any Silmarillion
+  detail view re-introduces a legacy entity-reference chip
+  (`EntityChip`/`ItemSourceChip`) instead of the shared primitive, so this
+  cannot silently regress. Do not re-flag detail-pane chips as a coverage gap;
+  the presentation axis is closed.
 
 ## History
 

--- a/tests/Silmarillion.Tests/Views/DetailViewGrammarConformanceTests.cs
+++ b/tests/Silmarillion.Tests/Views/DetailViewGrammarConformanceTests.cs
@@ -1,0 +1,81 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Silmarillion.Tests.Views;
+
+/// <summary>
+/// Phase-6 conformance guardrail for the #404 visual grammar. Every Silmarillion
+/// <c>*DetailView.xaml</c> renders entity references through the shared Phase-4
+/// primitives (<c>Link</c> / <c>SetRef</c> / <c>FactTable</c> / <c>FactFooter</c>);
+/// the legacy bordered-box entity chips (<c>EntityChip</c> / <c>ItemSourceChip</c>)
+/// are the exact "raw bordered box for an entity reference" the #404 program
+/// removed (the Fact↔Link↔Set-reference collision).
+/// <para>
+/// xunit never instantiates XAML and the bordered-box chips compile + pass every
+/// VM test fine, so a re-introduced <c>EntityChip</c> in a detail view would ship
+/// the original debt back silently. This source-scan is the cheapest layer that
+/// fails the build the moment a detail view regresses to the legacy control —
+/// the Phase-6 "flip the visual-debt note to resolved, and keep it resolved"
+/// guarantee (see <c>docs/silmarillion-field-coverage.md</c> §"Visual grammar
+/// (#404) — RESOLVED" and <c>docs/silmarillion-visual-grammar.md</c>).
+/// </para>
+/// </summary>
+public sealed class DetailViewGrammarConformanceTests
+{
+    // Matches a legacy entity-reference chip element regardless of the xmlns
+    // alias the view happens to use (c: / wpf: / …): "<{alias}:EntityChip" or
+    // "<{alias}:ItemSourceChip". The shared grammar primitives (Link/SetRef/
+    // FactTable/FactFooter) are intentionally NOT matched — they are the
+    // sanctioned replacements.
+    private static readonly Regex LegacyEntityChip =
+        new(@"<[A-Za-z0-9_]+:(EntityChip|ItemSourceChip)\b", RegexOptions.Compiled);
+
+    [Fact]
+    public void NoSilmarillionDetailView_RendersAnEntityReferenceAsALegacyBorderedChip()
+    {
+        var viewsDir = FindViewsDir();
+        if (viewsDir is null) return; // source tree not reachable (packaged run) — skip, don't false-fail
+
+        var detailViews = Directory
+            .EnumerateFiles(viewsDir, "*DetailView.xaml", SearchOption.AllDirectories)
+            .OrderBy(p => p)
+            .ToList();
+
+        // Sanity: the scan must actually see the detail views (a glob that
+        // matched nothing would make this guard vacuously pass forever).
+        detailViews.Should().NotBeEmpty(
+            "the Silmarillion detail views must be discoverable for the guardrail to be meaningful");
+
+        var offenders = detailViews
+            .Where(xaml => LegacyEntityChip.IsMatch(File.ReadAllText(xaml)))
+            .Select(Path.GetFileName)
+            .OrderBy(n => n)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "#404 is RESOLVED — every detail view must render entity references through the "
+            + "shared grammar primitives (c:Link / c:SetRef / c:FactTable / c:FactFooter), "
+            + "never the legacy bordered-box EntityChip/ItemSourceChip. A view in this list "
+            + "has regressed to the pre-#404 debt; migrate it per "
+            + "docs/silmarillion-visual-grammar.md.");
+    }
+
+    /// <summary>
+    /// Walk up from the test bin dir to the repo root (marked by <c>Mithril.slnx</c>),
+    /// then resolve <c>src/Silmarillion.Module/Views</c>. Returns null if not found
+    /// (mirrors <see cref="TabViewCodeBehindGuardTests"/>'s convention).
+    /// </summary>
+    private static string? FindViewsDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mithril.slnx")))
+            dir = dir.Parent;
+
+        if (dir is null) return null;
+        var views = Path.Combine(dir.FullName, "src", "Silmarillion.Module", "Views");
+        return Directory.Exists(views) ? views : null;
+    }
+}


### PR DESCRIPTION
## #404 Phase 6 — conformance guardrail + flip the visual-debt note (closes the #404 program)

The final #404 phase. Two parts:

### 1. Conformance guardrail — `DetailViewGrammarConformanceTests`

A source-scan that **fails the build** if any Silmarillion `*DetailView.xaml` renders an entity reference through the legacy bordered-box `EntityChip` / `ItemSourceChip` instead of the shared Phase-4 grammar primitives (`Link` / `SetRef` / `FactTable` / `FactFooter`).

- Mirrors the established `TabViewCodeBehindGuardTests` source-location convention (walk up to `Mithril.slnx` → `src/Silmarillion.Module/Views`; skip gracefully if the source tree isn't reachable in a packaged run — never false-fail).
- Alias-agnostic regex (`<{any}:EntityChip|ItemSourceChip`) so it can't be evaded by switching the xmlns prefix.
- Asserts the glob is non-empty, so it can never pass *vacuously*.

xunit never instantiates XAML and the bordered chips compile + pass every VM test fine, so a re-introduced `EntityChip` in a detail view would ship the original #404 debt back **silently**. This source-scan is the cheapest layer that catches that regression at build time — the "keep it resolved" guarantee.

### ⚠️ Merge ordering (important)

This guardrail is **deliberately RED on a branch cut from pre-fan-out `main`** — it correctly detects the legacy chips in the eight not-yet-migrated detail views (verified locally: 1 failed, the offender list = the unmigrated views). *That redness is the guardrail working* — it proves the test is meaningful, not vacuous. It goes **GREEN** once the Phase-5 fan-out lands.

**This PR must merge AFTER #415–#422** (or be rebased onto them). Its CI stays red until the fan-out is merged. The combined green state is demonstrated on the consolidated integration branch (all eight fan-out PRs + this) — see the orchestration summary.

### 2. Flip the visual-debt note

`docs/silmarillion-field-coverage.md` §"Known visual debt" → **"Visual grammar (#404) — RESOLVED"**, pointing at [`docs/silmarillion-visual-grammar.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/silmarillion-visual-grammar.md), the Phase-4 primitives, the Phase-5 pilot + eight-view fan-out, and this guardrail — so the presentation axis is recorded closed *and* protected from silent regression.

### Scope

Only the new guardrail test + the coverage-doc note. No primitive, no view, no VM. (The now-dead `RequirementChipVmConverter` surfaced by the Quest migration is a separately-tracked follow-up, deliberately not folded here.)

### Verification

- Guardrail on pre-fan-out main — **FAILS as designed** (detects the 8 unmigrated views; `RecipeDetailView` pilot already clean)
- Full `dotnet build Mithril.slnx` — **0W/0E**, `XamlResourceLint: OK`
- Green state proven on the consolidated integration branch (fan-out + this) — boot smoke included; see orchestration summary

Tracked in #404 · **Phase 6 — closes the #404 program.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
