### PR TITLE
feat(silmarillion): Treasure System Power + Profile detail views (ratified V1 spec) (#435)

### DIFF
--- a/docs/agent-plans/2026-05-18-silmarillion-412-treasure-detail-ratified-spec.md
+++ b/docs/agent-plans/2026-05-18-silmarillion-412-treasure-detail-ratified-spec.md
@@ -13,6 +13,37 @@ Claude Design's V1 passed the gate clean, owner-ratified 2026-05-17.
 > calls — cite [`silmarillion-visual-grammar.md`](../silmarillion-visual-grammar.md)
 > (G3 + G-d, binding) and this doc.
 
+## Implementation amendment — Recipes leg deferred to #214 (2026-05-18)
+
+The ratified design's `Power → Recipes` chain (`recipe → template.TSysProfile →
+profile → power`, rows marked **Recipes disclosure** / **Power → Recipes**
+below) was **verified data-invalid for the in-scope index** during the #435
+build and is **deferred to #214**:
+
+- `Item.TSysProfile` *is* populated and *does* match `tsysprofiles` keys
+  (`Sword`/`NewbSword`/`Dagger`/… verified v470) — the **Pools** links are
+  real and shipped.
+- But the recipe hop is not: `RecipesByProducedItem` only indexes recipes by
+  `ResultItems`/`ProtoResultItems`. TSysProfile-bearing items that *are*
+  recipe-produced are almost all `Crafted*` gear carrying the **catch-all
+  `"All"` profile** (which contains ≈ the entire power catalogue, `SwordBoost`
+  included). So the chain resolves to the *same* enormous
+  "every enchanted/max-enchanted crafted-gear recipe" set for nearly every
+  power — presenting it as power-specific implies precision the in-scope data
+  lacks (correctness-adjacent to the roll-resolution ban). Loot/Stock
+  TSysProfile items are not recipe-produced at all.
+- The power-precise join is recipe `ResultEffects`
+  (`AddItemTSysPower` / `ExtractTSysPower` / `TSysCraftedEquipment`) via
+  `ResultEffectsParser` — the **#214** surface (#433 Carry-forward #2 bound
+  recipe-side rendering to #214).
+
+**Net for #435:** no Recipes section is rendered; no `ItemsByTSysProfile`
+index ships; only `ProfilesByPower` (Pools) ships. The **Recipes disclosure**
+spec-card row and the **Power → Recipes** cross-link row below are retained as
+the *ratified intent* but are explicitly **NOT built here** — they are #214's.
+Q4/Q5 remain ratified as the design contract for when #214 supplies the
+precise index.
+
 ## Data shapes (verified live v470, 2026-05-18)
 
 - `tsysclientinfo` — 1946 entries, keyed `power_NNNN`. Fields are exactly

--- a/docs/agent-plans/2026-05-18-silmarillion-412-treasure-detail-ratified-spec.md
+++ b/docs/agent-plans/2026-05-18-silmarillion-412-treasure-detail-ratified-spec.md
@@ -1,0 +1,122 @@
+# Ratified visual spec — Silmarillion Treasure System detail views
+
+**Tracked in:** #435 (implement Power + Profile detail views).
+Design ratified via #433 (commission brief) + #434 (gate-review directive);
+Claude Design's V1 passed the gate clean, owner-ratified 2026-05-17.
+
+> This is the repo-resident lift of the **ratified V1 spec**. The V1 HTML
+> specimen is a design-bundle artifact and is **not** committed (per the #433
+> brief's rule: *only the ratified spec returns to the repo*). #433/#434 carry
+> the rulings narrative; this doc is the per-region grammar contract Phase 4
+> (the #435 build) encodes against, so the spec isn't bundle-trapped. It is the
+> source of truth for the Power/Profile detail panes; do not re-derive grammar
+> calls — cite [`silmarillion-visual-grammar.md`](../silmarillion-visual-grammar.md)
+> (G3 + G-d, binding) and this doc.
+
+## Data shapes (verified live v470, 2026-05-18)
+
+- `tsysclientinfo` — 1946 entries, keyed `power_NNNN`. Fields are exactly
+  `InternalName`, `Prefix`, `Suffix`, `Skill`, `Slots`, `Tiers` (plus the
+  parser-only `IsUnavailable` / `IsHiddenFromTransmutation`). **No
+  `DisplayName`; `resolve_strings` returns null for every candidate key.**
+  `Tiers` is keyed `id_N`; each tier carries `MinLevel`, `MaxLevel`,
+  `MinRarity`, `SkillLevelPrereq`, `EffectDescs`. `SwordBoost` (`power_1001`):
+  12 tiers, contiguous **overlapping** level bands (1–20 … 100–140),
+  monotonically scaling `{MOD_SKILL_SWORD}` 0.10 → 0.60, `MinRarity` constant
+  `Uncommon`. Some powers carry only a `Prefix`, some only a `Suffix`, some
+  both. `EffectDescs` is polymorphic: `{TOKEN}{value}` template **or**
+  already-rendered prose with inline `<icon=N>`.
+- `tsysprofiles` — 40 entries, each a flat JSON array of power `InternalName`
+  strings. The profile name is the **equipment family the pool rolls onto**,
+  NOT the powers' own `Skill` (the `Sword` pool carries `BardMaxHealth`,
+  `WerewolfMaxHealth`, …). Two orthogonal skill axes — never conflate
+  `Power.Skill` with the pool name.
+
+## Power detail · spec card (every region → exactly one ratified tier)
+
+| Region | Tier | Pigment | Glyph | Shape · spacing | Hover |
+|---|---|---|---|---|---|
+| **Power name** | Fact · title-loud | `--accent`, 1×/pane | none (the icon slot is the 40px title-glyph, not a glyph) | Cambria 18pt 600, no border. **`InternalName` verbatim — no humanization, no affix-derivation** (Q1; affix logic is non-replicable engine-side) | none |
+| **Affix flavor** | Fact · body · *illustrative only* | `--fg-quaternary` framing prose · `--fg-secondary` affix tokens · `--fg-quaternary` mono «item» slot | none | conditional render: **only the affix parts that exist** (Prefix-only / Suffix-only / both); framed approximate ("appears on items roughly as …", "— illustrative, not the canonical name"); **never** a reconstructed canonical item name | none |
+| **Skill row** | Structure + Link | label `--fg-tertiary` · Link name `--accent` · `sparkles` `--accent` | `sparkles` Lucide (abstract entity) | inline-prefix `Skill:` · Link no surface · 2px tap pad | 10% gold tint on Link · **Confirmed** (Degraded only if the Skills surface is unshipped at build) |
+| **Slots row** | Structure + Set-reference | chip text `--info` · idle fill `rgba(30,58,95,.30)` | none (Set-ref default) | `--radius-sm` · 1px blue border · 1×8 pad · `t-set-row` gap 5px | fill darkens / border brightens · **not active by default** (constraint members, not a live filter) |
+| **Tiers ladder** | Fact · CF#3 FactTable | values `--fg-primary` · labels `--fg-quaternary` · constant-rarity cells dimmed to `--fg-quaternary` in place · band fill `--info` 55% · **Rare rows: `--info` + 1px inset/white outline (weight, NOT `--accent`)** — G-b forbids a third gold meaning; reconcile with rarity scheme #54 in a Phase-4 follow-up | none in body · inline iconId baseline-aligned within rendered `EffectDescs` | 6-column grid · no surface · 1px `--border-faint` row dividers · tabular numerals · 24px ordinal rail · 72px band rail · effect col 1fr · row hover = 2% white wash (Fact-body affordance, not a Control) | row tint only · **no row-click action** (ladder is inert; navigation is the Skill/Pool Links above) |
+| **Pools section** | Link · **Confirmed** | `--accent` gold name · standard Link, no dashed underline, no tail | `layers` Lucide (abstract membership) | no surface · 2px tap pad · 5px gap between siblings | 10% gold tint · vanilla Link hover · *`tsysprofiles` is the authoritative join — G-d Unconfirmed does NOT apply to one-side normalized FKs (precedent on #404)* |
+| **Recipes disclosure** | Control · contents Link Confirmed | chassis `--bg-surface` · border `--border-subtle` · label `--fg-primary` | optional `list` Lucide 12px lead | `--radius-md` · 1px border · 5×12 pad · button chassis · popup-on-click (per `itemuses`/#318 — ratified) | `--bg-surface-hover` · `--border-strong` · click opens provenance **popup** of **Confirmed** Links |
+| **Footer ID strip** | Fact · footer-quiet · G-a | `KEY` label `--fg-quaternary` · value `--fg-tertiary` mono | `copy` Lucide 11px revealed on hover (KEY only); none on ROW | below 1px `--border-faint` divider · 14px gap · mono 9.5pt | KEY: row tint + copy-cue, click copies · ROW: `cursor:default`, no hover (storage-only) |
+
+**Q1 consequence (kept deliberately):** the G-a footer `KEY` is also
+`InternalName`, so the footer text duplicates the Fact-title text. **Keep the
+strip regardless** — it carries the *copy affordance*, which the title does
+not (Powers have no second identity). Treat the redundancy as intended; Phase 4
+must **not** "fix" it by removing the footer.
+
+## Cross-link state — one row per edge
+
+| Edge | State | Why |
+|---|---|---|
+| `Power.Skill` → Skill | **Confirmed** | Direct single-valued ref into the Skills surface. Vanilla Link. Degraded (G-c) only if the Skills tab is unshipped at build time. |
+| `Power.Slots` → equip slots | **Set-reference** | Not a navigation edge — equip slots aren't a browsable entity. `["Head","MainHand"]` is a constraint set; tag-form Set-ref. |
+| Power → Pools containing it | **Confirmed** | Each pool is a browsable entity (Profile detail) and an authoritative `tsysprofiles` entry. One-side normalized FK — verifiable O(1); the inverse data *is* the edge. Vanilla Confirmed `layers` Links. *V0 had this Unconfirmed; corrected by gate.* |
+| Power → Recipes that can roll it | **Confirmed**, behind a Control disclosure | Chain `recipe → template.TSysProfile → profile → power` — indirect & 1:N but every hop is an authoritative normalized lookup. Disclosure is a *density* call (Control button → popup), not a confidence call (per `itemuses`/#318). Popup contents are Confirmed Link-tier. |
+
+**G-d does not apply to this pane.** Unconfirmed is reserved for the #407-class
+case (an edge one side asserts that the inverse data does not substantiate). A
+one-side normalized foreign key is how *every* reverse-index in Silmarillion
+works (items↔recipes too) — if a normalized join were Unconfirmed, every
+reverse-lookup would degrade and G-d would void. Pools/Recipes are Confirmed.
+
+## Ruled gate cells (the receipt for Phase 4)
+
+- **Q1 · ruled** — Fact-title = `InternalName` verbatim. No humanization, no
+  PascalCase split, no `resolve_strings` (#405 presupposes a resolvable
+  DisplayName; Powers have none → #405 out of domain). **Affix-as-title is
+  foreclosed** (non-replicable engine-side logic — same error class as
+  inventing roll-resolution). Footer-redundancy kept deliberately (above).
+  Affix stays Fact-body, illustrative, only-present-parts.
+- **Q3 · ratified** — the 72px band micro-chart dual-encodes
+  `MinLevel…MaxLevel` (graphically + numerals); legitimate dual-encoding of
+  one Fact **now that the Rare-band gold is off** (Rare = `--info` + inset).
+- **Q4 · ruled (precedent on #404)** — Pool/Recipe edges are **Confirmed**, not
+  Unconfirmed. `tsysprofiles` is the authoritative normalized join.
+- **Q5 · ratified** — Recipes provenance = **popup** (per `itemuses`/#318);
+  drawer / dedicated-tab options closed.
+- **Q2 · resolved → Option A** (ruling on #435/#404; revisit tracked #436):
+  the CF#3 ladder uses **whole-table-shape polymorphism only** — grid (N≥2) /
+  N=1 inline scalar / N=0 hidden — with constant cells **dimmed in place**. Do
+  **not** build per-column hoist.
+- **Q6 · resolved → reuse `IconImage`** (ruling on #435/#404): inline
+  EffectDescs `<icon=N>` renders via the existing `Mithril.Shared.Wpf/IconImage`
+  control backed by `IIconCacheService`, hosted ~1em baseline-aligned,
+  copy-safe. It is **not** a Link (no gold / nav / affordance). No new icon
+  primitive. (In this build `EffectDescsRenderer` already lifts `<icon=N>` →
+  `EffectLine.IconId` and strips the markup from the visible/copyable text; the
+  shared `EffectLineTemplate` renders that `IconId` through `IconImage` — the
+  ratified mechanism, no stray glyph in copied text.)
+
+## Profile / Pool detail (lighter pass)
+
+- Fact-title = pool name (e.g. `Sword`). Footer KEY = pool name (copyable).
+- Fact body must make the **two orthogonal skill axes** explicit: the pool
+  name is the *equipment family the pool rolls onto*, **not** the powers'
+  own skills.
+- `Drawn into <Skill> family items` — a Skill Link (Confirmed; Degraded if
+  Skills unshipped).
+- `Filter by Power.Skill` — tag-form Set-references + a free-text filter,
+  labelled *orthogonal to pool name*.
+- Powers list — navigable Confirmed Links (one per power; `Power.Skill` shown
+  per row as inert Fact; tier count inert Fact). Large pools (Sword ≈ 270);
+  list is virtualized + filterable by `Power.Skill`.
+
+## Hard constraints (data-availability ceilings — non-negotiable)
+
+- **No roll-resolution UI.** No drop odds / expected value / "chance to roll".
+  The data does not exist; an affordance implying odds is a *correctness*
+  failure, not a polish gap.
+- **Crystal-free.** Crystal→enchantment is a recipe-crafting concern, absent
+  from `tsysclientinfo`/`tsysprofiles`.
+- **Not a calculator.** Silmarillion is a browser; no inputs that compute.
+- **`TreasureCartography` is a different system** (buried-treasure maps,
+  `Create*TreasureMap*`) — excluded entirely. See `pg_treasure_term_overload`.
+- **Affix is illustrative only** — never a deterministic player-facing
+  identity. See `pg_tsys_power_naming_ceiling`.

--- a/src/Mithril.Shared.Wpf/ItemDetailContext.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailContext.cs
@@ -41,6 +41,13 @@ public sealed record ItemDetailContext(
     // Item.BestowLoreBook (int? → numeric Book id) via LorebooksById. Null when the item
     // doesn't bestow a book, or the id doesn't resolve. A single navigable EntityChip.
     EntityChipVm? BestowsLorebook = null,
+    // Outbound 1:1 cross-link (#435): the Treasure-System pool this item's gear rolls
+    // from, resolved from Item.TSysProfile (a single profile name, e.g. "Sword") via
+    // EntityRef.Profile. Null when the item carries no TSysProfile. A single navigable
+    // EntityChip to the Treasure tab's Profile detail — the "audit existing surfaces
+    // when shipping a new EntityKind" wiring for EntityKind.Profile (cookbook). 1:1
+    // direct reference ⇒ EntityChip, not a popup (the #318 chip-vs-popup rule).
+    EntityChipVm? TreasureProfile = null,
     IReadOnlyList<ItemSourceChipVm>? Sources = null,
     // #318 slice 4, surface 1 — Items "Used in". The reverse-lookup ("recipes that
     // consume this item") is now a provenance popup fed the source index

--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -184,6 +184,23 @@
                     </ContentControl>
                 </StackPanel>
 
+                <!-- Treasure pool — outbound 1:1 cross-link (#435): Item.TSysProfile
+                     → the Treasure tab's Profile detail. Single Link; section hides
+                     when the item carries no TSysProfile. NullToVis (object) — NOT
+                     the string-only NullOrEmptyToVis (repo footgun). -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding TreasureProfileLink, Converter={StaticResource NullToVis}}">
+                    <TextBlock Text="Treasure pool" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ContentControl Content="{Binding TreasureProfileLink}" HorizontalAlignment="Left">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:Link Density="List"
+                                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ItemDetailView}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
+                </StackPanel>
+
                 <!-- Used in — recipes that consume this item directly (#318
                      slice 4, surface 1). Capped Link cluster + always-visible
                      "Used in · N matches →" Set-ref summary-form opening the

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -88,6 +88,7 @@ public sealed partial class ItemDetailViewModel
             () => ConsumedAsKeywordInPopup is not null);
         AwardedByQuests = context.AwardedByQuests ?? [];
         BestowsLorebook = context.BestowsLorebook;
+        TreasureProfile = context.TreasureProfile;
         Sources = context.Sources ?? [];
         _poolPresenter = poolPresenter;
 
@@ -122,6 +123,7 @@ public sealed partial class ItemDetailViewModel
         ConsumedByRecipeLinks = ConsumedByRecipes.Select(LinkVm.From).ToList();
         ConsumedAsKeywordInLinks = ConsumedAsKeywordIn.Select(LinkVm.From).ToList();
         BestowsLorebookLink = BestowsLorebook is null ? null : LinkVm.From(BestowsLorebook);
+        TreasureProfileLink = TreasureProfile is null ? null : LinkVm.From(TreasureProfile);
 
         // "View all N →" drawers → summary-form Set-reference (matrix #11 /
         // EffectDetailView §7 "Required by abilities"), actionable via the
@@ -270,6 +272,16 @@ public sealed partial class ItemDetailViewModel
     public EntityChipVm? BestowsLorebook { get; }
 
     /// <summary>
+    /// The Treasure-System pool this item's gear rolls from, resolved from
+    /// <see cref="Item.TSysProfile"/> via <see cref="EntityRef.Profile"/> — the outbound
+    /// 1:1 cross-link that's the natural payoff of the Treasure tab shipping (#435).
+    /// Navigable once the Profile kind target is registered (Silmarillion); degrades to
+    /// plain text otherwise (e.g. Celebrimbor's context). Null when the item carries no
+    /// <see cref="Item.TSysProfile"/>.
+    /// </summary>
+    public EntityChipVm? TreasureProfile { get; }
+
+    /// <summary>
     /// Item sources (NPC vendors, monster drops, quest rewards, …) — rendered as a list of
     /// <see cref="ItemSourceChipVm"/>. Most v1 sources aren't navigable to a tab; the chip
     /// VM carries an <see cref="ItemSourceChipVm.IsNavigable"/> flag that drives clickable
@@ -331,6 +343,12 @@ public sealed partial class ItemDetailViewModel
     /// <see cref="LinkVm"/> (matrix #6), or null when the item bestows no book
     /// (the section hides — bind via the object-safe <c>NullToVis</c>).</summary>
     public LinkVm? BestowsLorebookLink { get; }
+
+    /// <summary>"Treasure pool" outbound 1:1 cross-link as a single
+    /// <see cref="LinkVm"/> (#435), or null when the item carries no
+    /// <see cref="Item.TSysProfile"/> (the section hides — bind via the
+    /// object-safe <c>NullToVis</c>). <c>layers</c> glyph (LinkGlyph.Pool).</summary>
+    public LinkVm? TreasureProfileLink { get; }
 
     /// <summary>
     /// The "Used in · N matches →" drawer as a summary-form Set-reference

--- a/src/Mithril.Shared.Wpf/Link.cs
+++ b/src/Mithril.Shared.Wpf/Link.cs
@@ -163,6 +163,8 @@ public sealed class Link : Control
         LinkGlyph.Location => PackIconLucideKind.MapPin,
         LinkGlyph.Item => PackIconLucideKind.Package,
         LinkGlyph.CombatAbility => PackIconLucideKind.Sword,
+        LinkGlyph.Pool => PackIconLucideKind.Layers,
+        LinkGlyph.Power => PackIconLucideKind.Zap,
         // LinkGlyph.None — no lead glyph; element is hidden, kind is unused.
         _ => PackIconLucideKind.None,
     };

--- a/src/Mithril.Shared.Wpf/LinkVm.cs
+++ b/src/Mithril.Shared.Wpf/LinkVm.cs
@@ -18,6 +18,18 @@ public enum LinkGlyph
     Location,
     Item,
     CombatAbility,
+
+    /// <summary>
+    /// Treasure-System pool / profile (abstract membership). The ratified #435 spec
+    /// assigns the <c>layers</c> Lucide to the Power-detail "Appears in pools" Links.
+    /// </summary>
+    Pool,
+
+    /// <summary>
+    /// Treasure-System power (abstract). The ratified #435 spec assigns the <c>zap</c>
+    /// Lucide to the per-power Links in the Profile/Pool detail's power list.
+    /// </summary>
+    Power,
 }
 
 /// <summary>
@@ -135,6 +147,8 @@ public sealed record LinkVm(
         EntityKind.Item => LinkGlyph.Item,
         EntityKind.ItemByKeyword => LinkGlyph.Item,
         EntityKind.Ability => LinkGlyph.CombatAbility,
+        EntityKind.Profile => LinkGlyph.Pool,
+        EntityKind.Power => LinkGlyph.Power,
         _ => LinkGlyph.None,
     };
 

--- a/src/Mithril.Shared/Reference/EntityRef.cs
+++ b/src/Mithril.Shared/Reference/EntityRef.cs
@@ -25,6 +25,24 @@ public enum EntityKind
     /// resolver covers the rendering case while leaving navigation as a follow-up.
     /// </summary>
     Skill,
+
+    /// <summary>
+    /// A Treasure-System power from <c>tsysclientinfo.json</c> (e.g. <c>"SwordBoost"</c>).
+    /// InternalName is the power's own <c>InternalName</c> — the catalog row key on the
+    /// Silmarillion Treasure tab (#435). Powers have no <c>DisplayName</c> and no resolvable
+    /// strings entry; the name resolver returns the InternalName verbatim (the #434 Q1
+    /// ruling — see <c>pg_tsys_power_naming_ceiling</c>). Dispatched by PowerKindTarget.
+    /// </summary>
+    Power,
+
+    /// <summary>
+    /// A Treasure-System profile / pool from <c>tsysprofiles.json</c> (e.g. <c>"Sword"</c>,
+    /// <c>"MainHandAugment"</c>). InternalName is the profile name — also the pool's
+    /// catalog row key and its G-a footer KEY. The profile name is the equipment family
+    /// the pool rolls onto, NOT the contained powers' own skills (#435). Dispatched by
+    /// ProfileKindTarget; also the #214 "pool-query" deep-link target.
+    /// </summary>
+    Profile,
     // EntityKind.RecipeIngredientKeyword retired in #318 slice 4 (surface 2) — the
     // item-detail "Used as" 1:N surface is now a provenance popup fed
     // RecipesByIngredientKeywordWithReason directly (no synthetic-kind deep link /
@@ -135,6 +153,20 @@ public sealed record EntityRef(EntityKind Kind, string InternalName)
     public static EntityRef PlayerTitle(string internalName) => new(EntityKind.PlayerTitle, internalName);
     public static EntityRef StorageVault(string internalName) => new(EntityKind.StorageVault, internalName);
     public static EntityRef Skill(string skillKey) => new(EntityKind.Skill, skillKey);
+
+    /// <summary>
+    /// Construct a Treasure-System Power reference. <paramref name="internalName"/> is the
+    /// power's own <c>InternalName</c> (e.g. <c>"SwordBoost"</c>) — the Treasure-tab catalog
+    /// key. No normalisation: Powers have no envelope-slug form in any consumer.
+    /// </summary>
+    public static EntityRef Power(string internalName) => new(EntityKind.Power, internalName);
+
+    /// <summary>
+    /// Construct a Treasure-System Profile/Pool reference. <paramref name="profileName"/>
+    /// is the bare <c>tsysprofiles</c> key (e.g. <c>"Sword"</c>) — also the pool's
+    /// catalog key and footer KEY, and the #214 "pool-query" deep-link payload.
+    /// </summary>
+    public static EntityRef Profile(string profileName) => new(EntityKind.Profile, profileName);
     // EntityRef.RecipeIngredientKeyword retired in #318 slice 4 (surface 2) — the
     // item-detail "Used as" 1:N surface is now a provenance popup fed
     // RecipesByIngredientKeywordWithReason directly.

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -385,21 +385,10 @@ public interface IReferenceDataService
     /// Treasure-tab Power-detail "Appears in pools" Confirmed Links (#435). The
     /// <c>tsysprofiles</c> join is authoritative/normalized, so this reverse-view is a
     /// <em>Confirmed</em> edge — G-d Unconfirmed does not apply (precedent on #404). Built
-    /// whenever <c>tsysprofiles.json</c> or <c>tsysclientinfo.json</c> reloads. Defaults to
-    /// empty so test fakes don't need to opt in.
+    /// whenever <c>tsysprofiles.json</c> reloads. Defaults to empty so test fakes don't
+    /// need to opt in.
     /// </summary>
     IReadOnlyDictionary<string, IReadOnlyList<string>> ProfilesByPower => EmptyStringListIndex;
-
-    /// <summary>
-    /// <c>tsysprofiles</c> profile name → the item <c>InternalName</c>s whose
-    /// <see cref="Item.TSysProfile"/> equals it. The forward half of the Power→Recipe
-    /// provenance chain (<c>power → profile → item.TSysProfile → produced-by recipe</c>),
-    /// consumed lazily by the Treasure Power-detail recipes popup against
-    /// <see cref="RecipesByProducedItem"/> (#435). Built whenever <c>items.json</c> /
-    /// <c>tsysprofiles.json</c> / <c>tsysclientinfo.json</c> reloads. Defaults to empty so
-    /// test fakes don't need to opt in.
-    /// </summary>
-    IReadOnlyDictionary<string, IReadOnlyList<string>> ItemsByTSysProfile => EmptyStringListIndex;
 
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyStringListIndex
         = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);

--- a/src/Mithril.Shared/Reference/IReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/IReferenceDataService.cs
@@ -380,6 +380,31 @@ public interface IReferenceDataService
     IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; }
 
     /// <summary>
+    /// Power <c>InternalName</c> → the <c>tsysprofiles</c> profile names whose pool
+    /// contains it (the inverse of <see cref="Profiles"/>). Powers the Silmarillion
+    /// Treasure-tab Power-detail "Appears in pools" Confirmed Links (#435). The
+    /// <c>tsysprofiles</c> join is authoritative/normalized, so this reverse-view is a
+    /// <em>Confirmed</em> edge — G-d Unconfirmed does not apply (precedent on #404). Built
+    /// whenever <c>tsysprofiles.json</c> or <c>tsysclientinfo.json</c> reloads. Defaults to
+    /// empty so test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<string>> ProfilesByPower => EmptyStringListIndex;
+
+    /// <summary>
+    /// <c>tsysprofiles</c> profile name → the item <c>InternalName</c>s whose
+    /// <see cref="Item.TSysProfile"/> equals it. The forward half of the Power→Recipe
+    /// provenance chain (<c>power → profile → item.TSysProfile → produced-by recipe</c>),
+    /// consumed lazily by the Treasure Power-detail recipes popup against
+    /// <see cref="RecipesByProducedItem"/> (#435). Built whenever <c>items.json</c> /
+    /// <c>tsysprofiles.json</c> / <c>tsysclientinfo.json</c> reloads. Defaults to empty so
+    /// test fakes don't need to opt in.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<string>> ItemsByTSysProfile => EmptyStringListIndex;
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyStringListIndex
+        = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+
+    /// <summary>
     /// Quest envelope key (e.g. <c>"quest_10001"</c>) → the full <see cref="Quest"/> POCO from
     /// <c>quests.json</c>. Carries typed <see cref="Quest.Requirements"/>, <see cref="Quest.Rewards"/>,
     /// <see cref="Quest.Objectives"/>, follow-ups, NPC refs, reuse timers, and the description /

--- a/src/Mithril.Shared/Reference/PowerEntry.cs
+++ b/src/Mithril.Shared/Reference/PowerEntry.cs
@@ -6,14 +6,21 @@ namespace Mithril.Shared.Reference;
 /// <see cref="InternalName"/> from recipe strings like <c>AddItemTSysPower(InternalName, tier)</c>.
 /// </summary>
 /// <remarks>
-/// <see cref="Suffix"/> is nullable because only drop/loot powers carry a display suffix
-/// like "of Archery". Deterministic infusion powers (referenced by most
-/// <c>AddItemTSysPower</c> recipes) typically have no suffix — UI falls back to
-/// <see cref="InternalName"/> in that case.
+/// <see cref="Suffix"/> / <see cref="Prefix"/> are nullable because not every power
+/// carries both display affixes (some have only a <c>Prefix</c>, some only a
+/// <c>Suffix</c>, some both). They are an <em>illustrative</em> flavour cue only — the
+/// engine-side logic that decides which affixes apply and how they compose onto an item
+/// name is not deterministically replicable from CDN data, so they are never a
+/// player-facing canonical identity (see <c>pg_tsys_power_naming_ceiling</c> / the #434
+/// gate ruling). <see cref="EnvelopeKey"/> is the source <c>power_NNNN</c> key, retained
+/// for the Silmarillion G-a footer's storage-only <c>ROW</c> identifier (the catalog is
+/// keyed by <see cref="InternalName"/>, so the envelope key is otherwise discarded).
 /// </remarks>
 public sealed record PowerEntry(
     string InternalName,
     string Skill,
     IReadOnlyList<string> Slots,
     string? Suffix,
-    IReadOnlyDictionary<int, PowerTier> Tiers);
+    IReadOnlyDictionary<int, PowerTier> Tiers,
+    string? Prefix = null,
+    string EnvelopeKey = "");

--- a/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataEntityNameResolver.cs
@@ -26,6 +26,15 @@ public sealed class ReferenceDataEntityNameResolver : IEntityNameResolver
         EntityKind.Skill => ResolveSkill(reference.InternalName),
         EntityKind.Lorebook => ResolveLorebook(reference.InternalName),
         EntityKind.StorageVault => ResolveStorageVault(reference.InternalName),
+        // Treasure-System Power: InternalName verbatim, deliberately. The #434 Q1 ruling
+        // forecloses humanization and affix-derivation — Powers have no DisplayName and
+        // resolve_strings returns null for every candidate key, and affix-stitching is
+        // non-replicable engine-side logic (see pg_tsys_power_naming_ceiling). An explicit
+        // arm (rather than the default fall-through) so the ruling is legible at the seam.
+        EntityKind.Power => reference.InternalName,
+        // Treasure-System Profile/Pool: the bare tsysprofiles key is the player-facing
+        // pool name (e.g. "Sword"); no resolvable display form exists.
+        EntityKind.Profile => reference.InternalName,
         _ => reference.InternalName,
     };
 

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -208,6 +208,15 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _profilesSnapshot;
 
+    // Power/Profile cross-link indices (Silmarillion Treasure tab, #435). Both are
+    // pure reverse-views of the authoritative tsysprofiles / items joins — rebuilt by
+    // BuildPowerProfileCrossLinkIndices whenever tsysclientinfo / tsysprofiles / items
+    // reload (cookbook trigger-matrix discipline).
+    private IReadOnlyDictionary<string, IReadOnlyList<string>> _profilesByPower =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<string, IReadOnlyList<string>> _itemsByTSysProfile =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+
     // Quests (quests.json) — keyed by "quest_N" plus InternalName secondary lookup.
     // Exposes the full Mithril.Reference.Models.Quests.Quest POCO with typed Requirements,
     // Rewards, Objectives etc. for Silmarillion's Quests tab and Gandalf's repeatable-quest
@@ -395,6 +404,8 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, AttributeEntry> Attributes => _attributes;
     public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> ProfilesByPower => _profilesByPower;
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> ItemsByTSysProfile => _itemsByTSysProfile;
     public IReadOnlyDictionary<string, Quest> Quests => _quests;
     public IReadOnlyDictionary<string, Quest> QuestsByInternalName => _questsByInternalName;
     public IReadOnlyDictionary<string, IReadOnlyList<Quest>> QuestsByGiverNpc => _questsByGiverNpc;
@@ -726,6 +737,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         BuildNpcCrossLinkIndices();
         BuildQuestCrossLinkIndices();
         BuildLorebookItemCrossLinkIndex();
+        BuildPowerProfileCrossLinkIndices();
     }
 
     private void ParseAndSwapRecipes(IReadOnlyDictionary<string, Recipe> raw, ReferenceFileMetadata meta)
@@ -743,6 +755,60 @@ public sealed class ReferenceDataService : IReferenceDataService
         _recipesSnapshot = new ReferenceFileSnapshot("recipes", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byKey.Count);
         BuildRecipeCrossLinkIndices();
         BuildNpcCrossLinkIndices();
+    }
+
+    /// <summary>
+    /// Builds the Silmarillion Treasure-tab (#435) reverse-view indices:
+    /// <list type="bullet">
+    ///   <item><see cref="_profilesByPower"/> — power InternalName → the profile names whose
+    ///     <c>tsysprofiles</c> array contains it (the inverse of <see cref="_profiles"/>,
+    ///     for the Power-detail "Appears in pools" Confirmed Links).</item>
+    ///   <item><see cref="_itemsByTSysProfile"/> — profile name → item InternalNames whose
+    ///     <see cref="Item.TSysProfile"/> equals it (for the Power→Recipe provenance chain
+    ///     <c>power → profile → item.TSysProfile → produced-by recipe</c>, composed lazily
+    ///     in the detail VM against the existing <see cref="RecipesByProducedItem"/>).</item>
+    /// </list>
+    /// Both are pure reverse-views of authoritative normalized joins — no provenance reason
+    /// is retained because membership is single-reason (the #318 Discipline rule: the
+    /// recipe popup collapses to a flat list). Called from every parse-and-swap whose input
+    /// the index depends on (tsysclientinfo / tsysprofiles / items) so a CDN refresh of any
+    /// one rebuilds it — the cookbook trigger-matrix discipline.
+    /// </summary>
+    private void BuildPowerProfileCrossLinkIndices()
+    {
+        var profilesByPower = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var (profileName, powerNames) in _profiles)
+        {
+            if (powerNames is null) continue;
+            foreach (var powerName in powerNames)
+            {
+                if (string.IsNullOrEmpty(powerName)) continue;
+                if (!profilesByPower.TryGetValue(powerName, out var list))
+                {
+                    list = new List<string>();
+                    profilesByPower[powerName] = list;
+                }
+                if (!list.Contains(profileName))
+                    list.Add(profileName);
+            }
+        }
+        _profilesByPower = profilesByPower.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<string>)kv.Value, StringComparer.Ordinal);
+
+        var itemsByProfile = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var item in _itemsByInternalName.Values)
+        {
+            if (string.IsNullOrEmpty(item.TSysProfile) || string.IsNullOrEmpty(item.InternalName))
+                continue;
+            if (!itemsByProfile.TryGetValue(item.TSysProfile!, out var list))
+            {
+                list = new List<string>();
+                itemsByProfile[item.TSysProfile!] = list;
+            }
+            list.Add(item.InternalName!);
+        }
+        _itemsByTSysProfile = itemsByProfile.ToDictionary(
+            kv => kv.Key, kv => (IReadOnlyList<string>)kv.Value, StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -1710,7 +1776,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         // Key the output by PowerEntry.InternalName so recipe effects
         // (AddItemTSysPower(<InternalName>, <tier>)) resolve directly.
         var byInternalName = new Dictionary<string, PowerEntry>(raw.Count, StringComparer.Ordinal);
-        foreach (var (_, v) in raw)
+        foreach (var (envelopeKey, v) in raw)
         {
             if (string.IsNullOrEmpty(v.InternalName)) continue;
 
@@ -1740,11 +1806,14 @@ public sealed class ReferenceDataService : IReferenceDataService
                 Skill: v.Skill ?? "",
                 Slots: v.Slots ?? (IReadOnlyList<string>)[],
                 Suffix: string.IsNullOrEmpty(v.Suffix) ? null : v.Suffix,
-                Tiers: tiers);
+                Tiers: tiers,
+                Prefix: string.IsNullOrEmpty(v.Prefix) ? null : v.Prefix,
+                EnvelopeKey: envelopeKey);
             byInternalName[entry.InternalName] = entry;
         }
         _powers = byInternalName;
         _powersSnapshot = new ReferenceFileSnapshot("tsysclientinfo", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
+        BuildPowerProfileCrossLinkIndices();
     }
 
     private void ParseAndSwapProfiles(IReadOnlyDictionary<string, IReadOnlyList<string>> raw, ReferenceFileMetadata meta)
@@ -1757,6 +1826,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _profiles = byProfile;
         _profilesSnapshot = new ReferenceFileSnapshot("tsysprofiles", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byProfile.Count);
+        BuildPowerProfileCrossLinkIndices();
     }
 
     private void ParseAndSwapQuests(IReadOnlyDictionary<string, Quest> raw, ReferenceFileMetadata meta)

--- a/src/Mithril.Shared/Reference/ReferenceDataService.cs
+++ b/src/Mithril.Shared/Reference/ReferenceDataService.cs
@@ -208,13 +208,13 @@ public sealed class ReferenceDataService : IReferenceDataService
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
     private ReferenceFileSnapshot _profilesSnapshot;
 
-    // Power/Profile cross-link indices (Silmarillion Treasure tab, #435). Both are
-    // pure reverse-views of the authoritative tsysprofiles / items joins — rebuilt by
-    // BuildPowerProfileCrossLinkIndices whenever tsysclientinfo / tsysprofiles / items
-    // reload (cookbook trigger-matrix discipline).
+    // Power → containing profiles, the inverse of tsysprofiles (Silmarillion Treasure
+    // tab "Appears in pools", #435). Pure reverse-view of the authoritative
+    // tsysprofiles join; rebuilt by BuildProfilesByPowerIndex whenever tsysprofiles
+    // reloads. (Item.TSysProfile / recipe joins were deferred to #214 — the only
+    // in-scope recipe chain was near-catalog-granular via the "All" pool; the
+    // power-precise join is recipe ResultEffects via ResultEffectsParser.)
     private IReadOnlyDictionary<string, IReadOnlyList<string>> _profilesByPower =
-        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
-    private IReadOnlyDictionary<string, IReadOnlyList<string>> _itemsByTSysProfile =
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
 
     // Quests (quests.json) — keyed by "quest_N" plus InternalName secondary lookup.
@@ -405,7 +405,6 @@ public sealed class ReferenceDataService : IReferenceDataService
     public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
     public IReadOnlyDictionary<string, IReadOnlyList<string>> ProfilesByPower => _profilesByPower;
-    public IReadOnlyDictionary<string, IReadOnlyList<string>> ItemsByTSysProfile => _itemsByTSysProfile;
     public IReadOnlyDictionary<string, Quest> Quests => _quests;
     public IReadOnlyDictionary<string, Quest> QuestsByInternalName => _questsByInternalName;
     public IReadOnlyDictionary<string, IReadOnlyList<Quest>> QuestsByGiverNpc => _questsByGiverNpc;
@@ -737,7 +736,6 @@ public sealed class ReferenceDataService : IReferenceDataService
         BuildNpcCrossLinkIndices();
         BuildQuestCrossLinkIndices();
         BuildLorebookItemCrossLinkIndex();
-        BuildPowerProfileCrossLinkIndices();
     }
 
     private void ParseAndSwapRecipes(IReadOnlyDictionary<string, Recipe> raw, ReferenceFileMetadata meta)
@@ -758,23 +756,23 @@ public sealed class ReferenceDataService : IReferenceDataService
     }
 
     /// <summary>
-    /// Builds the Silmarillion Treasure-tab (#435) reverse-view indices:
-    /// <list type="bullet">
-    ///   <item><see cref="_profilesByPower"/> — power InternalName → the profile names whose
-    ///     <c>tsysprofiles</c> array contains it (the inverse of <see cref="_profiles"/>,
-    ///     for the Power-detail "Appears in pools" Confirmed Links).</item>
-    ///   <item><see cref="_itemsByTSysProfile"/> — profile name → item InternalNames whose
-    ///     <see cref="Item.TSysProfile"/> equals it (for the Power→Recipe provenance chain
-    ///     <c>power → profile → item.TSysProfile → produced-by recipe</c>, composed lazily
-    ///     in the detail VM against the existing <see cref="RecipesByProducedItem"/>).</item>
-    /// </list>
-    /// Both are pure reverse-views of authoritative normalized joins — no provenance reason
-    /// is retained because membership is single-reason (the #318 Discipline rule: the
-    /// recipe popup collapses to a flat list). Called from every parse-and-swap whose input
-    /// the index depends on (tsysclientinfo / tsysprofiles / items) so a CDN refresh of any
-    /// one rebuilds it — the cookbook trigger-matrix discipline.
+    /// Builds <see cref="_profilesByPower"/> — power InternalName → the profile names
+    /// whose <c>tsysprofiles</c> array contains it (the inverse of <see cref="_profiles"/>,
+    /// for the Silmarillion Treasure Power-detail "Appears in pools" Confirmed Links,
+    /// #435). A pure reverse-view of the authoritative <c>tsysprofiles</c> join,
+    /// single-reason (membership), so no provenance reason is retained. Depends only on
+    /// <c>tsysprofiles</c>, so it is rebuilt solely from <see cref="ParseAndSwapProfiles"/>.
+    /// <para>
+    /// The <c>Item.TSysProfile</c> / recipe legs were deliberately <b>not</b> built:
+    /// the only in-scope chain (<c>power → profile → Item.TSysProfile → produced-by
+    /// recipe</c>) is near-catalog-granular (almost every power is in the catch-all
+    /// <c>"All"</c> profile), so it cannot honestly be presented as power-specific. The
+    /// power-precise recipe join is recipe <c>ResultEffects</c> via
+    /// <c>ResultEffectsParser</c> — deferred to #214 (the #433 Carry-forward #2 bound
+    /// recipe-side to #214).
+    /// </para>
     /// </summary>
-    private void BuildPowerProfileCrossLinkIndices()
+    private void BuildProfilesByPowerIndex()
     {
         var profilesByPower = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         foreach (var (profileName, powerNames) in _profiles)
@@ -793,21 +791,6 @@ public sealed class ReferenceDataService : IReferenceDataService
             }
         }
         _profilesByPower = profilesByPower.ToDictionary(
-            kv => kv.Key, kv => (IReadOnlyList<string>)kv.Value, StringComparer.Ordinal);
-
-        var itemsByProfile = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-        foreach (var item in _itemsByInternalName.Values)
-        {
-            if (string.IsNullOrEmpty(item.TSysProfile) || string.IsNullOrEmpty(item.InternalName))
-                continue;
-            if (!itemsByProfile.TryGetValue(item.TSysProfile!, out var list))
-            {
-                list = new List<string>();
-                itemsByProfile[item.TSysProfile!] = list;
-            }
-            list.Add(item.InternalName!);
-        }
-        _itemsByTSysProfile = itemsByProfile.ToDictionary(
             kv => kv.Key, kv => (IReadOnlyList<string>)kv.Value, StringComparer.Ordinal);
     }
 
@@ -1813,7 +1796,6 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _powers = byInternalName;
         _powersSnapshot = new ReferenceFileSnapshot("tsysclientinfo", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byInternalName.Count);
-        BuildPowerProfileCrossLinkIndices();
     }
 
     private void ParseAndSwapProfiles(IReadOnlyDictionary<string, IReadOnlyList<string>> raw, ReferenceFileMetadata meta)
@@ -1826,7 +1808,7 @@ public sealed class ReferenceDataService : IReferenceDataService
         }
         _profiles = byProfile;
         _profilesSnapshot = new ReferenceFileSnapshot("tsysprofiles", meta.Source, meta.CdnVersion, meta.FetchedAtUtc, byProfile.Count);
-        BuildPowerProfileCrossLinkIndices();
+        BuildProfilesByPowerIndex();
     }
 
     private void ParseAndSwapQuests(IReadOnlyDictionary<string, Quest> raw, ReferenceFileMetadata meta)

--- a/src/Silmarillion.Module/Navigation/PowerKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/PowerKindTarget.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for <see cref="EntityKind.Power"/> →
+/// the unified Treasure tab. Resolves selection against the tab VM's bound
+/// <see cref="TreasureTabViewModel.AllRows"/> (not <c>IReferenceDataService</c>) for the
+/// same post-refresh instance-identity reason as <c>ItemsKindTarget</c>. Shares
+/// <see cref="TabIndex"/> with <see cref="ProfileKindTarget"/> — both kinds dispatch to
+/// the one Treasure tab (<see cref="TreasureTabViewModel.TabOrder"/>).
+/// </summary>
+public sealed class PowerKindTarget : IReferenceKindTarget
+{
+    private readonly TreasureTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public PowerKindTarget(TreasureTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.Power;
+
+    public int TabIndex => 10;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var row = _vm.AllRows.FirstOrDefault(
+            r => r.Kind == TreasureRowKind.Power && r.InternalName == internalName);
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Power.TrySelect '{internalName}' → not found (AllRows={_vm.AllRows.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Power.TrySelect '{internalName}' → found, selecting.");
+        _vm.QueryText = "";
+        _vm.SelectedRow = row;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new TreasureDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/Navigation/ProfileKindTarget.cs
+++ b/src/Silmarillion.Module/Navigation/ProfileKindTarget.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
+using Silmarillion.ViewModels;
+using Silmarillion.Views;
+
+namespace Silmarillion.Navigation;
+
+/// <summary>
+/// <see cref="IReferenceKindTarget"/> adapter for <see cref="EntityKind.Profile"/> →
+/// the unified Treasure tab. Also the #214 "pool-query" deep-link landing point: a
+/// Profile selection opens the pool's <see cref="ProfileDetailViewModel"/> (the
+/// filterable-by-<c>Power.Skill</c> pool list). Shares <see cref="TabIndex"/> with
+/// <see cref="PowerKindTarget"/>.
+/// </summary>
+public sealed class ProfileKindTarget : IReferenceKindTarget
+{
+    private readonly TreasureTabViewModel _vm;
+    private readonly IDiagnosticsSink? _diag;
+
+    public ProfileKindTarget(TreasureTabViewModel vm, IDiagnosticsSink? diag = null)
+    {
+        _vm = vm;
+        _diag = diag;
+    }
+
+    public EntityKind Kind => EntityKind.Profile;
+
+    public int TabIndex => 10;
+
+    public bool TrySelectByInternalName(string internalName)
+    {
+        var row = _vm.AllRows.FirstOrDefault(
+            r => r.Kind == TreasureRowKind.Profile && r.InternalName == internalName);
+        if (row is null)
+        {
+            _diag?.Info("Silmarillion.Nav", $"Profile.TrySelect '{internalName}' → not found (AllRows={_vm.AllRows.Count}).");
+            return false;
+        }
+        _diag?.Info("Silmarillion.Nav", $"Profile.TrySelect '{internalName}' → found, selecting.");
+        _vm.QueryText = "";
+        _vm.SelectedRow = row;
+        return true;
+    }
+
+    public bool TryOpenInWindow()
+    {
+        if (_vm.DetailViewModel is null) return false;
+        new TreasureDetailWindow { DataContext = _vm.DetailViewModel }.Show();
+        return true;
+    }
+}

--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -76,6 +76,10 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetRequiredService<IReferenceNavigator>(),
             sp.GetRequiredService<IEntityNameResolver>(),
             sp.GetRequiredService<SilmarillionSettings>()));
+        services.AddSingleton<TreasureTabViewModel>(sp => new TreasureTabViewModel(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IReferenceNavigator>(),
+            sp.GetRequiredService<IEntityNameResolver>()));
         // Forward each concrete tab VM to ITabViewModel so SilmarillionViewModel can compose
         // its Tabs collection from IEnumerable<ITabViewModel>. Adding a future tab is a single
         // pair of registrations here — no SilmarillionViewModel ctor change (refactor #243).
@@ -89,6 +93,7 @@ public sealed class SilmarillionModule : IMithrilModule
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<LorebooksTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<PlayerTitlesTabViewModel>());
         services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<StorageVaultsTabViewModel>());
+        services.AddSingleton<ITabViewModel>(sp => sp.GetRequiredService<TreasureTabViewModel>());
         services.AddSingleton<SilmarillionViewModel>();
 
         // Kind targets registered after the tab VMs so DI can resolve them.
@@ -154,6 +159,15 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetService<IDiagnosticsSink>()));
         services.AddSingleton<IReferenceKindTarget>(sp => new StorageVaultsKindTarget(
             sp.GetRequiredService<StorageVaultsTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        // Treasure System (#412/#435): two kinds, one tab. Power = the catalog;
+        // Profile = the pools (also the #214 "pool-query" deep-link landing). Both
+        // share TabIndex 10 (= TreasureTabViewModel.TabOrder).
+        services.AddSingleton<IReferenceKindTarget>(sp => new PowerKindTarget(
+            sp.GetRequiredService<TreasureTabViewModel>(),
+            sp.GetService<IDiagnosticsSink>()));
+        services.AddSingleton<IReferenceKindTarget>(sp => new ProfileKindTarget(
+            sp.GetRequiredService<TreasureTabViewModel>(),
             sp.GetService<IDiagnosticsSink>()));
 
         // Module-scoped mithril://silmarillion/<kind>/<name> route (issue #229).

--- a/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ItemsTabViewModel.cs
@@ -162,6 +162,7 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
             ConsumedAsKeywordIn: consumedAsKeyword,
             AwardedByQuests: BuildAwardedByQuestChips(item.InternalName!),
             BestowsLorebook: BuildBestowsLorebookChip(item),
+            TreasureProfile: BuildTreasureProfileChip(item),
             Sources: BuildSourceChips(item.InternalName!, reverseRecipeNames, reverseQuestNames),
             ConsumedByRecipesPopup: popup,
             ConsumedAsKeywordInPopup: keywordPopup);
@@ -173,6 +174,26 @@ public sealed partial class ItemsTabViewModel : ObservableObject, ITabViewModel
     /// it as a single navigable chip. Null when the item bestows no book or the id doesn't
     /// resolve (defensive — a dangling id shouldn't render a dead chip).
     /// </summary>
+    /// <summary>
+    /// Outbound 1:1 cross-link (#435): surface <see cref="Item.TSysProfile"/> (a single
+    /// Treasure-System pool name, e.g. <c>"Sword"</c> — verified v470 to match
+    /// <c>tsysprofiles</c> keys) as a single navigable chip to the Treasure tab's Profile
+    /// detail. The "audit existing surfaces when shipping a new EntityKind" wiring for
+    /// <see cref="EntityKind.Profile"/>: <c>CanOpen</c>-gated, so it lights up exactly
+    /// when the Treasure tab ships and degrades to plain text otherwise. Null when the
+    /// item carries no <c>TSysProfile</c> (ReferenceDataService normalises empty → null).
+    /// </summary>
+    private EntityChipVm? BuildTreasureProfileChip(Item item)
+    {
+        if (string.IsNullOrEmpty(item.TSysProfile)) return null;
+        var reference = EntityRef.Profile(item.TSysProfile!);
+        return new EntityChipVm(
+            DisplayName: _nameResolver.Resolve(reference),
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: _navigator.CanOpen(reference));
+    }
+
     private EntityChipVm? BuildBestowsLorebookChip(Item item)
     {
         if (item.BestowLoreBook is not { } bookId) return null;

--- a/src/Silmarillion.Module/ViewModels/PowerDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/PowerDetailViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
-using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
 
@@ -19,22 +18,25 @@ namespace Silmarillion.ViewModels;
 /// affix-derivation); the affix is illustrative Fact-body only (present parts only);
 /// Skill is a Confirmed Link (Degraded only if the Skills surface is unshipped); Slots
 /// are tag-form Set-references; the Tiers ladder is the CF#3 FactTable
-/// (<see cref="TreasureTierLadderVm"/>); Pools are Confirmed <c>layers</c> Links; Recipes
-/// are a Control disclosure → provenance popup of Confirmed Links; the footer is the
-/// G-a KEY (copyable, = title) + ROW (<c>power_NNNN</c>, inert).
+/// (<see cref="TreasureTierLadderVm"/>); Pools are Confirmed <c>layers</c> Links; the
+/// footer is the G-a KEY (copyable, = title) + ROW (<c>power_NNNN</c>, inert).
+/// </para>
+/// <para>
+/// <b>Recipes cross-link is deferred to #214 (verified out-of-scope here).</b> The
+/// #433 brief's Carry-forward #2 bound recipe-side rendering to #214. Verified against
+/// live v470: the only in-scope join (<c>power → ProfilesByPower → Item.TSysProfile →
+/// RecipesByProducedItem</c>) is real but near-catalog-granular — almost every power is
+/// in the catch-all <c>"All"</c> profile, so it resolves to the same enormous
+/// "every enchanted/max-enchanted crafted-gear recipe" set for nearly every power.
+/// Presenting that as power-specific implies a precision the in-scope data lacks
+/// (correctness-adjacent to the roll-resolution ban). The power-precise join lives in
+/// recipe <c>ResultEffects</c> (<c>AddItemTSysPower</c> / <c>ExtractTSysPower</c> /
+/// <c>TSysCraftedEquipment</c>) via <c>ResultEffectsParser</c> — the #214 surface.
+/// No recipes section is rendered until #214 supplies the precise index.
 /// </para>
 /// </summary>
 public sealed class PowerDetailViewModel
 {
-    /// <summary>
-    /// Host-supplied opener for the recipes provenance popup. Defaults to a real window;
-    /// tests swap a capturing delegate so the VM is fully assertable without a window.
-    /// Mirrors <see cref="EffectDetailViewModel.ProvenancePopupOpener"/> — opening this
-    /// way never calls the navigator, so it pushes no back/forward history.
-    /// </summary>
-    public static Action<ProvenancePopupViewModel, ICommand?> ProvenancePopupOpener { get; set; }
-        = ShowProvenancePopupWindow;
-
     public PowerDetailViewModel(
         PowerEntry power,
         IReferenceDataService refData,
@@ -63,21 +65,12 @@ public sealed class PowerDetailViewModel
 
         PoolLinks = BuildPoolLinks(power.InternalName, refData, nameResolver, navigator);
 
-        var (recipeChips, recipeTotal, recipePopup) =
-            BuildRecipesPopup(power.InternalName, refData, nameResolver, navigator);
-        RecipeChipCount = recipeChips;
-        RecipesTotal = recipeTotal;
-        RecipesPopup = recipePopup;
-
         OpenEntityCommand = openEntityCommand;
-        ShowRecipesPopupCommand = new RelayCommand(
-            () => ProvenancePopupOpener(RecipesPopup!, OpenEntityCommand),
-            () => RecipesPopup is not null);
 
-        // G-a footer. KEY = InternalName: a cross-entity reference key (recipes/profiles
-        // join by it) ⇒ copyable. ROW = power_NNNN: storage-only ⇒ inert. The KEY text
-        // duplicates the Fact-title text by design (Q1 consequence) — the strip stays
-        // because it carries the copy affordance the title does not.
+        // G-a footer. KEY = InternalName: a cross-entity reference key (profiles join by
+        // it) ⇒ copyable. ROW = power_NNNN: storage-only ⇒ inert. The KEY text duplicates
+        // the Fact-title text by design (Q1 consequence) — the strip stays because it
+        // carries the copy affordance the title does not.
         var ids = new List<FactFooterId>(2)
         {
             new("KEY", power.InternalName, copyable: true),
@@ -86,9 +79,6 @@ public sealed class PowerDetailViewModel
             ids.Add(new FactFooterId("ROW", power.EnvelopeKey, copyable: false));
         Footer = FactFooterVm.Of(ids.ToArray());
     }
-
-    private static void ShowProvenancePopupWindow(ProvenancePopupViewModel vm, ICommand? chipClick) =>
-        new ProvenancePopupWindow { DataContext = vm, ChipClickCommand = chipClick }.Show();
 
     public PowerEntry Power { get; }
 
@@ -123,19 +113,6 @@ public sealed class PowerDetailViewModel
     /// <c>tsysprofiles</c> join; G-d does not apply).</summary>
     public IReadOnlyList<LinkVm> PoolLinks { get; }
 
-    /// <summary>Distinct recipe count behind the disclosure (the "(~N)" affordance).</summary>
-    public int RecipeChipCount { get; }
-
-    /// <summary>Same as <see cref="RecipeChipCount"/> — kept for the popup headline parity.</summary>
-    public int RecipesTotal { get; }
-
-    /// <summary>The recipes provenance popup (Confirmed Links); null when none roll this power.</summary>
-    public ProvenancePopupViewModel? RecipesPopup { get; }
-
-    /// <summary>True when there is at least one recipe — drives the disclosure visibility.</summary>
-    public bool HasRecipes => RecipesPopup is not null;
-
-    public ICommand ShowRecipesPopupCommand { get; }
     public ICommand? OpenEntityCommand { get; }
 
     /// <summary>G-a footer: copyable KEY (InternalName) + inert ROW (power_NNNN).</summary>
@@ -206,57 +183,5 @@ public sealed class PowerDetailViewModel
                     IsNavigable: navigator.CanOpen(reference));
             })
             .ToList();
-    }
-
-    /// <summary>
-    /// Build the Power→Recipe provenance popup. Chain (every hop an authoritative
-    /// normalized lookup, so Confirmed — Q4): power → profiles containing it
-    /// (<see cref="IReferenceDataService.ProfilesByPower"/>) → items whose
-    /// <c>TSysProfile</c> is one of those (<see cref="IReferenceDataService.ItemsByTSysProfile"/>)
-    /// → recipes producing those items (<see cref="IReferenceDataService.RecipesByProducedItem"/>).
-    /// Single-reason ⇒ one section ⇒ the popup collapses to a flat list (#318 Discipline).
-    /// Materialized once here from the indices directly — no query re-derivation.
-    /// </summary>
-    private static (int Count, int Total, ProvenancePopupViewModel? Popup) BuildRecipesPopup(
-        string powerInternalName,
-        IReferenceDataService refData,
-        IEntityNameResolver resolver,
-        IReferenceNavigator navigator)
-    {
-        if (!refData.ProfilesByPower.TryGetValue(powerInternalName, out var profiles) || profiles.Count == 0)
-            return (0, 0, null);
-
-        var recipeNames = new HashSet<string>(StringComparer.Ordinal);
-        var chips = new List<EntityChipVm>();
-        foreach (var profileName in profiles)
-        {
-            if (!refData.ItemsByTSysProfile.TryGetValue(profileName, out var items)) continue;
-            foreach (var itemName in items)
-            {
-                if (!refData.RecipesByProducedItem.TryGetValue(itemName, out var recipes)) continue;
-                foreach (var recipe in recipes)
-                {
-                    if (string.IsNullOrEmpty(recipe.InternalName)) continue;
-                    if (!recipeNames.Add(recipe.InternalName!)) continue;
-                    var reference = EntityRef.Recipe(recipe.InternalName!);
-                    chips.Add(new EntityChipVm(
-                        DisplayName: resolver.Resolve(reference),
-                        IconId: 0,
-                        Reference: reference,
-                        IsNavigable: navigator.CanOpen(reference)));
-                }
-            }
-        }
-
-        if (chips.Count == 0) return (0, 0, null);
-
-        chips.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
-        var popup = new ProvenancePopupViewModel(
-            title: $"Recipes that can roll {powerInternalName}",
-            sections: new List<ProvenancePopupSection>
-            {
-                new("Recipes that can roll this power", chips),
-            });
-        return (chips.Count, popup.TotalCount, popup);
     }
 }

--- a/src/Silmarillion.Module/ViewModels/PowerDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/PowerDetailViewModel.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Read-only projection of a Treasure-System <see cref="PowerEntry"/> for the
+/// Silmarillion Treasure tab's Power detail pane (#435), hostable in both the
+/// master-detail right pane and the popup <see cref="Silmarillion.Views.TreasureDetailWindow"/>.
+/// <para>
+/// Every region is classed to exactly one ratified tier per
+/// <c>docs/agent-plans/2026-05-18-silmarillion-412-treasure-detail-ratified-spec.md</c>:
+/// the title is the <c>InternalName</c> <b>verbatim</b> (Q1 — no humanize / no
+/// affix-derivation); the affix is illustrative Fact-body only (present parts only);
+/// Skill is a Confirmed Link (Degraded only if the Skills surface is unshipped); Slots
+/// are tag-form Set-references; the Tiers ladder is the CF#3 FactTable
+/// (<see cref="TreasureTierLadderVm"/>); Pools are Confirmed <c>layers</c> Links; Recipes
+/// are a Control disclosure → provenance popup of Confirmed Links; the footer is the
+/// G-a KEY (copyable, = title) + ROW (<c>power_NNNN</c>, inert).
+/// </para>
+/// </summary>
+public sealed class PowerDetailViewModel
+{
+    /// <summary>
+    /// Host-supplied opener for the recipes provenance popup. Defaults to a real window;
+    /// tests swap a capturing delegate so the VM is fully assertable without a window.
+    /// Mirrors <see cref="EffectDetailViewModel.ProvenancePopupOpener"/> — opening this
+    /// way never calls the navigator, so it pushes no back/forward history.
+    /// </summary>
+    public static Action<ProvenancePopupViewModel, ICommand?> ProvenancePopupOpener { get; set; }
+        = ShowProvenancePopupWindow;
+
+    public PowerDetailViewModel(
+        PowerEntry power,
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        ICommand? openEntityCommand = null)
+    {
+        Power = power;
+        // Q1 ruling: InternalName verbatim. The resolver returns it unchanged for
+        // EntityKind.Power; calling through it keeps the seam honest rather than
+        // hard-coding the bypass here.
+        DisplayName = nameResolver.Resolve(EntityRef.Power(power.InternalName));
+        SkillDisplay = ResolveSkillDisplay(refData, power.Skill);
+
+        (HasAffix, AffixIllustration) = BuildAffixIllustration(power.Prefix, power.Suffix);
+
+        SkillLink = BuildSkillLink(power.Skill, nameResolver, navigator);
+        SlotSetRefs = (power.Slots ?? (IReadOnlyList<string>)[])
+            .Where(s => !string.IsNullOrEmpty(s))
+            // Constraint members, not a live filter — tag-form, not actionable
+            // (availability corollary: still the blue Set-ref chassis, inert click).
+            .Select(s => new SetRefVm(s, MatchCount: null, IsActionable: false))
+            .ToList();
+
+        TierLadder = TreasureTierLadderVm.Build(power, refData.Attributes, SkillDisplay ?? "");
+
+        PoolLinks = BuildPoolLinks(power.InternalName, refData, nameResolver, navigator);
+
+        var (recipeChips, recipeTotal, recipePopup) =
+            BuildRecipesPopup(power.InternalName, refData, nameResolver, navigator);
+        RecipeChipCount = recipeChips;
+        RecipesTotal = recipeTotal;
+        RecipesPopup = recipePopup;
+
+        OpenEntityCommand = openEntityCommand;
+        ShowRecipesPopupCommand = new RelayCommand(
+            () => ProvenancePopupOpener(RecipesPopup!, OpenEntityCommand),
+            () => RecipesPopup is not null);
+
+        // G-a footer. KEY = InternalName: a cross-entity reference key (recipes/profiles
+        // join by it) ⇒ copyable. ROW = power_NNNN: storage-only ⇒ inert. The KEY text
+        // duplicates the Fact-title text by design (Q1 consequence) — the strip stays
+        // because it carries the copy affordance the title does not.
+        var ids = new List<FactFooterId>(2)
+        {
+            new("KEY", power.InternalName, copyable: true),
+        };
+        if (!string.IsNullOrEmpty(power.EnvelopeKey))
+            ids.Add(new FactFooterId("ROW", power.EnvelopeKey, copyable: false));
+        Footer = FactFooterVm.Of(ids.ToArray());
+    }
+
+    private static void ShowProvenancePopupWindow(ProvenancePopupViewModel vm, ICommand? chipClick) =>
+        new ProvenancePopupWindow { DataContext = vm, ChipClickCommand = chipClick }.Show();
+
+    public PowerEntry Power { get; }
+
+    /// <summary>The gold Cambria Fact-title — <c>InternalName</c> verbatim (Q1).</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Resolved skill display name (e.g. "Sword"); null when the power has no skill.</summary>
+    public string? SkillDisplay { get; }
+
+    /// <summary>True when the power carries at least one affix part to illustrate.</summary>
+    public bool HasAffix { get; }
+
+    /// <summary>
+    /// The illustrative affix Fact-body sentence — present parts only, framed as
+    /// approximate ("appears on items roughly as …, illustrative, not the canonical
+    /// name"). Never a reconstructed canonical item name (Q1 / #434). Empty when
+    /// <see cref="HasAffix"/> is false.
+    /// </summary>
+    public string AffixIllustration { get; }
+
+    /// <summary>Skill cross-link — <c>sparkles</c> glyph, Confirmed (Degraded if the
+    /// Skills surface is unshipped — <c>IsNavigable</c> handles that at rest-identical).</summary>
+    public LinkVm? SkillLink { get; }
+
+    /// <summary>Equip-slot constraint set — tag-form Set-references (not navigation).</summary>
+    public IReadOnlyList<SetRefVm> SlotSetRefs { get; }
+
+    /// <summary>The Tiers ladder (CF#3 FactTable). Null ⇒ N=0, the section self-hides.</summary>
+    public TreasureTierLadderVm? TierLadder { get; }
+
+    /// <summary>"Appears in pools" — Confirmed <c>layers</c> Links (authoritative
+    /// <c>tsysprofiles</c> join; G-d does not apply).</summary>
+    public IReadOnlyList<LinkVm> PoolLinks { get; }
+
+    /// <summary>Distinct recipe count behind the disclosure (the "(~N)" affordance).</summary>
+    public int RecipeChipCount { get; }
+
+    /// <summary>Same as <see cref="RecipeChipCount"/> — kept for the popup headline parity.</summary>
+    public int RecipesTotal { get; }
+
+    /// <summary>The recipes provenance popup (Confirmed Links); null when none roll this power.</summary>
+    public ProvenancePopupViewModel? RecipesPopup { get; }
+
+    /// <summary>True when there is at least one recipe — drives the disclosure visibility.</summary>
+    public bool HasRecipes => RecipesPopup is not null;
+
+    public ICommand ShowRecipesPopupCommand { get; }
+    public ICommand? OpenEntityCommand { get; }
+
+    /// <summary>G-a footer: copyable KEY (InternalName) + inert ROW (power_NNNN).</summary>
+    public FactFooterVm Footer { get; }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string? ResolveSkillDisplay(IReferenceDataService refData, string? skillKey)
+    {
+        if (string.IsNullOrEmpty(skillKey)) return null;
+        if (refData.Skills.TryGetValue(skillKey!, out var s) && !string.IsNullOrEmpty(s.DisplayName))
+            return s.DisplayName;
+        return skillKey;
+    }
+
+    /// <summary>
+    /// Compose the illustrative affix sentence from whichever parts exist. The «item»
+    /// slot is a literal ellipsis placeholder — never a reconstructed item name. Phrased
+    /// as approximate per the #434 ruling (affix logic is non-replicable engine-side).
+    /// </summary>
+    private static (bool HasAffix, string Text) BuildAffixIllustration(string? prefix, string? suffix)
+    {
+        var hasPrefix = !string.IsNullOrWhiteSpace(prefix);
+        var hasSuffix = !string.IsNullOrWhiteSpace(suffix);
+        if (!hasPrefix && !hasSuffix) return (false, "");
+
+        string shape = (hasPrefix, hasSuffix) switch
+        {
+            (true, true) => $"“{prefix!.Trim()} … {suffix!.Trim()}”",
+            (true, false) => $"“{prefix!.Trim()} …”",
+            _ => $"“… {suffix!.Trim()}”",
+        };
+        return (true, $"Appears on items roughly as {shape} — illustrative, not the canonical name.");
+    }
+
+    private static LinkVm? BuildSkillLink(
+        string? skillKey,
+        IEntityNameResolver resolver,
+        IReferenceNavigator navigator)
+    {
+        if (string.IsNullOrEmpty(skillKey)) return null;
+        var reference = EntityRef.Skill(skillKey!);
+        var chip = new EntityChipVm(
+            DisplayName: resolver.Resolve(reference),
+            IconId: 0,
+            Reference: reference,
+            IsNavigable: navigator.CanOpen(reference));
+        return LinkVm.From(chip);
+    }
+
+    private static IReadOnlyList<LinkVm> BuildPoolLinks(
+        string powerInternalName,
+        IReferenceDataService refData,
+        IEntityNameResolver resolver,
+        IReferenceNavigator navigator)
+    {
+        if (!refData.ProfilesByPower.TryGetValue(powerInternalName, out var profiles) || profiles.Count == 0)
+            return [];
+        return profiles
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .Select(profileName =>
+            {
+                var reference = EntityRef.Profile(profileName);
+                return new LinkVm(
+                    DisplayName: resolver.Resolve(reference),
+                    Glyph: LinkGlyph.Pool,
+                    Reference: reference,
+                    IsNavigable: navigator.CanOpen(reference));
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// Build the Power→Recipe provenance popup. Chain (every hop an authoritative
+    /// normalized lookup, so Confirmed — Q4): power → profiles containing it
+    /// (<see cref="IReferenceDataService.ProfilesByPower"/>) → items whose
+    /// <c>TSysProfile</c> is one of those (<see cref="IReferenceDataService.ItemsByTSysProfile"/>)
+    /// → recipes producing those items (<see cref="IReferenceDataService.RecipesByProducedItem"/>).
+    /// Single-reason ⇒ one section ⇒ the popup collapses to a flat list (#318 Discipline).
+    /// Materialized once here from the indices directly — no query re-derivation.
+    /// </summary>
+    private static (int Count, int Total, ProvenancePopupViewModel? Popup) BuildRecipesPopup(
+        string powerInternalName,
+        IReferenceDataService refData,
+        IEntityNameResolver resolver,
+        IReferenceNavigator navigator)
+    {
+        if (!refData.ProfilesByPower.TryGetValue(powerInternalName, out var profiles) || profiles.Count == 0)
+            return (0, 0, null);
+
+        var recipeNames = new HashSet<string>(StringComparer.Ordinal);
+        var chips = new List<EntityChipVm>();
+        foreach (var profileName in profiles)
+        {
+            if (!refData.ItemsByTSysProfile.TryGetValue(profileName, out var items)) continue;
+            foreach (var itemName in items)
+            {
+                if (!refData.RecipesByProducedItem.TryGetValue(itemName, out var recipes)) continue;
+                foreach (var recipe in recipes)
+                {
+                    if (string.IsNullOrEmpty(recipe.InternalName)) continue;
+                    if (!recipeNames.Add(recipe.InternalName!)) continue;
+                    var reference = EntityRef.Recipe(recipe.InternalName!);
+                    chips.Add(new EntityChipVm(
+                        DisplayName: resolver.Resolve(reference),
+                        IconId: 0,
+                        Reference: reference,
+                        IsNavigable: navigator.CanOpen(reference)));
+                }
+            }
+        }
+
+        if (chips.Count == 0) return (0, 0, null);
+
+        chips.Sort((a, b) => string.Compare(a.DisplayName, b.DisplayName, StringComparison.OrdinalIgnoreCase));
+        var popup = new ProvenancePopupViewModel(
+            title: $"Recipes that can roll {powerInternalName}",
+            sections: new List<ProvenancePopupSection>
+            {
+                new("Recipes that can roll this power", chips),
+            });
+        return (chips.Count, popup.TotalCount, popup);
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/ProfileDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ProfileDetailViewModel.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>One power row in a <see cref="ProfileDetailViewModel"/>'s pool list: the
+/// navigable power Link plus the power's own <see cref="SkillText"/> and tier count as
+/// inert Fact. <see cref="SkillText"/> is the power's <em>own</em> skill — orthogonal
+/// to the pool name (which is the equipment family).</summary>
+public sealed record TreasureProfilePowerRow(LinkVm PowerLink, string PowerInternalName, string SkillText, string TierText);
+
+/// <summary>A clickable Power.Skill filter chip (tag-form Set-ref + Activate),
+/// mirroring the <see cref="AbilityFilterSetRefVm"/> idiom.</summary>
+public sealed class TreasureSkillFilterVm
+{
+    public TreasureSkillFilterVm(SetRefVm setRef, ICommand activate)
+    {
+        SetRef = setRef;
+        Activate = activate;
+    }
+
+    public SetRefVm SetRef { get; }
+    public ICommand Activate { get; }
+}
+
+/// <summary>
+/// Lighter-pass detail projection of a Treasure-System profile / pool (#435 task 3).
+/// A profile is a named pool of powers; the pool name is the <b>equipment family the
+/// pool rolls onto</b>, NOT the contained powers' own skills — two orthogonal skill
+/// axes. The copy makes that explicit and the list is filterable by
+/// <c>Power.Skill</c>.
+/// </summary>
+public sealed partial class ProfileDetailViewModel : ObservableObject
+{
+    private readonly List<TreasureProfilePowerRow> _allRows;
+
+    public ProfileDetailViewModel(
+        string profileName,
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver,
+        ICommand? openEntityCommand = null)
+    {
+        DisplayName = profileName;
+        OpenEntityCommand = openEntityCommand;
+
+        Explanation =
+            $"“{profileName}” is a Treasure-System pool — the bag of powers a roll draws from. " +
+            "The pool name is the equipment family the pool rolls onto, " +
+            "not the contained powers' own skills: the list below carries powers from many skills.";
+
+        // "Drawn into <name> family items" — a Skill-shaped Link. The Skills surface
+        // isn't a browsable Silmarillion tab today, so this degrades (identical at
+        // rest, click-copies) rather than dead-ending — exactly the G-c contract.
+        var familyRef = EntityRef.Skill(profileName);
+        FamilyLink = new LinkVm(
+            DisplayName: nameResolver.Resolve(familyRef),
+            Glyph: LinkGlyph.Skill,
+            Reference: familyRef,
+            IsNavigable: navigator.CanOpen(familyRef));
+
+        _allRows = BuildRows(profileName, refData, nameResolver, navigator);
+        PowerCount = _allRows.Count;
+
+        SkillFilters = _allRows
+            .Select(r => r.SkillText)
+            .Where(s => !string.IsNullOrEmpty(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .Select(skill => new TreasureSkillFilterVm(
+                new SetRefVm(skill, MatchCount: null, IsActionable: true),
+                new RelayCommand(() => ToggleSkillFilter(skill))))
+            .ToList();
+
+        VisiblePowerRows = new ObservableCollection<TreasureProfilePowerRow>(_allRows);
+
+        Footer = FactFooterVm.Of(new FactFooterId("KEY", profileName, copyable: true));
+    }
+
+    /// <summary>The pool name — gold Cambria Fact-title and the copyable footer KEY.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Fact-body copy making the two orthogonal skill axes explicit.</summary>
+    public string Explanation { get; }
+
+    /// <summary>"Drawn into … family items" — Skill-shaped Link (degrades if Skills unshipped).</summary>
+    public LinkVm FamilyLink { get; }
+
+    /// <summary>Distinct count of powers in the pool (unfiltered).</summary>
+    public int PowerCount { get; }
+
+    /// <summary>Distinct <c>Power.Skill</c> values as clickable tag-form Set-ref filters.</summary>
+    public IReadOnlyList<TreasureSkillFilterVm> SkillFilters { get; }
+
+    /// <summary>The filtered pool list (virtualized in the view; ~270 rows for Sword).</summary>
+    public ObservableCollection<TreasureProfilePowerRow> VisiblePowerRows { get; }
+
+    /// <summary>Free-text pool filter (matches power name or its own skill, case-insensitive).</summary>
+    [ObservableProperty]
+    private string _filterText = "";
+
+    /// <summary>Subtitle reflecting the active filter ("270 powers" / "12 of 270 powers").</summary>
+    public string CountSummary =>
+        VisiblePowerRows.Count == PowerCount
+            ? $"{PowerCount} powers"
+            : $"{VisiblePowerRows.Count} of {PowerCount} powers";
+
+    public ICommand? OpenEntityCommand { get; }
+
+    /// <summary>G-a footer: copyable KEY = the pool name (its only identifier).</summary>
+    public FactFooterVm Footer { get; }
+
+    partial void OnFilterTextChanged(string value) => Recompute();
+
+    private void ToggleSkillFilter(string skill)
+    {
+        // Click a skill chip to filter to it; click again (or any chip whose skill is
+        // already the active filter) to clear — a lightweight one-axis toggle.
+        FilterText = string.Equals(FilterText, skill, StringComparison.OrdinalIgnoreCase)
+            ? ""
+            : skill;
+    }
+
+    private void Recompute()
+    {
+        var q = FilterText?.Trim();
+        IEnumerable<TreasureProfilePowerRow> filtered = _allRows;
+        if (!string.IsNullOrEmpty(q))
+        {
+            filtered = _allRows.Where(r =>
+                r.PowerLink.DisplayName.Contains(q, StringComparison.OrdinalIgnoreCase)
+                || r.PowerInternalName.Contains(q, StringComparison.OrdinalIgnoreCase)
+                || r.SkillText.Contains(q, StringComparison.OrdinalIgnoreCase));
+        }
+
+        VisiblePowerRows.Clear();
+        foreach (var r in filtered) VisiblePowerRows.Add(r);
+        OnPropertyChanged(nameof(CountSummary));
+    }
+
+    private static List<TreasureProfilePowerRow> BuildRows(
+        string profileName,
+        IReferenceDataService refData,
+        IEntityNameResolver resolver,
+        IReferenceNavigator navigator)
+    {
+        if (!refData.Profiles.TryGetValue(profileName, out var powerNames) || powerNames is null)
+            return [];
+
+        var rows = new List<TreasureProfilePowerRow>(powerNames.Count);
+        foreach (var powerName in powerNames)
+        {
+            if (string.IsNullOrEmpty(powerName)) continue;
+            refData.Powers.TryGetValue(powerName, out var power);
+
+            var skillKey = power?.Skill;
+            var skillText = string.IsNullOrEmpty(skillKey)
+                ? ""
+                : (refData.Skills.TryGetValue(skillKey!, out var s) && !string.IsNullOrEmpty(s.DisplayName)
+                    ? s.DisplayName
+                    : skillKey!);
+            var tierCount = power?.Tiers?.Count ?? 0;
+
+            var reference = EntityRef.Power(powerName);
+            var link = new LinkVm(
+                DisplayName: resolver.Resolve(reference),
+                Glyph: LinkGlyph.Power,
+                Reference: reference,
+                IsNavigable: navigator.CanOpen(reference));
+
+            rows.Add(new TreasureProfilePowerRow(
+                PowerLink: link,
+                PowerInternalName: powerName,
+                SkillText: skillText,
+                TierText: tierCount == 1 ? "1 tier" : $"{tierCount} tiers"));
+        }
+
+        rows.Sort((a, b) =>
+        {
+            var s = string.Compare(a.SkillText, b.SkillText, StringComparison.OrdinalIgnoreCase);
+            if (s != 0) return s;
+            return string.Compare(a.PowerLink.DisplayName, b.PowerLink.DisplayName, StringComparison.OrdinalIgnoreCase);
+        });
+        return rows;
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/ProfileDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/ProfileDetailViewModel.cs
@@ -7,14 +7,23 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Wpf;
+using Mithril.Shared.Wpf.Query;
 
 namespace Silmarillion.ViewModels;
 
-/// <summary>One power row in a <see cref="ProfileDetailViewModel"/>'s pool list: the
-/// navigable power Link plus the power's own <see cref="SkillText"/> and tier count as
-/// inert Fact. <see cref="SkillText"/> is the power's <em>own</em> skill — orthogonal
-/// to the pool name (which is the equipment family).</summary>
-public sealed record TreasureProfilePowerRow(LinkVm PowerLink, string PowerInternalName, string SkillText, string TierText);
+/// <summary>One power row in a <see cref="ProfileDetailViewModel"/>'s pool list. The
+/// scalar columns (<see cref="Name"/> / <see cref="InternalName"/> / <see cref="Skill"/>
+/// / <see cref="Tiers"/>) are the surface the shared query system reflects + filters on
+/// (mirrors Celebrimbor's <c>PooledAugmentOption</c>); <see cref="PowerLink"/> and
+/// <see cref="TierText"/> are render-only. <see cref="Skill"/> is the power's <em>own</em>
+/// skill — orthogonal to the pool name (the equipment family).</summary>
+public sealed record TreasureProfilePowerRow(
+    LinkVm PowerLink,
+    string Name,
+    string InternalName,
+    string Skill,
+    int Tiers,
+    string TierText);
 
 /// <summary>A clickable Power.Skill filter chip (tag-form Set-ref + Activate),
 /// mirroring the <see cref="AbilityFilterSetRefVm"/> idiom.</summary>
@@ -39,6 +48,19 @@ public sealed class TreasureSkillFilterVm
 /// </summary>
 public sealed partial class ProfileDetailViewModel : ObservableObject
 {
+    // The pool list reuses the shared query system (the cookbook step-6 / query-system
+    // mandate), exactly mirroring Celebrimbor's AugmentPoolViewModel — which filters a
+    // tsysprofiles pool the same way. The reflected RowSchema drives both the in-VM
+    // QueryCompiler predicate and MithrilQueryBox's completion/highlighting; no bespoke
+    // substring filter. QueryCompiler is used in-VM (not the QueryFilter attached
+    // behaviour) because the ratified spec needs the post-filter count for CountSummary.
+    private static readonly Dictionary<string, ColumnBinding> RowSchema =
+        ColumnBindingHelper.BuildFromProperties(typeof(TreasureProfilePowerRow));
+
+    /// <summary>Schema snapshot bound to <c>MithrilQueryBox.Schema</c>.</summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(RowSchema);
+
     private readonly List<TreasureProfilePowerRow> _allRows;
 
     public ProfileDetailViewModel(
@@ -70,7 +92,7 @@ public sealed partial class ProfileDetailViewModel : ObservableObject
         PowerCount = _allRows.Count;
 
         SkillFilters = _allRows
-            .Select(r => r.SkillText)
+            .Select(r => r.Skill)
             .Where(s => !string.IsNullOrEmpty(s))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
@@ -102,9 +124,18 @@ public sealed partial class ProfileDetailViewModel : ObservableObject
     /// <summary>The filtered pool list (virtualized in the view; ~270 rows for Sword).</summary>
     public ObservableCollection<TreasureProfilePowerRow> VisiblePowerRows { get; }
 
-    /// <summary>Free-text pool filter (matches power name or its own skill, case-insensitive).</summary>
+    /// <summary>
+    /// Two-way bound to <c>MithrilQueryBox.QueryText</c>. The shared query language —
+    /// <c>Skill = "Sword"</c>, <c>Tiers &gt;= 10</c>, bare text, AND/OR — over the
+    /// reflected <see cref="SchemaSnapshot"/>; the Skill chips inject a clause into it.
+    /// </summary>
     [ObservableProperty]
-    private string _filterText = "";
+    private string _queryText = "";
+
+    /// <summary>Last query compile error, surfaced under the box (mirrors the tab VMs
+    /// / AugmentPoolViewModel); a malformed query shows everything, not nothing.</summary>
+    [ObservableProperty]
+    private string? _queryError;
 
     /// <summary>Subtitle reflecting the active filter ("270 powers" / "12 of 270 powers").</summary>
     public string CountSummary =>
@@ -117,28 +148,44 @@ public sealed partial class ProfileDetailViewModel : ObservableObject
     /// <summary>G-a footer: copyable KEY = the pool name (its only identifier).</summary>
     public FactFooterVm Footer { get; }
 
-    partial void OnFilterTextChanged(string value) => Recompute();
+    partial void OnQueryTextChanged(string value) => Recompute();
 
     private void ToggleSkillFilter(string skill)
     {
-        // Click a skill chip to filter to it; click again (or any chip whose skill is
-        // already the active filter) to clear — a lightweight one-axis toggle.
-        FilterText = string.Equals(FilterText, skill, StringComparison.OrdinalIgnoreCase)
+        // A skill chip is a shortcut that writes a real query clause; clicking the
+        // active one again clears it. The query box stays the single filter surface.
+        var clause = $"Skill = \"{skill}\"";
+        QueryText = string.Equals(QueryText, clause, StringComparison.OrdinalIgnoreCase)
             ? ""
-            : skill;
+            : clause;
+    }
+
+    private Func<TreasureProfilePowerRow, bool>? CompilePredicate(string queryText)
+    {
+        if (string.IsNullOrWhiteSpace(queryText))
+        {
+            QueryError = null;
+            return null;
+        }
+        try
+        {
+            var compiled = QueryCompiler.Compile(queryText, RowSchema, caseSensitive: false);
+            QueryError = null;
+            return compiled is null ? null : row => compiled(row!);
+        }
+        catch (QueryException qex)
+        {
+            QueryError = qex.Message;
+            // Malformed query → show everything; the error renders under the box.
+            return null;
+        }
     }
 
     private void Recompute()
     {
-        var q = FilterText?.Trim();
-        IEnumerable<TreasureProfilePowerRow> filtered = _allRows;
-        if (!string.IsNullOrEmpty(q))
-        {
-            filtered = _allRows.Where(r =>
-                r.PowerLink.DisplayName.Contains(q, StringComparison.OrdinalIgnoreCase)
-                || r.PowerInternalName.Contains(q, StringComparison.OrdinalIgnoreCase)
-                || r.SkillText.Contains(q, StringComparison.OrdinalIgnoreCase));
-        }
+        var predicate = CompilePredicate(QueryText);
+        IEnumerable<TreasureProfilePowerRow> filtered =
+            predicate is null ? _allRows : _allRows.Where(predicate);
 
         VisiblePowerRows.Clear();
         foreach (var r in filtered) VisiblePowerRows.Add(r);
@@ -161,7 +208,7 @@ public sealed partial class ProfileDetailViewModel : ObservableObject
             refData.Powers.TryGetValue(powerName, out var power);
 
             var skillKey = power?.Skill;
-            var skillText = string.IsNullOrEmpty(skillKey)
+            var skill = string.IsNullOrEmpty(skillKey)
                 ? ""
                 : (refData.Skills.TryGetValue(skillKey!, out var s) && !string.IsNullOrEmpty(s.DisplayName)
                     ? s.DisplayName
@@ -177,16 +224,18 @@ public sealed partial class ProfileDetailViewModel : ObservableObject
 
             rows.Add(new TreasureProfilePowerRow(
                 PowerLink: link,
-                PowerInternalName: powerName,
-                SkillText: skillText,
+                Name: link.DisplayName,
+                InternalName: powerName,
+                Skill: skill,
+                Tiers: tierCount,
                 TierText: tierCount == 1 ? "1 tier" : $"{tierCount} tiers"));
         }
 
         rows.Sort((a, b) =>
         {
-            var s = string.Compare(a.SkillText, b.SkillText, StringComparison.OrdinalIgnoreCase);
+            var s = string.Compare(a.Skill, b.Skill, StringComparison.OrdinalIgnoreCase);
             if (s != 0) return s;
-            return string.Compare(a.PowerLink.DisplayName, b.PowerLink.DisplayName, StringComparison.OrdinalIgnoreCase);
+            return string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
         });
         return rows;
     }

--- a/src/Silmarillion.Module/ViewModels/TreasureListRow.cs
+++ b/src/Silmarillion.Module/ViewModels/TreasureListRow.cs
@@ -1,0 +1,34 @@
+namespace Silmarillion.ViewModels;
+
+/// <summary>Discriminates the two entity kinds the unified Treasure tab catalogs.</summary>
+public enum TreasureRowKind
+{
+    /// <summary>A <c>tsysclientinfo</c> power (the catalog's primary content, ~1946 rows).</summary>
+    Power,
+
+    /// <summary>A <c>tsysprofiles</c> profile / pool (40 rows).</summary>
+    Profile,
+}
+
+/// <summary>
+/// One row in the Treasure tab's unified master list. The tab catalogs both
+/// <see cref="TreasureRowKind.Power"/> (tsysclientinfo) and
+/// <see cref="TreasureRowKind.Profile"/> (tsysprofiles) so a single browse list serves
+/// both entity kinds and both #214 deep-link targets (Power-select / pool-query); the
+/// detail pane is polymorphic on <see cref="Kind"/>.
+/// <para>
+/// Public get-only surface is reflected into <c>MithrilQueryBox.Schema</c> (cookbook
+/// step 6), so every property here is a queryable column. The card secondary line is
+/// the plain <see cref="Secondary"/> string — no unit-letter prefixes (cookbook card
+/// format rule).
+/// </para>
+/// </summary>
+public sealed record TreasureListRow(
+    TreasureRowKind Kind,
+    string InternalName,
+    string Name,
+    string KindLabel,
+    string? Skill,
+    string Secondary,
+    int TierCount,
+    int PowerCount);

--- a/src/Silmarillion.Module/ViewModels/TreasureTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/TreasureTabViewModel.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Wpf.Query;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Treasure-System master-detail tab (#412 / #435). One unified catalog over both
+/// Treasure entity kinds — <see cref="TreasureRowKind.Power"/> (tsysclientinfo, the
+/// primary content) and <see cref="TreasureRowKind.Profile"/> (tsysprofiles pools) —
+/// so a single browse list serves both #214 deep-link targets (Power-select /
+/// pool-query). The right pane is polymorphic on the selected row's kind:
+/// <see cref="PowerDetailViewModel"/> or <see cref="ProfileDetailViewModel"/>.
+/// <para>
+/// Silmarillion is a browser, not a calculator: this tab shows what the Treasure
+/// System is <em>composed of</em> — no roll-resolution UI, crystal-free,
+/// <c>TreasureCartography</c> excluded (that is a different system).
+/// </para>
+/// </summary>
+public sealed partial class TreasureTabViewModel : ObservableObject, ITabViewModel
+{
+    /// <summary>Reflected <see cref="TreasureListRow"/> schema for <c>MithrilQueryBox</c>
+    /// completion + column highlighting (cookbook step 6).</summary>
+    public static IReadOnlyList<ColumnSchema> SchemaSnapshot { get; } =
+        ColumnBindingHelper.ToSchema(ColumnBindingHelper.BuildFromProperties(typeof(TreasureListRow)));
+
+    public string TabHeader => "Treasure";
+    public int TabOrder => 10;
+
+    private readonly IReferenceDataService _refData;
+    private readonly IReferenceNavigator _navigator;
+    private readonly IEntityNameResolver _nameResolver;
+    private readonly RelayCommand<EntityRef?> _openEntityCommand;
+
+    public TreasureTabViewModel(
+        IReferenceDataService refData,
+        IReferenceNavigator navigator,
+        IEntityNameResolver nameResolver)
+    {
+        _refData = refData;
+        _navigator = navigator;
+        _nameResolver = nameResolver;
+        _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
+        _allRows = BuildAllRows(refData, nameResolver);
+        refData.FileUpdated += OnFileUpdated;
+    }
+
+    [ObservableProperty]
+    private IReadOnlyList<TreasureListRow> _allRows;
+
+    [ObservableProperty]
+    private string _queryText = "";
+
+    [ObservableProperty]
+    private string? _queryError;
+
+    [ObservableProperty]
+    private TreasureListRow? _selectedRow;
+
+    /// <summary>
+    /// Polymorphic detail VM — a <see cref="PowerDetailViewModel"/> or a
+    /// <see cref="ProfileDetailViewModel"/> resolved by the view's per-type DataTemplate.
+    /// </summary>
+    [ObservableProperty]
+    private object? _detailViewModel;
+
+    partial void OnSelectedRowChanged(TreasureListRow? value)
+    {
+        if (value is null)
+        {
+            DetailViewModel = null;
+            return;
+        }
+        DetailViewModel = BuildDetail(value);
+    }
+
+    private object? BuildDetail(TreasureListRow row) => row.Kind switch
+    {
+        TreasureRowKind.Power when _refData.Powers.TryGetValue(row.InternalName, out var power) =>
+            new PowerDetailViewModel(power, _refData, _navigator, _nameResolver, _openEntityCommand),
+        TreasureRowKind.Profile when _refData.Profiles.ContainsKey(row.InternalName) =>
+            new ProfileDetailViewModel(row.InternalName, _refData, _navigator, _nameResolver, _openEntityCommand),
+        _ => null,
+    };
+
+    private void OnFileUpdated(object? sender, string fileKey)
+    {
+        // tsysclientinfo / tsysprofiles drive the master list. items / recipes only
+        // affect the open detail's pool / recipe cross-links (which resolve through the
+        // ProfilesByPower / ItemsByTSysProfile / RecipesByProducedItem indices), so a
+        // refresh of any of the four rebuilds the open detail; the list itself only
+        // rebuilds for the two it's sourced from.
+        if (fileKey is not ("tsysclientinfo" or "tsysprofiles" or "items" or "recipes"))
+            return;
+
+        UiThread.Run(() =>
+        {
+            var captured = SelectedRow;
+            if (fileKey is "tsysclientinfo" or "tsysprofiles")
+                AllRows = BuildAllRows(_refData, _nameResolver);
+
+            if (captured is not null)
+            {
+                var resolved = AllRows.FirstOrDefault(
+                    r => r.Kind == captured.Kind
+                         && string.Equals(r.InternalName, captured.InternalName, StringComparison.Ordinal));
+                SelectedRow = null;
+                SelectedRow = resolved;
+            }
+        });
+    }
+
+    private static IReadOnlyList<TreasureListRow> BuildAllRows(
+        IReferenceDataService refData,
+        IEntityNameResolver nameResolver)
+    {
+        var rows = new List<TreasureListRow>(refData.Powers.Count + refData.Profiles.Count);
+
+        // Pools first (40) — the small, navigationally-central set sits at the top.
+        foreach (var (profileName, powers) in refData.Profiles
+                     .OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            rows.Add(new TreasureListRow(
+                Kind: TreasureRowKind.Profile,
+                InternalName: profileName,
+                Name: profileName,
+                KindLabel: "Pool",
+                Skill: null,
+                Secondary: "Pool",
+                TierCount: 0,
+                PowerCount: powers?.Count ?? 0));
+        }
+
+        foreach (var power in refData.Powers.Values
+                     .OrderBy(p => p.InternalName, StringComparer.OrdinalIgnoreCase))
+        {
+            var skillDisplay = string.IsNullOrEmpty(power.Skill)
+                ? null
+                : (refData.Skills.TryGetValue(power.Skill, out var s) && !string.IsNullOrEmpty(s.DisplayName)
+                    ? s.DisplayName
+                    : power.Skill);
+            rows.Add(new TreasureListRow(
+                Kind: TreasureRowKind.Power,
+                // Q1: InternalName verbatim is the power's identity (no DisplayName exists).
+                InternalName: power.InternalName,
+                Name: nameResolver.Resolve(EntityRef.Power(power.InternalName)),
+                KindLabel: "Power",
+                Skill: skillDisplay,
+                Secondary: skillDisplay ?? "Power",
+                TierCount: power.Tiers?.Count ?? 0,
+                PowerCount: 0));
+        }
+
+        return rows;
+    }
+}

--- a/src/Silmarillion.Module/ViewModels/TreasureTierLadderVm.cs
+++ b/src/Silmarillion.Module/ViewModels/TreasureTierLadderVm.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.ViewModels;
+
+/// <summary>
+/// Which whole-table shape the Tiers ladder renders. Q2 was ruled <b>Option A</b>
+/// (#435/#404; revisit tracked #436): the CF#3 FactTable ladder uses
+/// <em>whole-table-shape</em> polymorphism only — never per-column hoist. Constant
+/// columns (e.g. an all-<c>Uncommon</c> <c>MinRarity</c>) are <em>dimmed in place</em>,
+/// not lifted to a Structure prefix.
+/// </summary>
+public enum TreasureTierLayout
+{
+    /// <summary>Exactly one tier — inline scalar form: no header row, no band micro-chart
+    /// (a single span carries no overlap signal). The CF#3 flat-scalar degrade.</summary>
+    Scalar,
+
+    /// <summary>Two or more tiers — the full 6-column Fact-inert grid with the overlapping
+    /// level-band micro-chart. (N=0 is never built — the section self-hides.)</summary>
+    Grid,
+}
+
+/// <summary>
+/// One row of the Tiers ladder. Fact-inert per G-b: every value is plain text in the
+/// Style, no gold, no surface, no click. <see cref="IsAboveBaseRarity"/> drives the
+/// Rare-band <em>weight</em> treatment (<c>--info</c> + inset) — never <c>--accent</c>
+/// (Apply #2 / Q3). The band micro-chart is pre-computed to absolute pixels against a
+/// fixed <see cref="TreasureTierLadderVm.TrackWidth"/> so the XAML needs no GridLength
+/// binding gymnastics.
+/// </summary>
+public sealed record TreasureTierRow(
+    string Ordinal,
+    string LevelText,
+    string SkillPrereqText,
+    string RarityText,
+    bool RarityDimmed,
+    bool IsAboveBaseRarity,
+    double BandLeftPx,
+    double BandWidthPx,
+    IReadOnlyList<EffectLine> EffectLines);
+
+/// <summary>
+/// The Tiers ladder — the central design problem, resolved to the ratified CF#3
+/// FactTable shape (whole-table-shape polymorphism, Q2 Option A). Built only when the
+/// power has ≥1 tier; <see cref="TreasureTierLayout.Scalar"/> for N=1, otherwise the
+/// 6-column Fact-inert grid with the overlapping-band micro-chart. Constant
+/// <c>MinRarity</c> is signalled by <see cref="TreasureTierRow.RarityDimmed"/> (dim in
+/// place — Option A), and a Rare-or-above band by <see cref="TreasureTierRow.IsAboveBaseRarity"/>
+/// (weight, not gold).
+/// </summary>
+public sealed class TreasureTierLadderVm
+{
+    /// <summary>Fixed band-track width (px). The micro-chart maps a tier's
+    /// <c>MinLevel…MaxLevel</c> onto this span; not user-scaled (it's a chart, not text).</summary>
+    public const double TrackWidth = 72.0;
+
+    private TreasureTierLadderVm(TreasureTierLayout layout, IReadOnlyList<TreasureTierRow> rows, int maxBandLevel)
+    {
+        Layout = layout;
+        Rows = rows;
+        MaxBandLevel = maxBandLevel;
+    }
+
+    public TreasureTierLayout Layout { get; }
+    public IReadOnlyList<TreasureTierRow> Rows { get; }
+
+    /// <summary>The level the band track's right edge represents (max <c>MaxLevel</c>
+    /// across tiers). Surfaced for the axis caption only.</summary>
+    public int MaxBandLevel { get; }
+
+    public bool IsGrid => Layout == TreasureTierLayout.Grid;
+    public bool IsScalar => Layout == TreasureTierLayout.Scalar;
+
+    /// <summary>Convenience for the N=1 scalar form's single inline row.</summary>
+    public TreasureTierRow? SingleRow => Rows.Count == 1 ? Rows[0] : null;
+
+    /// <summary>
+    /// Build the ladder from a power's tiers, or <see langword="null"/> when the power has
+    /// no tiers (N=0 — the section self-hides; the grammar's "Strip hidden at 0" analogue).
+    /// </summary>
+    public static TreasureTierLadderVm? Build(
+        PowerEntry power,
+        IReadOnlyDictionary<string, AttributeEntry> attributes,
+        string skillDisplay)
+    {
+        if (power.Tiers is null || power.Tiers.Count == 0) return null;
+
+        var ordered = power.Tiers.OrderBy(kv => kv.Key).Select(kv => kv.Value).ToList();
+
+        // Band track spans 0..maxLevel. Tiers overlap (not a clean partition), so the
+        // chart's whole point is making that visible — normalise every band to the same
+        // max so adjacent overlapping bands read at a glance.
+        var maxBandLevel = ordered
+            .Select(t => Math.Max(t.MaxLevel, t.MinLevel ?? 0))
+            .DefaultIfEmpty(1)
+            .Max();
+        if (maxBandLevel <= 0) maxBandLevel = 1;
+
+        // Constant-column collapse (Q2 Option A): if MinRarity never varies across tiers,
+        // the column is dimmed in place — not hoisted.
+        var rarities = ordered
+            .Select(t => string.IsNullOrEmpty(t.MinRarity) ? "Uncommon" : t.MinRarity!)
+            .ToList();
+        var rarityConstant = rarities.Distinct(StringComparer.Ordinal).Count() <= 1;
+
+        var rows = new List<TreasureTierRow>(ordered.Count);
+        foreach (var tier in ordered)
+        {
+            var rarity = string.IsNullOrEmpty(tier.MinRarity) ? "Uncommon" : tier.MinRarity!;
+            var minLevel = tier.MinLevel ?? 0;
+            var maxLevel = tier.MaxLevel;
+
+            var leftFrac = Math.Clamp(minLevel / (double)maxBandLevel, 0, 1);
+            var widthFrac = Math.Clamp((maxLevel - minLevel) / (double)maxBandLevel, 0, 1);
+            var widthPx = Math.Max(widthFrac * TrackWidth, 2.0); // a zero-width band still shows
+            var leftPx = Math.Min(leftFrac * TrackWidth, TrackWidth - widthPx);
+            if (leftPx < 0) leftPx = 0;
+
+            var levelText = minLevel == maxLevel ? $"{minLevel}" : $"{minLevel}–{maxLevel}";
+            var prereq = tier.SkillLevelPrereq ?? 0;
+            var skillPrereqText = string.IsNullOrEmpty(skillDisplay)
+                ? prereq.ToString()
+                : $"{skillDisplay} {prereq}";
+
+            rows.Add(new TreasureTierRow(
+                Ordinal: tier.Tier.ToString("D2"),
+                LevelText: levelText,
+                SkillPrereqText: skillPrereqText,
+                RarityText: rarity,
+                RarityDimmed: rarityConstant,
+                IsAboveBaseRarity: !string.Equals(rarity, "Uncommon", StringComparison.Ordinal),
+                BandLeftPx: leftPx,
+                BandWidthPx: widthPx,
+                EffectLines: EffectDescsRenderer.Render(tier.EffectDescs, attributes)));
+        }
+
+        var layout = rows.Count == 1 ? TreasureTierLayout.Scalar : TreasureTierLayout.Grid;
+        return new TreasureTierLadderVm(layout, rows, maxBandLevel);
+    }
+}

--- a/src/Silmarillion.Module/Views/PowerDetailView.xaml
+++ b/src/Silmarillion.Module/Views/PowerDetailView.xaml
@@ -4,7 +4,6 @@
              xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
              xmlns:local="clr-namespace:Silmarillion.Views"
              xmlns:vm="clr-namespace:Silmarillion.ViewModels"
-             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
@@ -209,29 +208,14 @@
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- 7. Recipes that can roll this power — Control disclosure → popup
-                     of Confirmed Links (Q5, per itemuses/#318). -->
-                <StackPanel Margin="0,0,0,12"
-                            Visibility="{Binding HasRecipes, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="Recipes that can roll this power"
-                               Style="{StaticResource StructureSectionLabelStyle}"/>
-                    <Button Command="{Binding ShowRecipesPopupCommand}"
-                            HorizontalAlignment="Left" Margin="0,2,0,0"
-                            Background="#FF2A2A2A" BorderBrush="#33FFFFFF" BorderThickness="1"
-                            Foreground="#DDFFFFFF" Padding="10,5" Cursor="Hand">
-                        <StackPanel Orientation="Horizontal">
-                            <icon:PackIconLucide Kind="List" Width="13" Height="13"
-                                                 VerticalAlignment="Center" Margin="0,0,6,0"/>
-                            <TextBlock Text="See recipes" VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding RecipeChipCount, StringFormat=' ({0})'}"
-                                       Foreground="#88FFFFFF" VerticalAlignment="Center"
-                                       FontFamily="{DynamicResource AppMonoFontFamily}"
-                                       FontSize="{DynamicResource AppFontSizeSmall}"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
+                <!-- Recipes cross-link is deferred to #214 (verified out of scope):
+                     the only in-scope join is near-catalog-granular via the "All"
+                     pool, so it cannot honestly be presented as power-specific. The
+                     power-precise join is recipe ResultEffects (AddItemTSysPower /
+                     ExtractTSysPower / TSysCraftedEquipment) via ResultEffectsParser —
+                     the #214 surface. No recipes section is rendered until #214. -->
 
-                <!-- 8. G-a footer: copyable KEY (= title text, kept deliberately) +
+                <!-- G-a footer: copyable KEY (= title text, kept deliberately) +
                      inert ROW (power_NNNN). -->
                 <c:FactFooter DataContext="{Binding Footer}"/>
             </StackPanel>

--- a/src/Silmarillion.Module/Views/PowerDetailView.xaml
+++ b/src/Silmarillion.Module/Views/PowerDetailView.xaml
@@ -1,0 +1,240 @@
+<UserControl x:Class="Silmarillion.Views.PowerDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Inline Prose / list-density Link (canonical pilot patterns; mirrors
+                 AbilityDetailView). -->
+            <DataTemplate x:Key="InlineLinkTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="Prose"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:PowerDetailView}}}"/>
+            </DataTemplate>
+            <DataTemplate x:Key="PoolLinkListTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="List" Margin="0,0,0,3"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:PowerDetailView}}}"/>
+            </DataTemplate>
+
+            <!-- One Tiers-ladder row (Fact-inert: no surface, no gold, no click; the
+                 only decoration is a 1px bottom divider). -->
+            <DataTemplate x:Key="TierRowTemplate" DataType="{x:Type vm:TreasureTierRow}">
+                <Border BorderBrush="#14FFFFFF" BorderThickness="0,0,0,1" Padding="0,3">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="26"/>
+                            <ColumnDefinition Width="84"/>
+                            <ColumnDefinition Width="70"/>
+                            <ColumnDefinition Width="118"/>
+                            <ColumnDefinition Width="92"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{Binding Ordinal}"
+                                   Foreground="#66FFFFFF"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                   VerticalAlignment="Center"/>
+                        <!-- Level-band micro-chart. Q3 dual-encodes MinLevel/MaxLevel
+                             (graphic plus numerals). Rare-or-above uses info-blue
+                             weight plus an inset outline, NEVER accent-gold (Apply 2,
+                             G-b). -->
+                        <Border Grid.Column="1" Width="72" Height="9" Margin="0,0,12,0"
+                                HorizontalAlignment="Left" VerticalAlignment="Center"
+                                Background="#14FFFFFF" CornerRadius="1">
+                            <Canvas ClipToBounds="True">
+                                <Rectangle Height="9" Canvas.Top="0"
+                                           Canvas.Left="{Binding BandLeftPx}"
+                                           Width="{Binding BandWidthPx}" RadiusX="1" RadiusY="1">
+                                    <Rectangle.Style>
+                                        <Style TargetType="Rectangle">
+                                            <Setter Property="Fill" Value="#8C88B0E0"/>
+                                            <Setter Property="Stroke" Value="Transparent"/>
+                                            <Setter Property="StrokeThickness" Value="0"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsAboveBaseRarity}" Value="True">
+                                                    <Setter Property="Fill" Value="#FF88B0E0"/>
+                                                    <Setter Property="Stroke" Value="#FFFFFFFF"/>
+                                                    <Setter Property="StrokeThickness" Value="1"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Rectangle.Style>
+                                </Rectangle>
+                            </Canvas>
+                        </Border>
+                        <TextBlock Grid.Column="2" Text="{Binding LevelText}"
+                                   Foreground="#DDFFFFFF"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="3" Text="{Binding SkillPrereqText}"
+                                   Foreground="#DDFFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="4" Text="{Binding RarityText}"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   VerticalAlignment="Center">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <!-- Q2 Option A: a constant MinRarity column is dimmed
+                                         in place (quaternary), never hoisted. -->
+                                    <Setter Property="Foreground" Value="#DDFFFFFF"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RarityDimmed}" Value="True">
+                                            <Setter Property="Foreground" Value="#66FFFFFF"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <ItemsControl Grid.Column="5" ItemsSource="{Binding EffectLines}"
+                                      ItemTemplate="{StaticResource EffectLineTemplate}"
+                                      VerticalAlignment="Center"/>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <c:DetailExportHost>
+        <Border Padding="14,12">
+            <StackPanel>
+                <!-- 1. Identity header — Fact-title = InternalName verbatim (Q1).
+                     No title-glyph: Powers ship no icon. -->
+                <TextBlock Text="{Binding DisplayName}"
+                           Style="{StaticResource FactTitleStyle}"
+                           Margin="0,0,0,6"/>
+
+                <!-- 2. Affix flavor — illustrative Fact-body only, present parts only,
+                     never a reconstructed canonical name (Q1 / #434). -->
+                <TextBlock Text="{Binding AffixIllustration}"
+                           Style="{StaticResource FactBodyStyle}"
+                           Foreground="#88FFFFFF" FontStyle="Italic"
+                           MaxWidth="560" HorizontalAlignment="Left" Margin="0,0,0,12"
+                           Visibility="{Binding HasAffix, Converter={StaticResource BoolToVis}}"/>
+
+                <!-- 3. Skill (Structure prefix + Confirmed sparkles Link) -->
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,4"
+                            Visibility="{Binding SkillLink, Converter={StaticResource NullToVis}}">
+                    <TextBlock Text="Skill:" Style="{StaticResource StructureInlinePrefixStyle}"
+                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <ContentControl Content="{Binding SkillLink}"
+                                    ContentTemplate="{StaticResource InlineLinkTemplate}"
+                                    VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <!-- 4. Slots (Structure prefix + tag-form Set-references, inert) -->
+                <StackPanel Margin="0,0,0,12"
+                            Visibility="{Binding SlotSetRefs.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Slots:" Style="{StaticResource StructureInlinePrefixStyle}"
+                               Margin="0,0,0,3"/>
+                    <ItemsControl ItemsSource="{Binding SlotSetRefs}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type c:SetRefVm}">
+                                <c:SetRef Margin="0,0,5,4"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- 5. Tiers ladder — CF#3 FactTable (Q2 Option A whole-table-shape
+                     polymorphism). Section self-hides at N=0 (TierLadder == null). -->
+                <StackPanel Margin="0,0,0,12"
+                            Visibility="{Binding TierLadder, Converter={StaticResource NullToVis}}">
+                    <TextBlock Text="Tiers" Style="{StaticResource StructureSectionLabelStyle}"/>
+
+                    <!-- N >= 2 : the full 6-column Fact-inert grid + band micro-chart -->
+                    <StackPanel Visibility="{Binding TierLadder.IsGrid, Converter={StaticResource BoolToVis}}">
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="26"/>
+                                <ColumnDefinition Width="84"/>
+                                <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="118"/>
+                                <ColumnDefinition Width="92"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="1" Text="Band" Style="{StaticResource StructureGroupHeaderStyle}"/>
+                            <TextBlock Grid.Column="2" Text="Level" Style="{StaticResource StructureGroupHeaderStyle}"/>
+                            <TextBlock Grid.Column="3" Text="Skill prereq" Style="{StaticResource StructureGroupHeaderStyle}"/>
+                            <TextBlock Grid.Column="4" Text="Min rarity" Style="{StaticResource StructureGroupHeaderStyle}"/>
+                            <TextBlock Grid.Column="5" Text="Effect" Style="{StaticResource StructureGroupHeaderStyle}"/>
+                        </Grid>
+                        <ItemsControl ItemsSource="{Binding TierLadder.Rows}"
+                                      ItemTemplate="{StaticResource TierRowTemplate}"
+                                      VirtualizingStackPanel.IsVirtualizing="True"/>
+                    </StackPanel>
+
+                    <!-- N = 1 : CF#3 flat-scalar degrade — inline, no header, no chart -->
+                    <StackPanel Visibility="{Binding TierLadder.IsScalar, Converter={StaticResource BoolToVis}}">
+                        <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+                            <TextBlock Text="Level" Style="{StaticResource StructureInlinePrefixStyle}" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding TierLadder.SingleRow.LevelText}" Foreground="#DDFFFFFF"
+                                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                                       FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,14,0"/>
+                            <TextBlock Text="Skill prereq" Style="{StaticResource StructureInlinePrefixStyle}" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding TierLadder.SingleRow.SkillPrereqText}" Foreground="#DDFFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeHint}" Margin="0,0,14,0"/>
+                            <TextBlock Text="Min rarity" Style="{StaticResource StructureInlinePrefixStyle}" Margin="0,0,4,0"/>
+                            <TextBlock Text="{Binding TierLadder.SingleRow.RarityText}" Foreground="#DDFFFFFF"
+                                       FontSize="{DynamicResource AppFontSizeHint}"/>
+                        </StackPanel>
+                        <ItemsControl ItemsSource="{Binding TierLadder.SingleRow.EffectLines}"
+                                      ItemTemplate="{StaticResource EffectLineTemplate}"
+                                      Margin="0,4,0,0"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- 6. Appears in pools — Confirmed layers Links (authoritative
+                     tsysprofiles join; G-d does not apply). -->
+                <StackPanel Margin="0,0,0,12"
+                            Visibility="{Binding PoolLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Appears in pools" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <ItemsControl ItemsSource="{Binding PoolLinks}"
+                                  ItemTemplate="{StaticResource PoolLinkListTemplate}">
+                        <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- 7. Recipes that can roll this power — Control disclosure → popup
+                     of Confirmed Links (Q5, per itemuses/#318). -->
+                <StackPanel Margin="0,0,0,12"
+                            Visibility="{Binding HasRecipes, Converter={StaticResource BoolToVis}}">
+                    <TextBlock Text="Recipes that can roll this power"
+                               Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <Button Command="{Binding ShowRecipesPopupCommand}"
+                            HorizontalAlignment="Left" Margin="0,2,0,0"
+                            Background="#FF2A2A2A" BorderBrush="#33FFFFFF" BorderThickness="1"
+                            Foreground="#DDFFFFFF" Padding="10,5" Cursor="Hand">
+                        <StackPanel Orientation="Horizontal">
+                            <icon:PackIconLucide Kind="List" Width="13" Height="13"
+                                                 VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock Text="See recipes" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding RecipeChipCount, StringFormat=' ({0})'}"
+                                       Foreground="#88FFFFFF" VerticalAlignment="Center"
+                                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                                       FontSize="{DynamicResource AppFontSizeSmall}"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+
+                <!-- 8. G-a footer: copyable KEY (= title text, kept deliberately) +
+                     inert ROW (power_NNNN). -->
+                <c:FactFooter DataContext="{Binding Footer}"/>
+            </StackPanel>
+        </Border>
+    </c:DetailExportHost>
+</UserControl>

--- a/src/Silmarillion.Module/Views/PowerDetailView.xaml.cs
+++ b/src/Silmarillion.Module/Views/PowerDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class PowerDetailView : UserControl
+{
+    public PowerDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/ProfileDetailView.xaml
+++ b/src/Silmarillion.Module/Views/ProfileDetailView.xaml
@@ -50,7 +50,7 @@
                                 </DataTemplate>
                             </ContentControl.ContentTemplate>
                         </ContentControl>
-                        <TextBlock Grid.Column="1" Text="{Binding SkillText}"
+                        <TextBlock Grid.Column="1" Text="{Binding Skill}"
                                    Foreground="#AAFFFFFF"
                                    FontSize="{DynamicResource AppFontSizeHint}"
                                    TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
@@ -101,9 +101,14 @@
                                       Margin="0,2,0,4">
                             <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                         </ItemsControl>
-                        <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
-                                 Background="#FF202020" Foreground="#DDFFFFFF"
-                                 BorderBrush="#33FFFFFF" BorderThickness="1" Padding="6,4"/>
+                        <c:MithrilQueryBox Schema="{x:Static vm:ProfileDetailViewModel.SchemaSnapshot}"
+                                           QueryText="{Binding QueryText, Mode=TwoWay}"
+                                           Watermark="bare text, or e.g. Skill = 'Bard' AND Tiers &gt;= 10"/>
+                        <TextBlock Text="{Binding QueryError}"
+                                   Foreground="#FFD96A6A" FontStyle="Italic"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   Margin="0,4,0,0"
+                                   Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
                     </StackPanel>
 
                     <TextBlock Style="{StaticResource StructureSectionLabelStyle}" Margin="0,4,0,2">

--- a/src/Silmarillion.Module/Views/ProfileDetailView.xaml
+++ b/src/Silmarillion.Module/Views/ProfileDetailView.xaml
@@ -1,0 +1,137 @@
+<UserControl x:Class="Silmarillion.Views.ProfileDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <DataTemplate x:Key="ProfileFamilyLinkTemplate" DataType="{x:Type c:LinkVm}">
+                <c:Link Density="Prose"
+                        ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ProfileDetailView}}}"/>
+            </DataTemplate>
+
+            <!-- Clickable Power.Skill filter chip (tag-form Set-ref + Activate),
+                 mirroring AbilityDetailView's FilterSetRefTemplate idiom. -->
+            <DataTemplate x:Key="SkillFilterTemplate" DataType="{x:Type vm:TreasureSkillFilterVm}">
+                <ContentControl Content="{Binding SetRef}" Margin="0,0,5,4">
+                    <ContentControl.ContentTemplate>
+                        <DataTemplate>
+                            <c:SetRef ActivateCommand="{Binding DataContext.Activate, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                        </DataTemplate>
+                    </ContentControl.ContentTemplate>
+                </ContentControl>
+            </DataTemplate>
+
+            <!-- One pool-list row: navigable power Link + the power's OWN skill and
+                 tier count as inert Fact (orthogonal to the pool's family name). -->
+            <DataTemplate x:Key="PoolPowerRowTemplate" DataType="{x:Type vm:TreasureProfilePowerRow}">
+                <Border BorderBrush="#14FFFFFF" BorderThickness="0,0,0,1" Padding="0,3">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="74"/>
+                        </Grid.ColumnDefinitions>
+                        <ContentControl Grid.Column="0" Content="{Binding PowerLink}" VerticalAlignment="Center">
+                            <ContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <c:Link Density="List"
+                                            ClickCommand="{Binding DataContext.OpenEntityCommand, RelativeSource={RelativeSource AncestorType={x:Type local:ProfileDetailView}}}"/>
+                                </DataTemplate>
+                            </ContentControl.ContentTemplate>
+                        </ContentControl>
+                        <TextBlock Grid.Column="1" Text="{Binding SkillText}"
+                                   Foreground="#AAFFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeHint}"
+                                   TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{Binding TierText}"
+                                   Foreground="#66FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                   VerticalAlignment="Center"/>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <c:DetailExportHost>
+        <Border Padding="14,12">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Top">
+                    <!-- Fact-title = pool name -->
+                    <TextBlock Text="{Binding DisplayName}"
+                               Style="{StaticResource FactTitleStyle}" Margin="0,0,0,6"/>
+
+                    <!-- Two-orthogonal-skill-axes copy (Fact body) -->
+                    <TextBlock Text="{Binding Explanation}"
+                               Style="{StaticResource FactBodyStyle}"
+                               MaxWidth="600" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+
+                    <!-- Drawn into <family> items — Skill-shaped Link (degrades if
+                         the Skills surface is unshipped). -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                        <TextBlock Text="Drawn into:" Style="{StaticResource StructureInlinePrefixStyle}"
+                                   VerticalAlignment="Center" Margin="0,0,6,0"/>
+                        <ContentControl Content="{Binding FamilyLink}"
+                                        ContentTemplate="{StaticResource ProfileFamilyLinkTemplate}"
+                                        VerticalAlignment="Center"/>
+                        <TextBlock Text=" family items" Style="{StaticResource FactBodyStyle}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <!-- Filter by Power.Skill — orthogonal to the pool name -->
+                    <StackPanel Margin="0,0,0,6"
+                                Visibility="{Binding SkillFilters.Count, Converter={StaticResource PositiveIntToVis}}">
+                        <TextBlock Style="{StaticResource StructureSectionLabelStyle}">
+                            <Run Text="Filter by Power.Skill"/>
+                            <Run Text="  ·  orthogonal to pool name" Foreground="#66FFFFFF"/>
+                        </TextBlock>
+                        <ItemsControl ItemsSource="{Binding SkillFilters}"
+                                      ItemTemplate="{StaticResource SkillFilterTemplate}"
+                                      Margin="0,2,0,4">
+                            <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                        <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                                 Background="#FF202020" Foreground="#DDFFFFFF"
+                                 BorderBrush="#33FFFFFF" BorderThickness="1" Padding="6,4"/>
+                    </StackPanel>
+
+                    <TextBlock Style="{StaticResource StructureSectionLabelStyle}" Margin="0,4,0,2">
+                        <Run Text="Powers in this pool"/>
+                        <Run Text="  ·  "/>
+                        <Run Text="{Binding CountSummary, Mode=OneWay}" Foreground="#66FFFFFF"/>
+                    </TextBlock>
+                </StackPanel>
+
+                <c:FactFooter DockPanel.Dock="Bottom" DataContext="{Binding Footer}" Margin="0,8,0,0"/>
+
+                <ListBox ItemsSource="{Binding VisiblePowerRows}"
+                         ItemTemplate="{StaticResource PoolPowerRowTemplate}"
+                         Background="Transparent" BorderThickness="0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         VirtualizingStackPanel.IsVirtualizing="True"
+                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            <Setter Property="Padding" Value="0"/>
+                            <Setter Property="Background" Value="Transparent"/>
+                            <Setter Property="Focusable" Value="False"/>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                </ListBox>
+            </DockPanel>
+        </Border>
+    </c:DetailExportHost>
+</UserControl>

--- a/src/Silmarillion.Module/Views/ProfileDetailView.xaml
+++ b/src/Silmarillion.Module/Views/ProfileDetailView.xaml
@@ -115,8 +115,18 @@
 
                 <c:FactFooter DockPanel.Dock="Bottom" DataContext="{Binding Footer}" Margin="0,8,0,0"/>
 
+<!-- The pool list is the Profile pane's primary content and runs large
+                     (Sword ≈ 270; cross-skill pools larger). It is hosted inside the
+                     detail card's outer ScrollViewer (TreasureTabView.DetailScroller /
+                     the popup window), which measures content with infinite height —
+                     so a bare VirtualizingStackPanel would realise every row. Binding
+                     MaxHeight to the hosting ScrollViewer's viewport gives the ListBox a
+                     bounded height, engaging its own scroll region and therefore actual
+                     UI virtualization (recycling). This is the inline-list analogue of
+                     the cookbook's "large set ⇒ virtualized surface" rule. -->
                 <ListBox ItemsSource="{Binding VisiblePowerRows}"
                          ItemTemplate="{StaticResource PoolPowerRowTemplate}"
+                         MaxHeight="{Binding ViewportHeight, RelativeSource={RelativeSource AncestorType={x:Type ScrollViewer}}}"
                          Background="Transparent" BorderThickness="0"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"

--- a/src/Silmarillion.Module/Views/ProfileDetailView.xaml.cs
+++ b/src/Silmarillion.Module/Views/ProfileDetailView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class ProfileDetailView : UserControl
+{
+    public ProfileDetailView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Silmarillion.Module/Views/SilmarillionView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionView.xaml
@@ -46,6 +46,9 @@
             <DataTemplate DataType="{x:Type vm:StorageVaultsTabViewModel}">
                 <local:StorageVaultsTabView/>
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:TreasureTabViewModel}">
+                <local:TreasureTabView/>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.InputBindings>

--- a/src/Silmarillion.Module/Views/TreasureDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/TreasureDetailWindow.xaml
@@ -1,0 +1,61 @@
+<Window x:Class="Silmarillion.Views.TreasureDetailWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Silmarillion.Views"
+        xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+        xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="{Binding DisplayName}"
+        SizeToContent="WidthAndHeight"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        FontFamily="{DynamicResource AppFontFamily}"
+        FontSize="{DynamicResource AppFontSize}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+            MinWidth="420" MaxWidth="760">
+        <DockPanel>
+            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
+                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
+                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                            ToolTip="Close" Click="CloseButton_Click">
+                        <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
+                    </Button>
+                    <TextBlock Text="{Binding DisplayName}"
+                               FontFamily="{DynamicResource AppHeaderFontFamily}"
+                               FontSize="{DynamicResource AppFontSizeXLarge}"
+                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                </DockPanel>
+            </Border>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled" MaxHeight="720">
+                <ContentControl Content="{Binding}">
+                    <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type vm:PowerDetailViewModel}">
+                            <local:PowerDetailView/>
+                        </DataTemplate>
+                        <DataTemplate DataType="{x:Type vm:ProfileDetailViewModel}">
+                            <local:ProfileDetailView/>
+                        </DataTemplate>
+                    </ContentControl.Resources>
+                </ContentControl>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</Window>

--- a/src/Silmarillion.Module/Views/TreasureDetailWindow.xaml.cs
+++ b/src/Silmarillion.Module/Views/TreasureDetailWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Silmarillion.Views;
+
+public partial class TreasureDetailWindow : Window
+{
+    public TreasureDetailWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left) DragMove();
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/src/Silmarillion.Module/Views/TreasureTabView.xaml
+++ b/src/Silmarillion.Module/Views/TreasureTabView.xaml
@@ -1,0 +1,156 @@
+<UserControl x:Class="Silmarillion.Views.TreasureTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Silmarillion.Views"
+             xmlns:vm="clr-namespace:Silmarillion.ViewModels"
+             xmlns:wpf="clr-namespace:Mithril.Shared.Wpf;assembly=Mithril.Shared.Wpf"
+             xmlns:query="clr-namespace:Mithril.Shared.Wpf.Query;assembly=Mithril.Shared.Wpf"
+             xmlns:icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             FontFamily="{DynamicResource AppFontFamily}"
+             FontSize="{DynamicResource AppFontSize}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Mithril.Shared.Wpf;component/Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Two-line master-row card. Bound DataContext: TreasureListRow. Powers and
+                 pools ship no icon ids; a Lucide stands in (Zap = power, Layers = pool)
+                 to keep row height consistent with the other tabs. -->
+            <DataTemplate x:Key="TreasureCardTemplate" DataType="{x:Type vm:TreasureListRow}">
+                <DockPanel LastChildFill="True">
+                    <Border DockPanel.Dock="Left" Width="24" Height="24" Margin="6,3,6,3"
+                            VerticalAlignment="Center" Background="#FF1F1F1F" CornerRadius="3">
+                        <Grid>
+                            <icon:PackIconLucide Kind="Zap" Width="13" Height="13" Foreground="#88FFFFFF"
+                                                 HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <icon:PackIconLucide.Style>
+                                    <Style TargetType="icon:PackIconLucide">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding KindLabel}" Value="Pool">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </icon:PackIconLucide.Style>
+                            </icon:PackIconLucide>
+                            <icon:PackIconLucide Kind="Layers" Width="13" Height="13" Foreground="#88FFFFFF"
+                                                 HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <icon:PackIconLucide.Style>
+                                    <Style TargetType="icon:PackIconLucide">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding KindLabel}" Value="Pool">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </icon:PackIconLucide.Style>
+                            </icon:PackIconLucide>
+                        </Grid>
+                    </Border>
+                    <StackPanel VerticalAlignment="Center" Margin="0,3,6,3">
+                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                                   Foreground="#FFD4A847" TextTrimming="CharacterEllipsis"
+                                   FontSize="{DynamicResource AppFontSizeHint}"/>
+                        <TextBlock Text="{Binding Secondary}" Foreground="#88FFFFFF"
+                                   FontSize="{DynamicResource AppFontSizeSmall}"
+                                   TextTrimming="CharacterEllipsis"
+                                   Visibility="{Binding Secondary, Converter={StaticResource NullOrEmptyToVis}}"/>
+                    </StackPanel>
+                </DockPanel>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320" MinWidth="240"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.Row="0" Grid.ColumnSpan="2" Padding="8,6" Background="#FF252525">
+            <StackPanel>
+                <wpf:MithrilQueryBox Schema="{x:Static vm:TreasureTabViewModel.SchemaSnapshot}"
+                                     QueryText="{Binding QueryText, Mode=TwoWay}"
+                                     Watermark="bare text, or e.g. KindLabel = 'Power' AND Skill = 'Sword'"/>
+                <TextBlock Text="{Binding QueryError}"
+                           Foreground="#FFD96A6A" FontStyle="Italic"
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Margin="0,4,0,0"
+                           Visibility="{Binding QueryError, Converter={StaticResource NullOrEmptyToVis}}"/>
+            </StackPanel>
+        </Border>
+
+        <ListBox Grid.Row="1" Grid.Column="0"
+                 ItemsSource="{Binding AllRows}"
+                 ItemTemplate="{StaticResource TreasureCardTemplate}"
+                 SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                 query:QueryFilter.QueryText="{Binding QueryText}"
+                 query:QueryFilter.QueryError="{Binding QueryError, Mode=OneWayToSource}"
+                 Background="#FF1A1A1A" BorderThickness="0"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 VirtualizingStackPanel.IsVirtualizing="True"
+                 VirtualizingStackPanel.VirtualizationMode="Recycling">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
+
+        <Grid Grid.Row="1" Grid.Column="1" Background="#FF1A1A1A">
+            <ScrollViewer x:Name="DetailScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <ContentControl Content="{Binding DetailViewModel}"
+                                MinHeight="{Binding ViewportHeight, ElementName=DetailScroller}">
+                    <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type vm:PowerDetailViewModel}">
+                            <local:PowerDetailView/>
+                        </DataTemplate>
+                        <DataTemplate DataType="{x:Type vm:ProfileDetailViewModel}">
+                            <local:ProfileDetailView/>
+                        </DataTemplate>
+                    </ContentControl.Resources>
+                </ContentControl>
+            </ScrollViewer>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="340">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DetailViewModel}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <icon:PackIconLucide Kind="Gem" Width="48" Height="48"
+                                     Foreground="#33FFFFFF"
+                                     HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                <TextBlock Text="Browse the Treasure System"
+                           FontFamily="{DynamicResource AppHeaderFontFamily}"
+                           FontSize="{DynamicResource AppFontSizeLarge}"
+                           Foreground="#CCFFFFFF"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Pick a power to see its affix, tier ladder, pools and recipes — or a pool to browse the powers it can roll."
+                           FontSize="{DynamicResource AppFontSizeHint}"
+                           Foreground="#88FFFFFF"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,8,0,0"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Silmarillion.Module/Views/TreasureTabView.xaml.cs
+++ b/src/Silmarillion.Module/Views/TreasureTabView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Silmarillion.Views;
+
+public partial class TreasureTabView : UserControl
+{
+    public TreasureTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceTreasureCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceTreasureCrossLinkIndexTests.cs
@@ -9,10 +9,10 @@ namespace Mithril.Shared.Tests.Reference;
 /// <summary>
 /// #435: verifies the Treasure-System data layer — <see cref="PowerEntry.Prefix"/> /
 /// <see cref="PowerEntry.EnvelopeKey"/> capture and the
-/// <see cref="IReferenceDataService.ProfilesByPower"/> /
-/// <see cref="IReferenceDataService.ItemsByTSysProfile"/> reverse-view indices — built
-/// against real tsysclientinfo / tsysprofiles / items fixtures through the bundled-load
-/// plumbing (canonical pattern: <see cref="ReferenceDataServiceRecipeCrossLinkIndexTests"/>).
+/// <see cref="IReferenceDataService.ProfilesByPower"/> reverse-view index — built
+/// against real tsysclientinfo / tsysprofiles fixtures through the bundled-load plumbing
+/// (canonical pattern: <see cref="ReferenceDataServiceRecipeCrossLinkIndexTests"/>). The
+/// Item.TSysProfile / recipe legs were deferred to #214.
 /// </summary>
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
@@ -46,7 +46,7 @@ public sealed class ReferenceDataServiceTreasureCrossLinkIndexTests : IDisposabl
     }
 
     [Fact]
-    public void Power_CapturesPrefixAndEnvelopeKey_AndProfileReverseIndicesBuild()
+    public void Power_CapturesPrefixAndEnvelopeKey_AndProfilesByPowerBuilds()
     {
         Write("tsysclientinfo", """
         {
@@ -74,20 +74,6 @@ public sealed class ReferenceDataServiceTreasureCrossLinkIndexTests : IDisposabl
         Write("tsysprofiles", """
         { "Sword": ["SwordBoost", "BardMaxHealth"], "Chest": ["BardMaxHealth"] }
         """);
-        Write("items", """
-        {
-          "item_1": { "Name": "Iron Sword", "InternalName": "IronSword", "TSysProfile": "Sword" },
-          "item_2": { "Name": "Plain Boots", "InternalName": "PlainBoots" }
-        }
-        """);
-        Write("recipes", """
-        {
-          "recipe_1": {
-            "Name": "Forge Iron Sword", "InternalName": "ForgeIronSword", "Skill": "Blacksmithing",
-            "Ingredients": [], "ResultItems": [ { "ItemCode": 1, "StackSize": 1 } ]
-          }
-        }
-        """);
 
         var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
 
@@ -102,18 +88,11 @@ public sealed class ReferenceDataServiceTreasureCrossLinkIndexTests : IDisposabl
         svc.Powers["BardMaxHealth"].Prefix.Should().BeNull();
 
         // ProfilesByPower = inverse of tsysprofiles (authoritative join → Confirmed edge).
+        // This is the only Treasure cross-link index #435 ships; the Item.TSysProfile /
+        // recipe legs were deferred to #214 (the in-scope chain was near-catalog-granular
+        // via the "All" pool — see PowerDetailViewModel remarks).
         svc.ProfilesByPower["SwordBoost"].Should().BeEquivalentTo(new[] { "Sword" });
         svc.ProfilesByPower["BardMaxHealth"].Should().BeEquivalentTo(new[] { "Sword", "Chest" });
-
-        // ItemsByTSysProfile = items whose TSysProfile names the profile.
-        svc.ItemsByTSysProfile.Should().ContainKey("Sword");
-        svc.ItemsByTSysProfile["Sword"].Should().Contain("IronSword");
-        svc.ItemsByTSysProfile.Should().NotContainKey("Chest", "no item declares TSysProfile=Chest");
-
-        // Power → Recipe provenance chain end-to-end: SwordBoost ∈ Sword pool;
-        // IronSword.TSysProfile=Sword; ForgeIronSword produces IronSword.
-        svc.RecipesByProducedItem["IronSword"].Should().ContainSingle()
-            .Which.InternalName.Should().Be("ForgeIronSword");
     }
 
     private sealed class ThrowingHandler(string message) : HttpMessageHandler

--- a/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceTreasureCrossLinkIndexTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/ReferenceDataServiceTreasureCrossLinkIndexTests.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using System.Net.Http;
+using FluentAssertions;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Reference;
+
+/// <summary>
+/// #435: verifies the Treasure-System data layer — <see cref="PowerEntry.Prefix"/> /
+/// <see cref="PowerEntry.EnvelopeKey"/> capture and the
+/// <see cref="IReferenceDataService.ProfilesByPower"/> /
+/// <see cref="IReferenceDataService.ItemsByTSysProfile"/> reverse-view indices — built
+/// against real tsysclientinfo / tsysprofiles / items fixtures through the bundled-load
+/// plumbing (canonical pattern: <see cref="ReferenceDataServiceRecipeCrossLinkIndexTests"/>).
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class ReferenceDataServiceTreasureCrossLinkIndexTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _cacheDir;
+    private readonly string _bundledDir;
+
+    public ReferenceDataServiceTreasureCrossLinkIndexTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("mithril-treasure-crosslink-tests");
+        _cacheDir = Path.Combine(_root, "cache");
+        _bundledDir = Path.Combine(_root, "bundled");
+        Directory.CreateDirectory(_cacheDir);
+        Directory.CreateDirectory(_bundledDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static HttpClient NeverCallHttp() =>
+        new(new ThrowingHandler("HTTP must not be called in this test"));
+
+    private void Write(string name, string json)
+    {
+        File.WriteAllText(Path.Combine(_bundledDir, $"{name}.json"), json);
+        File.WriteAllText(Path.Combine(_bundledDir, $"{name}.meta.json"), "{\"cdnVersion\":\"v1\",\"source\":0}");
+    }
+
+    [Fact]
+    public void Power_CapturesPrefixAndEnvelopeKey_AndProfileReverseIndicesBuild()
+    {
+        Write("tsysclientinfo", """
+        {
+          "power_1001": {
+            "InternalName": "SwordBoost",
+            "Prefix": "Swordsman's",
+            "Suffix": "of Swordsmanship",
+            "Skill": "Sword",
+            "Slots": ["Head", "MainHand"],
+            "Tiers": {
+              "id_1": { "EffectDescs": ["{BOOST_SKILL_SWORD}{5}"], "MaxLevel": 20, "MinLevel": 1, "MinRarity": "Uncommon", "SkillLevelPrereq": 1 }
+            }
+          },
+          "power_1002": {
+            "InternalName": "BardMaxHealth",
+            "Suffix": "of the Bard",
+            "Skill": "Bard",
+            "Slots": ["Chest"],
+            "Tiers": {
+              "id_1": { "EffectDescs": ["{MAX_HEALTH}{10}"], "MaxLevel": 40, "MinLevel": 1, "MinRarity": "Uncommon", "SkillLevelPrereq": 1 }
+            }
+          }
+        }
+        """);
+        Write("tsysprofiles", """
+        { "Sword": ["SwordBoost", "BardMaxHealth"], "Chest": ["BardMaxHealth"] }
+        """);
+        Write("items", """
+        {
+          "item_1": { "Name": "Iron Sword", "InternalName": "IronSword", "TSysProfile": "Sword" },
+          "item_2": { "Name": "Plain Boots", "InternalName": "PlainBoots" }
+        }
+        """);
+        Write("recipes", """
+        {
+          "recipe_1": {
+            "Name": "Forge Iron Sword", "InternalName": "ForgeIronSword", "Skill": "Blacksmithing",
+            "Ingredients": [], "ResultItems": [ { "ItemCode": 1, "StackSize": 1 } ]
+          }
+        }
+        """);
+
+        var svc = new ReferenceDataService(_cacheDir, NeverCallHttp(), bundledDir: _bundledDir);
+
+        // PowerEntry now carries the affix prefix + the power_NNNN envelope key.
+        svc.Powers.Should().ContainKey("SwordBoost");
+        var sword = svc.Powers["SwordBoost"];
+        sword.Prefix.Should().Be("Swordsman's");
+        sword.Suffix.Should().Be("of Swordsmanship");
+        sword.EnvelopeKey.Should().Be("power_1001");
+
+        // Prefix-absent power: Prefix null (only-present-parts affix rule downstream).
+        svc.Powers["BardMaxHealth"].Prefix.Should().BeNull();
+
+        // ProfilesByPower = inverse of tsysprofiles (authoritative join → Confirmed edge).
+        svc.ProfilesByPower["SwordBoost"].Should().BeEquivalentTo(new[] { "Sword" });
+        svc.ProfilesByPower["BardMaxHealth"].Should().BeEquivalentTo(new[] { "Sword", "Chest" });
+
+        // ItemsByTSysProfile = items whose TSysProfile names the profile.
+        svc.ItemsByTSysProfile.Should().ContainKey("Sword");
+        svc.ItemsByTSysProfile["Sword"].Should().Contain("IronSword");
+        svc.ItemsByTSysProfile.Should().NotContainKey("Chest", "no item declares TSysProfile=Chest");
+
+        // Power → Recipe provenance chain end-to-end: SwordBoost ∈ Sword pool;
+        // IronSword.TSysProfile=Sword; ForgeIronSword produces IronSword.
+        svc.RecipesByProducedItem["IronSword"].Should().ContainSingle()
+            .Which.InternalName.Should().Be("ForgeIronSword");
+    }
+
+    private sealed class ThrowingHandler(string message) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException(message);
+    }
+}

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionDeepLinkHandlerTests.cs
@@ -90,6 +90,25 @@ public sealed class SilmarillionDeepLinkHandlerTests
         nav.LastOpened.Should().Be(EntityRef.StorageVault(expectedName));
     }
 
+    [Theory]
+    [InlineData("power/SwordBoost", EntityKind.Power, "SwordBoost")]
+    [InlineData("Power/SwordBoost", EntityKind.Power, "SwordBoost")]
+    [InlineData("profile/Sword", EntityKind.Profile, "Sword")]
+    [InlineData("PROFILE/MainHandAugment", EntityKind.Profile, "MainHandAugment")]
+    public void TryHandle_TreasureKinds_Dispatch(string subPath, EntityKind kind, string name)
+    {
+        // #214 deep-link scope: the Treasure System kinds route via the generic
+        // Enum.TryParse<EntityKind> dispatch (Power-select / pool-query) — no handler
+        // change needed once the enum values exist. Locks the route in place.
+        Enum.TryParse<EntityKind>(kind.ToString(), ignoreCase: true, out _).Should().BeTrue();
+
+        var nav = new PermissiveNavigator();
+        var handler = new SilmarillionDeepLinkHandler(nav);
+
+        handler.TryHandle(subPath, diag: null).Should().BeTrue();
+        nav.LastOpened.Should().Be(new EntityRef(kind, name));
+    }
+
     [Fact]
     public void DeepLinkRouter_UrlEncodedStar_DecodesAndDispatchesToStorageVault()
     {

--- a/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/SilmarillionReferenceNavigatorTests.cs
@@ -156,6 +156,8 @@ public sealed class SilmarillionReferenceNavigatorTests
     [InlineData(EntityKind.PlayerTitle)]
     [InlineData(EntityKind.StorageVault)]
     [InlineData(EntityKind.Effect)]
+    [InlineData(EntityKind.Power)]
+    [InlineData(EntityKind.Profile)]
     public void CanOpen_UnregisteredKind_ReturnsFalse(EntityKind kind)
     {
         var nav = new SilmarillionReferenceNavigator(NavTargets());

--- a/tests/Silmarillion.Tests/Navigation/TreasureKindTargetTests.cs
+++ b/tests/Silmarillion.Tests/Navigation/TreasureKindTargetTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using FluentAssertions;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.Navigation;
+
+public sealed class TreasureKindTargetTests
+{
+    private static (PowerKindTarget Power, ProfileKindTarget Profile, TreasureTabViewModel Vm) Build()
+    {
+        var d = new TreasureFakeReferenceData();
+        d.AddSkill("Sword", "Sword");
+        d.AddPower(new PowerEntry("SwordBoost", "Sword", new[] { "Head" }, "of Swordsmanship",
+            new Dictionary<int, PowerTier> { [1] = new PowerTier(1, new[] { "{BOOST_SKILL_SWORD}{5}" }, 20, MinLevel: 1, MinRarity: "Uncommon", SkillLevelPrereq: 1) },
+            Prefix: "Swordsman's", EnvelopeKey: "power_1001"));
+        d.AddProfile("Sword", "SwordBoost");
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new TreasureTabViewModel(d, nav, new ReferenceDataEntityNameResolver(d));
+        return (new PowerKindTarget(vm), new ProfileKindTarget(vm), vm);
+    }
+
+    [Fact]
+    public void Kinds_ArePowerAndProfile_BothTabIndexTen()
+    {
+        var (power, profile, _) = Build();
+        power.Kind.Should().Be(EntityKind.Power);
+        profile.Kind.Should().Be(EntityKind.Profile);
+        power.TabIndex.Should().Be(10);
+        profile.TabIndex.Should().Be(10);
+    }
+
+    [Fact]
+    public void PowerKindTarget_SelectsPowerRow_BuildsPowerDetail()
+    {
+        var (power, _, vm) = Build();
+
+        power.TrySelectByInternalName("SwordBoost").Should().BeTrue();
+
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRow!.Kind.Should().Be(TreasureRowKind.Power);
+        vm.SelectedRow.InternalName.Should().Be("SwordBoost");
+        vm.DetailViewModel.Should().BeOfType<PowerDetailViewModel>();
+    }
+
+    [Fact]
+    public void ProfileKindTarget_SelectsProfileRow_BuildsProfileDetail()
+    {
+        var (_, profile, vm) = Build();
+
+        profile.TrySelectByInternalName("Sword").Should().BeTrue();
+
+        vm.SelectedRow!.Kind.Should().Be(TreasureRowKind.Profile);
+        vm.DetailViewModel.Should().BeOfType<ProfileDetailViewModel>();
+    }
+
+    [Fact]
+    public void PowerKindTarget_DoesNotMatchProfileOfSameName()
+    {
+        // A profile named "Sword" must not be picked up by the Power kind target — the
+        // Kind discriminator keeps the two namespaces separate in the unified list.
+        var (power, _, vm) = Build();
+        power.TrySelectByInternalName("Sword").Should().BeFalse();
+        vm.SelectedRow.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySelect_Unknown_ReturnsFalse_VmUnchanged()
+    {
+        var (power, profile, vm) = Build();
+        power.TrySelectByInternalName("Nope").Should().BeFalse();
+        profile.TrySelectByInternalName("Nope").Should().BeFalse();
+        vm.SelectedRow.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySelect_ClearsResidualQueryText()
+    {
+        var (power, _, vm) = Build();
+        vm.QueryText = "KindLabel = 'Power'";
+
+        power.TrySelectByInternalName("SwordBoost").Should().BeTrue();
+
+        vm.QueryText.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryOpenInWindow_NoDetail_ReturnsFalse()
+    {
+        var (power, profile, _) = Build();
+        power.TryOpenInWindow().Should().BeFalse();
+        profile.TryOpenInWindow().Should().BeFalse();
+    }
+}

--- a/tests/Silmarillion.Tests/TreasureFakeReferenceData.cs
+++ b/tests/Silmarillion.Tests/TreasureFakeReferenceData.cs
@@ -21,8 +21,6 @@ public sealed class TreasureFakeReferenceData : IReferenceDataService
     private readonly Dictionary<string, PowerEntry> _powers = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IReadOnlyList<string>> _profiles = new(StringComparer.Ordinal);
     private readonly Dictionary<string, IReadOnlyList<string>> _profilesByPower = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, IReadOnlyList<string>> _itemsByProfile = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, IReadOnlyList<Recipe>> _recipesByItem = new(StringComparer.Ordinal);
     private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
 
     public void AddPower(PowerEntry power) => _powers[power.InternalName] = power;
@@ -45,20 +43,13 @@ public sealed class TreasureFakeReferenceData : IReferenceDataService
         }
     }
 
-    public void AddItemsForProfile(string profile, params string[] itemInternalNames) =>
-        _itemsByProfile[profile] = itemInternalNames;
-
-    public void AddRecipesProducing(string itemInternalName, params Recipe[] recipes) =>
-        _recipesByItem[itemInternalName] = recipes;
-
     public void RaiseFileUpdated(string key) => FileUpdated?.Invoke(this, key);
 
-    // ── Treasure surface ──────────────────────────────────────────────────────
+    // ── Treasure surface (#435: Pools = ProfilesByPower; the recipe leg was
+    //     deferred to #214, so no ItemsByTSysProfile / RecipesByProducedItem here). ──
     public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;
     public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
     public IReadOnlyDictionary<string, IReadOnlyList<string>> ProfilesByPower => _profilesByPower;
-    public IReadOnlyDictionary<string, IReadOnlyList<string>> ItemsByTSysProfile => _itemsByProfile;
-    public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesByProducedItem => _recipesByItem;
     public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
 
     // ── Required interface members (minimal, mirrors AbilityKindTargetTests' fake) ──

--- a/tests/Silmarillion.Tests/TreasureFakeReferenceData.cs
+++ b/tests/Silmarillion.Tests/TreasureFakeReferenceData.cs
@@ -1,0 +1,88 @@
+using Mithril.Reference.Models.Abilities;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Npcs;
+using Mithril.Reference.Models.Quests;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+
+namespace Silmarillion.Tests;
+
+/// <summary>
+/// Hand fake of <see cref="IReferenceDataService"/> for the Treasure tab tests
+/// (#435). Implements only the required (non-default) interface members plus the
+/// Treasure surface (<c>Powers</c> / <c>Profiles</c> / <c>ProfilesByPower</c> /
+/// <c>ItemsByTSysProfile</c> / <c>RecipesByProducedItem</c> / <c>Skills</c> /
+/// <c>Attributes</c>). The new reverse-view indices have interface-level
+/// <c>=&gt; Empty</c> defaults, so other modules' fakes are unaffected — but this
+/// fake supplies them so the detail VMs' pool/recipe cross-links resolve.
+/// </summary>
+public sealed class TreasureFakeReferenceData : IReferenceDataService
+{
+    private readonly Dictionary<string, PowerEntry> _powers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IReadOnlyList<string>> _profiles = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IReadOnlyList<string>> _profilesByPower = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IReadOnlyList<string>> _itemsByProfile = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IReadOnlyList<Recipe>> _recipesByItem = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.Ordinal);
+
+    public void AddPower(PowerEntry power) => _powers[power.InternalName] = power;
+
+    public void AddSkill(string key, string displayName) =>
+        _skills[key] = new SkillEntry(
+            Key: key, DisplayName: displayName, Id: 0, Combat: false, XpTable: "",
+            MaxBonusLevels: 0, Parents: Array.Empty<string>(),
+            Rewards: new Dictionary<string, SkillRewardEntry>());
+
+    /// <summary>Add a profile and (re)derive <see cref="ProfilesByPower"/> from it.</summary>
+    public void AddProfile(string name, params string[] powerNames)
+    {
+        _profiles[name] = powerNames;
+        foreach (var p in powerNames)
+        {
+            var existing = _profilesByPower.TryGetValue(p, out var l) ? new List<string>(l) : new List<string>();
+            if (!existing.Contains(name)) existing.Add(name);
+            _profilesByPower[p] = existing;
+        }
+    }
+
+    public void AddItemsForProfile(string profile, params string[] itemInternalNames) =>
+        _itemsByProfile[profile] = itemInternalNames;
+
+    public void AddRecipesProducing(string itemInternalName, params Recipe[] recipes) =>
+        _recipesByItem[itemInternalName] = recipes;
+
+    public void RaiseFileUpdated(string key) => FileUpdated?.Invoke(this, key);
+
+    // ── Treasure surface ──────────────────────────────────────────────────────
+    public IReadOnlyDictionary<string, PowerEntry> Powers => _powers;
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles => _profiles;
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> ProfilesByPower => _profilesByPower;
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> ItemsByTSysProfile => _itemsByProfile;
+    public IReadOnlyDictionary<string, IReadOnlyList<Recipe>> RecipesByProducedItem => _recipesByItem;
+    public IReadOnlyDictionary<string, SkillEntry> Skills => _skills;
+
+    // ── Required interface members (minimal, mirrors AbilityKindTargetTests' fake) ──
+    public IReadOnlyList<string> Keys => Array.Empty<string>();
+    public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+    public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>(StringComparer.Ordinal);
+    public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+    public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+    public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+    public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+    public IReadOnlyDictionary<string, Npc> NpcsByInternalName { get; } = new Dictionary<string, Npc>();
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+    public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+    public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+    public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>();
+    public IReadOnlyDictionary<string, Ability> Abilities { get; } = new Dictionary<string, Ability>();
+    public IReadOnlyDictionary<string, Ability> AbilitiesByInternalName { get; } = new Dictionary<string, Ability>();
+
+    public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "test", null, 0);
+    public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public void BeginBackgroundRefresh() { }
+    public event EventHandler<string>? FileUpdated;
+}

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -507,6 +507,61 @@ public sealed class ItemsTabViewModelTests
         }
     }
 
+    [Fact]
+    public void TreasureProfile_ItemWithTSysProfile_ProfileKindRegistered_NavigableChip()
+    {
+        // #435 audit-existing-surfaces: shipping EntityKind.Profile must light up the
+        // Item.TSysProfile → Profile 1:1 cross-link on the (shared) item detail.
+        var sword = new Item { Id = 1, InternalName = "BattleHardenedSword", Name = "Battle-Hardened Sword", TSysProfile = "Sword" };
+        var refData = new StubReferenceData { ItemsByName = { ["BattleHardenedSword"] = sword } };
+        var vm = new ItemsTabViewModel(refData, new SilmarillionReferenceNavigator(
+            new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Profile) }),
+            new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedItem = sword;
+
+        var chip = vm.DetailViewModel!.TreasureProfile;
+        chip.Should().NotBeNull();
+        chip!.Reference.Should().Be(EntityRef.Profile("Sword"));
+        chip.DisplayName.Should().Be("Sword", "Profile resolves to the bare pool name");
+        chip.IsNavigable.Should().BeTrue("the Profile kind target is registered");
+        vm.DetailViewModel.TreasureProfileLink.Should().NotBeNull();
+        vm.DetailViewModel.TreasureProfileLink!.Glyph.Should().Be(LinkGlyph.Pool);
+    }
+
+    [Fact]
+    public void TreasureProfile_ProfileKindUnregistered_ChipDegradesNotNull()
+    {
+        // G-c: when the Treasure tab isn't shipped the chip still renders (plain text),
+        // it does not vanish — IsNavigable false, but the link is present.
+        var sword = new Item { Id = 1, InternalName = "BattleHardenedSword", Name = "Battle-Hardened Sword", TSysProfile = "Sword" };
+        var refData = new StubReferenceData { ItemsByName = { ["BattleHardenedSword"] = sword } };
+        var vm = new ItemsTabViewModel(refData,
+            new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedItem = sword;
+
+        vm.DetailViewModel!.TreasureProfile.Should().NotBeNull();
+        vm.DetailViewModel.TreasureProfile!.IsNavigable.Should().BeFalse();
+        vm.DetailViewModel.TreasureProfileLink.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void TreasureProfile_ItemWithoutTSysProfile_ChipNull_SectionHidden()
+    {
+        var plain = new Item { Id = 1, InternalName = "PlainBoots", Name = "Plain Boots" };
+        var refData = new StubReferenceData { ItemsByName = { ["PlainBoots"] = plain } };
+        var vm = new ItemsTabViewModel(refData,
+            new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedItem = plain;
+
+        vm.DetailViewModel!.TreasureProfile.Should().BeNull();
+        vm.DetailViewModel.TreasureProfileLink.Should().BeNull();
+    }
+
     private static SilmarillionReferenceNavigator NavWithRecipe() =>
         new(new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Recipe) });
 

--- a/tests/Silmarillion.Tests/ViewModels/TreasureTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/TreasureTabViewModelTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using FluentAssertions;
-using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
 using Silmarillion.Navigation;
 using Silmarillion.ViewModels;
@@ -52,9 +51,6 @@ public sealed class TreasureTabViewModelTests
             Prefix: null, EnvelopeKey: "power_1002"));
         d.AddProfile("Sword", "SwordBoost", "BardMaxHealth");
         d.AddProfile("Chest", "BardMaxHealth");
-        d.AddItemsForProfile("Sword", "IronSword");
-        d.AddRecipesProducing("IronSword",
-            new Recipe { InternalName = "ForgeIronSword", Name = "Forge Iron Sword", Ingredients = [] });
         return d;
     }
 
@@ -95,12 +91,9 @@ public sealed class TreasureTabViewModelTests
         detail.PoolLinks.Should().OnlyContain(l => l.IsNavigable && l.Glyph == Mithril.Shared.Wpf.LinkGlyph.Pool);
         detail.PoolLinks.Should().OnlyContain(l => !l.IsUnconfirmed, "G-d does not apply to authoritative joins");
 
-        // Recipes that can roll it: SwordBoost ∈ Sword pool → IronSword (TSysProfile=Sword)
-        // → ForgeIronSword. One section ⇒ flat popup.
-        detail.HasRecipes.Should().BeTrue();
-        detail.RecipeChipCount.Should().Be(1);
-        detail.RecipesPopup!.IsFlat.Should().BeTrue();
-        detail.RecipesPopup.FlatChips.Single().Reference.Should().Be(EntityRef.Recipe("ForgeIronSword"));
+        // No recipes surface: the recipe↔power leg is deferred to #214 (the only
+        // in-scope chain was near-catalog-granular via the "All" pool). The VM
+        // exposes no recipes member at all — verified at compile time by this file.
 
         // Footer: copyable KEY (= title) + inert ROW (power_NNNN).
         detail.Footer.Ids.Should().HaveCount(2);

--- a/tests/Silmarillion.Tests/ViewModels/TreasureTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/TreasureTabViewModelTests.cs
@@ -1,0 +1,189 @@
+using System.Linq;
+using FluentAssertions;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Silmarillion.Navigation;
+using Silmarillion.ViewModels;
+using Xunit;
+
+namespace Silmarillion.Tests.ViewModels;
+
+file static class NavFactory
+{
+    public static SilmarillionReferenceNavigator WithKinds(params EntityKind[] kinds) =>
+        new SilmarillionReferenceNavigator(kinds.Select(k => (IReferenceKindTarget)new StubKindTarget(k)));
+
+    private sealed class StubKindTarget : IReferenceKindTarget
+    {
+        public StubKindTarget(EntityKind kind) => Kind = kind;
+        public EntityKind Kind { get; }
+        public int TabIndex => 10;
+        public bool TrySelectByInternalName(string internalName) => true;
+        public bool TryOpenInWindow() => false;
+    }
+}
+
+public sealed class TreasureTabViewModelTests
+{
+    private static PowerEntry SwordBoost() => new(
+        InternalName: "SwordBoost",
+        Skill: "Sword",
+        Slots: new[] { "Head", "MainHand" },
+        Suffix: "of Swordsmanship",
+        Tiers: new Dictionary<int, PowerTier>
+        {
+            // Prose row with an inline icon marker — exercises the Q6 path:
+            // EffectDescsRenderer lifts <icon=N> to EffectLine.IconId and strips it from
+            // the (copy-safe) text, with no attribute registry needed.
+            [1] = new PowerTier(1, new[] { "<icon=108>Sword abilities deal +3% damage" }, 20, MinLevel: 1, MinRarity: "Uncommon", SkillLevelPrereq: 1),
+            [2] = new PowerTier(2, new[] { "<icon=108>Sword abilities deal +6% damage" }, 40, MinLevel: 15, MinRarity: "Uncommon", SkillLevelPrereq: 15),
+        },
+        Prefix: "Swordsman's",
+        EnvelopeKey: "power_1001");
+
+    private static TreasureFakeReferenceData Data()
+    {
+        var d = new TreasureFakeReferenceData();
+        d.AddSkill("Sword", "Sword");
+        d.AddSkill("Bard", "Bard");
+        d.AddPower(SwordBoost());
+        d.AddPower(new PowerEntry("BardMaxHealth", "Bard", new[] { "Chest" }, "of the Bard",
+            new Dictionary<int, PowerTier> { [1] = new PowerTier(1, new[] { "{MAX_HEALTH}{10}" }, 40, MinLevel: 1, MinRarity: "Uncommon", SkillLevelPrereq: 1) },
+            Prefix: null, EnvelopeKey: "power_1002"));
+        d.AddProfile("Sword", "SwordBoost", "BardMaxHealth");
+        d.AddProfile("Chest", "BardMaxHealth");
+        d.AddItemsForProfile("Sword", "IronSword");
+        d.AddRecipesProducing("IronSword",
+            new Recipe { InternalName = "ForgeIronSword", Name = "Forge Iron Sword", Ingredients = [] });
+        return d;
+    }
+
+    private static TreasureTabViewModel Vm(TreasureFakeReferenceData d) =>
+        new(d, NavFactory.WithKinds(EntityKind.Power, EntityKind.Profile, EntityKind.Recipe),
+            new ReferenceDataEntityNameResolver(d));
+
+    [Fact]
+    public void AllRows_ContainsProfilesThenPowers()
+    {
+        var vm = Vm(Data());
+
+        vm.AllRows.Should().HaveCount(4); // 2 profiles + 2 powers
+        vm.AllRows.Take(2).Should().OnlyContain(r => r.Kind == TreasureRowKind.Profile);
+        vm.AllRows.Skip(2).Should().OnlyContain(r => r.Kind == TreasureRowKind.Power);
+        vm.AllRows.Single(r => r.Kind == TreasureRowKind.Power && r.InternalName == "SwordBoost")
+            .Name.Should().Be("SwordBoost", "Q1 — InternalName verbatim, no humanization");
+    }
+
+    [Fact]
+    public void SelectingPowerRow_BuildsPowerDetail_VerbatimTitle_AffixIllustrative_PoolsConfirmed()
+    {
+        var vm = Vm(Data());
+
+        vm.SelectedRow = vm.AllRows.Single(r => r.Kind == TreasureRowKind.Power && r.InternalName == "SwordBoost");
+
+        var detail = vm.DetailViewModel.Should().BeOfType<PowerDetailViewModel>().Subject;
+        detail.DisplayName.Should().Be("SwordBoost");
+        detail.HasAffix.Should().BeTrue();
+        detail.AffixIllustration.Should().Contain("Swordsman's")
+            .And.Contain("of Swordsmanship")
+            .And.Contain("illustrative, not the canonical name");
+        // Both affixes present ⇒ the «item» slot is an ellipsis placeholder, never a name.
+        detail.AffixIllustration.Should().Contain("…");
+
+        // Pools containing SwordBoost — Confirmed Links (authoritative tsysprofiles join).
+        detail.PoolLinks.Select(l => l.Reference!.InternalName).Should().BeEquivalentTo(new[] { "Sword" });
+        detail.PoolLinks.Should().OnlyContain(l => l.IsNavigable && l.Glyph == Mithril.Shared.Wpf.LinkGlyph.Pool);
+        detail.PoolLinks.Should().OnlyContain(l => !l.IsUnconfirmed, "G-d does not apply to authoritative joins");
+
+        // Recipes that can roll it: SwordBoost ∈ Sword pool → IronSword (TSysProfile=Sword)
+        // → ForgeIronSword. One section ⇒ flat popup.
+        detail.HasRecipes.Should().BeTrue();
+        detail.RecipeChipCount.Should().Be(1);
+        detail.RecipesPopup!.IsFlat.Should().BeTrue();
+        detail.RecipesPopup.FlatChips.Single().Reference.Should().Be(EntityRef.Recipe("ForgeIronSword"));
+
+        // Footer: copyable KEY (= title) + inert ROW (power_NNNN).
+        detail.Footer.Ids.Should().HaveCount(2);
+        detail.Footer.Ids[0].LabelTag.Should().Be("KEY");
+        detail.Footer.Ids[0].Value.Should().Be("SwordBoost");
+        detail.Footer.Ids[0].Copyable.Should().BeTrue();
+        detail.Footer.Ids[1].LabelTag.Should().Be("ROW");
+        detail.Footer.Ids[1].Value.Should().Be("power_1001");
+        detail.Footer.Ids[1].Copyable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PowerDetail_TierLadder_TwoTiers_RendersGrid_WithBandGeometry()
+    {
+        var vm = Vm(Data());
+        vm.SelectedRow = vm.AllRows.Single(r => r.Kind == TreasureRowKind.Power && r.InternalName == "SwordBoost");
+        var ladder = ((PowerDetailViewModel)vm.DetailViewModel!).TierLadder!;
+
+        ladder.IsGrid.Should().BeTrue("N=2 ⇒ the full grid shape");
+        ladder.Rows.Should().HaveCount(2);
+        ladder.Rows[0].Ordinal.Should().Be("01");
+        ladder.Rows[0].LevelText.Should().Be("1–20");
+        ladder.Rows[0].SkillPrereqText.Should().Be("Sword 1");
+        ladder.Rows.Should().OnlyContain(r => r.RarityDimmed, "constant Uncommon ⇒ dimmed in place (Q2 Option A)");
+        ladder.Rows.Should().OnlyContain(r => !r.IsAboveBaseRarity, "all Uncommon ⇒ no Rare weight");
+        ladder.Rows.Should().OnlyContain(r => r.BandWidthPx > 0 && r.BandWidthPx <= TreasureTierLadderVm.TrackWidth);
+
+        // Q6: <icon=N> lifted to EffectLine.IconId; marker stripped from copy-safe text.
+        var line = ladder.Rows[0].EffectLines.Should().ContainSingle().Subject;
+        line.IconId.Should().Be(108);
+        line.Text.Should().Be("Sword abilities deal +3% damage").And.NotContain("<icon=");
+    }
+
+    [Fact]
+    public void PowerDetail_AffixPrefixOnly_OmitsSuffix()
+    {
+        var d = new TreasureFakeReferenceData();
+        d.AddSkill("Sword", "Sword");
+        d.AddPower(new PowerEntry("PrefixOnly", "Sword", new[] { "Head" }, Suffix: null,
+            new Dictionary<int, PowerTier> { [1] = new PowerTier(1, new[] { "{BOOST_SKILL_SWORD}{1}" }, 10, MinLevel: 1, MinRarity: "Uncommon", SkillLevelPrereq: 1) },
+            Prefix: "Mighty", EnvelopeKey: "power_9"));
+        var vm = Vm(d);
+
+        vm.SelectedRow = vm.AllRows.Single(r => r.Kind == TreasureRowKind.Power);
+        var detail = (PowerDetailViewModel)vm.DetailViewModel!;
+
+        detail.AffixIllustration.Should().Contain("Mighty");
+        detail.AffixIllustration.Should().NotContain(" of ", "suffix is absent — render only present parts");
+    }
+
+    [Fact]
+    public void SelectingProfileRow_BuildsProfileDetail_FilterableBySkill()
+    {
+        var vm = Vm(Data());
+
+        vm.SelectedRow = vm.AllRows.Single(r => r.Kind == TreasureRowKind.Profile && r.InternalName == "Sword");
+
+        var detail = vm.DetailViewModel.Should().BeOfType<ProfileDetailViewModel>().Subject;
+        detail.DisplayName.Should().Be("Sword");
+        detail.Explanation.Should().Contain("equipment family")
+            .And.Contain("not the contained powers' own skills");
+        detail.PowerCount.Should().Be(2);
+        detail.VisiblePowerRows.Should().HaveCount(2);
+        detail.SkillFilters.Select(f => f.SetRef.Label).Should().BeEquivalentTo(new[] { "Bard", "Sword" });
+
+        // Click the "Bard" filter → only BardMaxHealth survives.
+        detail.SkillFilters.Single(f => f.SetRef.Label == "Bard").Activate.Execute(null);
+        detail.VisiblePowerRows.Should().ContainSingle()
+            .Which.PowerInternalName.Should().Be("BardMaxHealth");
+        detail.CountSummary.Should().Be("1 of 2 powers");
+    }
+
+    [Fact]
+    public void FileUpdated_Tsysclientinfo_RebuildsList_PreservesSelection()
+    {
+        var d = Data();
+        var vm = Vm(d);
+        vm.SelectedRow = vm.AllRows.Single(r => r.Kind == TreasureRowKind.Power && r.InternalName == "SwordBoost");
+
+        d.RaiseFileUpdated("tsysclientinfo");
+
+        vm.SelectedRow.Should().NotBeNull();
+        vm.SelectedRow!.InternalName.Should().Be("SwordBoost");
+        vm.DetailViewModel.Should().BeOfType<PowerDetailViewModel>();
+    }
+}

--- a/tests/Silmarillion.Tests/ViewModels/TreasureTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/TreasureTabViewModelTests.cs
@@ -168,9 +168,11 @@ public sealed class TreasureTabViewModelTests
 
         // Click the "Bard" filter → only BardMaxHealth survives.
         detail.SkillFilters.Single(f => f.SetRef.Label == "Bard").Activate.Execute(null);
+        detail.QueryText.Should().Be("Skill = \"Bard\"", "the skill chip injects a real query clause");
         detail.VisiblePowerRows.Should().ContainSingle()
-            .Which.PowerInternalName.Should().Be("BardMaxHealth");
+            .Which.InternalName.Should().Be("BardMaxHealth");
         detail.CountSummary.Should().Be("1 of 2 powers");
+        detail.QueryError.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Implements **#435** — the detail-view portion of #412 (Treasure System tab), per the owner-ratified V1 design (#433 brief + #434 gate directive). The V1 HTML stays bundle-only; the ratified spec is lifted into the repo.

## Shipped

**Task 1 — ratified spec lifted** to `docs/agent-plans/2026-05-18-silmarillion-412-treasure-detail-ratified-spec.md` (spec card, cross-link rationale, Q1/Q3/Q4/Q5 rulings, closed Q2/Q6 gates) + an **Implementation amendment** recording the recipe-leg deferral (below).

**Data layer.** `PowerEntry` gains `Prefix` + `EnvelopeKey`. New `IReferenceDataService.ProfilesByPower` (interface-default empty → non-rippling), rebuilt off `tsysprofiles`. `EntityKind.Power`/`Profile` + `EntityRef` factories + verbatim resolver arms (Q1). `LinkGlyph.Pool`(`layers`)/`.Power`(`zap`).

**Power detail** (shipped grammar primitives): Fact-title = `InternalName` verbatim (Q1); illustrative affix Fact-body, present parts only; Confirmed `sparkles` Skill Link; tag-form Slot Set-refs; the CF#3 Tiers ladder (N=0/1/≥2 polymorphism, overlapping-band micro-chart, Rare = info-blue weight not gold, constant rarity dimmed in place); Confirmed `layers` Pool Links; G-a footer (copyable KEY = title kept deliberately, inert ROW).

**Profile detail**: two-orthogonal-axes copy, Skill-shaped family Link, **shared query system** (`MithrilQueryBox` + `QueryCompiler` over a reflected schema, mirroring Celebrimbor's `AugmentPoolViewModel`) with Skill-chip clause shortcuts, virtualized navigable pool list (height-bound so VSP actually recycles).

**Item → Treasure pool cross-link**: `Item.TSysProfile` → `EntityRef.Profile` 1:1 `EntityChip` on the shared item detail (the cookbook "audit existing surfaces" obligation for the new kind; `CanOpen`-gated, degrades in non-Silmarillion contexts).

Hard constraints honoured: no roll-resolution UI, crystal-free, `TreasureCartography` excluded.

## Deferred to #214 (verified, not punted)

The ratified `Power → Recipes` popup was **verified data-invalid for the in-scope index** against live v470 and removed: `RecipesByProducedItem` only indexes by `ResultItems`/`ProtoResultItems`; TSysProfile-bearing recipe-produced items are almost all `Crafted*` gear on the catch-all `"All"` pool (≈ the whole power catalogue), so the chain resolved to the same enormous enchanted-gear recipe list for nearly every power — presenting it as power-specific implies precision the data lacks (correctness-adjacent to the roll-resolution ban). The power-precise join is recipe `ResultEffects` (`AddItemTSysPower`/`ExtractTSysPower`/`TSysCraftedEquipment`) via `ResultEffectsParser` — the **#214** surface (#433 Carry-forward #2 bound recipe-side to #214). Q4/Q5 remain the ratified contract for when #214 ships the precise index.

## Verification

- `dotnet build Mithril.slnx` clean (incl. `XamlResourceLint`).
- `dotnet test Mithril.slnx` green — full solution, **0 failures**, no regressions in `IReferenceDataService` consumers (shared `ItemDetailViewModel` change is additive; Celebrimbor's `QueryCompiler` precedent unaffected).
- Data shapes (affix polymorphism, `Item.TSysProfile` ↔ `tsysprofiles` keys, the recipe-leg invalidity) verified against **live v470**.

## Related

#412 · #214 (recipe-side ResultEffects — now carries the deferred recipe↔power leg) · #404 (Q2/Q6 closed) · #436 (post-ship Q2 revisit) · #54 · #433/#434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
