### PR TITLE
refactor(gamestate): promote area tracker to Mithril.GameState (#454)

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -4,6 +4,7 @@ using Gandalf.Parsing;
 using Gandalf.Services;
 using Gandalf.ViewModels;
 using Gandalf.Views;
+using Mithril.GameState.Areas;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
 // Mithril.GameState now owns the quest parsers + IQuestService; Gandalf only
@@ -85,8 +86,8 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<InteractionEndParser>();
         services.AddSingleton<InteractionDelayLoopParser>();
         services.AddSingleton<InteractionWaitParser>();
-        services.AddSingleton<AreaTransitionParser>();
-        services.AddSingleton<PlayerAreaTracker>();
+        // AreaTransitionParser + PlayerAreaTracker now registered once in
+        // AddMithrilGameState() (shared live game-state) — injected here.
         services.AddSingleton<BossKillCreditParser>();
         services.AddSingleton<DefeatCooldownParser>();
         services.AddSingleton<LootBracketTracker>();

--- a/src/Gandalf.Module/Parsing/LootEvents.cs
+++ b/src/Gandalf.Module/Parsing/LootEvents.cs
@@ -61,18 +61,3 @@ public sealed record InteractionDelayLoopEvent(DateTime Timestamp, string Verb, 
 /// </summary>
 public sealed record InteractionWaitEvent(DateTime Timestamp, long InteractorId, string Body)
     : LogEvent(Timestamp);
-
-/// <summary>
-/// Player transitioned to a new area (or out of game-world, e.g. character
-/// select / disconnect). Parsed from the <c>LOADING LEVEL Area&lt;Name&gt;</c>
-/// line every PG zone change emits.
-///
-/// <see cref="AreaKey"/> is the area code (matches <c>areas.json</c> keys
-/// exactly: <c>"AreaSerbule"</c>, <c>"AreaEltibule"</c>, …) when in a real
-/// area, or <c>null</c> for the character-select screen, disconnect, or any
-/// non-Area level load. Consumers should treat <c>null</c> as "current area
-/// is unknown" — chest commits during a null-area window persist with
-/// <c>Area = null</c> and self-heal on the next portal.
-/// </summary>
-public sealed record AreaTransitionEvent(DateTime Timestamp, string? AreaKey)
-    : LogEvent(Timestamp);

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -1,4 +1,5 @@
 using Gandalf.Parsing;
+using Mithril.GameState.Areas;
 using Microsoft.Extensions.Hosting;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
+using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;

--- a/src/Mithril.GameState/Areas/Parsing/AreaEvents.cs
+++ b/src/Mithril.GameState/Areas/Parsing/AreaEvents.cs
@@ -1,0 +1,18 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Areas.Parsing;
+
+/// <summary>
+/// Player transitioned to a new area (or out of game-world, e.g. character
+/// select / disconnect). Parsed from the <c>LOADING LEVEL Area&lt;Name&gt;</c>
+/// line every PG zone change emits.
+///
+/// <see cref="AreaKey"/> is the area code (matches <c>areas.json</c> keys
+/// exactly: <c>"AreaSerbule"</c>, <c>"AreaEltibule"</c>, …) when in a real
+/// area, or <c>null</c> for the character-select screen, disconnect, or any
+/// non-Area level load. Consumers should treat <c>null</c> as "current area
+/// is unknown" — e.g. Gandalf chest commits during a null-area window persist
+/// with <c>Area = null</c> and self-heal on the next portal.
+/// </summary>
+public sealed record AreaTransitionEvent(DateTime Timestamp, string? AreaKey)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Areas/Parsing/AreaTransitionParser.cs
+++ b/src/Mithril.GameState/Areas/Parsing/AreaTransitionParser.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using Mithril.Shared.Logging;
 
-namespace Gandalf.Parsing;
+namespace Mithril.GameState.Areas.Parsing;
 
 /// <summary>
 /// Parses Project Gorgon's <c>LOADING LEVEL Area&lt;Name&gt;</c> log line into

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -1,16 +1,17 @@
 using System.IO;
 using System.Text;
-using Gandalf.Parsing;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 
-namespace Gandalf.Services;
+namespace Mithril.GameState.Areas;
 
 /// <summary>
 /// Holds the player's current area code, parsed from
 /// <c>LOADING LEVEL Area&lt;Name&gt;</c> log lines via
-/// <see cref="AreaTransitionParser"/>. Consumed by <see cref="LootSource"/>
-/// at chest-commit time to stamp <c>LearnedChest.Area</c>.
+/// <see cref="AreaTransitionParser"/>. Shared live game-state: consumed by
+/// Gandalf (chest commits stamp <c>LearnedChest.Area</c>) and Legolas
+/// (per-area survey-projection calibration), among others.
 ///
 /// <para><b>Startup seeding.</b> <see cref="PlayerLogTailReader.SeedToSessionStart"/>
 /// rewinds the live replay window to the most recent <c>ProcessAddPlayer(</c>
@@ -67,7 +68,7 @@ public sealed class PlayerAreaTracker
                 if (_currentArea != evt.AreaKey)
                 {
                     _currentArea = evt.AreaKey;
-                    _diag?.Trace("Gandalf.Area",
+                    _diag?.Trace("GameState.Area",
                         $"Player area transition → {evt.AreaKey ?? "(none)"} at {timestamp:O}");
                 }
             }
@@ -134,7 +135,7 @@ public sealed class PlayerAreaTracker
         }
         catch (IOException ex)
         {
-            _diag?.Warn("Gandalf.Area", $"SeedFromLog failed: {ex.Message}");
+            _diag?.Warn("GameState.Area", $"SeedFromLog failed: {ex.Message}");
         }
     }
 

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
@@ -32,6 +34,12 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<InventoryService>()
             .AddSingleton<IInventoryService>(sp => sp.GetRequiredService<InventoryService>())
             .AddHostedService(sp => sp.GetRequiredService<InventoryService>());
+
+        // Area tracking is shared live game-state (Gandalf chest-area
+        // stamping, Legolas per-area survey calibration, …). One parser,
+        // one tracker, registered once here — consumers inject the tracker.
+        services.AddSingleton<AreaTransitionParser>();
+        services.AddSingleton<PlayerAreaTracker>();
 
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using Gandalf.Domain;
 using Gandalf.Parsing;
 using Gandalf.Services;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;

--- a/tests/Mithril.GameState.Tests/Areas/Parsing/AreaTransitionParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/Parsing/AreaTransitionParserTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
-using Gandalf.Parsing;
+using Mithril.GameState.Areas.Parsing;
 using Xunit;
 
-namespace Gandalf.Tests.Parsing;
+namespace Mithril.GameState.Tests.Areas.Parsing;
 
 public sealed class AreaTransitionParserTests
 {

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
@@ -1,11 +1,11 @@
 using System.IO;
 using System.Text;
 using FluentAssertions;
-using Gandalf.Parsing;
-using Gandalf.Services;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Xunit;
 
-namespace Gandalf.Tests;
+namespace Mithril.GameState.Tests.Areas;
 
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]


### PR DESCRIPTION
## Phase 1 of #454 — shared area tracker

First of 6 phased PRs delivering #454 (Legolas absolute-coordinate survey placement via `ProcessMapFx`, freehand pin calibration). This phase is **pure infrastructure with no behaviour change** — it relocates the `LOADING LEVEL Area*` tracking trio so both Gandalf and (in Phase 2) Legolas share one parser/tracker, per the issue's consolidated design of record ("shared area tracker — no duplicated regex").

### What moved
| From (Gandalf) | To (Mithril.GameState) |
|---|---|
| `Parsing/AreaTransitionParser.cs` | `Areas/Parsing/AreaTransitionParser.cs` |
| `Services/PlayerAreaTracker.cs` | `Areas/PlayerAreaTracker.cs` |
| `AreaTransitionEvent` (inline in `LootEvents.cs`) | `Areas/Parsing/AreaEvents.cs` (extracted) |
| `Gandalf.Tests/{Parsing/AreaTransitionParserTests,PlayerAreaTrackerTests}` | `Mithril.GameState.Tests/Areas/…` |

`Mithril.GameState` already hosts the analogous live-state services (`QuestService`, `InventoryService`, `GameSessionService`) with their parsers + `Mithril.GameState.Tests` — this is the natural home (per maintainer direction: "things that emulate game state live in Mithril.GameState").

### Wiring
- Registered once in `AddMithrilGameState()` (single source of truth); the two `AddSingleton` lines removed from `GandalfModule`. DI resolution is order-independent, so Gandalf's `LootIngestionService`/`LootSource` resolve the tracker unchanged.
- Diagnostics category `Gandalf.Area` → `GameState.Area` (accurate owner). Doc `cref` to Gandalf-only `LootSource` generalised (would otherwise be CS1574 under warnings-as-errors).

### Verification
- `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors).
- 29 area tests (relocated) + 37 Gandalf `LootSource` tests green. No assertions changed — usings/namespaces only.

### Deviation note
The planner flagged keeping the move Gandalf-local to minimise blast radius; overridden per maintainer direction to put shared game-state in `Mithril.GameState`. Single shared registration is the cleaner long-term seam for Phase 2 (Legolas injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
