### PR TITLE
perf(silmarillion): non-blocking icon decode for dense NPC detail views

### DIFF
--- a/src/Mithril.Shared.Wpf/IconImage.cs
+++ b/src/Mithril.Shared.Wpf/IconImage.cs
@@ -75,7 +75,11 @@ public sealed class IconImage : Image
             return;
         }
 
-        Source = _cache.GetOrLoadIcon(IconId);
+        // Deferred: never block the dispatcher on a per-icon disk decode. A
+        // detail view (e.g. an NPC that teaches 60 recipes + sells 37 items)
+        // realises ~100 of these at once; the synchronous path here was the
+        // visible render stall. IconReady re-pulls when each icon resolves.
+        Source = _cache.GetOrLoadIconDeferred(IconId);
         Visibility = Visibility.Visible;
     }
 }

--- a/src/Mithril.Shared/Icons/IIconCacheService.cs
+++ b/src/Mithril.Shared/Icons/IIconCacheService.cs
@@ -12,6 +12,22 @@ public interface IIconCacheService
     /// </summary>
     BitmapImage GetOrLoadIcon(int iconId);
 
+    /// <summary>
+    /// Non-blocking variant for live per-row UI binding (the <c>IconImage</c>
+    /// control). Returns a cached image only if it is already in memory;
+    /// otherwise returns the shared placeholder and resolves the icon — disk
+    /// decode <em>or</em> download — entirely off the calling thread, raising
+    /// <see cref="IconReady"/> when ready. Unlike <see cref="GetOrLoadIcon"/>
+    /// this never performs a synchronous PNG decode on the caller's thread, so a
+    /// detail view that realises dozens of chips at once doesn't stall the
+    /// dispatcher. Callers that must snapshot the real image immediately (share
+    /// cards) keep using <see cref="GetOrLoadIcon"/>.
+    ///
+    /// The default implementation falls back to <see cref="GetOrLoadIcon"/> so
+    /// test doubles need not implement it.
+    /// </summary>
+    BitmapImage GetOrLoadIconDeferred(int iconId) => GetOrLoadIcon(iconId);
+
     /// <summary>Fired on the UI thread when an icon finishes downloading.</summary>
     event EventHandler<int>? IconReady;
 

--- a/src/Mithril.Shared/Icons/IconCacheService.cs
+++ b/src/Mithril.Shared/Icons/IconCacheService.cs
@@ -82,6 +82,65 @@ public sealed class IconCacheService : IIconCacheService
         return GetPlaceholder();
     }
 
+    public BitmapImage GetOrLoadIconDeferred(int iconId)
+    {
+        if (iconId <= 0 || !_settings.Enabled)
+            return GetPlaceholder();
+
+        if (_memCache.TryGetValue(iconId, out var cached))
+            return cached;
+
+        bool isFailed;
+        lock (_failed) { isFailed = _failed.Contains(iconId); }
+        if (isFailed)
+            return GetPlaceholder();
+
+        // Not yet in memory. Resolve off the calling thread: decode the on-disk
+        // PNG (or download it), publish to the memory cache, then raise
+        // IconReady so the bound IconImage re-pulls. This keeps a detail view
+        // that realises ~100 chips at once from doing ~100 synchronous PNG
+        // decodes on the dispatcher thread (the visible NPC-detail render
+        // stall). Deduped per id via _inflight — shared with GetOrLoadIcon's
+        // download queue, so at most one task runs per icon.
+        _inflight.GetOrAdd(iconId, id => Task.Run(() => ResolveAsync(id)));
+        return GetPlaceholder();
+    }
+
+    /// <summary>
+    /// Background resolution for <see cref="GetOrLoadIconDeferred"/>: decode the
+    /// on-disk file if present (frozen, so it crosses back to the UI thread
+    /// safely), else fall through to the existing download path. Either way the
+    /// memory cache is populated and <see cref="IconReady"/> is raised on the
+    /// dispatcher.
+    /// </summary>
+    private async Task ResolveAsync(int iconId)
+    {
+        try
+        {
+            var path = GetDiskPath(iconId);
+            if (File.Exists(path))
+            {
+                var img = LoadFromDisk(path);
+                if (img is not null)
+                {
+                    _memCache[iconId] = img;
+                    _ = _dispatcher.BeginInvoke(() => IconReady?.Invoke(this, iconId));
+                    return;
+                }
+                // Corrupt/partial file — fall through and re-fetch.
+            }
+
+            await DownloadAsync(iconId).ConfigureAwait(false);
+        }
+        finally
+        {
+            // DownloadAsync's finally also removes the entry; TryRemove is
+            // idempotent so the disk-hit path (which never enters DownloadAsync)
+            // is the one that needs this.
+            _inflight.TryRemove(iconId, out _);
+        }
+    }
+
     public async Task ClearCacheAsync()
     {
         _memCache.Clear();

--- a/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
+++ b/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
@@ -3,6 +3,7 @@ using Mithril.Reference.Models.Recipes;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Windows.Media.Imaging;
 using FluentAssertions;
 using Mithril.Shared.Icons;
 using Mithril.Shared.Reference;
@@ -108,6 +109,44 @@ public sealed class IconCachePreloadTests : IDisposable
         // First report is (0, 3), final is (3, 3); intermediate counts can arrive in any order
         seen.First().Should().Be((0, 3));
         seen.Last().Should().Be((3, 3));
+    }
+
+    [Fact]
+    public void GetOrLoadIconDeferred_does_not_block_the_caller_on_a_disk_decode()
+    {
+        // Icon present on disk. The synchronous GetOrLoadIcon would decode it
+        // inline; the deferred variant must hand back the placeholder instead
+        // and resolve off-thread.
+        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_77.png"), MakePngBytes());
+        var svc = CreateService();
+
+        var placeholder = svc.GetOrLoadIconDeferred(0); // id <= 0 ⇒ shared placeholder
+        var first = svc.GetOrLoadIconDeferred(77);
+
+        first.Should().BeSameAs(placeholder,
+            "the deferred path must not synchronously decode an on-disk icon — it returns the placeholder and resolves off-thread");
+    }
+
+    [Fact]
+    public async Task GetOrLoadIconDeferred_resolves_an_on_disk_icon_into_the_memory_cache_off_thread()
+    {
+        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_88.png"), MakePngBytes());
+        var svc = CreateService();
+
+        var placeholder = svc.GetOrLoadIconDeferred(0);
+        svc.GetOrLoadIconDeferred(88); // queues the background decode
+
+        BitmapImage? resolved = null;
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var cur = svc.GetOrLoadIconDeferred(88);
+            if (!ReferenceEquals(cur, placeholder)) { resolved = cur; break; }
+            await Task.Delay(25);
+        }
+
+        resolved.Should().NotBeNull("the background task should have decoded the on-disk PNG into the memory cache");
+        resolved!.IsFrozen.Should().BeTrue("an image crossing back to the UI thread must be frozen");
     }
 
     private static HttpResponseMessage MakeOkPng() => new(HttpStatusCode.OK)


### PR DESCRIPTION
## Problem

The Silmarillion NPCs tab has a visible render stall on NPCs with lots of cross-links. Reported on **Amutasa** (Rahu), who teaches ~60 recipes and sells ~37 items.

## Root cause

Selecting that NPC realises ~100 `Link` chips at once — the detail `ItemsControl`s use a plain `<StackPanel/>` panel, so there's no virtualisation. Each chip's `IconImage` then called `IconCacheService.GetOrLoadIcon` **synchronously on the dispatcher thread**, which for an on-disk icon does a blocking `BitmapImage` decode in `EndInit()`. ~100 sequential file-read + PNG-decode operations on the UI thread before the frame can paint.

The data assembly in `NpcsTabViewModel` is all O(1) dictionary lookups — not the bottleneck.

## Fix

Centralised in the icon cache, so every dense detail view (Items/Recipes tabs too) benefits — not just the NPC tab.

- **`IIconCacheService.GetOrLoadIconDeferred(int)`** — new method with a default implementation delegating to `GetOrLoadIcon`, so the `NoopIconCache` test double and any other implementers need no change.
- **`IconCacheService`** — concrete `GetOrLoadIconDeferred`: returns the cached image only on a memory hit, otherwise returns the shared placeholder and resolves the icon (disk decode *or* download) off the calling thread via a new `ResolveAsync`, raising the existing `IconReady` event. Reuses the download path's existing off-thread + dispatcher-marshal pattern; deduped per icon id through the existing `_inflight` map.
- **`IconImage`** — the live per-row binding control now uses the deferred path. Placeholder shows immediately; each icon pops in via the existing `IconReady` → `Refresh()` wiring within a frame or two.
- **Share-card renderers (Pippin/Legolas) untouched** — they keep the synchronous `GetOrLoadIcon` so their snapshots still capture real icons (they preload via the share dialog banner first).

## Why not virtualisation

Considered virtualising the detail `ItemsControl`s but it's structurally awkward here — the detail is a vertically-stacking scroll container, so inner `ItemsControl`s measure with infinite height and won't virtualise without restructuring layout. The icon decode was the actual stall; the control count isn't. If sheer chip count ever becomes a problem on huge NPCs that's a separate, larger follow-up rather than scope creep here.

## Verification

- Full solution builds clean (0 warnings, 0 errors).
- `IconCachePreloadTests`: 9/9, including 2 new — one asserts the deferred call does not synchronously decode an on-disk icon (returns the placeholder), one asserts the on-disk icon resolves into the memory cache off-thread and the resulting image is frozen.
- Pippin sharing tests (the synchronous `GetOrLoadIcon` consumers): 8/8 — confirms the share-card path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
