### PR TITLE
Revert #441: non-blocking icon decode (introduced a startup stall)

### DIFF
--- a/src/Mithril.Shared.Wpf/IconImage.cs
+++ b/src/Mithril.Shared.Wpf/IconImage.cs
@@ -75,11 +75,7 @@ public sealed class IconImage : Image
             return;
         }
 
-        // Deferred: never block the dispatcher on a per-icon disk decode. A
-        // detail view (e.g. an NPC that teaches 60 recipes + sells 37 items)
-        // realises ~100 of these at once; the synchronous path here was the
-        // visible render stall. IconReady re-pulls when each icon resolves.
-        Source = _cache.GetOrLoadIconDeferred(IconId);
+        Source = _cache.GetOrLoadIcon(IconId);
         Visibility = Visibility.Visible;
     }
 }

--- a/src/Mithril.Shared/Icons/IIconCacheService.cs
+++ b/src/Mithril.Shared/Icons/IIconCacheService.cs
@@ -12,22 +12,6 @@ public interface IIconCacheService
     /// </summary>
     BitmapImage GetOrLoadIcon(int iconId);
 
-    /// <summary>
-    /// Non-blocking variant for live per-row UI binding (the <c>IconImage</c>
-    /// control). Returns a cached image only if it is already in memory;
-    /// otherwise returns the shared placeholder and resolves the icon — disk
-    /// decode <em>or</em> download — entirely off the calling thread, raising
-    /// <see cref="IconReady"/> when ready. Unlike <see cref="GetOrLoadIcon"/>
-    /// this never performs a synchronous PNG decode on the caller's thread, so a
-    /// detail view that realises dozens of chips at once doesn't stall the
-    /// dispatcher. Callers that must snapshot the real image immediately (share
-    /// cards) keep using <see cref="GetOrLoadIcon"/>.
-    ///
-    /// The default implementation falls back to <see cref="GetOrLoadIcon"/> so
-    /// test doubles need not implement it.
-    /// </summary>
-    BitmapImage GetOrLoadIconDeferred(int iconId) => GetOrLoadIcon(iconId);
-
     /// <summary>Fired on the UI thread when an icon finishes downloading.</summary>
     event EventHandler<int>? IconReady;
 

--- a/src/Mithril.Shared/Icons/IconCacheService.cs
+++ b/src/Mithril.Shared/Icons/IconCacheService.cs
@@ -82,65 +82,6 @@ public sealed class IconCacheService : IIconCacheService
         return GetPlaceholder();
     }
 
-    public BitmapImage GetOrLoadIconDeferred(int iconId)
-    {
-        if (iconId <= 0 || !_settings.Enabled)
-            return GetPlaceholder();
-
-        if (_memCache.TryGetValue(iconId, out var cached))
-            return cached;
-
-        bool isFailed;
-        lock (_failed) { isFailed = _failed.Contains(iconId); }
-        if (isFailed)
-            return GetPlaceholder();
-
-        // Not yet in memory. Resolve off the calling thread: decode the on-disk
-        // PNG (or download it), publish to the memory cache, then raise
-        // IconReady so the bound IconImage re-pulls. This keeps a detail view
-        // that realises ~100 chips at once from doing ~100 synchronous PNG
-        // decodes on the dispatcher thread (the visible NPC-detail render
-        // stall). Deduped per id via _inflight — shared with GetOrLoadIcon's
-        // download queue, so at most one task runs per icon.
-        _inflight.GetOrAdd(iconId, id => Task.Run(() => ResolveAsync(id)));
-        return GetPlaceholder();
-    }
-
-    /// <summary>
-    /// Background resolution for <see cref="GetOrLoadIconDeferred"/>: decode the
-    /// on-disk file if present (frozen, so it crosses back to the UI thread
-    /// safely), else fall through to the existing download path. Either way the
-    /// memory cache is populated and <see cref="IconReady"/> is raised on the
-    /// dispatcher.
-    /// </summary>
-    private async Task ResolveAsync(int iconId)
-    {
-        try
-        {
-            var path = GetDiskPath(iconId);
-            if (File.Exists(path))
-            {
-                var img = LoadFromDisk(path);
-                if (img is not null)
-                {
-                    _memCache[iconId] = img;
-                    _ = _dispatcher.BeginInvoke(() => IconReady?.Invoke(this, iconId));
-                    return;
-                }
-                // Corrupt/partial file — fall through and re-fetch.
-            }
-
-            await DownloadAsync(iconId).ConfigureAwait(false);
-        }
-        finally
-        {
-            // DownloadAsync's finally also removes the entry; TryRemove is
-            // idempotent so the disk-hit path (which never enters DownloadAsync)
-            // is the one that needs this.
-            _inflight.TryRemove(iconId, out _);
-        }
-    }
-
     public async Task ClearCacheAsync()
     {
         _memCache.Clear();

--- a/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
+++ b/tests/Mithril.Shared.Tests/Icons/IconCachePreloadTests.cs
@@ -3,7 +3,6 @@ using Mithril.Reference.Models.Recipes;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Windows.Media.Imaging;
 using FluentAssertions;
 using Mithril.Shared.Icons;
 using Mithril.Shared.Reference;
@@ -109,44 +108,6 @@ public sealed class IconCachePreloadTests : IDisposable
         // First report is (0, 3), final is (3, 3); intermediate counts can arrive in any order
         seen.First().Should().Be((0, 3));
         seen.Last().Should().Be((3, 3));
-    }
-
-    [Fact]
-    public void GetOrLoadIconDeferred_does_not_block_the_caller_on_a_disk_decode()
-    {
-        // Icon present on disk. The synchronous GetOrLoadIcon would decode it
-        // inline; the deferred variant must hand back the placeholder instead
-        // and resolve off-thread.
-        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_77.png"), MakePngBytes());
-        var svc = CreateService();
-
-        var placeholder = svc.GetOrLoadIconDeferred(0); // id <= 0 ⇒ shared placeholder
-        var first = svc.GetOrLoadIconDeferred(77);
-
-        first.Should().BeSameAs(placeholder,
-            "the deferred path must not synchronously decode an on-disk icon — it returns the placeholder and resolves off-thread");
-    }
-
-    [Fact]
-    public async Task GetOrLoadIconDeferred_resolves_an_on_disk_icon_into_the_memory_cache_off_thread()
-    {
-        File.WriteAllBytes(Path.Combine(_cacheDir, "icon_88.png"), MakePngBytes());
-        var svc = CreateService();
-
-        var placeholder = svc.GetOrLoadIconDeferred(0);
-        svc.GetOrLoadIconDeferred(88); // queues the background decode
-
-        BitmapImage? resolved = null;
-        var deadline = DateTime.UtcNow.AddSeconds(5);
-        while (DateTime.UtcNow < deadline)
-        {
-            var cur = svc.GetOrLoadIconDeferred(88);
-            if (!ReferenceEquals(cur, placeholder)) { resolved = cur; break; }
-            await Task.Delay(25);
-        }
-
-        resolved.Should().NotBeNull("the background task should have decoded the on-disk PNG into the memory cache");
-        resolved!.IsFrozen.Should().BeTrue("an image crossing back to the UI thread must be frozen");
     }
 
     private static HttpResponseMessage MakeOkPng() => new(HttpStatusCode.OK)


### PR DESCRIPTION
Reverts the icon-decode change from #441 (squash-commit `32da878`).

## Why

#441 introduced a significant app-wide startup stall — Mithril takes a long time to become responsive. The change was a net regression and must be backed out of `main`.

## Mechanism of the regression

`_memCache` is in-memory only and empty on every launch; only the disk cache persists. So at cold start essentially every visible icon misses memory and is found on disk.

- **Before:** `GetOrLoadIcon` decoded a disk-cached icon synchronously inline, stored it, returned the real image in **one** layout pass, and never raised `IconReady` for disk hits.
- **After (#441):** `GetOrLoadIconDeferred` returned a placeholder, decoded off-thread, then `BeginInvoke`'d the **global `IconReady` event that every loaded `IconImage` subscribes to**. Each fire fanned out across all icon controls; the matching one did a second `Refresh()` → second render pass.

Net effect at cold start: every icon rendered twice (placeholder then real, dispatcher-queued), an O(controls × icons) broadcast fan-out that didn't exist before for disk hits, and a thread-pool burst of decode tasks — turning one bounded layout pass into a dispatcher/render storm. The `IconReady` broadcast is only cheap because it normally fires rarely (genuine downloads); #441 made it fire for every icon on every cold start.

## Scope

Pure revert of all 4 files from #441 (`IconImage`, `IIconCacheService`, `IconCacheService`, `IconCachePreloadTests`) back to their `226ed4b` state. Solution builds clean; the pre-#441 `IconCachePreloadTests` are restored.

The original Amutasa NPC-detail stall that #441 tried to fix is real but minor (one tab, once per session per NPC) and needs a properly-scoped redesign that does not amplify the global `IconReady` broadcast — to be tracked separately, not reattempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
