### PR TITLE
feat(silmarillion): G-d — Link 'Unconfirmed' reference state (Variant C); supersedes the #407 provenance-suffix stopgap

### DIFF
--- a/docs/silmarillion-field-coverage.md
+++ b/docs/silmarillion-field-coverage.md
@@ -249,7 +249,20 @@ ships through the **existing `LinkVm.ProvenanceSuffix` slot the migrated
 grammar already renders** — no `*DetailView.xaml`, no Phase-4 primitive, no
 `Resources.xaml` edit (the #404/#424 presentation axis stays frozen). A louder
 warning treatment (colour/badge) would touch the frozen Link primitive and is a
-**separate presentation-axis issue**, deliberately out of scope here. The
+**separate presentation-axis issue**, deliberately out of scope here.
+
+> **Superseded (presentation only) by G-d (#431).** Claude Design's review of
+> this shipped stopgap confirmed the provenance-slot-overload concern flagged
+> on #429. The ratified **G-d Link reference-state axis**
+> ([silmarillion-visual-grammar.md](silmarillion-visual-grammar.md) · G-d;
+> #431) replaces the `ProvenanceSuffix` caveat with an additive
+> `IsUnconfirmed` flag → dashed gold underline + one-word `· unconfirmed` tail
+> + caveat `ToolTip`. **Only the presentation of the residue caveat changes**;
+> the #407 *coverage policy* (suppress-declared-keep-reverse per edge,
+> declared-only residue survives) is unchanged and remains correct. #429 was
+> left untouched; G-d ships as its own PR.
+
+The
 additive cross-module contract (`Sources`/`ProducedByRecipes`/`AwardedByQuests`
 /`Consumed*` — asserted by `ItemsTabViewModelTests`, consumed by Bilbo /
 Celebrimbor / `ItemDetailWindow`) is preserved; the only intended behavioural

--- a/docs/silmarillion-visual-grammar.md
+++ b/docs/silmarillion-visual-grammar.md
@@ -93,6 +93,67 @@ EntityChip and ItemSourceChip both collapse into this primitive in Phase 4.
 
 ---
 
+## G-d — Link reference-state axis (Confirmed · Degraded · Unconfirmed)
+
+*Ratified 2026-05-17 (G3 amend 3). Origin: Claude Design review of the #429
+(#407) shipped baseline; design doc captured on #431. Closes the Link-tier
+**state** axis G-c opened.*
+
+G-c settled one state question (target unshipped → **Degraded**). A second,
+orthogonal one was deferred: a reference can be **declared but uncorroborated**
+— `sources_items.json` asserts an edge the inverse data (`recipes.json` /
+`quests.json` reverse) does not back. #407 shipped a deliberate
+**projection-only stopgap**: the caveat rode the Link's provenance suffix
+(*"declared recipe source — not confirmed by recipe data"*). That overloads the
+slot — provenance is *where the entity came from*; a data-integrity caveat is a
+different thing, and a Link with real provenance *and* a brokenness caveat
+fights itself. No scan-time signal, wall-of-italic at 3+ rows.
+
+**The axis.** One question: *can the reader trust this edge?* Three positions,
+**none requiring a new pigment or glyph** beyond what V2 Link ships:
+
+| State | Meaning | Visual rule | Hover | Tail |
+|---|---|---|---|---|
+| **Confirmed** | Both ends agree (or asymmetric and this is the asserting side). | Gold name + type-glyph. No underline. | 10% gold tint. | Optional provenance only (italic, `--fg-quaternary`). |
+| **Degraded** (G-c) | Reference real; target detail unshipped. | Identical to Confirmed at rest. | Neutral tint; copy-cue glyph. | None. |
+| **Unconfirmed** (G-d) | Declared in the sources data; neither entity backs it in its own data. | Gold name + **dashed underline**, 1px, `rgba(212,168,71,0.55)`. Type-glyph unchanged. | Full caveat as the control `ToolTip`. | Short word `· unconfirmed`, `--fg-quaternary`. |
+
+**Rules.**
+
+- **Dashed underline is the primary, scan-time signal.** It carries an
+  existing cross-software meaning (*this thing has a caveat*) — no new
+  convention. It modifies the primitive locally (one decoration), works for
+  sprite / Lucide / degraded Links alike, introduces **no new pigment** (stays
+  out of the G-b gold pile — the gold name still navigates, the underline
+  qualifies it).
+- **The tail shrinks to one word.** `· unconfirmed` in `--fg-quaternary`; the
+  long-form caveat moves to the hover `ToolTip` (data-driven). The provenance
+  suffix slot is **freed** — never again double-loaded with a caveat.
+- **State ⊥ availability.** Unconfirmed (assertion axis) is orthogonal to
+  Degraded (`IsNavigable`, coverage axis) — same logic as the P2 weight ⊥ tier
+  rule. A Link can be both; the dashed underline rides on top of the copy-cue
+  hover, both legible because they live on different sub-elements
+  (border-bottom vs. inline glyph). The VM carries an **additive `IsUnconfirmed`
+  flag + optional tooltip**, *not* a single `state` enum (an enum can't express
+  the compose case).
+- **Section-level signal (optional, light).** When *every* Link in a Structure
+  section is Unconfirmed — the compounding case where the residue is the
+  entity's only source, so the pane would otherwise imply provenance it
+  effectively lacks — prepend the section label with a small `unlink` Lucide
+  glyph in `--fg-quaternary`. This is the light form of the rejected
+  "separate *Declared, unconfirmed* block" (variant E): same gesture at the
+  header, not a full split (a reader scanning "Sources" should still find the
+  row under Sources). Variant E is reserved as an opt-in maintainer overlay,
+  not the default.
+
+**Rejected alternatives** (one line each, from the review): *glyph badge* —
+fragile 9px sub-glyph composite on a busy sprite, costlier in WPF; *warn-hue
+name* — gold→warn (`#D4A847`→`#E0A030`) is two ticks apart, reads as "the same
+gold" in isolation; *separated section as default* — divorces the Link from the
+section it semantically belongs in.
+
+---
+
 ## The grammar — one target per tier
 
 ### Fact · inert · weight-axis
@@ -127,6 +188,7 @@ EntityChip and ItemSourceChip both collapse into this primitive in Phase 4.
 | **Shape · spacing** | No border. No surface at rest. 2px tap padding (`margin: 0 -2px`) so the tint hover-box fits visually. Inline with text baseline. **Two row modes:** `Density="Prose"` — inline in a sentence, single Link or short list; `Density="List"` — own line per entry, sprite scaled up to `1.5em`, line-height ~1.7. |
 | **Hover** | 10% gold tint background (`rgba(212,168,71,0.10)`). |
 | **Degrade** | Rest = identical to shipped. Hover swaps nav-tint for neutral row-tint + trailing `⧉` copy glyph. Click copies the canonical name. |
+| **State** *(G-d)* | Confirmed (default) · Degraded (above) · **Unconfirmed** — declared edge the inverse data doesn't back: gold name + dashed underline `rgba(212,168,71,0.55)`, short `· unconfirmed` tail (`--fg-quaternary`), full caveat as `ToolTip`. Additive `IsUnconfirmed` flag, orthogonal to Degrade. See G-d. |
 | **Replaces** | EntityChip, ItemSourceChip. |
 
 ### Set-reference · filter / keyword / group / stacking
@@ -218,6 +280,7 @@ log can't drift).
 | G2 | [comment 4468464536](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4468464536) | Inventory cleared; E1/E3/E4 ratified, E5/E6 scoped; G-a / G-b / G-c flagged open. |
 | **G3** | this document (2026-05-17) | **G-a / G-b / G-c closed; one visual target per tier ratified. Phase 4 unblocked.** |
 | **G3 amend 1** | [#404 comment 4469052562](https://github.com/moumantai-gg/mithril/issues/404#issuecomment-4469052562) (2026-05-17) | **Link lead element → hybrid icon family** (sprite for tangible nouns, Lucide fallback for abstract). + provenance suffix ≠ name-discriminator. Surgical single-rule; Phase-5 Recipe pilot G4 finding. |
+| **G3 amend 3** | #431 (2026-05-17); origin = Claude Design review of the #429/#407 baseline | **Link reference-state axis closed (G-d): Confirmed · Degraded · Unconfirmed.** Adds an additive `IsUnconfirmed` flag (⊥ the `IsNavigable`/Degraded axis) → dashed gold underline + one-word `· unconfirmed` tail + caveat `ToolTip`; frees the provenance slot the #407 stopgap overloaded. No new pigment/glyph. Re-touches Link primitive + `LinkVm`/`ItemSourceChipVm` carriers; supersedes #407's projection-only provenance-suffix caveat. Own PR, off latest `main`; #429 untouched. |
 | **G3 amend 2** | #404 (2026-05-17) | **System-wide em-relative sizing + Link `Density`** (Prose/List) + **new fixed-40px title-glyph** rule. Root-cause of the pilot's "sprites too small at 12px" finding (px ignored the Appearance accessibility slider). Scope expansion *consciously accepted by maintainer* — re-touches Link + FactTable + FactFooter + Structure + Fact-title (all Phase-4 primitives) + adds the title-glyph element. Supersedes amend-1's fixed-12px. Pilot re-run on PR #411. |
 
 ---

--- a/src/Mithril.Shared.Wpf/EntityChipVm.cs
+++ b/src/Mithril.Shared.Wpf/EntityChipVm.cs
@@ -20,10 +20,20 @@ public sealed record EntityChipVm(
 /// item-detail. Many sources don't map to a v1-tabbed entity kind, so
 /// <see cref="EntityReference"/> is nullable and <see cref="IsNavigable"/> may be false even
 /// when <see cref="EntityReference"/> is present (e.g. an Npc source until NPCs get a tab).
+/// <para>
+/// G-d (#431): <see cref="IsUnconfirmed"/> + <see cref="UnconfirmedTooltip"/> carry the
+/// reference-state axis through to <see cref="LinkVm"/>. A declared-but-uncorroborated
+/// source (the #407 declared-only residue) sets <see cref="IsUnconfirmed"/> and leaves
+/// <see cref="Detail"/> null — the dashed-underline + one-word-tail + tooltip treatment
+/// replaces the #407 stopgap that overloaded <see cref="Detail"/> (→ provenance suffix)
+/// with the verbose caveat. Both default off so every other source row is unaffected.
+/// </para>
 /// </summary>
 public sealed record ItemSourceChipVm(
     string DisplayName,
     string? Detail,
     int? IconId,
     EntityRef? EntityReference,
-    bool IsNavigable);
+    bool IsNavigable,
+    bool IsUnconfirmed = false,
+    string? UnconfirmedTooltip = null);

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -101,7 +101,23 @@
                      from the source Detail via LinkVm.From). -->
                 <StackPanel Margin="0,0,0,10"
                             Visibility="{Binding SourceLinks.Count, Converter={StaticResource PositiveIntToVis}}">
-                    <TextBlock Text="Sources" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <!-- G-d (#431) section-level compounding signal: when EVERY
+                         Sources row is Unconfirmed (the residue is the item's only
+                         declared provenance — the #407 screenshot case where the
+                         pane would otherwise imply sources it effectively lacks),
+                         prepend the label with a small quaternary `unlink` glyph.
+                         The light form of the rejected variant-E split: same
+                         gesture at the header, the rows stay under Sources. -->
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Sources" Style="{StaticResource StructureSectionLabelStyle}"/>
+                        <icon:PackIconLucide Kind="Unlink"
+                                             Width="11" Height="11"
+                                             Margin="6,0,0,0"
+                                             VerticalAlignment="Center"
+                                             Foreground="{StaticResource TextQuaternaryBrush}"
+                                             ToolTip="No declared source is corroborated by the recipe/quest reverse data."
+                                             Visibility="{Binding SourcesAllUnconfirmed, Converter={StaticResource BoolToVis}}"/>
+                    </StackPanel>
                     <ItemsControl ItemsSource="{Binding SourceLinks}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate>

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -302,6 +302,17 @@ public sealed partial class ItemDetailViewModel
     /// provenance suffix rides from <see cref="ItemSourceChipVm.Detail"/>).</summary>
     public IReadOnlyList<LinkVm> SourceLinks { get; }
 
+    /// <summary>
+    /// G-d (#431) section-level compounding signal: true iff there is at least one
+    /// Sources row and <em>every</em> one of them is Unconfirmed — the residue is
+    /// the item's only declared provenance (the #407 screenshot case). Drives the
+    /// quaternary <c>unlink</c> glyph on the "Sources" section label so the pane
+    /// doesn't imply provenance it effectively lacks. Get-only; the VM is rebuilt
+    /// per selection so no change notification is needed.
+    /// </summary>
+    public bool SourcesAllUnconfirmed =>
+        SourceLinks.Count > 0 && SourceLinks.All(l => l.IsUnconfirmed);
+
     /// <summary>"Produced by" recipe cross-links as <see cref="LinkVm"/> (matrix #12).</summary>
     public IReadOnlyList<LinkVm> ProducedByRecipeLinks { get; }
 

--- a/src/Mithril.Shared.Wpf/LinkVm.cs
+++ b/src/Mithril.Shared.Wpf/LinkVm.cs
@@ -85,6 +85,22 @@ public enum LinkDensity
 /// locations, keywords, factions). The sprite, when present, wins over
 /// <see cref="Glyph"/> — both render at the 12px lead position.
 /// </param>
+/// <param name="IsUnconfirmed">
+/// G-d reference-state axis (2026-05-17, #431). True when this Link is a declared
+/// edge the inverse data does not corroborate (a <c>sources_*.json</c> assertion
+/// the <c>recipes.json</c>/<c>quests.json</c> reverse does not back). Renders the
+/// gold name with a dashed underline + a one-word <c>· unconfirmed</c> tail; the
+/// full caveat is the control <see cref="UnconfirmedTooltip"/>. <b>Orthogonal to
+/// <see cref="IsNavigable"/></b> (the Degraded/G-c axis) — a Link can be both; the
+/// two signals live on different sub-elements and stay legible. Additive flag,
+/// deliberately not a single <c>state</c> enum (an enum can't express the compose
+/// case). False everywhere it doesn't apply; <see cref="ProvenanceSuffix"/> stays
+/// reserved for real provenance and is never double-loaded with the caveat.
+/// </param>
+/// <param name="UnconfirmedTooltip">
+/// The long-form data-integrity caveat shown as the control <c>ToolTip</c> when
+/// <see cref="IsUnconfirmed"/>. Null when not unconfirmed (or no caveat text).
+/// </param>
 public sealed record LinkVm(
     string DisplayName,
     LinkGlyph Glyph,
@@ -92,7 +108,9 @@ public sealed record LinkVm(
     bool IsNavigable,
     string? ProvenanceSuffix = null,
     string? KindLabel = null,
-    int IconId = 0)
+    int IconId = 0,
+    bool IsUnconfirmed = false,
+    string? UnconfirmedTooltip = null)
 {
     /// <summary>
     /// True when a real CDN sprite is present (<see cref="IconId"/> &gt; 0) and should
@@ -139,7 +157,10 @@ public sealed record LinkVm(
     /// (the ItemSourceChip "— from X" bit); the kind-derived <see cref="LinkGlyph"/>
     /// (<see cref="LinkGlyph.None"/> when the source maps to no entity) is the Lucide
     /// fallback. Per the G3 amendment <see cref="ItemSourceChipVm.IconId"/> (null ⇒ 0)
-    /// rides through as the preferred lead sprite.
+    /// rides through as the preferred lead sprite. G-d (#431): the chip's
+    /// <see cref="ItemSourceChipVm.IsUnconfirmed"/> / <see cref="ItemSourceChipVm.UnconfirmedTooltip"/>
+    /// ride through so a declared-but-uncorroborated source renders the dashed
+    /// reference-state treatment instead of an overloaded provenance suffix.
     /// </summary>
     public static LinkVm From(ItemSourceChipVm chip) => new(
         chip.DisplayName,
@@ -147,5 +168,7 @@ public sealed record LinkVm(
         chip.EntityReference,
         chip.IsNavigable,
         ProvenanceSuffix: string.IsNullOrEmpty(chip.Detail) ? null : chip.Detail,
-        IconId: chip.IconId ?? 0);
+        IconId: chip.IconId ?? 0,
+        IsUnconfirmed: chip.IsUnconfirmed,
+        UnconfirmedTooltip: chip.UnconfirmedTooltip);
 }

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1204,7 +1204,8 @@
                                              FontSize — the text itself already scales
                                              with the Appearance slider via inheritance;
                                              no converter needed at 1em. -->
-                                        <TextBlock Text="{Binding DisplayName}"
+                                        <TextBlock x:Name="NameText"
+                                                   Text="{Binding DisplayName}"
                                                    Foreground="{StaticResource AccentBrush}"
                                                    FontWeight="Normal"
                                                    VerticalAlignment="Center"/>
@@ -1225,6 +1226,23 @@
                                                    FontStyle="Italic"
                                                    VerticalAlignment="Center"
                                                    Visibility="{Binding KindLabel, Converter={StaticResource NullToVis}}"/>
+                                        <!-- G-d (#431) reference-state tail: the one-word
+                                             "· unconfirmed" token for a declared edge the
+                                             inverse data doesn't back. Quaternary, NOT
+                                             italic (distinct register from the italic
+                                             provenance suffix — this is a state token,
+                                             not provenance). Collapsed at rest; revealed
+                                             by the IsUnconfirmed trigger. The dashed
+                                             underline on NameText is the primary signal;
+                                             this tail is the secondary, and the long
+                                             caveat is the HoverBox ToolTip. -->
+                                        <TextBlock x:Name="UnconfirmedTail"
+                                                   Text="· unconfirmed"
+                                                   Margin="5,0,0,0"
+                                                   Foreground="{StaticResource TextQuaternaryBrush}"
+                                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                                   VerticalAlignment="Center"
+                                                   Visibility="Collapsed"/>
                                         <!-- G-c pending copy affordance: 11px Copy glyph,
                                              revealed only on hover of a non-navigable Link
                                              (HoverCopyGlyph trigger below). Hidden by
@@ -1307,6 +1325,39 @@
                                     <DataTrigger Binding="{Binding Copied, RelativeSource={RelativeSource AncestorType={x:Type c:Link}}}" Value="True">
                                         <Setter TargetName="CopyGlyph" Property="Visibility" Value="Collapsed"/>
                                         <Setter TargetName="CopiedAck" Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                    <!-- G-d (#431) Unconfirmed reference state: declared
+                                         edge the inverse data doesn't corroborate. PRIMARY
+                                         scan-time signal = a 1px dashed underline on the
+                                         gold name in rgba(212,168,71,0.55) (= #8CD4A847);
+                                         no new pigment (the gold name still navigates, the
+                                         underline qualifies it). SECONDARY = the one-word
+                                         "· unconfirmed" tail. The full data-integrity
+                                         caveat is the HoverBox ToolTip (data-driven from
+                                         UnconfirmedTooltip). ORTHOGONAL to IsNavigable
+                                         (Degraded/G-c) — both can be set; the underline
+                                         (border on the name) and the copy-cue (inline
+                                         glyph) live on different sub-elements and stay
+                                         legible together. Provenance suffix is untouched
+                                         and stays free for real provenance. -->
+                                    <DataTrigger Binding="{Binding IsUnconfirmed}" Value="True">
+                                        <Setter TargetName="NameText" Property="TextBlock.TextDecorations">
+                                            <Setter.Value>
+                                                <TextDecorationCollection>
+                                                    <TextDecoration Location="Underline">
+                                                        <TextDecoration.Pen>
+                                                            <Pen Thickness="1" Brush="#8CD4A847">
+                                                                <Pen.DashStyle>
+                                                                    <DashStyle Dashes="2 2"/>
+                                                                </Pen.DashStyle>
+                                                            </Pen>
+                                                        </TextDecoration.Pen>
+                                                    </TextDecoration>
+                                                </TextDecorationCollection>
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Setter TargetName="UnconfirmedTail" Property="Visibility" Value="Visible"/>
+                                        <Setter TargetName="HoverBox" Property="ToolTip" Value="{Binding UnconfirmedTooltip}"/>
                                     </DataTrigger>
                                 </ControlTemplate.Triggers>
                             </ControlTemplate>

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -449,26 +449,28 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
 
             var reference = ResolveSourceReference(s);
 
-            // #407 (2)+(3) declared-only residue: a Recipe/Quest declared source with
-            // NO reverse twin survives (never silently dropped), drops its now-
-            // redundant kind prefix (entity kind is carried by the Link lead-glyph
-            // standard, LinkVm.GlyphFor), and carries an in-pane warning — through
-            // the existing ProvenanceSuffix slot (ItemSourceChipVm.Detail) the
-            // migrated grammar already renders — that the declared↔reverse
-            // relationship is asymmetrical (uncorroborated by the recipe/quest
-            // reverse data; a sources/relational coverage signal, see
-            // docs/silmarillion-field-coverage.md §#407). Projection-layer only —
-            // no view / grammar-primitive change.
+            // #407 (2)+(3) declared-only residue: a Recipe/Quest declared source
+            // with NO reverse twin survives (never silently dropped) and drops its
+            // now-redundant kind prefix (entity kind is carried by the Link
+            // lead-glyph standard, LinkVm.GlyphFor). G-d (#431, supersedes the
+            // #407 projection-only stopgap): instead of overloading the provenance
+            // suffix with the verbose caveat, mark the chip Unconfirmed — the Link
+            // primitive renders the ratified dashed-underline + one-word
+            // "· unconfirmed" tail and surfaces the long-form caveat as the
+            // control ToolTip. Detail stays null so the provenance slot is freed.
+            // (see docs/silmarillion-visual-grammar.md §G-d.)
             if (isRecipe || isQuest)
             {
                 chips.Add(new ItemSourceChipVm(
                     DisplayName: reference is not null ? _nameResolver.Resolve(reference) : s.Context!,
-                    Detail: isRecipe
-                        ? "declared recipe source — not confirmed by recipe data"
-                        : "declared quest source — not confirmed by quest data",
+                    Detail: null,
                     IconId: null,
                     EntityReference: reference,
-                    IsNavigable: reference is not null && _navigator.CanOpen(reference)));
+                    IsNavigable: reference is not null && _navigator.CanOpen(reference),
+                    IsUnconfirmed: true,
+                    UnconfirmedTooltip: isRecipe
+                        ? "Declared as a source in this item's sources data, but the linked recipe does not list this item among its products — an unconfirmed cross-reference."
+                        : "Declared as a source in this item's sources data, but the linked quest does not list this item among its rewards — an unconfirmed cross-reference."));
                 continue;
             }
 

--- a/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
+++ b/tests/Mithril.Shared.Tests/Wpf/LinkTests.cs
@@ -140,6 +140,42 @@ public sealed class LinkTests
         vm.Glyph.Should().Be(LinkGlyph.Npc);
     }
 
+    // ── G-d (#431) reference-state axis ──
+
+    [Fact]
+    public void From_ItemSourceChip_CarriesUnconfirmedState_OrthogonalToNavigable()
+    {
+        // A declared-only residue chip: navigable AND unconfirmed at once. Both
+        // axes must ride through independently (G-d composes with G-c).
+        var chip = new ItemSourceChipVm(
+            "CraftedSnailBoots12", Detail: null, IconId: null,
+            EntityReference: EntityRef.Recipe("CraftedSnailBoots12"), IsNavigable: true,
+            IsUnconfirmed: true,
+            UnconfirmedTooltip: "Declared as a source … does not list this item among its products.");
+
+        var vm = LinkVm.From(chip);
+
+        vm.IsUnconfirmed.Should().BeTrue();
+        vm.UnconfirmedTooltip.Should().Contain("does not list this item among its products");
+        vm.IsNavigable.Should().BeTrue("Unconfirmed is orthogonal to the IsNavigable/Degraded axis");
+        // The provenance slot stays free — the caveat is the state, not provenance.
+        vm.ProvenanceSuffix.Should().BeNull();
+    }
+
+    [Fact]
+    public void From_ItemSourceChip_UnconfirmedDefaultsOff_ForOrdinarySources()
+    {
+        // Back-compat: existing 5-arg constructions stay Confirmed (no underline,
+        // no tail, no tooltip) — every non-residue source is unaffected.
+        var chip = new ItemSourceChipVm("Joeh", Detail: "Vendor", IconId: null,
+            EntityReference: EntityRef.Npc("NPC_Joeh"), IsNavigable: true);
+
+        var vm = LinkVm.From(chip);
+
+        vm.IsUnconfirmed.Should().BeFalse();
+        vm.UnconfirmedTooltip.Should().BeNull();
+    }
+
     // ── Glyph enum → PackIconLucideKind ──
 
     [Theory]

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -699,7 +699,11 @@ public sealed class ItemsTabViewModelTests
         var chip = vm.DetailViewModel!.Sources!.Single();
         // No "Recipe:" prefix — kind is carried by the Link lead-glyph standard.
         chip.DisplayName.Should().Be("CraftedSnailBoots12");
-        chip.Detail.Should().Be("declared recipe source — not confirmed by recipe data");
+        // G-d (#431): the caveat is the Unconfirmed reference state, NOT an
+        // overloaded provenance suffix. Detail (→ ProvenanceSuffix) stays free.
+        chip.Detail.Should().BeNull();
+        chip.IsUnconfirmed.Should().BeTrue();
+        chip.UnconfirmedTooltip.Should().Contain("does not list this item among its products");
         chip.EntityReference.Should().Be(EntityRef.Recipe("CraftedSnailBoots12"));
     }
 
@@ -722,7 +726,9 @@ public sealed class ItemsTabViewModelTests
 
         var chip = vm.DetailViewModel!.Sources!.Single();
         chip.DisplayName.Should().Be("LiveEvent_BunFu_Flopsy");
-        chip.Detail.Should().Be("declared quest source — not confirmed by quest data");
+        chip.Detail.Should().BeNull();
+        chip.IsUnconfirmed.Should().BeTrue();
+        chip.UnconfirmedTooltip.Should().Contain("does not list this item among its rewards");
         chip.EntityReference.Should().Be(EntityRef.Quest("LiveEvent_BunFu_Flopsy"));
     }
 
@@ -755,7 +761,8 @@ public sealed class ItemsTabViewModelTests
         var sources = vm.DetailViewModel!.Sources!;
         sources.Should().ContainSingle();
         sources[0].EntityReference.Should().Be(EntityRef.Recipe("OrphanApple"));
-        sources[0].Detail.Should().Be("declared recipe source — not confirmed by recipe data");
+        sources[0].Detail.Should().BeNull();
+        sources[0].IsUnconfirmed.Should().BeTrue();
     }
 
     private sealed class StubKindTarget : IReferenceKindTarget


### PR DESCRIPTION
## G-d — Link **Unconfirmed** reference state (Variant C)

Implements the ratified treatment from the **Claude Design review** of the #429/#407 baseline. Tracked in #431; closes the Link-tier state axis G-c opened (program #404). Rebased onto `main` after #429 merged — diff is exactly G-d's two commits (doc-first, then code).

### Why
#429 shipped a deliberate projection-only stopgap (residue caveat on the Link `ProvenanceSuffix`). The Claude Design review confirmed the **provenance-slot-overload** concern flagged on #429. **Only the residue caveat's presentation changes; the #407 coverage policy (now in `main`) is unchanged and correct.**

### What (doc-first)
`silmarillion-visual-grammar.md`: new **G-d** section + Link *State* row + decision-log **G3 amend 3**. `field-coverage.md §#407`: "superseded (presentation only) by G-d" note.

- **Primitive (additive, orthogonal — not a single `state` enum; composes with `IsNavigable`/Degraded):** `LinkVm`/`ItemSourceChipVm` + `IsUnconfirmed` + `UnconfirmedTooltip` (defaulted → existing constructions unaffected; additive cross-module contract held).
- **Link template:** 1px **dashed gold underline** `#8CD4A847` (= `rgba(212,168,71,0.55)`) + one-word `· unconfirmed` quaternary tail + long caveat as `ToolTip`. No new pigment/glyph; provenance slot freed.
- **Projection:** `BuildSourceChips` residue sets `IsUnconfirmed` + a model-correct tooltip (`sources_items.json` vs `recipes.json`/`quests.json` — not the mock's `relationships.json`), `Detail` null.
- **Section-level (light variant-E):** `SourcesAllUnconfirmed` → quaternary `unlink` glyph on the "Sources" label when every row is Unconfirmed (the #407 screenshot case). Full variant-E split reserved as opt-in maintainer overlay, not default.

Rejected alternatives (glyph badge / warn-hue / separated-as-default) recorded in G-d with one-line rationale.

### Verification
- `dotnet build Mithril.slnx` **0W/0E** · `XamlResourceLint OK` (117 keys).
- `dotnet test` green: **Silmarillion 522 · Mithril.Shared 1139 · Bilbo 31 · Celebrimbor 87**. #429 residue tests reconciled to the G-d contract; **+2** `LinkVm` G-d tests (orthogonality with `IsNavigable` + back-compat default-off); #407 real-corpus guard + `DetailViewGrammarConformanceTests` unaffected. Re-confirmed post-rebase onto `main`.
- **Boot smoke clean** (12 modules incl. `silmarillion`, startup done, no DI stall).
- ⚠️ **Live visual eyeball owed** (headless-impossible). Specimens: `CraftedSnailBoots12` (residue → dashed underline + `· unconfirmed` + tooltip + Sources-label `unlink` glyph, being its only source) and any vendor item (Confirmed rows visually unchanged).

Tracked in: #431. Refs #407, #429, #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
