### PR TITLE
refactor(silmarillion): centralise detail/popup window chrome (DRY) — #446

### DIFF
--- a/docs/silmarillion-window-chrome.md
+++ b/docs/silmarillion-window-chrome.md
@@ -1,0 +1,110 @@
+# Detail / popup window chrome — the open #404 conformance question
+
+> **Status:** open design question. The DRY half (centralising the duplicated
+> chrome) is **done** (this doc's "What shipped"). The conformance half
+> (should the frame obey the visual grammar, and how) is **not decided** — it
+> needs a design pass / gate, not free-handing. See the tracking issue for the
+> task side; this doc holds the *why* and the options.
+
+## The observation
+
+The #404 visual-grammar program migrated every Silmarillion detail **view
+body** to the ratified grammar primitives (`FactTitleStyle`, `FactTable`,
+`Link`, `SetRef`, `FactFooter`, the `--accent` / `--fg-*` token vocabulary).
+The **window that frames those views was never touched** — and it is identical
+across all 11 such windows:
+
+- `src/Mithril.Shared.Wpf/ProvenancePopupWindow.xaml` (the set/member-list popup)
+- the 10 `src/Silmarillion.Module/Views/*DetailWindow.xaml`
+  (Ability, Area, Effect, Lorebook, Npc, PlayerTitle, Quest, Recipe,
+  StorageVault, Treasure)
+
+Each hand-rolled the same dark chrome: frame `#FF1A1A1A` / border `#33FFFFFF`,
+title bar `#FF202020`, **title as a bespoke `AppHeaderFontFamily` `#FFD4A847`
+gold `TextBlock` — not `FactTitleStyle`**, subtitle / section headers
+`#88FFFFFF`.
+
+## Why this is *not* a #404 regression
+
+This was investigated before acting:
+
+1. **The grammar deliberately scopes itself out of the frame.**
+   `docs/silmarillion-visual-grammar.md` § "What this doc does NOT do" bounds
+   the spec to the five *content* tiers; line 63 is explicit — *"Structure is
+   a frame, not a finding."* There is **no ratified spec** for window/popup
+   chrome anywhere.
+2. **Chrome was never in any #404 phase's scope.** The Phase-5 fan-out plan's
+   out-of-scope list is *"coverage #407/#408, the #214 Effects-stub"*. Window
+   chrome is not named as in-scope, deferred, *or* excluded — it was simply
+   outside the program's entire remit. The migration swept *view-body call
+   sites*; the frame was never claimed.
+3. **No shared chrome style was ever intended.** `Resources.xaml` had
+   `FactTitleStyle` / `FactBodyStyle` (content) but no window-chrome style. The
+   11× duplication **predates #404 entirely**. The grammar made the contrast
+   *visible*; it did not create it.
+
+So "make the popup obey the visual language" has **no authoritative target to
+conform to** — deciding one is new design, not mechanical migration.
+
+## The real tension this exposes (the G-b problem)
+
+The grammar's central rule **G-b** ("gold reads as *title* — serif, large, no
+glyph — or *link*; two unambiguous patterns; one gold title per pane") is
+obeyed inside the view body but **violated by the frame around it**: open any
+entity in a popup and the gold title renders **twice, in two different
+languages** — the old bespoke `AppHeaderFontFamily` gold in the title bar, and
+the new `FactTitleStyle` Cambria-serif gold in the body beneath it. The
+grammar has **no ratified answer** for the popped-into-a-window case.
+`ProvenancePopupWindow`'s gold title + `#88FFFFFF` "N total" subtitle +
+`#88FFFFFF` section headers are the same violation for set display.
+
+## What shipped (the DRY half — done)
+
+The pre-existing identical pigment/typography was extracted to four keyed
+styles in `src/Mithril.Shared.Wpf/Resources.xaml`, and all 11 windows now
+reference them:
+
+| Key | Was (inline, ×11) |
+|---|---|
+| `MithrilChromeWindowFrameStyle` | `#FF1A1A1A` / `#33FFFFFF` / 1 / radius 6 |
+| `MithrilChromeWindowTitleBarStyle` | `#FF202020` / radius 6,6,0,0 / pad 14,10 |
+| `MithrilChromeWindowCloseButtonStyle` | 24×24 transparent hand "Close" button |
+| `MithrilChromeWindowTitleTextStyle` | `AppHeaderFontFamily` / XLarge / `#FFD4A847` |
+
+**The look is preserved byte-for-byte** — this is a pure refactor. Its only
+purpose is to make the conformance decision below a **single-file edit**.
+
+Intentionally left inline (out of scope for the DRY pass):
+
+- **Window-level behavioural attrs** (`WindowStyle=None`,
+  `AllowsTransparency`, `SizeToContent`, etc.) — not pigment, not the
+  grammar's concern, and a Window-self `Style` via the window's own merged
+  dictionary hits the classic *StaticResource-parses-before-`Window.Resources`*
+  ordering pitfall. Untouched on every window.
+- **Per-window `MinWidth` / `MaxWidth` / `MaxHeight`** — 4 distinct size bins
+  (360/620, 320/520, 420/680/h760, Treasure 420/760, popup 360/560/h640).
+- **Residual `#88FFFFFF`** — the close-`X` glyph (all 11) and the
+  `ProvenancePopupWindow` subtitle + section headers. These are child-content
+  pigment; folding them in belongs to the conformance decision, not the
+  no-op DRY pass. Inventoried here so they are not lost.
+
+## The open decision (the conformance half — not decided)
+
+| Option | Sketch | Cost / risk |
+|---|---|---|
+| **A — Frame is deliberate non-grammar chrome** | Ratify that the dark window shell is *intentionally* outside the grammar (it is OS-window chrome, not a content finding). Title bar keeps a distinct treatment; resolve the double-title by **suppressing the body `FactTitleStyle` when hosted in a window** (the title bar is the pane's one title). | Lowest churn. Needs a body/window "am I popped?" signal. Settles G-b by declaring the frame exempt. |
+| **B — Conform the frame to the grammar** | Title bar adopts `FactTitleStyle` + token vocabulary (`--bg-surface` / `--border-*` / `--fg-tertiary` for the subtitle); the body title is then the duplicate and is suppressed instead. Pull `#88FFFFFF` into tokens too. | Highest fidelity. Now a 1-file edit thanks to the shipped DRY. Still needs the double-title resolution + a gate (it is a visual change to 11 surfaces). |
+| **C — Hybrid** | Frame keeps its shell pigment (A) but the *title text* becomes `FactTitleStyle` so there is one gold-title language system-wide; subtitle/headers move to tokens. | Middle. Smallest visible change that kills the two-gold-languages problem without re-pigmenting the shell. |
+
+All three require resolving **where the single per-pane gold title lives when
+a detail is shown in a window** — that is the actual G-b gap, and it is a
+design call for the #404 owners / Claude Design, not an implementation
+default.
+
+## Pointers
+
+- `docs/silmarillion-visual-grammar.md` — G-b, § "What this doc does NOT do".
+- `docs/agent-plans/2026-05-17-silmarillion-404-phase5-fanout.md` — scope list
+  proving chrome was never in remit.
+- `src/Mithril.Shared.Wpf/Resources.xaml` — the four `MithrilChromeWindow*`
+  keys (the single swap point for options B/C).

--- a/src/Mithril.Shared.Wpf/ProvenancePopupWindow.xaml
+++ b/src/Mithril.Shared.Wpf/ProvenancePopupWindow.xaml
@@ -69,23 +69,20 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="360" MaxWidth="560" MaxHeight="640">
         <DockPanel>
             <!-- Title bar: draggable, distinct-count subtitle, close. -->
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <StackPanel>
                         <TextBlock Text="{Binding Title}"
-                                   FontFamily="{DynamicResource AppHeaderFontFamily}"
-                                   FontSize="{DynamicResource AppFontSizeXLarge}"
-                                   Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                                   Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                         <TextBlock Foreground="#88FFFFFF"
                                    FontSize="{DynamicResource AppFontSizeSmall}"
                                    Margin="0,2,0,0">

--- a/src/Mithril.Shared.Wpf/Resources.xaml
+++ b/src/Mithril.Shared.Wpf/Resources.xaml
@@ -1822,6 +1822,62 @@
          Phase 5 call site (pass already-upper text; tracking would need a
          custom behavior). Surfaced in the Phase 4 reconciliation flags. -->
 
+    <!-- ════════════════════════════════════════════════════════════════════
+         Detail / popup WINDOW CHROME — pre-grammar frame, centralised (DRY).
+
+         This is the hand-rolled dark chrome shared verbatim by all 11 detail /
+         popup windows (ProvenancePopupWindow + the 10 *DetailWindow). It is
+         NOT #404 grammar: the visual-grammar doc explicitly scopes itself to
+         CONTENT tiers ("Structure is a frame, not a finding"; § "What this doc
+         does NOT do"), so the window FRAME was never in any #404 phase. These
+         styles only DE-DUPLICATE the pre-existing identical pigment so the open
+         "should the frame conform to the grammar?" decision (incl. the
+         double-gold-title G-b tension when a detail opens in a window) becomes a
+         single-file edit. Look is preserved byte-for-byte. See
+         docs/silmarillion-window-chrome.md for the open conformance question.
+
+         Window-level behavioural attrs (WindowStyle/AllowsTransparency/sizing)
+         are intentionally LEFT INLINE: they are not pigment, not the grammar's
+         concern, and a Window-self Style via the window's own merged dict hits
+         the classic StaticResource-parses-before-Resources ordering pitfall.
+         Per-window MinWidth/MaxWidth/MaxHeight also stay inline (4 size bins).
+         ════════════════════════════════════════════════════════════════════ -->
+
+    <Style x:Key="MithrilChromeWindowFrameStyle" TargetType="Border">
+        <Setter Property="Background" Value="#FF1A1A1A"/>
+        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="6"/>
+    </Style>
+
+    <Style x:Key="MithrilChromeWindowTitleBarStyle" TargetType="Border">
+        <Setter Property="Background" Value="#FF202020"/>
+        <Setter Property="CornerRadius" Value="6,6,0,0"/>
+        <Setter Property="Padding" Value="14,10"/>
+    </Style>
+
+    <Style x:Key="MithrilChromeWindowCloseButtonStyle" TargetType="Button">
+        <Setter Property="Width" Value="24"/>
+        <Setter Property="Height" Value="24"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="ToolTip" Value="Close"/>
+    </Style>
+
+    <!-- The window title-bar gold text. Today this is the OLD bespoke gold
+         (AppHeaderFontFamily / XLarge / #FFD4A847) — deliberately NOT
+         FactTitleStyle. Resolving that (and the resulting double-gold-title
+         when a detail opens in a window) is the open (B) decision; this key is
+         the single swap point for it. -->
+    <Style x:Key="MithrilChromeWindowTitleTextStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource AppHeaderFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource AppFontSizeXLarge}"/>
+        <Setter Property="Foreground" Value="#FFD4A847"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
     <!-- Fact · title-loud: Cambria / 600 / accent, one per pane. G3-amend-2:
          size is 1.5em (was the fixed AppFontSizeHeader=18, which equalled 1.5×
          the AppFontSize=12 default — now it TRACKS the Appearance slider).

--- a/src/Silmarillion.Module/Views/AbilityDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/AbilityDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="360" MaxWidth="620">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/AreaDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/AreaDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="360" MaxWidth="620">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/EffectDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/EffectDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="360" MaxWidth="620">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/LorebookDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/LorebookDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="420" MaxWidth="680" MaxHeight="760">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/NpcDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/NpcDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="320" MaxWidth="520">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/PlayerTitleDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/PlayerTitleDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="420" MaxWidth="680" MaxHeight="760">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/QuestDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/QuestDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="360" MaxWidth="620">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/RecipeDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/RecipeDetailWindow.xaml
@@ -24,22 +24,19 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="320" MaxWidth="520">
         <DockPanel>
             <!-- Title bar (drag + close) -->
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/StorageVaultDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailWindow.xaml
@@ -24,21 +24,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="420" MaxWidth="680" MaxHeight="760">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 

--- a/src/Silmarillion.Module/Views/TreasureDetailWindow.xaml
+++ b/src/Silmarillion.Module/Views/TreasureDetailWindow.xaml
@@ -25,21 +25,18 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border Background="#FF1A1A1A" BorderBrush="#33FFFFFF" BorderThickness="1" CornerRadius="6"
+    <Border Style="{StaticResource MithrilChromeWindowFrameStyle}"
             MinWidth="420" MaxWidth="760">
         <DockPanel>
-            <Border DockPanel.Dock="Top" Background="#FF202020" CornerRadius="6,6,0,0"
-                    Padding="14,10" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <Border DockPanel.Dock="Top" Style="{StaticResource MithrilChromeWindowTitleBarStyle}"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
                 <DockPanel>
-                    <Button DockPanel.Dock="Right" Width="24" Height="24" Padding="0"
-                            Background="Transparent" BorderThickness="0" Cursor="Hand"
-                            ToolTip="Close" Click="CloseButton_Click">
+                    <Button DockPanel.Dock="Right" Style="{StaticResource MithrilChromeWindowCloseButtonStyle}"
+                            Click="CloseButton_Click">
                         <icon:PackIconLucide Kind="X" Width="14" Height="14" Foreground="#88FFFFFF"/>
                     </Button>
                     <TextBlock Text="{Binding DisplayName}"
-                               FontFamily="{DynamicResource AppHeaderFontFamily}"
-                               FontSize="{DynamicResource AppFontSizeXLarge}"
-                               Foreground="#FFD4A847" VerticalAlignment="Center"/>
+                               Style="{StaticResource MithrilChromeWindowTitleTextStyle}"/>
                 </DockPanel>
             </Border>
 


### PR DESCRIPTION
## What

Centralises the byte-identical, pre-grammar chrome duplicated across all 11 detail/popup windows (`ProvenancePopupWindow` + the 10 Silmarillion `*DetailWindow`) into four keyed styles in `Mithril.Shared.Wpf/Resources.xaml`, and adds a design note framing the open grammar-conformance decision.

**This is the DRY half only — a pure, byte-for-byte-preserving refactor.** The conformance decision itself (should the frame obey the #404 grammar; how to resolve the double-gold-title G-b tension when a detail opens in a window) is **left open and tracked in #446** — it is an un-specced design call, not mechanical migration. Full rationale + options A/B/C: `docs/silmarillion-window-chrome.md`.

## Why this isn't a #404 follow-up

Investigated before acting: the grammar deliberately scopes itself out of the frame (`silmarillion-visual-grammar.md` § "What this doc does NOT do"; *"Structure is a frame, not a finding"*). Window chrome was never named in any #404 phase's scope; the 11× duplication predates the program. The grammar only made the contrast visible.

## Changes

- `Mithril.Shared.Wpf/Resources.xaml`: + `MithrilChromeWindow{Frame,TitleBar,CloseButton,TitleText}Style` (exact prior pigment/typography, commented with the rationale + the StaticResource-ordering pitfall that shaped the design)
- 11 windows: inline chrome → `Style="{StaticResource …}"`. Handlers, per-window size bins, body content, title bindings, window-level behavioural attrs all untouched
- `docs/silmarillion-window-chrome.md`: new design note (finding, G-b tension, options)

Intentionally left inline (documented): window-level behavioural attrs (Window-self Style via the window's own merged dict hits a StaticResource-parses-before-Resources pitfall), per-window dimensions, residual `#88FFFFFF` (close-X glyph / popup subtitle) — folded into #446 scope.

## Test

- `dotnet build Mithril.slnx`: 0 warnings / 0 errors (warnings-as-errors on)
- `Silmarillion.Tests` 544/544, `Mithril.Shared.Tests` 1142/1142
- Verified: 4 keys defined, each referenced exactly 11×, no leftover frame hex

**Caveat:** no live-shell runtime XAML smoke (the guard test is static code-behind analysis). Confidence high — keys verified consistent, same merged dictionary the view bodies already resolve from, correct child-element parse ordering — but opening a detail window in a running shell is the gold-standard check not performed here.

Closes nothing; tracks the open conformance decision in #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
