### PR TITLE
feat(legolas): consume IPlayerLogStream — area→calibration bridge (#454)

### DIFF
--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -4,6 +4,7 @@ using Gandalf.Parsing;
 using Gandalf.Services;
 using Gandalf.ViewModels;
 using Gandalf.Views;
+using Mithril.GameState.Areas;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
 // Mithril.GameState now owns the quest parsers + IQuestService; Gandalf only
@@ -85,8 +86,8 @@ public sealed class GandalfModule : IMithrilModule
         services.AddSingleton<InteractionEndParser>();
         services.AddSingleton<InteractionDelayLoopParser>();
         services.AddSingleton<InteractionWaitParser>();
-        services.AddSingleton<AreaTransitionParser>();
-        services.AddSingleton<PlayerAreaTracker>();
+        // AreaTransitionParser + PlayerAreaTracker now registered once in
+        // AddMithrilGameState() (shared live game-state) — injected here.
         services.AddSingleton<BossKillCreditParser>();
         services.AddSingleton<DefeatCooldownParser>();
         services.AddSingleton<LootBracketTracker>();

--- a/src/Gandalf.Module/Parsing/LootEvents.cs
+++ b/src/Gandalf.Module/Parsing/LootEvents.cs
@@ -61,18 +61,3 @@ public sealed record InteractionDelayLoopEvent(DateTime Timestamp, string Verb, 
 /// </summary>
 public sealed record InteractionWaitEvent(DateTime Timestamp, long InteractorId, string Body)
     : LogEvent(Timestamp);
-
-/// <summary>
-/// Player transitioned to a new area (or out of game-world, e.g. character
-/// select / disconnect). Parsed from the <c>LOADING LEVEL Area&lt;Name&gt;</c>
-/// line every PG zone change emits.
-///
-/// <see cref="AreaKey"/> is the area code (matches <c>areas.json</c> keys
-/// exactly: <c>"AreaSerbule"</c>, <c>"AreaEltibule"</c>, …) when in a real
-/// area, or <c>null</c> for the character-select screen, disconnect, or any
-/// non-Area level load. Consumers should treat <c>null</c> as "current area
-/// is unknown" — chest commits during a null-area window persist with
-/// <c>Area = null</c> and self-heal on the next portal.
-/// </summary>
-public sealed record AreaTransitionEvent(DateTime Timestamp, string? AreaKey)
-    : LogEvent(Timestamp);

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -1,4 +1,5 @@
 using Gandalf.Parsing;
+using Mithril.GameState.Areas;
 using Microsoft.Extensions.Hosting;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;

--- a/src/Gandalf.Module/Services/LootSource.cs
+++ b/src/Gandalf.Module/Services/LootSource.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Gandalf.Domain;
+using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;

--- a/src/Legolas.Module/Legolas.Module.csproj
+++ b/src/Legolas.Module/Legolas.Module.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Vortice.Direct3D11" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Mithril.GameState\Mithril.GameState.csproj" />
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
     <ProjectReference Include="..\Mithril.Shared.Wpf\Mithril.Shared.Wpf.csproj" />
   </ItemGroup>

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -201,8 +201,12 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<IHotkeyCommand, NudgePinRightFastCommand>();
         services.AddSingleton<IHotkeyCommand, NudgePinRightFineCommand>();
 
-        // Chat-log ingestion
+        // Chat-log ingestion (relative [Status] survey/collect lines).
         services.AddHostedService<LogIngestionService>();
+        // Player-log ingestion (#454). Phase 2: area→calibration bridge via
+        // the shared PlayerAreaTracker. ProcessMapFx / ProcessMapPinAdd
+        // parsing layers onto this same subscription in Phases 3/4.
+        services.AddHostedService<PlayerLogIngestionService>();
 
         // Diagnostics — frame-time logger + synthetic-load harness. The logger
         // writes CSV + summary to %LocalAppData%/Mithril/Legolas/perf/. Both

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -1,0 +1,125 @@
+using System.Windows;
+using Mithril.GameState.Areas;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.Shared.Modules;
+using Microsoft.Extensions.Hosting;
+
+namespace Legolas.Services;
+
+/// <summary>
+/// Legolas-owned <see cref="IPlayerLogStream"/> consumer. Distinct from
+/// <see cref="LogIngestionService"/> (which tails the <em>chat</em> log for
+/// <c>[Status]</c> survey/collect lines): this service watches
+/// <c>Player.log</c>, which is where #454's absolute-coordinate signals live.
+///
+/// <para><b>This phase (Phase 2 of #454) — area context only.</b> The single
+/// responsibility wired here is the area→calibration bridge: feed the shared
+/// <see cref="PlayerAreaTracker"/> and, whenever the player's area changes,
+/// apply that area's persisted <see cref="Domain.AreaCalibration"/> via
+/// <see cref="IAreaCalibrationService.SelectArea"/>. <c>ProcessMapFx</c>
+/// (absolute survey/treasure targets) and <c>ProcessMapPinAdd</c> (freehand
+/// pin calibration) parsing land in Phases 3 and 4 on this same subscription —
+/// one Player.log subscription, consistent with the other consumers.</para>
+///
+/// <para>The shared tracker is reverse-scan-seeded at startup
+/// (<see cref="PlayerAreaTracker.SeedFromLog"/>) to close the gap where the
+/// live replay window starts after the <c>LOADING LEVEL</c> line for the
+/// current area — so a session that opens Legolas while already standing in a
+/// calibrated area still applies that calibration immediately. The tracker is
+/// a thread-safe singleton; double-observing it (Gandalf also feeds it) is
+/// idempotent.</para>
+///
+/// <para>Gated on the <c>"legolas"</c> module gate, mirroring
+/// <see cref="LogIngestionService"/> — Legolas is a lazy module, so log work
+/// starts on first tab activation. The ChatLog <c>Entering Area:</c> path in
+/// <see cref="LogIngestionService"/> is retained as a complementary fallback;
+/// both converge on the same area key (last-writer-wins, idempotent).</para>
+/// </summary>
+public sealed class PlayerLogIngestionService : BackgroundService
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly PlayerAreaTracker _areaTracker;
+    private readonly IAreaCalibrationService _areaCalibration;
+    private readonly ModuleGates _gates;
+    private readonly GameConfig _config;
+    private readonly IDiagnosticsSink? _diag;
+
+    private string? _lastAppliedArea;
+
+    public PlayerLogIngestionService(
+        IPlayerLogStream stream,
+        PlayerAreaTracker areaTracker,
+        IAreaCalibrationService areaCalibration,
+        ModuleGates gates,
+        GameConfig config,
+        IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _areaTracker = areaTracker;
+        _areaCalibration = areaCalibration;
+        _gates = gates;
+        _config = config;
+        _diag = diag;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _gates.For("legolas").WaitAsync(stoppingToken).ConfigureAwait(false);
+
+        // One-shot reverse-scan for the most recent LOADING LEVEL Area* line
+        // before the live tail kicks in — best-effort, never blocks ingestion.
+        if (!string.IsNullOrEmpty(_config.PlayerLogPath))
+            _areaTracker.SeedFromLog(_config.PlayerLogPath);
+        ApplyAreaIfChanged();
+
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                // Update the shared tracker, then mirror any area change into
+                // the calibration service. Survey/pin parsing arrives here in
+                // Phases 3/4 on this same loop.
+                _areaTracker.Observe(raw);
+                ApplyAreaIfChanged();
+            }
+            catch (Exception ex)
+            {
+                _diag?.Warn("Legolas.PlayerLog", $"Ingestion error: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Apply the current area's persisted calibration when (and only when) the
+    /// tracker's area actually changes. A null area (character-select /
+    /// disconnect) resets the latch so re-entering the same area later
+    /// re-applies — defensive against any intervening projector reset.
+    /// </summary>
+    private void ApplyAreaIfChanged()
+    {
+        var area = _areaTracker.CurrentArea;
+        if (area is null)
+        {
+            _lastAppliedArea = null;
+            return;
+        }
+        if (area == _lastAppliedArea) return;
+        _lastAppliedArea = area;
+        PostToUi(() => _areaCalibration.SelectArea(area));
+    }
+
+    /// <summary>
+    /// Marshal to the WPF dispatcher — <see cref="IAreaCalibrationService.SelectArea"/>
+    /// touches the projector and raises <c>Changed</c>, which calibration VMs
+    /// observe. Falls back to a direct call in headless/test contexts. Mirrors
+    /// <see cref="LogIngestionService"/>'s helper of the same name.
+    /// </summary>
+    private static void PostToUi(Action action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null) action();
+        else dispatcher.InvokeAsync(action);
+    }
+}

--- a/src/Mithril.GameState/Areas/Parsing/AreaEvents.cs
+++ b/src/Mithril.GameState/Areas/Parsing/AreaEvents.cs
@@ -1,0 +1,18 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Areas.Parsing;
+
+/// <summary>
+/// Player transitioned to a new area (or out of game-world, e.g. character
+/// select / disconnect). Parsed from the <c>LOADING LEVEL Area&lt;Name&gt;</c>
+/// line every PG zone change emits.
+///
+/// <see cref="AreaKey"/> is the area code (matches <c>areas.json</c> keys
+/// exactly: <c>"AreaSerbule"</c>, <c>"AreaEltibule"</c>, …) when in a real
+/// area, or <c>null</c> for the character-select screen, disconnect, or any
+/// non-Area level load. Consumers should treat <c>null</c> as "current area
+/// is unknown" — e.g. Gandalf chest commits during a null-area window persist
+/// with <c>Area = null</c> and self-heal on the next portal.
+/// </summary>
+public sealed record AreaTransitionEvent(DateTime Timestamp, string? AreaKey)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Areas/Parsing/AreaTransitionParser.cs
+++ b/src/Mithril.GameState/Areas/Parsing/AreaTransitionParser.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using Mithril.Shared.Logging;
 
-namespace Gandalf.Parsing;
+namespace Mithril.GameState.Areas.Parsing;
 
 /// <summary>
 /// Parses Project Gorgon's <c>LOADING LEVEL Area&lt;Name&gt;</c> log line into

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -1,16 +1,17 @@
 using System.IO;
 using System.Text;
-using Gandalf.Parsing;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 
-namespace Gandalf.Services;
+namespace Mithril.GameState.Areas;
 
 /// <summary>
 /// Holds the player's current area code, parsed from
 /// <c>LOADING LEVEL Area&lt;Name&gt;</c> log lines via
-/// <see cref="AreaTransitionParser"/>. Consumed by <see cref="LootSource"/>
-/// at chest-commit time to stamp <c>LearnedChest.Area</c>.
+/// <see cref="AreaTransitionParser"/>. Shared live game-state: consumed by
+/// Gandalf (chest commits stamp <c>LearnedChest.Area</c>) and Legolas
+/// (per-area survey-projection calibration), among others.
 ///
 /// <para><b>Startup seeding.</b> <see cref="PlayerLogTailReader.SeedToSessionStart"/>
 /// rewinds the live replay window to the most recent <c>ProcessAddPlayer(</c>
@@ -67,7 +68,7 @@ public sealed class PlayerAreaTracker
                 if (_currentArea != evt.AreaKey)
                 {
                     _currentArea = evt.AreaKey;
-                    _diag?.Trace("Gandalf.Area",
+                    _diag?.Trace("GameState.Area",
                         $"Player area transition → {evt.AreaKey ?? "(none)"} at {timestamp:O}");
                 }
             }
@@ -134,7 +135,7 @@ public sealed class PlayerAreaTracker
         }
         catch (IOException ex)
         {
-            _diag?.Warn("Gandalf.Area", $"SeedFromLog failed: {ex.Message}");
+            _diag?.Warn("GameState.Area", $"SeedFromLog failed: {ex.Message}");
         }
     }
 

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
@@ -32,6 +34,12 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<InventoryService>()
             .AddSingleton<IInventoryService>(sp => sp.GetRequiredService<InventoryService>())
             .AddHostedService(sp => sp.GetRequiredService<InventoryService>());
+
+        // Area tracking is shared live game-state (Gandalf chest-area
+        // stamping, Legolas per-area survey calibration, …). One parser,
+        // one tracker, registered once here — consumers inject the tracker.
+        services.AddSingleton<AreaTransitionParser>();
+        services.AddSingleton<PlayerAreaTracker>();
 
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();

--- a/tests/Gandalf.Tests/LootSourceTests.cs
+++ b/tests/Gandalf.Tests/LootSourceTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using Gandalf.Domain;
 using Gandalf.Parsing;
 using Gandalf.Services;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -1,0 +1,232 @@
+using System.IO;
+using System.Text;
+using System.Threading.Channels;
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Legolas.Tests.Services;
+
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class PlayerLogIngestionServiceTests : IDisposable
+{
+    private readonly string _tempDir =
+        Mithril.TestSupport.TestPaths.CreateTempDir("legolas_playerlog");
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private static (PlayerLogIngestionService svc, ScriptedStream stream, SpyAreaCalibration spy)
+        Build(GameConfig? config = null)
+    {
+        var stream = new ScriptedStream();
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var spy = new SpyAreaCalibration();
+        var gates = new ModuleGates();
+        gates.For("legolas").Open();
+        var svc = new PlayerLogIngestionService(
+            stream, tracker, spy, gates, config ?? new GameConfig());
+        return (svc, stream, spy);
+    }
+
+    [Fact]
+    public async Task Area_load_line_applies_that_area_calibration_once()
+    {
+        var (svc, stream, spy) = Build();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            spy.SelectedAreas.Should().Equal("AreaEltibule");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Duplicate_area_line_does_not_re_apply()
+    {
+        var (svc, stream, spy) = Build();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
+            stream.Push("[08:30:00] LOADING LEVEL AreaEltibule");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            spy.SelectedAreas.Should().Equal("AreaEltibule");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Area_change_applies_each_distinct_area_in_order()
+    {
+        var (svc, stream, spy) = Build();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
+            stream.Push("[08:57:37] LOADING LEVEL AreaSerbule");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaSerbule");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Unrelated_line_is_a_noop()
+    {
+        var (svc, stream, spy) = Build();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push("[08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, \"x\", ImportantInfo, \"y\")");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            spy.SelectedAreas.Should().BeEmpty();
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task ChooseCharacter_resets_latch_so_same_area_re_applies()
+    {
+        var (svc, stream, spy) = Build();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
+            stream.Push("[08:57:00] LOADING LEVEL ChooseCharacter");
+            stream.Push("[09:00:39] LOADING LEVEL AreaEltibule");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            // Re-entry after character-select re-applies — defensive against an
+            // intervening projector reset.
+            spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaEltibule");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Startup_seed_applies_current_area_before_live_lines()
+    {
+        var logPath = Path.Combine(_tempDir, "Player.log");
+        // BOM-less UTF-8 — real Player.log carries no BOM (mirrors the
+        // PlayerAreaTracker seed-test convention).
+        File.WriteAllText(
+            logPath,
+            "LocalPlayer: ProcessAddItem(Apple(1), -1, True)\n" +
+            "LOADING LEVEL AreaEltibule\n" +
+            "LocalPlayer: ProcessAddPlayer(...)\n",
+            new UTF8Encoding(false));
+        var config = new GameConfig { GameRoot = _tempDir };
+
+        var (svc, stream, spy) = Build(config);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            // No live line pushed — the seed alone must have applied the area.
+            await WaitUntil(() => spy.SelectedAreas.Count > 0, cts.Token);
+            spy.SelectedAreas.Should().Equal("AreaEltibule");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate, CancellationToken ct)
+    {
+        while (!predicate())
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Delay(15, ct);
+        }
+    }
+
+    private static async Task Stop(
+        PlayerLogIngestionService svc, Task run, CancellationTokenSource cts)
+    {
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = run;
+        svc.Dispose();
+    }
+
+    /// <summary>
+    /// Captures <see cref="IAreaCalibrationService.SelectArea"/> invocations
+    /// in order. Every other member is an inert stub — Phase 2 only exercises
+    /// the area→calibration bridge.
+    /// </summary>
+    private sealed class SpyAreaCalibration : IAreaCalibrationService
+    {
+        public List<string> SelectedAreas { get; } = new();
+
+        public void SelectArea(string areaKey) => SelectedAreas.Add(areaKey);
+
+        public string? CurrentAreaKey => null;
+        public string? CurrentAreaFriendlyName => null;
+        public bool IsCurrentAreaCalibrated => false;
+        public AreaCalibration? CurrentCalibration => null;
+        public IReadOnlyList<CalibrationReference> CurrentAreaReferences =>
+            Array.Empty<CalibrationReference>();
+        public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
+        public event EventHandler? Changed { add { } remove { } }
+        public void OnAreaEntered(string areaFriendlyName) { }
+        public AreaCalibration? CalibrateCurrentArea(
+            IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements,
+            double calibrationZoom = 1.0) => null;
+        public void ClearCurrentAreaCalibration() { }
+        public void NoteSurvey(string name, MetreOffset offset) { }
+        public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public void Push(string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Areas/Parsing/AreaTransitionParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/Parsing/AreaTransitionParserTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
-using Gandalf.Parsing;
+using Mithril.GameState.Areas.Parsing;
 using Xunit;
 
-namespace Gandalf.Tests.Parsing;
+namespace Mithril.GameState.Tests.Areas.Parsing;
 
 public sealed class AreaTransitionParserTests
 {

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
@@ -1,11 +1,11 @@
 using System.IO;
 using System.Text;
 using FluentAssertions;
-using Gandalf.Parsing;
-using Gandalf.Services;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Xunit;
 
-namespace Gandalf.Tests;
+namespace Mithril.GameState.Tests.Areas;
 
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]


### PR DESCRIPTION
## Phase 2 of #454 — Legolas consumes `IPlayerLogStream` (area→calibration bridge)

> **Stacked on [#456](https://github.com/moumantai-gg/mithril/pull/456) (Phase 1).** Base is `feat/454-area-tracker-gamestate` — it needs the `Mithril.GameState.Areas` types. Will rebase onto `main` and retarget base once #456 squash-merges.

Second of 6 phased PRs for #454. **Plumbing only — no survey/placement behaviour change.** Legolas was ChatLog-only (`IChatLogStream`); the issue's design of record requires one Legolas-owned `Player.log` subscription (where the absolute-coordinate `ProcessMapFx`/`ProcessMapPinAdd` signals live, landing in Phases 3/4).

### What this adds
- **`PlayerLogIngestionService`** (`BackgroundService`) — mirrors the ChatLog `LogIngestionService`: gated on the `"legolas"` module gate (Legolas is lazy), `PostToUi` dispatcher marshalling. Single responsibility this phase: the **area→calibration bridge**.
  - Feeds the shared `PlayerAreaTracker` (from #456) and, on area change, applies that area's persisted `AreaCalibration` via `IAreaCalibrationService.SelectArea(key)`.
  - Startup reverse-scan **seed** (`PlayerAreaTracker.SeedFromLog`) so opening Legolas while already standing in a calibrated area applies it immediately (the live replay window starts *after* the `LOADING LEVEL` line).
  - Same-area changes de-duped; a null area (char-select/disconnect) resets the latch so re-entry re-applies (defensive vs. an intervening projector reset).
- `Legolas.Module` now `ProjectReference`s `Mithril.GameState` — it didn't (only `Mithril.Shared`/`.Wpf`). Required for `PlayerAreaTracker`; flagged by the "shell must ProjectReference shared libs" gotcha.

### Decided deviation (per maintainer)
ChatLog `Entering Area:` path **retained** as a complementary fallback rather than removed. Both paths converge on the same internal area key (`OnAreaEntered(friendly)`→resolve vs. `SelectArea(key)`); last-writer-wins is idempotent, and the de-dup latch keeps Player.log churn out.

### Verification
- `dotnet build Mithril.slnx` clean (0/0). 6 new `PlayerLogIngestionServiceTests` (scripted-stream + spy `IAreaCalibrationService`) covering: single apply, dedupe, ordered multi-area, unrelated-line no-op, char-select latch reset, startup seed. Full **260** Legolas tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
