### PR TITLE
feat(legolas): ProcessMapFx absolute placement — calibrated-area authority (#454)

### DIFF
--- a/src/Legolas.Module/Domain/AreaCalibration.cs
+++ b/src/Legolas.Module/Domain/AreaCalibration.cs
@@ -48,4 +48,30 @@ public sealed record AreaCalibration(
     /// and migrate in <see cref="LegolasSettings.Migrate"/>. Default 1 (current).
     /// </summary>
     public int SchemaVersion { get; init; } = 1;
+
+    /// <summary>
+    /// Canonical <b>absolute</b> world→overlay-pixel projection (#454): maps a
+    /// raw area-local world coordinate straight to the 1:1 map overlay using
+    /// the full solved transform (origin + scale + rotation + the
+    /// <see cref="MirrorNorth"/> handedness — a reflection a similarity fit
+    /// can't absorb). This is the single source of the absolute transform; the
+    /// calibration window's landmark "ghost" projection delegates here so the
+    /// two can't drift.
+    ///
+    /// <para>Uses <see cref="Scale"/> verbatim, so it is only exact at
+    /// <see cref="CalibrationZoom"/> — the long-standing zoom limitation
+    /// (the in-game zoom isn't machine-readable; OCR/CV deferred). Survey
+    /// targets are absolute identities regardless; only where the marker
+    /// <em>draws</em> carries the ±10% non-affine ceiling.</para>
+    /// </summary>
+    public PixelPoint ProjectWorld(WorldCoord world)
+    {
+        var east = world.X;
+        var north = MirrorNorth ? -world.Z : world.Z;
+        var cos = Math.Cos(RotationRadians);
+        var sin = Math.Sin(RotationRadians);
+        var rotE = east * cos + north * sin;
+        var rotN = -east * sin + north * cos;
+        return new PixelPoint(OriginX + Scale * rotE, OriginY - Scale * rotN);
+    }
 }

--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -9,6 +9,27 @@ public sealed record SurveyDetected(
     string Name,
     MetreOffset Offset) : GameEvent(Timestamp);
 
+/// <summary>
+/// Player.log <c>LocalPlayer: ProcessMapFx((X,Y,Z), …, "&lt;short&gt;",
+/// &lt;Category&gt;, "&lt;msg&gt;")</c> — emitted once per survey
+/// (<c>Check Survey</c>, Mining/Geology) or treasure-map (<c>Check Map</c>,
+/// Treasure Cartography) use, carrying the target's <b>exact absolute world
+/// coordinate</b> (#454). Verified invariant in <c>(X,Z)</c> across re-pings
+/// while the relative <c>&lt;msg&gt;</c> text drifts. Keyed off
+/// <c>ProcessMapFx</c> itself, not the use-verb, so both survey families are
+/// handled uniformly; Motherlode is auto-excluded (it emits
+/// <c>ProcessScreenText</c>, never <c>ProcessMapFx</c>).
+///
+/// <para><see cref="Short"/>/<see cref="Category"/>/<see cref="Message"/> are
+/// diagnostic-only — placement uses <see cref="World"/> exclusively.</para>
+/// </summary>
+public sealed record MapTargetDetected(
+    DateTime Timestamp,
+    WorldCoord World,
+    string Short,
+    string Category,
+    string Message) : GameEvent(Timestamp);
+
 public sealed record ItemCollected(
     DateTime Timestamp,
     string Name,

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -76,6 +76,27 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
         }
     }
 
+    private double _mapTargetDedupRadiusMetres = 5.0;
+    /// <summary>
+    /// #454 absolute path: a new <c>ProcessMapFx</c> target whose world
+    /// <c>(X,Z)</c> is within this many metres of an existing uncollected
+    /// absolute pin updates that pin instead of adding a duplicate (the same
+    /// node re-surveyed re-emits an identical coord). Sibling of
+    /// <see cref="SurveyDedupRadiusMetres"/> (the relative-path equivalent);
+    /// additive — old settings JSON without it loads the 5 m default.
+    /// </summary>
+    public double MapTargetDedupRadiusMetres
+    {
+        get => _mapTargetDedupRadiusMetres;
+        set
+        {
+            var clamped = Math.Max(0, value);
+            if (Math.Abs(_mapTargetDedupRadiusMetres - clamped) < 1e-6) return;
+            _mapTargetDedupRadiusMetres = clamped;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MapTargetDedupRadiusMetres)));
+        }
+    }
+
     private double _surveyPinRadiusMetres = 8.0;
     public double SurveyPinRadiusMetres
     {

--- a/src/Legolas.Module/Domain/Survey.cs
+++ b/src/Legolas.Module/Domain/Survey.cs
@@ -11,10 +11,30 @@ public sealed record Survey(
     bool Skipped,
     int? RouteOrder)
 {
+    /// <summary>
+    /// Absolute world coordinate (#454) when this pin came from a Player.log
+    /// <c>ProcessMapFx</c> target rather than a relative chat <c>[Status]</c>
+    /// offset. Drives <c>(X,Z)</c> dedupe and diagnostics; null for the legacy
+    /// relative path (init-only so the positional ctor / <c>with</c> stay
+    /// source-compatible).
+    /// </summary>
+    public WorldCoord? World { get; init; }
+
     public PixelPoint? EffectivePixel => ManualOverride ?? PixelPos;
 
     public bool IsCorrected => ManualOverride.HasValue;
 
     public static Survey Create(string name, MetreOffset offset, int gridIndex) =>
         new(Guid.NewGuid(), name, offset, null, null, gridIndex, false, false, null);
+
+    /// <summary>
+    /// A pin from an absolute <c>ProcessMapFx</c> target: the world coord is
+    /// authoritative and already projected to <paramref name="pixel"/>. No
+    /// metre offset (the relative model doesn't apply to absolute targets).
+    /// </summary>
+    public static Survey CreateAbsolute(string name, WorldCoord world, PixelPoint pixel, int gridIndex) =>
+        new(Guid.NewGuid(), name, MetreOffset.Zero, pixel, null, gridIndex, false, false, null)
+        {
+            World = world,
+        };
 }

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -56,9 +56,16 @@ public sealed partial class SurveyFlowController : ObservableObject
     /// </summary>
     private void OnSurveysChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
+        // First pin → Listening + StartedAt stamp. Ready is the relative path
+        // (anchor click already happened). AwaitingPosition is the #454
+        // absolute path: ProcessMapFx targets need no anchor, so the first
+        // absolute pin advances straight to Listening. The relative chat path
+        // can't add a pin while AwaitingPosition (LogIngestionService gates on
+        // CanAcceptSurvey), so this edge only ever fires for the absolute
+        // flow. Phase 5 removes AwaitingPosition entirely.
         if (e.Action == NotifyCollectionChangedAction.Add
             && _session.Surveys.Count == 1
-            && CurrentState == SurveyFlowState.Ready)
+            && CurrentState is SurveyFlowState.Ready or SurveyFlowState.AwaitingPosition)
         {
             _session.StartedAt = _clock.GetUtcNow();
             TransitionTo(SurveyFlowState.Listening, "FirstSurvey");

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -50,6 +50,7 @@ public sealed class LegolasModule : IMithrilModule
 
         // Core services
         services.AddSingleton<IChatLogParser, ChatLogParser>();
+        services.AddSingleton<PlayerLogParser>();
         services.AddSingleton<HeldKarpOptimizer>();
         services.AddSingleton<NearestNeighbourTwoOptOptimizer>();
         services.AddSingleton<IRouteOptimizer>(sp => new AdaptiveRouteOptimizer(

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -127,6 +127,21 @@ public sealed class LogIngestionService : BackgroundService
             _session.LastLogEvent = $"Survey: {sd.Name} → ignored (mode is Motherlode)";
             return;
         }
+
+        // #454 calibrated-area authority: when the current area has a
+        // calibration, the absolute ProcessMapFx path (PlayerLogIngestionService)
+        // owns placement. A survey use emits BOTH this chat [Status] line and a
+        // Player.log ProcessMapFx line — suppress the relative auto-place here
+        // so it doesn't double-place. NoteSurvey above still feeds the
+        // calibration window's test mode. Uncalibrated areas fall through to
+        // the legacy relative path (cold-start fallback until pin calibration).
+        if (_areaCalibration.IsCurrentAreaCalibrated)
+        {
+            _session.LastLogEvent =
+                $"Survey: {sd.Name} → absolute path owns placement (area calibrated)";
+            return;
+        }
+
         if (!_surveyFlow.CanAcceptSurvey)
         {
             // Controller writes its own diagnostic to LastLogEvent.

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using Legolas.Domain;
+using Legolas.ViewModels;
 using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;
@@ -40,8 +42,11 @@ namespace Legolas.Services;
 public sealed class PlayerLogIngestionService : BackgroundService
 {
     private readonly IPlayerLogStream _stream;
+    private readonly PlayerLogParser _parser;
     private readonly PlayerAreaTracker _areaTracker;
     private readonly IAreaCalibrationService _areaCalibration;
+    private readonly SessionState _session;
+    private readonly LegolasSettings _settings;
     private readonly ModuleGates _gates;
     private readonly GameConfig _config;
     private readonly IDiagnosticsSink? _diag;
@@ -50,15 +55,21 @@ public sealed class PlayerLogIngestionService : BackgroundService
 
     public PlayerLogIngestionService(
         IPlayerLogStream stream,
+        PlayerLogParser parser,
         PlayerAreaTracker areaTracker,
         IAreaCalibrationService areaCalibration,
+        SessionState session,
+        LegolasSettings settings,
         ModuleGates gates,
         GameConfig config,
         IDiagnosticsSink? diag = null)
     {
         _stream = stream;
+        _parser = parser;
         _areaTracker = areaTracker;
         _areaCalibration = areaCalibration;
+        _session = session;
+        _settings = settings;
         _gates = gates;
         _config = config;
         _diag = diag;
@@ -78,11 +89,13 @@ public sealed class PlayerLogIngestionService : BackgroundService
         {
             try
             {
-                // Update the shared tracker, then mirror any area change into
-                // the calibration service. Survey/pin parsing arrives here in
-                // Phases 3/4 on this same loop.
+                // Area first — a target line in the same batch must read the
+                // correct current-area calibration.
                 _areaTracker.Observe(raw);
                 ApplyAreaIfChanged();
+
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is MapTargetDetected mt)
+                    PostToUi(() => HandleMapTarget(mt));
             }
             catch (Exception ex)
             {
@@ -90,6 +103,84 @@ public sealed class PlayerLogIngestionService : BackgroundService
             }
         }
     }
+
+    /// <summary>
+    /// Place an absolute <c>ProcessMapFx</c> target. Authoritative only for a
+    /// <b>calibrated</b> area (#454 "calibrated-area authority"): uncalibrated
+    /// areas keep the legacy relative chat path (the cold-start fallback until
+    /// pin calibration exists, Phase 4). The relative chat auto-place is
+    /// suppressed for calibrated areas in <see cref="LogIngestionService"/> so
+    /// a survey use — which emits both a chat <c>[Status]</c> line and this
+    /// Player.log line — produces exactly one pin.
+    /// </summary>
+    private void HandleMapTarget(MapTargetDetected mt)
+    {
+        if (_session.Mode != SessionMode.Survey)
+        {
+            _session.LastLogEvent = $"Map target: {Describe(mt)} → ignored (mode is Motherlode)";
+            return;
+        }
+        if (_areaCalibration.CurrentCalibration is not { } cal)
+        {
+            _session.LastLogEvent =
+                $"Map target: {Describe(mt)} → area not calibrated; run pin calibration";
+            return;
+        }
+
+        var name = CleanName(mt.Short);
+        var pixel = cal.ProjectWorld(mt.World);
+
+        if (FindDuplicateAbsolute(mt.World, _settings.MapTargetDedupRadiusMetres) is { } dup)
+        {
+            // Same node re-surveyed re-emits an identical (X,Z); refresh its
+            // projected pixel (a mid-session recalibration may have moved it)
+            // rather than stacking a duplicate.
+            dup.UpdateModel(dup.Model with { PixelPos = pixel, World = mt.World });
+            _session.LastLogEvent = $"Map target: {name} → duplicate (X,Z), updated";
+            return;
+        }
+
+        var index = _session.Surveys.Count;
+        var pinVm = new SurveyItemViewModel(
+            Survey.CreateAbsolute(name, mt.World, pixel, index));
+        _session.Surveys.Add(pinVm);
+        // New pin becomes the keyboard-nudge target (parity with the chat
+        // path); surface the inventory grid so the next slot is visible.
+        _session.SelectedSurvey = pinVm;
+        _session.IsInventoryVisible = true;
+        _session.LastLogEvent = $"Map target: {name} → placed (absolute)";
+    }
+
+    private SurveyItemViewModel? FindDuplicateAbsolute(WorldCoord world, double radiusMetres)
+    {
+        var r2 = radiusMetres * radiusMetres;
+        foreach (var s in _session.Surveys)
+        {
+            if (s.Collected) continue;
+            if (s.Model.World is not { } w) continue;
+            var dx = w.X - world.X;
+            var dz = w.Z - world.Z;
+            if (dx * dx + dz * dz <= r2) return s;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// The <c>short</c> field is consistently <c>"&lt;NodeName&gt; is here"</c>;
+    /// strip the suffix for a clean pin label. Display-only — placement uses
+    /// <see cref="MapTargetDetected.World"/> exclusively.
+    /// </summary>
+    private static string CleanName(string shortText)
+    {
+        const string suffix = " is here";
+        var t = shortText.Trim();
+        return t.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? t[..^suffix.Length].Trim()
+            : t;
+    }
+
+    private static string Describe(MapTargetDetected mt) =>
+        $"{CleanName(mt.Short)} @ ({mt.World.X:0},{mt.World.Z:0})";
 
     /// <summary>
     /// Apply the current area's persisted calibration when (and only when) the

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -1,0 +1,54 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+using Legolas.Domain;
+
+namespace Legolas.Services;
+
+/// <summary>
+/// Player.log analog of <see cref="ChatLogParser"/> — pure line→event. #454
+/// Phase 3 parses <c>ProcessMapFx</c> (absolute survey/treasure-map targets);
+/// Phase 4 adds <c>ProcessMapPinAdd</c> on this same parser. One parser, many
+/// patterns, mirroring the ChatLog parser's shape.
+///
+/// <para>Real captured grammar (live Player.log, 2026-05-18):</para>
+/// <code>
+/// [08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, "Good Metal Slab is here", ImportantInfo, "The Good Metal Slab is 67m west and 1181m south.")
+/// </code>
+/// The two middle integers vary; the regex skips them non-greedily and anchors
+/// on the leading coord triple plus the trailing <c>"short", Category,
+/// "msg")</c> structure. Coordinates are <b>signed</b> (negative X/Z are
+/// common — see <see cref="WorldCoord"/>). Lines that aren't
+/// <c>ProcessMapFx</c> (incl. Motherlode's <c>ProcessScreenText</c>) fast-path
+/// to null, so Motherlode is excluded with no special-casing.
+/// </summary>
+public sealed partial class PlayerLogParser : ILogParser
+{
+    [GeneratedRegex(
+        """ProcessMapFx\(\(\s*(?<x>-?\d+(?:\.\d+)?)\s*,\s*(?<y>-?\d+(?:\.\d+)?)\s*,\s*(?<z>-?\d+(?:\.\d+)?)\s*\)\s*,.*?,\s*"(?<short>[^"]*)"\s*,\s*(?<cat>[A-Za-z]+)\s*,\s*"(?<msg>[^"]*)"\s*\)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex MapFxRx();
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(line)) return null;
+        if (!line.Contains("ProcessMapFx", StringComparison.Ordinal)) return null;
+
+        var m = MapFxRx().Match(line);
+        if (!m.Success) return null;
+        if (!TryNum(m.Groups["x"].ValueSpan, out var x) ||
+            !TryNum(m.Groups["y"].ValueSpan, out var y) ||
+            !TryNum(m.Groups["z"].ValueSpan, out var z))
+            return null;
+
+        return new MapTargetDetected(
+            timestamp,
+            new WorldCoord(x, y, z),
+            m.Groups["short"].Value,
+            m.Groups["cat"].Value,
+            m.Groups["msg"].Value);
+    }
+
+    private static bool TryNum(ReadOnlySpan<char> s, out double v) =>
+        double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+}

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -478,12 +478,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             RaiseDebug();
             return;
         }
-        var worldOrigin = new PixelPoint(c.OriginX, c.OriginY);
         foreach (var r in References)
         {
             if (Placements.Any(p => ReferenceEquals(p.Reference, r))) continue;
-            var north = c.MirrorNorth ? -r.World.Z : r.World.Z;
-            GhostPins.Add(new GhostPin(r.Name, Project(c, worldOrigin, new MetreOffset(r.World.X, north))));
+            // Canonical absolute world→pixel — shared with the #454
+            // ProcessMapFx placement path so the two can't drift.
+            GhostPins.Add(new GhostPin(r.Name, c.ProjectWorld(r.World)));
         }
         ClickWarning = null;
         RaiseDebug();
@@ -569,12 +569,6 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         s.DisplayX = Math.Clamp(px.X, inset, _viewportW - inset);
         s.DisplayY = Math.Clamp(px.Y, inset, _viewportH - inset);
     }
-
-    /// <summary>Raw projection at the calibration's own zoom (used by ghosts —
-    /// they're absolute world→pixel via the cal-zoom origin, so only valid at
-    /// the calibration zoom anyway).</summary>
-    private static PixelPoint Project(AreaCalibration c, PixelPoint origin, MetreOffset off)
-        => ProjectAtScale(c, origin, off, c.Scale);
 
     /// <summary>Survey projection from the (current-zoom) player pixel: only
     /// <see cref="AreaCalibration.Scale"/> needs the zoom factor because the

--- a/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
+++ b/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
@@ -93,6 +93,30 @@ public class SurveyFlowControllerTests
     }
 
     [Fact]
+    public void FirstAbsolutePin_in_AwaitingPosition_transitions_to_Listening_and_stamps()
+    {
+        // #454: ProcessMapFx targets are absolute and need no anchor click, so
+        // the first absolute pin advances AwaitingPosition→Listening directly.
+        // The relative chat path can't add a pin while AwaitingPosition
+        // (LogIngestionService gates on CanAcceptSurvey), so this edge only
+        // fires for the absolute flow.
+        var (flow, session, _, transitions, clock) = BuildSut();
+        flow.CurrentState.Should().Be(SurveyFlowState.AwaitingPosition);
+        var stampMoment = new DateTimeOffset(FixedTime.AddMinutes(3), TimeSpan.Zero);
+        clock.Set(stampMoment);
+
+        session.Surveys.Add(new SurveyItemViewModel(
+            Survey.CreateAbsolute("Good Metal Slab", new WorldCoord(1236, 38, 2528),
+                new PixelPoint(10, 20), 0)));
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        session.StartedAt.Should().Be(stampMoment);
+        transitions.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new SurveyTransition(
+                SurveyFlowState.AwaitingPosition, SurveyFlowState.Listening, "FirstSurvey"));
+    }
+
+    [Fact]
     public void SubsequentSurveys_do_not_re_stamp_StartedAt()
     {
         // StartedAt is set once per Listening session. Adding more pins shouldn't

--- a/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+using Xunit;
+
+namespace Legolas.Tests.LogTail;
+
+public class PlayerLogParserTests
+{
+    private readonly PlayerLogParser _parser = new();
+
+    // Real captured lines (live Player.log, 2026-05-18). Two middle ints (25, 1)
+    // vary across uses; the regex skips them.
+    [Theory]
+    [InlineData(
+        "[08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, \"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 67m west and 1181m south.\")",
+        1236.00, 38.17, 2528.00)]
+    [InlineData(
+        "[08:33:17] LocalPlayer: ProcessMapFx((1666.00, 36.95, 2620.00), 25, 1, \"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")",
+        1666.00, 36.95, 2620.00)]
+    public void Parses_ProcessMapFx_absolute_world_coord(string line, double x, double y, double z)
+    {
+        var evt = (MapTargetDetected?)_parser.TryParse(line, DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.World.X.Should().Be(x);
+        evt.World.Y.Should().Be(y);
+        evt.World.Z.Should().Be(z);
+        evt.Short.Should().Be("Good Metal Slab is here");
+        evt.Category.Should().Be("ImportantInfo");
+        evt.Message.Should().Contain("south.");
+    }
+
+    [Fact]
+    public void Parses_signed_negative_coords()
+    {
+        // Negative X/Z are common (Myconian Cave, Sun Vale, …) — a positive-only
+        // assumption silently misprojects whole zones (see WorldCoord).
+        var line =
+            "[09:10:00] LocalPlayer: ProcessMapFx((-521.96, 12.00, -322.68), 7, 1, \"Iron Vein is here\", ImportantInfo, \"The Iron Vein is 5m east and 9m north.\")";
+        var evt = (MapTargetDetected?)_parser.TryParse(line, DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.World.X.Should().Be(-521.96);
+        evt.World.Z.Should().Be(-322.68);
+    }
+
+    [Fact]
+    public void Preserves_event_timestamp()
+    {
+        var ts = new DateTime(2026, 5, 18, 8, 25, 39, DateTimeKind.Utc);
+        var evt = (MapTargetDetected?)_parser.TryParse(
+            "LocalPlayer: ProcessMapFx((1.0, 2.0, 3.0), 1, 1, \"X is here\", Info, \"msg\")", ts);
+        evt!.Timestamp.Should().Be(ts);
+    }
+
+    [Theory]
+    // Motherlode is distance-only ProcessScreenText / ProcessDoDelayLoop —
+    // never ProcessMapFx, so it's excluded with no special-casing.
+    [InlineData("[09:03:31] LocalPlayer: ProcessScreenText(ImportantInfo, \"The treasure is 1285 meters from here.\")")]
+    [InlineData("[09:03:30] LocalPlayer: ProcessDoDelayLoop(1, Unset, \"Using Kur Mountains Simple Metal Motherlode Map\", 5305, AbortIfAttacked)")]
+    [InlineData("[08:25:38] LocalPlayer: ProcessDoDelayLoop(0.5, Unset, \"Using Eltibule Good Mining Survey\", 5305, AbortIfAttacked)")]
+    [InlineData("[08:22:22] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), \"Calib 1\")")]
+    [InlineData("LOADING LEVEL AreaEltibule")]
+    [InlineData("")]
+    public void Returns_null_for_non_ProcessMapFx_lines(string line)
+    {
+        _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
+    }
+}

--- a/tests/Legolas.Tests/Projection/AreaCalibrationProjectWorldTests.cs
+++ b/tests/Legolas.Tests/Projection/AreaCalibrationProjectWorldTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+using Xunit;
+
+namespace Legolas.Tests.Projection;
+
+/// <summary>
+/// #454: <see cref="AreaCalibration.ProjectWorld"/> must reproduce exactly the
+/// transform <see cref="LandmarkCalibrationSolver"/> fits (it's the canonical
+/// absolute world→pixel used by both ProcessMapFx placement and the landmark
+/// "ghost" preview). Round-trips synthetic exact-fit references and pins the
+/// <see cref="AreaCalibration.MirrorNorth"/> handedness.
+/// </summary>
+public class AreaCalibrationProjectWorldTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ProjectWorld_reproduces_the_solved_reference_pixels(bool mirrorNorth)
+    {
+        // A known similarity: pixel = origin + s·R(θ)·(east, north),
+        // north = mirrorNorth ? -Z : Z — exactly the solver/Project model.
+        const double s = 0.42;
+        const double thetaDeg = 23.0;
+        var theta = thetaDeg * Math.PI / 180.0;
+        const double ox = 360.0, oy = 540.0;
+
+        var world = new[]
+        {
+            new WorldCoord(-521.96, 0, 368.39),
+            new WorldCoord(367.28, 0, 2798.03),
+            new WorldCoord(1145.39, 0, 1323.40),
+            new WorldCoord(1666.00, 0, -322.68),
+        };
+
+        PixelPoint Forward(WorldCoord w)
+        {
+            var east = w.X;
+            var north = mirrorNorth ? -w.Z : w.Z;
+            var rotE = east * Math.Cos(theta) + north * Math.Sin(theta);
+            var rotN = -east * Math.Sin(theta) + north * Math.Cos(theta);
+            return new PixelPoint(ox + s * rotE, oy - s * rotN);
+        }
+
+        var refs = world
+            .Select(w => new LandmarkCalibrationSolver.Reference(w.X, w.Z, Forward(w)))
+            .ToList();
+
+        var cal = LandmarkCalibrationSolver.Solve(refs);
+        cal.Should().NotBeNull();
+        cal!.ResidualPixels.Should().BeLessThan(1e-6, "the references are an exact similarity");
+        cal.MirrorNorth.Should().Be(mirrorNorth, "the lower-residual handedness must win");
+
+        foreach (var w in world)
+        {
+            var projected = cal.ProjectWorld(w);
+            var expected = Forward(w);
+            projected.X.Should().BeApproximately(expected.X, 1e-6);
+            projected.Y.Should().BeApproximately(expected.Y, 1e-6);
+        }
+    }
+
+    [Fact]
+    public void ProjectWorld_honours_MirrorNorth_flag()
+    {
+        // Same scale/rotation/origin, opposite handedness → Z sign flips the
+        // north component, so the two projections differ for any Z != 0.
+        var plus = new AreaCalibration(1.0, 0.0, 0, 0, 2, 0) { MirrorNorth = false };
+        var minus = new AreaCalibration(1.0, 0.0, 0, 0, 2, 0) { MirrorNorth = true };
+        var w = new WorldCoord(10, 0, 7);
+
+        plus.ProjectWorld(w).Should().Be(new PixelPoint(10, -7));
+        minus.ProjectWorld(w).Should().Be(new PixelPoint(10, 7));
+    }
+}

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Services;
+using Legolas.ViewModels;
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Game;
@@ -26,39 +27,36 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
     }
 
-    private static (PlayerLogIngestionService svc, ScriptedStream stream, SpyAreaCalibration spy)
-        Build(GameConfig? config = null)
+    // Identity calibration: ProjectWorld(x,y,z) = (x, z) → trivial assertions.
+    private static AreaCalibration Identity() =>
+        new(1.0, 0.0, 0.0, 0.0, 2, 0.0);
+
+    private const string MapFx =
+        "[08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, " +
+        "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 67m west and 1181m south.\")";
+
+    private static (PlayerLogIngestionService svc, ScriptedStream stream, SpyAreaCalibration spy,
+        SessionState session) Build(AreaCalibration? calibration = null, GameConfig? config = null)
     {
         var stream = new ScriptedStream();
         var tracker = new PlayerAreaTracker(new AreaTransitionParser());
-        var spy = new SpyAreaCalibration();
+        var spy = new SpyAreaCalibration(calibration);
+        var session = new SessionState();
+        var settings = new LegolasSettings();
         var gates = new ModuleGates();
         gates.For("legolas").Open();
         var svc = new PlayerLogIngestionService(
-            stream, tracker, spy, gates, config ?? new GameConfig());
-        return (svc, stream, spy);
+            stream, new PlayerLogParser(), tracker, spy, session, settings, gates,
+            config ?? new GameConfig());
+        return (svc, stream, spy, session);
     }
+
+    // ---- area→calibration bridge (Phase 2) -------------------------------
 
     [Fact]
     public async Task Area_load_line_applies_that_area_calibration_once()
     {
-        var (svc, stream, spy) = Build();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
-        try
-        {
-            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
-            await stream.WaitForDrainAsync(cts.Token);
-
-            spy.SelectedAreas.Should().Equal("AreaEltibule");
-        }
-        finally { await Stop(svc, run, cts); }
-    }
-
-    [Fact]
-    public async Task Duplicate_area_line_does_not_re_apply()
-    {
-        var (svc, stream, spy) = Build();
+        var (svc, stream, spy, _) = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -66,7 +64,6 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
             stream.Push("[08:30:00] LOADING LEVEL AreaEltibule");
             await stream.WaitForDrainAsync(cts.Token);
-
             spy.SelectedAreas.Should().Equal("AreaEltibule");
         }
         finally { await Stop(svc, run, cts); }
@@ -75,7 +72,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Area_change_applies_each_distinct_area_in_order()
     {
-        var (svc, stream, spy) = Build();
+        var (svc, stream, spy, _) = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -83,24 +80,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
             stream.Push("[08:57:37] LOADING LEVEL AreaSerbule");
             await stream.WaitForDrainAsync(cts.Token);
-
             spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaSerbule");
-        }
-        finally { await Stop(svc, run, cts); }
-    }
-
-    [Fact]
-    public async Task Unrelated_line_is_a_noop()
-    {
-        var (svc, stream, spy) = Build();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
-        try
-        {
-            stream.Push("[08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, \"x\", ImportantInfo, \"y\")");
-            await stream.WaitForDrainAsync(cts.Token);
-
-            spy.SelectedAreas.Should().BeEmpty();
         }
         finally { await Stop(svc, run, cts); }
     }
@@ -108,7 +88,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task ChooseCharacter_resets_latch_so_same_area_re_applies()
     {
-        var (svc, stream, spy) = Build();
+        var (svc, stream, spy, _) = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -117,9 +97,6 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             stream.Push("[08:57:00] LOADING LEVEL ChooseCharacter");
             stream.Push("[09:00:39] LOADING LEVEL AreaEltibule");
             await stream.WaitForDrainAsync(cts.Token);
-
-            // Re-entry after character-select re-applies — defensive against an
-            // intervening projector reset.
             spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaEltibule");
         }
         finally { await Stop(svc, run, cts); }
@@ -129,27 +106,130 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     public async Task Startup_seed_applies_current_area_before_live_lines()
     {
         var logPath = Path.Combine(_tempDir, "Player.log");
-        // BOM-less UTF-8 — real Player.log carries no BOM (mirrors the
-        // PlayerAreaTracker seed-test convention).
         File.WriteAllText(
             logPath,
             "LocalPlayer: ProcessAddItem(Apple(1), -1, True)\n" +
             "LOADING LEVEL AreaEltibule\n" +
             "LocalPlayer: ProcessAddPlayer(...)\n",
             new UTF8Encoding(false));
-        var config = new GameConfig { GameRoot = _tempDir };
 
-        var (svc, stream, spy) = Build(config);
+        var (svc, _, spy, _) = Build(config: new GameConfig { GameRoot = _tempDir });
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
         {
-            // No live line pushed — the seed alone must have applied the area.
             await WaitUntil(() => spy.SelectedAreas.Count > 0, cts.Token);
             spy.SelectedAreas.Should().Equal("AreaEltibule");
         }
         finally { await Stop(svc, run, cts); }
     }
+
+    // ---- absolute ProcessMapFx placement (Phase 3) -----------------------
+
+    [Fact]
+    public async Task Calibrated_area_places_one_absolute_pin_at_projected_pixel()
+    {
+        var (svc, stream, _, session) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx);
+            await stream.WaitForDrainAsync(cts.Token);
+            // Wait on the terminal signal HandleMapTarget sets last, so the
+            // SelectedSurvey/IsInventoryVisible writes aren't raced.
+            await WaitUntil(() => session.LastLogEvent?.Contains("placed (absolute)") == true, cts.Token);
+
+            session.Surveys.Should().HaveCount(1);
+            var pin = session.Surveys[0];
+            pin.Name.Should().Be("Good Metal Slab");        // " is here" stripped
+            pin.Model.World.Should().Be(new WorldCoord(1236.00, 38.17, 2528.00));
+            // Identity calibration (s=1, θ=0, origin=0): px=X, py=-Z — screen-Y
+            // grows down while world-north (Z) grows up, so Z is negated.
+            pin.Model.PixelPos.Should().Be(new PixelPoint(1236.00, -2528.00));
+            session.SelectedSurvey.Should().BeSameAs(pin);
+            session.IsInventoryVisible.Should().BeTrue();
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Duplicate_world_coord_within_radius_does_not_stack()
+    {
+        var (svc, stream, _, session) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx);
+            // Same node re-surveyed re-emits the identical (X,Z); only the
+            // relative msg text drifts (67m → 66m).
+            stream.Push(MapFx.Replace("67m west and 1181m", "66m west and 1180m"));
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.Surveys.Count >= 1, cts.Token);
+
+            session.Surveys.Should().HaveCount(1);
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Distinct_targets_place_separate_pins()
+    {
+        var (svc, stream, _, session) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx);
+            stream.Push(
+                "[08:33:17] LocalPlayer: ProcessMapFx((1666.00, 36.95, 2620.00), 25, 1, " +
+                "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")");
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.Surveys.Count == 2, cts.Token);
+
+            session.Surveys.Should().HaveCount(2);
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Uncalibrated_area_does_not_place_and_reports_diagnostic()
+    {
+        var (svc, stream, _, session) = Build(calibration: null);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx);
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.LastLogEvent?.Contains("not calibrated") == true, cts.Token);
+
+            session.Surveys.Should().BeEmpty();
+            session.LastLogEvent.Should().Contain("not calibrated");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Motherlode_mode_ignores_absolute_targets()
+    {
+        var (svc, stream, _, session) = Build(calibration: Identity());
+        session.Mode = SessionMode.Motherlode;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx);
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.LastLogEvent?.Contains("Motherlode") == true, cts.Token);
+
+            session.Surveys.Should().BeEmpty();
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    // ---- helpers ----------------------------------------------------------
 
     private static async Task WaitUntil(Func<bool> predicate, CancellationToken ct)
     {
@@ -170,20 +250,23 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     }
 
     /// <summary>
-    /// Captures <see cref="IAreaCalibrationService.SelectArea"/> invocations
-    /// in order. Every other member is an inert stub — Phase 2 only exercises
-    /// the area→calibration bridge.
+    /// Captures <see cref="IAreaCalibrationService.SelectArea"/> calls and
+    /// reports a fixed <see cref="AreaCalibration"/> (or none) as the current
+    /// area's calibration.
     /// </summary>
     private sealed class SpyAreaCalibration : IAreaCalibrationService
     {
-        public List<string> SelectedAreas { get; } = new();
+        private readonly AreaCalibration? _cal;
+        public SpyAreaCalibration(AreaCalibration? cal) => _cal = cal;
 
+        public List<string> SelectedAreas { get; } = new();
         public void SelectArea(string areaKey) => SelectedAreas.Add(areaKey);
+
+        public AreaCalibration? CurrentCalibration => _cal;
+        public bool IsCurrentAreaCalibrated => _cal is not null;
 
         public string? CurrentAreaKey => null;
         public string? CurrentAreaFriendlyName => null;
-        public bool IsCurrentAreaCalibrated => false;
-        public AreaCalibration? CurrentCalibration => null;
         public IReadOnlyList<CalibrationReference> CurrentAreaReferences =>
             Array.Empty<CalibrationReference>();
         public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();


### PR DESCRIPTION
## Phase 3 of #454 — `ProcessMapFx` absolute placement (calibrated-area authority)

> **Stacked on [#457](https://github.com/moumantai-gg/mithril/pull/457) (Phase 2)** → base `feat/454-legolas-playerlog-ingestion`. Will rebase + retarget to `main` as #456→#457→this land.

The core pivot. Survey (`Check Survey`, Mining/Geology) and treasure-map (`Check Map`, Treasure Cartography) targets now come from Player.log `ProcessMapFx` as **exact absolute world coordinates**, projected through the per-area calibration — no anchor click, no relative offsets.

### What this adds
- **`PlayerLogParser`** (`ILogParser`) — parses the real captured grammar (signed coords; tolerant of the two varying middle ints `25, 1`). Motherlode emits `ProcessScreenText`, never `ProcessMapFx`, so it's excluded with **no special-casing** (verified with a real Motherlode line in the parser tests).
- **`AreaCalibration.ProjectWorld`** — the single canonical absolute world→pixel transform (origin + scale + rotation + the `MirrorNorth` reflection a similarity fit can't absorb). The calibration window's landmark "ghost" preview now delegates here, so the two **can't drift** (the duplicated formula and the now-dead `Project()` helper are removed — net DRY).
- **`PlayerLogIngestionService`** places one absolute pin per `ProcessMapFx`, `(X,Z)`-deduped (`MapTargetDedupRadiusMetres`, additive setting — no migration).

### Calibrated-area authority (the sequencing decision)
A survey use emits **both** a chat `[Status]` line *and* a Player.log `ProcessMapFx` line. To avoid double-placement during the 3→5 transition (the relative path isn't retired until Phase 5): when the current area **is calibrated**, the absolute path owns placement and the relative chat auto-place is **suppressed** (one pin); **uncalibrated** areas keep today's relative behaviour untouched (cold-start fallback until pin calibration lands in Phase 4). This matches the issue's "calibrate-by-playing primary; landmark/relative is the fallback for never-surveyed areas."

### Minimal FSM accommodation
Absolute targets need no anchor, so the **first absolute pin advances `AwaitingPosition→Listening`** (+ stamps `StartedAt`). The relative chat path can't add a pin while `AwaitingPosition` (gated on `CanAcceptSurvey`), so this edge is **absolute-only** and doesn't perturb existing FSM tests. The full FSM collapse remains Phase 5.

### Verification
`dotnet build Mithril.slnx` clean (0/0). New tests: `PlayerLogParser` (real grammar incl. negative coords + Motherlode/`ProcessMapPinAdd`/area non-match), `AreaCalibration.ProjectWorld` (solver exact-fit round-trip both handedness + `MirrorNorth`), `PlayerLogIngestionService` (placement, `(X,Z)` dedupe, distinct targets, uncalibrated diagnostic, Motherlode-mode), FSM `AwaitingPosition→Listening`. **277** Legolas tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
