### PR TITLE
feat(legolas): per-area projector calibration from landmark/NPC clicks (#443)

### DIFF
--- a/src/Legolas.Module/Domain/AreaCalibration.cs
+++ b/src/Legolas.Module/Domain/AreaCalibration.cs
@@ -1,0 +1,29 @@
+namespace Legolas.Domain;
+
+/// <summary>
+/// A solved, persistable similarity transform for one Project&#160;Gorgon area:
+/// the projector <see cref="Scale"/> (pixels per metre), <see cref="RotationRadians"/>,
+/// and pixel <see cref="OriginX"/>/<see cref="OriginY"/> that map a metre offset to
+/// the 1:1 map overlay. Derived once from &#8805;2 known landmark/NPC reference
+/// clicks (see <c>LandmarkCalibrationSolver</c>) and reused across sessions because
+/// landmarks/NPCs don't move — keyed by area in
+/// <see cref="LegolasSettings.AreaCalibrations"/>.
+///
+/// <para><see cref="ResidualPixels"/> is the RMS pixel error of the fit across the
+/// reference points; a large value means the references were placed inconsistently
+/// (or the map was at a different zoom) and the calibration should be redone.</para>
+/// </summary>
+public sealed record AreaCalibration(
+    double Scale,
+    double RotationRadians,
+    double OriginX,
+    double OriginY,
+    int ReferenceCount,
+    double ResidualPixels)
+{
+    /// <summary>
+    /// Schema version for this persisted record. Bump alongside any shape change
+    /// and migrate in <see cref="LegolasSettings.Migrate"/>. Default 1 (current).
+    /// </summary>
+    public int SchemaVersion { get; init; } = 1;
+}

--- a/src/Legolas.Module/Domain/AreaCalibration.cs
+++ b/src/Legolas.Module/Domain/AreaCalibration.cs
@@ -33,6 +33,17 @@ public sealed record AreaCalibration(
     public bool MirrorNorth { get; init; }
 
     /// <summary>
+    /// The in-game map zoom the user was at when this was solved (read off the
+    /// game UI — Mithril can't see it). <see cref="Scale"/> is px-per-unit at
+    /// THIS zoom; pixels-per-metre scales linearly with zoom, so a projection
+    /// at a different current zoom must be scaled by
+    /// <c>currentZoom / CalibrationZoom</c>. Additive — old saves / unset
+    /// default to <c>1.0</c>, which (with a current-zoom of 1.0) is a no-op, so
+    /// existing behaviour is unchanged until the zoom field is actually used.
+    /// </summary>
+    public double CalibrationZoom { get; init; } = 1.0;
+
+    /// <summary>
     /// Schema version for this persisted record. Bump alongside any shape change
     /// and migrate in <see cref="LegolasSettings.Migrate"/>. Default 1 (current).
     /// </summary>

--- a/src/Legolas.Module/Domain/AreaCalibration.cs
+++ b/src/Legolas.Module/Domain/AreaCalibration.cs
@@ -22,6 +22,17 @@ public sealed record AreaCalibration(
     double ResidualPixels)
 {
     /// <summary>
+    /// Which world-axis→compass handedness the solver chose: when true, world
+    /// North = −Z (a reflection of the +Z convention). A similarity transform
+    /// cannot absorb a reflection, so this MUST be carried to re-project raw
+    /// world coords (e.g. the ghost-landmark test). Irrelevant to survey
+    /// projection (surveys already arrive in compass E/N). Additive — old saved
+    /// calibrations default false; recalibrate if a mirrored area's ghosts look
+    /// flipped. Default false (the +Z convention).
+    /// </summary>
+    public bool MirrorNorth { get; init; }
+
+    /// <summary>
     /// Schema version for this persisted record. Bump alongside any shape change
     /// and migrate in <see cref="LegolasSettings.Migrate"/>. Default 1 (current).
     /// </summary>

--- a/src/Legolas.Module/Domain/CalibrationReference.cs
+++ b/src/Legolas.Module/Domain/CalibrationReference.cs
@@ -7,3 +7,10 @@ namespace Legolas.Domain;
 /// named, on-map set; landmarks are the sparse same-format supplement.
 /// </summary>
 public sealed record CalibrationReference(string Name, string Kind, WorldCoord World);
+
+/// <summary>
+/// A survey/treasure reading observed while the calibration window's test mode
+/// is active — the relative metre offset the game reported. The calibration VM
+/// projects it from the user's test origin so projected-vs-actual can be eyeballed.
+/// </summary>
+public sealed record CalibrationSurveyObservation(string Name, MetreOffset Offset);

--- a/src/Legolas.Module/Domain/CalibrationReference.cs
+++ b/src/Legolas.Module/Domain/CalibrationReference.cs
@@ -1,0 +1,9 @@
+namespace Legolas.Domain;
+
+/// <summary>
+/// A known fixed point in the current area the user can click on the map overlay
+/// to calibrate: a landmark (teleport circle, portal, …) or an NPC. <see cref="World"/>
+/// is its area-local engine-unit position (ground plane X/Z). NPCs are the dense,
+/// named, on-map set; landmarks are the sparse same-format supplement.
+/// </summary>
+public sealed record CalibrationReference(string Name, string Kind, WorldCoord World);

--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -32,6 +32,16 @@ public sealed record MotherlodeDistance(
     DateTime Timestamp,
     int DistanceMetres) : GameEvent(Timestamp);
 
+/// <summary>
+/// The chat-log area banner (<c>"******* Entering Area: Eltibule"</c>). Carries
+/// the area's <em>friendly</em> name (the only thing the log gives); the calibration
+/// service resolves it to the internal area key. This is the sole area signal
+/// available — Player.log has no area-change marker.
+/// </summary>
+public sealed record AreaEntered(
+    DateTime Timestamp,
+    string AreaFriendlyName) : GameEvent(Timestamp);
+
 public sealed record UnknownLine(
     DateTime Timestamp,
     string RawLine) : GameEvent(Timestamp);

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -108,6 +108,7 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     public Dictionary<string, AreaCalibration> AreaCalibrations { get; set; } = new(StringComparer.Ordinal);
     public WindowLayout MapOverlay { get; set; } = new() { Width = 800, Height = 600 };
     public WindowLayout InventoryOverlay { get; set; } = new() { Width = 540, Height = 440 };
+    public WindowLayout CalibrationOverlay { get; set; } = new() { Width = 940, Height = 660 };
 
     // WPF stops hit-testing fully-transparent elements regardless of IsHitTestVisible,
     // so a 0-opacity overlay silently becomes unclickable. Floor at 1% — visually

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -5,7 +5,7 @@ namespace Legolas.Domain;
 
 public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<LegolasSettings>
 {
-    public const int Version = 2;
+    public const int Version = 3;
     public static int CurrentVersion => Version;
 
     /// <summary>
@@ -18,6 +18,11 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     /// triggers <see cref="Migrate"/>. Fresh in-memory instances also start at
     /// <c>1</c> — no-op migration since their legacy fields are null — and the
     /// loader bumps to current after persisting.
+    ///
+    /// v2 → v3 adds <see cref="AreaCalibrations"/> (per-area projector
+    /// calibration). The migration is a no-op: the new dictionary defaults to
+    /// empty, which is exactly the "no calibration yet" state, so v2 JSON loads
+    /// unchanged and simply starts uncalibrated per area.
     /// </summary>
     public int SchemaVersion { get; set; } = 1;
 
@@ -91,6 +96,16 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     public LegolasPinStyle PinStyle { get; set; } = new();
     public LegolasPinStyle PlayerPinStyle { get; set; } = LegolasPinStyle.PlayerDefaults();
     public LegolasActivePinStyle ActivePinStyle { get; set; } = new();
+
+    /// <summary>
+    /// Per-area solved projector calibration, keyed by the internal area key
+    /// (e.g. <c>"AreaEltibule"</c>). Populated by the standalone calibration
+    /// window from landmark/NPC reference clicks; landmarks/NPCs don't move so a
+    /// calibration is reused on every later visit to that area, eliminating the
+    /// first-pins-land-off-frame warmup for surveys and treasure alike. Empty =
+    /// no area calibrated yet (the v2 default; see <see cref="SchemaVersion"/>).
+    /// </summary>
+    public Dictionary<string, AreaCalibration> AreaCalibrations { get; set; } = new(StringComparer.Ordinal);
     public WindowLayout MapOverlay { get; set; } = new() { Width = 800, Height = 600 };
     public WindowLayout InventoryOverlay { get; set; } = new() { Width = 540, Height = 440 };
 

--- a/src/Legolas.Module/Domain/WorldCoord.cs
+++ b/src/Legolas.Module/Domain/WorldCoord.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// A point in a Project&#160;Gorgon area's local engine-unit coordinate space, as
+/// stored in reference data (<c>landmarks.json</c> <c>Loc</c>, <c>npcs.json</c>
+/// <c>Pos</c>). Format is <c>"x:&lt;f&gt; y:&lt;f&gt; z:&lt;f&gt;"</c>; the ground
+/// plane is <see cref="X"/>/<see cref="Z"/> and <see cref="Y"/> is elevation
+/// (ignored for map projection). Verified 2026-05-18 to be the same frame the game
+/// positions the player in (Player.log <c>ProcessNewPosition</c>), and coordinates
+/// are <b>signed</b> — negative X/Z are common (Myconian Cave, Sun Vale, Desert,
+/// Gazluk). Any parse that assumes positive-only silently misprojects whole zones.
+/// </summary>
+public readonly record struct WorldCoord(double X, double Y, double Z)
+{
+    /// <summary>
+    /// Parses the reference-data position string. Accepts the canonical
+    /// <c>"x:1.5 y:2 z:-3.25"</c> form (tokens may appear in any order and the
+    /// sign is preserved) and a bare space/comma-separated <c>"1.5 2 -3.25"</c>
+    /// fallback. Returns null when fewer than three numeric components resolve.
+    /// </summary>
+    public static WorldCoord? TryParse(string? loc)
+    {
+        if (string.IsNullOrWhiteSpace(loc)) return null;
+
+        double? x = null, y = null, z = null;
+        var sawLabel = false;
+
+        foreach (var token in loc.Split(new[] { ' ', '\t', ',' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var colon = token.IndexOf(':');
+            if (colon > 0)
+            {
+                sawLabel = true;
+                var axis = token.AsSpan(0, colon).Trim();
+                var valSpan = token.AsSpan(colon + 1);
+                if (!double.TryParse(valSpan, NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                    continue;
+                if (axis.Equals("x", StringComparison.OrdinalIgnoreCase)) x = v;
+                else if (axis.Equals("y", StringComparison.OrdinalIgnoreCase)) y = v;
+                else if (axis.Equals("z", StringComparison.OrdinalIgnoreCase)) z = v;
+            }
+            else if (!sawLabel)
+            {
+                // Bare "x y z" fallback — fill positionally.
+                if (!double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                    return null;
+                if (x is null) x = v;
+                else if (y is null) y = v;
+                else if (z is null) z = v;
+            }
+        }
+
+        if (x is null || y is null || z is null) return null;
+        return new WorldCoord(x.Value, y.Value, z.Value);
+    }
+}

--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -120,6 +120,24 @@ public sealed class ToggleInventoryOverlayCommand : IHotkeyCommand
     }
 }
 
+public sealed class ToggleCalibrationOverlayCommand : IHotkeyCommand
+{
+    private readonly SessionState _session;
+    public ToggleCalibrationOverlayCommand(SessionState session) => _session = session;
+    public string Id => "legolas.overlay.calibration.toggle";
+    public string DisplayName => "Toggle Map Calibration";
+    public string? Category => "Legolas · Overlay";
+    public HotkeyBinding? DefaultBinding => null;
+    // Calibration is done with the in-game map open, so it must stay registered
+    // while the game (not Mithril) has focus — same as the other overlays.
+    public bool RespectsFocusGate => false;
+    public Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _session.IsCalibrationVisible = !_session.IsCalibrationVisible;
+        return Task.CompletedTask;
+    }
+}
+
 public sealed class OptimizeRouteCommand : IHotkeyCommand
 {
     private readonly MapOverlayViewModel _map;

--- a/src/Legolas.Module/Hotkeys/OverlayController.cs
+++ b/src/Legolas.Module/Hotkeys/OverlayController.cs
@@ -33,6 +33,7 @@ public sealed class OverlayController : IHostedService
     private bool _subscribed;
     private MapOverlayView? _map;
     private InventoryOverlayView? _inventory;
+    private CalibrationOverlayView? _calibration;
 
     public OverlayController(
         IServiceProvider services,
@@ -65,6 +66,7 @@ public sealed class OverlayController : IHostedService
                     _subscribed = true;
                     SyncMap();
                     SyncInventory();
+                    SyncCalibration();
                 });
             }
             catch (OperationCanceledException) { }
@@ -87,8 +89,10 @@ public sealed class OverlayController : IHostedService
             }
             _map?.Close();
             _inventory?.Close();
+            _calibration?.Close();
             _map = null;
             _inventory = null;
+            _calibration = null;
         });
     }
 
@@ -96,6 +100,7 @@ public sealed class OverlayController : IHostedService
     {
         if (e.PropertyName == nameof(SessionState.IsMapVisible)) SyncMap();
         else if (e.PropertyName == nameof(SessionState.IsInventoryVisible)) SyncInventory();
+        else if (e.PropertyName == nameof(SessionState.IsCalibrationVisible)) SyncCalibration();
     }
 
     private void OnFocusGatePropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -103,6 +108,7 @@ public sealed class OverlayController : IHostedService
         if (e.PropertyName != nameof(ForegroundFocusGate.IsInApp)) return;
         SyncMap();
         SyncInventory();
+        SyncCalibration();
     }
 
     private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -114,6 +120,7 @@ public sealed class OverlayController : IHostedService
         if (e.PropertyName != nameof(LegolasSettings.AutoHideOverlaysOnGameUnfocused)) return;
         SyncMap();
         SyncInventory();
+        SyncCalibration();
     }
 
     private bool ShouldRender(bool sessionFlag) =>
@@ -129,6 +136,12 @@ public sealed class OverlayController : IHostedService
     {
         if (ShouldRender(_session.IsInventoryVisible)) EnsureInventory().Show();
         else _inventory?.Hide();
+    }
+
+    private void SyncCalibration()
+    {
+        if (ShouldRender(_session.IsCalibrationVisible)) EnsureCalibration().Show();
+        else _calibration?.Hide();
     }
 
     private MapOverlayView EnsureMap()
@@ -153,5 +166,17 @@ public sealed class OverlayController : IHostedService
             _session.IsInventoryVisible = false;
         };
         return _inventory;
+    }
+
+    private CalibrationOverlayView EnsureCalibration()
+    {
+        if (_calibration is not null) return _calibration;
+        _calibration = _services.GetRequiredService<CalibrationOverlayView>();
+        _calibration.Closed += (_, _) =>
+        {
+            _calibration = null;
+            _session.IsCalibrationVisible = false;
+        };
+        return _calibration;
     }
 }

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -57,6 +57,7 @@ public sealed class LegolasModule : IMithrilModule
             sp.GetRequiredService<NearestNeighbourTwoOptOptimizer>()));
         services.AddSingleton<ITrilaterationSolver, TrilaterationSolver>();
         services.AddSingleton<ICoordinateProjector, CoordinateProjector>();
+        services.AddSingleton<IAreaCalibrationService, AreaCalibrationService>();
 
         // Session + flow controllers + VMs.
         // Session.MapOpacity / InventoryOpacity hydrate from persisted settings on

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -121,6 +121,7 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<InventoryGridSettingsViewModel>();
         services.AddSingleton<MotherlodeViewModel>();
         services.AddSingleton<NudgePadViewModel>();
+        services.AddSingleton<CalibrationSessionViewModel>();
 
         // Panel view (shell-hosted UserControl) — singleton so it keeps scroll/state across tab switches.
         // The panel directly hosts the wizard; settings live in the per-module settings tab.
@@ -151,6 +152,14 @@ public sealed class LegolasModule : IMithrilModule
             view.DataContext = sp.GetRequiredService<InventoryOverlayViewModel>();
             return view;
         });
+        services.AddTransient<CalibrationOverlayView>(sp =>
+        {
+            var view = new CalibrationOverlayView(
+                sp.GetRequiredService<LegolasSettings>(),
+                sp.GetRequiredService<SettingsAutoSaver<LegolasSettings>>());
+            view.DataContext = sp.GetRequiredService<CalibrationSessionViewModel>();
+            return view;
+        });
 
         // Foreground-focus tracking (issue #116). Singleton + hosted-service
         // so OverlayController can read its IsInApp state directly.
@@ -172,6 +181,7 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<IHotkeyCommand, SetMotherlodeModeCommand>();
         services.AddSingleton<IHotkeyCommand, ToggleMapOverlayCommand>();
         services.AddSingleton<IHotkeyCommand, ToggleInventoryOverlayCommand>();
+        services.AddSingleton<IHotkeyCommand, ToggleCalibrationOverlayCommand>();
         services.AddSingleton<IHotkeyCommand, OptimizeRouteCommand>();
         services.AddSingleton<IHotkeyCommand, ToggleMapClickThroughCommand>();
         services.AddSingleton<IHotkeyCommand, ToggleInventoryClickThroughCommand>();

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -61,6 +61,16 @@ public interface IAreaCalibrationService
 
     /// <summary>Drop the current area's persisted calibration (forces a recalibrate).</summary>
     void ClearCurrentAreaCalibration();
+
+    /// <summary>
+    /// Fed every survey/treasure reading by the log pipeline. Re-raised as
+    /// <see cref="SurveyObserved"/> so the calibration window's test mode can
+    /// project it and show projected-vs-actual. A no-op for everyone else.
+    /// </summary>
+    void NoteSurvey(string name, MetreOffset offset);
+
+    /// <summary>Raised for each <see cref="NoteSurvey"/> — the test-mode hook.</summary>
+    event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
 }
 
 /// <summary>
@@ -161,6 +171,11 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
         Changed?.Invoke(this, EventArgs.Empty);
         return calibration;
     }
+
+    public event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
+
+    public void NoteSurvey(string name, MetreOffset offset) =>
+        SurveyObserved?.Invoke(this, new CalibrationSurveyObservation(name, offset));
 
     public void ClearCurrentAreaCalibration()
     {

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -25,6 +25,14 @@ public interface IAreaCalibrationService
     /// </summary>
     IReadOnlyList<CalibrationReference> CurrentAreaReferences { get; }
 
+    /// <summary>
+    /// Every known area (from reference data), sorted by friendly name — the
+    /// source for the manual area picker. Lets the user calibrate without
+    /// waiting for a live <c>Entering Area:</c> banner (e.g. Mithril was started
+    /// after they were already in the area).
+    /// </summary>
+    IReadOnlyList<AreaEntry> AllAreas { get; }
+
     /// <summary>Raised (CurrentAreaKey changed or calibration (re)applied) so UI can refresh.</summary>
     event EventHandler? Changed;
 
@@ -34,6 +42,13 @@ public interface IAreaCalibrationService
     /// projector immediately so the first survey/treasure projects correctly.
     /// </summary>
     void OnAreaEntered(string areaFriendlyName);
+
+    /// <summary>
+    /// Manually set the current area by internal key (the area-picker path).
+    /// Same effect as <see cref="OnAreaEntered"/> but bypasses friendly-name
+    /// resolution — used when the chat banner was missed.
+    /// </summary>
+    void SelectArea(string areaKey);
 
     /// <summary>
     /// Solve a calibration from user-placed reference clicks (a world point
@@ -88,16 +103,34 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
 
     public IReadOnlyList<CalibrationReference> CurrentAreaReferences => _currentRefs;
 
+    private IReadOnlyList<AreaEntry>? _allAreas;
+    public IReadOnlyList<AreaEntry> AllAreas =>
+        _allAreas ??= _refData.Areas.Values
+            .OrderBy(a => a.FriendlyName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
     public event EventHandler? Changed;
 
     public void OnAreaEntered(string areaFriendlyName)
     {
         if (string.IsNullOrWhiteSpace(areaFriendlyName)) return;
+        // Even if the key can't be resolved (unknown / missing reference data),
+        // record the raw friendly name so the UI can show it.
+        SetArea(ResolveAreaKey(areaFriendlyName), areaFriendlyName.Trim());
+    }
 
-        var key = ResolveAreaKey(areaFriendlyName);
-        // Even if we can't resolve the key (reference data missing / unknown
-        // friendly name), record what we saw so the UI can show the raw name.
-        CurrentAreaFriendlyName = areaFriendlyName.Trim();
+    public void SelectArea(string areaKey)
+    {
+        if (string.IsNullOrWhiteSpace(areaKey)) return;
+        if (_refData.Areas.TryGetValue(areaKey, out var entry))
+            SetArea(entry.Key, entry.FriendlyName);
+        else
+            SetArea(areaKey, areaKey); // unknown key: still switch, no refs
+    }
+
+    private void SetArea(string? key, string friendlyName)
+    {
+        CurrentAreaFriendlyName = friendlyName;
         CurrentAreaKey = key;
         _currentRefs = key is null ? Array.Empty<CalibrationReference>() : BuildReferences(key);
 

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -57,7 +57,9 @@ public interface IAreaCalibrationService
     /// calibration, or null if it couldn't be solved (no current area, &lt;2
     /// non-degenerate references).
     /// </summary>
-    AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements);
+    AreaCalibration? CalibrateCurrentArea(
+        IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements,
+        double calibrationZoom = 1.0);
 
     /// <summary>Drop the current area's persisted calibration (forces a recalibrate).</summary>
     void ClearCurrentAreaCalibration();
@@ -153,7 +155,9 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
-    public AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements)
+    public AreaCalibration? CalibrateCurrentArea(
+        IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements,
+        double calibrationZoom = 1.0)
     {
         if (CurrentAreaKey is not { } key || placements is null || placements.Count < 2)
             return null;
@@ -162,8 +166,15 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
             .Select(p => new LandmarkCalibrationSolver.Reference(p.World.X, p.World.Z, p.Pixel))
             .ToList();
 
-        var calibration = LandmarkCalibrationSolver.Solve(refs);
-        if (calibration is null) return null;
+        var solved = LandmarkCalibrationSolver.Solve(refs);
+        if (solved is null) return null;
+        // Stamp the zoom the user solved at (solver is zoom-agnostic — it just
+        // fits the clicked pixels). > 0 guard so a bad value can't poison the
+        // later currentZoom/CalibrationZoom division.
+        var calibration = solved with
+        {
+            CalibrationZoom = calibrationZoom > 1e-6 ? calibrationZoom : 1.0,
+        };
 
         _settings.AreaCalibrations[key] = calibration;
         _saver.Touch(); // AreaCalibrations is a sibling object — no PropertyChanged.

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -1,0 +1,188 @@
+using Legolas.Domain;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Settings;
+
+namespace Legolas.Services;
+
+public interface IAreaCalibrationService
+{
+    /// <summary>Internal area key of the area the player is currently in (e.g. <c>"AreaEltibule"</c>), or null if unknown.</summary>
+    string? CurrentAreaKey { get; }
+
+    /// <summary>Friendly name of the current area (as seen in the chat banner), or null.</summary>
+    string? CurrentAreaFriendlyName { get; }
+
+    /// <summary>True when the current area has a persisted <see cref="AreaCalibration"/> applied.</summary>
+    bool IsCurrentAreaCalibrated { get; }
+
+    /// <summary>Persisted calibration for the current area, if any.</summary>
+    AreaCalibration? CurrentCalibration { get; }
+
+    /// <summary>
+    /// Landmark + NPC reference points in the current area, with parseable
+    /// positions, ordered NPCs-then-landmarks (NPCs are the dense recognizable
+    /// set). Empty when no current area or no reference data loaded.
+    /// </summary>
+    IReadOnlyList<CalibrationReference> CurrentAreaReferences { get; }
+
+    /// <summary>Raised (CurrentAreaKey changed or calibration (re)applied) so UI can refresh.</summary>
+    event EventHandler? Changed;
+
+    /// <summary>
+    /// Handle the chat banner. Resolves the friendly name to an internal area
+    /// key; if a calibration is already persisted for it, applies it to the
+    /// projector immediately so the first survey/treasure projects correctly.
+    /// </summary>
+    void OnAreaEntered(string areaFriendlyName);
+
+    /// <summary>
+    /// Solve a calibration from user-placed reference clicks (a world point
+    /// paired with the pixel the user clicked it at) for the current area,
+    /// persist it, and apply it to the projector. Returns the solved
+    /// calibration, or null if it couldn't be solved (no current area, &lt;2
+    /// non-degenerate references).
+    /// </summary>
+    AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements);
+
+    /// <summary>Drop the current area's persisted calibration (forces a recalibrate).</summary>
+    void ClearCurrentAreaCalibration();
+}
+
+/// <summary>
+/// Owns the per-area calibration lifecycle: chat-banner area detection &#8594;
+/// internal-key resolution &#8594; apply persisted <see cref="AreaCalibration"/> on
+/// entry, and the solve/persist path the calibration window drives. Reference
+/// points come from <see cref="IReferenceDataService"/> (landmarks + NPCs with a
+/// parseable <c>Pos</c>), which is the same engine-unit world frame the game
+/// positions the player in (verified 2026-05-18).
+/// </summary>
+public sealed class AreaCalibrationService : IAreaCalibrationService
+{
+    private readonly IReferenceDataService _refData;
+    private readonly LegolasSettings _settings;
+    private readonly ICoordinateProjector _projector;
+    private readonly SettingsAutoSaver<LegolasSettings> _saver;
+
+    private IReadOnlyList<CalibrationReference> _currentRefs = Array.Empty<CalibrationReference>();
+
+    public AreaCalibrationService(
+        IReferenceDataService refData,
+        LegolasSettings settings,
+        ICoordinateProjector projector,
+        SettingsAutoSaver<LegolasSettings> saver)
+    {
+        _refData = refData;
+        _settings = settings;
+        _projector = projector;
+        _saver = saver;
+    }
+
+    public string? CurrentAreaKey { get; private set; }
+    public string? CurrentAreaFriendlyName { get; private set; }
+
+    public bool IsCurrentAreaCalibrated =>
+        CurrentAreaKey is { } k && _settings.AreaCalibrations.ContainsKey(k);
+
+    public AreaCalibration? CurrentCalibration =>
+        CurrentAreaKey is { } k && _settings.AreaCalibrations.TryGetValue(k, out var c) ? c : null;
+
+    public IReadOnlyList<CalibrationReference> CurrentAreaReferences => _currentRefs;
+
+    public event EventHandler? Changed;
+
+    public void OnAreaEntered(string areaFriendlyName)
+    {
+        if (string.IsNullOrWhiteSpace(areaFriendlyName)) return;
+
+        var key = ResolveAreaKey(areaFriendlyName);
+        // Even if we can't resolve the key (reference data missing / unknown
+        // friendly name), record what we saw so the UI can show the raw name.
+        CurrentAreaFriendlyName = areaFriendlyName.Trim();
+        CurrentAreaKey = key;
+        _currentRefs = key is null ? Array.Empty<CalibrationReference>() : BuildReferences(key);
+
+        if (key is not null
+            && _settings.AreaCalibrations.TryGetValue(key, out var calibration))
+        {
+            _projector.ApplyCalibration(calibration);
+        }
+
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements)
+    {
+        if (CurrentAreaKey is not { } key || placements is null || placements.Count < 2)
+            return null;
+
+        var refs = placements
+            .Select(p => new LandmarkCalibrationSolver.Reference(p.World.X, p.World.Z, p.Pixel))
+            .ToList();
+
+        var calibration = LandmarkCalibrationSolver.Solve(refs);
+        if (calibration is null) return null;
+
+        _settings.AreaCalibrations[key] = calibration;
+        _saver.Touch(); // AreaCalibrations is a sibling object — no PropertyChanged.
+        _projector.ApplyCalibration(calibration);
+        Changed?.Invoke(this, EventArgs.Empty);
+        return calibration;
+    }
+
+    public void ClearCurrentAreaCalibration()
+    {
+        if (CurrentAreaKey is not { } key) return;
+        if (_settings.AreaCalibrations.Remove(key))
+        {
+            _saver.Touch();
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Friendly name &#8594; internal area key. Matches <see cref="AreaEntry.FriendlyName"/>
+    /// first, then <see cref="AreaEntry.ShortFriendlyName"/>, case-insensitively.
+    /// </summary>
+    private string? ResolveAreaKey(string friendlyName)
+    {
+        var name = friendlyName.Trim();
+        foreach (var area in _refData.Areas.Values)
+        {
+            if (string.Equals(area.FriendlyName, name, StringComparison.OrdinalIgnoreCase))
+                return area.Key;
+        }
+        foreach (var area in _refData.Areas.Values)
+        {
+            if (!string.IsNullOrEmpty(area.ShortFriendlyName)
+                && string.Equals(area.ShortFriendlyName, name, StringComparison.OrdinalIgnoreCase))
+                return area.Key;
+        }
+        return null;
+    }
+
+    private IReadOnlyList<CalibrationReference> BuildReferences(string areaKey)
+    {
+        var list = new List<CalibrationReference>();
+
+        // NPCs first — dense, named, labelled on the in-game map.
+        foreach (var npc in _refData.NpcsByInternalName.Values)
+        {
+            if (!string.Equals(npc.AreaName, areaKey, StringComparison.Ordinal)) continue;
+            if (WorldCoord.TryParse(npc.Pos) is not { } w) continue;
+            list.Add(new CalibrationReference(npc.Name ?? "(unnamed NPC)", "NPC", w));
+        }
+
+        // Landmarks — sparse same-format supplement.
+        if (_refData.Landmarks.TryGetValue(areaKey, out var landmarks))
+        {
+            foreach (var lm in landmarks)
+            {
+                if (WorldCoord.TryParse(lm.Loc) is not { } w) continue;
+                var kind = string.IsNullOrEmpty(lm.Type) ? "Landmark" : lm.Type!;
+                list.Add(new CalibrationReference(lm.Name ?? "(unnamed landmark)", kind, w));
+            }
+        }
+
+        return list;
+    }
+}

--- a/src/Legolas.Module/Services/ChatLogParser.cs
+++ b/src/Legolas.Module/Services/ChatLogParser.cs
@@ -29,6 +29,13 @@ public sealed partial class ChatLogParser : IChatLogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
     private static partial Regex MotherlodeRegex();
 
+    // Area banner: a run of asterisks then "Entering Area: <FriendlyName>".
+    // The name runs to end-of-line; trim trailing whitespace via the lazy group
+    // plus an explicit \s* tail so a trailing CR/space doesn't bleed into it.
+    [GeneratedRegex(@"Entering Area:\s*(?<area>.+?)\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex AreaEnteredRegex();
+
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
         if (string.IsNullOrWhiteSpace(line))
@@ -93,6 +100,14 @@ public sealed partial class ChatLogParser : IChatLogParser
             && int.TryParse(motherlodeMatch.Groups["dist"].ValueSpan, out var mlDist))
         {
             return new MotherlodeDistance(timestamp, mlDist);
+        }
+
+        var areaMatch = AreaEnteredRegex().Match(line);
+        if (areaMatch.Success)
+        {
+            var area = areaMatch.Groups["area"].Value.Trim();
+            if (!string.IsNullOrEmpty(area))
+                return new AreaEntered(timestamp, area);
         }
 
         return new UnknownLine(timestamp, line);

--- a/src/Legolas.Module/Services/CoordinateProjector.cs
+++ b/src/Legolas.Module/Services/CoordinateProjector.cs
@@ -27,9 +27,16 @@ public sealed class CoordinateProjector : ICoordinateProjector
 
     public void ApplyCalibration(AreaCalibration calibration)
     {
+        // Adopt ONLY scale + rotation. The landmark solve's origin is the pixel
+        // where absolute world-(0,0) lands — meaningless for the survey
+        // pipeline, which projects offsets *relative to the player's anchor*.
+        // Overwriting _origin with the world-origin pixel made every survey
+        // project relative to world-0 instead of the player (the wrong-place /
+        // wrong-direction symptom). Scale + rotation are the area-stable parts
+        // worth persisting; the origin remains whatever SetOrigin / the
+        // player-position click established this session.
         _scale = calibration.Scale;
         _rotation = calibration.RotationRadians;
-        _origin = new PixelPoint(calibration.OriginX, calibration.OriginY);
     }
 
     public void CalibrateFromClick(PixelPoint playerPixel, PixelPoint click, MetreOffset offset)

--- a/src/Legolas.Module/Services/CoordinateProjector.cs
+++ b/src/Legolas.Module/Services/CoordinateProjector.cs
@@ -25,6 +25,13 @@ public sealed class CoordinateProjector : ICoordinateProjector
 
     public void SetOrigin(PixelPoint origin) => _origin = origin;
 
+    public void ApplyCalibration(AreaCalibration calibration)
+    {
+        _scale = calibration.Scale;
+        _rotation = calibration.RotationRadians;
+        _origin = new PixelPoint(calibration.OriginX, calibration.OriginY);
+    }
+
     public void CalibrateFromClick(PixelPoint playerPixel, PixelPoint click, MetreOffset offset)
     {
         _origin = playerPixel;

--- a/src/Legolas.Module/Services/ICoordinateProjector.cs
+++ b/src/Legolas.Module/Services/ICoordinateProjector.cs
@@ -36,10 +36,12 @@ public interface ICoordinateProjector
     void Refit(IReadOnlyList<(MetreOffset Offset, PixelPoint Pixel)> corrections);
 
     /// <summary>
-    /// Applies a previously-solved per-area calibration (scale, rotation, origin)
-    /// wholesale — used when entering an area that already has a persisted
-    /// <see cref="AreaCalibration"/> so the very first survey/treasure projects
-    /// correctly with no in-session warmup.
+    /// Adopts a persisted per-area calibration's <b>scale and rotation only</b>
+    /// (the area-stable parts). The origin is deliberately left untouched — it
+    /// is the player's per-session anchor (<see cref="SetOrigin"/> / the
+    /// position click), not the calibration's world-(0,0) pixel. Removes the
+    /// scale/rotation warmup on area entry without breaking the player-relative
+    /// projection model.
     /// </summary>
     void ApplyCalibration(AreaCalibration calibration);
 }

--- a/src/Legolas.Module/Services/ICoordinateProjector.cs
+++ b/src/Legolas.Module/Services/ICoordinateProjector.cs
@@ -34,4 +34,12 @@ public interface ICoordinateProjector
     /// no dependency, numerically stable.
     /// </summary>
     void Refit(IReadOnlyList<(MetreOffset Offset, PixelPoint Pixel)> corrections);
+
+    /// <summary>
+    /// Applies a previously-solved per-area calibration (scale, rotation, origin)
+    /// wholesale — used when entering an area that already has a persisted
+    /// <see cref="AreaCalibration"/> so the very first survey/treasure projects
+    /// correctly with no in-session warmup.
+    /// </summary>
+    void ApplyCalibration(AreaCalibration calibration);
 }

--- a/src/Legolas.Module/Services/LandmarkCalibrationSolver.cs
+++ b/src/Legolas.Module/Services/LandmarkCalibrationSolver.cs
@@ -121,7 +121,10 @@ public static class LandmarkCalibrationSolver
         }
         var residual = Math.Sqrt(sumSq / n);
 
-        return new AreaCalibration(scale, rotation, originX, originY, n, residual);
+        return new AreaCalibration(scale, rotation, originX, originY, n, residual)
+        {
+            MirrorNorth = mirrorNorth, // carried so raw world coords re-project
+        };
     }
 
     private static double NormaliseAngle(double radians)

--- a/src/Legolas.Module/Services/LandmarkCalibrationSolver.cs
+++ b/src/Legolas.Module/Services/LandmarkCalibrationSolver.cs
@@ -1,0 +1,135 @@
+using Legolas.Domain;
+
+namespace Legolas.Services;
+
+/// <summary>
+/// Pure solver: given &#8805;2 known reference points — a landmark/NPC's area-local
+/// world position (ground plane X/Z) paired with where the user clicked it on the
+/// 1:1 map overlay — derives the projector similarity transform
+/// (<see cref="AreaCalibration"/>) for that area.
+///
+/// <para>Uses the same closed-form 2D-similarity least-squares as
+/// <see cref="CoordinateProjector.Refit"/> (Umeyama specialised to 2D, uniform
+/// scale, expressed via complex arithmetic). A similarity transform recovers an
+/// arbitrary <em>rotation</em> and scale, but <b>not a reflection</b> — so the
+/// world-axis &#8594; (East, North) <em>handedness</em> cannot be absorbed by the
+/// fit and must be chosen explicitly. We solve under both handedness conventions
+/// and keep whichever yields the lower RMS pixel residual; the wrong handedness
+/// would require a reflection and therefore fit poorly. This makes the
+/// X/Z &#8594; compass convention self-correcting from real geometry rather than
+/// an unverified assumption.</para>
+///
+/// <para>The unit&#8596;metre scalar (engine units vs. the metres survey/treasure
+/// offsets are reported in) is folded into <see cref="AreaCalibration.Scale"/>:
+/// references are fed in world units, so the solved px-per-metre already absorbs
+/// any constant unit&#8596;metre ratio (PG/Unity is &#8776;1:1; a residual scalar,
+/// if any, is corrected by a single in-game survey drag as before).</para>
+/// </summary>
+public static class LandmarkCalibrationSolver
+{
+    public readonly record struct Reference(double WorldX, double WorldZ, PixelPoint Pixel);
+
+    /// <summary>
+    /// Solves for the area calibration. Returns null when fewer than 2
+    /// non-degenerate references are supplied (coincident world points carry no
+    /// scale/rotation information — same threshold as <see cref="CoordinateProjector.Refit"/>).
+    /// </summary>
+    public static AreaCalibration? Solve(IReadOnlyList<Reference> references)
+    {
+        if (references is null || references.Count < 2) return null;
+
+        AreaCalibration? best = null;
+        // Pure rotation is absorbed by the fit; only the two handedness classes
+        // are genuinely distinct. North = +Z vs North = -Z are representatives.
+        foreach (var mirrorNorth in new[] { false, true })
+        {
+            var candidate = SolveForHandedness(references, mirrorNorth);
+            if (candidate is null) continue;
+            if (best is null || candidate.ResidualPixels < best.ResidualPixels)
+                best = candidate;
+        }
+        return best;
+    }
+
+    private static AreaCalibration? SolveForHandedness(IReadOnlyList<Reference> references, bool mirrorNorth)
+    {
+        var n = references.Count;
+
+        // East = WorldX, North = ±WorldZ. Encode z = East - j*North, w = px + j*py.
+        double zSumRe = 0, zSumIm = 0, wSumRe = 0, wSumIm = 0;
+        foreach (var r in references)
+        {
+            var east = r.WorldX;
+            var north = mirrorNorth ? -r.WorldZ : r.WorldZ;
+            zSumRe += east;
+            zSumIm += -north;
+            wSumRe += r.Pixel.X;
+            wSumIm += r.Pixel.Y;
+        }
+        var zMeanRe = zSumRe / n;
+        var zMeanIm = zSumIm / n;
+        var wMeanRe = wSumRe / n;
+        var wMeanIm = wSumIm / n;
+
+        double numRe = 0, numIm = 0, denom = 0;
+        var contributing = 0;
+        foreach (var r in references)
+        {
+            var east = r.WorldX;
+            var north = mirrorNorth ? -r.WorldZ : r.WorldZ;
+            var zRe = east - zMeanRe;
+            var zIm = -north - zMeanIm;
+            var wRe = r.Pixel.X - wMeanRe;
+            var wIm = r.Pixel.Y - wMeanIm;
+            var mag2 = zRe * zRe + zIm * zIm;
+            if (mag2 < 1e-9) continue;
+            numRe += wRe * zRe + wIm * zIm;
+            numIm += wIm * zRe - wRe * zIm;
+            denom += mag2;
+            contributing++;
+        }
+
+        if (contributing < 2 || denom < 1e-9) return null;
+
+        var cRe = numRe / denom;
+        var cIm = numIm / denom;
+        var scale = Math.Sqrt(cRe * cRe + cIm * cIm);
+        if (scale < 1e-9) return null;
+
+        var rotation = NormaliseAngle(Math.Atan2(cIm, cRe));
+        var cZmeanRe = cRe * zMeanRe - cIm * zMeanIm;
+        var cZmeanIm = cRe * zMeanIm + cIm * zMeanRe;
+        var originX = wMeanRe - cZmeanRe;
+        var originY = wMeanIm - cZmeanIm;
+
+        // RMS pixel residual under the recovered transform (same Project math as
+        // CoordinateProjector so the residual reflects real on-screen error).
+        var cos = Math.Cos(rotation);
+        var sin = Math.Sin(rotation);
+        double sumSq = 0;
+        foreach (var r in references)
+        {
+            var east = r.WorldX;
+            var north = mirrorNorth ? -r.WorldZ : r.WorldZ;
+            var rotE = east * cos + north * sin;
+            var rotN = -east * sin + north * cos;
+            var px = originX + scale * rotE;
+            var py = originY - scale * rotN;
+            var dx = px - r.Pixel.X;
+            var dy = py - r.Pixel.Y;
+            sumSq += dx * dx + dy * dy;
+        }
+        var residual = Math.Sqrt(sumSq / n);
+
+        return new AreaCalibration(scale, rotation, originX, originY, n, residual);
+    }
+
+    private static double NormaliseAngle(double radians)
+    {
+        var twoPi = 2 * Math.PI;
+        var r = radians % twoPi;
+        if (r > Math.PI) r -= twoPi;
+        if (r < -Math.PI) r += twoPi;
+        return r;
+    }
+}

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -118,6 +118,10 @@ public sealed class LogIngestionService : BackgroundService
 
     private void HandleSurveyDetected(SurveyDetected sd)
     {
+        // Feed calibration test mode unconditionally — it must see the raw
+        // reading even when survey mode is off or the FSM isn't accepting.
+        _areaCalibration.NoteSurvey(sd.Name, sd.Offset);
+
         if (_session.Mode != SessionMode.Survey)
         {
             _session.LastLogEvent = $"Survey: {sd.Name} → ignored (mode is Motherlode)";

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -24,6 +24,7 @@ public sealed class LogIngestionService : BackgroundService
     private readonly ICoordinateProjector _projector;
     private readonly MotherlodeViewModel _motherlode;
     private readonly SurveyFlowController _surveyFlow;
+    private readonly IAreaCalibrationService _areaCalibration;
 
     public LogIngestionService(
         IChatLogStream stream,
@@ -33,7 +34,8 @@ public sealed class LogIngestionService : BackgroundService
         SessionState session,
         ICoordinateProjector projector,
         MotherlodeViewModel motherlode,
-        SurveyFlowController surveyFlow)
+        SurveyFlowController surveyFlow,
+        IAreaCalibrationService areaCalibration)
     {
         _stream = stream;
         _parser = parser;
@@ -43,6 +45,7 @@ public sealed class LogIngestionService : BackgroundService
         _projector = projector;
         _motherlode = motherlode;
         _surveyFlow = surveyFlow;
+        _areaCalibration = areaCalibration;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -87,6 +90,9 @@ public sealed class LogIngestionService : BackgroundService
                 case MotherlodeDistance md when _session.Mode == SessionMode.Motherlode:
                     _motherlode.RecordDistanceCommand.Execute(md.DistanceMetres);
                     break;
+                case AreaEntered ae:
+                    _areaCalibration.OnAreaEntered(ae.AreaFriendlyName);
+                    break;
             }
         });
     }
@@ -98,6 +104,7 @@ public sealed class LogIngestionService : BackgroundService
         ItemCollected ic when ic.SpeedBonusItem is not null => $"Collected: {ic.Name} (+ {ic.SpeedBonusItem} speed bonus)",
         ItemCollected ic => $"Collected: {ic.Name}",
         MotherlodeDistance md => $"Motherlode: {md.DistanceMetres}m",
+        AreaEntered ae => $"Area: {ae.AreaFriendlyName}",
         UnknownLine ul => $"Unknown: {ul.RawLine}",
         _ => evt.GetType().Name,
     };

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -197,15 +197,15 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             TestOrigin = pixel;
             TestPins.Clear();
             ClickWarning = _service.CurrentCalibration is null
-                ? "Solve a calibration first — nothing to test yet."
+                ? "Solve a calibration first, then click where you are to verify."
                 : null;
             return;
         }
         PlaceSelectedAt(pixel);
     }
 
-    /// <summary>Enter/leave test mode (calibrate → fire a survey → see the
-    /// projected pin vs the real ping, without a full survey run).</summary>
+    /// <summary>Enter/leave the position+verify step (also auto-entered after a
+    /// successful Solve — prompting for position is part of calibrating).</summary>
     [RelayCommand]
     private void ToggleTestMode()
     {
@@ -220,8 +220,8 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             TestPins.Clear();
             TestOrigin = null;
             Instruction = _service.CurrentCalibration is null
-                ? "Test mode: no calibration yet — Solve one first, then click your position and fire a survey/treasure."
-                : "Test mode: click where you ARE on the map, then use a survey/treasure. The projected pin should land on the real ping.";
+                ? "Place ≥2 references and Solve first — then click where you are and fire a survey/treasure to verify."
+                : "Verify: click where you ARE on the map now, then use a survey/treasure — the projected pin should land on the real ping. (Surveying still asks for your position separately; this only checks the calibration.)";
         }
         else
         {
@@ -248,12 +248,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         if (!TestMode) return;
         if (_service.CurrentCalibration is not { } c)
         {
-            ClickWarning = "Solve a calibration before testing.";
+            ClickWarning = "Solve a calibration before verifying.";
             return;
         }
         if (TestOrigin is not { } o)
         {
-            ClickWarning = "Click the map to set your test position first.";
+            ClickWarning = "Click where you are on the map first.";
             return;
         }
 
@@ -299,9 +299,14 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
         ResultText = calibration.ResidualPixels <= 12
             ? $"Calibrated: {calibration.ResidualPixels:0.0} px residual, scale {calibration.Scale:0.000} px/m. " +
-              "Surveys & treasure now project correctly here."
+              "Now verify: click where you are, then use a survey/treasure."
             : $"Solved but residual is high ({calibration.ResidualPixels:0.0} px) — references were likely " +
               "placed imprecisely or the map was at a different zoom. Clear and redo for a tighter fit.";
+
+        // Calibration isn't "done" until it's verified. Auto-continue into the
+        // position+verify step so the user doesn't have to discover a separate
+        // toggle — prompting for position is part of calibrating.
+        TestMode = true;
         Refresh();
     }
 

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -126,8 +126,9 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(DiagnosticSnapshot));
     }
 
-    /// <summary>Full multi-line diagnostic for the clipboard, incl. the selected
-    /// survey pin's projected-vs-overlay math.</summary>
+    /// <summary>Full multi-line diagnostic for the clipboard — dumps EVERY
+    /// survey pin's projected-vs-corrected math + raw coords so the scale factor
+    /// is readable without selecting/eyeballing each one.</summary>
     public string DiagnosticSnapshot
     {
         get
@@ -138,18 +139,31 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
                 : $"calibration: scale={c.Scale:0.0000} rotDeg={c.RotationRadians * 180.0 / Math.PI:0.00} " +
                   $"origin=({c.OriginX:0.0},{c.OriginY:0.0}) mirrorNorth={c.MirrorNorth} " +
                   $"refs={c.ReferenceCount} residual={c.ResidualPixels:0.0}px";
-            return string.Join('\n', new[]
+
+            var lines = new List<string>
             {
                 "Legolas calibration diagnostic",
                 DebugState,
                 cal,
+                $"player: {(PlayerPin is { } pp ? $"({pp.X:0.0},{pp.Y:0.0})" : "-")}",
                 $"status: {StatusText}",
                 $"lastSurvey: {LastSurveyText ?? "-"}",
                 $"result: {ResultText ?? "-"}",
                 $"nudgeTarget: {NudgeTargetText ?? "-"}",
-                $"selectedSurvey: {(SelectedSurveyPin?.MathText ?? "-")}",
                 $"clickWarning: {ClickWarning ?? "-"}",
-            });
+                $"surveyPins ({SurveyPins.Count}):",
+            };
+            if (SurveyPins.Count == 0)
+                lines.Add("  (none)");
+            else
+                foreach (var s in SurveyPins)
+                    lines.Add(
+                        $"  {(ReferenceEquals(s, SelectedSurveyPin) ? "*" : " ")} " +
+                        $"off=({s.Offset.East:0},{s.Offset.North:0})m  " +
+                        $"origin=({s.OriginPixel.X:0.0},{s.OriginPixel.Y:0.0})  " +
+                        $"proj=({s.ProjX:0.0},{s.ProjY:0.0})  " +
+                        $"overlay=({s.OverlayX:0.0},{s.OverlayY:0.0}){(s.Corrected ? "" : " uncorrected")}  | {s.MathText}");
+            return string.Join('\n', lines);
         }
     }
 

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -59,6 +59,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
         ReprojectTestPins(); // green pins follow your position as you nudge it
+        RaiseDebug();
     }
 
     /// <summary>Every known area, for the manual picker (no live banner needed).</summary>
@@ -90,6 +91,19 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     /// test position in verify mode). Drives the code-behind key handler.</summary>
     public bool CanNudge => (TestMode && TestOrigin is not null) || SelectedPlacement is not null;
 
+    /// <summary>Blunt always-visible state readout — so "no pin" is never a
+    /// mystery: it shows whether the area/refs loaded, what's selected, how many
+    /// pins exist + the last one's pixel, and the test origin. If a click made a
+    /// pin, <c>pins=</c> increments here even if the on-map marker doesn't draw.</summary>
+    public string DebugState =>
+        $"area={_service.CurrentAreaKey ?? "-"}  refs={References.Count}  " +
+        $"sel={SelectedReference?.Name ?? "-"}  pins={Placements.Count}  " +
+        $"last={(Placements.Count > 0 ? $"({Placements[^1].X:0},{Placements[^1].Y:0})" : "-")}  " +
+        $"you={(TestOrigin is { } o ? $"({o.X:0},{o.Y:0})" : "-")}  " +
+        $"test={TestMode}  pinsShown={TestPins.Count}";
+
+    private void RaiseDebug() => OnPropertyChanged(nameof(DebugState));
+
     partial void OnSelectedPlacementChanged(PlacedReference? oldValue, PlacedReference? newValue)
     {
         if (oldValue is not null) oldValue.IsSelected = false;
@@ -102,6 +116,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             SelectedReference = newValue.Reference;
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
+        RaiseDebug();
     }
 
     /// <summary>
@@ -117,6 +132,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             : Placements.FirstOrDefault(p => ReferenceEquals(p.Reference, value));
         if (!ReferenceEquals(SelectedPlacement, pin))
             SelectedPlacement = pin; // null until this reference is dropped
+        RaiseDebug();
     }
 
     /// <summary>Non-null when the last map click could not be placed — tells the
@@ -171,6 +187,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
     private void Refresh()
     {
+        RefreshCore();
+        RaiseDebug();
+    }
+
+    private void RefreshCore()
+    {
         References.Clear();
         foreach (var r in _service.CurrentAreaReferences) References.Add(r);
 
@@ -218,6 +240,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             ClickWarning = References.Count == 0
                 ? "No area selected — choose an area above first."
                 : "Pick a landmark/NPC from the list, then click where it is on the map.";
+            RaiseDebug();
             return;
         }
 
@@ -242,6 +265,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         // stray click/nudge does nothing. (Earlier the persistence was a *bug*
         // only because it was invisible and unstoppable — now it's an explicit,
         // visible state with an exit.)
+        RaiseDebug();
     }
 
     /// <summary>
@@ -289,6 +313,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         }
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
+        RaiseDebug();
     }
 
     /// <summary>Commit &amp; stop: deselect the active reference/pin so a stray
@@ -300,6 +325,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         SelectedReference = null; // OnSelectedReferenceChanged clears the pin too
         SelectedPlacement = null;
         ClickWarning = null;
+        RaiseDebug();
     }
 
     [RelayCommand]
@@ -307,13 +333,14 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     {
         TestPins.Clear();
         TestOrigin = null;
+        RaiseDebug();
     }
 
     private void OnSurveyObserved(object? sender, CalibrationSurveyObservation obs)
     {
         var disp = Application.Current?.Dispatcher;
-        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => ProjectTest(obs));
-        else ProjectTest(obs);
+        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => { ProjectTest(obs); RaiseDebug(); });
+        else { ProjectTest(obs); RaiseDebug(); }
     }
 
     private void ProjectTest(CalibrationSurveyObservation obs)
@@ -373,6 +400,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         if (ReferenceEquals(SelectedPlacement, removed)) SelectedPlacement = null;
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
+        RaiseDebug();
     }
 
     [RelayCommand]
@@ -383,6 +411,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
         ResultText = null;
+        RaiseDebug();
     }
 
     [RelayCommand(CanExecute = nameof(CanSolve))]

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -118,7 +118,8 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         $"sel={SelectedReference?.Name ?? "-"}  pins={Placements.Count}  " +
         $"last={(Placements.Count > 0 ? $"({Placements[^1].X:0},{Placements[^1].Y:0})" : "-")}  " +
         $"you={(PlayerPin is { } pp ? $"({pp.X:0},{pp.Y:0}){(pp.IsSelected ? "*" : "")}" : "-")}  " +
-        $"surveys={SurveyPins.Count}  ghosts={GhostPins.Count}";
+        $"surveys={SurveyPins.Count}  ghosts={GhostPins.Count}  " +
+        $"mapZoom={MapZoom:0.###}  calZoom={_service.CurrentCalibration?.CalibrationZoom.ToString("0.###") ?? "-"}";
 
     private void RaiseDebug()
     {
@@ -209,6 +210,18 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     [ObservableProperty] private string _instruction =
         "Pick an area, place ≥2 landmark/NPC references, Solve. Then Set player position and fire a survey to verify.";
     [ObservableProperty] private string? _resultText;
+
+    /// <summary>The in-game map zoom the user reads off the game UI (Mithril
+    /// can't see it). Stamped onto the calibration at Solve; survey projections
+    /// scale by currentMapZoom / calibration.CalibrationZoom so a calibration
+    /// stays correct when you change zoom. 1.0 default = no-op until set.</summary>
+    [ObservableProperty] private double _mapZoom = 1.0;
+
+    partial void OnMapZoomChanged(double value)
+    {
+        ReprojectSurveyPins(); // existing pins re-scale to the new zoom live
+        RaiseDebug();
+    }
 
     partial void OnSelectedAreaChanged(AreaEntry? value)
     {
@@ -521,7 +534,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             return;
         }
 
-        var projected = Project(c, pp.Pixel, obs.Offset);
+        var projected = ProjectSurvey(c, pp.Pixel, obs.Offset);
         var sp = new SurveyPin(obs.Name, obs.Offset, pp.Pixel, projected);
         ClampSurvey(sp);
         SurveyPins.Add(sp);
@@ -557,14 +570,31 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         s.DisplayY = Math.Clamp(px.Y, inset, _viewportH - inset);
     }
 
-    /// <summary>Same math as <c>CoordinateProjector.Project</c>.</summary>
+    /// <summary>Raw projection at the calibration's own zoom (used by ghosts —
+    /// they're absolute world→pixel via the cal-zoom origin, so only valid at
+    /// the calibration zoom anyway).</summary>
     private static PixelPoint Project(AreaCalibration c, PixelPoint origin, MetreOffset off)
+        => ProjectAtScale(c, origin, off, c.Scale);
+
+    /// <summary>Survey projection from the (current-zoom) player pixel: only
+    /// <see cref="AreaCalibration.Scale"/> needs the zoom factor because the
+    /// origin is the player pin the user placed at the CURRENT zoom (no stored
+    /// origin to also rescale) — so this is exact across zooms.</summary>
+    private PixelPoint ProjectSurvey(AreaCalibration c, PixelPoint origin, MetreOffset off)
+        => ProjectAtScale(c, origin, off, c.Scale * ZoomFactor(c));
+
+    /// <summary><c>currentZoom / calibrationZoom</c>, guarded. 1.0 when either
+    /// is unset (default) → behaviour unchanged until the field is used.</summary>
+    public double ZoomFactor(AreaCalibration c) =>
+        MapZoom > 1e-6 && c.CalibrationZoom > 1e-6 ? MapZoom / c.CalibrationZoom : 1.0;
+
+    private static PixelPoint ProjectAtScale(AreaCalibration c, PixelPoint origin, MetreOffset off, double scale)
     {
         var cos = Math.Cos(c.RotationRadians);
         var sin = Math.Sin(c.RotationRadians);
         var rotE = off.East * cos + off.North * sin;
         var rotN = -off.East * sin + off.North * cos;
-        return new PixelPoint(origin.X + c.Scale * rotE, origin.Y - c.Scale * rotN);
+        return new PixelPoint(origin.X + scale * rotE, origin.Y - scale * rotN);
     }
 
     /// <summary>Re-project every survey pin from the (moved) player pin. The
@@ -577,7 +607,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         foreach (var s in SurveyPins)
         {
             s.OriginPixel = pp.Pixel;
-            s.ProjectedPixel = Project(c, pp.Pixel, s.Offset);
+            s.ProjectedPixel = ProjectSurvey(c, pp.Pixel, s.Offset);
             if (!s.Corrected) s.OverlayPixel = s.ProjectedPixel;
             ClampSurvey(s);
         }
@@ -610,7 +640,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     private void Solve()
     {
         var pairs = Placements.Select(p => (p.Reference.World, p.Pixel)).ToList();
-        var calibration = _service.CalibrateCurrentArea(pairs);
+        var calibration = _service.CalibrateCurrentArea(pairs, MapZoom);
         if (calibration is null)
         {
             ResultText = "Couldn't solve — need ≥2 references at meaningfully different spots.";

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -1,0 +1,174 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Legolas.Domain;
+using Legolas.Services;
+
+namespace Legolas.ViewModels;
+
+/// <summary>
+/// Drives the standalone calibration overlay: lists the current area's
+/// landmark/NPC references, accumulates the user's reference clicks (a known
+/// world point paired with where they clicked it on the in-game map, captured
+/// through the transparent overlay), and solves+persists the per-area projector
+/// calibration via <see cref="IAreaCalibrationService"/>.
+///
+/// Calibration is decoupled from the survey FSM entirely — placing references
+/// here never touches <see cref="SessionState"/> or the survey pipeline; it only
+/// feeds the solver. Once solved, every later survey/treasure in that area
+/// projects correctly with no warmup.
+/// </summary>
+public sealed partial class CalibrationSessionViewModel : ObservableObject
+{
+    private readonly IAreaCalibrationService _service;
+
+    public CalibrationSessionViewModel(IAreaCalibrationService service)
+    {
+        _service = service;
+        _service.Changed += OnServiceChanged;
+        Refresh();
+    }
+
+    public ObservableCollection<CalibrationReference> References { get; } = new();
+    public ObservableCollection<PlacedReference> Placements { get; } = new();
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SolveCommand))]
+    private CalibrationReference? _selectedReference;
+
+    [ObservableProperty] private string _statusText = "No area detected yet.";
+    [ObservableProperty] private string _instruction =
+        "Walk into an area, pick a landmark or NPC below, then click exactly where it sits on the in-game map.";
+    [ObservableProperty] private string? _resultText;
+
+    public bool CanSolve => Placements.Count >= 2;
+
+    private void OnServiceChanged(object? sender, EventArgs e)
+    {
+        // Service.Changed already fires on the UI dispatcher in the live path
+        // (LogIngestionService posts area events to the dispatcher), but guard
+        // anyway — bound-collection mutation off the UI thread is a documented
+        // Mithril footgun.
+        var disp = Application.Current?.Dispatcher;
+        if (disp is not null && !disp.CheckAccess()) disp.Invoke(Refresh);
+        else Refresh();
+    }
+
+    private void Refresh()
+    {
+        References.Clear();
+        foreach (var r in _service.CurrentAreaReferences) References.Add(r);
+
+        if (_service.CurrentAreaFriendlyName is not { } area)
+        {
+            StatusText = "No area detected yet — walk into an area in-game.";
+            return;
+        }
+
+        if (_service.CurrentAreaKey is null)
+        {
+            StatusText = $"{area} — unrecognised area (no reference data); calibration unavailable.";
+            return;
+        }
+
+        if (_service.CurrentCalibration is { } c)
+        {
+            StatusText = $"{area} — calibrated " +
+                $"({c.ReferenceCount} refs, residual {c.ResidualPixels:0.0} px). " +
+                "Recalibrate if pins still land wrong.";
+        }
+        else
+        {
+            StatusText = $"{area} — not calibrated. Place ≥2 references and Solve.";
+        }
+    }
+
+    /// <summary>
+    /// Record where the user clicked the currently-selected reference on the
+    /// map overlay. Auto-advances the selection to the next not-yet-placed
+    /// reference so a calibration run is a steady pick-less click cadence.
+    /// </summary>
+    [RelayCommand]
+    private void PlaceSelectedAt(PixelPoint pixel)
+    {
+        if (SelectedReference is not { } reference) return;
+
+        // Replace any prior placement of the same reference (a re-click is a
+        // correction, not a second point).
+        for (var i = Placements.Count - 1; i >= 0; i--)
+            if (ReferenceEquals(Placements[i].Reference, reference))
+                Placements.RemoveAt(i);
+
+        Placements.Add(new PlacedReference(reference, pixel));
+        OnPropertyChanged(nameof(CanSolve));
+        SolveCommand.NotifyCanExecuteChanged();
+
+        SelectedReference = References.FirstOrDefault(r =>
+            Placements.All(p => !ReferenceEquals(p.Reference, r)));
+    }
+
+    [RelayCommand]
+    private void RemoveLastPlacement()
+    {
+        if (Placements.Count == 0) return;
+        Placements.RemoveAt(Placements.Count - 1);
+        OnPropertyChanged(nameof(CanSolve));
+        SolveCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void ClearPlacements()
+    {
+        Placements.Clear();
+        OnPropertyChanged(nameof(CanSolve));
+        SolveCommand.NotifyCanExecuteChanged();
+        ResultText = null;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSolve))]
+    private void Solve()
+    {
+        var pairs = Placements.Select(p => (p.Reference.World, p.Pixel)).ToList();
+        var calibration = _service.CalibrateCurrentArea(pairs);
+        if (calibration is null)
+        {
+            ResultText = "Couldn't solve — need ≥2 references at meaningfully different spots.";
+            return;
+        }
+
+        ResultText = calibration.ResidualPixels <= 12
+            ? $"Calibrated: {calibration.ResidualPixels:0.0} px residual, scale {calibration.Scale:0.000} px/m. " +
+              "Surveys & treasure now project correctly here."
+            : $"Solved but residual is high ({calibration.ResidualPixels:0.0} px) — references were likely " +
+              "placed imprecisely or the map was at a different zoom. Clear and redo for a tighter fit.";
+        Refresh();
+    }
+
+    /// <summary>Drop the persisted calibration for this area and start over.</summary>
+    [RelayCommand]
+    private void Recalibrate()
+    {
+        _service.ClearCurrentAreaCalibration();
+        ClearPlacements();
+        Refresh();
+    }
+}
+
+/// <summary>A reference the user has pinned on the map; <see cref="X"/>/<see cref="Y"/>
+/// expose the click pixel for Canvas marker placement.</summary>
+public sealed class PlacedReference
+{
+    public PlacedReference(CalibrationReference reference, PixelPoint pixel)
+    {
+        Reference = reference;
+        Pixel = pixel;
+    }
+
+    public CalibrationReference Reference { get; }
+    public PixelPoint Pixel { get; }
+    public string Name => Reference.Name;
+    public string Kind => Reference.Kind;
+    public double X => Pixel.X;
+    public double Y => Pixel.Y;
+}

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -94,8 +94,29 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     {
         if (oldValue is not null) oldValue.IsSelected = false;
         if (newValue is not null) newValue.IsSelected = true;
+        // Selecting a pin in the Placed list also selects its reference (so the
+        // References list agrees — "pick from either list"). Only sync upward
+        // when a pin is chosen; clearing the pin because an *unplaced*
+        // reference was picked must NOT wipe that reference selection.
+        if (newValue is not null && !ReferenceEquals(SelectedReference, newValue.Reference))
+            SelectedReference = newValue.Reference;
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
+    }
+
+    /// <summary>
+    /// Selecting a reference (either list) makes it the active target and links
+    /// to its dropped pin if one exists — so nudging only works once a pin has
+    /// been placed for it. Switching references leaves the previous pin where
+    /// it was (it's already stored in <see cref="Placements"/>).
+    /// </summary>
+    partial void OnSelectedReferenceChanged(CalibrationReference? value)
+    {
+        var pin = value is null
+            ? null
+            : Placements.FirstOrDefault(p => ReferenceEquals(p.Reference, value));
+        if (!ReferenceEquals(SelectedPlacement, pin))
+            SelectedPlacement = pin; // null until this reference is dropped
     }
 
     /// <summary>Non-null when the last map click could not be placed — tells the
@@ -208,17 +229,19 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
         var placed = new PlacedReference(reference, pixel);
         Placements.Add(placed);
-        SelectedPlacement = placed; // immediately arrow-key nudgeable
+        SelectedPlacement = placed;     // dropped → now nudgeable
+        SelectedReference = reference;  // stays the active target (both lists agree)
         ClickWarning = null;
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
 
-        // Clear the selection so the click is "spent". Otherwise the reference
-        // stays selected and the *next* click re-places (visibly moves) the
-        // same pin — every stray click drags it. To correct a point: nudge it
-        // with the arrow keys, or deliberately re-select that reference and
-        // click again. A click never silently moves an existing pin.
-        SelectedReference = null;
+        // Selection deliberately persists: the just-dropped pin is the clearly
+        // indicated active target (halo + "Nudging …" text). Arrow keys nudge
+        // it; clicking again repositions it; picking another reference swaps
+        // (the prior pin stays put — already stored); "Done" deselects so a
+        // stray click/nudge does nothing. (Earlier the persistence was a *bug*
+        // only because it was invisible and unstoppable — now it's an explicit,
+        // visible state with an exit.)
     }
 
     /// <summary>
@@ -266,6 +289,17 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         }
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
+    }
+
+    /// <summary>Commit &amp; stop: deselect the active reference/pin so a stray
+    /// click or arrow key does nothing until something is picked again. The
+    /// pin's final nudged position is already stored in <see cref="Placements"/>.</summary>
+    [RelayCommand]
+    private void Deselect()
+    {
+        SelectedReference = null; // OnSelectedReferenceChanged clears the pin too
+        SelectedPlacement = null;
+        ClickWarning = null;
     }
 
     [RelayCommand]

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -73,6 +73,18 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     /// recently placed; also click-selectable in the Placed list).</summary>
     [ObservableProperty] private PlacedReference? _selectedPlacement;
 
+    /// <summary>Panel text naming what a nudge will move (null = nothing armed).</summary>
+    public string? NudgeTargetText => SelectedPlacement is { } p
+        ? $"Nudging “{p.Name}” — arrow keys move it (Shift = 5px)"
+        : null;
+
+    partial void OnSelectedPlacementChanged(PlacedReference? oldValue, PlacedReference? newValue)
+    {
+        if (oldValue is not null) oldValue.IsSelected = false;
+        if (newValue is not null) newValue.IsSelected = true;
+        OnPropertyChanged(nameof(NudgeTargetText));
+    }
+
     /// <summary>Non-null when the last map click could not be placed — tells the
     /// user why instead of silently doing nothing.</summary>
     [ObservableProperty] private string? _clickWarning;
@@ -272,7 +284,9 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     private void RemoveLastPlacement()
     {
         if (Placements.Count == 0) return;
+        var removed = Placements[^1];
         Placements.RemoveAt(Placements.Count - 1);
+        if (ReferenceEquals(SelectedPlacement, removed)) SelectedPlacement = null;
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
     }
@@ -281,6 +295,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     private void ClearPlacements()
     {
         Placements.Clear();
+        SelectedPlacement = null; // don't leave the nudge target dangling
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
         ResultText = null;
@@ -350,6 +365,11 @@ public sealed partial class PlacedReference : ObservableObject
     public CalibrationReference Reference { get; }
 
     [ObservableProperty] private PixelPoint _pixel;
+
+    /// <summary>True for the one placement the arrow-key nudge currently acts
+    /// on — drives the on-map "active target" highlight so it's obvious what
+    /// you're moving.</summary>
+    [ObservableProperty] private bool _isSelected;
 
     partial void OnPixelChanged(PixelPoint value)
     {

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -108,7 +108,44 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         $"you={(TestOrigin is { } o ? $"({o.X:0},{o.Y:0})" : "-")}  " +
         $"test={TestMode}  pinsShown={TestPins.Count}  ghosts={GhostPins.Count}";
 
-    private void RaiseDebug() => OnPropertyChanged(nameof(DebugState));
+    private void RaiseDebug()
+    {
+        OnPropertyChanged(nameof(DebugState));
+        OnPropertyChanged(nameof(DiagnosticSnapshot));
+    }
+
+    /// <summary>Full multi-line diagnostic for the clipboard — the panel line
+    /// gets clipped, so "Copy debug" dumps everything I'd need to see.</summary>
+    public string DiagnosticSnapshot
+    {
+        get
+        {
+            var c = _service.CurrentCalibration;
+            var cal = c is null
+                ? "calibration: none"
+                : $"calibration: scale={c.Scale:0.0000} rotDeg={c.RotationRadians * 180.0 / Math.PI:0.00} " +
+                  $"origin=({c.OriginX:0.0},{c.OriginY:0.0}) mirrorNorth={c.MirrorNorth} " +
+                  $"refs={c.ReferenceCount} residual={c.ResidualPixels:0.0}px";
+            return string.Join('\n', new[]
+            {
+                "Legolas calibration diagnostic",
+                DebugState,
+                cal,
+                $"status: {StatusText}",
+                $"lastSurvey: {LastSurveyText ?? "-"}",
+                $"result: {ResultText ?? "-"}",
+                $"nudgeTarget: {NudgeTargetText ?? "-"}",
+                $"clickWarning: {ClickWarning ?? "-"}",
+            });
+        }
+    }
+
+    [RelayCommand]
+    private void CopyDebug()
+    {
+        try { System.Windows.Clipboard.SetText(DiagnosticSnapshot); }
+        catch { /* clipboard can be transiently locked — best-effort */ }
+    }
 
     partial void OnSelectedPlacementChanged(PlacedReference? oldValue, PlacedReference? newValue)
     {

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -176,11 +176,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
 
-        // No auto-advance: the click only ever affects the reference the user
-        // explicitly selected. Keeping the selection means a second click on
-        // the same reference is a *correction* (replaces its point above), and
-        // moving to the next reference is a deliberate pick — not something
-        // every stray click silently consumes.
+        // Clear the selection so the click is "spent". Otherwise the reference
+        // stays selected and the *next* click re-places (visibly moves) the
+        // same pin — every stray click drags it. To correct a point: nudge it
+        // with the arrow keys, or deliberately re-select that reference and
+        // click again. A click never silently moves an existing pin.
+        SelectedReference = null;
     }
 
     /// <summary>

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -56,6 +56,9 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(HasTestOrigin));
         OnPropertyChanged(nameof(TestOriginX));
         OnPropertyChanged(nameof(TestOriginY));
+        OnPropertyChanged(nameof(NudgeTargetText));
+        OnPropertyChanged(nameof(CanNudge));
+        ReprojectTestPins(); // green pins follow your position as you nudge it
     }
 
     /// <summary>Every known area, for the manual picker (no live banner needed).</summary>
@@ -73,16 +76,26 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     /// recently placed; also click-selectable in the Placed list).</summary>
     [ObservableProperty] private PlacedReference? _selectedPlacement;
 
-    /// <summary>Panel text naming what a nudge will move (null = nothing armed).</summary>
-    public string? NudgeTargetText => SelectedPlacement is { } p
-        ? $"Nudging “{p.Name}” — arrow keys move it (Shift = 5px)"
-        : null;
+    /// <summary>Panel text naming what a nudge will move (null = nothing armed).
+    /// In verify mode with a position set, the arrows move <em>your position</em>
+    /// (and the green pins follow); otherwise the selected reference.</summary>
+    public string? NudgeTargetText =>
+        TestMode && TestOrigin is not null
+            ? "Nudging your position — arrow keys move it, green pins follow (Shift = 5px)"
+            : SelectedPlacement is { } p
+                ? $"Nudging “{p.Name}” — arrow keys move it (Shift = 5px)"
+                : null;
+
+    /// <summary>True when arrow keys have something to move (a placement, or the
+    /// test position in verify mode). Drives the code-behind key handler.</summary>
+    public bool CanNudge => (TestMode && TestOrigin is not null) || SelectedPlacement is not null;
 
     partial void OnSelectedPlacementChanged(PlacedReference? oldValue, PlacedReference? newValue)
     {
         if (oldValue is not null) oldValue.IsSelected = false;
         if (newValue is not null) newValue.IsSelected = true;
         OnPropertyChanged(nameof(NudgeTargetText));
+        OnPropertyChanged(nameof(CanNudge));
     }
 
     /// <summary>Non-null when the last map click could not be placed — tells the
@@ -107,12 +120,19 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         _service.SelectArea(value.Key);
     }
 
-    /// <summary>Move the selected placement by (dx, dy) screen pixels — the
-    /// arrow-key fine-tune. No-op if nothing is selected.</summary>
+    /// <summary>Arrow-key fine-tune. In verify mode with a position set it moves
+    /// <em>your position</em> (and re-projects the green pins); otherwise it
+    /// moves the selected reference placement. No-op if neither applies.</summary>
     public void NudgeSelected(double dx, double dy)
     {
-        if (SelectedPlacement is not { } p) return;
-        p.Pixel = new PixelPoint(p.Pixel.X + dx, p.Pixel.Y + dy);
+        if (TestMode && TestOrigin is { } o)
+        {
+            // Moves your position; OnTestOriginChanged re-projects the pins.
+            TestOrigin = new PixelPoint(o.X + dx, o.Y + dy);
+            return;
+        }
+        if (SelectedPlacement is { } p)
+            p.Pixel = new PixelPoint(p.Pixel.X + dx, p.Pixel.Y + dy);
     }
 
     public bool CanSolve => Placements.Count >= 2;
@@ -244,6 +264,8 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         {
             Instruction = "Pick an area (or walk into one), choose a landmark/NPC, then click exactly where it sits on the in-game map. Arrow keys nudge the last point.";
         }
+        OnPropertyChanged(nameof(NudgeTargetText));
+        OnPropertyChanged(nameof(CanNudge));
     }
 
     [RelayCommand]
@@ -283,16 +305,29 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             return;
         }
 
-        // Same math as CoordinateProjector.Project, with origin = the test
-        // position and scale/rotation from the live calibration.
-        var cos = Math.Cos(c.RotationRadians);
-        var sin = Math.Sin(c.RotationRadians);
-        var rotE = obs.Offset.East * cos + obs.Offset.North * sin;
-        var rotN = -obs.Offset.East * sin + obs.Offset.North * cos;
-        var pixel = new PixelPoint(o.X + c.Scale * rotE, o.Y - c.Scale * rotN);
-        TestPins.Add(new TestPin(obs.Name, pixel));
+        TestPins.Add(new TestPin(obs.Name, obs.Offset, Project(c, o, obs.Offset)));
         LastSurveyText = seen + " → green pin projected.";
         ClickWarning = null;
+    }
+
+    /// <summary>Same math as <c>CoordinateProjector.Project</c>: a metre offset
+    /// from <paramref name="origin"/> through the calibration's scale/rotation.</summary>
+    private static PixelPoint Project(AreaCalibration c, PixelPoint origin, MetreOffset off)
+    {
+        var cos = Math.Cos(c.RotationRadians);
+        var sin = Math.Sin(c.RotationRadians);
+        var rotE = off.East * cos + off.North * sin;
+        var rotN = -off.East * sin + off.North * cos;
+        return new PixelPoint(origin.X + c.Scale * rotE, origin.Y - c.Scale * rotN);
+    }
+
+    /// <summary>Re-place every projected pin from the (moved) test origin so the
+    /// green pins track your position live while you align them.</summary>
+    private void ReprojectTestPins()
+    {
+        if (_service.CurrentCalibration is not { } c || TestOrigin is not { } o) return;
+        foreach (var pin in TestPins)
+            pin.Pixel = Project(c, o, pin.Offset);
     }
 
     [RelayCommand]
@@ -353,18 +388,29 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 /// <summary>A reference the user has pinned on the map. Observable so an
 /// arrow-key nudge to <see cref="Pixel"/> moves the on-map marker and updates
 /// the Placed list live; <see cref="X"/>/<see cref="Y"/> drive Canvas placement.</summary>
-/// <summary>A projected test reading dropped while test mode is active.
-/// Static once placed (unlike <see cref="PlacedReference"/> it isn't nudged).</summary>
-public sealed class TestPin
+/// <summary>A projected test reading. Keeps its source <see cref="Offset"/> so
+/// it can be re-projected when the test origin (your position) is nudged —
+/// the green pins track your position live while you align them.</summary>
+public sealed partial class TestPin : ObservableObject
 {
-    public TestPin(string name, PixelPoint pixel)
+    public TestPin(string name, MetreOffset offset, PixelPoint pixel)
     {
         Name = name;
-        Pixel = pixel;
+        Offset = offset;
+        _pixel = pixel;
     }
 
     public string Name { get; }
-    public PixelPoint Pixel { get; }
+    public MetreOffset Offset { get; }
+
+    [ObservableProperty] private PixelPoint _pixel;
+
+    partial void OnPixelChanged(PixelPoint value)
+    {
+        OnPropertyChanged(nameof(X));
+        OnPropertyChanged(nameof(Y));
+    }
+
     public double X => Pixel.X;
     public double Y => Pixel.Y;
 }

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
 using Legolas.Services;
+using Mithril.Shared.Reference;
 
 namespace Legolas.ViewModels;
 
@@ -33,14 +34,45 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     public ObservableCollection<CalibrationReference> References { get; } = new();
     public ObservableCollection<PlacedReference> Placements { get; } = new();
 
+    /// <summary>Every known area, for the manual picker (no live banner needed).</summary>
+    public IReadOnlyList<AreaEntry> AvailableAreas => _service.AllAreas;
+
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SolveCommand))]
     private CalibrationReference? _selectedReference;
 
+    /// <summary>Manually-chosen area. Switching it drives the service the same
+    /// way a live <c>Entering Area:</c> banner would.</summary>
+    [ObservableProperty] private AreaEntry? _selectedArea;
+
+    /// <summary>The placement the keyboard nudge acts on (set to the most
+    /// recently placed; also click-selectable in the Placed list).</summary>
+    [ObservableProperty] private PlacedReference? _selectedPlacement;
+
+    /// <summary>Non-null when the last map click could not be placed — tells the
+    /// user why instead of silently doing nothing.</summary>
+    [ObservableProperty] private string? _clickWarning;
+
     [ObservableProperty] private string _statusText = "No area detected yet.";
     [ObservableProperty] private string _instruction =
-        "Walk into an area, pick a landmark or NPC below, then click exactly where it sits on the in-game map.";
+        "Pick an area (or walk into one), choose a landmark/NPC, then click exactly where it sits on the in-game map. Arrow keys nudge the last point.";
     [ObservableProperty] private string? _resultText;
+
+    partial void OnSelectedAreaChanged(AreaEntry? value)
+    {
+        // Guard the Refresh→set→change loop: Refresh sets SelectedArea to the
+        // already-current area, which must NOT re-drive the service.
+        if (value is null || value.Key == _service.CurrentAreaKey) return;
+        _service.SelectArea(value.Key);
+    }
+
+    /// <summary>Move the selected placement by (dx, dy) screen pixels — the
+    /// arrow-key fine-tune. No-op if nothing is selected.</summary>
+    public void NudgeSelected(double dx, double dy)
+    {
+        if (SelectedPlacement is not { } p) return;
+        p.Pixel = new PixelPoint(p.Pixel.X + dx, p.Pixel.Y + dy);
+    }
 
     public bool CanSolve => Placements.Count >= 2;
 
@@ -60,9 +92,14 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         References.Clear();
         foreach (var r in _service.CurrentAreaReferences) References.Add(r);
 
+        // Keep the area picker reflecting the live area without re-driving the
+        // service (OnSelectedAreaChanged guards on key equality).
+        if (_service.CurrentAreaKey is { } curKey)
+            SelectedArea = AvailableAreas.FirstOrDefault(a => a.Key == curKey);
+
         if (_service.CurrentAreaFriendlyName is not { } area)
         {
-            StatusText = "No area detected yet — walk into an area in-game.";
+            StatusText = "No area detected — pick one from the dropdown, or walk into one in-game.";
             return;
         }
 
@@ -92,7 +129,15 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     [RelayCommand]
     private void PlaceSelectedAt(PixelPoint pixel)
     {
-        if (SelectedReference is not { } reference) return;
+        if (SelectedReference is not { } reference)
+        {
+            // Don't fail silently — the click WAS captured, it just had no
+            // target. Tell the user which precondition is missing.
+            ClickWarning = References.Count == 0
+                ? "No area selected — choose an area above first."
+                : "Pick a landmark/NPC from the list, then click where it is on the map.";
+            return;
+        }
 
         // Replace any prior placement of the same reference (a re-click is a
         // correction, not a second point).
@@ -100,7 +145,10 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             if (ReferenceEquals(Placements[i].Reference, reference))
                 Placements.RemoveAt(i);
 
-        Placements.Add(new PlacedReference(reference, pixel));
+        var placed = new PlacedReference(reference, pixel);
+        Placements.Add(placed);
+        SelectedPlacement = placed; // immediately arrow-key nudgeable
+        ClickWarning = null;
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
 
@@ -155,18 +203,27 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     }
 }
 
-/// <summary>A reference the user has pinned on the map; <see cref="X"/>/<see cref="Y"/>
-/// expose the click pixel for Canvas marker placement.</summary>
-public sealed class PlacedReference
+/// <summary>A reference the user has pinned on the map. Observable so an
+/// arrow-key nudge to <see cref="Pixel"/> moves the on-map marker and updates
+/// the Placed list live; <see cref="X"/>/<see cref="Y"/> drive Canvas placement.</summary>
+public sealed partial class PlacedReference : ObservableObject
 {
     public PlacedReference(CalibrationReference reference, PixelPoint pixel)
     {
         Reference = reference;
-        Pixel = pixel;
+        _pixel = pixel;
     }
 
     public CalibrationReference Reference { get; }
-    public PixelPoint Pixel { get; }
+
+    [ObservableProperty] private PixelPoint _pixel;
+
+    partial void OnPixelChanged(PixelPoint value)
+    {
+        OnPropertyChanged(nameof(X));
+        OnPropertyChanged(nameof(Y));
+    }
+
     public string Name => Reference.Name;
     public string Kind => Reference.Kind;
     public double X => Pixel.X;

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -35,6 +35,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     public ObservableCollection<CalibrationReference> References { get; } = new();
     public ObservableCollection<PlacedReference> Placements { get; } = new();
 
+    /// <summary>Projected positions of the *unplaced* landmarks per the solved
+    /// calibration — a pure world→pixel sanity check (they never feed the solve,
+    /// which would be circular). If the math is right they sit on the real
+    /// landmarks on the in-game map.</summary>
+    public ObservableCollection<GhostPin> GhostPins { get; } = new();
+
     /// <summary>Projected test pins (a survey/treasure fired while test mode is
     /// on, projected from <see cref="TestOrigin"/> via the live calibration).</summary>
     public ObservableCollection<TestPin> TestPins { get; } = new();
@@ -100,7 +106,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         $"sel={SelectedReference?.Name ?? "-"}  pins={Placements.Count}  " +
         $"last={(Placements.Count > 0 ? $"({Placements[^1].X:0},{Placements[^1].Y:0})" : "-")}  " +
         $"you={(TestOrigin is { } o ? $"({o.X:0},{o.Y:0})" : "-")}  " +
-        $"test={TestMode}  pinsShown={TestPins.Count}";
+        $"test={TestMode}  pinsShown={TestPins.Count}  ghosts={GhostPins.Count}";
 
     private void RaiseDebug() => OnPropertyChanged(nameof(DebugState));
 
@@ -336,6 +342,44 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         RaiseDebug();
     }
 
+    /// <summary>
+    /// Drop a magenta "ghost" at every *unplaced* landmark/NPC's projected
+    /// position per the solved calibration. Pure world→pixel — these never feed
+    /// the solve (that'd be circular). If the math is right each ghost sits on
+    /// the real landmark on the in-game map; rotated/mirrored ghosts expose a
+    /// convention error directly, with no survey or position involved.
+    /// </summary>
+    [RelayCommand]
+    private void ProjectLandmarks()
+    {
+        GhostPins.Clear();
+        if (_service.CurrentCalibration is not { } c)
+        {
+            ClickWarning = "Solve a calibration first — nothing to project.";
+            RaiseDebug();
+            return;
+        }
+
+        var worldOrigin = new PixelPoint(c.OriginX, c.OriginY);
+        foreach (var r in References)
+        {
+            // Skip the ones used to solve — only the *remaining* landmarks test it.
+            if (Placements.Any(p => ReferenceEquals(p.Reference, r))) continue;
+            var north = c.MirrorNorth ? -r.World.Z : r.World.Z;
+            var px = Project(c, worldOrigin, new MetreOffset(r.World.X, north));
+            GhostPins.Add(new GhostPin(r.Name, px));
+        }
+        ClickWarning = null;
+        RaiseDebug();
+    }
+
+    [RelayCommand]
+    private void ClearGhosts()
+    {
+        GhostPins.Clear();
+        RaiseDebug();
+    }
+
     private void OnSurveyObserved(object? sender, CalibrationSurveyObservation obs)
     {
         var disp = Application.Current?.Dispatcher;
@@ -451,6 +495,23 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 /// <summary>A reference the user has pinned on the map. Observable so an
 /// arrow-key nudge to <see cref="Pixel"/> moves the on-map marker and updates
 /// the Placed list live; <see cref="X"/>/<see cref="Y"/> drive Canvas placement.</summary>
+/// <summary>A projected unplaced-landmark "ghost" — pure world→pixel sanity
+/// marker. Static; deliberately minimal so its render path differs from the
+/// crosshair template (doubles as a render probe).</summary>
+public sealed class GhostPin
+{
+    public GhostPin(string name, PixelPoint pixel)
+    {
+        Name = name;
+        Pixel = pixel;
+    }
+
+    public string Name { get; }
+    public PixelPoint Pixel { get; }
+    public double X => Pixel.X;
+    public double Y => Pixel.Y;
+}
+
 /// <summary>A projected test reading. Keeps its source <see cref="Offset"/> so
 /// it can be re-projected when the test origin (your position) is nudged —
 /// the green pins track your position live while you align them.</summary>

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -152,8 +152,11 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
 
-        SelectedReference = References.FirstOrDefault(r =>
-            Placements.All(p => !ReferenceEquals(p.Reference, r)));
+        // No auto-advance: the click only ever affects the reference the user
+        // explicitly selected. Keeping the selection means a second click on
+        // the same reference is a *correction* (replaces its point above), and
+        // moving to the next reference is a deliberate pick — not something
+        // every stray click silently consumes.
     }
 
     [RelayCommand]

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -9,16 +9,17 @@ using Mithril.Shared.Reference;
 namespace Legolas.ViewModels;
 
 /// <summary>
-/// Drives the standalone calibration overlay: lists the current area's
-/// landmark/NPC references, accumulates the user's reference clicks (a known
-/// world point paired with where they clicked it on the in-game map, captured
-/// through the transparent overlay), and solves+persists the per-area projector
-/// calibration via <see cref="IAreaCalibrationService"/>.
-///
-/// Calibration is decoupled from the survey FSM entirely — placing references
-/// here never touches <see cref="SessionState"/> or the survey pipeline; it only
-/// feeds the solver. Once solved, every later survey/treasure in that area
-/// projects correctly with no warmup.
+/// Drives the standalone calibration overlay. Two pin families share one
+/// select → nudge → Done state machine:
+/// <list type="bullet">
+/// <item><b>Reference placements</b> — landmark/NPC clicks that feed the solve.</item>
+/// <item><b>Verify</b> — a single <see cref="PlayerPin"/> ("you") plus
+/// <see cref="SurveyPins"/>: each survey/treasure vector becomes a pin that
+/// stores BOTH its calibration-<see cref="SurveyPin.ProjectedPixel"/> and the
+/// user-corrected <see cref="SurveyPin.OverlayPixel"/> (dragged onto the real
+/// ping), so the projected-vs-actual delta is fully recoverable for the math.</item>
+/// </list>
+/// All decoupled from the survey FSM — nothing here touches SessionState.
 /// </summary>
 public sealed partial class CalibrationSessionViewModel : ObservableObject
 {
@@ -36,35 +37,53 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     public ObservableCollection<PlacedReference> Placements { get; } = new();
 
     /// <summary>Projected positions of the *unplaced* landmarks per the solved
-    /// calibration — a pure world→pixel sanity check (they never feed the solve,
-    /// which would be circular). If the math is right they sit on the real
-    /// landmarks on the in-game map.</summary>
+    /// calibration — a pure world→pixel sanity check (never feeds the solve).</summary>
     public ObservableCollection<GhostPin> GhostPins { get; } = new();
 
-    /// <summary>Projected test pins (a survey/treasure fired while test mode is
-    /// on, projected from <see cref="TestOrigin"/> via the live calibration).</summary>
-    public ObservableCollection<TestPin> TestPins { get; } = new();
+    /// <summary>Survey/treasure vectors as correctable pins (own list, behaves
+    /// like a landmark pin). Each keeps projected + overlay coords + the player
+    /// pixel it was projected from, for the math.</summary>
+    public ObservableCollection<SurveyPin> SurveyPins { get; } = new();
 
-    /// <summary>Test mode: a click sets a synthetic "you are here" origin, and
-    /// each subsequent survey/treasure drops a projected pin to eyeball against
-    /// the real in-game ping — verifies the calibration without a survey run.</summary>
-    [ObservableProperty] private bool _testMode;
+    /// <summary>"You are here" — a first-class selectable/nudgeable pin (not a
+    /// click-mode). Set via the panel button; moving it re-projects every
+    /// survey pin's <see cref="SurveyPin.ProjectedPixel"/>.</summary>
+    [ObservableProperty] private PlayerPin? _playerPin;
 
-    /// <summary>The synthetic player position test projections emanate from.</summary>
-    [ObservableProperty] private PixelPoint? _testOrigin;
+    [ObservableProperty] private SurveyPin? _selectedSurveyPin;
 
-    public bool HasTestOrigin => TestOrigin is not null;
-    public double TestOriginX => TestOrigin?.X ?? 0;
-    public double TestOriginY => TestOrigin?.Y ?? 0;
+    // Next viewport click drops/moves the player pin (armed by the button).
+    private bool _armPlayerClick;
 
-    partial void OnTestOriginChanged(PixelPoint? value)
+    public bool HasPlayerPin => PlayerPin is not null;
+    public double PlayerPinX => PlayerPin?.X ?? 0;
+    public double PlayerPinY => PlayerPin?.Y ?? 0;
+    public bool IsPlayerSelected => PlayerPin?.IsSelected == true;
+
+    partial void OnPlayerPinChanged(PlayerPin? oldValue, PlayerPin? newValue)
     {
-        OnPropertyChanged(nameof(HasTestOrigin));
-        OnPropertyChanged(nameof(TestOriginX));
-        OnPropertyChanged(nameof(TestOriginY));
+        OnPropertyChanged(nameof(HasPlayerPin));
+        OnPropertyChanged(nameof(PlayerPinX));
+        OnPropertyChanged(nameof(PlayerPinY));
+        OnPropertyChanged(nameof(IsPlayerSelected));
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
-        ReprojectTestPins(); // green pins follow your position as you nudge it
+        RaiseDebug();
+    }
+
+    partial void OnSelectedSurveyPinChanged(SurveyPin? oldValue, SurveyPin? newValue)
+    {
+        if (oldValue is not null) oldValue.IsSelected = false;
+        if (newValue is not null)
+        {
+            newValue.IsSelected = true;
+            // Mutually exclusive across the families.
+            SelectedPlacement = null;
+            SelectedReference = null;
+            ClearPlayerSelection();
+        }
+        OnPropertyChanged(nameof(NudgeTargetText));
+        OnPropertyChanged(nameof(CanNudge));
         RaiseDebug();
     }
 
@@ -75,38 +94,31 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(SolveCommand))]
     private CalibrationReference? _selectedReference;
 
-    /// <summary>Manually-chosen area. Switching it drives the service the same
-    /// way a live <c>Entering Area:</c> banner would.</summary>
+    /// <summary>Manually-chosen area. Switching it drives the service.</summary>
     [ObservableProperty] private AreaEntry? _selectedArea;
 
-    /// <summary>The placement the keyboard nudge acts on (set to the most
-    /// recently placed; also click-selectable in the Placed list).</summary>
+    /// <summary>The reference placement the nudge acts on.</summary>
     [ObservableProperty] private PlacedReference? _selectedPlacement;
 
-    /// <summary>Panel text naming what a nudge will move (null = nothing armed).
-    /// In verify mode with a position set, the arrows move <em>your position</em>
-    /// (and the green pins follow); otherwise the selected reference.</summary>
     public string? NudgeTargetText =>
-        TestMode && TestOrigin is not null
-            ? "Nudging your position — arrow keys move it, green pins follow (Shift = 5px)"
-            : SelectedPlacement is { } p
-                ? $"Nudging “{p.Name}” — arrow keys move it (Shift = 5px)"
-                : null;
+        IsPlayerSelected
+            ? "Nudging your position — arrow keys move it; survey pins re-project (Shift = 5px)"
+            : SelectedSurveyPin is { } s
+                ? $"Nudging survey “{s.Name}” onto the real ping — arrow keys (Shift = 5px)"
+                : SelectedPlacement is { } p
+                    ? $"Nudging “{p.Name}” — arrow keys move it (Shift = 5px)"
+                    : null;
 
-    /// <summary>True when arrow keys have something to move (a placement, or the
-    /// test position in verify mode). Drives the code-behind key handler.</summary>
-    public bool CanNudge => (TestMode && TestOrigin is not null) || SelectedPlacement is not null;
+    public bool CanNudge =>
+        IsPlayerSelected || SelectedSurveyPin is not null || SelectedPlacement is not null;
 
-    /// <summary>Blunt always-visible state readout — so "no pin" is never a
-    /// mystery: it shows whether the area/refs loaded, what's selected, how many
-    /// pins exist + the last one's pixel, and the test origin. If a click made a
-    /// pin, <c>pins=</c> increments here even if the on-map marker doesn't draw.</summary>
+    /// <summary>Blunt always-visible state readout.</summary>
     public string DebugState =>
         $"area={_service.CurrentAreaKey ?? "-"}  refs={References.Count}  " +
         $"sel={SelectedReference?.Name ?? "-"}  pins={Placements.Count}  " +
         $"last={(Placements.Count > 0 ? $"({Placements[^1].X:0},{Placements[^1].Y:0})" : "-")}  " +
-        $"you={(TestOrigin is { } o ? $"({o.X:0},{o.Y:0})" : "-")}  " +
-        $"test={TestMode}  pinsShown={TestPins.Count}  ghosts={GhostPins.Count}";
+        $"you={(PlayerPin is { } pp ? $"({pp.X:0},{pp.Y:0}){(pp.IsSelected ? "*" : "")}" : "-")}  " +
+        $"surveys={SurveyPins.Count}  ghosts={GhostPins.Count}";
 
     private void RaiseDebug()
     {
@@ -114,8 +126,8 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         OnPropertyChanged(nameof(DiagnosticSnapshot));
     }
 
-    /// <summary>Full multi-line diagnostic for the clipboard — the panel line
-    /// gets clipped, so "Copy debug" dumps everything I'd need to see.</summary>
+    /// <summary>Full multi-line diagnostic for the clipboard, incl. the selected
+    /// survey pin's projected-vs-overlay math.</summary>
     public string DiagnosticSnapshot
     {
         get
@@ -135,6 +147,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
                 $"lastSurvey: {LastSurveyText ?? "-"}",
                 $"result: {ResultText ?? "-"}",
                 $"nudgeTarget: {NudgeTargetText ?? "-"}",
+                $"selectedSurvey: {(SelectedSurveyPin?.MathText ?? "-")}",
                 $"clickWarning: {ClickWarning ?? "-"}",
             });
         }
@@ -150,65 +163,65 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     partial void OnSelectedPlacementChanged(PlacedReference? oldValue, PlacedReference? newValue)
     {
         if (oldValue is not null) oldValue.IsSelected = false;
-        if (newValue is not null) newValue.IsSelected = true;
-        // Selecting a pin in the Placed list also selects its reference (so the
-        // References list agrees — "pick from either list"). Only sync upward
-        // when a pin is chosen; clearing the pin because an *unplaced*
-        // reference was picked must NOT wipe that reference selection.
-        if (newValue is not null && !ReferenceEquals(SelectedReference, newValue.Reference))
-            SelectedReference = newValue.Reference;
+        if (newValue is not null)
+        {
+            newValue.IsSelected = true;
+            if (!ReferenceEquals(SelectedReference, newValue.Reference))
+                SelectedReference = newValue.Reference;
+            SelectedSurveyPin = null;
+            ClearPlayerSelection();
+        }
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
         RaiseDebug();
     }
 
-    /// <summary>
-    /// Selecting a reference (either list) makes it the active target and links
-    /// to its dropped pin if one exists — so nudging only works once a pin has
-    /// been placed for it. Switching references leaves the previous pin where
-    /// it was (it's already stored in <see cref="Placements"/>).
-    /// </summary>
     partial void OnSelectedReferenceChanged(CalibrationReference? value)
     {
         var pin = value is null
             ? null
             : Placements.FirstOrDefault(p => ReferenceEquals(p.Reference, value));
         if (!ReferenceEquals(SelectedPlacement, pin))
-            SelectedPlacement = pin; // null until this reference is dropped
+            SelectedPlacement = pin;
         RaiseDebug();
     }
 
-    /// <summary>Non-null when the last map click could not be placed — tells the
-    /// user why instead of silently doing nothing.</summary>
     [ObservableProperty] private string? _clickWarning;
 
-    /// <summary>Always set whenever a survey/treasure reaches the window — proves
-    /// the chat→pipeline→window path is alive, and says what's missing if it
-    /// didn't project. Never silently swallowed.</summary>
+    /// <summary>Always set whenever a survey/treasure reaches the window.</summary>
     [ObservableProperty] private string? _lastSurveyText;
 
     [ObservableProperty] private string _statusText = "No area detected yet.";
     [ObservableProperty] private string _instruction =
-        "Pick an area (or walk into one), choose a landmark/NPC, then click exactly where it sits on the in-game map. Arrow keys nudge the last point.";
+        "Pick an area, place ≥2 landmark/NPC references, Solve. Then Set player position and fire a survey to verify.";
     [ObservableProperty] private string? _resultText;
 
     partial void OnSelectedAreaChanged(AreaEntry? value)
     {
-        // Guard the Refresh→set→change loop: Refresh sets SelectedArea to the
-        // already-current area, which must NOT re-drive the service.
         if (value is null || value.Key == _service.CurrentAreaKey) return;
         _service.SelectArea(value.Key);
     }
 
-    /// <summary>Arrow-key fine-tune. In verify mode with a position set it moves
-    /// <em>your position</em> (and re-projects the green pins); otherwise it
-    /// moves the selected reference placement. No-op if neither applies.</summary>
+    /// <summary>Arrow-key fine-tune of whatever is selected: the player pin
+    /// (re-projects surveys), a survey pin's overlay (drag onto the real ping),
+    /// or a reference placement.</summary>
     public void NudgeSelected(double dx, double dy)
     {
-        if (TestMode && TestOrigin is { } o)
+        if (PlayerPin is { IsSelected: true } pp)
         {
-            // Moves your position; OnTestOriginChanged re-projects the pins.
-            TestOrigin = new PixelPoint(o.X + dx, o.Y + dy);
+            pp.Pixel = new PixelPoint(pp.Pixel.X + dx, pp.Pixel.Y + dy);
+            OnPropertyChanged(nameof(PlayerPinX));
+            OnPropertyChanged(nameof(PlayerPinY));
+            ReprojectSurveyPins();
+            RaiseDebug();
+            return;
+        }
+        if (SelectedSurveyPin is { } s)
+        {
+            s.OverlayPixel = new PixelPoint(s.OverlayPixel.X + dx, s.OverlayPixel.Y + dy);
+            s.Corrected = true; // it's now the real-ping position, not the projection
+            ClampSurvey(s);
+            RaiseDebug();
             return;
         }
         if (SelectedPlacement is { } p)
@@ -219,10 +232,6 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
     private void OnServiceChanged(object? sender, EventArgs e)
     {
-        // Service.Changed already fires on the UI dispatcher in the live path
-        // (LogIngestionService posts area events to the dispatcher), but guard
-        // anyway — bound-collection mutation off the UI thread is a documented
-        // Mithril footgun.
         var disp = Application.Current?.Dispatcher;
         if (disp is not null && !disp.CheckAccess()) disp.Invoke(Refresh);
         else Refresh();
@@ -239,8 +248,6 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         References.Clear();
         foreach (var r in _service.CurrentAreaReferences) References.Add(r);
 
-        // Keep the area picker reflecting the live area without re-driving the
-        // service (OnSelectedAreaChanged guards on key equality).
         if (_service.CurrentAreaKey is { } curKey)
             SelectedArea = AvailableAreas.FirstOrDefault(a => a.Key == curKey);
 
@@ -249,37 +256,22 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             StatusText = "No area detected — pick one from the dropdown, or walk into one in-game.";
             return;
         }
-
         if (_service.CurrentAreaKey is null)
         {
             StatusText = $"{area} — unrecognised area (no reference data); calibration unavailable.";
             return;
         }
-
-        if (_service.CurrentCalibration is { } c)
-        {
-            StatusText = $"{area} — calibrated " +
-                $"({c.ReferenceCount} refs, residual {c.ResidualPixels:0.0} px). " +
-                "Recalibrate if pins still land wrong.";
-        }
-        else
-        {
-            StatusText = $"{area} — not calibrated. Place ≥2 references and Solve.";
-        }
+        StatusText = _service.CurrentCalibration is { } c
+            ? $"{area} — calibrated ({c.ReferenceCount} refs, residual {c.ResidualPixels:0.0} px). " +
+              "Set player position + fire a survey to verify; Recalibrate if off."
+            : $"{area} — not calibrated. Place ≥2 references and Solve.";
     }
 
-    /// <summary>
-    /// Record where the user clicked the currently-selected reference on the
-    /// map overlay. Auto-advances the selection to the next not-yet-placed
-    /// reference so a calibration run is a steady pick-less click cadence.
-    /// </summary>
     [RelayCommand]
     private void PlaceSelectedAt(PixelPoint pixel)
     {
         if (SelectedReference is not { } reference)
         {
-            // Don't fail silently — the click WAS captured, it just had no
-            // target. Tell the user which precondition is missing.
             ClickWarning = References.Count == 0
                 ? "No area selected — choose an area above first."
                 : "Pick a landmark/NPC from the list, then click where it is on the map.";
@@ -287,105 +279,101 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             return;
         }
 
-        // Replace any prior placement of the same reference (a re-click is a
-        // correction, not a second point).
         for (var i = Placements.Count - 1; i >= 0; i--)
             if (ReferenceEquals(Placements[i].Reference, reference))
                 Placements.RemoveAt(i);
 
         var placed = new PlacedReference(reference, pixel);
         Placements.Add(placed);
-        SelectedPlacement = placed;     // dropped → now nudgeable
-        SelectedReference = reference;  // stays the active target (both lists agree)
+        SelectedPlacement = placed;
+        SelectedReference = reference;
         ClickWarning = null;
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
-
-        // Selection deliberately persists: the just-dropped pin is the clearly
-        // indicated active target (halo + "Nudging …" text). Arrow keys nudge
-        // it; clicking again repositions it; picking another reference swaps
-        // (the prior pin stays put — already stored); "Done" deselects so a
-        // stray click/nudge does nothing. (Earlier the persistence was a *bug*
-        // only because it was invisible and unstoppable — now it's an explicit,
-        // visible state with an exit.)
         RaiseDebug();
     }
 
-    /// <summary>
-    /// Single entry point for a click on the map surface. In test mode a click
-    /// sets the synthetic player origin; otherwise it places the selected
-    /// reference. Keeps the code-behind dumb (it doesn't know the mode).
-    /// </summary>
+    /// <summary>Single map-click entry point. If the player-pin click is armed,
+    /// the click drops/moves "you"; otherwise it places the selected reference.</summary>
     [RelayCommand]
     private void ViewportClicked(PixelPoint pixel)
     {
-        if (TestMode)
+        if (_armPlayerClick)
         {
-            TestOrigin = pixel;
-            TestPins.Clear();
+            _armPlayerClick = false;
+            if (PlayerPin is { } pp) pp.Pixel = pixel;
+            else PlayerPin = new PlayerPin(pixel);
+            SelectPlayerInternal();
+            ReprojectSurveyPins();
             ClickWarning = _service.CurrentCalibration is null
-                ? "Solve a calibration first, then click where you are to verify."
+                ? "Player set. Solve a calibration, then fire a survey to verify."
                 : null;
+            RaiseDebug();
             return;
         }
         PlaceSelectedAt(pixel);
     }
 
-    /// <summary>Enter/leave the position+verify step (also auto-entered after a
-    /// successful Solve — prompting for position is part of calibrating).</summary>
+    /// <summary>Panel button: if no player pin yet, arm the next click to drop
+    /// it; if it exists, select it as the nudge target (same as picking a
+    /// landmark pin from a list).</summary>
     [RelayCommand]
-    private void ToggleTestMode()
+    private void SetPlayerPosition()
     {
-        TestMode = !TestMode;
-        ClickWarning = null;
-    }
-
-    partial void OnTestModeChanged(bool value)
-    {
-        if (value)
+        if (PlayerPin is null)
         {
-            TestPins.Clear();
-            TestOrigin = null;
-            Instruction = _service.CurrentCalibration is null
-                ? "Place ≥2 references and Solve first — then click where you are and fire a survey/treasure to verify."
-                : "Verify: click where you ARE on the map now, then use a survey/treasure — the projected pin should land on the real ping. (Surveying still asks for your position separately; this only checks the calibration.)";
+            _armPlayerClick = true;
+            ClickWarning = "Click on the map where you are.";
         }
         else
         {
-            Instruction = "Pick an area (or walk into one), choose a landmark/NPC, then click exactly where it sits on the in-game map. Arrow keys nudge the last point.";
+            SelectPlayerInternal();
         }
+        RaiseDebug();
+    }
+
+    private void SelectPlayerInternal()
+    {
+        SelectedPlacement = null;
+        SelectedReference = null;
+        SelectedSurveyPin = null;
+        if (PlayerPin is { } pp) pp.IsSelected = true;
+        OnPropertyChanged(nameof(IsPlayerSelected));
+        OnPropertyChanged(nameof(NudgeTargetText));
+        OnPropertyChanged(nameof(CanNudge));
+    }
+
+    private void ClearPlayerSelection()
+    {
+        if (PlayerPin is { IsSelected: true } pp) pp.IsSelected = false;
+        OnPropertyChanged(nameof(IsPlayerSelected));
+    }
+
+    /// <summary>Commit &amp; stop: deselect everything so a stray click/arrow
+    /// does nothing until something is picked again.</summary>
+    [RelayCommand]
+    private void Deselect()
+    {
+        SelectedReference = null;
+        SelectedPlacement = null;
+        SelectedSurveyPin = null;
+        ClearPlayerSelection();
+        ClickWarning = null;
         OnPropertyChanged(nameof(NudgeTargetText));
         OnPropertyChanged(nameof(CanNudge));
         RaiseDebug();
     }
 
-    /// <summary>Commit &amp; stop: deselect the active reference/pin so a stray
-    /// click or arrow key does nothing until something is picked again. The
-    /// pin's final nudged position is already stored in <see cref="Placements"/>.</summary>
     [RelayCommand]
-    private void Deselect()
+    private void ClearSurveyPins()
     {
-        SelectedReference = null; // OnSelectedReferenceChanged clears the pin too
-        SelectedPlacement = null;
-        ClickWarning = null;
+        SurveyPins.Clear();
+        SelectedSurveyPin = null;
         RaiseDebug();
     }
 
-    [RelayCommand]
-    private void ClearTestPins()
-    {
-        TestPins.Clear();
-        TestOrigin = null;
-        RaiseDebug();
-    }
-
-    /// <summary>
-    /// Drop a magenta "ghost" at every *unplaced* landmark/NPC's projected
-    /// position per the solved calibration. Pure world→pixel — these never feed
-    /// the solve (that'd be circular). If the math is right each ghost sits on
-    /// the real landmark on the in-game map; rotated/mirrored ghosts expose a
-    /// convention error directly, with no survey or position involved.
-    /// </summary>
+    /// <summary>Ghost every *unplaced* landmark at its calibrated position
+    /// (pure world→pixel; never feeds the solve).</summary>
     [RelayCommand]
     private void ProjectLandmarks()
     {
@@ -396,15 +384,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             RaiseDebug();
             return;
         }
-
         var worldOrigin = new PixelPoint(c.OriginX, c.OriginY);
         foreach (var r in References)
         {
-            // Skip the ones used to solve — only the *remaining* landmarks test it.
             if (Placements.Any(p => ReferenceEquals(p.Reference, r))) continue;
             var north = c.MirrorNorth ? -r.World.Z : r.World.Z;
-            var px = Project(c, worldOrigin, new MetreOffset(r.World.X, north));
-            GhostPins.Add(new GhostPin(r.Name, px));
+            GhostPins.Add(new GhostPin(r.Name, Project(c, worldOrigin, new MetreOffset(r.World.X, north))));
         }
         ClickWarning = null;
         RaiseDebug();
@@ -420,71 +405,63 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     private void OnSurveyObserved(object? sender, CalibrationSurveyObservation obs)
     {
         var disp = Application.Current?.Dispatcher;
-        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => { ProjectTest(obs); RaiseDebug(); });
-        else { ProjectTest(obs); RaiseDebug(); }
+        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => AddSurvey(obs));
+        else AddSurvey(obs);
     }
 
-    private void ProjectTest(CalibrationSurveyObservation obs)
+    private void AddSurvey(CalibrationSurveyObservation obs)
     {
-        // ALWAYS record that the survey reached the window — before any gate —
-        // so "nothing happened" is never ambiguous. This is the signal that the
-        // chat→pipeline→window path is alive.
         var seen = $"Last survey: {obs.Name} ({obs.Offset.East:0}E, {obs.Offset.North:0}N)";
-
-        if (!TestMode)
-        {
-            LastSurveyText = seen + " — turn on “Verify (set position)” to project it.";
-            return;
-        }
         if (_service.CurrentCalibration is not { } c)
         {
             LastSurveyText = seen + " — solve a calibration first.";
+            RaiseDebug();
             return;
         }
-        if (TestOrigin is not { } o)
+        if (PlayerPin is not { } pp)
         {
-            LastSurveyText = seen + " — click where you are on the map first.";
+            LastSurveyText = seen + " — Set player position first.";
+            RaiseDebug();
             return;
         }
 
-        var tp = new TestPin(obs.Name, obs.Offset, Project(c, o, obs.Offset));
-        ClampToViewport(tp);
-        TestPins.Add(tp);
-        LastSurveyText = seen + " → green pin projected." +
-            (tp.IsOffscreen ? " (off-screen — clamped to edge; nudge ‘you’ to bring it in)" : "");
+        var projected = Project(c, pp.Pixel, obs.Offset);
+        var sp = new SurveyPin(obs.Name, obs.Offset, pp.Pixel, projected);
+        ClampSurvey(sp);
+        SurveyPins.Add(sp);
+        LastSurveyText = seen + " → added to Surveys; select it and drag it onto the real ping.";
         ClickWarning = null;
+        RaiseDebug();
     }
 
-    // The Viewport's pixel size, pushed from the view on load/resize. Lets a
-    // far projection clamp to the border instead of vanishing off-window.
+    // Viewport size, pushed from the view, so a far overlay pin clamps to the
+    // edge instead of vanishing.
     private double _viewportW, _viewportH;
 
     public void SetViewport(double width, double height)
     {
         _viewportW = width;
         _viewportH = height;
-        foreach (var p in TestPins) ClampToViewport(p);
+        foreach (var s in SurveyPins) ClampSurvey(s);
     }
 
-    private void ClampToViewport(TestPin p)
+    private void ClampSurvey(SurveyPin s)
     {
         const double inset = 14;
+        var px = s.OverlayPixel;
         if (_viewportW <= 0 || _viewportH <= 0)
         {
-            p.DisplayX = p.Pixel.X;
-            p.DisplayY = p.Pixel.Y;
-            p.IsOffscreen = false;
+            s.DisplayX = px.X;
+            s.DisplayY = px.Y;
+            s.IsOffscreen = false;
             return;
         }
-        p.IsOffscreen =
-            p.Pixel.X < 0 || p.Pixel.X > _viewportW ||
-            p.Pixel.Y < 0 || p.Pixel.Y > _viewportH;
-        p.DisplayX = Math.Clamp(p.Pixel.X, inset, _viewportW - inset);
-        p.DisplayY = Math.Clamp(p.Pixel.Y, inset, _viewportH - inset);
+        s.IsOffscreen = px.X < 0 || px.X > _viewportW || px.Y < 0 || px.Y > _viewportH;
+        s.DisplayX = Math.Clamp(px.X, inset, _viewportW - inset);
+        s.DisplayY = Math.Clamp(px.Y, inset, _viewportH - inset);
     }
 
-    /// <summary>Same math as <c>CoordinateProjector.Project</c>: a metre offset
-    /// from <paramref name="origin"/> through the calibration's scale/rotation.</summary>
+    /// <summary>Same math as <c>CoordinateProjector.Project</c>.</summary>
     private static PixelPoint Project(AreaCalibration c, PixelPoint origin, MetreOffset off)
     {
         var cos = Math.Cos(c.RotationRadians);
@@ -494,15 +471,19 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         return new PixelPoint(origin.X + c.Scale * rotE, origin.Y - c.Scale * rotN);
     }
 
-    /// <summary>Re-place every projected pin from the (moved) test origin so the
-    /// green pins track your position live while you align them.</summary>
-    private void ReprojectTestPins()
+    /// <summary>Re-project every survey pin from the (moved) player pin. The
+    /// overlay follows the projection until the user corrects it; once dragged
+    /// (<see cref="SurveyPin.Corrected"/>) the overlay sticks — it's the real
+    /// ping, fixed on the map regardless of where the player marker is.</summary>
+    private void ReprojectSurveyPins()
     {
-        if (_service.CurrentCalibration is not { } c || TestOrigin is not { } o) return;
-        foreach (var pin in TestPins)
+        if (_service.CurrentCalibration is not { } c || PlayerPin is not { } pp) return;
+        foreach (var s in SurveyPins)
         {
-            pin.Pixel = Project(c, o, pin.Offset);
-            ClampToViewport(pin); // keep edge-clamp current as "you" moves
+            s.OriginPixel = pp.Pixel;
+            s.ProjectedPixel = Project(c, pp.Pixel, s.Offset);
+            if (!s.Corrected) s.OverlayPixel = s.ProjectedPixel;
+            ClampSurvey(s);
         }
     }
 
@@ -522,7 +503,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     private void ClearPlacements()
     {
         Placements.Clear();
-        SelectedPlacement = null; // don't leave the nudge target dangling
+        SelectedPlacement = null;
         OnPropertyChanged(nameof(CanSolve));
         SolveCommand.NotifyCanExecuteChanged();
         ResultText = null;
@@ -542,18 +523,15 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
         ResultText = calibration.ResidualPixels <= 12
             ? $"Calibrated: {calibration.ResidualPixels:0.0} px residual, scale {calibration.Scale:0.000} px/m. " +
-              "Now verify: click where you are, then use a survey/treasure."
+              "Now Set player position and fire a survey to verify."
             : $"Solved but residual is high ({calibration.ResidualPixels:0.0} px) — references were likely " +
               "placed imprecisely or the map was at a different zoom. Clear and redo for a tighter fit.";
-
-        // Calibration isn't "done" until it's verified. Auto-continue into the
-        // position+verify step so the user doesn't have to discover a separate
-        // toggle — prompting for position is part of calibrating.
-        TestMode = true;
+        Instruction = "Set player position (button), then fire a survey/treasure — it joins the Surveys " +
+            "list; select it and drag it onto the real ping. Projected vs corrected = the scale check.";
+        ReprojectSurveyPins();
         Refresh();
     }
 
-    /// <summary>Drop the persisted calibration for this area and start over.</summary>
     [RelayCommand]
     private void Recalibrate()
     {
@@ -563,12 +541,8 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     }
 }
 
-/// <summary>A reference the user has pinned on the map. Observable so an
-/// arrow-key nudge to <see cref="Pixel"/> moves the on-map marker and updates
-/// the Placed list live; <see cref="X"/>/<see cref="Y"/> drive Canvas placement.</summary>
 /// <summary>A projected unplaced-landmark "ghost" — pure world→pixel sanity
-/// marker. Static; deliberately minimal so its render path differs from the
-/// crosshair template (doubles as a render probe).</summary>
+/// marker (minimal, static).</summary>
 public sealed class GhostPin
 {
     public GhostPin(string name, PixelPoint pixel)
@@ -583,33 +557,13 @@ public sealed class GhostPin
     public double Y => Pixel.Y;
 }
 
-/// <summary>A projected test reading. Keeps its source <see cref="Offset"/> so
-/// it can be re-projected when the test origin (your position) is nudged —
-/// the green pins track your position live while you align them.</summary>
-public sealed partial class TestPin : ObservableObject
+/// <summary>The "you are here" pin — selectable/nudgeable like a placement.</summary>
+public sealed partial class PlayerPin : ObservableObject
 {
-    public TestPin(string name, MetreOffset offset, PixelPoint pixel)
-    {
-        Name = name;
-        Offset = offset;
-        _pixel = pixel;
-    }
-
-    public string Name { get; }
-    public MetreOffset Offset { get; }
+    public PlayerPin(PixelPoint pixel) => _pixel = pixel;
 
     [ObservableProperty] private PixelPoint _pixel;
-
-    /// <summary>Where the marker actually renders — equals <see cref="Pixel"/>
-    /// when on-screen, else clamped to the Viewport edge so a far projection is
-    /// never silently lost. Set by the VM (it knows the Viewport size).</summary>
-    [ObservableProperty] private double _displayX;
-    [ObservableProperty] private double _displayY;
-
-    /// <summary>True when the true projected pixel is outside the Viewport, so
-    /// the marker is edge-clamped (shown as an orange dashed ring, not the true
-    /// position). Nudge "you" to bring it on-screen.</summary>
-    [ObservableProperty] private bool _isOffscreen;
+    [ObservableProperty] private bool _isSelected;
 
     partial void OnPixelChanged(PixelPoint value)
     {
@@ -619,6 +573,85 @@ public sealed partial class TestPin : ObservableObject
 
     public double X => Pixel.X;
     public double Y => Pixel.Y;
+}
+
+/// <summary>A survey/treasure vector as a correctable pin. Stores the player
+/// pixel it was projected from (<see cref="OriginPixel"/>), the calibration's
+/// <see cref="ProjectedPixel"/>, and the user-corrected <see cref="OverlayPixel"/>
+/// (dragged onto the real ping). The projected↔overlay delta vs. the metre
+/// offset is the empirical scale check.</summary>
+public sealed partial class SurveyPin : ObservableObject
+{
+    public SurveyPin(string name, MetreOffset offset, PixelPoint origin, PixelPoint projected)
+    {
+        Name = name;
+        Offset = offset;
+        _originPixel = origin;
+        _projectedPixel = projected;
+        _overlayPixel = projected; // starts on the projection; user drags to truth
+    }
+
+    public string Name { get; }
+    public MetreOffset Offset { get; }
+
+    [ObservableProperty] private PixelPoint _originPixel;
+    [ObservableProperty] private PixelPoint _projectedPixel;
+    [ObservableProperty] private PixelPoint _overlayPixel;
+    [ObservableProperty] private bool _isSelected;
+
+    /// <summary>True once the user has dragged the overlay — it then sticks
+    /// (the real ping is fixed on the map) instead of following re-projection.</summary>
+    [ObservableProperty] private bool _corrected;
+
+    // Clamped render position for the overlay marker (edge-visible).
+    [ObservableProperty] private double _displayX;
+    [ObservableProperty] private double _displayY;
+    [ObservableProperty] private bool _isOffscreen;
+
+    partial void OnProjectedPixelChanged(PixelPoint value)
+    {
+        OnPropertyChanged(nameof(ProjX));
+        OnPropertyChanged(nameof(ProjY));
+        OnPropertyChanged(nameof(MathText));
+    }
+
+    partial void OnOverlayPixelChanged(PixelPoint value)
+    {
+        OnPropertyChanged(nameof(OverlayX));
+        OnPropertyChanged(nameof(OverlayY));
+        OnPropertyChanged(nameof(MathText));
+    }
+
+    public double ProjX => ProjectedPixel.X;
+    public double ProjY => ProjectedPixel.Y;
+    public double OverlayX => OverlayPixel.X;
+    public double OverlayY => OverlayPixel.Y;
+
+    /// <summary>The math: metre distance, projected px distance, corrected px
+    /// distance (all from the player pixel), and the implied scale factor —
+    /// i.e. what px/m the corrected position actually needs vs. what the
+    /// calibration used.</summary>
+    public string MathText
+    {
+        get
+        {
+            var metres = Math.Sqrt(Offset.East * Offset.East + Offset.North * Offset.North);
+            var projDist = Dist(OriginPixel, ProjectedPixel);
+            var overDist = Dist(OriginPixel, OverlayPixel);
+            var impliedScale = metres > 1e-6 ? overDist / metres : 0;
+            var ratio = projDist > 1e-6 ? overDist / projDist : 0;
+            return $"{Name}: {metres:0}m  proj={projDist:0}px  corrected={overDist:0}px  " +
+                   $"ratio={ratio:0.000}  impliedScale={impliedScale:0.0000}px/m" +
+                   (Corrected ? "" : "  (not yet corrected)");
+        }
+    }
+
+    private static double Dist(PixelPoint a, PixelPoint b)
+    {
+        var dx = a.X - b.X;
+        var dy = a.Y - b.Y;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
 }
 
 public sealed partial class PlacedReference : ObservableObject
@@ -632,10 +665,6 @@ public sealed partial class PlacedReference : ObservableObject
     public CalibrationReference Reference { get; }
 
     [ObservableProperty] private PixelPoint _pixel;
-
-    /// <summary>True for the one placement the arrow-key nudge currently acts
-    /// on — drives the on-map "active target" highlight so it's obvious what
-    /// you're moving.</summary>
     [ObservableProperty] private bool _isSelected;
 
     partial void OnPixelChanged(PixelPoint value)

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -89,6 +89,11 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     /// user why instead of silently doing nothing.</summary>
     [ObservableProperty] private string? _clickWarning;
 
+    /// <summary>Always set whenever a survey/treasure reaches the window — proves
+    /// the chat→pipeline→window path is alive, and says what's missing if it
+    /// didn't project. Never silently swallowed.</summary>
+    [ObservableProperty] private string? _lastSurveyText;
+
     [ObservableProperty] private string _statusText = "No area detected yet.";
     [ObservableProperty] private string _instruction =
         "Pick an area (or walk into one), choose a landmark/NPC, then click exactly where it sits on the in-game map. Arrow keys nudge the last point.";
@@ -257,15 +262,24 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
     private void ProjectTest(CalibrationSurveyObservation obs)
     {
-        if (!TestMode) return;
+        // ALWAYS record that the survey reached the window — before any gate —
+        // so "nothing happened" is never ambiguous. This is the signal that the
+        // chat→pipeline→window path is alive.
+        var seen = $"Last survey: {obs.Name} ({obs.Offset.East:0}E, {obs.Offset.North:0}N)";
+
+        if (!TestMode)
+        {
+            LastSurveyText = seen + " — turn on “Verify (set position)” to project it.";
+            return;
+        }
         if (_service.CurrentCalibration is not { } c)
         {
-            ClickWarning = "Solve a calibration before verifying.";
+            LastSurveyText = seen + " — solve a calibration first.";
             return;
         }
         if (TestOrigin is not { } o)
         {
-            ClickWarning = "Click where you are on the map first.";
+            LastSurveyText = seen + " — click where you are on the map first.";
             return;
         }
 
@@ -277,6 +291,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         var rotN = -obs.Offset.East * sin + obs.Offset.North * cos;
         var pixel = new PixelPoint(o.X + c.Scale * rotE, o.Y - c.Scale * rotN);
         TestPins.Add(new TestPin(obs.Name, pixel));
+        LastSurveyText = seen + " → green pin projected.";
         ClickWarning = null;
     }
 

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -447,9 +447,40 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             return;
         }
 
-        TestPins.Add(new TestPin(obs.Name, obs.Offset, Project(c, o, obs.Offset)));
-        LastSurveyText = seen + " → green pin projected.";
+        var tp = new TestPin(obs.Name, obs.Offset, Project(c, o, obs.Offset));
+        ClampToViewport(tp);
+        TestPins.Add(tp);
+        LastSurveyText = seen + " → green pin projected." +
+            (tp.IsOffscreen ? " (off-screen — clamped to edge; nudge ‘you’ to bring it in)" : "");
         ClickWarning = null;
+    }
+
+    // The Viewport's pixel size, pushed from the view on load/resize. Lets a
+    // far projection clamp to the border instead of vanishing off-window.
+    private double _viewportW, _viewportH;
+
+    public void SetViewport(double width, double height)
+    {
+        _viewportW = width;
+        _viewportH = height;
+        foreach (var p in TestPins) ClampToViewport(p);
+    }
+
+    private void ClampToViewport(TestPin p)
+    {
+        const double inset = 14;
+        if (_viewportW <= 0 || _viewportH <= 0)
+        {
+            p.DisplayX = p.Pixel.X;
+            p.DisplayY = p.Pixel.Y;
+            p.IsOffscreen = false;
+            return;
+        }
+        p.IsOffscreen =
+            p.Pixel.X < 0 || p.Pixel.X > _viewportW ||
+            p.Pixel.Y < 0 || p.Pixel.Y > _viewportH;
+        p.DisplayX = Math.Clamp(p.Pixel.X, inset, _viewportW - inset);
+        p.DisplayY = Math.Clamp(p.Pixel.Y, inset, _viewportH - inset);
     }
 
     /// <summary>Same math as <c>CoordinateProjector.Project</c>: a metre offset
@@ -469,7 +500,10 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     {
         if (_service.CurrentCalibration is not { } c || TestOrigin is not { } o) return;
         foreach (var pin in TestPins)
+        {
             pin.Pixel = Project(c, o, pin.Offset);
+            ClampToViewport(pin); // keep edge-clamp current as "you" moves
+        }
     }
 
     [RelayCommand]
@@ -565,6 +599,17 @@ public sealed partial class TestPin : ObservableObject
     public MetreOffset Offset { get; }
 
     [ObservableProperty] private PixelPoint _pixel;
+
+    /// <summary>Where the marker actually renders — equals <see cref="Pixel"/>
+    /// when on-screen, else clamped to the Viewport edge so a far projection is
+    /// never silently lost. Set by the VM (it knows the Viewport size).</summary>
+    [ObservableProperty] private double _displayX;
+    [ObservableProperty] private double _displayY;
+
+    /// <summary>True when the true projected pixel is outside the Viewport, so
+    /// the marker is edge-clamped (shown as an orange dashed ring, not the true
+    /// position). Nudge "you" to bring it on-screen.</summary>
+    [ObservableProperty] private bool _isOffscreen;
 
     partial void OnPixelChanged(PixelPoint value)
     {

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -28,11 +28,35 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     {
         _service = service;
         _service.Changed += OnServiceChanged;
+        _service.SurveyObserved += OnSurveyObserved;
         Refresh();
     }
 
     public ObservableCollection<CalibrationReference> References { get; } = new();
     public ObservableCollection<PlacedReference> Placements { get; } = new();
+
+    /// <summary>Projected test pins (a survey/treasure fired while test mode is
+    /// on, projected from <see cref="TestOrigin"/> via the live calibration).</summary>
+    public ObservableCollection<TestPin> TestPins { get; } = new();
+
+    /// <summary>Test mode: a click sets a synthetic "you are here" origin, and
+    /// each subsequent survey/treasure drops a projected pin to eyeball against
+    /// the real in-game ping — verifies the calibration without a survey run.</summary>
+    [ObservableProperty] private bool _testMode;
+
+    /// <summary>The synthetic player position test projections emanate from.</summary>
+    [ObservableProperty] private PixelPoint? _testOrigin;
+
+    public bool HasTestOrigin => TestOrigin is not null;
+    public double TestOriginX => TestOrigin?.X ?? 0;
+    public double TestOriginY => TestOrigin?.Y ?? 0;
+
+    partial void OnTestOriginChanged(PixelPoint? value)
+    {
+        OnPropertyChanged(nameof(HasTestOrigin));
+        OnPropertyChanged(nameof(TestOriginX));
+        OnPropertyChanged(nameof(TestOriginY));
+    }
 
     /// <summary>Every known area, for the manual picker (no live banner needed).</summary>
     public IReadOnlyList<AreaEntry> AvailableAreas => _service.AllAreas;
@@ -159,6 +183,90 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         // every stray click silently consumes.
     }
 
+    /// <summary>
+    /// Single entry point for a click on the map surface. In test mode a click
+    /// sets the synthetic player origin; otherwise it places the selected
+    /// reference. Keeps the code-behind dumb (it doesn't know the mode).
+    /// </summary>
+    [RelayCommand]
+    private void ViewportClicked(PixelPoint pixel)
+    {
+        if (TestMode)
+        {
+            TestOrigin = pixel;
+            TestPins.Clear();
+            ClickWarning = _service.CurrentCalibration is null
+                ? "Solve a calibration first — nothing to test yet."
+                : null;
+            return;
+        }
+        PlaceSelectedAt(pixel);
+    }
+
+    /// <summary>Enter/leave test mode (calibrate → fire a survey → see the
+    /// projected pin vs the real ping, without a full survey run).</summary>
+    [RelayCommand]
+    private void ToggleTestMode()
+    {
+        TestMode = !TestMode;
+        ClickWarning = null;
+    }
+
+    partial void OnTestModeChanged(bool value)
+    {
+        if (value)
+        {
+            TestPins.Clear();
+            TestOrigin = null;
+            Instruction = _service.CurrentCalibration is null
+                ? "Test mode: no calibration yet — Solve one first, then click your position and fire a survey/treasure."
+                : "Test mode: click where you ARE on the map, then use a survey/treasure. The projected pin should land on the real ping.";
+        }
+        else
+        {
+            Instruction = "Pick an area (or walk into one), choose a landmark/NPC, then click exactly where it sits on the in-game map. Arrow keys nudge the last point.";
+        }
+    }
+
+    [RelayCommand]
+    private void ClearTestPins()
+    {
+        TestPins.Clear();
+        TestOrigin = null;
+    }
+
+    private void OnSurveyObserved(object? sender, CalibrationSurveyObservation obs)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => ProjectTest(obs));
+        else ProjectTest(obs);
+    }
+
+    private void ProjectTest(CalibrationSurveyObservation obs)
+    {
+        if (!TestMode) return;
+        if (_service.CurrentCalibration is not { } c)
+        {
+            ClickWarning = "Solve a calibration before testing.";
+            return;
+        }
+        if (TestOrigin is not { } o)
+        {
+            ClickWarning = "Click the map to set your test position first.";
+            return;
+        }
+
+        // Same math as CoordinateProjector.Project, with origin = the test
+        // position and scale/rotation from the live calibration.
+        var cos = Math.Cos(c.RotationRadians);
+        var sin = Math.Sin(c.RotationRadians);
+        var rotE = obs.Offset.East * cos + obs.Offset.North * sin;
+        var rotN = -obs.Offset.East * sin + obs.Offset.North * cos;
+        var pixel = new PixelPoint(o.X + c.Scale * rotE, o.Y - c.Scale * rotN);
+        TestPins.Add(new TestPin(obs.Name, pixel));
+        ClickWarning = null;
+    }
+
     [RelayCommand]
     private void RemoveLastPlacement()
     {
@@ -209,6 +317,22 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 /// <summary>A reference the user has pinned on the map. Observable so an
 /// arrow-key nudge to <see cref="Pixel"/> moves the on-map marker and updates
 /// the Placed list live; <see cref="X"/>/<see cref="Y"/> drive Canvas placement.</summary>
+/// <summary>A projected test reading dropped while test mode is active.
+/// Static once placed (unlike <see cref="PlacedReference"/> it isn't nudged).</summary>
+public sealed class TestPin
+{
+    public TestPin(string name, PixelPoint pixel)
+    {
+        Name = name;
+        Pixel = pixel;
+    }
+
+    public string Name { get; }
+    public PixelPoint Pixel { get; }
+    public double X => Pixel.X;
+    public double Y => Pixel.Y;
+}
+
 public sealed partial class PlacedReference : ObservableObject
 {
     public PlacedReference(CalibrationReference reference, PixelPoint pixel)

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -242,6 +242,73 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             p.Pixel = new PixelPoint(p.Pixel.X + dx, p.Pixel.Y + dy);
     }
 
+    private static double Dist(double ax, double ay, double bx, double by)
+    {
+        var dx = ax - bx;
+        var dy = ay - by;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    /// <summary>Mouse-down hit-test: if a pin (player / survey overlay /
+    /// placement) is within <paramref name="radius"/> px of the click, select
+    /// it (mutually exclusive) and return true so the view starts a drag.
+    /// Otherwise false → the click falls through to place/arm. Priority:
+    /// player, then nearest on-screen survey overlay, then nearest placement.</summary>
+    public bool TrySelectPinAt(PixelPoint at, double radius)
+    {
+        if (PlayerPin is { } pp && Dist(at.X, at.Y, pp.X, pp.Y) <= radius)
+        {
+            SelectPlayerInternal();
+            return true;
+        }
+
+        SurveyPin? bestS = null;
+        var bestSd = radius;
+        foreach (var s in SurveyPins)
+        {
+            if (s.IsOffscreen) continue; // can't grab a clamped (not-true) pin
+            var d = Dist(at.X, at.Y, s.OverlayX, s.OverlayY);
+            if (d <= bestSd) { bestSd = d; bestS = s; }
+        }
+        if (bestS is not null) { SelectedSurveyPin = bestS; return true; }
+
+        PlacedReference? bestP = null;
+        var bestPd = radius;
+        foreach (var p in Placements)
+        {
+            var d = Dist(at.X, at.Y, p.X, p.Y);
+            if (d <= bestPd) { bestPd = d; bestP = p; }
+        }
+        if (bestP is not null) { SelectedPlacement = bestP; return true; }
+
+        return false;
+    }
+
+    /// <summary>Drag: move the selected pin to the absolute pixel (not a delta).
+    /// Same target rules as <see cref="NudgeSelected"/>.</summary>
+    public void DragSelectedTo(PixelPoint at)
+    {
+        if (PlayerPin is { IsSelected: true } pp)
+        {
+            pp.Pixel = at;
+            OnPropertyChanged(nameof(PlayerPinX));
+            OnPropertyChanged(nameof(PlayerPinY));
+            ReprojectSurveyPins();
+            RaiseDebug();
+            return;
+        }
+        if (SelectedSurveyPin is { } s)
+        {
+            s.OverlayPixel = at;
+            s.Corrected = true;
+            ClampSurvey(s);
+            RaiseDebug();
+            return;
+        }
+        if (SelectedPlacement is { } p)
+            p.Pixel = at;
+    }
+
     public bool CanSolve => Placements.Count >= 2;
 
     private void OnServiceChanged(object? sender, EventArgs e)
@@ -435,6 +502,21 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         if (PlayerPin is not { } pp)
         {
             LastSurveyText = seen + " — Set player position first.";
+            RaiseDebug();
+            return;
+        }
+
+        // Dedup: the same node surveyed again from the same spot (or a
+        // double-parsed line) repeats the exact vector. Treat same name +
+        // offset within ~2 m as the same pin and skip — don't pile duplicates
+        // (and don't clobber a correction already made on it).
+        const double dedupMetres = 2.0;
+        if (SurveyPins.Any(s =>
+                string.Equals(s.Name, obs.Name, StringComparison.OrdinalIgnoreCase) &&
+                Math.Abs(s.Offset.East - obs.Offset.East) <= dedupMetres &&
+                Math.Abs(s.Offset.North - obs.Offset.North) <= dedupMetres))
+        {
+            LastSurveyText = seen + " → duplicate vector, ignored (already in Surveys).";
             RaiseDebug();
             return;
         }

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -131,6 +131,16 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _session.IsInventoryVisible = target;
     }
 
+    /// <summary>
+    /// Opens/closes the standalone map-calibration overlay (same flag the
+    /// unbound <c>ToggleCalibrationOverlayCommand</c> hotkey flips). This is the
+    /// discoverable entry point — the feature is otherwise reachable only via a
+    /// user-assigned hotkey.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleCalibration() =>
+        _session.IsCalibrationVisible = !_session.IsCalibrationVisible;
+
     /// <summary>True once the user has clicked Survey or Motherlode in step 0.</summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CurrentStep))]

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -119,6 +119,7 @@ public sealed partial class SessionState : ObservableObject
     [ObservableProperty] private double _inventoryOpacity = 1.0;
     [ObservableProperty] private bool _isMapVisible;
     [ObservableProperty] private bool _isInventoryVisible;
+    [ObservableProperty] private bool _isCalibrationVisible;
 
     [ObservableProperty]
     private SurveyItemViewModel? _selectedSurvey;

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -37,6 +37,24 @@
                                    Foreground="#FFB9C7D6" TextWrapping="Wrap"
                                    FontSize="12" Margin="0,0,0,10" />
 
+                        <TextBlock DockPanel.Dock="Top" Text="Area" Foreground="#FF8FA6BD"
+                                   FontWeight="SemiBold" Margin="0,0,0,4" />
+                        <ComboBox DockPanel.Dock="Top" Margin="0,0,0,8"
+                                  ItemsSource="{Binding AvailableAreas}"
+                                  SelectedItem="{Binding SelectedArea, Mode=TwoWay}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding FriendlyName}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+
+                        <!-- Why the last click did nothing (amber). Empty when
+                             the click placed a point. -->
+                        <TextBlock DockPanel.Dock="Top" Text="{Binding ClickWarning}"
+                                   Foreground="#FFE0B060" TextWrapping="Wrap"
+                                   FontSize="12" Margin="0,0,0,8" />
+
                         <TextBlock DockPanel.Dock="Top" Text="References in this area"
                                    Foreground="#FF8FA6BD" FontWeight="SemiBold" Margin="0,0,0,4" />
 
@@ -59,24 +77,30 @@
                         <!-- Placed references -->
                         <Border DockPanel.Dock="Bottom" Margin="0,10,0,0" MaxHeight="150">
                             <DockPanel>
-                                <TextBlock DockPanel.Dock="Top" Text="Placed" Foreground="#FF8FA6BD"
-                                           FontWeight="SemiBold" Margin="0,0,0,4" />
-                                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                                    <ItemsControl ItemsSource="{Binding Placements}">
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Foreground="#FFB9C7D6" FontSize="12">
-                                                    <Run Text="{Binding Name, Mode=OneWay}" />
-                                                    <Run Text=" @ (" Foreground="#FF6E8AA5" />
-                                                    <Run Text="{Binding X, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
-                                                    <Run Text=", " Foreground="#FF6E8AA5" />
-                                                    <Run Text="{Binding Y, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
-                                                    <Run Text=")" Foreground="#FF6E8AA5" />
-                                                </TextBlock>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </ScrollViewer>
+                                <TextBlock DockPanel.Dock="Top" Foreground="#FF8FA6BD"
+                                           FontWeight="SemiBold" Margin="0,0,0,4">
+                                    <Run Text="Placed" />
+                                    <Run Text=" — select a row, arrow keys nudge (Shift = 5px)"
+                                         Foreground="#FF6E8AA5" FontWeight="Normal" FontSize="11" />
+                                </TextBlock>
+                                <ListBox ItemsSource="{Binding Placements}"
+                                         SelectedItem="{Binding SelectedPlacement, Mode=TwoWay}"
+                                         Background="#FF12161B" Foreground="#FFB9C7D6"
+                                         BorderBrush="#FF2C3540"
+                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock FontSize="12">
+                                                <Run Text="{Binding Name, Mode=OneWay}" />
+                                                <Run Text=" @ (" Foreground="#FF6E8AA5" />
+                                                <Run Text="{Binding X, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
+                                                <Run Text=", " Foreground="#FF6E8AA5" />
+                                                <Run Text="{Binding Y, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
+                                                <Run Text=")" Foreground="#FF6E8AA5" />
+                                            </TextBlock>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
                             </DockPanel>
                         </Border>
 

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -177,6 +177,7 @@
                      fill. ~1% alpha is visually imperceptible over the map. -->
                 <Grid x:Name="Viewport" Background="#03000000"
                       Focusable="True" FocusVisualStyle="{x:Null}"
+                      SizeChanged="Viewport_SizeChanged"
                       MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
                     <!-- Placed-reference markers. IsHitTestVisible=False so they
                          never swallow a calibration click. -->
@@ -204,16 +205,23 @@
                                      Margin -10,-10 puts geometry-(0,0) on the
                                      placement pixel. Active target = amber/thick
                                      via the IsSelected trigger; name on hover. -->
-                                <Path Margin="-10,-10,0,0" ToolTip="{Binding Name}"
-                                      Data="M-10,0 L-4,0 M4,0 L10,0 M0,-10 L0,-4 M0,4 L0,10 M3,0 A3,3 0 1 1 -3,0 A3,3 0 1 1 3,0">
+                                <Path Margin="-12,-12,0,0" ToolTip="{Binding Name}"
+                                      Data="M-12,0 L-5,0 M5,0 L12,0 M0,-12 L0,-5 M0,5 L0,12 M4,0 A4,4 0 1 1 -4,0 A4,4 0 1 1 4,0"
+                                      StrokeStartLineCap="Round" StrokeEndLineCap="Round">
+                                    <Path.Effect>
+                                        <!-- black casing so the bright lines read
+                                             on any terrain (was invisible at 1px). -->
+                                        <DropShadowEffect Color="Black" ShadowDepth="0"
+                                                          BlurRadius="3" Opacity="0.95" />
+                                    </Path.Effect>
                                     <Path.Style>
                                         <Style TargetType="Path">
                                             <Setter Property="Stroke" Value="#FFFF3B30" />
-                                            <Setter Property="StrokeThickness" Value="1.4" />
+                                            <Setter Property="StrokeThickness" Value="2.2" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                                                    <Setter Property="Stroke" Value="#FFFFC400" />
-                                                    <Setter Property="StrokeThickness" Value="2.4" />
+                                                    <Setter Property="Stroke" Value="#FFFFD400" />
+                                                    <Setter Property="StrokeThickness" Value="3" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -242,18 +250,38 @@
                                 <Canvas />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
+                        <!-- Render at the CLAMPED (Display) position so a far
+                             projection never vanishes off-window. -->
                         <ItemsControl.ItemContainerStyle>
                             <Style TargetType="ContentPresenter">
-                                <Setter Property="Canvas.Left" Value="{Binding X}" />
-                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                                <Setter Property="Canvas.Left" Value="{Binding DisplayX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding DisplayY}" />
                             </Style>
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- Proven minimal idiom (matches the ghosts). -->
-                                <Ellipse Width="12" Height="12" Margin="-6,-6,0,0"
-                                         Fill="#CC34C759" Stroke="White" StrokeThickness="1.5"
-                                         ToolTip="{Binding Name}" />
+                                <!-- On-screen: solid green dot at the true pixel.
+                                     Off-screen: orange dashed hollow ring clamped
+                                     to the edge (NOT the true spot — nudge "you"
+                                     to bring it in; it follows live). -->
+                                <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
+                                         ToolTip="{Binding Name}">
+                                    <Ellipse.Style>
+                                        <Style TargetType="Ellipse">
+                                            <Setter Property="Fill" Value="#CC34C759" />
+                                            <Setter Property="Stroke" Value="White" />
+                                            <Setter Property="StrokeThickness" Value="1.5" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsOffscreen}" Value="True">
+                                                    <Setter Property="Fill" Value="Transparent" />
+                                                    <Setter Property="Stroke" Value="#FFFF9500" />
+                                                    <Setter Property="StrokeThickness" Value="2.5" />
+                                                    <Setter Property="StrokeDashArray" Value="2 2" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Ellipse.Style>
+                                </Ellipse>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -195,29 +195,30 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- PROVEN minimal idiom (same as the ghosts that
-                                     render): a single Ellipse, centred on the
-                                     placement pixel via negative Margin. The
-                                     zero-size nested-Canvas crosshair did NOT
-                                     render in a ContentPresenter — do not bring
-                                     it back. Active (nudge) target = amber thick
-                                     ring via the IsSelected trigger. Name on hover. -->
-                                <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
-                                         ToolTip="{Binding Name}">
-                                    <Ellipse.Style>
-                                        <Style TargetType="Ellipse">
-                                            <Setter Property="Fill" Value="#CCFF3B30" />
-                                            <Setter Property="Stroke" Value="White" />
-                                            <Setter Property="StrokeThickness" Value="1.5" />
+                                <!-- Crosshair, restored — but as a SINGLE Path
+                                     (one fixed-size element, like the ghosts that
+                                     render), NOT the zero-size nested Canvas that
+                                     never drew. Geometry is centred on (0,0):
+                                     four arms with a centre gap so the exact pixel
+                                     stays visible to aim at, plus a 3px ring.
+                                     Margin -10,-10 puts geometry-(0,0) on the
+                                     placement pixel. Active target = amber/thick
+                                     via the IsSelected trigger; name on hover. -->
+                                <Path Margin="-10,-10,0,0" ToolTip="{Binding Name}"
+                                      Data="M-10,0 L-4,0 M4,0 L10,0 M0,-10 L0,-4 M0,4 L0,10 M3,0 A3,3 0 1 1 -3,0 A3,3 0 1 1 3,0">
+                                    <Path.Style>
+                                        <Style TargetType="Path">
+                                            <Setter Property="Stroke" Value="#FFFF3B30" />
+                                            <Setter Property="StrokeThickness" Value="1.4" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsSelected}" Value="True">
                                                     <Setter Property="Stroke" Value="#FFFFC400" />
-                                                    <Setter Property="StrokeThickness" Value="3" />
+                                                    <Setter Property="StrokeThickness" Value="2.4" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
-                                    </Ellipse.Style>
-                                </Ellipse>
+                                    </Path.Style>
+                                </Path>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -1,0 +1,136 @@
+<Window x:Class="Legolas.Views.CalibrationOverlayView"
+        x:Name="Self"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:Legolas.ViewModels"
+        xmlns:controls="clr-namespace:Legolas.Controls"
+        Title="Calibrate Map"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        Width="940" Height="660"
+        d:DataContext="{d:DesignInstance vm:CalibrationSessionViewModel}"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d">
+    <Grid>
+        <Border BorderBrush="#FF3A6EA5" BorderThickness="1">
+            <DockPanel>
+                <!-- Draggable header -->
+                <Border DockPanel.Dock="Top" Background="#FF1E2A38" Padding="10,6"
+                        MouseLeftButtonDown="Header_MouseLeftButtonDown">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Map Calibration" Foreground="White" FontWeight="SemiBold" />
+                        <TextBlock Text="  —  " Foreground="#FF6E8AA5" />
+                        <TextBlock Text="{Binding StatusText}" Foreground="#FFCDE3F5"
+                                   TextTrimming="CharacterEllipsis" MaxWidth="640" />
+                    </StackPanel>
+                </Border>
+
+                <!-- Right control panel (opaque; clicks here never reach the map viewport) -->
+                <Border DockPanel.Dock="Right" Width="320" Background="#F21A1F26"
+                        BorderBrush="#FF2C3540" BorderThickness="1,0,0,0">
+                    <DockPanel Margin="12">
+                        <TextBlock DockPanel.Dock="Top" Text="{Binding Instruction}"
+                                   Foreground="#FFB9C7D6" TextWrapping="Wrap"
+                                   FontSize="12" Margin="0,0,0,10" />
+
+                        <TextBlock DockPanel.Dock="Top" Text="References in this area"
+                                   Foreground="#FF8FA6BD" FontWeight="SemiBold" Margin="0,0,0,4" />
+
+                        <!-- Action buttons pinned to the bottom -->
+                        <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">
+                            <TextBlock Text="{Binding ResultText}" Foreground="#FFCFE8C9"
+                                       TextWrapping="Wrap" FontSize="12" Margin="0,0,0,8" />
+                            <Button Content="Solve &amp; save calibration"
+                                    Command="{Binding SolveCommand}" Padding="8,6" />
+                            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                <Button Content="Remove last" Command="{Binding RemoveLastPlacementCommand}"
+                                        Padding="8,4" Margin="0,0,6,0" />
+                                <Button Content="Clear" Command="{Binding ClearPlacementsCommand}"
+                                        Padding="8,4" Margin="0,0,6,0" />
+                                <Button Content="Recalibrate" Command="{Binding RecalibrateCommand}"
+                                        Padding="8,4" />
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!-- Placed references -->
+                        <Border DockPanel.Dock="Bottom" Margin="0,10,0,0" MaxHeight="150">
+                            <DockPanel>
+                                <TextBlock DockPanel.Dock="Top" Text="Placed" Foreground="#FF8FA6BD"
+                                           FontWeight="SemiBold" Margin="0,0,0,4" />
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ItemsControl ItemsSource="{Binding Placements}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Foreground="#FFB9C7D6" FontSize="12">
+                                                    <Run Text="{Binding Name, Mode=OneWay}" />
+                                                    <Run Text=" @ (" Foreground="#FF6E8AA5" />
+                                                    <Run Text="{Binding X, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
+                                                    <Run Text=", " Foreground="#FF6E8AA5" />
+                                                    <Run Text="{Binding Y, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
+                                                    <Run Text=")" Foreground="#FF6E8AA5" />
+                                                </TextBlock>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </ScrollViewer>
+                            </DockPanel>
+                        </Border>
+
+                        <!-- Reference picker -->
+                        <ListBox ItemsSource="{Binding References}"
+                                 SelectedItem="{Binding SelectedReference, Mode=TwoWay}"
+                                 Background="#FF12161B" Foreground="#FFE0E6EC"
+                                 BorderBrush="#FF2C3540">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding Name}" />
+                                        <TextBlock Text=" · " Foreground="#FF6E8AA5" />
+                                        <TextBlock Text="{Binding Kind}" Foreground="#FF7E97AE" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </DockPanel>
+                </Border>
+
+                <!-- Transparent click-capture surface over the in-game map -->
+                <Grid x:Name="Viewport" Background="Transparent"
+                      MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
+                    <!-- Placed-reference markers. IsHitTestVisible=False so they
+                         never swallow a calibration click. -->
+                    <ItemsControl ItemsSource="{Binding Placements}" IsHitTestVisible="False">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <!-- Offset so the dot centres on the click point. -->
+                                <Grid Margin="-7,-7,0,0">
+                                    <Ellipse Width="14" Height="14"
+                                             Fill="#CC3A9BDC" Stroke="White" StrokeThickness="2" />
+                                    <TextBlock Text="{Binding Name}" Foreground="White"
+                                               FontSize="11" Margin="18,-2,0,0"
+                                               Background="#99000000" Padding="3,1" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
+            </DockPanel>
+        </Border>
+        <controls:ResizeGrips />
+    </Grid>
+</Window>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -61,6 +61,10 @@
 
                         <!-- Action buttons pinned to the bottom -->
                         <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">
+                            <!-- What an arrow-key nudge will move (amber, matches
+                                 the on-map halo). Empty when nothing is armed. -->
+                            <TextBlock Text="{Binding NudgeTargetText}" Foreground="#FFFFC400"
+                                       TextWrapping="Wrap" FontSize="12" Margin="0,0,0,6" />
                             <TextBlock Text="{Binding ResultText}" Foreground="#FFCFE8C9"
                                        TextWrapping="Wrap" FontSize="12" Margin="0,0,0,8" />
                             <Button Content="Solve &amp; save calibration"
@@ -172,6 +176,14 @@
                                      clearly up-and-right with a gap so it never
                                      covers the point being calibrated. -->
                                 <Canvas>
+                                    <!-- Active-target halo: only the placement
+                                         the arrow keys will move. Amber dashed
+                                         ring well clear of the crosshair so the
+                                         exact pixel stays readable. -->
+                                    <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
+                                             Stroke="#FFFFC400" StrokeThickness="1.5"
+                                             StrokeDashArray="2 2"
+                                             Visibility="{Binding IsSelected, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
                                     <!-- crosshair arms (gap left at the centre so
                                          the exact pixel stays visible) -->
                                     <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -59,6 +59,12 @@
                         <TextBlock DockPanel.Dock="Top" Text="References in this area"
                                    Foreground="#FF8FA6BD" FontWeight="SemiBold" Margin="0,0,0,4" />
 
+                        <!-- Blunt always-visible state readout — pins= proves a
+                             click made a placement even if the marker doesn't draw. -->
+                        <TextBlock DockPanel.Dock="Bottom" Text="{Binding DebugState}"
+                                   Foreground="#FF7E97AE" FontFamily="Consolas" FontSize="11"
+                                   TextWrapping="Wrap" Margin="0,8,0,0" />
+
                         <!-- Action buttons pinned to the bottom -->
                         <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">
                             <!-- What an arrow-key nudge will move (amber, matches

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -63,6 +63,10 @@
                         <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">
                             <!-- What an arrow-key nudge will move (amber, matches
                                  the on-map halo). Empty when nothing is armed. -->
+                            <!-- Proof the survey/treasure reached the window
+                                 (always set), and what's missing if no pin. -->
+                            <TextBlock Text="{Binding LastSurveyText}" Foreground="#FF59C7E0"
+                                       TextWrapping="Wrap" FontSize="12" Margin="0,0,0,6" />
                             <TextBlock Text="{Binding NudgeTargetText}" Foreground="#FFFFC400"
                                        TextWrapping="Wrap" FontSize="12" Margin="0,0,0,6" />
                             <TextBlock Text="{Binding ResultText}" Foreground="#FFCFE8C9"

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -205,7 +205,9 @@
                 <Grid x:Name="Viewport" Background="#03000000"
                       Focusable="True" FocusVisualStyle="{x:Null}"
                       SizeChanged="Viewport_SizeChanged"
-                      MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
+                      MouseLeftButtonDown="Viewport_MouseLeftButtonDown"
+                      MouseMove="Viewport_MouseMove"
+                      MouseLeftButtonUp="Viewport_MouseLeftButtonUp">
                     <!-- Placed-reference markers. IsHitTestVisible=False so they
                          never swallow a calibration click. -->
                     <ItemsControl ItemsSource="{Binding Placements}" IsHitTestVisible="False"

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -50,6 +50,22 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
 
+                        <!-- In-game map zoom (read off the game UI — Mithril
+                             can't see it). Stamped onto the calibration at
+                             Solve; survey projections scale by
+                             currentZoom/calibrationZoom so a calibration stays
+                             correct across zoom changes. -->
+                        <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+                            <TextBlock Text="Map zoom" Foreground="#FF8FA6BD"
+                                       FontWeight="SemiBold" VerticalAlignment="Center"
+                                       Margin="0,0,8,0" />
+                            <TextBox Width="70" HorizontalAlignment="Left"
+                                     Background="#FF12161B" Foreground="#FFE0E6EC"
+                                     BorderBrush="#FF2C3540"
+                                     ToolTip="The in-game map's zoom value. Set this to match the game before Solve and before/while verifying."
+                                     Text="{Binding MapZoom, Mode=TwoWay, StringFormat=0.###, UpdateSourceTrigger=LostFocus}" />
+                        </DockPanel>
+
                         <!-- Why the last click did nothing (amber). Empty when
                              the click placed a point. -->
                         <TextBlock DockPanel.Dock="Top" Text="{Binding ClickWarning}"

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -196,50 +196,50 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- Crosshair, restored — but as a SINGLE Path
-                                     (one fixed-size element, like the ghosts that
-                                     render), NOT the zero-size nested Canvas that
-                                     never drew. Geometry is centred on (0,0):
-                                     four arms with a centre gap so the exact pixel
-                                     stays visible to aim at, plus a 3px ring.
-                                     Margin -10,-10 puts geometry-(0,0) on the
-                                     placement pixel. Active target = amber/thick
-                                     via the IsSelected trigger; name on hover. -->
-                                <Path Margin="-12,-12,0,0" ToolTip="{Binding Name}"
-                                      Data="M-12,0 L-5,0 M5,0 L12,0 M0,-12 L0,-5 M0,5 L0,12 M4,0 A4,4 0 1 1 -4,0 A4,4 0 1 1 4,0"
-                                      StrokeStartLineCap="Round" StrokeEndLineCap="Round">
-                                    <Path.Effect>
-                                        <!-- black casing so the bright lines read
-                                             on any terrain (was invisible at 1px). -->
-                                        <DropShadowEffect Color="Black" ShadowDepth="0"
-                                                          BlurRadius="3" Opacity="0.95" />
-                                    </Path.Effect>
-                                    <Path.Style>
-                                        <Style TargetType="Path">
-                                            <Setter Property="Stroke" Value="#FFFF3B30" />
-                                            <Setter Property="StrokeThickness" Value="2.2" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                                                    <Setter Property="Stroke" Value="#FFFFD400" />
-                                                    <Setter Property="StrokeThickness" Value="3" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Path.Style>
-                                </Path>
+                                <!-- v1 marker, restored (user-confirmed it DID
+                                     render — the 1px lines were just hard to see
+                                     in screenshots; my Path "fix" introduced a
+                                     down-right shift). Zero-size Canvas: every
+                                     part at an EXACT negative offset so the
+                                     crosshair centre is pixel-accurately on the
+                                     placement point. Centre gap + ring keep the
+                                     exact pixel aim-able; label up-right. Active
+                                     (nudge) target = amber dashed halo. -->
+                                <Canvas>
+                                    <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
+                                             Stroke="#FFFFC400" StrokeThickness="1.5"
+                                             StrokeDashArray="2 2"
+                                             Visibility="{Binding IsSelected, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
+                                    <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />
+                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FFFF3B30" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="6" Fill="#FFFF3B30" />
+                                    <Ellipse Canvas.Left="-4" Canvas.Top="-4" Width="8" Height="8"
+                                             Stroke="White" StrokeThickness="1" />
+                                    <Border Canvas.Left="9" Canvas.Top="-9"
+                                            Background="#CC000000" CornerRadius="2" Padding="3,1">
+                                        <TextBlock Text="{Binding Name}" Foreground="White" FontSize="11" />
+                                    </Border>
+                                </Canvas>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <!-- Test-mode "you are here". Single Ellipse, proven idiom:
-                         positioned by Canvas.Left/Top and centred via negative
-                         Margin (no nested zero-size Canvas). -->
+                    <!-- v1 "you are here": zero-size Canvas at the origin pixel,
+                         parts at exact offsets. Amber halo (it's the nudge
+                         target), blue ring, label. -->
                     <Canvas IsHitTestVisible="False"
                             Visibility="{Binding HasTestOrigin, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                        <Ellipse Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}"
-                                 Width="16" Height="16" Margin="-8,-8,0,0"
-                                 Fill="#5540C4FF" Stroke="#FF40C4FF" StrokeThickness="2"
-                                 ToolTip="you (test position) — arrow keys nudge" />
+                        <Canvas Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}">
+                            <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
+                                     Stroke="#FFFFC400" StrokeThickness="1.5" StrokeDashArray="2 2" />
+                            <Ellipse Canvas.Left="-7" Canvas.Top="-7" Width="14" Height="14"
+                                     Stroke="#FF40C4FF" StrokeThickness="2" Fill="#5540C4FF" />
+                            <Border Canvas.Left="14" Canvas.Top="-9" Background="#CC000000"
+                                    CornerRadius="2" Padding="3,1">
+                                <TextBlock Text="you" Foreground="#FF40C4FF" FontSize="11" />
+                            </Border>
+                        </Canvas>
                     </Canvas>
 
                     <!-- Projected test pins (green) — compare to the real ping. -->
@@ -260,28 +260,34 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- On-screen: solid green dot at the true pixel.
-                                     Off-screen: orange dashed hollow ring clamped
-                                     to the edge (NOT the true spot — nudge "you"
-                                     to bring it in; it follows live). -->
-                                <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
-                                         ToolTip="{Binding Name}">
-                                    <Ellipse.Style>
-                                        <Style TargetType="Ellipse">
-                                            <Setter Property="Fill" Value="#CC34C759" />
-                                            <Setter Property="Stroke" Value="White" />
-                                            <Setter Property="StrokeThickness" Value="1.5" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsOffscreen}" Value="True">
-                                                    <Setter Property="Fill" Value="Transparent" />
-                                                    <Setter Property="Stroke" Value="#FFFF9500" />
-                                                    <Setter Property="StrokeThickness" Value="2.5" />
-                                                    <Setter Property="StrokeDashArray" Value="2 2" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Ellipse.Style>
-                                </Ellipse>
+                                <!-- v1 green crosshair+ring+label (renders at the
+                                     clamped Display position so a far projection
+                                     still shows at the window edge). The white
+                                     centre ring goes orange when edge-clamped so
+                                     you can tell it's NOT at the true spot. -->
+                                <Canvas>
+                                    <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
+                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FF34C759" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="6" Fill="#FF34C759" />
+                                    <Ellipse Canvas.Left="-4" Canvas.Top="-4" Width="8" Height="8"
+                                             StrokeThickness="1">
+                                        <Ellipse.Style>
+                                            <Style TargetType="Ellipse">
+                                                <Setter Property="Stroke" Value="White" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsOffscreen}" Value="True">
+                                                        <Setter Property="Stroke" Value="#FFFF9500" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Ellipse.Style>
+                                    </Ellipse>
+                                    <Border Canvas.Left="9" Canvas.Top="-9"
+                                            Background="#CC0A2A12" CornerRadius="2" Padding="3,1">
+                                        <TextBlock Text="{Binding Name}" Foreground="#FF8FF0AB" FontSize="11" />
+                                    </Border>
+                                </Canvas>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -98,12 +98,12 @@
                                         Command="{Binding DeselectCommand}" Padding="8,4" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                                <ToggleButton Content="Verify (set position)"
-                                              IsChecked="{Binding TestMode, Mode=OneWay}"
-                                              Command="{Binding ToggleTestModeCommand}"
-                                              Padding="8,4" Margin="0,0,6,0" />
-                                <Button Content="Clear verify"
-                                        Command="{Binding ClearTestPinsCommand}" Padding="8,4" />
+                                <Button Content="Set player position"
+                                        ToolTip="No pin yet: arms a map click to drop &quot;you&quot;. Already placed: selects it so arrow keys nudge it (survey pins re-project)."
+                                        Command="{Binding SetPlayerPositionCommand}"
+                                        Padding="8,4" Margin="0,0,6,0" />
+                                <Button Content="Clear surveys"
+                                        Command="{Binding ClearSurveyPinsCommand}" Padding="8,4" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                 <Button Content="Project landmarks (ghosts)"
@@ -140,6 +140,33 @@
                                                 <Run Text="{Binding Y, Mode=OneWay, StringFormat=0}" Foreground="#FF6E8AA5" />
                                                 <Run Text=")" Foreground="#FF6E8AA5" />
                                             </TextBlock>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </DockPanel>
+                        </Border>
+
+                        <!-- Surveys: each vector is a correctable pin. Select a
+                             row → arrow-nudge its overlay onto the real ping;
+                             the math line shows projected vs corrected. -->
+                        <Border DockPanel.Dock="Bottom" Margin="0,10,0,0" MaxHeight="170">
+                            <DockPanel>
+                                <TextBlock DockPanel.Dock="Top" Foreground="#FF8FA6BD"
+                                           FontWeight="SemiBold" Margin="0,0,0,4">
+                                    <Run Text="Surveys" />
+                                    <Run Text=" — select, drag onto the real ping (arrows); proj vs corrected = scale"
+                                         Foreground="#FF6E8AA5" FontWeight="Normal" FontSize="11" />
+                                </TextBlock>
+                                <ListBox ItemsSource="{Binding SurveyPins}"
+                                         SelectedItem="{Binding SelectedSurveyPin, Mode=TwoWay}"
+                                         IsSynchronizedWithCurrentItem="False"
+                                         Background="#FF12161B" Foreground="#FFB9C7D6"
+                                         BorderBrush="#FF2C3540"
+                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding MathText}" FontSize="11"
+                                                       TextWrapping="Wrap" />
                                         </DataTemplate>
                                     </ListBox.ItemTemplate>
                                 </ListBox>
@@ -225,14 +252,14 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <!-- v1 "you are here": zero-size Canvas at the origin pixel,
-                         parts at exact offsets. Amber halo (it's the nudge
-                         target), blue ring, label. -->
+                    <!-- "You are here" pin (single PlayerPin). Amber halo when
+                         it's the selected nudge target; blue ring; label. -->
                     <Canvas IsHitTestVisible="False"
-                            Visibility="{Binding HasTestOrigin, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                        <Canvas Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}">
+                            Visibility="{Binding HasPlayerPin, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <Canvas Canvas.Left="{Binding PlayerPinX}" Canvas.Top="{Binding PlayerPinY}">
                             <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
-                                     Stroke="#FFFFC400" StrokeThickness="1.5" StrokeDashArray="2 2" />
+                                     Stroke="#FFFFC400" StrokeThickness="1.5" StrokeDashArray="2 2"
+                                     Visibility="{Binding IsPlayerSelected, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
                             <Ellipse Canvas.Left="-7" Canvas.Top="-7" Width="14" Height="14"
                                      Stroke="#FF40C4FF" StrokeThickness="2" Fill="#5540C4FF" />
                             <Border Canvas.Left="14" Canvas.Top="-9" Background="#CC000000"
@@ -242,16 +269,43 @@
                         </Canvas>
                     </Canvas>
 
-                    <!-- Projected test pins (green) — compare to the real ping. -->
-                    <ItemsControl ItemsSource="{Binding TestPins}" IsHitTestVisible="False"
+                    <!-- Survey pins: PROJECTED marker (faint dashed cyan) at the
+                         calibration's prediction — the reference you correct
+                         toward. Rendered at true ProjX/ProjY. -->
+                    <ItemsControl ItemsSource="{Binding SurveyPins}" IsHitTestVisible="False"
                                   Padding="0" BorderThickness="0" Margin="0">
                         <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <Canvas />
-                            </ItemsPanelTemplate>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
-                        <!-- Render at the CLAMPED (Display) position so a far
-                             projection never vanishes off-window. -->
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding ProjX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding ProjY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Canvas>
+                                    <Rectangle Canvas.Left="-8" Canvas.Top="-0.5" Width="5" Height="1" Fill="#9959C7E0" />
+                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="5" Height="1" Fill="#9959C7E0" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-8" Width="1" Height="5" Fill="#9959C7E0" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="5" Fill="#9959C7E0" />
+                                    <Ellipse Canvas.Left="-3" Canvas.Top="-3" Width="6" Height="6"
+                                             Stroke="#9959C7E0" StrokeThickness="1" StrokeDashArray="1 1" />
+                                </Canvas>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Survey pins: OVERLAY marker (solid green crosshair) — the
+                         one you select & drag onto the real ping. Clamped to the
+                         edge when off-window; amber when it's the nudge target;
+                         orange ring when edge-clamped (not the true spot). -->
+                    <ItemsControl ItemsSource="{Binding SurveyPins}" IsHitTestVisible="False"
+                                  Padding="0" BorderThickness="0" Margin="0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemContainerStyle>
                             <Style TargetType="ContentPresenter">
                                 <Setter Property="Canvas.Left" Value="{Binding DisplayX}" />
@@ -260,12 +314,10 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- v1 green crosshair+ring+label (renders at the
-                                     clamped Display position so a far projection
-                                     still shows at the window edge). The white
-                                     centre ring goes orange when edge-clamped so
-                                     you can tell it's NOT at the true spot. -->
                                 <Canvas>
+                                    <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
+                                             Stroke="#FFFFC400" StrokeThickness="1.5" StrokeDashArray="2 2"
+                                             Visibility="{Binding IsSelected, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
                                     <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
                                     <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
                                     <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FF34C759" />

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -195,60 +195,42 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- Marker root is a zero-size Canvas: its (0,0)
-                                     is pinned exactly to the placement pixel by
-                                     the container's Canvas.Left/Top. Every part
-                                     is positioned with explicit negative offsets
-                                     so the crosshair centre is THE clicked pixel,
-                                     regardless of label width. The label sits
-                                     clearly up-and-right with a gap so it never
-                                     covers the point being calibrated. -->
-                                <Canvas>
-                                    <!-- Active-target halo: only the placement
-                                         the arrow keys will move. Amber dashed
-                                         ring well clear of the crosshair so the
-                                         exact pixel stays readable. -->
-                                    <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
-                                             Stroke="#FFFFC400" StrokeThickness="1.5"
-                                             StrokeDashArray="2 2"
-                                             Visibility="{Binding IsSelected, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
-                                    <!-- crosshair arms (gap left at the centre so
-                                         the exact pixel stays visible) -->
-                                    <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />
-                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />
-                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FFFF3B30" />
-                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="6" Fill="#FFFF3B30" />
-                                    <!-- 1px hairline ring around the point -->
-                                    <Ellipse Canvas.Left="-4" Canvas.Top="-4" Width="8" Height="8"
-                                             Stroke="White" StrokeThickness="1" />
-                                    <!-- label, offset away from the point -->
-                                    <Border Canvas.Left="9" Canvas.Top="-9"
-                                            Background="#CC000000" CornerRadius="2" Padding="3,1">
-                                        <TextBlock Text="{Binding Name}" Foreground="White" FontSize="11" />
-                                    </Border>
-                                </Canvas>
+                                <!-- PROVEN minimal idiom (same as the ghosts that
+                                     render): a single Ellipse, centred on the
+                                     placement pixel via negative Margin. The
+                                     zero-size nested-Canvas crosshair did NOT
+                                     render in a ContentPresenter — do not bring
+                                     it back. Active (nudge) target = amber thick
+                                     ring via the IsSelected trigger. Name on hover. -->
+                                <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
+                                         ToolTip="{Binding Name}">
+                                    <Ellipse.Style>
+                                        <Style TargetType="Ellipse">
+                                            <Setter Property="Fill" Value="#CCFF3B30" />
+                                            <Setter Property="Stroke" Value="White" />
+                                            <Setter Property="StrokeThickness" Value="1.5" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                    <Setter Property="Stroke" Value="#FFFFC400" />
+                                                    <Setter Property="StrokeThickness" Value="3" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Ellipse.Style>
+                                </Ellipse>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <!-- Test-mode synthetic player origin ("you are here"). -->
+                    <!-- Test-mode "you are here". Single Ellipse, proven idiom:
+                         positioned by Canvas.Left/Top and centred via negative
+                         Margin (no nested zero-size Canvas). -->
                     <Canvas IsHitTestVisible="False"
                             Visibility="{Binding HasTestOrigin, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                        <!-- Zero-size anchor at the test origin pixel; parts placed
-                             by explicit offsets (NOT a Grid — Grid would centre
-                             the ring in a label-sized cell, the offset bug). -->
-                        <Canvas Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}">
-                            <!-- Amber dashed halo: this is the active nudge
-                                 target in verify mode (arrow keys move it). -->
-                            <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
-                                     Stroke="#FFFFC400" StrokeThickness="1.5" StrokeDashArray="2 2" />
-                            <Ellipse Canvas.Left="-7" Canvas.Top="-7" Width="14" Height="14"
-                                     Stroke="#FF40C4FF" StrokeThickness="2" Fill="#5540C4FF" />
-                            <Border Canvas.Left="14" Canvas.Top="-9" Background="#CC000000"
-                                    CornerRadius="2" Padding="3,1">
-                                <TextBlock Text="you" Foreground="#FF40C4FF" FontSize="11" />
-                            </Border>
-                        </Canvas>
+                        <Ellipse Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}"
+                                 Width="16" Height="16" Margin="-8,-8,0,0"
+                                 Fill="#5540C4FF" Stroke="#FF40C4FF" StrokeThickness="2"
+                                 ToolTip="you (test position) — arrow keys nudge" />
                     </Canvas>
 
                     <!-- Projected test pins (green) — compare to the real ping. -->
@@ -267,18 +249,10 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Canvas>
-                                    <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
-                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
-                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FF34C759" />
-                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="6" Fill="#FF34C759" />
-                                    <Ellipse Canvas.Left="-4" Canvas.Top="-4" Width="8" Height="8"
-                                             Stroke="White" StrokeThickness="1" />
-                                    <Border Canvas.Left="9" Canvas.Top="-9"
-                                            Background="#CC0A2A12" CornerRadius="2" Padding="3,1">
-                                        <TextBlock Text="{Binding Name}" Foreground="#FF8FF0AB" FontSize="11" />
-                                    </Border>
-                                </Canvas>
+                                <!-- Proven minimal idiom (matches the ghosts). -->
+                                <Ellipse Width="12" Height="12" Margin="-6,-6,0,0"
+                                         Fill="#CC34C759" Stroke="White" StrokeThickness="1.5"
+                                         ToolTip="{Binding Name}" />
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -214,9 +214,13 @@
                              by explicit offsets (NOT a Grid — Grid would centre
                              the ring in a label-sized cell, the offset bug). -->
                         <Canvas Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}">
+                            <!-- Amber dashed halo: this is the active nudge
+                                 target in verify mode (arrow keys move it). -->
+                            <Ellipse Canvas.Left="-13" Canvas.Top="-13" Width="26" Height="26"
+                                     Stroke="#FFFFC400" StrokeThickness="1.5" StrokeDashArray="2 2" />
                             <Ellipse Canvas.Left="-7" Canvas.Top="-7" Width="14" Height="14"
                                      Stroke="#FF40C4FF" StrokeThickness="2" Fill="#5540C4FF" />
-                            <Border Canvas.Left="11" Canvas.Top="-9" Background="#CC000000"
+                            <Border Canvas.Left="14" Canvas.Top="-9" Background="#CC000000"
                                     CornerRadius="2" Padding="3,1">
                                 <TextBlock Text="you" Foreground="#FF40C4FF" FontSize="11" />
                             </Border>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -40,6 +40,7 @@
                         <TextBlock DockPanel.Dock="Top" Text="Area" Foreground="#FF8FA6BD"
                                    FontWeight="SemiBold" Margin="0,0,0,4" />
                         <ComboBox DockPanel.Dock="Top" Margin="0,0,0,8"
+                                  IsSynchronizedWithCurrentItem="False"
                                   ItemsSource="{Binding AvailableAreas}"
                                   SelectedItem="{Binding SelectedArea, Mode=TwoWay}">
                             <ComboBox.ItemTemplate>
@@ -85,6 +86,7 @@
                                 </TextBlock>
                                 <ListBox ItemsSource="{Binding Placements}"
                                          SelectedItem="{Binding SelectedPlacement, Mode=TwoWay}"
+                                         IsSynchronizedWithCurrentItem="False"
                                          Background="#FF12161B" Foreground="#FFB9C7D6"
                                          BorderBrush="#FF2C3540"
                                          ScrollViewer.VerticalScrollBarVisibility="Auto">
@@ -107,6 +109,7 @@
                         <!-- Reference picker -->
                         <ListBox ItemsSource="{Binding References}"
                                  SelectedItem="{Binding SelectedReference, Mode=TwoWay}"
+                                 IsSynchronizedWithCurrentItem="False"
                                  Background="#FF12161B" Foreground="#FFE0E6EC"
                                  BorderBrush="#FF2C3540">
                             <ListBox.ItemTemplate>
@@ -133,6 +136,7 @@
                      has no backdrop, so the Viewport must paint its own faint
                      fill. ~1% alpha is visually imperceptible over the map. -->
                 <Grid x:Name="Viewport" Background="#03000000"
+                      Focusable="True" FocusVisualStyle="{x:Null}"
                       MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
                     <!-- Placed-reference markers. IsHitTestVisible=False so they
                          never swallow a calibration click. -->

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -98,6 +98,14 @@
                                 <Button Content="Clear verify"
                                         Command="{Binding ClearTestPinsCommand}" Padding="8,4" />
                             </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                <Button Content="Project landmarks (ghosts)"
+                                        ToolTip="Drop every unplaced landmark at its calibrated position — they should sit on the real landmarks"
+                                        Command="{Binding ProjectLandmarksCommand}"
+                                        Padding="8,4" Margin="0,0,6,0" />
+                                <Button Content="Clear ghosts"
+                                        Command="{Binding ClearGhostsCommand}" Padding="8,4" />
+                            </StackPanel>
                         </StackPanel>
 
                         <!-- Placed references -->
@@ -264,6 +272,33 @@
                                         <TextBlock Text="{Binding Name}" Foreground="#FF8FF0AB" FontSize="11" />
                                     </Border>
                                 </Canvas>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Ghost landmarks (magenta). DELIBERATELY a different,
+                         minimal render idiom from the crosshair: the template
+                         root is a single Ellipse (no nested Canvas/Grid) so if
+                         these draw and the crosshairs don't, the crosshair
+                         template is the bug. Centred via negative Margin. -->
+                    <ItemsControl ItemsSource="{Binding GhostPins}" IsHitTestVisible="False"
+                                  Padding="0" BorderThickness="0" Margin="0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Ellipse Width="11" Height="11" Margin="-5.5,-5.5,0,0"
+                                         Fill="#CCFF2BD6" Stroke="White" StrokeThickness="1"
+                                         ToolTip="{Binding Name}" />
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -74,11 +74,11 @@
                                         Padding="8,4" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                                <ToggleButton Content="Test calibration"
+                                <ToggleButton Content="Verify (set position)"
                                               IsChecked="{Binding TestMode, Mode=OneWay}"
                                               Command="{Binding ToggleTestModeCommand}"
                                               Padding="8,4" Margin="0,0,6,0" />
-                                <Button Content="Clear test"
+                                <Button Content="Clear verify"
                                         Command="{Binding ClearTestPinsCommand}" Padding="8,4" />
                             </StackPanel>
                         </StackPanel>
@@ -202,7 +202,7 @@
                                      Stroke="#FF40C4FF" StrokeThickness="2" Fill="#5540C4FF" />
                             <Border Canvas.Left="11" Canvas.Top="-9" Background="#CC000000"
                                     CornerRadius="2" Padding="3,1">
-                                <TextBlock Text="you (test)" Foreground="#FF40C4FF" FontSize="11" />
+                                <TextBlock Text="you" Foreground="#FF40C4FF" FontSize="11" />
                             </Border>
                         </Canvas>
                     </Canvas>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -140,7 +140,8 @@
                       MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
                     <!-- Placed-reference markers. IsHitTestVisible=False so they
                          never swallow a calibration click. -->
-                    <ItemsControl ItemsSource="{Binding Placements}" IsHitTestVisible="False">
+                    <ItemsControl ItemsSource="{Binding Placements}" IsHitTestVisible="False"
+                                  Padding="0" BorderThickness="0" Margin="0">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <Canvas />
@@ -154,14 +155,30 @@
                         </ItemsControl.ItemContainerStyle>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <!-- Offset so the dot centres on the click point. -->
-                                <Grid Margin="-7,-7,0,0">
-                                    <Ellipse Width="14" Height="14"
-                                             Fill="#CC3A9BDC" Stroke="White" StrokeThickness="2" />
-                                    <TextBlock Text="{Binding Name}" Foreground="White"
-                                               FontSize="11" Margin="18,-2,0,0"
-                                               Background="#99000000" Padding="3,1" />
-                                </Grid>
+                                <!-- Marker root is a zero-size Canvas: its (0,0)
+                                     is pinned exactly to the placement pixel by
+                                     the container's Canvas.Left/Top. Every part
+                                     is positioned with explicit negative offsets
+                                     so the crosshair centre is THE clicked pixel,
+                                     regardless of label width. The label sits
+                                     clearly up-and-right with a gap so it never
+                                     covers the point being calibrated. -->
+                                <Canvas>
+                                    <!-- crosshair arms (gap left at the centre so
+                                         the exact pixel stays visible) -->
+                                    <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />
+                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FFFF3B30" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FFFF3B30" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="6" Fill="#FFFF3B30" />
+                                    <!-- 1px hairline ring around the point -->
+                                    <Ellipse Canvas.Left="-4" Canvas.Top="-4" Width="8" Height="8"
+                                             Stroke="White" StrokeThickness="1" />
+                                    <!-- label, offset away from the point -->
+                                    <Border Canvas.Left="9" Canvas.Top="-9"
+                                            Background="#CC000000" CornerRadius="2" Padding="3,1">
+                                        <TextBlock Text="{Binding Name}" Foreground="White" FontSize="11" />
+                                    </Border>
+                                </Canvas>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -73,6 +73,14 @@
                                 <Button Content="Recalibrate" Command="{Binding RecalibrateCommand}"
                                         Padding="8,4" />
                             </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                <ToggleButton Content="Test calibration"
+                                              IsChecked="{Binding TestMode, Mode=OneWay}"
+                                              Command="{Binding ToggleTestModeCommand}"
+                                              Padding="8,4" Margin="0,0,6,0" />
+                                <Button Content="Clear test"
+                                        Command="{Binding ClearTestPinsCommand}" Padding="8,4" />
+                            </StackPanel>
                         </StackPanel>
 
                         <!-- Placed references -->
@@ -177,6 +185,54 @@
                                     <Border Canvas.Left="9" Canvas.Top="-9"
                                             Background="#CC000000" CornerRadius="2" Padding="3,1">
                                         <TextBlock Text="{Binding Name}" Foreground="White" FontSize="11" />
+                                    </Border>
+                                </Canvas>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Test-mode synthetic player origin ("you are here"). -->
+                    <Canvas IsHitTestVisible="False"
+                            Visibility="{Binding HasTestOrigin, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                        <!-- Zero-size anchor at the test origin pixel; parts placed
+                             by explicit offsets (NOT a Grid — Grid would centre
+                             the ring in a label-sized cell, the offset bug). -->
+                        <Canvas Canvas.Left="{Binding TestOriginX}" Canvas.Top="{Binding TestOriginY}">
+                            <Ellipse Canvas.Left="-7" Canvas.Top="-7" Width="14" Height="14"
+                                     Stroke="#FF40C4FF" StrokeThickness="2" Fill="#5540C4FF" />
+                            <Border Canvas.Left="11" Canvas.Top="-9" Background="#CC000000"
+                                    CornerRadius="2" Padding="3,1">
+                                <TextBlock Text="you (test)" Foreground="#FF40C4FF" FontSize="11" />
+                            </Border>
+                        </Canvas>
+                    </Canvas>
+
+                    <!-- Projected test pins (green) — compare to the real ping. -->
+                    <ItemsControl ItemsSource="{Binding TestPins}" IsHitTestVisible="False"
+                                  Padding="0" BorderThickness="0" Margin="0">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Canvas>
+                                    <Rectangle Canvas.Left="-9" Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
+                                    <Rectangle Canvas.Left="3"  Canvas.Top="-0.5" Width="6" Height="1" Fill="#FF34C759" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="-9" Width="1" Height="6" Fill="#FF34C759" />
+                                    <Rectangle Canvas.Left="-0.5" Canvas.Top="3"  Width="1" Height="6" Fill="#FF34C759" />
+                                    <Ellipse Canvas.Left="-4" Canvas.Top="-4" Width="8" Height="8"
+                                             Stroke="White" StrokeThickness="1" />
+                                    <Border Canvas.Left="9" Canvas.Top="-9"
+                                            Background="#CC0A2A12" CornerRadius="2" Padding="3,1">
+                                        <TextBlock Text="{Binding Name}" Foreground="#FF8FF0AB" FontSize="11" />
                                     </Border>
                                 </Canvas>
                             </DataTemplate>

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -79,7 +79,10 @@
                                 <Button Content="Clear" Command="{Binding ClearPlacementsCommand}"
                                         Padding="8,4" Margin="0,0,6,0" />
                                 <Button Content="Recalibrate" Command="{Binding RecalibrateCommand}"
-                                        Padding="8,4" />
+                                        Padding="8,4" Margin="0,0,6,0" />
+                                <Button Content="Done"
+                                        ToolTip="Stop nudging / deselect the active pin"
+                                        Command="{Binding DeselectCommand}" Padding="8,4" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                 <ToggleButton Content="Verify (set position)"

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -60,10 +60,17 @@
                                    Foreground="#FF8FA6BD" FontWeight="SemiBold" Margin="0,0,0,4" />
 
                         <!-- Blunt always-visible state readout — pins= proves a
-                             click made a placement even if the marker doesn't draw. -->
-                        <TextBlock DockPanel.Dock="Bottom" Text="{Binding DebugState}"
-                                   Foreground="#FF7E97AE" FontFamily="Consolas" FontSize="11"
-                                   TextWrapping="Wrap" Margin="0,8,0,0" />
+                             click made a placement even if the marker doesn't draw.
+                             The line clips in a short panel, so "Copy debug"
+                             puts the full multi-line snapshot on the clipboard. -->
+                        <DockPanel DockPanel.Dock="Bottom" Margin="0,8,0,0">
+                            <Button DockPanel.Dock="Right" Content="Copy debug"
+                                    Command="{Binding CopyDebugCommand}"
+                                    Padding="6,2" Margin="6,0,0,0" VerticalAlignment="Top" />
+                            <TextBlock Text="{Binding DebugState}"
+                                       Foreground="#FF7E97AE" FontFamily="Consolas" FontSize="11"
+                                       TextWrapping="Wrap" />
+                        </DockPanel>
 
                         <!-- Action buttons pinned to the bottom -->
                         <StackPanel DockPanel.Dock="Bottom" Margin="0,10,0,0">

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -98,8 +98,17 @@
                     </DockPanel>
                 </Border>
 
-                <!-- Transparent click-capture surface over the in-game map -->
-                <Grid x:Name="Viewport" Background="Transparent"
+                <!-- Click-capture surface over the in-game map. Background is a
+                     near-zero-alpha fill (#03000000 ≈ 1%), NOT "Transparent":
+                     this is an AllowsTransparency layered window, so the OS only
+                     delivers clicks on pixels with non-zero composited alpha.
+                     A pure-Transparent (alpha 0) region lets the click fall
+                     through to the game underneath — which is why "clicking
+                     through the overlay" dropped no marker. The survey overlay
+                     gets this for free via its #80101010 backdrop; this window
+                     has no backdrop, so the Viewport must paint its own faint
+                     fill. ~1% alpha is visually imperceptible over the map. -->
+                <Grid x:Name="Viewport" Background="#03000000"
                       MouseLeftButtonDown="Viewport_MouseLeftButtonDown">
                     <!-- Placed-reference markers. IsHitTestVisible=False so they
                          never swallow a calibration click. -->

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -43,20 +43,44 @@ public partial class CalibrationOverlayView : Window
             DragMove();
     }
 
+    private bool _dragging;
+
     private void Viewport_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
         if (DataContext is not CalibrationSessionViewModel vm) return;
-        // Only the transparent viewport background is a placement click — markers
-        // are IsHitTestVisible=False, and the control panel is a separate opaque
-        // dock that never routes here.
         if (e.OriginalSource is not FrameworkElement fe || !ReferenceEquals(fe, Viewport)) return;
 
-        var pos = Mouse.GetPosition(Viewport);
-        vm.ViewportClickedCommand.Execute(new PixelPoint(pos.X, pos.Y));
-        // Pull keyboard focus onto the (focusable) Viewport so arrow-key nudge
-        // works immediately after placing — otherwise focus stays on the
-        // reference list and the list eats the arrows.
+        var p = Mouse.GetPosition(Viewport);
+        var pos = new PixelPoint(p.X, p.Y);
+
+        // Hit an existing pin → grab it and drag (mouse, not arrow keys —
+        // bypasses the listbox/hotkey fight). Miss → click-to-place / arm.
+        if (vm.TrySelectPinAt(pos, 14))
+        {
+            _dragging = true;
+            vm.DragSelectedTo(pos);
+            Viewport.CaptureMouse();
+        }
+        else
+        {
+            vm.ViewportClickedCommand.Execute(pos);
+        }
         Viewport.Focus();
+        e.Handled = true;
+    }
+
+    private void Viewport_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_dragging || DataContext is not CalibrationSessionViewModel vm) return;
+        var p = Mouse.GetPosition(Viewport);
+        vm.DragSelectedTo(new PixelPoint(p.X, p.Y));
+    }
+
+    private void Viewport_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_dragging) return;
+        _dragging = false;
+        Viewport.ReleaseMouseCapture();
         e.Handled = true;
     }
 

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -1,7 +1,5 @@
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using Mithril.Shared.Settings;
 using Legolas.Controls;
 using Legolas.Domain;
@@ -49,21 +47,25 @@ public partial class CalibrationOverlayView : Window
 
         var pos = Mouse.GetPosition(Viewport);
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(pos.X, pos.Y));
+        // Pull keyboard focus onto the (focusable) Viewport so arrow-key nudge
+        // works immediately after placing — otherwise focus stays on the
+        // reference list and the list eats the arrows.
+        Viewport.Focus();
         e.Handled = true;
     }
 
     /// <summary>
-    /// Arrow keys fine-tune the selected placement (Shift = 5px). Skipped when
-    /// focus is inside the area combo or a list — those need arrows for their
-    /// own navigation; after a map click focus is on the window, which is the
-    /// normal nudge case.
+    /// Arrow keys fine-tune the selected placement (Shift = 5px). Handled at
+    /// the window's PreviewKeyDown (tunnels before any child), and marked
+    /// Handled, so the reference/area lists never also arrow-navigate — pick
+    /// those by mouse. Only requires the calibration window to be the active
+    /// window (true right after a placement click).
     /// </summary>
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
         if (DataContext is CalibrationSessionViewModel vm
             && vm.SelectedPlacement is not null
-            && TryArrowDelta(e.Key, out var ux, out var uy)
-            && !FocusIsInListOrCombo())
+            && TryArrowDelta(e.Key, out var ux, out var uy))
         {
             var step = (Keyboard.Modifiers & ModifierKeys.Shift) != 0 ? 5.0 : 1.0;
             vm.NudgeSelected(ux * step, uy * step);
@@ -84,14 +86,5 @@ public partial class CalibrationOverlayView : Window
             _ => (0.0, 0.0),
         };
         return dx != 0 || dy != 0;
-    }
-
-    private static bool FocusIsInListOrCombo()
-    {
-        if (Keyboard.FocusedElement is not DependencyObject d) return false;
-        for (var n = d; n is not null; n = VisualTreeHelper.GetParent(n))
-            if (n is ListBox or ComboBox or ComboBoxItem)
-                return true;
-        return false;
     }
 }

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -31,6 +31,12 @@ public partial class CalibrationOverlayView : Window
         Activated += (_, _) => ClickThrough.ForceTopmost(this);
     }
 
+    private void Viewport_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (DataContext is CalibrationSessionViewModel vm)
+            vm.SetViewport(Viewport.ActualWidth, Viewport.ActualHeight);
+    }
+
     private void Header_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
         if (e.ChangedButton == MouseButton.Left)

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -1,0 +1,52 @@
+using System.Windows;
+using System.Windows.Input;
+using Mithril.Shared.Settings;
+using Legolas.Controls;
+using Legolas.Domain;
+using Legolas.ViewModels;
+
+namespace Legolas.Views;
+
+/// <summary>
+/// Standalone transparent, topmost click-capture window for per-area map
+/// calibration. The user sees the in-game region map through it and clicks
+/// where each picked landmark/NPC sits; those clicks feed
+/// <see cref="CalibrationSessionViewModel"/> (no survey-FSM coupling).
+///
+/// Deliberately NOT click-through (unlike the survey overlay's optional mode):
+/// the whole point is to capture clicks. <see cref="ClickThrough.ForceTopmost"/>
+/// only keeps it above the game while it's open.
+/// </summary>
+public partial class CalibrationOverlayView : Window
+{
+    public CalibrationOverlayView()
+    {
+        InitializeComponent();
+    }
+
+    public CalibrationOverlayView(LegolasSettings settings, SettingsAutoSaver<LegolasSettings> saver) : this()
+    {
+        WindowLayoutBinder.Bind(this, settings.CalibrationOverlay, saver.Touch);
+        Loaded += (_, _) => ClickThrough.ForceTopmost(this);
+        Activated += (_, _) => ClickThrough.ForceTopmost(this);
+    }
+
+    private void Header_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left)
+            DragMove();
+    }
+
+    private void Viewport_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is not CalibrationSessionViewModel vm) return;
+        // Only the transparent viewport background is a placement click — markers
+        // are IsHitTestVisible=False, and the control panel is a separate opaque
+        // dock that never routes here.
+        if (e.OriginalSource is not FrameworkElement fe || !ReferenceEquals(fe, Viewport)) return;
+
+        var pos = Mouse.GetPosition(Viewport);
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(pos.X, pos.Y));
+        e.Handled = true;
+    }
+}

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -46,7 +46,7 @@ public partial class CalibrationOverlayView : Window
         if (e.OriginalSource is not FrameworkElement fe || !ReferenceEquals(fe, Viewport)) return;
 
         var pos = Mouse.GetPosition(Viewport);
-        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(pos.X, pos.Y));
+        vm.ViewportClickedCommand.Execute(new PixelPoint(pos.X, pos.Y));
         // Pull keyboard focus onto the (focusable) Viewport so arrow-key nudge
         // works immediately after placing — otherwise focus stays on the
         // reference list and the list eats the arrows.

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using Mithril.Shared.Settings;
 using Legolas.Controls;
 using Legolas.Domain;
@@ -48,5 +50,48 @@ public partial class CalibrationOverlayView : Window
         var pos = Mouse.GetPosition(Viewport);
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(pos.X, pos.Y));
         e.Handled = true;
+    }
+
+    /// <summary>
+    /// Arrow keys fine-tune the selected placement (Shift = 5px). Skipped when
+    /// focus is inside the area combo or a list — those need arrows for their
+    /// own navigation; after a map click focus is on the window, which is the
+    /// normal nudge case.
+    /// </summary>
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        if (DataContext is CalibrationSessionViewModel vm
+            && vm.SelectedPlacement is not null
+            && TryArrowDelta(e.Key, out var ux, out var uy)
+            && !FocusIsInListOrCombo())
+        {
+            var step = (Keyboard.Modifiers & ModifierKeys.Shift) != 0 ? 5.0 : 1.0;
+            vm.NudgeSelected(ux * step, uy * step);
+            e.Handled = true;
+            return;
+        }
+        base.OnPreviewKeyDown(e);
+    }
+
+    private static bool TryArrowDelta(Key key, out double dx, out double dy)
+    {
+        (dx, dy) = key switch
+        {
+            Key.Left => (-1.0, 0.0),
+            Key.Right => (1.0, 0.0),
+            Key.Up => (0.0, -1.0),
+            Key.Down => (0.0, 1.0),
+            _ => (0.0, 0.0),
+        };
+        return dx != 0 || dy != 0;
+    }
+
+    private static bool FocusIsInListOrCombo()
+    {
+        if (Keyboard.FocusedElement is not DependencyObject d) return false;
+        for (var n = d; n is not null; n = VisualTreeHelper.GetParent(n))
+            if (n is ListBox or ComboBox or ComboBoxItem)
+                return true;
+        return false;
     }
 }

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -64,7 +64,7 @@ public partial class CalibrationOverlayView : Window
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
         if (DataContext is CalibrationSessionViewModel vm
-            && vm.SelectedPlacement is not null
+            && vm.CanNudge
             && TryArrowDelta(e.Key, out var ux, out var uy))
         {
             var step = (Keyboard.Modifiers & ModifierKeys.Shift) != 0 ? 5.0 : 1.0;

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -160,24 +160,29 @@
                                FontSize="32" FontWeight="SemiBold"
                                HorizontalAlignment="Center" TextAlignment="Center"
                                Foreground="{StaticResource TextPrimaryBrush}" />
-                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
-                                Visibility="{Binding HasPickedMode, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                        <!-- Calibration is per-area and FSM-independent — always
+                             available, including before a mode is picked. -->
                         <Button Style="{StaticResource MithrilToolbarButtonStyle}"
                                 Command="{Binding ToggleCalibrationCommand}"
                                 ToolTip="Open the map-calibration overlay (click landmarks/NPCs to fix this area's projection)"
                                 Margin="0,0,4,0">
                             <icon:PackIconLucide Kind="Crosshair" Width="14" Height="14" />
                         </Button>
-                        <Button Style="{StaticResource MithrilToolbarButtonStyle}"
-                                Command="{Binding ToggleOverlaysCommand}"
-                                ToolTip="Show or hide both overlays (map and inventory)"
-                                Margin="0,0,4,0">
-                            <icon:PackIconLucide Kind="Eye" Width="14" Height="14" />
-                        </Button>
-                        <Button Style="{StaticResource MithrilToolbarButtonStyle}"
-                                Command="{Binding WizardResetCommand}" ToolTip="Reset this flow (overlays stay open)">
-                            <icon:PackIconLucide Kind="RotateCcw" Width="14" Height="14" />
-                        </Button>
+                        <!-- Overlay/reset are flow controls — only after a mode is picked. -->
+                        <StackPanel Orientation="Horizontal"
+                                    Visibility="{Binding HasPickedMode, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                            <Button Style="{StaticResource MithrilToolbarButtonStyle}"
+                                    Command="{Binding ToggleOverlaysCommand}"
+                                    ToolTip="Show or hide both overlays (map and inventory)"
+                                    Margin="0,0,4,0">
+                                <icon:PackIconLucide Kind="Eye" Width="14" Height="14" />
+                            </Button>
+                            <Button Style="{StaticResource MithrilToolbarButtonStyle}"
+                                    Command="{Binding WizardResetCommand}" ToolTip="Reset this flow (overlays stay open)">
+                                <icon:PackIconLucide Kind="RotateCcw" Width="14" Height="14" />
+                            </Button>
+                        </StackPanel>
                     </StackPanel>
                 </Grid>
 

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -163,6 +163,12 @@
                     <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
                                 Visibility="{Binding HasPickedMode, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
                         <Button Style="{StaticResource MithrilToolbarButtonStyle}"
+                                Command="{Binding ToggleCalibrationCommand}"
+                                ToolTip="Open the map-calibration overlay (click landmarks/NPCs to fix this area's projection)"
+                                Margin="0,0,4,0">
+                            <icon:PackIconLucide Kind="Crosshair" Width="14" Height="14" />
+                        </Button>
+                        <Button Style="{StaticResource MithrilToolbarButtonStyle}"
                                 Command="{Binding ToggleOverlaysCommand}"
                                 ToolTip="Show or hide both overlays (map and inventory)"
                                 Margin="0,0,4,0">

--- a/tests/Legolas.Tests/Domain/WorldCoordTests.cs
+++ b/tests/Legolas.Tests/Domain/WorldCoordTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Legolas.Domain;
+
+namespace Legolas.Tests.Domain;
+
+public class WorldCoordTests
+{
+    [Theory]
+    [InlineData("x:1138.161865 y:39.093884 z:1367.77417", 1138.161865, 39.093884, 1367.77417)]
+    [InlineData("x:-723.900024 y:71.419998 z:-399.079987", -723.900024, 71.419998, -399.079987)]
+    [InlineData("z:10 y:2 x:-5", -5, 2, 10)] // tokens out of order
+    [InlineData("1.5 2 -3.25", 1.5, 2, -3.25)] // bare fallback
+    public void Parses_canonical_and_fallback_forms(string loc, double x, double y, double z)
+    {
+        var w = WorldCoord.TryParse(loc);
+
+        w.Should().NotBeNull();
+        w!.Value.X.Should().BeApproximately(x, 1e-6);
+        w.Value.Y.Should().BeApproximately(y, 1e-6);
+        w.Value.Z.Should().BeApproximately(z, 1e-6);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("x:1 y:2")]          // missing z
+    [InlineData("garbage")]
+    [InlineData("x:foo y:2 z:3")]    // unparseable component
+    public void Returns_null_when_three_components_do_not_resolve(string? loc)
+    {
+        WorldCoord.TryParse(loc).Should().BeNull();
+    }
+}

--- a/tests/Legolas.Tests/LogTail/LogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/LogParserTests.cs
@@ -75,6 +75,29 @@ public class LogParserTests
     }
 
     [Theory]
+    [InlineData("******************** Entering Area: Eltibule", "Eltibule")]
+    [InlineData("*** Entering Area: Serbule Hills", "Serbule Hills")]
+    [InlineData("Entering Area: Kur Mountains ", "Kur Mountains")]
+    public void Parses_area_entered(string line, string expectedArea)
+    {
+        var evt = _parser.TryParse(line, FixedTime);
+
+        evt.Should().BeOfType<AreaEntered>()
+            .Which.AreaFriendlyName.Should().Be(expectedArea);
+    }
+
+    [Fact]
+    public void Survey_line_still_parses_as_survey_not_area()
+    {
+        // Precedence guard: the survey grammar must win over the area banner
+        // for a normal survey line (no "Entering Area:" substring anyway, but
+        // pin the intent so a future regex tweak can't regress it).
+        var evt = _parser.TryParse("[Status] The Iron Vein is 50m east and 30m north.", FixedTime);
+
+        evt.Should().BeOfType<SurveyDetected>().Which.Name.Should().Be("Iron Vein");
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("   ")]
     public void Returns_null_for_blank(string line)

--- a/tests/Legolas.Tests/Projection/CoordinateProjectorTests.cs
+++ b/tests/Legolas.Tests/Projection/CoordinateProjectorTests.cs
@@ -26,6 +26,31 @@ public class CoordinateProjectorTests
     }
 
     [Fact]
+    public void ApplyCalibration_adopts_scale_and_rotation_but_keeps_the_player_anchor_origin()
+    {
+        var projector = new CoordinateProjector();
+        projector.SetOrigin(new PixelPoint(640, 360)); // the player's anchor click
+
+        projector.ApplyCalibration(new AreaCalibration(
+            Scale: 2.5, RotationRadians: 0.7,
+            OriginX: 99999, OriginY: -99999, // world-(0,0) pixel — must be ignored
+            ReferenceCount: 3, ResidualPixels: 0.5));
+
+        projector.Scale.Should().BeApproximately(2.5, 1e-9);
+        projector.RotationRadians.Should().BeApproximately(0.7, 1e-9);
+        // Origin stays the anchor, NOT the calibration's world-origin pixel.
+        projector.Origin.X.Should().Be(640);
+        projector.Origin.Y.Should().Be(360);
+
+        // A pure-north offset still projects straight "up" from the anchor
+        // (origin-relative), not from some absolute world-0 pixel.
+        var p = projector.Project(new MetreOffset(0, 10));
+        var cos = Math.Cos(0.7);
+        p.X.Should().BeApproximately(640 + 2.5 * (10 * Math.Sin(0.7)), 1e-6);
+        p.Y.Should().BeApproximately(360 - 2.5 * (10 * cos), 1e-6);
+    }
+
+    [Fact]
     public void Refit_recovers_known_scale_and_rotation()
     {
         // Ground truth: scale=3 px/m, rotation=30 deg (clockwise)

--- a/tests/Legolas.Tests/Projection/LandmarkCalibrationSolverTests.cs
+++ b/tests/Legolas.Tests/Projection/LandmarkCalibrationSolverTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+
+namespace Legolas.Tests.Projection;
+
+public class LandmarkCalibrationSolverTests
+{
+    // Project the way CoordinateProjector does, given a ground-truth transform
+    // and a world point treated as (East=X, North=Z).
+    private static PixelPoint Project(double scale, double rot, PixelPoint origin, double x, double z)
+    {
+        var cos = Math.Cos(rot);
+        var sin = Math.Sin(rot);
+        var rotE = x * cos + z * sin;
+        var rotN = -x * sin + z * cos;
+        return new PixelPoint(origin.X + scale * rotE, origin.Y - scale * rotN);
+    }
+
+    [Fact]
+    public void Recovers_known_scale_rotation_and_origin_from_exact_references()
+    {
+        const double scale = 1.7;
+        var rot = Math.PI / 5;
+        var origin = new PixelPoint(640, 360);
+
+        // Signed world coords (negative X/Z are real — Myconian/SunVale/etc.).
+        var world = new[]
+        {
+            (X: -677.0, Z: 803.0),
+            (X: 1138.0, Z: 1367.0),
+            (X: -1459.0, Z: -860.0),
+            (X: 254.0, Z: -55.0),
+        };
+
+        var refs = world
+            .Select(p => new LandmarkCalibrationSolver.Reference(
+                p.X, p.Z, Project(scale, rot, origin, p.X, p.Z)))
+            .ToList();
+
+        var cal = LandmarkCalibrationSolver.Solve(refs);
+
+        cal.Should().NotBeNull();
+        cal!.Scale.Should().BeApproximately(scale, 1e-6);
+        cal.RotationRadians.Should().BeApproximately(rot, 1e-6);
+        cal.OriginX.Should().BeApproximately(origin.X, 1e-4);
+        cal.OriginY.Should().BeApproximately(origin.Y, 1e-4);
+        cal.ResidualPixels.Should().BeApproximately(0, 1e-6);
+        cal.ReferenceCount.Should().Be(4);
+    }
+
+    [Fact]
+    public void Picks_the_handedness_that_fits_a_reflected_world_layout()
+    {
+        // Construct pixels from a model where North = -Z (the mirrored
+        // handedness). The orientation-preserving fit cannot represent a
+        // reflection, so the solver must select the mirrored candidate and
+        // still drive residual to ~0.
+        const double scale = 2.0;
+        var rot = 0.4;
+        var origin = new PixelPoint(100, 200);
+
+        var world = new[]
+        {
+            (X: 10.0, Z: 0.0),
+            (X: 0.0, Z: 12.0),
+            (X: -7.0, Z: 5.0),
+            (X: 4.0, Z: -9.0),
+        };
+
+        PixelPoint Mirrored(double x, double z)
+        {
+            var cos = Math.Cos(rot);
+            var sin = Math.Sin(rot);
+            var east = x;
+            var north = -z; // reflection
+            var rotE = east * cos + north * sin;
+            var rotN = -east * sin + north * cos;
+            return new PixelPoint(origin.X + scale * rotE, origin.Y - scale * rotN);
+        }
+
+        var refs = world
+            .Select(p => new LandmarkCalibrationSolver.Reference(p.X, p.Z, Mirrored(p.X, p.Z)))
+            .ToList();
+
+        var cal = LandmarkCalibrationSolver.Solve(refs);
+
+        cal.Should().NotBeNull();
+        cal!.ResidualPixels.Should().BeApproximately(0, 1e-6);
+        cal.Scale.Should().BeApproximately(scale, 1e-6);
+    }
+
+    [Fact]
+    public void Returns_null_with_fewer_than_two_references()
+    {
+        LandmarkCalibrationSolver.Solve(new[]
+        {
+            new LandmarkCalibrationSolver.Reference(1, 2, new PixelPoint(3, 4)),
+        }).Should().BeNull();
+
+        LandmarkCalibrationSolver.Solve(Array.Empty<LandmarkCalibrationSolver.Reference>())
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_when_all_world_points_are_coincident()
+    {
+        // Degenerate: identical world coords carry no scale/rotation info
+        // (same threshold as CoordinateProjector.Refit).
+        var refs = new[]
+        {
+            new LandmarkCalibrationSolver.Reference(50, 50, new PixelPoint(10, 10)),
+            new LandmarkCalibrationSolver.Reference(50, 50, new PixelPoint(99, 99)),
+        };
+
+        LandmarkCalibrationSolver.Solve(refs).Should().BeNull();
+    }
+
+    [Fact]
+    public void Residual_reflects_real_pixel_error_when_a_reference_is_misplaced()
+    {
+        const double scale = 1.0;
+        const double rot = 0.0;
+        var origin = new PixelPoint(0, 0);
+        var world = new[] { (1000.0, 0.0), (0.0, 1000.0), (1000.0, 1000.0) };
+
+        var refs = world
+            .Select(p => new LandmarkCalibrationSolver.Reference(
+                p.Item1, p.Item2, Project(scale, rot, origin, p.Item1, p.Item2)))
+            .ToList();
+        // Nudge one reference's clicked pixel well off true.
+        refs[2] = refs[2] with { Pixel = new PixelPoint(refs[2].Pixel.X + 60, refs[2].Pixel.Y - 80) };
+
+        var cal = LandmarkCalibrationSolver.Solve(refs);
+
+        cal.Should().NotBeNull();
+        cal!.ResidualPixels.Should().BeGreaterThan(5); // a real, surfaced error
+    }
+}

--- a/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
+++ b/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
@@ -1,0 +1,249 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Misc;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Settings;
+using Npc = Mithril.Reference.Models.Npcs.Npc;
+using Quest = Mithril.Reference.Models.Quests.Quest;
+
+namespace Legolas.Tests.Services;
+
+public class AreaCalibrationServiceTests
+{
+    private static (AreaCalibrationService svc, FakeProjector proj, LegolasSettings settings)
+        Build(FakeRefData refData)
+    {
+        var settings = new LegolasSettings();
+        var proj = new FakeProjector();
+        var saver = new SettingsAutoSaver<LegolasSettings>(new InMemoryStore(settings), settings);
+        var svc = new AreaCalibrationService(refData, settings, proj, saver);
+        return (svc, proj, settings);
+    }
+
+    [Fact]
+    public void Resolves_area_key_by_friendly_name_then_short_name()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey =
+            {
+                ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", ""),
+                ["AreaSerbule2"] = new AreaEntry("AreaSerbule2", "Serbule Hills", "Beneath Serbule"),
+            },
+        };
+        var (svc, _, _) = Build(refData);
+
+        svc.OnAreaEntered("Eltibule");
+        svc.CurrentAreaKey.Should().Be("AreaEltibule");
+
+        svc.OnAreaEntered("Beneath Serbule"); // ShortFriendlyName match
+        svc.CurrentAreaKey.Should().Be("AreaSerbule2");
+    }
+
+    [Fact]
+    public void Unknown_area_records_friendly_name_but_null_key()
+    {
+        var (svc, _, _) = Build(new FakeRefData());
+
+        svc.OnAreaEntered("Nowheresville");
+
+        svc.CurrentAreaKey.Should().BeNull();
+        svc.CurrentAreaFriendlyName.Should().Be("Nowheresville");
+        svc.CurrentAreaReferences.Should().BeEmpty();
+        svc.IsCurrentAreaCalibrated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Entering_a_calibrated_area_applies_the_persisted_calibration_to_the_projector()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
+        };
+        var (svc, proj, settings) = Build(refData);
+        var persisted = new AreaCalibration(3.0, 0.5, 11, 22, 4, 0.9);
+        settings.AreaCalibrations["AreaEltibule"] = persisted;
+
+        svc.OnAreaEntered("Eltibule");
+
+        svc.IsCurrentAreaCalibrated.Should().BeTrue();
+        svc.CurrentCalibration.Should().Be(persisted);
+        proj.LastApplied.Should().Be(persisted);
+    }
+
+    [Fact]
+    public void Entering_an_uncalibrated_area_builds_references_and_does_not_touch_projector()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
+            NpcsByKey =
+            {
+                ["NPC_Marn"] = new Npc { Name = "Marn", AreaName = "AreaEltibule", Pos = "x:10 y:0 z:20" },
+                ["NPC_NoPos"] = new Npc { Name = "Ghost", AreaName = "AreaEltibule", Pos = null },
+                ["NPC_Other"] = new Npc { Name = "Far", AreaName = "AreaSerbule", Pos = "x:1 y:0 z:1" },
+            },
+            LandmarksByArea =
+            {
+                ["AreaEltibule"] = new List<Landmark>
+                {
+                    new() { Name = "Teleport Circle", Type = "TeleportationPlatform", Loc = "x:5 y:1 z:6" },
+                    new() { Name = "Broken", Type = "Portal", Loc = "not-a-loc" },
+                },
+            },
+        };
+        var (svc, proj, _) = Build(refData);
+
+        svc.OnAreaEntered("Eltibule");
+
+        proj.LastApplied.Should().BeNull(); // no persisted calibration → projector untouched
+        svc.CurrentAreaReferences.Select(r => r.Name)
+            .Should().BeEquivalentTo(new[] { "Marn", "Teleport Circle" });
+        svc.CurrentAreaReferences.Should().ContainSingle(r => r.Kind == "NPC");
+        svc.CurrentAreaReferences.Should().ContainSingle(r => r.Kind == "TeleportationPlatform");
+    }
+
+    [Fact]
+    public void CalibrateCurrentArea_solves_persists_applies_and_raises_changed()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
+        };
+        var (svc, proj, settings) = Build(refData);
+        svc.OnAreaEntered("Eltibule");
+
+        var changed = 0;
+        svc.Changed += (_, _) => changed++;
+
+        // Identity-ish transform: pixel == world ground plane (scale 1, rot 0).
+        var placements = new (WorldCoord, PixelPoint)[]
+        {
+            (new WorldCoord(0, 0, 0), new PixelPoint(0, 0)),
+            (new WorldCoord(100, 0, 0), new PixelPoint(100, 0)),
+            (new WorldCoord(0, 0, 100), new PixelPoint(0, -100)), // north → up
+        };
+
+        var cal = svc.CalibrateCurrentArea(placements);
+
+        cal.Should().NotBeNull();
+        cal!.Scale.Should().BeApproximately(1.0, 1e-6);
+        settings.AreaCalibrations.Should().ContainKey("AreaEltibule");
+        settings.AreaCalibrations["AreaEltibule"].Should().Be(cal);
+        proj.LastApplied.Should().Be(cal);
+        changed.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public void CalibrateCurrentArea_returns_null_with_fewer_than_two_placements_or_no_area()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
+        };
+        var (svc, _, settings) = Build(refData);
+
+        // No current area yet.
+        svc.CalibrateCurrentArea(new (WorldCoord, PixelPoint)[]
+        {
+            (new WorldCoord(0, 0, 0), new PixelPoint(0, 0)),
+            (new WorldCoord(1, 0, 1), new PixelPoint(1, 1)),
+        }).Should().BeNull();
+
+        svc.OnAreaEntered("Eltibule");
+        svc.CalibrateCurrentArea(new (WorldCoord, PixelPoint)[]
+        {
+            (new WorldCoord(0, 0, 0), new PixelPoint(0, 0)),
+        }).Should().BeNull();
+
+        settings.AreaCalibrations.Should().NotContainKey("AreaEltibule");
+    }
+
+    [Fact]
+    public void ClearCurrentAreaCalibration_removes_and_raises_changed()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
+        };
+        var (svc, _, settings) = Build(refData);
+        settings.AreaCalibrations["AreaEltibule"] = new AreaCalibration(1, 0, 0, 0, 2, 0);
+        svc.OnAreaEntered("Eltibule");
+        svc.IsCurrentAreaCalibrated.Should().BeTrue();
+
+        var changed = 0;
+        svc.Changed += (_, _) => changed++;
+
+        svc.ClearCurrentAreaCalibration();
+
+        settings.AreaCalibrations.Should().NotContainKey("AreaEltibule");
+        svc.IsCurrentAreaCalibrated.Should().BeFalse();
+        changed.Should().Be(1);
+    }
+
+    // ---- fakes ------------------------------------------------------------
+
+    private sealed class FakeProjector : ICoordinateProjector
+    {
+        public AreaCalibration? LastApplied { get; private set; }
+        public double Scale => 1;
+        public double RotationRadians => 0;
+        public PixelPoint Origin => PixelPoint.Zero;
+        public PixelPoint Project(MetreOffset offset) => PixelPoint.Zero;
+        public void SetOrigin(PixelPoint origin) { }
+        public void CalibrateFromClick(PixelPoint playerPixel, PixelPoint click, MetreOffset offset) { }
+        public void Refit(IReadOnlyList<(MetreOffset Offset, PixelPoint Pixel)> corrections) { }
+        public void ApplyCalibration(AreaCalibration calibration) => LastApplied = calibration;
+    }
+
+    private sealed class InMemoryStore : ISettingsStore<LegolasSettings>
+    {
+        private LegolasSettings _v;
+        public InMemoryStore(LegolasSettings v) => _v = v;
+        public string FilePath => "(memory)";
+        public LegolasSettings Load() => _v;
+        public Task<LegolasSettings> LoadAsync(CancellationToken ct = default) => Task.FromResult(_v);
+        public Task SaveAsync(LegolasSettings value, CancellationToken ct = default) { _v = value; return Task.CompletedTask; }
+        public void Save(LegolasSettings value) => _v = value;
+    }
+
+    private sealed class FakeRefData : IReferenceDataService
+    {
+        public Dictionary<string, AreaEntry> AreasByKey { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, Npc> NpcsByKey { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, List<Landmark>> LandmarksByArea { get; } = new(StringComparer.Ordinal);
+
+        public IReadOnlyDictionary<string, AreaEntry> Areas => AreasByKey;
+        public IReadOnlyDictionary<string, Npc> NpcsByInternalName => NpcsByKey;
+        public IReadOnlyDictionary<string, IReadOnlyList<Landmark>> Landmarks =>
+            LandmarksByArea.ToDictionary(kv => kv.Key, kv => (IReadOnlyList<Landmark>)kv.Value, StringComparer.Ordinal);
+
+        // Required (non-default) members — empty, mirrors the established Legolas
+        // test stub pattern (LegolasReportServiceTests.StubRefData).
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items { get; } = new Dictionary<long, Item>();
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Quest> Quests { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, Quest> QuestsByInternalName { get; } = new Dictionary<string, Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        public event EventHandler<string>? FileUpdated;
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        private void Suppress() => FileUpdated?.Invoke(this, "");
+    }
+}

--- a/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
+++ b/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
@@ -163,6 +163,44 @@ public class AreaCalibrationServiceTests
     }
 
     [Fact]
+    public void SelectArea_sets_current_area_builds_refs_and_applies_persisted()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
+            NpcsByKey = { ["NPC_Marn"] = new Npc { Name = "Marn", AreaName = "AreaEltibule", Pos = "x:1 y:0 z:2" } },
+        };
+        var (svc, proj, settings) = Build(refData);
+        var persisted = new AreaCalibration(2, 0.1, 5, 6, 3, 0.5);
+        settings.AreaCalibrations["AreaEltibule"] = persisted;
+
+        svc.SelectArea("AreaEltibule");
+
+        svc.CurrentAreaKey.Should().Be("AreaEltibule");
+        svc.CurrentAreaFriendlyName.Should().Be("Eltibule");
+        svc.CurrentAreaReferences.Should().ContainSingle(r => r.Name == "Marn");
+        proj.LastApplied.Should().Be(persisted);
+    }
+
+    [Fact]
+    public void AllAreas_lists_every_area_sorted_by_friendly_name()
+    {
+        var refData = new FakeRefData
+        {
+            AreasByKey =
+            {
+                ["AreaServbule"] = new AreaEntry("AreaServbule", "Serbule", ""),
+                ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", ""),
+                ["AreaAnagoge"] = new AreaEntry("AreaAnagoge", "Anagoge Island", ""),
+            },
+        };
+        var (svc, _, _) = Build(refData);
+
+        svc.AllAreas.Select(a => a.FriendlyName)
+            .Should().ContainInOrder("Anagoge Island", "Eltibule", "Serbule");
+    }
+
+    [Fact]
     public void ClearCurrentAreaCalibration_removes_and_raises_changed()
     {
         var refData = new FakeRefData

--- a/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
+++ b/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
@@ -127,10 +127,11 @@ public class AreaCalibrationServiceTests
             (new WorldCoord(0, 0, 100), new PixelPoint(0, -100)), // north → up
         };
 
-        var cal = svc.CalibrateCurrentArea(placements);
+        var cal = svc.CalibrateCurrentArea(placements, calibrationZoom: 0.39);
 
         cal.Should().NotBeNull();
         cal!.Scale.Should().BeApproximately(1.0, 1e-6);
+        cal.CalibrationZoom.Should().BeApproximately(0.39, 1e-9); // stamped + persisted
         settings.AreaCalibrations.Should().ContainKey("AreaEltibule");
         settings.AreaCalibrations["AreaEltibule"].Should().Be(cal);
         proj.LastApplied.Should().Be(cal);

--- a/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
+++ b/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
@@ -201,6 +201,20 @@ public class AreaCalibrationServiceTests
     }
 
     [Fact]
+    public void NoteSurvey_reraises_as_SurveyObserved()
+    {
+        var (svc, _, _) = Build(new FakeRefData());
+        CalibrationSurveyObservation? seen = null;
+        svc.SurveyObserved += (_, o) => seen = o;
+
+        svc.NoteSurvey("Iron Vein", new MetreOffset(12, -7));
+
+        seen.Should().NotBeNull();
+        seen!.Name.Should().Be("Iron Vein");
+        seen.Offset.Should().Be(new MetreOffset(12, -7));
+    }
+
+    [Fact]
     public void ClearCurrentAreaCalibration_removes_and_raises_changed()
     {
         var refData = new FakeRefData

--- a/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
@@ -121,6 +121,49 @@ public class LegolasSettingsMigrationTests
         written.Should().NotContain("pinPending");
         written.Should().NotContain("pinFinalized");
         written.Should().NotContain("playerMarker");
-        written.Should().Contain("\"schemaVersion\": 2");
+        written.Should().Contain($"\"schemaVersion\": {LegolasSettings.CurrentVersion}");
+    }
+
+    [Fact]
+    public void V2_json_without_areaCalibrations_migrates_to_empty_dictionary()
+    {
+        // A v2 blob: has schemaVersion 2, no areaCalibrations key at all.
+        var v2 = """
+            {
+              "schemaVersion": 2,
+              "pinStyle": { "outer": { "strokeColor": "#FFAA0000" } }
+            }
+            """;
+        var loaded = JsonSerializer.Deserialize(v2, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+        loaded.SchemaVersion.Should().Be(2);
+
+        var migrated = LegolasSettings.Migrate(loaded);
+
+        // v2 → v3 is a no-op: new dict defaults to empty (= "no area calibrated"),
+        // and the user's prior customisation is untouched.
+        migrated.AreaCalibrations.Should().BeEmpty();
+        migrated.PinStyle.Outer.StrokeColor.Should().Be("#FFAA0000");
+    }
+
+    [Fact]
+    public void AreaCalibrations_round_trip_through_json()
+    {
+        var settings = new LegolasSettings { SchemaVersion = LegolasSettings.CurrentVersion };
+        settings.AreaCalibrations["AreaEltibule"] =
+            new AreaCalibration(Scale: 2.5, RotationRadians: 0.3, OriginX: 120, OriginY: 340,
+                ReferenceCount: 3, ResidualPixels: 1.75);
+
+        var written = JsonSerializer.Serialize(settings, LegolasSettingsJsonContext.Default.LegolasSettings);
+        var reloaded = JsonSerializer.Deserialize(written, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+
+        reloaded.AreaCalibrations.Should().ContainKey("AreaEltibule");
+        var c = reloaded.AreaCalibrations["AreaEltibule"];
+        c.Scale.Should().BeApproximately(2.5, 1e-9);
+        c.RotationRadians.Should().BeApproximately(0.3, 1e-9);
+        c.OriginX.Should().BeApproximately(120, 1e-9);
+        c.OriginY.Should().BeApproximately(340, 1e-9);
+        c.ReferenceCount.Should().Be(3);
+        c.ResidualPixels.Should().BeApproximately(1.75, 1e-9);
+        c.SchemaVersion.Should().Be(1);
     }
 }

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -42,13 +42,15 @@ public class CalibrationSessionViewModelTests
         vm.SelectedReference = vm.References[0];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
         vm.CanSolve.Should().BeFalse();
-        // No auto-advance: the selection stays where the user put it. A second
-        // click with the same reference would *correct* it, not add a point.
-        vm.SelectedReference.Should().Be(vm.References[0]);
+        // Selection is spent after a placement — a stray next click does NOT
+        // move the pin (it warns instead of silently re-placing).
+        vm.SelectedReference.Should().BeNull();
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(11, 11));
-        vm.Placements.Should().HaveCount(1); // still one — that was a correction
+        vm.Placements.Should().HaveCount(1);            // unchanged
+        vm.Placements[0].X.Should().Be(10);            // not moved
+        vm.ClickWarning.Should().NotBeNull();
 
-        // Advancing to the next point is a deliberate pick.
+        // Each point is a deliberate pick.
         vm.SelectedReference = vm.References[1];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(200, 10));
         vm.Placements.Should().HaveCount(2);
@@ -66,14 +68,14 @@ public class CalibrationSessionViewModelTests
             Refs = { Ref("A", 0, 0) },
         };
         var vm = new CalibrationSessionViewModel(svc);
-        vm.SelectedReference = vm.References[0];
 
+        vm.SelectedReference = vm.References[0];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
-        // Selection stays on References[0] (no auto-advance); a second click is
-        // a correction of the same point.
+        // Correction is explicit: re-select the same reference, then click.
+        vm.SelectedReference = vm.References[0];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(50, 60));
 
-        vm.Placements.Should().HaveCount(1);
+        vm.Placements.Should().HaveCount(1);   // replaced, not appended
         vm.Placements[0].X.Should().Be(50);
         vm.Placements[0].Y.Should().Be(60);
     }

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -303,6 +303,88 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
+    public void Duplicate_survey_vector_is_deduped()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(100, 100));
+
+        svc.NoteSurvey("Vein", new MetreOffset(50, 20));
+        svc.NoteSurvey("Vein", new MetreOffset(51, 19));    // within 2m → dup
+        vm.SurveyPins.Should().ContainSingle();
+        vm.LastSurveyText.Should().Contain("duplicate");
+
+        svc.NoteSurvey("Vein", new MetreOffset(80, 20));     // far enough → new
+        vm.SurveyPins.Should().HaveCount(2);
+        svc.NoteSurvey("Other", new MetreOffset(50, 20));    // diff name → new
+        vm.SurveyPins.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Click_hit_test_selects_a_pin_for_drag_else_falls_through()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(300, 300)); // player
+
+        // Within radius of the player pin → selects it.
+        vm.TrySelectPinAt(new PixelPoint(307, 304), 14).Should().BeTrue();
+        vm.IsPlayerSelected.Should().BeTrue();
+
+        // Empty space → no hit.
+        vm.TrySelectPinAt(new PixelPoint(10, 10), 14).Should().BeFalse();
+
+        // A placement gets hit-selected too.
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(50, 60));
+        vm.TrySelectPinAt(new PixelPoint(52, 58), 14).Should().BeTrue();
+        vm.SelectedPlacement.Should().NotBeNull();
+        vm.IsPlayerSelected.Should().BeFalse(); // mutually exclusive
+    }
+
+    [Fact]
+    public void DragSelectedTo_moves_the_pin_to_an_absolute_point()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(100, 100));
+        svc.NoteSurvey("Vein", new MetreOffset(0, 50)); // proj (100,50)
+        var s = vm.SurveyPins[0];
+
+        vm.SelectedSurveyPin = s;
+        vm.DragSelectedTo(new PixelPoint(420, 360));
+        s.OverlayX.Should().Be(420);
+        s.OverlayY.Should().Be(360);
+        s.Corrected.Should().BeTrue();
+
+        // Drag the player pin (absolute) → survey re-projects from it.
+        vm.SetPlayerPositionCommand.Execute(null); // selects existing player
+        vm.DragSelectedTo(new PixelPoint(200, 100));
+        vm.PlayerPinX.Should().Be(200);
+        s.ProjX.Should().BeApproximately(200, 1e-6); // re-projected
+        s.OverlayX.Should().Be(420);                 // corrected → unaffected
+    }
+
+    [Fact]
     public void NudgeSelected_is_a_noop_with_nothing_selected()
     {
         var vm = new CalibrationSessionViewModel(new FakeService());

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -226,6 +226,53 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
+    public void In_verify_mode_nudge_moves_your_position_and_reprojects_the_pins()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.ToggleTestModeCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200)); // your position
+        svc.NoteSurvey("Vein", new MetreOffset(East: 0, North: 50));  // pin at (200,150)
+
+        vm.TestPins.Should().ContainSingle();
+        vm.TestPins[0].Y.Should().BeApproximately(150, 1e-6);
+
+        vm.CanNudge.Should().BeTrue();                       // armed via test origin, no placement
+        vm.NudgeTargetText.Should().Contain("your position");
+
+        vm.NudgeSelected(10, 5); // move "you" right+down
+
+        vm.TestOrigin.Should().Be(new PixelPoint(210, 205));
+        // The green pin tracked the moved origin (same offset, new base).
+        vm.TestPins[0].X.Should().BeApproximately(210, 1e-6);
+        vm.TestPins[0].Y.Should().BeApproximately(155, 1e-6);
+    }
+
+    [Fact]
+    public void Placement_nudge_still_works_when_not_in_verify_mode()
+    {
+        var vm = new CalibrationSessionViewModel(new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+        });
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(100, 100));
+
+        vm.CanNudge.Should().BeTrue();
+        vm.NudgeSelected(-3, 4);
+
+        vm.Placements[0].X.Should().Be(97);
+        vm.Placements[0].Y.Should().Be(104);
+    }
+
+    [Fact]
     public void Active_nudge_target_is_singular_visible_and_named()
     {
         var vm = new CalibrationSessionViewModel(new FakeService

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -323,7 +323,7 @@ public class CalibrationSessionViewModelTests
         vm1.ToggleTestModeCommand.Execute(null);
         noCal.NoteSurvey("X", new MetreOffset(1, 1));
         vm1.TestPins.Should().BeEmpty();
-        vm1.ClickWarning.Should().Contain("Solve a calibration");
+        vm1.LastSurveyText.Should().Contain("solve a calibration");
 
         var hasCal = new FakeService
         {
@@ -335,11 +335,11 @@ public class CalibrationSessionViewModelTests
         vm2.ToggleTestModeCommand.Execute(null); // test mode, but no origin clicked yet
         hasCal.NoteSurvey("X", new MetreOffset(1, 1));
         vm2.TestPins.Should().BeEmpty();
-        vm2.ClickWarning.Should().Contain("Click where you are");
+        vm2.LastSurveyText.Should().Contain("click where you are");
     }
 
     [Fact]
-    public void Survey_observed_outside_test_mode_is_ignored()
+    public void Survey_outside_test_mode_still_records_that_it_was_seen()
     {
         var svc = new FakeService
         {
@@ -348,8 +348,13 @@ public class CalibrationSessionViewModelTests
             CurrentCalibration = new AreaCalibration(1, 0, 0, 0, 2, 0),
         };
         var vm = new CalibrationSessionViewModel(svc); // test mode OFF
-        svc.NoteSurvey("X", new MetreOffset(10, 10));
+
+        svc.NoteSurvey("Iron Vein", new MetreOffset(10, -4));
+
         vm.TestPins.Should().BeEmpty();
+        // The survey is NEVER silently swallowed — proves the pipeline is alive.
+        vm.LastSurveyText.Should().Contain("Iron Vein");
+        vm.LastSurveyText.Should().Contain("Verify");
     }
 
     private sealed class FakeService : IAreaCalibrationService

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -303,6 +303,53 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
+    public void Survey_projection_scales_by_current_over_calibration_zoom()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            // scale 1 px/unit, solved at zoom 2.
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1) { CalibrationZoom = 2.0 },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.MapZoom = 4.0;                                 // currently 2× the cal zoom
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(0, 0));
+
+        svc.NoteSurvey("Vein", new MetreOffset(East: 100, North: 0));
+        var s = vm.SurveyPins[0];
+        s.ProjX.Should().BeApproximately(200, 1e-6);      // 100 × scale1 × (4/2)
+
+        vm.MapZoom = 2.0;                                 // now == cal zoom → factor 1
+        s.ProjX.Should().BeApproximately(100, 1e-6);      // live re-projected
+        s.OverlayX.Should().BeApproximately(100, 1e-6);   // uncorrected → follows
+    }
+
+    [Fact]
+    public void Solve_stamps_the_current_map_zoom_onto_the_calibration()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0), Ref("B", 100, 0) },
+            SolveResult = new AreaCalibration(1.0, 0.0, 0, 0, 2, 0.2),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.MapZoom = 0.39;
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
+        vm.SelectedReference = vm.References[1];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(200, 10));
+
+        vm.SolveCommand.Execute(null);
+
+        svc.LastCalibrationZoom.Should().BeApproximately(0.39, 1e-9);
+        svc.CurrentCalibration!.CalibrationZoom.Should().BeApproximately(0.39, 1e-9);
+    }
+
+    [Fact]
     public void Duplicate_survey_vector_is_deduped()
     {
         var svc = new FakeService
@@ -634,11 +681,16 @@ public class CalibrationSessionViewModelTests
             Changed?.Invoke(this, EventArgs.Empty);
         }
 
-        public AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements)
+        public double LastCalibrationZoom { get; private set; } = 1.0;
+
+        public AreaCalibration? CalibrateCurrentArea(
+            IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements,
+            double calibrationZoom = 1.0)
         {
             LastSolvePairs = placements.Select(p => (p.World, p.Pixel)).ToList();
-            CurrentCalibration = SolveResult;
-            return SolveResult;
+            LastCalibrationZoom = calibrationZoom;
+            CurrentCalibration = SolveResult is { } r ? r with { CalibrationZoom = calibrationZoom } : null;
+            return CurrentCalibration;
         }
 
         public void ClearCurrentAreaCalibration()

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Services;
 using Legolas.ViewModels;
+using Mithril.Shared.Reference;
 
 namespace Legolas.Tests.ViewModels;
 
@@ -134,6 +135,88 @@ public class CalibrationSessionViewModelTests
         vm.CanSolve.Should().BeFalse();
     }
 
+    [Fact]
+    public void Choosing_an_area_in_the_picker_drives_the_service()
+    {
+        var svc = new FakeService
+        {
+            Areas = { new AreaEntry("AreaEltibule", "Eltibule", ""), new AreaEntry("AreaSerbule", "Serbule", "") },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+
+        vm.SelectedArea = vm.AvailableAreas.First(a => a.Key == "AreaSerbule");
+
+        svc.SelectedAreaKey.Should().Be("AreaSerbule");
+    }
+
+    [Fact]
+    public void Dead_click_sets_an_explanatory_warning_instead_of_silently_failing()
+    {
+        var noArea = new CalibrationSessionViewModel(new FakeService());
+        noArea.PlaceSelectedAtCommand.Execute(new PixelPoint(5, 5));
+        noArea.ClickWarning.Should().Contain("No area");
+
+        var withRefs = new CalibrationSessionViewModel(new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+        });
+        withRefs.PlaceSelectedAtCommand.Execute(new PixelPoint(5, 5)); // nothing selected
+        withRefs.ClickWarning.Should().Contain("Pick a landmark");
+    }
+
+    [Fact]
+    public void Successful_placement_clears_warning_and_arms_nudge_target()
+    {
+        var vm = new CalibrationSessionViewModel(new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+        });
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(5, 5)); // sets a warning
+        vm.ClickWarning.Should().NotBeNull();
+
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(40, 60));
+
+        vm.ClickWarning.Should().BeNull();
+        vm.SelectedPlacement.Should().NotBeNull();
+        vm.SelectedPlacement!.X.Should().Be(40);
+    }
+
+    [Fact]
+    public void NudgeSelected_moves_the_selected_placement_and_notifies()
+    {
+        var vm = new CalibrationSessionViewModel(new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+        });
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(100, 100));
+        var placed = vm.SelectedPlacement!;
+
+        var xRaised = false;
+        placed.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(PlacedReference.X)) xRaised = true; };
+
+        vm.NudgeSelected(-3, 5);
+
+        placed.Pixel.X.Should().Be(97);
+        placed.Pixel.Y.Should().Be(105);
+        placed.X.Should().Be(97);
+        xRaised.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NudgeSelected_is_a_noop_with_nothing_selected()
+    {
+        var vm = new CalibrationSessionViewModel(new FakeService());
+        vm.Invoking(v => v.NudgeSelected(1, 1)).Should().NotThrow();
+    }
+
     private sealed class FakeService : IAreaCalibrationService
     {
         public List<CalibrationReference> Refs { get; } = new();
@@ -141,14 +224,26 @@ public class CalibrationSessionViewModelTests
         public List<(WorldCoord, PixelPoint)>? LastSolvePairs { get; private set; }
         public bool ClearCalled { get; private set; }
 
+        public List<AreaEntry> Areas { get; } = new();
+        public string? SelectedAreaKey { get; private set; }
+
         public string? CurrentAreaKey { get; set; }
         public string? CurrentAreaFriendlyName { get; set; }
         public bool IsCurrentAreaCalibrated => CurrentCalibration is not null;
         public AreaCalibration? CurrentCalibration { get; set; }
         public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Refs;
+        public IReadOnlyList<AreaEntry> AllAreas => Areas;
         public event EventHandler? Changed;
 
         public void OnAreaEntered(string areaFriendlyName) => Changed?.Invoke(this, EventArgs.Empty);
+
+        public void SelectArea(string areaKey)
+        {
+            SelectedAreaKey = areaKey;
+            CurrentAreaKey = areaKey;
+            CurrentAreaFriendlyName = Areas.FirstOrDefault(a => a.Key == areaKey)?.FriendlyName ?? areaKey;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
 
         public AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements)
         {

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -226,6 +226,44 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
+    public void Active_nudge_target_is_singular_visible_and_named()
+    {
+        var vm = new CalibrationSessionViewModel(new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0), Ref("B", 100, 0) },
+        });
+
+        vm.NudgeTargetText.Should().BeNull(); // nothing armed yet
+
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
+        var a = vm.Placements[0];
+        a.IsSelected.Should().BeTrue();
+        vm.NudgeTargetText.Should().Contain("A");
+
+        vm.SelectedReference = vm.References[1];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(200, 10));
+        var b = vm.Placements[1];
+        // Exactly one is highlighted — the new one.
+        b.IsSelected.Should().BeTrue();
+        a.IsSelected.Should().BeFalse();
+        vm.NudgeTargetText.Should().Contain("B");
+
+        // Click-selecting the first row in the Placed list moves the highlight.
+        vm.SelectedPlacement = a;
+        a.IsSelected.Should().BeTrue();
+        b.IsSelected.Should().BeFalse();
+
+        // Clearing drops the target entirely.
+        vm.ClearPlacementsCommand.Execute(null);
+        vm.SelectedPlacement.Should().BeNull();
+        vm.NudgeTargetText.Should().BeNull();
+        a.IsSelected.Should().BeFalse();
+    }
+
+    [Fact]
     public void ViewportClicked_in_test_mode_sets_the_test_origin_not_a_placement()
     {
         var svc = new FakeService

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -297,7 +297,7 @@ public class CalibrationSessionViewModelTests
         vm2.ToggleTestModeCommand.Execute(null); // test mode, but no origin clicked yet
         hasCal.NoteSurvey("X", new MetreOffset(1, 1));
         vm2.TestPins.Should().BeEmpty();
-        vm2.ClickWarning.Should().Contain("test position");
+        vm2.ClickWarning.Should().Contain("Click where you are");
     }
 
     [Fact]

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -272,6 +272,41 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
+    public void Offscreen_test_pin_is_flagged_and_clamped_to_the_viewport_edge()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.2),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SetViewport(200, 200);
+        vm.ToggleTestModeCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(50, 50)); // "you"
+
+        // Far east → projects to x≈1050 (off the right edge).
+        svc.NoteSurvey("Far", new MetreOffset(East: 1000, North: 0));
+        var far = vm.TestPins[0];
+        far.IsOffscreen.Should().BeTrue();
+        far.Pixel.X.Should().BeApproximately(1050, 1e-6);  // true projection kept
+        far.DisplayX.Should().BeApproximately(186, 1e-6);  // clamped to 200-14
+        far.DisplayY.Should().BeApproximately(50, 1e-6);
+
+        // Near → on-screen, display == true pixel.
+        svc.NoteSurvey("Near", new MetreOffset(East: 20, North: 0));
+        var near = vm.TestPins[1];
+        near.IsOffscreen.Should().BeFalse();
+        near.DisplayX.Should().BeApproximately(70, 1e-6);
+        near.DisplayY.Should().BeApproximately(50, 1e-6);
+
+        // Resizing the viewport re-evaluates existing pins.
+        vm.SetViewport(2000, 2000);
+        far.IsOffscreen.Should().BeFalse();
+        far.DisplayX.Should().BeApproximately(1050, 1e-6); // now fits → true pos
+    }
+
+    [Fact]
     public void NudgeSelected_is_a_noop_with_nothing_selected()
     {
         var vm = new CalibrationSessionViewModel(new FakeService());

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -42,20 +42,27 @@ public class CalibrationSessionViewModelTests
         vm.SelectedReference = vm.References[0];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
         vm.CanSolve.Should().BeFalse();
-        // Selection is spent after a placement — a stray next click does NOT
-        // move the pin (it warns instead of silently re-placing).
-        vm.SelectedReference.Should().BeNull();
-        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(11, 11));
-        vm.Placements.Should().HaveCount(1);            // unchanged
-        vm.Placements[0].X.Should().Be(10);            // not moved
-        vm.ClickWarning.Should().NotBeNull();
+        // The dropped reference stays the active target — visible & nudgeable.
+        vm.SelectedReference.Should().Be(vm.References[0]);
+        vm.SelectedPlacement.Should().NotBeNull();
+        vm.CanNudge.Should().BeTrue();
 
-        // Each point is a deliberate pick.
+        // Picking another reference swaps target; the first pin stays put.
         vm.SelectedReference = vm.References[1];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(200, 10));
         vm.Placements.Should().HaveCount(2);
+        vm.Placements[0].X.Should().Be(10);   // untouched by the swap
         vm.CanSolve.Should().BeTrue();
         vm.SolveCommand.CanExecute(null).Should().BeTrue();
+
+        // Done deselects: a stray click then warns instead of moving anything.
+        vm.DeselectCommand.Execute(null);
+        vm.SelectedReference.Should().BeNull();
+        vm.SelectedPlacement.Should().BeNull();
+        vm.CanNudge.Should().BeFalse();
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(5, 5));
+        vm.Placements.Should().HaveCount(2);  // nothing placed/moved
+        vm.ClickWarning.Should().NotBeNull();
     }
 
     [Fact]
@@ -71,8 +78,8 @@ public class CalibrationSessionViewModelTests
 
         vm.SelectedReference = vm.References[0];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
-        // Correction is explicit: re-select the same reference, then click.
-        vm.SelectedReference = vm.References[0];
+        // Selection persists, so clicking again repositions the same pin
+        // (it's the clearly-indicated active target).
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(50, 60));
 
         vm.Placements.Should().HaveCount(1);   // replaced, not appended

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -42,9 +42,14 @@ public class CalibrationSessionViewModelTests
         vm.SelectedReference = vm.References[0];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
         vm.CanSolve.Should().BeFalse();
-        // Auto-advanced to the only remaining unplaced reference.
-        vm.SelectedReference.Should().Be(vm.References[1]);
+        // No auto-advance: the selection stays where the user put it. A second
+        // click with the same reference would *correct* it, not add a point.
+        vm.SelectedReference.Should().Be(vm.References[0]);
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(11, 11));
+        vm.Placements.Should().HaveCount(1); // still one — that was a correction
 
+        // Advancing to the next point is a deliberate pick.
+        vm.SelectedReference = vm.References[1];
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(200, 10));
         vm.Placements.Should().HaveCount(2);
         vm.CanSolve.Should().BeTrue();
@@ -64,7 +69,8 @@ public class CalibrationSessionViewModelTests
         vm.SelectedReference = vm.References[0];
 
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
-        vm.SelectedReference = vm.References[0]; // re-select (auto-advance cleared it)
+        // Selection stays on References[0] (no auto-advance); a second click is
+        // a correction of the same point.
         vm.PlaceSelectedAtCommand.Execute(new PixelPoint(50, 60));
 
         vm.Placements.Should().HaveCount(1);

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -226,6 +226,52 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
+    public void ProjectLandmarks_ghosts_only_unplaced_refs_via_full_world_transform()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 10, 20), Ref("B", 40, -15) },
+            // Full solved transform: scale 1, rot 0, world-origin pixel (100,100).
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 100, 100, 2, 0.3) { MirrorNorth = false },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+
+        // A is "used" (placed); only B should ghost.
+        vm.SelectedReference = vm.References.First(r => r.Name == "A");
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(0, 0));
+
+        vm.ProjectLandmarksCommand.Execute(null);
+
+        vm.GhostPins.Should().ContainSingle();
+        var g = vm.GhostPins[0];
+        g.Name.Should().Be("B");
+        // East=40,North=-15 → px = 100 + 1*40 = 140 ; py = 100 - 1*(-15) = 115
+        g.X.Should().BeApproximately(140, 1e-6);
+        g.Y.Should().BeApproximately(115, 1e-6);
+
+        vm.ClearGhostsCommand.Execute(null);
+        vm.GhostPins.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProjectLandmarks_without_a_calibration_warns()
+    {
+        var vm = new CalibrationSessionViewModel(new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 1, 1) },
+        });
+
+        vm.ProjectLandmarksCommand.Execute(null);
+
+        vm.GhostPins.Should().BeEmpty();
+        vm.ClickWarning.Should().Contain("Solve a calibration");
+    }
+
+    [Fact]
     public void NudgeSelected_is_a_noop_with_nothing_selected()
     {
         var vm = new CalibrationSessionViewModel(new FakeService());

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+using Legolas.ViewModels;
+
+namespace Legolas.Tests.ViewModels;
+
+public class CalibrationSessionViewModelTests
+{
+    private static CalibrationReference Ref(string name, double x, double z) =>
+        new(name, "NPC", new WorldCoord(x, 0, z));
+
+    [Fact]
+    public void Refresh_pulls_references_and_status_from_service()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("Marn", 10, 20), Ref("Yetta", -5, 8) },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+
+        vm.References.Should().HaveCount(2);
+        vm.StatusText.Should().Contain("not calibrated");
+    }
+
+    [Fact]
+    public void Placing_references_accumulates_and_gates_solve_at_two()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0), Ref("B", 100, 0) },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+
+        vm.CanSolve.Should().BeFalse();
+
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
+        vm.CanSolve.Should().BeFalse();
+        // Auto-advanced to the only remaining unplaced reference.
+        vm.SelectedReference.Should().Be(vm.References[1]);
+
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(200, 10));
+        vm.Placements.Should().HaveCount(2);
+        vm.CanSolve.Should().BeTrue();
+        vm.SolveCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Re_clicking_a_reference_replaces_its_placement_not_adds_a_second()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SelectedReference = vm.References[0];
+
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(10, 10));
+        vm.SelectedReference = vm.References[0]; // re-select (auto-advance cleared it)
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(50, 60));
+
+        vm.Placements.Should().HaveCount(1);
+        vm.Placements[0].X.Should().Be(50);
+        vm.Placements[0].Y.Should().Be(60);
+    }
+
+    [Fact]
+    public void Solve_passes_placements_to_service_and_reports_residual()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0), Ref("B", 100, 0) },
+            SolveResult = new AreaCalibration(1.0, 0, 0, 0, 2, 0.4),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(0, 0));
+        vm.SelectedReference = vm.References[1];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(100, 0));
+
+        vm.SolveCommand.Execute(null);
+
+        svc.LastSolvePairs.Should().HaveCount(2);
+        vm.ResultText.Should().Contain("0.4 px");
+    }
+
+    [Fact]
+    public void Solve_reports_high_residual_warning()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0), Ref("B", 100, 0) },
+            SolveResult = new AreaCalibration(1.0, 0, 0, 0, 2, 47.0),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(0, 0));
+        vm.SelectedReference = vm.References[1];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(100, 0));
+
+        vm.SolveCommand.Execute(null);
+
+        vm.ResultText.Should().Contain("residual is high");
+    }
+
+    [Fact]
+    public void Recalibrate_clears_persisted_calibration_and_placements()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0), Ref("B", 100, 0) },
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SelectedReference = vm.References[0];
+        vm.PlaceSelectedAtCommand.Execute(new PixelPoint(1, 1));
+
+        vm.RecalibrateCommand.Execute(null);
+
+        svc.ClearCalled.Should().BeTrue();
+        vm.Placements.Should().BeEmpty();
+        vm.CanSolve.Should().BeFalse();
+    }
+
+    private sealed class FakeService : IAreaCalibrationService
+    {
+        public List<CalibrationReference> Refs { get; } = new();
+        public AreaCalibration? SolveResult { get; set; }
+        public List<(WorldCoord, PixelPoint)>? LastSolvePairs { get; private set; }
+        public bool ClearCalled { get; private set; }
+
+        public string? CurrentAreaKey { get; set; }
+        public string? CurrentAreaFriendlyName { get; set; }
+        public bool IsCurrentAreaCalibrated => CurrentCalibration is not null;
+        public AreaCalibration? CurrentCalibration { get; set; }
+        public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Refs;
+        public event EventHandler? Changed;
+
+        public void OnAreaEntered(string areaFriendlyName) => Changed?.Invoke(this, EventArgs.Empty);
+
+        public AreaCalibration? CalibrateCurrentArea(IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements)
+        {
+            LastSolvePairs = placements.Select(p => (p.World, p.Pixel)).ToList();
+            CurrentCalibration = SolveResult;
+            return SolveResult;
+        }
+
+        public void ClearCurrentAreaCalibration()
+        {
+            ClearCalled = true;
+            CurrentCalibration = null;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -223,6 +223,95 @@ public class CalibrationSessionViewModelTests
         vm.Invoking(v => v.NudgeSelected(1, 1)).Should().NotThrow();
     }
 
+    [Fact]
+    public void ViewportClicked_in_test_mode_sets_the_test_origin_not_a_placement()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            Refs = { Ref("A", 0, 0) },
+            CurrentCalibration = new AreaCalibration(1, 0, 0, 0, 2, 0.1),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SelectedReference = vm.References[0];
+
+        vm.ToggleTestModeCommand.Execute(null);
+        vm.TestMode.Should().BeTrue();
+
+        vm.ViewportClickedCommand.Execute(new PixelPoint(120, 80));
+
+        vm.TestOrigin.Should().Be(new PixelPoint(120, 80));
+        vm.HasTestOrigin.Should().BeTrue();
+        vm.Placements.Should().BeEmpty(); // it was a test-origin click, not a placement
+    }
+
+    [Fact]
+    public void Test_mode_projects_a_survey_from_the_test_origin_in_the_correct_direction()
+    {
+        // Identity calibration: scale 1, rotation 0. A purely-north 50m offset
+        // must project straight UP (screen-y decreases) from the test origin.
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.2),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.ToggleTestModeCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200)); // test origin
+
+        svc.NoteSurvey("Iron Vein", new MetreOffset(East: 0, North: 50));
+
+        vm.TestPins.Should().ContainSingle();
+        var pin = vm.TestPins[0];
+        pin.Name.Should().Be("Iron Vein");
+        pin.X.Should().BeApproximately(200, 1e-6);
+        pin.Y.Should().BeApproximately(150, 1e-6); // north → up (smaller y)
+
+        // And east projects to the right.
+        svc.NoteSurvey("Slab", new MetreOffset(East: 30, North: 0));
+        vm.TestPins[1].X.Should().BeApproximately(230, 1e-6);
+        vm.TestPins[1].Y.Should().BeApproximately(200, 1e-6);
+    }
+
+    [Fact]
+    public void Test_survey_without_origin_or_calibration_warns_instead_of_projecting()
+    {
+        var noCal = new FakeService { CurrentAreaKey = "AreaEltibule", CurrentAreaFriendlyName = "Eltibule" };
+        var vm1 = new CalibrationSessionViewModel(noCal);
+        vm1.ToggleTestModeCommand.Execute(null);
+        noCal.NoteSurvey("X", new MetreOffset(1, 1));
+        vm1.TestPins.Should().BeEmpty();
+        vm1.ClickWarning.Should().Contain("Solve a calibration");
+
+        var hasCal = new FakeService
+        {
+            CurrentAreaKey = "AreaEltibule",
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentCalibration = new AreaCalibration(1, 0, 0, 0, 2, 0),
+        };
+        var vm2 = new CalibrationSessionViewModel(hasCal);
+        vm2.ToggleTestModeCommand.Execute(null); // test mode, but no origin clicked yet
+        hasCal.NoteSurvey("X", new MetreOffset(1, 1));
+        vm2.TestPins.Should().BeEmpty();
+        vm2.ClickWarning.Should().Contain("test position");
+    }
+
+    [Fact]
+    public void Survey_observed_outside_test_mode_is_ignored()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaKey = "AreaEltibule",
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentCalibration = new AreaCalibration(1, 0, 0, 0, 2, 0),
+        };
+        var vm = new CalibrationSessionViewModel(svc); // test mode OFF
+        svc.NoteSurvey("X", new MetreOffset(10, 10));
+        vm.TestPins.Should().BeEmpty();
+    }
+
     private sealed class FakeService : IAreaCalibrationService
     {
         public List<CalibrationReference> Refs { get; } = new();
@@ -264,5 +353,10 @@ public class CalibrationSessionViewModelTests
             CurrentCalibration = null;
             Changed?.Invoke(this, EventArgs.Empty);
         }
+
+        public event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
+
+        public void NoteSurvey(string name, MetreOffset offset) =>
+            SurveyObserved?.Invoke(this, new CalibrationSurveyObservation(name, offset));
     }
 }

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -272,7 +272,7 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
-    public void Offscreen_test_pin_is_flagged_and_clamped_to_the_viewport_edge()
+    public void Offscreen_survey_pin_clamps_to_the_viewport_edge_and_re_evals_on_resize()
     {
         var svc = new FakeService
         {
@@ -282,28 +282,24 @@ public class CalibrationSessionViewModelTests
         };
         var vm = new CalibrationSessionViewModel(svc);
         vm.SetViewport(200, 200);
-        vm.ToggleTestModeCommand.Execute(null);
-        vm.ViewportClickedCommand.Execute(new PixelPoint(50, 50)); // "you"
+        vm.SetPlayerPositionCommand.Execute(null);            // arm
+        vm.ViewportClickedCommand.Execute(new PixelPoint(50, 50)); // drop "you"
 
-        // Far east → projects to x≈1050 (off the right edge).
         svc.NoteSurvey("Far", new MetreOffset(East: 1000, North: 0));
-        var far = vm.TestPins[0];
+        var far = vm.SurveyPins[0];
+        far.OverlayPixel.X.Should().BeApproximately(1050, 1e-6); // true projection kept
         far.IsOffscreen.Should().BeTrue();
-        far.Pixel.X.Should().BeApproximately(1050, 1e-6);  // true projection kept
-        far.DisplayX.Should().BeApproximately(186, 1e-6);  // clamped to 200-14
+        far.DisplayX.Should().BeApproximately(186, 1e-6);        // clamped to 200-14
         far.DisplayY.Should().BeApproximately(50, 1e-6);
 
-        // Near → on-screen, display == true pixel.
         svc.NoteSurvey("Near", new MetreOffset(East: 20, North: 0));
-        var near = vm.TestPins[1];
+        var near = vm.SurveyPins[1];
         near.IsOffscreen.Should().BeFalse();
         near.DisplayX.Should().BeApproximately(70, 1e-6);
-        near.DisplayY.Should().BeApproximately(50, 1e-6);
 
-        // Resizing the viewport re-evaluates existing pins.
         vm.SetViewport(2000, 2000);
         far.IsOffscreen.Should().BeFalse();
-        far.DisplayX.Should().BeApproximately(1050, 1e-6); // now fits → true pos
+        far.DisplayX.Should().BeApproximately(1050, 1e-6);
     }
 
     [Fact]
@@ -314,7 +310,7 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
-    public void In_verify_mode_nudge_moves_your_position_and_reprojects_the_pins()
+    public void Nudging_player_pin_reprojects_uncorrected_survey_pins()
     {
         var svc = new FakeService
         {
@@ -323,26 +319,58 @@ public class CalibrationSessionViewModelTests
             CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
         };
         var vm = new CalibrationSessionViewModel(svc);
-        vm.ToggleTestModeCommand.Execute(null);
-        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200)); // your position
-        svc.NoteSurvey("Vein", new MetreOffset(East: 0, North: 50));  // pin at (200,150)
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200));
+        svc.NoteSurvey("Vein", new MetreOffset(East: 0, North: 50)); // proj (200,150)
 
-        vm.TestPins.Should().ContainSingle();
-        vm.TestPins[0].Y.Should().BeApproximately(150, 1e-6);
-
-        vm.CanNudge.Should().BeTrue();                       // armed via test origin, no placement
+        var s = vm.SurveyPins.Should().ContainSingle().Subject;
+        s.ProjY.Should().BeApproximately(150, 1e-6);
+        vm.IsPlayerSelected.Should().BeTrue(); // dropped → selected
+        vm.CanNudge.Should().BeTrue();
         vm.NudgeTargetText.Should().Contain("your position");
 
-        vm.NudgeSelected(10, 5); // move "you" right+down
+        vm.NudgeSelected(10, 5); // move "you"
 
-        vm.TestOrigin.Should().Be(new PixelPoint(210, 205));
-        // The green pin tracked the moved origin (same offset, new base).
-        vm.TestPins[0].X.Should().BeApproximately(210, 1e-6);
-        vm.TestPins[0].Y.Should().BeApproximately(155, 1e-6);
+        vm.PlayerPinX.Should().Be(210);
+        vm.PlayerPinY.Should().Be(205);
+        s.ProjX.Should().BeApproximately(210, 1e-6);   // re-projected
+        s.ProjY.Should().BeApproximately(155, 1e-6);
+        s.OverlayX.Should().BeApproximately(210, 1e-6); // uncorrected → follows
+        s.OverlayY.Should().BeApproximately(155, 1e-6);
     }
 
     [Fact]
-    public void Placement_nudge_still_works_when_not_in_verify_mode()
+    public void Correcting_a_survey_pin_makes_its_overlay_stick_through_player_moves()
+    {
+        var svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200));
+        svc.NoteSurvey("Vein", new MetreOffset(East: 0, North: 50));
+        var s = vm.SurveyPins[0];
+
+        vm.SelectedSurveyPin = s;            // select the survey pin
+        vm.NudgeSelected(7, -3);             // drag its overlay onto the real ping
+        s.Corrected.Should().BeTrue();
+        s.OverlayX.Should().BeApproximately(207, 1e-6);
+        s.OverlayY.Should().BeApproximately(147, 1e-6);
+
+        // Re-select & move the player; corrected overlay must NOT follow.
+        vm.SetPlayerPositionCommand.Execute(null); // player exists → selects it
+        vm.IsPlayerSelected.Should().BeTrue();
+        vm.NudgeSelected(50, 50);
+        s.OverlayX.Should().BeApproximately(207, 1e-6); // stuck (real ping is fixed)
+        s.OverlayY.Should().BeApproximately(147, 1e-6);
+        s.ProjX.Should().BeApproximately(250, 1e-6);    // projection still moves
+    }
+
+    [Fact]
+    public void Placement_nudge_still_works()
     {
         var vm = new CalibrationSessionViewModel(new FakeService
         {
@@ -399,7 +427,7 @@ public class CalibrationSessionViewModelTests
     }
 
     [Fact]
-    public void ViewportClicked_in_test_mode_sets_the_test_origin_not_a_placement()
+    public void Armed_player_click_sets_the_player_pin_not_a_placement()
     {
         var svc = new FakeService
         {
@@ -411,21 +439,20 @@ public class CalibrationSessionViewModelTests
         var vm = new CalibrationSessionViewModel(svc);
         vm.SelectedReference = vm.References[0];
 
-        vm.ToggleTestModeCommand.Execute(null);
-        vm.TestMode.Should().BeTrue();
-
+        vm.SetPlayerPositionCommand.Execute(null);            // arm
         vm.ViewportClickedCommand.Execute(new PixelPoint(120, 80));
 
-        vm.TestOrigin.Should().Be(new PixelPoint(120, 80));
-        vm.HasTestOrigin.Should().BeTrue();
-        vm.Placements.Should().BeEmpty(); // it was a test-origin click, not a placement
+        vm.HasPlayerPin.Should().BeTrue();
+        vm.PlayerPinX.Should().Be(120);
+        vm.PlayerPinY.Should().Be(80);
+        vm.IsPlayerSelected.Should().BeTrue();
+        vm.Placements.Should().BeEmpty(); // it was a player click, not a placement
     }
 
     [Fact]
-    public void Test_mode_projects_a_survey_from_the_test_origin_in_the_correct_direction()
+    public void Survey_projects_from_player_in_the_correct_direction()
     {
-        // Identity calibration: scale 1, rotation 0. A purely-north 50m offset
-        // must project straight UP (screen-y decreases) from the test origin.
+        // Identity calibration: north → up, east → right, from the player pin.
         var svc = new FakeService
         {
             CurrentAreaFriendlyName = "Eltibule",
@@ -433,31 +460,30 @@ public class CalibrationSessionViewModelTests
             CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.2),
         };
         var vm = new CalibrationSessionViewModel(svc);
-        vm.ToggleTestModeCommand.Execute(null);
-        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200)); // test origin
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(200, 200));
 
         svc.NoteSurvey("Iron Vein", new MetreOffset(East: 0, North: 50));
-
-        vm.TestPins.Should().ContainSingle();
-        var pin = vm.TestPins[0];
+        var pin = vm.SurveyPins.Should().ContainSingle().Subject;
         pin.Name.Should().Be("Iron Vein");
-        pin.X.Should().BeApproximately(200, 1e-6);
-        pin.Y.Should().BeApproximately(150, 1e-6); // north → up (smaller y)
+        pin.ProjX.Should().BeApproximately(200, 1e-6);
+        pin.ProjY.Should().BeApproximately(150, 1e-6);   // north → up
+        pin.OverlayX.Should().BeApproximately(200, 1e-6); // overlay starts on projection
+        pin.OverlayY.Should().BeApproximately(150, 1e-6);
 
-        // And east projects to the right.
         svc.NoteSurvey("Slab", new MetreOffset(East: 30, North: 0));
-        vm.TestPins[1].X.Should().BeApproximately(230, 1e-6);
-        vm.TestPins[1].Y.Should().BeApproximately(200, 1e-6);
+        vm.SurveyPins[1].ProjX.Should().BeApproximately(230, 1e-6); // east → right
+        vm.SurveyPins[1].ProjY.Should().BeApproximately(200, 1e-6);
     }
 
     [Fact]
-    public void Test_survey_without_origin_or_calibration_warns_instead_of_projecting()
+    public void Survey_without_calibration_or_player_records_why_no_pin()
     {
         var noCal = new FakeService { CurrentAreaKey = "AreaEltibule", CurrentAreaFriendlyName = "Eltibule" };
         var vm1 = new CalibrationSessionViewModel(noCal);
-        vm1.ToggleTestModeCommand.Execute(null);
         noCal.NoteSurvey("X", new MetreOffset(1, 1));
-        vm1.TestPins.Should().BeEmpty();
+        vm1.SurveyPins.Should().BeEmpty();
+        vm1.LastSurveyText.Should().Contain("X");
         vm1.LastSurveyText.Should().Contain("solve a calibration");
 
         var hasCal = new FakeService
@@ -467,29 +493,35 @@ public class CalibrationSessionViewModelTests
             CurrentCalibration = new AreaCalibration(1, 0, 0, 0, 2, 0),
         };
         var vm2 = new CalibrationSessionViewModel(hasCal);
-        vm2.ToggleTestModeCommand.Execute(null); // test mode, but no origin clicked yet
-        hasCal.NoteSurvey("X", new MetreOffset(1, 1));
-        vm2.TestPins.Should().BeEmpty();
-        vm2.LastSurveyText.Should().Contain("click where you are");
+        hasCal.NoteSurvey("X", new MetreOffset(1, 1)); // calibrated but no player pin
+        vm2.SurveyPins.Should().BeEmpty();
+        vm2.LastSurveyText.Should().Contain("Set player position");
     }
 
     [Fact]
-    public void Survey_outside_test_mode_still_records_that_it_was_seen()
+    public void Survey_pin_math_text_reports_projected_vs_corrected_ratio()
     {
         var svc = new FakeService
         {
-            CurrentAreaKey = "AreaEltibule",
             CurrentAreaFriendlyName = "Eltibule",
-            CurrentCalibration = new AreaCalibration(1, 0, 0, 0, 2, 0),
+            CurrentAreaKey = "AreaEltibule",
+            CurrentCalibration = new AreaCalibration(1.0, 0.0, 0, 0, 3, 0.1),
         };
-        var vm = new CalibrationSessionViewModel(svc); // test mode OFF
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.SetPlayerPositionCommand.Execute(null);
+        vm.ViewportClickedCommand.Execute(new PixelPoint(0, 0));
+        svc.NoteSurvey("Vein", new MetreOffset(East: 100, North: 0)); // 100m → proj 100px
+        var s = vm.SurveyPins[0];
 
-        svc.NoteSurvey("Iron Vein", new MetreOffset(10, -4));
+        s.MathText.Should().Contain("100m");
+        s.MathText.Should().Contain("proj=100px");
+        s.MathText.Should().Contain("not yet corrected");
 
-        vm.TestPins.Should().BeEmpty();
-        // The survey is NEVER silently swallowed — proves the pipeline is alive.
-        vm.LastSurveyText.Should().Contain("Iron Vein");
-        vm.LastSurveyText.Should().Contain("Verify");
+        vm.SelectedSurveyPin = s;
+        vm.NudgeSelected(-50, 0); // drag corrected to 50px from player
+        s.MathText.Should().Contain("corrected=50px");
+        s.MathText.Should().Contain("ratio=0.500");      // half → implied scale halved
+        s.MathText.Should().Contain("impliedScale=0.5000px/m");
     }
 
     private sealed class FakeService : IAreaCalibrationService


### PR DESCRIPTION
Closes #443. Advances #444 (parse half).

## What

Per-area projector calibration for Legolas, in a standalone transparent overlay, plus a verify subsystem and the empirical resolution of the long-open unit↔metre/zoom question.

### Calibration engine
- `WorldCoord` parse (`x:y:z:`, signed, X/Z ground plane); `LandmarkCalibrationSolver` (closed-form 2D similarity, residual-picked handedness — a reflection isn't a rotation, so handedness is chosen by min RMS, persisted as `AreaCalibration.MirrorNorth`).
- `AreaCalibration` (Scale/Rotation/Origin/MirrorNorth/**CalibrationZoom**) + `LegolasSettings` v3 (no-op v2→v3 migration); `CoordinateProjector.ApplyCalibration` (scale+rotation only — origin stays the player anchor).
- `ChatLogParser` `AreaEntered`; `AreaCalibrationService` (friendly-name→key, apply-persisted-on-entry, reference list, solve/persist/clear, survey re-raise), wired through `LogIngestionService` + DI.
- Empirically grounded: `npcs.Pos`/`landmarks.Loc` proven (via `Player.log ProcessNewPosition`) to be the live game-world frame; coords are signed.

### Standalone calibration overlay
- Transparent topmost click-capture window. Manual area picker; landmark/NPC reference placement with a select→drag/nudge→Done state machine; **drag-to-move** any pin (mouse hit-test) plus click-to-place; v1 crosshair+ring markers; ghost-landmark projection (pure world→pixel sanity check); always-on DebugState + "Copy debug" full snapshot.

### Verify
- `PlayerPin` ("you", first-class selectable/draggable) + `SurveyPin`s in their own list. Each survey vector stores **both** the calibration `ProjectedPixel` and the user-corrected `OverlayPixel` (drag onto the real ping) + origin + offset; `MathText` surfaces metres/proj/corrected/ratio/impliedScale. Survey dedup (~2 m). Off-screen overlay edge-clamps.
- **Manual map-zoom field**: Mithril can't read the in-game map zoom, so a calibration is only valid at the zoom it was solved at. The user enters the zoom; it's stamped onto the calibration at Solve; survey projection scales by `currentZoom / CalibrationZoom` (exact for surveys — origin is the player pin placed at the current zoom). Calibrate once, stays correct across zoom changes.

## Result of the verify investigation

`k` (engine-unit↔metre) measured empirically via corrected survey pins: **k ≈ 1** (pin at ratio 1.026 / impliedScale 0.341 vs calibration 0.3325) — there is **no missing unit↔metre constant**; PG/Unity 1:1 confirmed, not assumed. Two corrected pins disagree ~15% → that residual is **not** a derivable factor: it's manual drag precision + PG's stylised, slightly **non-affine** in-game map. Inherent **~±10% accuracy ceiling**; tightened by spreading references / longer vectors, not by any scalar.

## Tests / status

254 Legolas tests green; full solution builds clean (warnings-as-errors). Covers solver (transform/handedness/degeneracy/residual), WorldCoord, AreaCalibrationService, settings v2→v3, AreaEntered+precedence, the full verify VM (player/survey select/drag/nudge, projected-vs-corrected, reproject-on-move, corrected-sticks, dedup, hit-test, off-screen clamp, zoom scaling, Solve-stamps-zoom).

## Notes / follow-ups

- Live runtime WPF behaviour was iterated extensively against the running app (markers/hit-test/focus); logic + bindings are test-covered.
- #444 cosmetic half (treasure label / `You dig…` terminal) intentionally deferred.
- Auto-recalibrating from survey corrections (metre-space refit) deliberately **not** built — projected+overlay are captured so it's a clean follow-up if ever wanted; unneeded given k≈1.
- The `~±10%` non-affine ceiling is inherent to PG's map art — documented, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
