### PR TITLE
fix(silmarillion): StorageVault detail — gate empty Capacity section; copyable footer KEY for operator-NPC vaults

### DIFF
--- a/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
+++ b/src/Silmarillion.Module/ViewModels/StorageVaultDetailViewModel.cs
@@ -121,8 +121,13 @@ public sealed class StorageVaultDetailViewModel
         //     chassis, IsActionable=false (the filter is not wired; these are
         //     keyword tags, not navigable entities).
         // Cross-links: Area / operator-NPC / quest-completed are 1:1 entity
-        // refs ⇒ Link. EnvelopeKey was an inert mono footer (matrix T14) ⇒
-        // storage-only inert ROW (PlayerTitle's path).
+        // refs ⇒ Link. EnvelopeKey footer is polymorphic under E5's OWN
+        // discriminator ("copyable iff a cross-entity reference key"): an
+        // operator-NPC vault's EnvelopeKey IS that NPC's InternalName (the same
+        // reference key the NPCs tab exposes as a copyable KEY — see
+        // BuildNpcChip), so it is a copyable KEY here too; an account-wide
+        // transfer chest's "*"-prefixed key is genuinely storage-only ⇒ the
+        // inert ROW (PlayerTitle's path).
 
         AreaLink = AreaChip is null ? null : LinkVm.From(AreaChip);
         OperatorNpcLink = OperatorNpcChip is null ? null : LinkVm.From(OperatorNpcChip);
@@ -156,9 +161,18 @@ public sealed class StorageVaultDetailViewModel
             .Select(t => new SetRefVm(t, MatchCount: null, IsActionable: false))
             .ToList();
 
+        // E5 (G-a) — copyable iff a cross-entity reference key. When the vault
+        // has an operator NPC, EnvelopeKey IS that NPC's InternalName (see
+        // BuildNpcChip: it is fed verbatim into EntityRef.Npc + the
+        // NpcsByInternalName lookup) — the SAME identity the NPCs tab surfaces
+        // as a copyable KEY, so it is a copyable KEY here too (E5 applied, not
+        // reversed). An account-wide transfer chest ("*"-prefixed, no operator)
+        // has a genuinely storage-only key ⇒ the inert ROW.
         Footer = string.IsNullOrEmpty(EnvelopeKey)
             ? FactFooterVm.None()
-            : FactFooterVm.Of(new FactFooterId("ROW", EnvelopeKey, copyable: false));
+            : HasOperatorNpc
+                ? FactFooterVm.Key(EnvelopeKey)
+                : FactFooterVm.Of(new FactFooterId("ROW", EnvelopeKey, copyable: false));
     }
 
     public StorageVaultListRow Row { get; }
@@ -173,9 +187,10 @@ public sealed class StorageVaultDetailViewModel
     public ICommand? OpenEntityCommand { get; }
 
     /// <summary>
-    /// Envelope key (operator NPC internal name, or a <c>"*"</c>-prefixed account-wide
-    /// form) — rendered as the bottom-right monospace footer per the detail-view
-    /// internal-name footer convention.
+    /// Envelope key — the operator NPC internal name (a cross-entity reference key,
+    /// rendered as a copyable <c>KEY</c> footer), or a <c>"*"</c>-prefixed account-wide
+    /// form (storage-only, rendered as the inert <c>ROW</c> footer). Bottom-right
+    /// monospace per the detail-view internal-name footer convention.
     /// </summary>
     public string EnvelopeKey { get; }
 
@@ -213,6 +228,15 @@ public sealed class StorageVaultDetailViewModel
     /// <summary>Rare event-gated slot overrides (≈1 entry in the corpus); labeled distinctly.</summary>
     public IReadOnlyList<StorageVaultCapacityRow> EventLevelRows { get; }
     public bool HasEventLevels { get; }
+
+    /// <summary>
+    /// True when ANY capacity form is present (favor-tier table, flat slots,
+    /// script-atomic range, or event-gated overrides). The whole Capacity
+    /// section — including its "Capacity" label — self-hides when false, so a
+    /// vault with no capacity data never shows a bare header over empty space.
+    /// </summary>
+    public bool HasAnyCapacity =>
+        HasCapacityTable || HasFlatSlots || HasScriptAtomicRange || HasEventLevels;
 
     // ── Access requirements ──
     public string? RequirementDescription { get; }
@@ -275,10 +299,14 @@ public sealed class StorageVaultDetailViewModel
     public IReadOnlyList<SetRefVm> ItemKeywordSetRefs { get; }
 
     /// <summary>
-    /// Footer identifier strip (matrix #14 / G-a · ratified E5). The EnvelopeKey
-    /// was already an inert-mono footer (matrix T14) — a display/storage-only
-    /// key ⇒ the inert <c>ROW</c> cell (PlayerTitle's path), not a copyable
-    /// <c>KEY</c>. <see cref="FactFooterVm.None"/> if keyless.
+    /// Footer identifier strip (matrix #14 / G-a · ratified E5). Polymorphic
+    /// under E5's own discriminator ("copyable iff a cross-entity reference
+    /// key"): an operator-NPC vault's EnvelopeKey IS that NPC's InternalName —
+    /// the cross-entity reference key the NPCs tab itself exposes as a copyable
+    /// <c>KEY</c> — so it is a copyable <c>KEY</c> here too. An account-wide
+    /// transfer chest's <c>"*"</c>-prefixed key is genuinely storage-only ⇒ the
+    /// inert <c>ROW</c> cell (PlayerTitle's path). <see cref="FactFooterVm.None"/>
+    /// if keyless.
     /// </summary>
     public FactFooterVm Footer { get; }
 

--- a/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml
+++ b/src/Silmarillion.Module/Views/StorageVaultDetailView.xaml
@@ -42,9 +42,12 @@
              MUST correct, not preserve → tag-form Set-ref on the blue chassis,
              IsActionable=false (the filter is not wired).
 
-         Footer (matrix #14 / G-a · ratified E5): the inert DockPanel.Bottom
-         mono TextBlock (matrix T14 — already non-copyable) becomes
-         <c:FactFooter/> at the foot; storage-only ⇒ inert ROW. Host retained. -->
+         Footer (matrix #14 / G-a · ratified E5): the DockPanel.Bottom mono
+         TextBlock becomes <c:FactFooter/> at the foot. Polymorphic under E5's
+         OWN discriminator — an operator-NPC vault's EnvelopeKey IS that NPC's
+         InternalName (a cross-entity reference key) ⇒ copyable KEY; an
+         account-wide chest's "*"-key is storage-only ⇒ inert ROW. Host
+         retained. -->
     <c:DetailExportHost>
 
     <Border Padding="14,12">
@@ -84,8 +87,11 @@
                 <!-- Capacity — carry-forward #3: ONE polymorphic FactTable
                      (Grid favor table / Scalar flat-or-range; self-hides empty).
                      Event-gated overrides = more Grid rows under their own
-                     Structure group label. -->
-                <StackPanel Margin="0,0,0,10">
+                     Structure group label. The whole section (incl. the
+                     "Capacity" label) self-hides when the vault carries no
+                     capacity data at all — no bare header over empty space. -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding HasAnyCapacity, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="Capacity" Style="{StaticResource StructureSectionLabelStyle}"/>
                     <c:FactTable DataContext="{Binding CapacityFact}"
                                  HorizontalAlignment="Left"/>

--- a/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/StorageVaultDetailViewModelTests.cs
@@ -360,6 +360,71 @@ public sealed class StorageVaultDetailViewModelTests
         FactFooter.ResolveCellClick(vm.Footer.Ids[0]).Should().Be(FactFooterCellAction.Inert);
     }
 
+    [Fact]
+    public void Footer_OperatorNpcVault_EnvelopeKeyIsCopyableCrossReferenceKey()
+    {
+        // E5's discriminator is "copyable iff a cross-entity reference key".
+        // For an operator-NPC vault the EnvelopeKey IS that NPC's InternalName
+        // (BuildNpcChip feeds it verbatim into EntityRef.Npc + the
+        // NpcsByInternalName lookup) — the SAME identity the NPCs tab exposes
+        // as a copyable KEY. So it must be a copyable KEY here too, not an
+        // inert ROW (this is E5 applied to the data, not E5 reversed).
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "NPC_CharlesThompson", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Charles Thompson",
+            HasAssociatedNpc = true,
+            NumSlots = 24,
+        });
+
+        vm.Footer.Ids.Should().ContainSingle();
+        vm.Footer.Ids[0].LabelTag.Should().Be("KEY");
+        vm.Footer.Ids[0].Value.Should().Be("NPC_CharlesThompson");
+        vm.Footer.Ids[0].Copyable.Should().BeTrue(
+            "the operator-NPC EnvelopeKey is the NPC's InternalName — a cross-entity reference key (E5)");
+        FactFooter.ResolveCellClick(vm.Footer.Ids[0]).Should().Be(FactFooterCellAction.Copy);
+    }
+
+    [Fact]
+    public void Footer_AccountWideChest_NoOperator_IsInertStorageRow()
+    {
+        // The "*"-prefixed account-wide transfer chest has no operator NPC; its
+        // envelope key is genuinely storage-only ⇒ E5 keeps it the inert ROW.
+        var refData = new FakeReferenceData();
+        var vm = Build(refData, "*GuildVault", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Guild Vault",
+            HasAssociatedNpc = false,
+        });
+
+        vm.IsAccountWide.Should().BeTrue();
+        vm.Footer.Ids.Should().ContainSingle();
+        vm.Footer.Ids[0].LabelTag.Should().Be("ROW");
+        vm.Footer.Ids[0].Value.Should().Be("*GuildVault");
+        vm.Footer.Ids[0].Copyable.Should().BeFalse(
+            "an account-wide chest's envelope key is storage-only, not a cross-entity reference (E5)");
+        FactFooter.ResolveCellClick(vm.Footer.Ids[0]).Should().Be(FactFooterCellAction.Inert);
+    }
+
+    [Fact]
+    public void Capacity_SectionSelfHides_WhenVaultCarriesNoCapacityData()
+    {
+        var refData = new FakeReferenceData();
+
+        // Nothing: no Levels, no NumSlots, no script-atomic range, no EventLevels.
+        var bare = Build(refData, "*EmptyChest", new StorageVaultPoco { NpcFriendlyName = "Empty" });
+        bare.HasAnyCapacity.Should().BeFalse(
+            "a vault with no capacity data must not render a bare 'Capacity' header over empty space");
+
+        // Any single capacity form flips it back on (here: a flat slot count).
+        var sized = Build(refData, "*SizedChest", new StorageVaultPoco
+        {
+            NpcFriendlyName = "Sized",
+            NumSlots = 12,
+        });
+        sized.HasAnyCapacity.Should().BeTrue();
+    }
+
     private static StorageVaultDetailViewModel Build(
         FakeReferenceData refData, string envelopeKey, StorageVaultPoco vault)
     {


### PR DESCRIPTION
## Summary

Two fixes to the Silmarillion **StorageVault** detail view.

### 1. Empty "Capacity" section no longer shows a bare header

The `Capacity` section label rendered unconditionally. The inner `FactTable` self-hid when empty, but the `"Capacity"` `TextBlock` did not — so a vault with no `Levels`, no `NumSlots`, no script-atomic range, and no `EventLevels` showed a bare "Capacity" header over empty space.

Added `HasAnyCapacity` and gated the whole section `StackPanel` on it.

### 2. Footer is a copyable `KEY` for operator-NPC vaults (not an inert `ROW`)

This started as "ROW is never copyable" — but it turned out **not** to be an E5 reversal. E5's discriminator is *"copyable iff a cross-entity reference key"*. For an **operator-NPC vault**, `EnvelopeKey` **is** that NPC's `InternalName` — it's fed verbatim into `EntityRef.Npc(...)` and the `NpcsByInternalName` lookup in `BuildNpcChip`, i.e. the *same* identity the NPCs tab itself exposes as a copyable `KEY`. So it was an E5 **misclassification**, not a policy we needed to overturn.

- Operator-NPC vault → copyable **`KEY`** (matches the NPCs tab's identity for that NPC)
- Account-wide transfer chest (`"*"`-prefixed, no operator) → inert **`ROW`** (genuinely storage-only — E5 unchanged)

PlayerTitle / Lorebook / Effect ROWs are **untouched**: those envelope keys are genuinely storage-only (Lorebook's cross-reference is its *separate* copyable `KEY`). No grammar docs reversed, no shared `FactFooter` policy flipped, no other call-site changed.

## Tests

Added to `StorageVaultDetailViewModelTests`:

- Operator-NPC footer is a copyable `KEY` (`ResolveCellClick` → `Copy`)
- Account-wide chest stays an inert `ROW` (`ResolveCellClick` → `Inert`)
- Capacity section self-hides when the vault carries no capacity data

The pre-existing inert-ROW test still passes unchanged — its fixture doesn't set `HasAssociatedNpc`, so it correctly exercises the no-operator path.

Rebased onto latest `main` (incl. #446 detail/popup chrome centralisation) and re-verified on the rebased tree:

- Silmarillion.Tests **547/547**
- Mithril.Shared.Tests **1140/1140**

## Note for reviewers

The doc comments in `FactFooterVm.cs` / `FactFooter.cs` / `docs/silmarillion-visual-grammar.md` still describe the `ROW` *tag* generically as "storage-only ⇒ inert", which remains accurate as a definition of the tag. They were intentionally left as-is since the StorageVault operator-NPC case is now correctly a `KEY`, not a copyable `ROW`. Happy to add a clarifying sentence ("an EnvelopeKey that resolves an entity is a KEY, not a ROW") if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
