### PR TITLE
feat(silmarillion): #407 — declared-vs-reverse source-dedup (audit, ratified policy, conformed projection + guard)

### DIFF
--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -196,8 +196,94 @@ an unwired edge. This is the priority and stands alone.
   retained. Do not re-flag this pane as a remaining grammar surface; it is
   closed.
 
+### Declared-vs-reverse source duplication (#407) — RESOLVED (policy ratified 2026-05-17)
+
+This is the **coverage axis's** own debt, the deliberate sibling of the #404
+*presentation* axis above — the two were fenced apart on purpose. It governs
+*whether a source row appears at all*, never how it is styled.
+
+**The class.** A pane can surface the same entity twice under two headers when
+one path reads declared `sources_*.json` and the other is the reverse-lookup of
+the inverse relationship. A fresh cross-pane audit (production indices, v470 —
+[#407](https://github.com/moumantai-gg/mithril/issues/407#issuecomment-4470910146))
+found the class is **confined to the shared `Mithril.Shared.Wpf/ItemDetailView`
+pane**, exactly two pairs:
+
+| Declared "Sources" kind | Reverse twin header | Duplicate edges (v470) | Declared-only residue (no reverse twin) |
+|---|---|--:|--:|
+| `Recipe` → `EntityRef.Recipe` | **Produced by** (`RecipesByProducedItem`) | 4076 / 2702 items | **59 / 34 items** |
+| `Quest` → `EntityRef.Quest` | **Awarded by** (`QuestsRewardingItem`) | 816 / 306 items | **45 / 45 items** |
+
+RecipeDetail's "Taught by" (`sources_recipes.json`) and AbilityDetail's
+NPC-trainer sources have **no in-pane reverse twin** — the class is genuinely
+`ItemDetailView`-only (re-derived, not inherited from the prior
+`ItemDetailView`-scoped check). Overlap is near-total but **partial**: the two
+sides come from different JSON, so a real declared-only residue exists and is a
+genuine sources/relational data-coverage signal.
+
+**Ratified policy (maintainer sign-off — @arthur-conde, 2026-05-17;
+[#407](https://github.com/moumantai-gg/mithril/issues/407#issuecomment-4471012842)):**
+
+1. **Suppress declared, keep reverse — per (item, entity) edge.** A declared
+   `ItemSource` row is dropped from "Sources" iff its resolved `Context` entity
+   is already shown for that item under its dedicated reverse header
+   (`Recipe`↔"Produced by", `Quest`↔"Awarded by"). The reverse header is the
+   single role-appropriate home. The test is per-edge, never per-kind.
+2. **Declared-only residue survives + carries an in-pane asymmetry warning.**
+   Residue rows (no reverse twin) are **never silently dropped**; each carries
+   an in-pane note that the declared↔reverse relationship is asymmetrical (the
+   declared source is uncorroborated by the recipe/quest reverse data). This is
+   a **verification-owed coverage signal** — see "Verification owed" below.
+3. **Kind-prefix dropped for the entity-resolving kinds.** The leading
+   `Quest:`/`Recipe:` text prefix is removed from residue rows; entity kind is
+   carried by the established kind→lead-glyph standard (`LinkVm.GlyphFor`) the
+   migrated Link grammar already encodes, and the asymmetry-warning text names
+   the kind for `Quest` (glyph-less by grammar design). The NPC-*mechanic*
+   prefixes (`Vendor:`/`Barter:`/`NpcGift:`/`HangOut:`) are **kept** — they
+   encode acquisition method, which the NPC kind-glyph cannot.
+
+**Implementation fence (load-bearing).** Remediation is **projection-layer
+only** (`ItemsTabViewModel.BuildSourceChips`/`BuildCrossLinkContext`/
+`ResolveSourceReference`/`FormatSourceDisplayName`). The asymmetry warning
+ships through the **existing `LinkVm.ProvenanceSuffix` slot the migrated
+grammar already renders** — no `*DetailView.xaml`, no Phase-4 primitive, no
+`Resources.xaml` edit (the #404/#424 presentation axis stays frozen). A louder
+warning treatment (colour/badge) would touch the frozen Link primitive and is a
+**separate presentation-axis issue**, deliberately out of scope here. The
+additive cross-module contract (`Sources`/`ProducedByRecipes`/`AwardedByQuests`
+/`Consumed*` — asserted by `ItemsTabViewModelTests`, consumed by Bilbo /
+Celebrimbor / `ItemDetailWindow`) is preserved; the only intended behavioural
+change is `Sources` shrinking by the suppressed dupes and residue rows gaining
+the provenance-suffix warning, with the asserting tests updated deliberately
+and the delta called out in the PR. A coverage-policy regression guard
+(spirit-analogue of the Phase-6 `DetailViewGrammarConformanceTests`) asserts no
+entity appears under both "Sources" and its reverse header for the same item.
+
+> **Verification owed.** The declared-only residue (59 Recipe / 45 Quest edges
+> as of v470) is a *real sources/relational data-coverage asymmetry*, not just a
+> dedupe leftover: `sources_items.json` declares a recipe/quest the inverse
+> `recipes.json`/`quests.json` data does not corroborate. Surfaced in-pane (the
+> asymmetry warning) and tracked here; a future data-side reconciliation pass
+> against the CDN is the task side. When this residue's scale changes materially
+> on a CDN bump, re-audit and update the table above.
+
+**Out of scope (filed separately — not folded in).**
+`QuestObjectiveMacGuffin` (8/8) resolves `Context`→quest InternalName but is
+not matched by `ResolveSourceReference`, rendering as a bare
+`QuestObjectiveMacGuffin` text row that drops the resolved quest name. A latent
+display defect, **not** a dedupe target (macguffin = the quest *consumes* the
+item — the consume role, no reverse twin). Its own issue.
+
 ## History
 
+- **2026-05-17** — #407 ratified: declared-vs-reverse source-duplication
+  policy decided (suppress declared per-edge, keep reverse; declared-only
+  residue survives with an in-pane asymmetry warning; entity-kind prefix
+  dropped in favour of the kind→glyph standard). Cross-pane audit (production
+  indices, v470) confirmed the class is `ItemDetailView`-only and quantified
+  the partial overlap (4076 Recipe + 816 Quest duplicate edges; 59 + 45
+  declared-only residue). Coverage axis, fenced from the #404/#424
+  presentation axis; remediation is projection-layer only.
 - **2026-05-16** — #342 resolved: `OtherRequirements` (typed lines + recipe
   cross-link chips, `RecipeRequirementProjector`), `Costs`, and reset-timer
   surfaced in the recipe detail. Reframed from "long-tail completeness" to the

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -148,13 +148,21 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
         }
         var (consumed, popup) = BuildConsumedBy(item);
         var (consumedAsKeyword, keywordPopup) = BuildConsumedAsKeyword(item);
+        // #407: the per-(item,entity)-edge suppression sets — the exact recipe /
+        // quest InternalNames the reverse headers ("Produced by" /
+        // "Awarded by") show for this item, read from the same indices those
+        // headers project from so the dedupe cannot drift from what is rendered.
+        var reverseRecipeNames = ReverseTargetSet(
+            _refData.RecipesByProducedItem, item.InternalName!, r => r.InternalName);
+        var reverseQuestNames = ReverseTargetSet(
+            _refData.QuestsRewardingItem, item.InternalName!, q => q.InternalName);
         return new ItemDetailContext(
             ProducedByRecipes: BuildRecipeChips(_refData.RecipesByProducedItem, item.InternalName!),
             ConsumedByRecipes: consumed,
             ConsumedAsKeywordIn: consumedAsKeyword,
             AwardedByQuests: BuildAwardedByQuestChips(item.InternalName!),
             BestowsLorebook: BuildBestowsLorebookChip(item),
-            Sources: BuildSourceChips(item.InternalName!),
+            Sources: BuildSourceChips(item.InternalName!, reverseRecipeNames, reverseQuestNames),
             ConsumedByRecipesPopup: popup,
             ConsumedAsKeywordInPopup: keywordPopup);
     }
@@ -387,7 +395,34 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
         return 0;
     }
 
-    private IReadOnlyList<ItemSourceChipVm>? BuildSourceChips(string itemInternalName)
+    /// <summary>
+    /// #407: the set of reverse-header target InternalNames a given reverse index
+    /// shows for <paramref name="itemInternalName"/> (recipe names from
+    /// <c>RecipesByProducedItem</c> / quest names from <c>QuestsRewardingItem</c>).
+    /// Read from the very index the reverse header projects from so a declared
+    /// "Sources" row is suppressed iff the same entity is genuinely already on the
+    /// rendered pane under its dedicated header — per-edge, never per-kind.
+    /// </summary>
+    private static IReadOnlySet<string> ReverseTargetSet<T>(
+        IReadOnlyDictionary<string, IReadOnlyList<T>> reverseIndex,
+        string itemInternalName,
+        Func<T, string?> internalNameOf)
+    {
+        if (!reverseIndex.TryGetValue(itemInternalName, out var list) || list.Count == 0)
+            return System.Collections.Immutable.ImmutableHashSet<string>.Empty;
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var t in list)
+        {
+            var n = internalNameOf(t);
+            if (!string.IsNullOrEmpty(n)) set.Add(n!);
+        }
+        return set;
+    }
+
+    private IReadOnlyList<ItemSourceChipVm>? BuildSourceChips(
+        string itemInternalName,
+        IReadOnlySet<string> reverseRecipeNames,
+        IReadOnlySet<string> reverseQuestNames)
     {
         if (!_refData.ItemSources.TryGetValue(itemInternalName, out var sources) || sources.Count == 0)
         {
@@ -395,23 +430,56 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
         }
         // NPC-anchored source kinds (Vendor / Barter / NpcGift / HangOut / Training) carry an
         // <see cref="EntityRef.Npc"/> — navigable since #241 shipped the NPCs kind target.
-        // Quest sources resolve s.Context to the quest InternalName via the parser's
-        // ResolveSourceContext; surface them as EntityRef.Quest chips so the moment the Quests
-        // kind target is registered (#242 — this PR), every "Quest reward" chip across the
-        // codebase becomes navigable without further changes. Other source kinds (Monster /
-        // Recipe / Skill / …) leave the reference null and render as plain text.
-        return sources
-            .Select(s =>
+        // Quest / Recipe sources resolve s.Context to the quest / recipe InternalName via the
+        // parser's ResolveSourceContext and surface as EntityRef.Quest / EntityRef.Recipe.
+        // Other source kinds (Monster / Skill / …) leave the reference null and render as text.
+        var chips = new List<ItemSourceChipVm>(sources.Count);
+        foreach (var s in sources)
+        {
+            var isRecipe = string.Equals(s.Type, "Recipe", StringComparison.Ordinal)
+                && !string.IsNullOrEmpty(s.Context);
+            var isQuest = string.Equals(s.Type, "Quest", StringComparison.Ordinal)
+                && !string.IsNullOrEmpty(s.Context);
+
+            // #407 (1) suppress declared, keep reverse — per (item, entity) edge:
+            // drop the declared row when the same entity is already shown for this
+            // item under its dedicated reverse header ("Produced by" / "Awarded by").
+            if (isRecipe && reverseRecipeNames.Contains(s.Context!)) continue;
+            if (isQuest && reverseQuestNames.Contains(s.Context!)) continue;
+
+            var reference = ResolveSourceReference(s);
+
+            // #407 (2)+(3) declared-only residue: a Recipe/Quest declared source with
+            // NO reverse twin survives (never silently dropped), drops its now-
+            // redundant kind prefix (entity kind is carried by the Link lead-glyph
+            // standard, LinkVm.GlyphFor), and carries an in-pane warning — through
+            // the existing ProvenanceSuffix slot (ItemSourceChipVm.Detail) the
+            // migrated grammar already renders — that the declared↔reverse
+            // relationship is asymmetrical (uncorroborated by the recipe/quest
+            // reverse data; a sources/relational coverage signal, see
+            // docs/silmarillion-field-coverage.md §#407). Projection-layer only —
+            // no view / grammar-primitive change.
+            if (isRecipe || isQuest)
             {
-                var reference = ResolveSourceReference(s);
-                return new ItemSourceChipVm(
-                    DisplayName: FormatSourceDisplayName(s),
-                    Detail: s.Context,
+                chips.Add(new ItemSourceChipVm(
+                    DisplayName: reference is not null ? _nameResolver.Resolve(reference) : s.Context!,
+                    Detail: isRecipe
+                        ? "declared recipe source — not confirmed by recipe data"
+                        : "declared quest source — not confirmed by quest data",
                     IconId: null,
                     EntityReference: reference,
-                    IsNavigable: reference is not null && _navigator.CanOpen(reference));
-            })
-            .ToList();
+                    IsNavigable: reference is not null && _navigator.CanOpen(reference)));
+                continue;
+            }
+
+            chips.Add(new ItemSourceChipVm(
+                DisplayName: FormatSourceDisplayName(s),
+                Detail: s.Context,
+                IconId: null,
+                EntityReference: reference,
+                IsNavigable: reference is not null && _navigator.CanOpen(reference)));
+        }
+        return chips.Count == 0 ? null : chips;
     }
 
     private static EntityRef? ResolveSourceReference(ItemSource s)
@@ -424,14 +492,18 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
         return null;
     }
 
+    /// <summary>
+    /// Display name for the non-entity-resolving source kinds only. The NPC-anchored
+    /// kinds keep their <c>{Type}: {npc}</c> prefix — it encodes the *acquisition
+    /// mechanic* (Vendor vs Barter vs NpcGift vs HangOut), which the NPC kind-glyph
+    /// cannot convey, so it is deliberately retained (#407). Recipe/Quest sources
+    /// never reach here — they are either suppressed as reverse-twin duplicates or
+    /// rendered prefix-less as declared-only residue by <see cref="BuildSourceChips"/>.
+    /// </summary>
     private string FormatSourceDisplayName(ItemSource s)
     {
         if (!string.IsNullOrEmpty(s.Npc))
             return $"{s.Type}: {_nameResolver.Resolve(EntityRef.Npc(s.Npc!))}";
-        if (string.Equals(s.Type, "Quest", StringComparison.Ordinal) && !string.IsNullOrEmpty(s.Context))
-            return $"Quest: {_nameResolver.Resolve(EntityRef.Quest(s.Context!))}";
-        if (string.Equals(s.Type, "Recipe", StringComparison.Ordinal) && !string.IsNullOrEmpty(s.Context))
-            return $"Recipe: {_nameResolver.Resolve(EntityRef.Recipe(s.Context!))}";
         return s.Type;
     }
 }

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -581,8 +581,10 @@ public sealed class ItemsTabViewModelTests
     [Fact]
     public void SourceChips_NonNpcSource_LeavesEntityReferenceNull_AndChipNotNavigable()
     {
-        // Source kinds without an Npc field (Monster drop, Recipe, Quest, Skill, …) leave the
-        // chip's EntityReference null so the UI renders them as plain text in a transparent frame.
+        // Non-entity-resolving source kinds (Monster drop, Skill, plain-text kinds) leave the
+        // chip's EntityReference null so the UI renders them as plain text in a transparent
+        // frame. (Recipe/Quest DO resolve to an EntityRef now and are either suppressed as a
+        // reverse-twin dup or kept as declared-only residue — see the #407 tests below.)
         var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple" };
         var refData = new ItemSourceStub
         {
@@ -606,6 +608,156 @@ public sealed class ItemsTabViewModelTests
         chip.IsNavigable.Should().BeFalse();
     }
 
+    // ── #407 declared-vs-reverse source-duplication policy ─────────────────────
+    // Ratified policy (docs/silmarillion-field-coverage.md §#407): suppress a
+    // declared Recipe/Quest "Sources" row per (item,entity) edge when the same
+    // entity is already shown under its reverse header; declared-only residue
+    // survives prefix-less with an in-pane asymmetry warning (the ProvenanceSuffix
+    // slot, i.e. ItemSourceChipVm.Detail). Projection-layer only.
+
+    [Fact]
+    public void Source407_RecipeDeclared_AlsoProducedBy_IsSuppressedFromSources()
+    {
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["Apple"] = apple },
+            ItemSourcesByName = { ["Apple"] = new[] { new ItemSource("Recipe", null, "MakeApple") } },
+            ProducedByByName =
+            {
+                ["Apple"] = new[] { new Recipe { Key = "recipe_1", InternalName = "MakeApple", Name = "Make Apple" } },
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, NavWithRecipe(), new FakeEntityNameResolver());
+
+        vm.SelectedItem = apple;
+
+        // The only declared source is the reverse-twin dup → "Sources" collapses to null;
+        // the entity still appears, once, under its dedicated "Produced by" header.
+        vm.DetailViewModel!.Sources.Should().BeNullOrEmpty();
+        vm.DetailViewModel!.ProducedByRecipes.Select(c => c.DisplayName).Should().ContainSingle()
+            .Which.Should().Be("Make Apple");
+    }
+
+    [Fact]
+    public void Source407_QuestDeclared_AlsoAwardedBy_IsSuppressedFromSources()
+    {
+        var slab = new Item { Id = 1, InternalName = "MetalSlab1", Name = "Simple Metal Slab" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["MetalSlab1"] = slab },
+            ItemSourcesByName =
+            {
+                ["MetalSlab1"] = new[]
+                {
+                    new ItemSource("Quest", null, "AllTheFishYouCouldWant"),
+                    new ItemSource("Vendor", "NPC_Way", null),
+                },
+            },
+            AwardedByByName =
+            {
+                ["MetalSlab1"] = new[]
+                {
+                    new Mithril.Reference.Models.Quests.Quest
+                    { InternalName = "AllTheFishYouCouldWant", Name = "All The Fish You Could Want" },
+                },
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(
+            new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Npc) }),
+            new FakeEntityNameResolver());
+
+        vm.SelectedItem = slab;
+
+        // The Quest dup is gone from Sources; the NPC-mechanic row survives with its
+        // (deliberately kept) acquisition-method prefix. The quest stays under "Awarded by".
+        vm.DetailViewModel!.Sources!.Select(c => c.DisplayName).Should().ContainSingle()
+            .Which.Should().Be("Vendor: NPC_Way");
+        // FakeEntityNameResolver (no map) echoes the InternalName — the assertion is
+        // that the quest is *present* under "Awarded by", not its friendly form.
+        vm.DetailViewModel!.AwardedByQuests.Select(c => c.Reference)
+            .Should().Equal(EntityRef.Quest("AllTheFishYouCouldWant"));
+    }
+
+    [Fact]
+    public void Source407_RecipeDeclaredOnly_NoReverseTwin_SurvivesPrefixlessWithAsymmetryWarning()
+    {
+        var boots = new Item { Id = 1, InternalName = "CraftedSnailBoots12", Name = "Snail Boots" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["CraftedSnailBoots12"] = boots },
+            ItemSourcesByName =
+            {
+                ["CraftedSnailBoots12"] = new[] { new ItemSource("Recipe", null, "CraftedSnailBoots12") },
+            },
+            // ProducedByByName intentionally empty — the declared-only residue case.
+        };
+        var vm = new ItemsTabViewModel(refData, NavWithRecipe(), new FakeEntityNameResolver());
+
+        vm.SelectedItem = boots;
+
+        var chip = vm.DetailViewModel!.Sources!.Single();
+        // No "Recipe:" prefix — kind is carried by the Link lead-glyph standard.
+        chip.DisplayName.Should().Be("CraftedSnailBoots12");
+        chip.Detail.Should().Be("declared recipe source — not confirmed by recipe data");
+        chip.EntityReference.Should().Be(EntityRef.Recipe("CraftedSnailBoots12"));
+    }
+
+    [Fact]
+    public void Source407_QuestDeclaredOnly_NoReverseTwin_SurvivesPrefixlessWithAsymmetryWarning()
+    {
+        var seed = new Item { Id = 1, InternalName = "CarrotSeedling", Name = "Carrot Seedling" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["CarrotSeedling"] = seed },
+            ItemSourcesByName =
+            {
+                ["CarrotSeedling"] = new[] { new ItemSource("Quest", null, "LiveEvent_BunFu_Flopsy") },
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(
+            Array.Empty<IReferenceKindTarget>()), new FakeEntityNameResolver());
+
+        vm.SelectedItem = seed;
+
+        var chip = vm.DetailViewModel!.Sources!.Single();
+        chip.DisplayName.Should().Be("LiveEvent_BunFu_Flopsy");
+        chip.Detail.Should().Be("declared quest source — not confirmed by quest data");
+        chip.EntityReference.Should().Be(EntityRef.Quest("LiveEvent_BunFu_Flopsy"));
+    }
+
+    [Fact]
+    public void Source407_PartialOverlap_DupSuppressed_ResidueKept_PerEdge()
+    {
+        // Two declared Recipe sources for the same item: one has a reverse twin
+        // (suppressed), one does not (kept as residue). Proves the test is per-edge.
+        var apple = new Item { Id = 1, InternalName = "Apple", Name = "Apple" };
+        var refData = new ItemSourceStub
+        {
+            ItemsByName = { ["Apple"] = apple },
+            ItemSourcesByName =
+            {
+                ["Apple"] = new[]
+                {
+                    new ItemSource("Recipe", null, "MakeApple"),     // reverse twin → suppressed
+                    new ItemSource("Recipe", null, "OrphanApple"),   // no reverse twin → residue
+                },
+            },
+            ProducedByByName =
+            {
+                ["Apple"] = new[] { new Recipe { Key = "recipe_1", InternalName = "MakeApple", Name = "Make Apple" } },
+            },
+        };
+        var vm = new ItemsTabViewModel(refData, NavWithRecipe(), new FakeEntityNameResolver());
+
+        vm.SelectedItem = apple;
+
+        var sources = vm.DetailViewModel!.Sources!;
+        sources.Should().ContainSingle();
+        sources[0].EntityReference.Should().Be(EntityRef.Recipe("OrphanApple"));
+        sources[0].Detail.Should().Be("declared recipe source — not confirmed by recipe data");
+    }
+
     private sealed class StubKindTarget : IReferenceKindTarget
     {
         public StubKindTarget(EntityKind kind) => Kind = kind;
@@ -621,6 +773,13 @@ public sealed class ItemsTabViewModelTests
         public Dictionary<string, Item> ItemsByName { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, IReadOnlyList<ItemSource>> ItemSourcesByName { get; } = new(StringComparer.Ordinal);
         public Dictionary<string, Mithril.Reference.Models.Npcs.Npc> NpcsByKey { get; } = new(StringComparer.Ordinal);
+        // #407: reverse-header membership. When seeded, BuildSourceChips suppresses a
+        // declared Recipe/Quest "Sources" row whose Context is present here (the
+        // per-edge dedupe); unseeded entries default to the interface's empty index.
+        public Dictionary<string, IReadOnlyList<Recipe>> ProducedByByName { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, IReadOnlyList<Mithril.Reference.Models.Quests.Quest>> AwardedByByName { get; } = new(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesByProducedItem => ProducedByByName;
+        public IReadOnlyDictionary<string, IReadOnlyList<Mithril.Reference.Models.Quests.Quest>> QuestsRewardingItem => AwardedByByName;
 
         public IReadOnlyList<string> Keys { get; } = [];
         public IReadOnlyDictionary<long, Item> Items => ItemsByName.Values.ToDictionary(i => i.Id);

--- a/tests/Silmarillion.Tests/ViewModels/Source407CoveragePolicyGuardTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/Source407CoveragePolicyGuardTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+/// <summary>
+/// #407 coverage-policy regression guard (spirit-analogue of the Phase-6
+/// <c>DetailViewGrammarConformanceTests</c>, but for the coverage axis). Over the
+/// real bundled corpus, projects every item that has declared sources through the
+/// actual <see cref="ItemsTabViewModel"/> and asserts the ratified policy holds:
+/// <b>no entity appears under both "Sources" and its dedicated reverse header
+/// ("Produced by" / "Awarded by") for the same item.</b> xunit never renders the
+/// pane, so the duplication compiles + passes without this — it would silently rot
+/// back. Declared-only residue (no reverse twin) is expected to survive and is
+/// explicitly allowed.
+/// </summary>
+public sealed class Source407CoveragePolicyGuardTests
+{
+    [Fact]
+    public void NoEntity_AppearsUnderBoth_Sources_AndItsReverseHeader_ForTheSameItem()
+    {
+        var bundled = Path.Combine(AppContext.BaseDirectory, "Reference", "BundledData");
+        if (!File.Exists(Path.Combine(bundled, "sources_items.json"))) return;
+
+        var refData = BuildRealRefData(bundled);
+        if (refData is null) return;
+
+        // Kinds registered so Recipe/Quest sources resolve to a real EntityRef — the
+        // assertion compares references, so they must be non-null on both sides.
+        var nav = new SilmarillionReferenceNavigator(new IReferenceKindTarget[]
+        {
+            new GuardKindTarget(EntityKind.Recipe),
+            new GuardKindTarget(EntityKind.Quest),
+            new GuardKindTarget(EntityKind.Npc),
+        });
+        var vm = new ItemsTabViewModel(refData, nav, new ReferenceDataEntityNameResolver(refData));
+
+        // Precise corpus: only items that actually declare sources can exhibit the
+        // class. ~6155 items in v470 — bounded and fast (one index build, O(sources)
+        // per select).
+        var itemsWithSources = refData.ItemSources.Keys
+            .Select(n => refData.ItemsByInternalName.TryGetValue(n, out var it) ? it : null)
+            .Where(it => it is not null)
+            .ToList();
+
+        itemsWithSources.Should().NotBeEmpty("bundled sources_items.json ships ~6155 sourced items");
+
+        var violations = new List<string>();
+
+        foreach (var item in itemsWithSources)
+        {
+            vm.SelectedItem = null;
+            vm.SelectedItem = item;
+            var d = vm.DetailViewModel;
+            if (d is null) continue;
+
+            var reverseRefs = new HashSet<EntityRef>(
+                d.ProducedByRecipes.Select(c => c.Reference)
+                    .Concat(d.AwardedByQuests.Select(c => c.Reference)));
+
+            foreach (var src in d.Sources)
+            {
+                if (src.EntityReference is not { } r) continue;
+                if (r.Kind is not (EntityKind.Recipe or EntityKind.Quest)) continue;
+                if (reverseRefs.Contains(r))
+                    violations.Add($"{item!.InternalName}: {r.Kind} '{r.InternalName}' is under BOTH Sources and its reverse header");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "the #407 ratified policy (docs/silmarillion-field-coverage.md §#407) suppresses a "
+            + "declared Recipe/Quest Sources row per (item,entity) edge when the same entity is "
+            + "already under its reverse header; declared-only residue survives but must not also "
+            + "appear under a reverse header. First few: "
+            + string.Join(" | ", violations.Take(5)));
+    }
+
+    private static IReferenceDataService? BuildRealRefData(string bundled)
+    {
+        try
+        {
+            var cacheDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(cacheDir);
+            using var http = new HttpClient(new ThrowingHttpHandler());
+            return new ReferenceDataService(cacheDir, http, bundledDir: bundled);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed class ThrowingHttpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("HTTP must not be called in this test");
+    }
+
+    private sealed class GuardKindTarget : IReferenceKindTarget
+    {
+        public GuardKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 0;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+}


### PR DESCRIPTION
## #407 — declared-vs-reverse source-duplication: audit → ratified policy → conformed projection

Owns [#407](https://github.com/moumantai-gg/mithril/issues/407) end-to-end per the cold-start dispatch `docs/agent-plans/2026-05-17-silmarillion-407-source-dedup.md`. **Coverage axis** — the deliberate sibling of the now-closed #404/#424 **presentation** axis; the two stay fenced apart.

### Audit (re-derived, not inherited)
Fresh cross-pane audit through the **production indices** over the live v470 bundle ([audit comment](https://github.com/moumantai-gg/mithril/issues/407#issuecomment-4470910146)):
- Prior `ItemDetailView` scale numbers reproduce exactly (Recipe 4135/2736, Quest 861/351).
- **New partial-overlap quantification:** Recipe↔"Produced by" 4076 dup / 59 declared-only; Quest↔"Awarded by" 816 dup / 45 declared-only / 0 reverse-only.
- **Cross-pane negative re-derived:** the class is confined to the shared `ItemDetailView` — RecipeDetail's "Taught by" and AbilityDetail's NPC-trainer sources have **no in-pane reverse twin**. The dispatch-flagged RecipeDetail candidate is clean.

### Ratified policy (maintainer sign-off — @arthur-conde; [policy comment](https://github.com/moumantai-gg/mithril/issues/407#issuecomment-4471012842))
Written into the coverage-axis owner doc `docs/silmarillion-field-coverage.md` **first** (commit 1), then the projection conformed (commit 2):
1. **Suppress declared, keep reverse — per (item,entity) edge.**
2. **Declared-only residue survives** with an in-pane asymmetry warning (never silently dropped).
3. **Kind-prefix dropped** for the entity-resolving residue (kind → lead-glyph standard); NPC-mechanic prefixes kept.

### Implementation discipline
- **Projection-layer only** (`ItemsTabViewModel`). No `*DetailView.xaml`, no Phase-4 primitive, no `Resources.xaml`. The asymmetry warning ships through the **existing `LinkVm.ProvenanceSuffix` slot** the migrated grammar already renders — a louder treatment would touch the frozen primitive and is a deliberately-separate presentation issue.
- **Additive cross-module contract preserved** — `Sources`/`ProducedByRecipes`/`AwardedByQuests`/`Consumed*` all stay. The only intended behavioural delta: `Sources` membership drops the suppressed dupes; residue rows gain the provenance-suffix warning + lose their kind prefix. `ItemsTabViewModelTests` updated **deliberately and visibly** (+5 #407 facts); Bilbo / Celebrimbor / Mithril.Shared consumer tests unchanged and green.
- **Regression guard:** `Source407CoveragePolicyGuardTests` projects every sourced item (~6155, v470) through the real `ItemsTabViewModel` and asserts **0** entities under two source-family headers — xunit never renders the pane, so without this it would silently rot back.

### Verification
- `dotnet build Mithril.slnx` → **0W / 0E** · `XamlResourceLint OK` (117 keys)
- `dotnet test` green: **Silmarillion 522 · Mithril.Shared 1137 · Bilbo 31 · Celebrimbor 87**
- ⚠️ **Live visual eyeball owed** (cannot be done headless per the dispatch). A worktree boot smoke is additionally masked by the installed `Mithril.exe` holding the single-instance mutex (documented gotcha). The change makes **zero DI/ctor surface change** (private method bodies + one private static helper), so cycle/boot risk is nil; the real-corpus guard constructs the actual VM and projects all sourced items. Recommend an eyeball on **`MetalSlab1`** (declared Quest dup → now once under "Awarded by") and **`CraftedSnailBoots12`** (declared-only residue → survives prefix-less with the asymmetry warning).

### Out of scope (filed separately — not folded in, anti-goal #4)
`QuestObjectiveMacGuffin` (8/8) resolves Context→quest InternalName but isn't matched by `ResolveSourceReference`, rendering as a bare text row — a latent display defect, **not** a dedupe target (consume role). Its own issue.

Tracked in: #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)
