### PR TITLE
fix(reference): #438 — AsBuffMod is additive delta, not a multiplier

### DIFF
--- a/src/Mithril.Shared/Reference/EffectDescsRenderer.cs
+++ b/src/Mithril.Shared/Reference/EffectDescsRenderer.cs
@@ -68,9 +68,10 @@ public static class EffectDescsRenderer
 
         if (!ShouldRender(attr, value)) return false;
 
-        // AsBuffMod expects DefaultValue=1; combined with DefaultValue=0 it's an upstream-data
-        // anomaly — 39 tokens in attributes.json (all "Chance to..." probability bonuses).
-        // Treat as additive AsPercent. See issue #278.
+        // The 39 DefaultValue=0 AsBuffMod tokens (all "Chance to..." probability bonuses,
+        // issue #278) stay routed to AsPercent purely for its unsigned "15%" form — reads
+        // better than the signed "+15%" AsBuffMod now produces (#438). The value math is
+        // identical (value * 100) post-#438; this remap is now sign-only.
         var effectiveDisplayType = attr.DisplayType == "AsBuffMod" && attr.DefaultValue is double dv && dv == 0
             ? "AsPercent"
             : attr.DisplayType;
@@ -96,8 +97,12 @@ public static class EffectDescsRenderer
     {
         "AsInt" => ((int)Math.Round(value, MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture),
         "AsBuffDelta" => value.ToString("+0;-0;0", CultureInfo.InvariantCulture),
-        // Multiplier semantics: 1.08 → +8%.
-        "AsBuffMod" => ((value - 1) * 100).ToString("+0.##;-0.##;0", CultureInfo.InvariantCulture) + "%",
+        // Additive-delta semantics (#438): bundled MOD_*/AsBuffMod data stores the bonus
+        // fraction directly (0.07 → +7%), never a 1.x multiplier — across 177 observed
+        // DefaultValue:1 tokens not one shows a multiplier distribution. The old
+        // (value - 1) * 100 reading inverted every damage augment (0.07 → -93%, climbing
+        // back toward 0 as the real bonus grew). Generalizes the #278 DV:0 remap.
+        "AsBuffMod" => (value * 100).ToString("+0.##;-0.##;0", CultureInfo.InvariantCulture) + "%",
         "AsPercent" => (value * 100).ToString("0.##", CultureInfo.InvariantCulture) + "%",
         "AsDoubleTimes100" => (value * 100).ToString("0.##", CultureInfo.InvariantCulture) + "%",
         _ => value.ToString("0.##", CultureInfo.InvariantCulture),

--- a/tests/Mithril.Shared.Tests/Reference/EffectDescsRendererTests.cs
+++ b/tests/Mithril.Shared.Tests/Reference/EffectDescsRendererTests.cs
@@ -46,12 +46,14 @@ public class EffectDescsRendererTests
     }
 
     [Fact]
-    public void AsBuffMod_InterpretsMultiplierAsSignedPercent()
+    public void AsBuffMod_RendersAdditiveDeltaAsSignedPercent_Issue438()
     {
+        // Real MOD_SKILL_ALL_KNIFE data is 0.03–0.14 (a +3%–+14% delta), never a 1.x
+        // multiplier. The value is the bonus fraction itself: 0.08 → +8%.
         var registry = Registry(
             new AttributeEntry("MOD_SKILL_ALL_KNIFE", "Knife Damage %", "AsBuffMod", "IfNotDefault", 1, [108]));
 
-        var lines = EffectDescsRenderer.Render(["{MOD_SKILL_ALL_KNIFE}{1.08}"], registry);
+        var lines = EffectDescsRenderer.Render(["{MOD_SKILL_ALL_KNIFE}{0.08}"], registry);
 
         lines.Should().ContainSingle().Which.Text.Should().Be("+8% Knife Damage %");
     }
@@ -93,16 +95,20 @@ public class EffectDescsRendererTests
     }
 
     [Fact]
-    public void AsBuffMod_WithDefaultOne_StillUsesMultiplierSemantics_Issue278()
+    public void AsBuffMod_WithDefaultOne_IsAdditiveNotMultiplier_Issue438()
     {
-        // Negative control: a true AsBuffMod entry (DefaultValue:1) must keep multiplier math
-        // so the data-anomaly heuristic doesn't misfire on legitimate AsBuffMod tokens.
+        // Regression for the WerewolfTraumaBoost (power_6005) inversion: MOD_TRAUMA is
+        // AsBuffMod/IfNotDefault/DefaultValue:1 and its tsysclientinfo tiers run 0.07 (L5)
+        // → 0.92 (L125). The old (value-1)*100 multiplier reading rendered tier 1 as
+        // "-93%" and *weakened* toward "-8%" as the real boost grew. Additive: +7% → +92%.
         var registry = Registry(
-            new AttributeEntry("MOD_SKILL_ALL_KNIFE", "Knife Damage %", "AsBuffMod", "IfNotDefault", 1, [108]));
+            new AttributeEntry("MOD_TRAUMA", "Trauma Damage (Direct & Per-Tick) %", "AsBuffMod", "IfNotDefault", 1, [107]));
 
-        var lines = EffectDescsRenderer.Render(["{MOD_SKILL_ALL_KNIFE}{1.08}"], registry);
+        var low = EffectDescsRenderer.Render(["{MOD_TRAUMA}{0.07}"], registry);
+        var high = EffectDescsRenderer.Render(["{MOD_TRAUMA}{0.92}"], registry);
 
-        lines.Should().ContainSingle().Which.Text.Should().Be("+8% Knife Damage %");
+        low.Should().ContainSingle().Which.Text.Should().Be("+7% Trauma Damage (Direct & Per-Tick) %");
+        high.Should().ContainSingle().Which.Text.Should().Be("+92% Trauma Damage (Direct & Per-Tick) %");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #438.

## Problem

You flagged `WerewolfTraumaBoost` (`power_6005`) on the Silmarillion #412 Treasure System detail: a Trauma-damage *Boost* showing `-93%` at tier 1 and *weakening* to `-8%` at tier 25 as Lycanthropy level rises — an inverted, nonsensical curve.

## Root cause

`EffectDescsRenderer.FormatValue`'s `AsBuffMod` branch used multiplier semantics `(value − 1) × 100` (assuming `1.08 → +8%`). But the bundled `MOD_*`/`AsBuffMod` data stores the bonus **fraction directly** — `MOD_TRAUMA` tiers run `0.07` (L5) → `0.92` (L125). `(0.07 − 1) × 100 = −93%`.

Evidence the convention is uniformly additive, not bimodal:
- `items.json` `MOD_TRAUMA` 0.06–0.12, `MOD_NATURE` 0.02–0.24 — small positive deltas.
- 177 observed `DefaultValue:1` `AsBuffMod` tokens: 134 purely <0.9, 41 delta tier-curves that merely climb past 1.0 at high tier (`MOD_ABILITY_DEATHSHOLD` 0.08→1.52 = +152%), 2 ever ≥0.9 — **none** shows a 1.x-centered multiplier distribution.
- The old negative-control test fed a **synthetic `1.08`**; real `MOD_SKILL_ALL_KNIFE` is **0.03–0.14**. It encoded the bug.

This is the sibling of #278 (closed), which only remapped the 39 `DefaultValue:0` tokens and reaffirmed the wrong multiplier model for the `DefaultValue:1` majority.

## Change

- `AsBuffMod` → additive `value * 100` (signed). The multiplier branch is removed.
- The #278 `DefaultValue:0 → AsPercent` remap is kept but is now **sign-only** (same `value*100` math; preserves the unsigned `15%` form for "Chance to…" tokens). Comment updated.
- Rewrote the two synthetic-`1.08` tests against real-shaped delta values; added a `WerewolfTraumaBoost` regression (`0.07 → +7%`, `0.92 → +92%`).

## Verification

`Mithril.Shared.Tests` (1139), `Silmarillion.Tests` (522), `Celebrimbor.Tests` (87) — all green. No downstream snapshot fallout.

## Out of scope

The stray trailing `%` (`+7% Trauma Damage (Direct & Per-Tick) %` — label already ends in `" %"`) is broader (hits `AsPercent` too) and tracked in #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
