### PR TITLE
docs(silmarillion): #404 Phase 6 — scope the RESOLVED claim to Silmarillion tab views (re-land post-#423)

### DIFF
--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -144,9 +144,10 @@ an unwired edge. This is the priority and stands alone.
 - Everything else unsurfaced is deliberate; do not file "increase coverage" issues
   against it. If a future audit re-flags class 1–4 properties, point it here.
 
-### Visual grammar (#404) — RESOLVED
+### Visual grammar (#404) — RESOLVED for the Silmarillion tab detail views
 
-- **No fact / control / link visual grammar** (#404) — **RESOLVED 2026-05-17.**
+- **No fact / control / link visual grammar** (#404) — **RESOLVED 2026-05-17
+  for the nine Silmarillion *tab* detail views.**
   The original debt: the shared `EntityChip` was visually identical to the
   header stat badges (`Skill N`, `MaxUses`, cooldown) and broke prose in
   `{prefix} [chip]` rows; root cause was the *absence of a grammar*
@@ -157,20 +158,36 @@ an unwired edge. This is the priority and stands alone.
   Closed by the #404 program: the ratified five-tier grammar
   (Fact · Control · Link · Set-reference · Structure) is encoded as shared WPF
   primitives (`Link` / `SetRef` / `FactTable` / `FactFooter` + the Structure
-  styles — Phase 4) and **every** Silmarillion detail view is migrated to them
-  (Phase 5: the Recipe pilot + the eight-view fan-out — PlayerTitle, Lorebook,
-  Area, Effect, Npc, StorageVault, Ability, Quest). The link tier is the V2
+  styles — Phase 4) and **every Silmarillion *tab* detail view** is migrated to
+  them (Phase 5: the Recipe pilot + the eight-view fan-out — PlayerTitle,
+  Lorebook, Area, Effect, Npc, StorageVault, Ability, Quest). The link tier is the V2
   form (small lead-icon + gold name, no box); stat badges read inert via
   `FactTable`; keyword/stacking chips are Set-reference (ratified E4); the
   footer is the G-a/E5 `FactFooter`. The full grammar +
   amendments + decision log: [`docs/silmarillion-visual-grammar.md`](silmarillion-visual-grammar.md).
 
   A Phase-6 conformance guardrail
-  (`DetailViewGrammarConformanceTests`) fails the build if any Silmarillion
-  detail view re-introduces a legacy entity-reference chip
-  (`EntityChip`/`ItemSourceChip`) instead of the shared primitive, so this
-  cannot silently regress. Do not re-flag detail-pane chips as a coverage gap;
-  the presentation axis is closed.
+  (`DetailViewGrammarConformanceTests`) fails the build if any
+  `src/Silmarillion.Module/Views/*DetailView.xaml` re-introduces a legacy
+  entity-reference chip (`EntityChip`/`ItemSourceChip`) instead of the shared
+  primitive, so the Silmarillion tab detail views cannot silently regress. Do
+  not re-flag *those* detail-pane chips as a coverage gap; that surface is
+  closed.
+
+- **Remaining grammar surface (NOT closed): the shared
+  `Mithril.Shared.Wpf/ItemDetailView` / `ItemDetailWindow`.** Item has no
+  Silmarillion *tab* detail by design (see "Modeled but no detail view"
+  above) — its detail is the cross-module shared pane (`ItemDetailWindow`
+  popups, Bilbo, cross-link "open in window"). That pane was deliberately
+  **out of #404 Phase-5 scope** (Phase-5 anti-goal #3 forbade editing shared
+  `Mithril.Shared.Wpf` primitives) and still carries the pre-#404 boxed-chip
+  grammar — so clicking an item Link from a now-migrated Silmarillion view
+  lands in an un-migrated window (the grammar break is visible at that
+  navigation boundary). The Phase-4 primitives + the pilot pattern make this
+  migration mechanical, but it is shared infra with cross-module blast radius
+  and is its **own** gated effort, tracked separately — NOT presumed closed by
+  the #404 program. The conformance guardrail intentionally does **not** cover
+  it (it scopes to `src/Silmarillion.Module/Views`).
 
 ## History
 

--- a/tests/Silmarillion.Tests/Views/DetailViewGrammarConformanceTests.cs
+++ b/tests/Silmarillion.Tests/Views/DetailViewGrammarConformanceTests.cs
@@ -22,6 +22,15 @@ namespace Silmarillion.Tests.Views;
 /// guarantee (see <c>docs/silmarillion-field-coverage.md</c> §"Visual grammar
 /// (#404) — RESOLVED" and <c>docs/silmarillion-visual-grammar.md</c>).
 /// </para>
+/// <para>
+/// <b>Scope:</b> intentionally only <c>src/Silmarillion.Module/Views/*DetailView.xaml</c>
+/// — the nine Silmarillion <em>tab</em> detail panes #404 Phase-5 migrated. It does
+/// NOT cover the shared <c>Mithril.Shared.Wpf/ItemDetailView</c> /
+/// <c>ItemDetailWindow</c>: Item has no Silmarillion tab detail by design, that pane
+/// is cross-module shared infra (Phase-5 anti-goal #3 forbade editing it), and its
+/// grammar migration is its own separately-tracked effort — explicitly NOT closed by
+/// #404 (see the "Remaining grammar surface" bullet in the coverage doc).
+/// </para>
 /// </summary>
 public sealed class DetailViewGrammarConformanceTests
 {


### PR DESCRIPTION
## #404 Phase 6 — scope the "RESOLVED" claim to the Silmarillion tab views

**Re-lands a tightening that missed the #423 merge window.** PR #423 (Phase 6 guardrail + visual-debt-note flip) merged at `d861909` while the `ItemDetailView` scope question was still being discussed, so the over-claiming wording shipped to `main`. This PR applies the agreed tightening on top of merged `main`.

### What the flip over-claimed

#423's note said *"the presentation axis is closed."* That reads as a blanket statement, but the shared `Mithril.Shared.Wpf/ItemDetailView` (`ItemDetailWindow` popups / Bilbo / cross-link "open in window") still carries the pre-#404 boxed-chip grammar — visible the moment a user clicks an item Link from a now-migrated Silmarillion view (the grammar break sits exactly on the navigation boundary #404 created). That pane was correctly out of #404 Phase-5 scope (Item has no Silmarillion tab detail by design; Phase-5 anti-goal #3 forbade editing shared `Mithril.Shared.Wpf` primitives) — the orchestration didn't miss it, but the doc wording presumed it closed.

### Changes (doc + test-xmldoc only — no behaviour change)

- `silmarillion-field-coverage.md`: heading + body scope "RESOLVED" to the nine Silmarillion **tab** detail views; new **"Remaining grammar surface (NOT closed)"** bullet naming the shared `ItemDetailView`/`ItemDetailWindow` as its own separately-tracked migration (**#424**).
- `DetailViewGrammarConformanceTests` xmldoc states it intentionally scopes to `src/Silmarillion.Module/Views` and does **not** cover the shared `ItemDetailView`, so a future reader doesn't mistake the green guard for app-wide closure.

### Verification

- Post-merge re-verify of actual squash-merged `main` (the `#415–#422` then `#423` order landed correctly): full `Mithril.slnx` build **0W/0E** + `XamlResourceLint OK`, `tests/Silmarillion.Tests` **516/516**, the Phase-6 guardrail **GREEN**, boot smoke clean (shell shown / startup done).
- This PR on top of `main`: guardrail still **GREEN** (comment/doc-only; no behaviour change).

Follow-up tracked in **#424** (migrate the shared `ItemDetailView` to the grammar — shared infra, its own gated effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
