### PR TITLE
chore(tooling): auto-build mithril-logs MCP server on session start

### DIFF
--- a/.claude/hooks/ensure-mithril-logs-built.ps1
+++ b/.claude/hooks/ensure-mithril-logs-built.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+# SessionStart hook: ensures tools/MithrilLogMcp is built so the project-scoped
+# `mithril-logs` MCP server (see .mcp.json) can start in ANY session/worktree.
+#
+# dist/ and node_modules are gitignored, so a fresh clone or worktree has
+# neither. This rebuilds ONLY when stale and writes NOTHING to stdout on the
+# common path, so it adds ~0 tokens to session context and no perceptible
+# latency once built. A full build runs only on first use in a location or
+# after src/ changes; its output is redirected to a temp log. The single
+# stderr line emitted on failure is intentional — Claude should know.
+#
+# Anchored to this script's location so it targets the current worktree.
+
+$ErrorActionPreference = 'Stop'
+try {
+    $proj = Join-Path (Resolve-Path "$PSScriptRoot/../..") 'tools/MithrilLogMcp'
+    $server = Join-Path $proj 'dist/src/server.js'
+    $nodeModules = Join-Path $proj 'node_modules'
+
+    # Staleness check: server.js present, node_modules present, and server.js
+    # at least as new as the newest build input. Scope the scan to src/ +
+    # config files only (never node_modules) so this stays sub-100ms.
+    if ((Test-Path $server) -and (Test-Path $nodeModules)) {
+        $serverTime = (Get-Item $server).LastWriteTimeUtc
+        $inputs = @((Join-Path $proj 'src'), (Join-Path $proj 'package.json'), (Join-Path $proj 'tsconfig.json'))
+        $newest = Get-ChildItem -Path $inputs -Recurse -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+        if (-not $newest -or $newest.LastWriteTimeUtc -le $serverTime) {
+            exit 0  # fresh — silent no-op
+        }
+    }
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        [Console]::Error.WriteLine('[mithril-logs] npm not on PATH; cannot build MCP server. Install Node >=22.')
+        exit 0  # never block session start
+    }
+
+    $log = Join-Path ([System.IO.Path]::GetTempPath()) 'mithril-logs-build.log'
+    Push-Location $proj
+    try {
+        if (-not (Test-Path $nodeModules)) {
+            npm install *> $log 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                [Console]::Error.WriteLine("[mithril-logs] npm install failed; see $log")
+                exit 0
+            }
+        }
+        npm run build *>> $log 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            [Console]::Error.WriteLine("[mithril-logs] build failed; see $log")
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+catch {
+    [Console]::Error.WriteLine("[mithril-logs] build hook error: $($_.Exception.Message)")
+}
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,19 @@
       "Read(//c/Users/arthu/AppData/Local/Mithril/Legolas/perf/**)"
     ]
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File \"$CLAUDE_PROJECT_DIR/.claude/hooks/ensure-mithril-logs-built.ps1\"",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "csharp-lsp@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,


### PR DESCRIPTION
## Problem

The project-scoped `mithril-logs` MCP server in [.mcp.json](../blob/main/.mcp.json) is launched via a **relative** path: `tools/MithrilLogMcp/dist/src/server.js`. Both `dist/` and `node_modules` are gitignored, so a fresh clone or any git worktree has neither — the server silently fails to start there. Building in one location doesn't help others because the relative path resolves per-session-cwd and build artifacts are never shared via git.

## Change

A `SessionStart` hook that ensures the server is built for whichever worktree/checkout the session launched from.

- **`.claude/hooks/ensure-mithril-logs-built.ps1`** — anchored to its own location (targets the active worktree), stale-guarded, output-suppressed.
- **`.claude/settings.json`** — registers the hook (`timeout: 300` for the first cold `npm install` + build).

## Cost profile (verified)

| Situation | Behavior | Token cost |
|---|---|---|
| Built & fresh | sub-100ms check, `exit 0`, no output | ~0 |
| Fresh worktree / `dist` missing | `npm install` + build → temp log | ~0 (suppressed) |
| `src/**` edited | rebuild silently | ~0 (suppressed) |
| npm missing / build fails | one stderr line pointing at the temp log | 1 line, failure only |

Build output is redirected to a temp file, so nothing enters session context on the common path.

## Why not extract to a standalone repo (the `pg-data` pattern)

`mithril-logs` reads `src/Mithril.Shared/Reference/log-patterns.json` from this repo at runtime, and `LogPatternCatalogParityTests` enforces parity with the .NET parsers *in this repo*. Extracting it would split that single source of truth across two repos and break the parity guarantee. This hook keeps the server in-tree and self-healing without that tradeoff.

## Notes

- Takes effect on the **next** session launch (hooks load at startup).
- `.claude/settings.json` is committed, so all teammates/worktrees self-heal on next pull.
- No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
