### PR TITLE
feat(silmarillion): #424 — migrate shared ItemDetailView to the #404 visual grammar

### DIFF
--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -144,10 +144,11 @@ an unwired edge. This is the priority and stands alone.
 - Everything else unsurfaced is deliberate; do not file "increase coverage" issues
   against it. If a future audit re-flags class 1–4 properties, point it here.
 
-### Visual grammar (#404) — RESOLVED for the Silmarillion tab detail views
+### Visual grammar (#404) — RESOLVED (all detail panes, incl. the shared item-detail #424)
 
 - **No fact / control / link visual grammar** (#404) — **RESOLVED 2026-05-17
-  for the nine Silmarillion *tab* detail views.**
+  for the nine Silmarillion *tab* detail views; the shared cross-module
+  item-detail pane followed via #424 (2026-05-17).**
   The original debt: the shared `EntityChip` was visually identical to the
   header stat badges (`Skill N`, `MaxUses`, cooldown) and broke prose in
   `{prefix} [chip]` rows; root cause was the *absence of a grammar*
@@ -168,26 +169,32 @@ an unwired edge. This is the priority and stands alone.
 
   A Phase-6 conformance guardrail
   (`DetailViewGrammarConformanceTests`) fails the build if any
-  `src/Silmarillion.Module/Views/*DetailView.xaml` re-introduces a legacy
+  `src/Silmarillion.Module/Views/*DetailView.xaml` **or the shared
+  `src/Mithril.Shared.Wpf/ItemDetailView.xaml`** re-introduces a legacy
   entity-reference chip (`EntityChip`/`ItemSourceChip`) instead of the shared
-  primitive, so the Silmarillion tab detail views cannot silently regress. Do
-  not re-flag *those* detail-pane chips as a coverage gap; that surface is
-  closed.
+  primitive, so neither the Silmarillion tab detail views nor the cross-module
+  item-detail pane can silently regress. Do not re-flag *those* detail-pane
+  chips as a coverage gap; that surface is closed.
 
-- **Remaining grammar surface (NOT closed): the shared
-  `Mithril.Shared.Wpf/ItemDetailView` / `ItemDetailWindow`.** Item has no
-  Silmarillion *tab* detail by design (see "Modeled but no detail view"
-  above) — its detail is the cross-module shared pane (`ItemDetailWindow`
-  popups, Bilbo, cross-link "open in window"). That pane was deliberately
-  **out of #404 Phase-5 scope** (Phase-5 anti-goal #3 forbade editing shared
-  `Mithril.Shared.Wpf` primitives) and still carries the pre-#404 boxed-chip
-  grammar — so clicking an item Link from a now-migrated Silmarillion view
-  lands in an un-migrated window (the grammar break is visible at that
-  navigation boundary). The Phase-4 primitives + the pilot pattern make this
-  migration mechanical, but it is shared infra with cross-module blast radius
-  and is its **own** gated effort, tracked separately — NOT presumed closed by
-  the #404 program. The conformance guardrail intentionally does **not** cover
-  it (it scopes to `src/Silmarillion.Module/Views`).
+- **Shared cross-module item-detail pane — RESOLVED (#424, 2026-05-17).** The
+  shared `Mithril.Shared.Wpf/ItemDetailView` / `ItemDetailWindow` (Item has no
+  Silmarillion *tab* detail by design — see "Modeled but no detail view"
+  above; its detail is the cross-module pane used by `ItemDetailWindow`
+  popups, Bilbo, Celebrimbor, and cross-link "open in window") was
+  deliberately **out of #404 Phase-5 scope** (Phase-5 anti-goal #3 forbade
+  editing shared `Mithril.Shared.Wpf` primitives during the fan-out). It was
+  migrated by its **own gated follow-up #424**: a mini-Phase-1 classification
+  then a consistency-diff against the merged pilot + `EffectDetailView` —
+  EquipSlot + skill-req pills folded into one inert `FactTable` strip;
+  Sources / Produced by / Awarded by / Bestows lorebook / Used in / Used as
+  rendered through `Link`; the two "View all N →" drawers as summary-form
+  `SetRef`; the InternalName footer as the copyable-`KEY` `FactFooter`; the
+  per-`*Preview` sections as inert Fact body. The grammar break at the
+  Silmarillion→item-window navigation boundary is closed, and the Phase-6
+  guardrail now covers this pane too (above). The VM change was additive — the
+  legacy chip/string members the `ItemsTabViewModel` tests assert are
+  retained. Do not re-flag this pane as a remaining grammar surface; it is
+  closed.
 
 ## History
 

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -17,313 +17,249 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <c:DetailExportHost FooterText="{Binding InternalName}">
+    <!-- #424 — the shared item-detail pane migrated to the #404 visual grammar.
+         A consistency-diff against the merged Recipe pilot
+         (src/Silmarillion.Module/Views/RecipeDetailView.xaml) + the merged
+         EffectDetailView fan-out (#418), NOT fresh design. Tier classification
+         (a mini Phase-1; Item has no Phase-1/2 matrix row by design):
+           • title → FactTitleStyle; header icon → fixed-40px FactTitleGlyphStyle
+           • EquipSlot + skill-req pills → ONE inert Fact strip (FactTable Strip,
+             no box/gold — G-b); the legacy boxed "Skill requirements" section
+             and EquipSlot subtitle are folded into it (the pilot StatStrip idiom)
+           • Sources / Produced by / Awarded by / Bestows lorebook / Used in /
+             Used as = entity refs → Link enumeration (Density="List"); the two
+             "View all N →" ghost-gold buttons → Set-ref summary-form on the
+             EXISTING popup commands (gold→blue, ratified G-b) — exactly
+             EffectDetailView §7 "Required by abilities"
+           • every *Preview.DisplayLine/DisplayText section = plain-text Fact →
+             FactBodyStyle (gold sub-headers dropped, G-b)
+           • Augment/Wax/Infusion per-group DisplayLine headers → Structure
+             group header; nested effect rows keep the SHARED EffectLineTemplate
+             (already inert — shared template, intentionally untouched per the
+             flag-and-stop anti-goal)
+           • section labels → Structure section labels
+           • Treasure/Extraction #252525 boxes dropped (Fact has no surface);
+             "Browse pool" → Control (GrammarControlChassisStyle); the "?" help
+             tooltip is not a grammar tier — kept verbatim
+           • footer → c:FactFooter (matrix #14 · G-a). The Item InternalName is a
+             cross-entity reference KEY ⇒ copyable (NOT the inert ROW). The
+             DetailExportHost wrapper is RETAINED unchanged for the export-camera
+             affordance; we simply stop binding FooterText and place
+             <c:FactFooter/> at the foot of the wrapped content — no shared-infra
+             surgery, purely a per-view change (the pilot move).
+         WPF footgun honoured: object/record bindings use NullToVis, never the
+         string-only NullOrEmptyToVis (string bindings keep the latter). -->
+    <c:DetailExportHost>
 
     <Border Padding="14,12">
         <DockPanel>
-            <!-- Internal-name footer is owned by the wrapping DetailExportHost (FooterText). -->
             <StackPanel>
-                <!-- children below, reordered: cross-links float up to right
-                     after Description (was rows 19-21, now rows 2-4). -->
 
-                <!-- Header: icon + equip slot -->
+                <!-- ─── Header: title-glyph + Fact-title ───
+                     Icon → the fixed-40px FactTitleGlyphStyle (entity stamp,
+                     exempt from em/accessibility scaling). Title → FactTitleStyle
+                     (inline gold/bold/Large dropped — the style owns it, G-b). -->
                 <DockPanel Margin="0,0,0,10">
                     <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                 Width="48" Height="48" Margin="0,0,12,0" VerticalAlignment="Top"/>
+                                 Style="{StaticResource FactTitleGlyphStyle}"
+                                 Margin="0,0,12,0" VerticalAlignment="Top"/>
                     <StackPanel VerticalAlignment="Center">
-                        <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"
-                                   Foreground="#FFD4A847"
-                                   FontSize="{DynamicResource AppFontSizeLarge}" TextWrapping="Wrap"/>
-                        <TextBlock Text="{Binding EquipSlot, Converter={StaticResource CamelCaseSplit}}"
-                                   Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}" Margin="0,2,0,0"
-                                   Visibility="{Binding EquipSlot, Converter={StaticResource NullOrEmptyToVis}}"/>
+                        <TextBlock Text="{Binding DisplayName}"
+                                   Style="{StaticResource FactTitleStyle}"/>
                     </StackPanel>
                 </DockPanel>
 
-                <!-- Description + optional food effect (FormattedText parses any inline <i>/<b> markup). -->
+                <!-- One inert Fact stat strip (matrix #3): EquipSlot + skill
+                     requirements as dot-separated segments. No box, no gold
+                     (G-b — the FactTable Strip Style carries the inert pigment).
+                     Self-renders nothing when empty (StripText ""). Replaces
+                     both the EquipSlot subtitle and the boxed "Skill
+                     requirements" section (the pilot/Effect single-strip idiom,
+                     maintainer-confirmed for #424). -->
+                <c:FactTable DataContext="{Binding StatStrip}" HorizontalAlignment="Left"
+                             Margin="0,0,0,10"/>
+
+                <!-- Description + optional food effect. Matrix #4 / Effect §2,9:
+                     FactBodyStyle (+ keep italic); the inline #CCFFFFFF / #88 /
+                     hint-size dropped — the style owns family·size·fg·wrap.
+                     FormattedText parses any inline <i>/<b> markup. -->
                 <StackPanel Margin="0,0,0,10">
-                    <TextBlock c:FormattedText.Text="{Binding Description}" Foreground="#CCFFFFFF"
-                               FontStyle="Italic" FontSize="{DynamicResource AppFontSize}"
-                               TextWrapping="Wrap" MaxWidth="460"
-                               HorizontalAlignment="Left"
+                    <TextBlock c:FormattedText.Text="{Binding Description}"
+                               FontStyle="Italic"
+                               Style="{StaticResource FactBodyStyle}"
+                               MaxWidth="460" HorizontalAlignment="Left"
                                Visibility="{Binding Description, Converter={StaticResource NullOrEmptyToVis}}"/>
-                    <TextBlock Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}"
-                               TextWrapping="Wrap" MaxWidth="460" Margin="0,4,0,0"
-                               HorizontalAlignment="Left"
+                    <TextBlock Style="{StaticResource FactBodyStyle}" FontStyle="Italic"
+                               MaxWidth="460" HorizontalAlignment="Left" Margin="0,4,0,0"
                                Visibility="{Binding FoodDesc, Converter={StaticResource NullOrEmptyToVis}}">
-                        <Run Text="Food effect: " FontWeight="SemiBold"/>
-                        <Run Text="{Binding FoodDesc, Mode=OneWay}"/>
+                        <Run Text="Food effect: " FontWeight="SemiBold"/><Run Text="{Binding FoodDesc, Mode=OneWay}"/>
                     </TextBlock>
                 </StackPanel>
 
-                <!-- Sources (vendor / drop / quest reward / …). Renders as ItemSourceChip:
-                     navigable chip when the source resolves to a tabbed entity (e.g. NPC vendors
-                     after #241 shipped the NPCs tab), plain-text otherwise. -->
-                <StackPanel Margin="0,10,0,0"
-                            Visibility="{Binding Sources.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Sources" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding Sources}">
+                <!-- Sources (vendor / drop / quest reward / …). ItemSourceChip →
+                     Link enumeration (Density="List"; provenance suffix rides
+                     from the source Detail via LinkVm.From). -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding SourceLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Sources" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding SourceLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:ItemSourceChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Produced by recipes — cross-link to recipes whose result is this item -->
-                <StackPanel Margin="0,10,0,0"
-                            Visibility="{Binding ProducedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Produced by" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding ProducedByRecipes}">
+                <!-- Produced by recipes — cross-link to recipes whose result is
+                     this item. EntityChip → Link enumeration. -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding ProducedByRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Produced by" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding ProducedByRecipeLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Awarded by quests — chips fed from QuestsRewardingItem. Each chip
-                     deep-links to the Quests tab via EntityRef.Quest; degrades to plain text
-                     when the Quests kind target isn't registered. -->
-                <StackPanel Margin="0,10,0,0"
-                            Visibility="{Binding AwardedByQuests.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Awarded by" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding AwardedByQuests}">
+                <!-- Awarded by quests. EntityChip → Link enumeration; degrades
+                     to copy-on-click when the Quests tab isn't open (G-c). -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding AwardedByQuestLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Awarded by" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding AwardedByQuestLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Bestows lorebook — inbound 1:1 cross-link (#247). Item.BestowLoreBook
-                     resolved to the lorebook via LorebooksById; a single navigable chip
-                     (becomes clickable once the Lorebooks kind target is registered, plain
-                     text otherwise). Hidden when the item bestows no book. -->
-                <StackPanel Margin="0,10,0,0"
-                            Visibility="{Binding BestowsLorebook, Converter={StaticResource NullToVis}}">
-                    <TextBlock Text="Bestows lorebook" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ContentControl Content="{Binding BestowsLorebook}" HorizontalAlignment="Left">
-                        <ContentControl.Resources>
-                            <DataTemplate DataType="{x:Type c:EntityChipVm}">
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                <!-- Bestows lorebook — inbound 1:1 cross-link (#247). A single
+                     Link; section hides when the item bestows no book.
+                     NullToVis (object) — NOT the string-only NullOrEmptyToVis,
+                     which silently collapses a LinkVm binding (repo footgun). -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding BestowsLorebookLink, Converter={StaticResource NullToVis}}">
+                    <TextBlock Text="Bestows lorebook" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ContentControl Content="{Binding BestowsLorebookLink}" HorizontalAlignment="Left">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:Link Density="List"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
-                        </ContentControl.Resources>
+                        </ContentControl.ContentTemplate>
                     </ContentControl>
                 </StackPanel>
 
-                <!-- Used in recipes — cross-link to recipes that consume this item. Capped at
-                     SilmarillionSettings.UsedInChipCap to keep selection-change cheap (long-tail
-                     items like MetalSlab1 ship 60+ recipes). The trailing always-visible
-                     "View all N →" affordance opens the shared provenance popup fed the source
-                     index (RecipesByIngredientItemWithReason) directly (#318 slice 4) — no
-                     longer a RecipeIngredientItem synthetic-kind deep link. The popup renders
-                     the full set with no second derivation, so its count cannot diverge from
-                     the index. Single-reason (DirectIngredient) ⇒ the popup is a flat list. -->
-                <StackPanel Margin="0,10,0,0">
+                <!-- Used in — recipes that consume this item directly (#318
+                     slice 4, surface 1). Capped Link cluster + always-visible
+                     "Used in · N matches →" Set-ref summary-form opening the
+                     existing provenance popup. Mirrors EffectDetailView §7
+                     exactly. Visible whenever either the capped cluster OR the
+                     drawer exists. -->
+                <StackPanel Margin="0,0,0,10">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
                             <Setter Property="Visibility" Value="Collapsed"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding ConsumedByRecipes.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding ConsumedByRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding ConsumedByRecipesPopup, Converter={StaticResource NullToVis}}" Value="Visible">
+                                <!-- NullToVis (object) — NOT NullOrEmptyToVis. -->
+                                <DataTrigger Binding="{Binding ConsumedByRecipesSetRef, Converter={StaticResource NullToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </StackPanel.Style>
-                    <TextBlock FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4">
-                        <Run Text="Used in" />
-                    </TextBlock>
-                    <ItemsControl ItemsSource="{Binding ConsumedByRecipes}">
+                    <TextBlock Text="Used in" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding ConsumedByRecipeLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <!-- "View all N →" — opens the shared provenance popup (#318). Always
-                         visible whenever any recipe consumes the item (independent of the
-                         chip cap), styled like ActionChip (ghost fill, ListFilter glyph) so
-                         it reads as "go see the full set", not "open an entity". Mirrors the
-                         slice-2 EffectDetailView affordance. -->
-                    <Button Margin="0,4,0,0" Padding="6,2"
-                            HorizontalAlignment="Left" Cursor="Hand"
-                            Command="{Binding ShowConsumedByRecipesPopupCommand}"
-                            Visibility="{Binding ConsumedByRecipesPopup, Converter={StaticResource NullToVis}}">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Setter Property="Background" Value="Transparent"/>
-                                <Setter Property="BorderBrush" Value="#66D4A847"/>
-                                <Setter Property="BorderThickness" Value="1"/>
-                                <Setter Property="Foreground" Value="#FFD4A847"/>
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="Background" Value="#22D4A847"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="3" Padding="{TemplateBinding Padding}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <icon:PackIconLucide Kind="ListFilter" Width="12" Height="12"
-                                                             Foreground="{TemplateBinding Foreground}"
-                                                             Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                        <TextBlock Foreground="{TemplateBinding Foreground}"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   VerticalAlignment="Center">
-                                            <Run Text="View all "/><Run Text="{Binding ConsumedByRecipesTotal, Mode=OneWay}"/><Run Text=" →"/>
-                                        </TextBlock>
-                                    </StackPanel>
-                                </Border>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
+                    <ContentControl Content="{Binding ConsumedByRecipesSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding ConsumedByRecipesSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowConsumedByRecipesPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- Used as: recipes that consume this item via a keyword-ingredient slot.
-                     #318 slice 4, surface 2 — the per-keyword RecipeIngredientKeyword
-                     synthetic-kind ActionChips are retired. Mirrors the "Used in" section:
-                     a chip cluster capped at SilmarillionSettings.UsedInChipCap plus a
-                     trailing always-visible "View all N →" affordance that opens the shared
-                     provenance popup fed the source index (RecipesByIngredientKeywordWithReason)
-                     directly — no query re-derivation, so the count cannot diverge from the
-                     index. Single-reason (KeywordIngredientSlot) ⇒ the popup is a flat list. -->
-                <StackPanel Margin="0,10,0,0">
+                <!-- Used as — recipes that consume this item via a keyword
+                     ingredient slot (#318 slice 4, surface 2). Same shape as
+                     "Used in": capped Link cluster + summary-form Set-ref. -->
+                <StackPanel Margin="0,0,0,10">
                     <StackPanel.Style>
                         <Style TargetType="StackPanel">
                             <Setter Property="Visibility" Value="Collapsed"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding ConsumedAsKeywordIn.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding ConsumedAsKeywordInLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding ConsumedAsKeywordInPopup, Converter={StaticResource NullToVis}}" Value="Visible">
+                                <DataTrigger Binding="{Binding ConsumedAsKeywordInSetRef, Converter={StaticResource NullToVis}}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </StackPanel.Style>
-                    <TextBlock Text="Used as" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding ConsumedAsKeywordIn}">
+                    <TextBlock Text="Used as" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding ConsumedAsKeywordInLinks}">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                            <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <c:EntityChip ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                                <c:Link Density="List" Margin="0,0,0,3"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <!-- "View all N →" — opens the shared provenance popup (#318). Always
-                         visible whenever any recipe consumes the item via a keyword slot
-                         (independent of the chip cap), styled like ActionChip (ghost fill,
-                         ListFilter glyph). Mirrors the surface-1 "Used in" affordance. -->
-                    <Button Margin="0,4,0,0" Padding="6,2"
-                            HorizontalAlignment="Left" Cursor="Hand"
-                            Command="{Binding ShowConsumedAsKeywordInPopupCommand}"
-                            Visibility="{Binding ConsumedAsKeywordInPopup, Converter={StaticResource NullToVis}}">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Setter Property="Background" Value="Transparent"/>
-                                <Setter Property="BorderBrush" Value="#66D4A847"/>
-                                <Setter Property="BorderThickness" Value="1"/>
-                                <Setter Property="Foreground" Value="#FFD4A847"/>
-                                <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
-                                        <Setter Property="Background" Value="#22D4A847"/>
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <Button.Template>
-                            <ControlTemplate TargetType="Button">
-                                <Border Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="3" Padding="{TemplateBinding Padding}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <icon:PackIconLucide Kind="ListFilter" Width="12" Height="12"
-                                                             Foreground="{TemplateBinding Foreground}"
-                                                             Margin="0,0,4,0" VerticalAlignment="Center"/>
-                                        <TextBlock Foreground="{TemplateBinding Foreground}"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   VerticalAlignment="Center">
-                                            <Run Text="View all "/><Run Text="{Binding ConsumedAsKeywordInTotal, Mode=OneWay}"/><Run Text=" →"/>
-                                        </TextBlock>
-                                    </StackPanel>
-                                </Border>
-                            </ControlTemplate>
-                        </Button.Template>
-                    </Button>
+                    <ContentControl Content="{Binding ConsumedAsKeywordInSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding ConsumedAsKeywordInSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowConsumedAsKeywordInPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- Skill requirements (hidden when empty) -->
+                <!-- Effects — inert Fact rows via the SHARED EffectLineTemplate
+                     (icon + text, no box/gold). The template lives in
+                     Resources.xaml and is consumed by many views; it is already
+                     grammar-inert, so it is intentionally left untouched
+                     (flag-and-stop anti-goal). Section label → Structure. -->
                 <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding SkillReqChips.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Skill requirements" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
-                    <ItemsControl ItemsSource="{Binding SkillReqChips}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel/>
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Border Background="#FF252525" BorderBrush="#33FFFFFF"
-                                        BorderThickness="1" CornerRadius="3"
-                                        Padding="6,2" Margin="0,0,4,4">
-                                    <TextBlock Text="{Binding}" Foreground="#CCFFFFFF"
-                                               FontSize="{DynamicResource AppFontSizeHint}"/>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </StackPanel>
-
-                <!-- Effects -->
-                <StackPanel>
-                    <TextBlock Text="Effects" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"
-                               Visibility="{Binding EffectLines.Count, Converter={StaticResource PositiveIntToVis}}"/>
+                            Visibility="{Binding EffectLines.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Effects" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
                                   MaxHeight="480">
                         <ItemsControl ItemsSource="{Binding EffectLines}"
@@ -331,19 +267,18 @@
                     </ScrollViewer>
                 </StackPanel>
 
-                <!-- Augmentation (hidden when empty) -->
-                <StackPanel Margin="0,10,0,0"
+                <!-- Augmentation — per-augment group header → Structure group
+                     header (gold dropped, G-b); nested effect rows keep the
+                     shared inert EffectLineTemplate. -->
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding Augments.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Augmentation" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Augmentation" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding Augments}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="0,0,0,6">
-                                    <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
-                                               Foreground="#FFD4A847"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                    <TextBlock Text="{Binding DisplayLine}"
+                                               Style="{StaticResource StructureGroupHeaderStyle}"
                                                Margin="0,0,0,2"/>
                                     <ItemsControl ItemsSource="{Binding EffectLines}"
                                                   ItemTemplate="{StaticResource EffectLineTemplate}"
@@ -355,18 +290,15 @@
                 </StackPanel>
 
                 <!-- Applied augment waxes -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding WaxAugments.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Applied augment waxes" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Applied augment waxes" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding WaxAugments}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="0,0,0,6">
-                                    <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
-                                               Foreground="#FFD4A847"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                    <TextBlock Text="{Binding DisplayLine}"
+                                               Style="{StaticResource StructureGroupHeaderStyle}"
                                                Margin="0,0,0,2"/>
                                     <ItemsControl ItemsSource="{Binding EffectLines}"
                                                   ItemTemplate="{StaticResource EffectLineTemplate}"
@@ -378,18 +310,15 @@
                 </StackPanel>
 
                 <!-- Infusions -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding WaxItems.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Infusions" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Infusions" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding WaxItems}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="0,0,0,6">
-                                    <TextBlock Text="{Binding DisplayLine}" FontWeight="SemiBold"
-                                               Foreground="#FFD4A847"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
+                                    <TextBlock Text="{Binding DisplayLine}"
+                                               Style="{StaticResource StructureGroupHeaderStyle}"
                                                Margin="0,0,0,2"/>
                                     <ItemsControl ItemsSource="{Binding EffectLines}"
                                                   ItemTemplate="{StaticResource EffectLineTemplate}"
@@ -400,13 +329,16 @@
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Treasure effects -->
-                <StackPanel Margin="0,10,0,0"
+                <!-- Treasure effects — section label → Structure. The "?" help
+                     tooltip is a help affordance, not a grammar tier — kept
+                     verbatim. Per-pool: the #252525 box is dropped (Fact has no
+                     surface, G-b); DisplayLine → Fact body; "Browse pool" →
+                     Control chassis (GrammarControlChassisStyle). -->
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding AugmentPools.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                        <TextBlock Text="Treasure Effects" FontWeight="SemiBold"
-                                   Foreground="#88FFFFFF"
-                                   FontSize="{DynamicResource AppFontSizeHint}"
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Treasure Effects"
+                                   Style="{StaticResource StructureSectionLabelStyle}"
                                    VerticalAlignment="Center"/>
                         <Border Background="Transparent" Cursor="Help"
                                 VerticalAlignment="Center" Margin="5,0,0,0">
@@ -417,58 +349,47 @@
                                 </ToolTip>
                             </Border.ToolTip>
                             <icon:PackIconLucide Kind="CircleQuestionMark" Width="12" Height="12"
-                                                 Foreground="#88FFFFFF"/>
+                                                 Foreground="{DynamicResource TextTertiaryBrush}"/>
                         </Border>
                     </StackPanel>
                     <ItemsControl ItemsSource="{Binding AugmentPools}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Background="#FF252525" BorderBrush="#33FFFFFF"
-                                        BorderThickness="1" CornerRadius="3"
-                                        Padding="8,6" Margin="0,0,0,6">
-                                    <DockPanel>
-                                        <Button DockPanel.Dock="Right" VerticalAlignment="Center"
-                                                Margin="8,0,0,0" Padding="8,3"
-                                                Content="Browse pool"
-                                                Cursor="Hand"
-                                                Command="{Binding DataContext.BrowsePoolCommand,
-                                                          RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"
-                                                CommandParameter="{Binding}"
-                                                Visibility="{Binding DataContext.HasPoolPresenter,
-                                                             RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}},
-                                                             Converter={StaticResource BoolToVis}}"/>
-                                        <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   VerticalAlignment="Center"
-                                                   TextWrapping="Wrap"/>
-                                    </DockPanel>
-                                </Border>
+                                <DockPanel Margin="0,0,0,6">
+                                    <Button DockPanel.Dock="Right" VerticalAlignment="Center"
+                                            Margin="8,0,0,0"
+                                            Content="Browse pool"
+                                            Style="{StaticResource GrammarControlChassisStyle}"
+                                            Command="{Binding DataContext.BrowsePoolCommand,
+                                                      RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"
+                                            CommandParameter="{Binding}"
+                                            Visibility="{Binding DataContext.HasPoolPresenter,
+                                                         RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}},
+                                                         Converter={StaticResource BoolToVis}}"/>
+                                    <TextBlock Text="{Binding DisplayLine}"
+                                               Style="{StaticResource FactBodyStyle}"
+                                               VerticalAlignment="Center"/>
+                                </DockPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Teaches recipe -->
-                <StackPanel Margin="0,10,0,0"
+                <!-- Teaches recipe — plain-text preview (no EntityRef) → Fact
+                     body; the gold "Teaches: X" is gold-in-prose for a
+                     non-navigable proper noun, dropped per G-b. -->
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding TaughtRecipes.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Teaches recipe" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Teaches recipe" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding TaughtRecipes}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="0,0,0,6">
-                                    <TextBlock FontWeight="SemiBold" Foreground="#FFD4A847"
-                                               FontSize="{DynamicResource AppFontSizeHint}">
-                                        <Run Text="Teaches: "/>
-                                        <Run Text="{Binding DisplayName, Mode=OneWay}"/>
+                                    <TextBlock Style="{StaticResource FactBodyStyle}">
+                                        <Run Text="Teaches: " FontWeight="SemiBold"/><Run Text="{Binding DisplayName, Mode=OneWay}"/>
                                     </TextBlock>
-                                    <TextBlock Foreground="#88FFFFFF"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
-                                               Margin="10,1,0,0">
-                                        <Run Text="{Binding Skill, Mode=OneWay}"/>
-                                        <Run Text=" "/>
-                                        <Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
+                                    <TextBlock Style="{StaticResource FactBodyStyle}" Margin="10,1,0,0">
+                                        <Run Text="{Binding Skill, Mode=OneWay}"/><Run Text=" "/><Run Text="{Binding SkillLevelReq, Mode=OneWay}"/>
                                     </TextBlock>
                                 </StackPanel>
                             </DataTemplate>
@@ -477,96 +398,83 @@
                 </StackPanel>
 
                 <!-- Additional effects -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding EffectTags.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Additional effects" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Additional effects" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding EffectTags}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayText}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayText}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- Research progress -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding ResearchProgress.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Progresses research" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Progresses research" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding ResearchProgress}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayLine}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- XP grants -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding XpGrants.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Grants XP" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Grants XP" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding XpGrants}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayLine}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- Words of Power -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding WordsOfPower.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Reveals words of power" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Reveals words of power" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding WordsOfPower}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayLine}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Learned abilities -->
-                <StackPanel Margin="0,10,0,0"
+                <!-- Learned abilities — plain-text preview (no EntityRef) →
+                     Fact body. (If a future projection carried an Ability ref
+                     this would become a Link; the preview is plain text by
+                     design — the Recipe-pilot ResultEffects-stub precedent.) -->
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding LearnedAbilities.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Teaches ability" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Teaches ability" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding LearnedAbilities}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayLine}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Produces -->
-                <StackPanel Margin="0,10,0,0"
+                <!-- Produces — inert Fact rows (small leading icon + text),
+                     mirroring the shared EffectLine row shape. -->
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding ProducedItems.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Produces" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Produces" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding ProducedItems}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -575,10 +483,9 @@
                                                  Width="20" Height="20" Margin="0,0,8,0"
                                                  VerticalAlignment="Center"
                                                  Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
-                                    <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                               FontSize="{DynamicResource AppFontSizeHint}"
-                                               VerticalAlignment="Center"
-                                               TextWrapping="Wrap"/>
+                                    <TextBlock Text="{Binding DisplayLine}"
+                                               Style="{StaticResource FactBodyStyle}"
+                                               VerticalAlignment="Center"/>
                                 </DockPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -586,85 +493,76 @@
                 </StackPanel>
 
                 <!-- Equip bonuses -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding EquipBonuses.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Bonuses while equipped" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Bonuses while equipped" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding EquipBonuses}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayLine}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- Crafting enhancements -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding CraftingEnhancements.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Modifies crafted item" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Modifies crafted item" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding CraftingEnhancements}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayLine}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayLine}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
                 <!-- Recipe cooldowns -->
-                <StackPanel Margin="0,10,0,0"
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding RecipeCooldowns.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Cooldown adjustments" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Cooldown adjustments" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding RecipeCooldowns}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding DisplayText}" Foreground="#CCFFFFFF"
-                                           FontSize="{DynamicResource AppFontSizeHint}"
-                                           TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                <TextBlock Text="{Binding DisplayText}"
+                                           Style="{StaticResource FactBodyStyle}" Margin="0,0,0,2"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Unpreviewable extractions -->
-                <StackPanel Margin="0,10,0,0"
+                <!-- Unpreviewable extractions — the #252525 box is dropped (Fact
+                     has no surface, G-b); icon + italic DisplayLine → Fact body
+                     (mirrors the italic Description treatment). -->
+                <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding UnpreviewableExtractions.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Extraction" FontWeight="SemiBold"
-                               Foreground="#88FFFFFF"
-                               FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,0,4"/>
+                    <TextBlock Text="Extraction" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding UnpreviewableExtractions}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Background="#FF252525" BorderBrush="#33FFFFFF"
-                                        BorderThickness="1" CornerRadius="3"
-                                        Padding="8,6" Margin="0,0,0,6">
-                                    <DockPanel>
-                                        <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
-                                                     Width="20" Height="20" Margin="0,0,8,0"
-                                                     VerticalAlignment="Center"
-                                                     Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
-                                        <TextBlock Text="{Binding DisplayLine}"
-                                                   Foreground="#AAFFFFFF"
-                                                   FontStyle="Italic"
-                                                   FontSize="{DynamicResource AppFontSizeHint}"
-                                                   VerticalAlignment="Center"
-                                                   TextWrapping="Wrap"/>
-                                    </DockPanel>
-                                </Border>
+                                <DockPanel Margin="0,0,0,6">
+                                    <c:IconImage DockPanel.Dock="Left" IconId="{Binding IconId}"
+                                                 Width="20" Height="20" Margin="0,0,8,0"
+                                                 VerticalAlignment="Center"
+                                                 Visibility="{Binding IconId, Converter={StaticResource PositiveIntToVis}}"/>
+                                    <TextBlock Text="{Binding DisplayLine}"
+                                               Style="{StaticResource FactBodyStyle}"
+                                               FontStyle="Italic"
+                                               VerticalAlignment="Center"/>
+                                </DockPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
+
+                <!-- Footer ID strip (matrix #14 · G-a). InternalName is a
+                     cross-entity reference KEY ⇒ a copyable cell;
+                     FactFooterVm.None() self-hides at 0 ids. The DetailExportHost
+                     wrapper is retained unchanged (no FooterText binding). -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
 
             </StackPanel>
         </DockPanel>

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Items;
@@ -88,6 +90,58 @@ public sealed partial class ItemDetailViewModel
         BestowsLorebook = context.BestowsLorebook;
         Sources = context.Sources ?? [];
         _poolPresenter = poolPresenter;
+
+        // ── #424 grammar-primitive projections (additive) ──────────────────────
+        // The legacy chip/string/command members assigned above STAY (the
+        // ItemsTabViewModel tests + the cross-module detail contract assert
+        // them); these are the #404 grammar-tier carriers the migrated
+        // ItemDetailView binds. Mechanical mapping — a consistency-diff vs the
+        // merged EffectDetailView fan-out (#418) + the Recipe pilot, not fresh
+        // design.
+
+        // One inert Fact stat strip under the title (pilot StatStrip /
+        // EffectDetailView MetadataStrip): EquipSlot (camel-split, labelled) +
+        // every skill requirement as a value-only segment. No box, no gold
+        // (G-b) — the shared FactTable Strip Style owns the inert pigment.
+        // Empties skipped; an all-empty strip renders nothing (StripText "").
+        var stat = new List<FactPair>(1 + SkillReqChips.Count);
+        if (!string.IsNullOrEmpty(EquipSlot))
+            stat.Add(new FactPair("Equip slot", SplitCamel(EquipSlot!)));
+        foreach (var req in SkillReqChips)
+            stat.Add(new FactPair(null, req));
+        StatStrip = FactTableVm.Strip(stat);
+
+        // Cross-link sections → the unified Link (matrix #6/#9/#10/#12), via the
+        // ratified EntityChip/ItemSourceChip adapters; the view renders them
+        // Density="List" (the canonical pilot enumeration pattern). Glyph is
+        // kind-derived by the adapter; the chip IconId rides through as the
+        // preferred lead sprite per the G3 amendment.
+        SourceLinks = Sources.Select(LinkVm.From).ToList();
+        ProducedByRecipeLinks = ProducedByRecipes.Select(LinkVm.From).ToList();
+        AwardedByQuestLinks = AwardedByQuests.Select(LinkVm.From).ToList();
+        ConsumedByRecipeLinks = ConsumedByRecipes.Select(LinkVm.From).ToList();
+        ConsumedAsKeywordInLinks = ConsumedAsKeywordIn.Select(LinkVm.From).ToList();
+        BestowsLorebookLink = BestowsLorebook is null ? null : LinkVm.From(BestowsLorebook);
+
+        // "View all N →" drawers → summary-form Set-reference (matrix #11 /
+        // EffectDetailView §7 "Required by abilities"), actionable via the
+        // EXISTING popup commands (gold→blue per ratified G-b). Null when no
+        // recipe relates ⇒ the SetRef row hides; the capped Link cluster carries
+        // the rest. The count mirrors the popup's TotalCount (cannot diverge).
+        ConsumedByRecipesSetRef = ConsumedByRecipesPopup is null
+            ? null
+            : new SetRefVm("Used in", MatchCount: ConsumedByRecipesTotal, IsActionable: true);
+        ConsumedAsKeywordInSetRef = ConsumedAsKeywordInPopup is null
+            ? null
+            : new SetRefVm("Used as", MatchCount: ConsumedAsKeywordInTotal, IsActionable: true);
+
+        // Footer ID (matrix #14 · G-a · ratified E5). The Item InternalName is a
+        // cross-entity reference KEY — recipes/quests/NPCs resolve items by it —
+        // ⇒ the copyable `KEY` cell (NOT the inert storage-only `ROW`; cf.
+        // EffectDetailView's EnvelopeKey). None() self-hides when absent.
+        Footer = string.IsNullOrEmpty(InternalName)
+            ? FactFooterVm.None()
+            : FactFooterVm.Key(InternalName);
     }
 
     public Item Item { get; }
@@ -230,6 +284,68 @@ public sealed partial class ItemDetailViewModel
     /// </summary>
     public ICommand? OpenEntityCommand { get; }
 
+    // ── #424 grammar-primitive carriers (additive; the legacy members above
+    //    stay — the ItemsTabViewModel tests + the cross-module detail contract
+    //    assert them). The migrated ItemDetailView binds these. ───────────────
+
+    /// <summary>
+    /// One inert Fact stat strip under the title (matrix #3 — the pilot
+    /// <c>StatStrip</c> / <c>EffectDetailViewModel.MetadataStrip</c> idiom):
+    /// EquipSlot (camel-split, labelled) + every <see cref="SkillReqChips"/>
+    /// entry as a value-only segment. G-b: no box, no gold — the shared
+    /// <c>FactTable</c> Strip Style owns the inert pigment. Empties skipped; an
+    /// all-empty strip renders nothing.
+    /// </summary>
+    public FactTableVm StatStrip { get; }
+
+    /// <summary>"Sources" rows as the unified <see cref="LinkVm"/> (matrix #9 —
+    /// provenance suffix rides from <see cref="ItemSourceChipVm.Detail"/>).</summary>
+    public IReadOnlyList<LinkVm> SourceLinks { get; }
+
+    /// <summary>"Produced by" recipe cross-links as <see cref="LinkVm"/> (matrix #12).</summary>
+    public IReadOnlyList<LinkVm> ProducedByRecipeLinks { get; }
+
+    /// <summary>"Awarded by" quest cross-links as <see cref="LinkVm"/> (matrix #10).</summary>
+    public IReadOnlyList<LinkVm> AwardedByQuestLinks { get; }
+
+    /// <summary>"Used in" capped recipe cluster as <see cref="LinkVm"/> (matrix #10).
+    /// The full set is the <see cref="ConsumedByRecipesSetRef"/> drawer.</summary>
+    public IReadOnlyList<LinkVm> ConsumedByRecipeLinks { get; }
+
+    /// <summary>"Used as" capped recipe cluster as <see cref="LinkVm"/> (matrix #10).
+    /// The full set is the <see cref="ConsumedAsKeywordInSetRef"/> drawer.</summary>
+    public IReadOnlyList<LinkVm> ConsumedAsKeywordInLinks { get; }
+
+    /// <summary>"Bestows lorebook" inbound 1:1 cross-link as a single
+    /// <see cref="LinkVm"/> (matrix #6), or null when the item bestows no book
+    /// (the section hides — bind via the object-safe <c>NullToVis</c>).</summary>
+    public LinkVm? BestowsLorebookLink { get; }
+
+    /// <summary>
+    /// The "Used in · N matches →" drawer as a summary-form Set-reference
+    /// (matrix #11), actionable via <see cref="ShowConsumedByRecipesPopupCommand"/>.
+    /// Null when no recipe consumes this item (the SetRef row hides). Gold→blue
+    /// per ratified G-b. <see cref="SetRefVm.MatchCount"/> mirrors
+    /// <see cref="ConsumedByRecipesTotal"/> so it cannot diverge from the popup.
+    /// </summary>
+    public SetRefVm? ConsumedByRecipesSetRef { get; }
+
+    /// <summary>
+    /// The "Used as · N matches →" drawer as a summary-form Set-reference
+    /// (matrix #11), actionable via <see cref="ShowConsumedAsKeywordInPopupCommand"/>.
+    /// Null when no recipe consumes this item via a keyword slot. Gold→blue per
+    /// ratified G-b; count mirrors <see cref="ConsumedAsKeywordInTotal"/>.
+    /// </summary>
+    public SetRefVm? ConsumedAsKeywordInSetRef { get; }
+
+    /// <summary>
+    /// Footer identifier strip (matrix #14 · G-a · ratified E5). The Item
+    /// <see cref="InternalName"/> is a cross-entity reference KEY (recipes /
+    /// quests / NPCs resolve items by it) ⇒ a single copyable <c>KEY</c> cell;
+    /// <c>None()</c> (the strip self-hides) when the item has no internal name.
+    /// </summary>
+    public FactFooterVm Footer { get; }
+
     /// <summary>
     /// True when an <see cref="IAugmentPoolPresenter"/> is available — i.e. the Celebrimbor
     /// module is loaded and registered the implementation. Drives the "Browse pool" button
@@ -239,6 +355,15 @@ public sealed partial class ItemDetailViewModel
 
     private static string ResolveSkillDisplayName(IReferenceDataService refData, string skillKey) =>
         refData.Skills.TryGetValue(skillKey, out var s) ? s.DisplayName : skillKey;
+
+    // EquipSlot is an id-shaped token ("MainHand" → "Main Hand"); split on the
+    // lowercase→uppercase boundary so the Fact strip reads as a display value,
+    // per the skill-key→display-name convention. The XAML previously did this
+    // with the CamelCaseSplit converter; the migrated view binds one strip
+    // string, so the split moves VM-side (single source of truth, testable).
+    // Single-token slots ("Chest") pass through unchanged.
+    private static string SplitCamel(string token) =>
+        Regex.Replace(token, "(?<=[a-z])([A-Z])", " $1");
 
     [RelayCommand(CanExecute = nameof(HasPoolPresenter))]
     private void BrowsePool(AugmentPoolPreview? pool)

--- a/tests/Silmarillion.Tests/Views/DetailViewGrammarConformanceTests.cs
+++ b/tests/Silmarillion.Tests/Views/DetailViewGrammarConformanceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,10 +8,10 @@ using Xunit;
 namespace Silmarillion.Tests.Views;
 
 /// <summary>
-/// Phase-6 conformance guardrail for the #404 visual grammar. Every Silmarillion
-/// <c>*DetailView.xaml</c> renders entity references through the shared Phase-4
-/// primitives (<c>Link</c> / <c>SetRef</c> / <c>FactTable</c> / <c>FactFooter</c>);
-/// the legacy bordered-box entity chips (<c>EntityChip</c> / <c>ItemSourceChip</c>)
+/// Phase-6 conformance guardrail for the #404 visual grammar. Every migrated
+/// detail view renders entity references through the shared Phase-4 primitives
+/// (<c>Link</c> / <c>SetRef</c> / <c>FactTable</c> / <c>FactFooter</c>); the
+/// legacy bordered-box entity chips (<c>EntityChip</c> / <c>ItemSourceChip</c>)
 /// are the exact "raw bordered box for an entity reference" the #404 program
 /// removed (the Fact↔Link↔Set-reference collision).
 /// <para>
@@ -20,16 +21,16 @@ namespace Silmarillion.Tests.Views;
 /// fails the build the moment a detail view regresses to the legacy control —
 /// the Phase-6 "flip the visual-debt note to resolved, and keep it resolved"
 /// guarantee (see <c>docs/silmarillion-field-coverage.md</c> §"Visual grammar
-/// (#404) — RESOLVED" and <c>docs/silmarillion-visual-grammar.md</c>).
+/// (#404)" and <c>docs/silmarillion-visual-grammar.md</c>).
 /// </para>
 /// <para>
-/// <b>Scope:</b> intentionally only <c>src/Silmarillion.Module/Views/*DetailView.xaml</c>
-/// — the nine Silmarillion <em>tab</em> detail panes #404 Phase-5 migrated. It does
-/// NOT cover the shared <c>Mithril.Shared.Wpf/ItemDetailView</c> /
-/// <c>ItemDetailWindow</c>: Item has no Silmarillion tab detail by design, that pane
-/// is cross-module shared infra (Phase-5 anti-goal #3 forbade editing it), and its
-/// grammar migration is its own separately-tracked effort — explicitly NOT closed by
-/// #404 (see the "Remaining grammar surface" bullet in the coverage doc).
+/// <b>Scope:</b> the nine Silmarillion <em>tab</em> detail panes
+/// (<c>src/Silmarillion.Module/Views/*DetailView.xaml</c>) <b>and</b> the shared
+/// cross-module <c>src/Mithril.Shared.Wpf/ItemDetailView.xaml</c>. The shared
+/// item-detail pane was deliberately out of #404 Phase-5 scope (Phase-5
+/// anti-goal #3 forbade editing shared <c>Mithril.Shared.Wpf</c> primitives) and
+/// was migrated by its own gated follow-up (#424); it is now covered here so it
+/// cannot silently regress to the pre-#404 boxed-chip grammar either.
 /// </para>
 /// </summary>
 public sealed class DetailViewGrammarConformanceTests
@@ -43,20 +44,28 @@ public sealed class DetailViewGrammarConformanceTests
         new(@"<[A-Za-z0-9_]+:(EntityChip|ItemSourceChip)\b", RegexOptions.Compiled);
 
     [Fact]
-    public void NoSilmarillionDetailView_RendersAnEntityReferenceAsALegacyBorderedChip()
+    public void NoMigratedDetailView_RendersAnEntityReferenceAsALegacyBorderedChip()
     {
-        var viewsDir = FindViewsDir();
-        if (viewsDir is null) return; // source tree not reachable (packaged run) — skip, don't false-fail
+        var repoRoot = FindRepoRoot();
+        if (repoRoot is null) return; // source tree not reachable (packaged run) — skip, don't false-fail
 
-        var detailViews = Directory
-            .EnumerateFiles(viewsDir, "*DetailView.xaml", SearchOption.AllDirectories)
+        var detailViews = EnumerateGuardedViews(repoRoot)
             .OrderBy(p => p)
             .ToList();
 
         // Sanity: the scan must actually see the detail views (a glob that
         // matched nothing would make this guard vacuously pass forever).
         detailViews.Should().NotBeEmpty(
-            "the Silmarillion detail views must be discoverable for the guardrail to be meaningful");
+            "the migrated detail views must be discoverable for the guardrail to be meaningful");
+
+        // Sanity: the shared item-detail pane (#424) is explicitly part of the
+        // guarded set — if the path moves, fail loudly rather than silently
+        // dropping coverage of the highest-blast-radius pane.
+        detailViews.Select(Path.GetFileName)
+            .Should().Contain("ItemDetailView.xaml",
+                "#424 brought the shared Mithril.Shared.Wpf/ItemDetailView into the "
+                + "Phase-6 guardrail scope; losing it would let the cross-module pane "
+                + "silently regress.");
 
         var offenders = detailViews
             .Where(xaml => LegacyEntityChip.IsMatch(File.ReadAllText(xaml)))
@@ -65,26 +74,48 @@ public sealed class DetailViewGrammarConformanceTests
             .ToList();
 
         offenders.Should().BeEmpty(
-            "#404 is RESOLVED — every detail view must render entity references through the "
-            + "shared grammar primitives (c:Link / c:SetRef / c:FactTable / c:FactFooter), "
-            + "never the legacy bordered-box EntityChip/ItemSourceChip. A view in this list "
-            + "has regressed to the pre-#404 debt; migrate it per "
+            "#404 is RESOLVED — every migrated detail view (the nine Silmarillion tab "
+            + "panes + the shared ItemDetailView, #424) must render entity references "
+            + "through the shared grammar primitives (c:Link / c:SetRef / c:FactTable / "
+            + "c:FactFooter), never the legacy bordered-box EntityChip/ItemSourceChip. A "
+            + "view in this list has regressed to the pre-#404 debt; migrate it per "
             + "docs/silmarillion-visual-grammar.md.");
     }
 
     /// <summary>
-    /// Walk up from the test bin dir to the repo root (marked by <c>Mithril.slnx</c>),
-    /// then resolve <c>src/Silmarillion.Module/Views</c>. Returns null if not found
-    /// (mirrors <see cref="TabViewCodeBehindGuardTests"/>'s convention).
+    /// The full guarded set: every <c>*DetailView.xaml</c> under
+    /// <c>src/Silmarillion.Module/Views</c> plus the shared cross-module
+    /// <c>src/Mithril.Shared.Wpf/ItemDetailView.xaml</c> (#424). Missing
+    /// directories/files are skipped silently (a packaged run); the
+    /// not-empty + must-contain assertions catch a genuine scope loss.
     /// </summary>
-    private static string? FindViewsDir()
+    private static IEnumerable<string> EnumerateGuardedViews(string repoRoot)
+    {
+        var silmarillionViews = Path.Combine(repoRoot, "src", "Silmarillion.Module", "Views");
+        if (Directory.Exists(silmarillionViews))
+        {
+            foreach (var v in Directory.EnumerateFiles(
+                         silmarillionViews, "*DetailView.xaml", SearchOption.AllDirectories))
+                yield return v;
+        }
+
+        var sharedItemDetail = Path.Combine(
+            repoRoot, "src", "Mithril.Shared.Wpf", "ItemDetailView.xaml");
+        if (File.Exists(sharedItemDetail))
+            yield return sharedItemDetail;
+    }
+
+    /// <summary>
+    /// Walk up from the test bin dir to the repo root (marked by
+    /// <c>Mithril.slnx</c>). Returns null if not found (mirrors
+    /// <see cref="TabViewCodeBehindGuardTests"/>'s convention).
+    /// </summary>
+    private static string? FindRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Mithril.slnx")))
             dir = dir.Parent;
 
-        if (dir is null) return null;
-        var views = Path.Combine(dir.FullName, "src", "Silmarillion.Module", "Views");
-        return Directory.Exists(views) ? views : null;
+        return dir?.FullName;
     }
 }


### PR DESCRIPTION
## Migrate the shared `ItemDetailView` to the #404 visual grammar

**Tracked in #424.** Closes the one deliberately-deferred surface of the #404 program: the shared cross-module `Mithril.Shared.Wpf/ItemDetailView` (+ `ItemDetailViewModel`). It was out of Phase-5 scope by design (anti-goal #3 forbade editing shared primitives during the fan-out), so clicking an item `Link` from a now-migrated Silmarillion view landed in an un-migrated, pre-#404 boxed-chip window. This is its own gated effort.

### Approach

A mini-Phase-1 element classification (Item has no Phase-1/2 matrix row by design) then a **consistency-diff** against the merged Recipe pilot + `EffectDetailView` (#418) — not fresh design.

| Element | → tier / primitive |
|---|---|
| Title / header icon / footer | `FactTitleStyle` · fixed-40px `FactTitleGlyphStyle` · `c:FactFooter` (InternalName = copyable **KEY**) |
| EquipSlot + skill-req pills | **one** inert `FactTable` Strip (no box/gold, G-b) — folded per the pilot single-strip idiom (maintainer-confirmed in the dispatch) |
| Sources / Produced by / Awarded by / Bestows lorebook / Used in / Used as | **`Link`** enumeration (`Density="List"`) |
| "View all N →" (Used in / Used as) | **`SetRef`** summary-form on the *existing* popup commands (gold→blue, ratified G-b) — exactly `EffectDetailView` §7 |
| every `*Preview` section | inert **Fact** body; gold sub-headers dropped (G-b); Augment/Wax/Infusion group headers → Structure group header |
| Treasure/Extraction `#252525` boxes | dropped (Fact has no surface); "Browse pool" → Control chassis; "?" help tooltip kept verbatim (not a grammar tier) |

The shared `EffectLineTemplate` is already grammar-inert and is intentionally **not** touched (flag-and-stop anti-goal). The dead `RequirementChipVmConverter.cs` is a *separate* net-zero cleanup and is **not** folded in (dispatch anti-goal #5).

### Blast radius

`ItemDetailView`/VM are consumed cross-module. The VM change is **additive only** — the legacy chip/string members the `ItemsTabViewModel` tests + the cross-module detail contract assert are retained; new `*Links` / `*SetRef` / `StatStrip` / `Footer` carriers are added (the pilot VM-projection idiom). The DetailExportHost wrapper is retained unchanged (FooterText binding dropped).

### Definition of done

- ✅ `ItemDetailView` renders entity refs via `Link` / `SetRef` / `FactTable` / `FactFooter`.
- ✅ Phase-6 guardrail (`DetailViewGrammarConformanceTests`) **extended** to also scan the shared `ItemDetailView` so the cross-module pane cannot silently regress.
- ✅ `docs/silmarillion-field-coverage.md` "Remaining grammar surface (NOT closed)" bullet flipped to **RESOLVED (#424)**.

### Verification

- `dotnet build Mithril.slnx` → **0W/0E**; `XamlResourceLint: OK` (117 keys).
- All item-detail consumer suites green: **Silmarillion 516 · Mithril.Shared 1137 · Bilbo 31 · Celebrimbor 87** (0 failures).
- `scripts/start.ps1 -Build` → `Build 0W/0E`, `XamlResourceLint OK`, `Application started` (clean DI graph; no boot cycle/blank-control).
- Diff scope: exactly 4 files — the shared view XAML, its additive VM, the guardrail test, the doc. No other views, no Phase-4 primitives, no `Resources.xaml`.

**⚠️ One verification owed (cannot be done headless):** the live eyeball — open an item from a Silmarillion cross-link ("open in window": Recipes/Quests tab → click an item `Link` → it opens the shared `ItemDetailWindow`) and confirm the window now renders in the grammar with no break at the navigation boundary #404 created. G4 acceptance = maintainer consistency-review vs the merged pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
