### PR TITLE
perf(silmarillion): cap NPC-detail chip lists + provenance-popup drawer

### DIFF
--- a/src/Silmarillion.Module/SilmarillionModule.cs
+++ b/src/Silmarillion.Module/SilmarillionModule.cs
@@ -51,7 +51,11 @@ public sealed class SilmarillionModule : IMithrilModule
             sp.GetRequiredService<IEntityNameResolver>(),
             sp.GetRequiredService<SilmarillionSettings>()));
         services.AddSingleton<RecipesTabViewModel>();
-        services.AddSingleton<NpcsTabViewModel>();
+        services.AddSingleton<NpcsTabViewModel>(sp => new NpcsTabViewModel(
+            sp.GetRequiredService<IReferenceDataService>(),
+            sp.GetRequiredService<IReferenceNavigator>(),
+            sp.GetRequiredService<IEntityNameResolver>(),
+            sp.GetRequiredService<SilmarillionSettings>()));
         services.AddSingleton<QuestsTabViewModel>();
         services.AddSingleton<AbilitiesTabViewModel>();
         services.AddSingleton<EffectsTabViewModel>(sp => new EffectsTabViewModel(

--- a/src/Silmarillion.Module/SilmarillionSettings.cs
+++ b/src/Silmarillion.Module/SilmarillionSettings.cs
@@ -25,9 +25,18 @@ public sealed class SilmarillionSettings : INotifyPropertyChanged
     /// <summary>Default cap for the Effects-tab "Required by abilities" chip cluster.</summary>
     public const int DefaultRequiredByAbilitiesChipCap = 12;
 
+    /// <summary>
+    /// Default cap for the NPC-detail chip enumerations ("Teaches recipes", "Teaches
+    /// abilities", "Sells items", "Quests"). An NPC like a major crafting trainer teaches
+    /// 60+ recipes and sells 30+ items — every chip carries an icon that decodes on the UI
+    /// thread, so an uncapped detail stalls the pane on selection.
+    /// </summary>
+    public const int DefaultNpcChipCap = 12;
+
     private int _schemaVersion = 1;
     private int _usedInChipCap = DefaultUsedInChipCap;
     private int _requiredByAbilitiesChipCap = DefaultRequiredByAbilitiesChipCap;
+    private int _npcChipCap = DefaultNpcChipCap;
 
     /// <summary>
     /// Persisted schema version. Always written so a future <c>IVersionedState</c> migration
@@ -62,6 +71,20 @@ public sealed class SilmarillionSettings : INotifyPropertyChanged
     {
         get => _requiredByAbilitiesChipCap;
         set => Set(ref _requiredByAbilitiesChipCap, Math.Clamp(value, MinUsedInChipCap, MaxUsedInChipCap));
+    }
+
+    /// <summary>
+    /// Maximum number of chips rendered in each NPC-detail enumeration ("Teaches recipes",
+    /// "Teaches abilities", "Sells items", "Quests") before the remainder is reachable via
+    /// the always-visible "View all N →" affordance that opens the shared provenance popup.
+    /// A separate knob from <see cref="UsedInChipCap"/> so NPC density tunes independently of
+    /// the item-detail "Used in" cluster. Clamped to
+    /// <see cref="MinUsedInChipCap"/>..<see cref="MaxUsedInChipCap"/>.
+    /// </summary>
+    public int NpcChipCap
+    {
+        get => _npcChipCap;
+        set => Set(ref _npcChipCap, Math.Clamp(value, MinUsedInChipCap, MaxUsedInChipCap));
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/Silmarillion.Module/ViewModels/NpcDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcDetailViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
@@ -20,6 +21,22 @@ public sealed class NpcDetailViewModel
 {
     private readonly IEntityNameResolver _nameResolver;
 
+    /// <summary>
+    /// Host-supplied opener for the four NPC-detail provenance popups ("Teaches recipes" /
+    /// "Teaches abilities" / "Sells items" / "Quests"). Defaults to
+    /// <see cref="ShowProvenancePopupWindow"/> (creates + <c>Show()</c>s a
+    /// <see cref="ProvenancePopupWindow"/>). Tests swap in a capturing delegate so the VM is
+    /// fully assertable without spawning a window. Opening the popup this way never calls
+    /// <c>IReferenceNavigator</c>, so it pushes no back/forward history — identical
+    /// non-navigating contract to <c>AreaDetailViewModel.ProvenancePopupOpener</c> /
+    /// <c>ItemDetailViewModel.ProvenancePopupOpener</c>.
+    /// </summary>
+    public static Action<ProvenancePopupViewModel, ICommand?> ProvenancePopupOpener { get; set; }
+        = ShowProvenancePopupWindow;
+
+    private static void ShowProvenancePopupWindow(ProvenancePopupViewModel vm, ICommand? chipClick) =>
+        new ProvenancePopupWindow { DataContext = vm, ChipClickCommand = chipClick }.Show();
+
     public NpcDetailViewModel(
         Npc npc,
         string internalName,
@@ -32,7 +49,11 @@ public sealed class NpcDetailViewModel
         IReadOnlyList<NpcPreferenceRow> preferences,
         IReadOnlyList<string> giftSentimentTiers,
         EntityChipVm? areaChip = null,
-        ICommand? openEntityCommand = null)
+        ICommand? openEntityCommand = null,
+        ProvenancePopupViewModel? taughtRecipesPopup = null,
+        ProvenancePopupViewModel? taughtAbilitiesPopup = null,
+        ProvenancePopupViewModel? soldItemsPopup = null,
+        ProvenancePopupViewModel? questsPopup = null)
     {
         Npc = npc;
         InternalName = internalName;
@@ -70,6 +91,50 @@ public sealed class NpcDetailViewModel
         TaughtAbilityLinks = TaughtAbilities.Select(LinkVm.From).ToList();
         SoldItemLinks = SoldItems.Select(LinkVm.From).ToList();
         QuestLinks = Quests.Select(LinkVm.From).ToList();
+
+        // "View all N →" drawers (#318 idiom — mirrors AreaDetailViewModel /
+        // ItemDetailViewModel). The capped Link cluster above carries the first
+        // SilmarillionSettings.NpcChipCap; the full set is the popup. Each SetRef is the
+        // summary-form "{label} · N matches →" actionable via its Show…PopupCommand. Null
+        // popup ⇒ null SetRef ⇒ the section's SetRef row hides; the count mirrors the
+        // popup's TotalCount so it cannot diverge. Amutasa (teaches ~60 recipes, sells ~37
+        // items) renders 12+12 chips instead of ~100 synchronous icon decodes — the NPC
+        // detail no longer stalls the pane on selection.
+        TaughtRecipesPopup = taughtRecipesPopup;
+        TaughtRecipesTotal = taughtRecipesPopup?.TotalCount ?? 0;
+        ShowTaughtRecipesPopupCommand = new RelayCommand(
+            () => ProvenancePopupOpener(TaughtRecipesPopup!, OpenEntityCommand),
+            () => TaughtRecipesPopup is not null);
+        TaughtRecipesSetRef = taughtRecipesPopup is null
+            ? null
+            : new SetRefVm("Teaches recipes", MatchCount: TaughtRecipesTotal, IsActionable: true);
+
+        TaughtAbilitiesPopup = taughtAbilitiesPopup;
+        TaughtAbilitiesTotal = taughtAbilitiesPopup?.TotalCount ?? 0;
+        ShowTaughtAbilitiesPopupCommand = new RelayCommand(
+            () => ProvenancePopupOpener(TaughtAbilitiesPopup!, OpenEntityCommand),
+            () => TaughtAbilitiesPopup is not null);
+        TaughtAbilitiesSetRef = taughtAbilitiesPopup is null
+            ? null
+            : new SetRefVm("Teaches abilities", MatchCount: TaughtAbilitiesTotal, IsActionable: true);
+
+        SoldItemsPopup = soldItemsPopup;
+        SoldItemsTotal = soldItemsPopup?.TotalCount ?? 0;
+        ShowSoldItemsPopupCommand = new RelayCommand(
+            () => ProvenancePopupOpener(SoldItemsPopup!, OpenEntityCommand),
+            () => SoldItemsPopup is not null);
+        SoldItemsSetRef = soldItemsPopup is null
+            ? null
+            : new SetRefVm("Sells items", MatchCount: SoldItemsTotal, IsActionable: true);
+
+        QuestsPopup = questsPopup;
+        QuestsTotal = questsPopup?.TotalCount ?? 0;
+        ShowQuestsPopupCommand = new RelayCommand(
+            () => ProvenancePopupOpener(QuestsPopup!, OpenEntityCommand),
+            () => QuestsPopup is not null);
+        QuestsSetRef = questsPopup is null
+            ? null
+            : new SetRefVm("Quests", MatchCount: QuestsTotal, IsActionable: true);
 
         ServiceRowVms = Services
             .Select(s => new NpcServiceRowVm(
@@ -147,6 +212,64 @@ public sealed class NpcDetailViewModel
     /// <summary>Quest cross-links as <see cref="LinkVm"/> (Density="List"; G-c
     /// degrade keeps them identical at rest until the Quests tab ships).</summary>
     public IReadOnlyList<LinkVm> QuestLinks { get; }
+
+    // ── "View all N →" drawers (#318 idiom; mirrors Area/Item detail) ──────────
+    // Each section's capped Link cluster is paired with a flat provenance popup
+    // over the full set + a summary-form Set-reference. Null popup ⇒ null SetRef
+    // ⇒ the SetRef row hides (the capped cluster, if any, still renders).
+
+    /// <summary>"Teaches recipes" provenance popup (full set), or null when the NPC teaches
+    /// no recipes. Built by <see cref="NpcsTabViewModel"/> from
+    /// <see cref="IReferenceDataService.RecipesTaughtByNpc"/>.</summary>
+    public ProvenancePopupViewModel? TaughtRecipesPopup { get; }
+
+    /// <summary>Distinct recipe count — equals <see cref="ProvenancePopupViewModel.TotalCount"/>
+    /// of <see cref="TaughtRecipesPopup"/>. Drives the "View all N →" label.</summary>
+    public int TaughtRecipesTotal { get; }
+
+    /// <summary>Opens <see cref="TaughtRecipesPopup"/> via <see cref="ProvenancePopupOpener"/>
+    /// (non-navigating; pushes no navigator history).</summary>
+    public ICommand ShowTaughtRecipesPopupCommand { get; }
+
+    /// <summary>Summary-form Set-reference ("Teaches recipes · N matches →") for the
+    /// always-visible drawer; null when no recipes (the row hides).</summary>
+    public SetRefVm? TaughtRecipesSetRef { get; }
+
+    /// <summary>"Teaches abilities" provenance popup (full set), or null when none.</summary>
+    public ProvenancePopupViewModel? TaughtAbilitiesPopup { get; }
+
+    /// <summary>Distinct ability count — equals <see cref="TaughtAbilitiesPopup"/>'s TotalCount.</summary>
+    public int TaughtAbilitiesTotal { get; }
+
+    /// <summary>Opens <see cref="TaughtAbilitiesPopup"/> (non-navigating).</summary>
+    public ICommand ShowTaughtAbilitiesPopupCommand { get; }
+
+    /// <summary>Summary-form Set-reference for the abilities drawer; null when none.</summary>
+    public SetRefVm? TaughtAbilitiesSetRef { get; }
+
+    /// <summary>"Sells items" provenance popup (full set), or null when none.</summary>
+    public ProvenancePopupViewModel? SoldItemsPopup { get; }
+
+    /// <summary>Distinct sold-item count — equals <see cref="SoldItemsPopup"/>'s TotalCount.</summary>
+    public int SoldItemsTotal { get; }
+
+    /// <summary>Opens <see cref="SoldItemsPopup"/> (non-navigating).</summary>
+    public ICommand ShowSoldItemsPopupCommand { get; }
+
+    /// <summary>Summary-form Set-reference for the sold-items drawer; null when none.</summary>
+    public SetRefVm? SoldItemsSetRef { get; }
+
+    /// <summary>"Quests" provenance popup (full set), or null when none.</summary>
+    public ProvenancePopupViewModel? QuestsPopup { get; }
+
+    /// <summary>Distinct quest count — equals <see cref="QuestsPopup"/>'s TotalCount.</summary>
+    public int QuestsTotal { get; }
+
+    /// <summary>Opens <see cref="QuestsPopup"/> (non-navigating).</summary>
+    public ICommand ShowQuestsPopupCommand { get; }
+
+    /// <summary>Summary-form Set-reference for the quests drawer; null when none.</summary>
+    public SetRefVm? QuestsSetRef { get; }
 
     /// <summary>
     /// Services wrapped for the grammar: the gold Type label is dropped (named

--- a/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/NpcsTabViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.Reference.Models.Abilities;
@@ -43,16 +44,27 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     private readonly IReferenceDataService _refData;
     private readonly IReferenceNavigator _navigator;
     private readonly IEntityNameResolver _nameResolver;
+    private readonly SilmarillionSettings _settings;
     private readonly RelayCommand<EntityRef?> _openEntityCommand;
 
     public NpcsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator, IEntityNameResolver nameResolver)
+        : this(refData, navigator, nameResolver, settings: null)
+    {
+    }
+
+    public NpcsTabViewModel(IReferenceDataService refData, IReferenceNavigator navigator, IEntityNameResolver nameResolver, SilmarillionSettings? settings)
     {
         _refData = refData;
         _navigator = navigator;
         _nameResolver = nameResolver;
+        // null → owned default instance keeps non-DI callers (tests) working without forcing
+        // every fixture to construct one. The DI path always passes the live singleton
+        // (see SilmarillionModule). Mirrors ItemsTabViewModel.
+        _settings = settings ?? new SilmarillionSettings();
         _openEntityCommand = new RelayCommand<EntityRef?>(r => { if (r is not null) _navigator.Open(r); });
         _allNpcs = BuildAllNpcs(refData);
         refData.FileUpdated += OnFileUpdated;
+        _settings.PropertyChanged += OnSettingsChanged;
     }
 
     [ObservableProperty]
@@ -120,6 +132,21 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
         });
     }
 
+    private void OnSettingsChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // NpcChipCap controls the per-section overflow threshold; rebuild the live detail VM
+        // when it changes so the slider feels immediate. Toggle through null to sidestep
+        // [ObservableProperty]'s reference-equality check (mirrors ItemsTabViewModel).
+        if (e.PropertyName != nameof(SilmarillionSettings.NpcChipCap)) return;
+        var captured = SelectedRow;
+        if (captured is null) return;
+        UiThread.Run(() =>
+        {
+            SelectedRow = null;
+            SelectedRow = captured;
+        });
+    }
+
     private IReadOnlyList<NpcListRow> BuildAllNpcs(IReferenceDataService refData) =>
         refData.NpcsByInternalName
             .Select(kv => BuildRow(kv.Key, kv.Value))
@@ -166,10 +193,10 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     private NpcDetailViewModel BuildDetailViewModel(NpcListRow row)
     {
         var services = BuildServiceRows(row.Npc);
-        var taught = BuildTaughtRecipeChips(row.InternalName);
-        var taughtAbilities = BuildTaughtAbilityChips(row.InternalName);
-        var sold = BuildSoldItemChips(row.InternalName);
-        var quests = BuildQuestLinks(row.InternalName);
+        var taught = BuildTaughtRecipeChips(row.InternalName, row.Name);
+        var taughtAbilities = BuildTaughtAbilityChips(row.InternalName, row.Name);
+        var sold = BuildSoldItemChips(row.InternalName, row.Name);
+        var quests = BuildQuestLinks(row.InternalName, row.Name);
         var preferences = BuildPreferenceRows(row.Npc);
         var giftTiers = row.Npc.ItemGifts ?? (IReadOnlyList<string>)[];
         var areaChip = BuildAreaChip(row.Npc);
@@ -179,14 +206,18 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
             row.InternalName,
             _nameResolver,
             services,
-            taught,
-            taughtAbilities,
-            sold,
-            quests,
+            taught.Capped,
+            taughtAbilities.Capped,
+            sold.Capped,
+            quests.Capped,
             preferences,
             giftTiers,
             areaChip,
-            _openEntityCommand);
+            _openEntityCommand,
+            taughtRecipesPopup: taught.Popup,
+            taughtAbilitiesPopup: taughtAbilities.Popup,
+            soldItemsPopup: sold.Popup,
+            questsPopup: quests.Popup);
     }
 
     /// <summary>
@@ -350,11 +381,36 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
         return chips;
     }
 
-    private IReadOnlyList<EntityChipVm> BuildTaughtRecipeChips(string npcInternalName)
+    /// <summary>
+    /// Cap a fully-materialized chip list to <see cref="SilmarillionSettings.NpcChipCap"/>
+    /// and build the single-section flat provenance popup over the <em>full</em> set. Both
+    /// the capped cluster and the popup are views over the same <paramref name="allChips"/>
+    /// list — no second derivation, so the popup's "View all N" count cannot diverge
+    /// (the #318 invariant; mirrors <c>AreaDetailViewModel.BuildNpcs</c>). The relationship
+    /// is single-reason so the popup collapses to a flat list (#318 Discipline);
+    /// ToQueryCommand intentionally unset (the popup-from-index is the count-bearing
+    /// surface). Returns <c>([], null)</c> for an empty input so the section hides.
+    /// </summary>
+    private (IReadOnlyList<EntityChipVm> Capped, ProvenancePopupViewModel? Popup) CapAndPopup(
+        IReadOnlyList<EntityChipVm> allChips, string title, string sectionLabel)
+    {
+        if (allChips.Count == 0) return ([], null);
+        var cap = _settings.NpcChipCap;
+        var capped = cap == 0
+            ? (IReadOnlyList<EntityChipVm>)Array.Empty<EntityChipVm>()
+            : allChips.Take(cap).ToList();
+        var popup = new ProvenancePopupViewModel(
+            title: title,
+            sections: new List<ProvenancePopupSection> { new(sectionLabel, allChips) });
+        return (capped, popup);
+    }
+
+    private (IReadOnlyList<EntityChipVm> Capped, ProvenancePopupViewModel? Popup) BuildTaughtRecipeChips(
+        string npcInternalName, string npcDisplayName)
     {
         if (!_refData.RecipesTaughtByNpc.TryGetValue(npcInternalName, out var recipes) || recipes.Count == 0)
-            return [];
-        return recipes
+            return ([], null);
+        var allChips = recipes
             .OrderBy(r => r.Name ?? r.InternalName ?? r.Key, StringComparer.OrdinalIgnoreCase)
             .Select(r => new EntityChipVm(
                 DisplayName: r.Name ?? r.InternalName ?? r.Key,
@@ -362,6 +418,7 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
                 Reference: EntityRef.Recipe(r.InternalName ?? r.Key),
                 IsNavigable: _navigator.CanOpen(EntityRef.Recipe(r.InternalName ?? r.Key))))
             .ToList();
+        return CapAndPopup(allChips, $"Recipes taught by {npcDisplayName}", "Teaches recipes");
     }
 
     private int ResolveRecipeFallbackIcon(Recipe recipe)
@@ -376,11 +433,12 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
         return 0;
     }
 
-    private IReadOnlyList<EntityChipVm> BuildTaughtAbilityChips(string npcInternalName)
+    private (IReadOnlyList<EntityChipVm> Capped, ProvenancePopupViewModel? Popup) BuildTaughtAbilityChips(
+        string npcInternalName, string npcDisplayName)
     {
         if (!_refData.AbilitiesTaughtByNpc.TryGetValue(npcInternalName, out var abilities) || abilities.Count == 0)
-            return [];
-        return abilities
+            return ([], null);
+        var allChips = abilities
             .Where(a => !string.IsNullOrEmpty(a.InternalName))
             .OrderBy(a => a.Skill ?? "", StringComparer.OrdinalIgnoreCase)
             .ThenBy(a => a.Level)
@@ -395,13 +453,15 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
                     IsNavigable: _navigator.CanOpen(reference));
             })
             .ToList();
+        return CapAndPopup(allChips, $"Abilities taught by {npcDisplayName}", "Teaches abilities");
     }
 
-    private IReadOnlyList<EntityChipVm> BuildSoldItemChips(string npcInternalName)
+    private (IReadOnlyList<EntityChipVm> Capped, ProvenancePopupViewModel? Popup) BuildSoldItemChips(
+        string npcInternalName, string npcDisplayName)
     {
         if (!_refData.ItemsSoldByNpc.TryGetValue(npcInternalName, out var items) || items.Count == 0)
-            return [];
-        return items
+            return ([], null);
+        var allChips = items
             .OrderBy(i => i.Name ?? i.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
             .Select(i => new EntityChipVm(
                 DisplayName: i.Name ?? i.InternalName ?? "",
@@ -409,6 +469,7 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
                 Reference: EntityRef.Item(i.InternalName ?? ""),
                 IsNavigable: _navigator.CanOpen(EntityRef.Item(i.InternalName ?? ""))))
             .ToList();
+        return CapAndPopup(allChips, $"Items sold by {npcDisplayName}", "Sells items");
     }
 
     /// <summary>
@@ -417,11 +478,12 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
     /// NPC is the giver, the turn-in, or the favor anchor all surface. Rendered as navigable
     /// <see cref="EntityChipVm"/> chips that route to the Quests tab via <see cref="EntityRef.Quest"/>.
     /// </summary>
-    private IReadOnlyList<EntityChipVm> BuildQuestLinks(string npcInternalName)
+    private (IReadOnlyList<EntityChipVm> Capped, ProvenancePopupViewModel? Popup) BuildQuestLinks(
+        string npcInternalName, string npcDisplayName)
     {
         if (!_refData.QuestsByGiverNpc.TryGetValue(npcInternalName, out var quests) || quests.Count == 0)
-            return [];
-        return quests
+            return ([], null);
+        var allChips = quests
             .OrderBy(q => q.Name ?? q.InternalName ?? "", StringComparer.OrdinalIgnoreCase)
             .Select(q =>
             {
@@ -434,6 +496,7 @@ public sealed partial class NpcsTabViewModel : ObservableObject, ITabViewModel
                     IsNavigable: _navigator.CanOpen(reference));
             })
             .ToList();
+        return CapAndPopup(allChips, $"Quests from {npcDisplayName}", "Quests");
     }
 
     private static IReadOnlyList<NpcPreferenceRow> BuildPreferenceRows(Npc npc)

--- a/src/Silmarillion.Module/Views/NpcDetailView.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailView.xaml
@@ -133,44 +133,136 @@
                     </ItemsControl>
                 </StackPanel>
 
-                <!-- Teaches recipes — Link enumeration (Density="List"). -->
-                <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding TaughtRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <!-- Teaches recipes — capped Link enumeration + "Teaches
+                     recipes · N matches →" Set-ref drawer opening the shared
+                     provenance popup (#318 idiom; mirrors ItemDetailView
+                     "Used in"). Capping the icon-bearing chip clusters is what
+                     keeps a dense NPC (Amutasa: ~60 recipes + ~37 items) from
+                     stalling the pane on selection. Visible whenever the capped
+                     cluster OR the drawer exists. -->
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding TaughtRecipeLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <!-- NullToVis (object) — NOT NullOrEmptyToVis. -->
+                                <DataTrigger Binding="{Binding TaughtRecipesSetRef, Converter={StaticResource NullToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock Text="Teaches recipes" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding TaughtRecipeLinks}"
                                   ItemTemplate="{StaticResource EntityLinkListTemplate}">
                         <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
+                    <ContentControl Content="{Binding TaughtRecipesSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding TaughtRecipesSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowTaughtRecipesPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- Teaches abilities -->
-                <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding TaughtAbilityLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <!-- Teaches abilities — same cap + drawer shape. -->
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding TaughtAbilityLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding TaughtAbilitiesSetRef, Converter={StaticResource NullToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock Text="Teaches abilities" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding TaughtAbilityLinks}"
                                   ItemTemplate="{StaticResource EntityLinkListTemplate}">
                         <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
+                    <ContentControl Content="{Binding TaughtAbilitiesSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding TaughtAbilitiesSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowTaughtAbilitiesPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- Sells items -->
-                <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding SoldItemLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <!-- Sells items — same cap + drawer shape. -->
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SoldItemLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding SoldItemsSetRef, Converter={StaticResource NullToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock Text="Sells items" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding SoldItemLinks}"
                                   ItemTemplate="{StaticResource EntityLinkListTemplate}">
                         <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
+                    <ContentControl Content="{Binding SoldItemsSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding SoldItemsSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowSoldItemsPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
-                <!-- Quests this NPC gives, turns in, or anchors favor for. -->
-                <StackPanel Margin="0,0,0,10"
-                            Visibility="{Binding QuestLinks.Count, Converter={StaticResource PositiveIntToVis}}">
+                <!-- Quests this NPC gives, turns in, or anchors favor for —
+                     same cap + drawer shape. -->
+                <StackPanel Margin="0,0,0,10">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding QuestLinks.Count, Converter={StaticResource PositiveIntToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding QuestsSetRef, Converter={StaticResource NullToVis}}" Value="Visible">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
                     <TextBlock Text="Quests" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <ItemsControl ItemsSource="{Binding QuestLinks}"
                                   ItemTemplate="{StaticResource EntityLinkListTemplate}">
                         <ItemsControl.ItemsPanel><ItemsPanelTemplate><StackPanel/></ItemsPanelTemplate></ItemsControl.ItemsPanel>
                     </ItemsControl>
+                    <ContentControl Content="{Binding QuestsSetRef}"
+                                    HorizontalAlignment="Left" Margin="0,4,0,0"
+                                    Visibility="{Binding QuestsSetRef, Converter={StaticResource NullToVis}}">
+                        <ContentControl.ContentTemplate>
+                            <DataTemplate>
+                                <c:SetRef ActivateCommand="{Binding DataContext.ShowQuestsPopupCommand, RelativeSource={RelativeSource AncestorType={x:Type ContentControl}}}"/>
+                            </DataTemplate>
+                        </ContentControl.ContentTemplate>
+                    </ContentControl>
                 </StackPanel>
 
                 <!-- Gift preferences — section label → Structure. The Desire

--- a/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml
+++ b/src/Silmarillion.Module/Views/SilmarillionSettingsView.xaml
@@ -53,6 +53,26 @@
                 Abilities tab pre-filtered to abilities requiring this effect keyword. Default
                 12. Set to 0 to always collapse; raise to 100 to show everything.
             </TextBlock>
+
+            <!-- NPC detail chip cap -->
+            <TextBlock Text="NPC detail · chip lists" Foreground="#88FFFFFF" Margin="0,0,0,6" FontWeight="SemiBold"/>
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock DockPanel.Dock="Left" Text="Show at most" VerticalAlignment="Center" Foreground="#FFE8E8E8" Width="110"/>
+                <TextBlock DockPanel.Dock="Right" VerticalAlignment="Center" Foreground="#88FFFFFF" Width="60"
+                           Text="{Binding NpcChipCap, StringFormat={}{0} chips}"/>
+                <Slider Minimum="0" Maximum="100" TickFrequency="4" IsSnapToTickEnabled="True"
+                        Value="{Binding NpcChipCap, Mode=TwoWay}"
+                        VerticalAlignment="Center" Margin="0,0,8,0"/>
+            </DockPanel>
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource AppFontSizeHint}" Foreground="#88FFFFFF" Margin="0,0,0,24">
+                A major trainer (e.g. Amutasa) teaches 60+ recipes and sells 30+ items; every
+                chip carries an icon that decodes on the UI thread, so an uncapped NPC stalls
+                the detail pane on selection. This cap applies to each of the &quot;Teaches
+                recipes&quot;, &quot;Teaches abilities&quot;, &quot;Sells items&quot; and
+                &quot;Quests&quot; lists; above it the rest are reachable via the
+                &quot;View all N →&quot; popup. Default 12. Set to 0 to always collapse;
+                raise to 100 to show everything.
+            </TextBlock>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/NpcsTabViewModelTests.cs
@@ -313,6 +313,145 @@ public sealed class NpcsTabViewModelTests
         chip.IsNavigable.Should().BeTrue();
     }
 
+    // ── NPC-detail cap + provenance-popup drawer (mirrors the item/area #318 idiom) ──
+    // A dense NPC (Amutasa: ~60 recipes + ~37 items) realised ~100 icon-bearing chips at
+    // once, stalling the detail pane. Each of the four enumerations is now capped at
+    // SilmarillionSettings.NpcChipCap with the full set behind a "View all N →" Set-ref.
+
+    private static Recipe[] MakeRecipes(int count) =>
+        Enumerable.Range(1, count)
+            .Select(i => new Recipe
+            {
+                Key = $"recipe_{i}",
+                InternalName = $"Recipe{i:D3}",
+                Name = $"Recipe {i:D3}",
+                IconId = i,
+            })
+            .ToArray();
+
+    [Fact]
+    public void DetailViewModel_TaughtRecipes_belowCap_emitsAllChips_andBuildsPopupAndSetRef()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+            RecipesTaughtByNpcMap = { ["NPC_Joeh"] = MakeRecipes(5) },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.Recipe),
+            new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings { NpcChipCap = 12 });
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+        var detail = vm.DetailViewModel!;
+
+        detail.TaughtRecipes.Should().HaveCount(5, because: "5 is within the cap");
+        detail.TaughtRecipeLinks.Should().HaveCount(5);
+        detail.TaughtRecipesPopup.Should().NotBeNull(
+            because: "the View-all drawer is always built, even within the cap (mirrors item/area)");
+        detail.TaughtRecipesPopup!.TotalCount.Should().Be(5);
+        detail.TaughtRecipesPopup.IsFlat.Should().BeTrue(because: "single-reason ⇒ flat list");
+        detail.TaughtRecipesTotal.Should().Be(5);
+        detail.TaughtRecipesSetRef.Should().NotBeNull();
+        detail.TaughtRecipesSetRef!.MatchCount.Should().Be(5);
+        detail.ShowTaughtRecipesPopupCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetailViewModel_TaughtRecipes_aboveCap_capsChips_butSetRefAndPopupCarryFullTotal()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Amutasa"] = new Npc { Name = "Amutasa" } },
+            RecipesTaughtByNpcMap = { ["NPC_Amutasa"] = MakeRecipes(60) },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.Recipe),
+            new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings { NpcChipCap = 12 });
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+        var detail = vm.DetailViewModel!;
+
+        detail.TaughtRecipes.Should().HaveCount(12, because: "the cap bounds the rendered chips");
+        detail.TaughtRecipeLinks.Should().HaveCount(12);
+        detail.TaughtRecipesTotal.Should().Be(60);
+        detail.TaughtRecipesPopup!.TotalCount.Should().Be(60,
+            because: "the popup carries the full set so the count cannot diverge");
+        detail.TaughtRecipesPopup.FlatChips.Should().HaveCount(60);
+        detail.TaughtRecipesSetRef!.MatchCount.Should().Be(60);
+    }
+
+    [Fact]
+    public void DetailViewModel_NpcChipCap_zero_collapsesEverythingIntoThePopup()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Amutasa"] = new Npc { Name = "Amutasa" } },
+            RecipesTaughtByNpcMap = { ["NPC_Amutasa"] = MakeRecipes(8) },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.Recipe),
+            new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings { NpcChipCap = 0 });
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+        var detail = vm.DetailViewModel!;
+
+        detail.TaughtRecipes.Should().BeEmpty(because: "cap 0 collapses every chip into the drawer");
+        detail.TaughtRecipesSetRef.Should().NotBeNull(because: "the drawer still carries the full set");
+        detail.TaughtRecipesSetRef!.MatchCount.Should().Be(8);
+        detail.TaughtRecipesPopup!.TotalCount.Should().Be(8);
+    }
+
+    [Fact]
+    public void DetailViewModel_TaughtRecipes_noRelationship_noPopupNoSetRef_commandDisabled()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Joeh"] = new Npc { Name = "Joeh" } },
+        };
+        var vm = new NpcsTabViewModel(refData, NavFactory.WithKinds(EntityKind.Recipe),
+            new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings());
+
+        vm.SelectedRow = vm.AllNpcs.Single();
+        var detail = vm.DetailViewModel!;
+
+        detail.TaughtRecipes.Should().BeEmpty();
+        detail.TaughtRecipesPopup.Should().BeNull();
+        detail.TaughtRecipesSetRef.Should().BeNull(because: "no popup ⇒ the SetRef row hides");
+        detail.ShowTaughtRecipesPopupCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DetailViewModel_openingTaughtRecipesPopup_invokesOpener_pushesNoNavigatorHistory()
+    {
+        var refData = new StubReferenceData
+        {
+            NpcsByKey = { ["NPC_Amutasa"] = new Npc { Name = "Amutasa" } },
+            RecipesTaughtByNpcMap = { ["NPC_Amutasa"] = MakeRecipes(30) },
+        };
+        var nav = new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>());
+        var vm = new NpcsTabViewModel(refData, nav,
+            new ReferenceDataEntityNameResolver(refData), new SilmarillionSettings { NpcChipCap = 12 });
+
+        var prior = NpcDetailViewModel.ProvenancePopupOpener;
+        ProvenancePopupViewModel? captured = null;
+        NpcDetailViewModel.ProvenancePopupOpener = (popupVm, _) => captured = popupVm;
+        try
+        {
+            vm.SelectedRow = vm.AllNpcs.Single();
+            var detail = vm.DetailViewModel!;
+
+            nav.Current.Should().BeNull();
+
+            detail.ShowTaughtRecipesPopupCommand.Execute(null);
+
+            captured.Should().NotBeNull(because: "the command invoked the opener with the built popup VM");
+            captured!.TotalCount.Should().Be(30);
+            nav.Current.Should().BeNull(because: "opening the popup must not push navigator history (#229)");
+            nav.CanGoBack.Should().BeFalse();
+        }
+        finally
+        {
+            NpcDetailViewModel.ProvenancePopupOpener = prior;
+        }
+    }
+
     [Fact]
     public void DetailViewModel_EmptyNpc_ProducesEmptyCrossLinkSections_HeaderAndFooterOnly()
     {


### PR DESCRIPTION
## Problem

The Silmarillion NPCs tab stalls when rendering a dense NPC. Reported on **Amutasa** (Rahu): teaches ~60 recipes and sells ~37 items, so the detail pane realises ~100 icon-bearing `Link` chips at once with no virtualisation — every chip's icon decodes synchronously on the UI thread before the pane can paint.

This is the original problem #441 tried to fix app-wide and regressed; that change was reverted (#442). This PR fixes it the scoped, already-designed way.

## Approach

Apply the **existing, shipped item/area "cap + popup" idiom (#318)** to the four NPC-detail chip enumerations — *Teaches recipes*, *Teaches abilities*, *Sells items*, *Quests*. No new design (no designer needed): the closest in-module analog is `AreaDetailViewModel`'s "NPCs in this area" cluster, mirrored exactly.

Each section renders the first `SilmarillionSettings.NpcChipCap` chips inline; the full set is reachable via an always-visible `"<label> · N matches →"` Set-reference that opens the shared `ProvenancePopupWindow`. The capped cluster and the popup are both views over **one** materialised list, so the "View all N" count cannot diverge from the rendered set (the #318 invariant). Single-reason ⇒ the popup is a flat list.

Effect on Amutasa: ~100 synchronous icon decodes on selection → 12 + 12 + a Set-ref each. The decode cost only returns if the user explicitly opens a "view all" popup — a separate, user-initiated window, identical to how the existing item/area popups already behave.

## Scope / why this won't regress like #441

- **No shared icon-cache change. No app-startup path change.** Entirely contained to the Silmarillion NPC detail VM/view + a new settings knob.
- `NpcChipCap` is a **new, NPC-specific** cap (default 12), parallel to `UsedInChipCap` / `RequiredByAbilitiesChipCap`. Additive to the already-`SchemaVersion`-stamped `SilmarillionSettings` — no migration. Slider added to the settings view.
- `NpcsTabViewModel` gains the standard settings-injected ctor; the 3-arg overload is kept so the ~20 existing test fixtures and DI stay green. Registered with an explicit factory passing the live `SilmarillionSettings` singleton.

Services and Gift preferences are left as-is (structured card list / small text — not chip lists, not the perf problem).

## Verification

- Full **Silmarillion suite: 549/549** green. Solution builds clean (0 warnings/errors).
- **+5 NpcsTabViewModel tests**: below-cap (all chips + popup + Set-ref built), above-cap (chips capped at N, Set-ref/popup carry full total), cap 0 (everything collapses into the drawer), no relationship (no popup/Set-ref, command disabled), opening the popup invokes the opener and pushes no navigator history (#229).
- Coverage boundary, stated plainly: unit tests cover the VM / cap / popup-VM / command wiring. They do **not** instantiate `ProvenancePopupWindow` or the XAML `SetRef` binding (the opener is swapped in tests) — the same coverage boundary the existing item/area cap+popup shipped on. **Recommend a quick live check** of the NPCs tab on Amutasa: fast render, the four "· N matches →" drawers, and the popup window opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
