### PR TITLE
feat(legolas): freehand pin calibration via ProcessMapPinAdd (#454)

### DIFF
--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -30,6 +30,23 @@ public sealed record MapTargetDetected(
     string Category,
     string Message) : GameEvent(Timestamp);
 
+/// <summary>
+/// Player.log <c>LocalPlayer: ProcessMapPinAdd(1, 0, 0, (X, 0.00, Z),
+/// "&lt;label&gt;")</c> — a user-dropped map pin's <b>exact world
+/// coordinate</b> (#454). Emitted live on placement <em>and bulk-replayed on
+/// area entry</em>, so consumers must gate on an explicit "begin calibration"
+/// arm to avoid ingesting the replay backlog.
+///
+/// <para><b>Label is diagnostic-only — never keyed off.</b> The
+/// (world↔overlay-pixel) pairing is established by the user's overlay click in
+/// turn order during the calibration flow, identified by interaction order,
+/// never by name (hard rule, #454).</para>
+/// </summary>
+public sealed record MapPinAdded(
+    DateTime Timestamp,
+    WorldCoord World,
+    string Label) : GameEvent(Timestamp);
+
 public sealed record ItemCollected(
     DateTime Timestamp,
     string Name,

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -73,6 +73,18 @@ public interface IAreaCalibrationService
 
     /// <summary>Raised for each <see cref="NoteSurvey"/> — the test-mode hook.</summary>
     event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
+
+    /// <summary>
+    /// Fed every <c>ProcessMapPinAdd</c> world coord by the Player.log
+    /// pipeline (#454). Re-raised as <see cref="PinAdded"/> so the calibration
+    /// window — and only when the user has armed pin calibration — can pair it
+    /// with an overlay click. A no-op for everyone else; this decouples the
+    /// ingestion service from the VM exactly like <see cref="NoteSurvey"/>.
+    /// </summary>
+    void NotePinAdded(WorldCoord world);
+
+    /// <summary>Raised for each <see cref="NotePinAdded"/> — the pin-calibration hook.</summary>
+    event EventHandler<WorldCoord>? PinAdded;
 }
 
 /// <summary>
@@ -187,6 +199,11 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
 
     public void NoteSurvey(string name, MetreOffset offset) =>
         SurveyObserved?.Invoke(this, new CalibrationSurveyObservation(name, offset));
+
+    public event EventHandler<WorldCoord>? PinAdded;
+
+    public void NotePinAdded(WorldCoord world) =>
+        PinAdded?.Invoke(this, world);
 
     public void ClearCurrentAreaCalibration()
     {

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -94,8 +94,19 @@ public sealed class PlayerLogIngestionService : BackgroundService
                 _areaTracker.Observe(raw);
                 ApplyAreaIfChanged();
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is MapTargetDetected mt)
-                    PostToUi(() => HandleMapTarget(mt));
+                switch (_parser.TryParse(raw.Line, raw.Timestamp))
+                {
+                    case MapTargetDetected mt:
+                        PostToUi(() => HandleMapTarget(mt));
+                        break;
+                    case MapPinAdded mp:
+                        // The calibration VM ignores this unless the user has
+                        // armed pin calibration (drops the area-entry replay
+                        // backlog). Label is never read — pairing is by the
+                        // user's overlay click in turn order.
+                        PostToUi(() => _areaCalibration.NotePinAdded(mp.World));
+                        break;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -6,10 +6,10 @@ using Legolas.Domain;
 namespace Legolas.Services;
 
 /// <summary>
-/// Player.log analog of <see cref="ChatLogParser"/> — pure line→event. #454
-/// Phase 3 parses <c>ProcessMapFx</c> (absolute survey/treasure-map targets);
-/// Phase 4 adds <c>ProcessMapPinAdd</c> on this same parser. One parser, many
-/// patterns, mirroring the ChatLog parser's shape.
+/// Player.log analog of <see cref="ChatLogParser"/> — pure line→event. #454:
+/// <c>ProcessMapFx</c> (absolute survey/treasure-map targets) and
+/// <c>ProcessMapPinAdd</c> (freehand pin-calibration world coords). One
+/// parser, many patterns, mirroring the ChatLog parser's shape.
 ///
 /// <para>Real captured grammar (live Player.log, 2026-05-18):</para>
 /// <code>
@@ -29,24 +29,45 @@ public sealed partial class PlayerLogParser : ILogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
     private static partial Regex MapFxRx();
 
+    // ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), "Calib 1")
+    // Leading three ints + the (x, y, z) triple + quoted label. The label is
+    // captured for diagnostics ONLY — pairing is turn-order, never by name.
+    [GeneratedRegex(
+        """ProcessMapPinAdd\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*\(\s*(?<x>-?\d+(?:\.\d+)?)\s*,\s*(?<y>-?\d+(?:\.\d+)?)\s*,\s*(?<z>-?\d+(?:\.\d+)?)\s*\)\s*,\s*"(?<label>[^"]*)"\s*\)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex MapPinAddRx();
+
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
         if (string.IsNullOrEmpty(line)) return null;
-        if (!line.Contains("ProcessMapFx", StringComparison.Ordinal)) return null;
 
-        var m = MapFxRx().Match(line);
-        if (!m.Success) return null;
-        if (!TryNum(m.Groups["x"].ValueSpan, out var x) ||
-            !TryNum(m.Groups["y"].ValueSpan, out var y) ||
-            !TryNum(m.Groups["z"].ValueSpan, out var z))
-            return null;
+        if (line.Contains("ProcessMapFx", StringComparison.Ordinal)
+            && MapFxRx().Match(line) is { Success: true } m
+            && TryNum(m.Groups["x"].ValueSpan, out var x)
+            && TryNum(m.Groups["y"].ValueSpan, out var y)
+            && TryNum(m.Groups["z"].ValueSpan, out var z))
+        {
+            return new MapTargetDetected(
+                timestamp,
+                new WorldCoord(x, y, z),
+                m.Groups["short"].Value,
+                m.Groups["cat"].Value,
+                m.Groups["msg"].Value);
+        }
 
-        return new MapTargetDetected(
-            timestamp,
-            new WorldCoord(x, y, z),
-            m.Groups["short"].Value,
-            m.Groups["cat"].Value,
-            m.Groups["msg"].Value);
+        if (line.Contains("ProcessMapPinAdd", StringComparison.Ordinal)
+            && MapPinAddRx().Match(line) is { Success: true } p
+            && TryNum(p.Groups["x"].ValueSpan, out var px)
+            && TryNum(p.Groups["y"].ValueSpan, out var py)
+            && TryNum(p.Groups["z"].ValueSpan, out var pz))
+        {
+            return new MapPinAdded(
+                timestamp,
+                new WorldCoord(px, py, pz),
+                p.Groups["label"].Value);
+        }
+
+        return null;
     }
 
     private static bool TryNum(ReadOnlySpan<char> s, out double v) =>

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -30,6 +30,7 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         _service = service;
         _service.Changed += OnServiceChanged;
         _service.SurveyObserved += OnSurveyObserved;
+        _service.PinAdded += OnPinAdded;
         Refresh();
     }
 
@@ -54,6 +55,29 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
     // Next viewport click drops/moves the player pin (armed by the button).
     private bool _armPlayerClick;
+
+    // #454 freehand pin calibration. ProcessMapPinAdd world coords queue up
+    // ONLY while armed (the area-entry bulk replay arrives disarmed → dropped);
+    // each subsequent overlay click pairs the OLDEST unpaired world point —
+    // turn-order, never by the pin's label.
+    private readonly Queue<WorldCoord> _pendingPins = new();
+    private int _pinSeq;
+
+    [ObservableProperty] private bool _pinCalibrationArmed;
+
+    public int PendingPinCount => _pendingPins.Count;
+
+    public string PinCalibrationStatus => PinCalibrationArmed
+        ? $"Pin calibration ARMED — drop ≥3 well-spread map pins in-game, then " +
+          $"click each on the overlay in the same order. {PendingPinCount} pending."
+        : "Pin calibration off. Cold-start path: works on a fogged map (no " +
+          "landmarks needed).";
+
+    partial void OnPinCalibrationArmedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(PinCalibrationStatus));
+        RaiseDebug();
+    }
 
     public bool HasPlayerPin => PlayerPin is not null;
     public double PlayerPinX => PlayerPin?.X ?? 0;
@@ -405,6 +429,27 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
             RaiseDebug();
             return;
         }
+        if (PinCalibrationArmed && _pendingPins.Count > 0)
+        {
+            // Pair the OLDEST unpaired world point with this click (turn
+            // order). A synthetic CalibrationReference flows through the exact
+            // same Placements/Solve path as landmark calibration — the ONLY
+            // delta is the world-coord source. The "Map pin N" name is the
+            // turn index, display-only; the ProcessMapPinAdd label is never
+            // consulted.
+            var world = _pendingPins.Dequeue();
+            var placed = new PlacedReference(
+                new CalibrationReference($"Map pin {++_pinSeq}", "MapPin", world), pixel);
+            Placements.Add(placed);
+            SelectedPlacement = placed;
+            ClickWarning = null;
+            OnPropertyChanged(nameof(CanSolve));
+            OnPropertyChanged(nameof(PendingPinCount));
+            OnPropertyChanged(nameof(PinCalibrationStatus));
+            SolveCommand.NotifyCanExecuteChanged();
+            RaiseDebug();
+            return;
+        }
         PlaceSelectedAt(pixel);
     }
 
@@ -543,6 +588,47 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         RaiseDebug();
     }
 
+    /// <summary>Arm/disarm freehand pin calibration. Arming clears any stale
+    /// pending pins so the area-entry replay can't leak in; disarming clears
+    /// the queue too.</summary>
+    [RelayCommand]
+    private void TogglePinCalibration()
+    {
+        PinCalibrationArmed = !PinCalibrationArmed;
+        _pendingPins.Clear();
+        if (PinCalibrationArmed)
+        {
+            _pinSeq = 0;
+            Instruction =
+                "Pin calibration: drop ≥3 (ideally 4) well-spread map pins in-game " +
+                "(works on a fogged/blank map — no landmarks needed), then click each " +
+                "on the overlay in the SAME order. Solve when ≥3 are placed.";
+            ClickWarning = null;
+        }
+        OnPropertyChanged(nameof(PendingPinCount));
+        OnPropertyChanged(nameof(PinCalibrationStatus));
+        RaiseDebug();
+    }
+
+    private void OnPinAdded(object? sender, WorldCoord world)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => EnqueuePin(world));
+        else EnqueuePin(world);
+    }
+
+    private void EnqueuePin(WorldCoord world)
+    {
+        // Disarmed → ignore (this is how the bulk area-entry replay is
+        // discarded). The label is intentionally not part of MapPinAdded's
+        // contract here — pairing is the user's next overlay click, in order.
+        if (!PinCalibrationArmed) return;
+        _pendingPins.Enqueue(world);
+        OnPropertyChanged(nameof(PendingPinCount));
+        OnPropertyChanged(nameof(PinCalibrationStatus));
+        RaiseDebug();
+    }
+
     // Viewport size, pushed from the view, so a far overlay pin clamps to the
     // edge instead of vanishing.
     private double _viewportW, _viewportH;
@@ -624,7 +710,14 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
     {
         Placements.Clear();
         SelectedPlacement = null;
+        // Pin calibration shares Placements — clear its queue + disarm so a
+        // half-done pin session can't bleed into the next (also covers
+        // Recalibrate, which routes through here).
+        _pendingPins.Clear();
+        PinCalibrationArmed = false;
         OnPropertyChanged(nameof(CanSolve));
+        OnPropertyChanged(nameof(PendingPinCount));
+        OnPropertyChanged(nameof(PinCalibrationStatus));
         SolveCommand.NotifyCanExecuteChanged();
         ResultText = null;
         RaiseDebug();

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml
@@ -121,6 +121,41 @@
                                 <Button Content="Clear surveys"
                                         Command="{Binding ClearSurveyPinsCommand}" Padding="8,4" />
                             </StackPanel>
+                            <!-- #454 freehand pin calibration — the cold-start
+                                 path (works on a fogged map; landmark calibration
+                                 can't, nothing visible to click). -->
+                            <Border Margin="0,8,0,0" Padding="6" CornerRadius="3"
+                                    Background="#FF12161B" BorderBrush="#FF2C3540" BorderThickness="1">
+                                <StackPanel>
+                                    <Button Command="{Binding TogglePinCalibrationCommand}"
+                                            Padding="8,4" HorizontalAlignment="Stretch">
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Setter Property="Content" Value="Begin pin calibration (cold-start)" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding PinCalibrationArmed}" Value="True">
+                                                        <Setter Property="Content" Value="Stop pin calibration" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                    </Button>
+                                    <TextBlock Text="{Binding PinCalibrationStatus}"
+                                               TextWrapping="Wrap" FontSize="11" Margin="0,5,0,0">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="#FF7E97AE" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding PinCalibrationArmed}" Value="True">
+                                                        <Setter Property="Foreground" Value="#FFFFC400" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Border>
+
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                 <Button Content="Project landmarks (ghosts)"
                                         ToolTip="Drop every unplaced landmark at its calibrated position — they should sit on the real landmarks"

--- a/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
@@ -58,11 +58,33 @@ public class PlayerLogParserTests
     [InlineData("[09:03:31] LocalPlayer: ProcessScreenText(ImportantInfo, \"The treasure is 1285 meters from here.\")")]
     [InlineData("[09:03:30] LocalPlayer: ProcessDoDelayLoop(1, Unset, \"Using Kur Mountains Simple Metal Motherlode Map\", 5305, AbortIfAttacked)")]
     [InlineData("[08:25:38] LocalPlayer: ProcessDoDelayLoop(0.5, Unset, \"Using Eltibule Good Mining Survey\", 5305, AbortIfAttacked)")]
-    [InlineData("[08:22:22] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), \"Calib 1\")")]
     [InlineData("LOADING LEVEL AreaEltibule")]
     [InlineData("")]
-    public void Returns_null_for_non_ProcessMapFx_lines(string line)
+    public void Returns_null_for_unrecognised_lines(string line)
     {
         _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
+    }
+
+    // Real captured ProcessMapPinAdd lines (live Player.log, 2026-05-18).
+    [Theory]
+    [InlineData(
+        "[08:22:22] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), \"\")",
+        -521.96, 368.39, "")]
+    [InlineData(
+        "[08:32:20] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")",
+        1145.39, 1323.40, "Calib 1")]
+    // A label that looks like an area/verb must STILL just be a label —
+    // pairing is turn-order, never by name (hard rule #454).
+    [InlineData(
+        "[08:32:38] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-355.16, 0.00, -392.82), \"AreaEltibule Check Survey\")",
+        -355.16, -392.82, "AreaEltibule Check Survey")]
+    public void Parses_ProcessMapPinAdd_world_coord_and_label(
+        string line, double x, double z, string label)
+    {
+        var evt = (MapPinAdded?)_parser.TryParse(line, DateTime.UtcNow);
+        evt.Should().NotBeNull();
+        evt!.World.X.Should().Be(x);
+        evt.World.Z.Should().Be(z);
+        evt.Label.Should().Be(label); // captured for diagnostics only
     }
 }

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -229,6 +229,26 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         finally { await Stop(svc, run, cts); }
     }
 
+    [Fact]
+    public async Task ProcessMapPinAdd_is_forwarded_to_NotePinAdded()
+    {
+        var (svc, stream, spy, session) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push("[08:32:20] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")");
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => spy.NotedPins.Count > 0, cts.Token);
+
+            spy.NotedPins.Should().ContainSingle()
+                .Which.Should().Be(new WorldCoord(1145.39, 0.00, 1323.40));
+            // It's a pin, not a target — no survey pin placed by ingestion.
+            session.Surveys.Should().BeEmpty();
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
     // ---- helpers ----------------------------------------------------------
 
     private static async Task WaitUntil(Func<bool> predicate, CancellationToken ct)
@@ -261,6 +281,10 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
 
         public List<string> SelectedAreas { get; } = new();
         public void SelectArea(string areaKey) => SelectedAreas.Add(areaKey);
+
+        public List<WorldCoord> NotedPins { get; } = new();
+        public void NotePinAdded(WorldCoord world) => NotedPins.Add(world);
+        public event EventHandler<WorldCoord>? PinAdded { add { } remove { } }
 
         public AreaCalibration? CurrentCalibration => _cal;
         public bool IsCurrentAreaCalibrated => _cal is not null;

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -653,6 +653,86 @@ public class CalibrationSessionViewModelTests
         s.MathText.Should().Contain("impliedScale=0.5000px/m");
     }
 
+    // ---- #454 freehand pin calibration ----------------------------------
+
+    private static CalibrationSessionViewModel ArmedPinVm(out FakeService svc)
+    {
+        svc = new FakeService
+        {
+            CurrentAreaFriendlyName = "Eltibule",
+            CurrentAreaKey = "AreaEltibule",
+            SolveResult = new AreaCalibration(0.4, 0.1, 5, 6, 3, 0.0),
+        };
+        var vm = new CalibrationSessionViewModel(svc);
+        vm.TogglePinCalibrationCommand.Execute(null);
+        vm.PinCalibrationArmed.Should().BeTrue();
+        return vm;
+    }
+
+    [Fact]
+    public void Disarmed_pins_are_dropped_so_area_entry_replay_cannot_leak()
+    {
+        var svc = new FakeService { CurrentAreaKey = "AreaEltibule" };
+        var vm = new CalibrationSessionViewModel(svc);
+
+        // Bulk area-entry replay arrives BEFORE the user arms — must be ignored.
+        svc.NotePinAdded(new WorldCoord(-521.96, 0, 368.39));
+        svc.NotePinAdded(new WorldCoord(367.28, 0, 2798.03));
+        vm.PendingPinCount.Should().Be(0);
+
+        // A click while disarmed/empty doesn't fabricate a placement.
+        vm.ViewportClickedCommand.Execute(new PixelPoint(100, 100));
+        vm.Placements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Pins_pair_with_overlay_clicks_in_turn_order_never_by_label()
+    {
+        var vm = ArmedPinVm(out var svc);
+
+        // The PinAdded contract is a bare WorldCoord — there is structurally
+        // no label the VM could key off. Drop three distinct world points…
+        var w0 = new WorldCoord(-521.96, 0, 368.39);
+        var w1 = new WorldCoord(367.28, 0, 2798.03);
+        var w2 = new WorldCoord(1145.39, 0, 1323.40);
+        svc.NotePinAdded(w0);
+        svc.NotePinAdded(w1);
+        svc.NotePinAdded(w2);
+        vm.PendingPinCount.Should().Be(3);
+
+        // …then click three overlay spots. Pairing is OLDEST-first (turn
+        // order): click#i ↔ pin#i, irrespective of anything else.
+        vm.ViewportClickedCommand.Execute(new PixelPoint(10, 11));
+        vm.ViewportClickedCommand.Execute(new PixelPoint(20, 22));
+        vm.ViewportClickedCommand.Execute(new PixelPoint(30, 33));
+
+        vm.Placements.Should().HaveCount(3);
+        vm.PendingPinCount.Should().Be(0);
+        vm.CanSolve.Should().BeTrue();
+
+        vm.SolveCommand.Execute(null);
+        svc.LastSolvePairs.Should().Equal(
+            (w0, new PixelPoint(10, 11)),
+            (w1, new PixelPoint(20, 22)),
+            (w2, new PixelPoint(30, 33)));
+    }
+
+    [Fact]
+    public void ClearPlacements_disarms_and_drops_pending_pins()
+    {
+        var vm = ArmedPinVm(out var svc);
+        svc.NotePinAdded(new WorldCoord(1, 0, 2));
+        vm.PendingPinCount.Should().Be(1);
+
+        vm.ClearPlacementsCommand.Execute(null);
+
+        vm.PinCalibrationArmed.Should().BeFalse();
+        vm.PendingPinCount.Should().Be(0);
+        // A pin arriving now is ignored again (disarmed).
+        svc.NotePinAdded(new WorldCoord(3, 0, 4));
+        vm.PendingPinCount.Should().Be(0);
+    }
+
     private sealed class FakeService : IAreaCalibrationService
     {
         public List<CalibrationReference> Refs { get; } = new();
@@ -704,5 +784,10 @@ public class CalibrationSessionViewModelTests
 
         public void NoteSurvey(string name, MetreOffset offset) =>
             SurveyObserved?.Invoke(this, new CalibrationSurveyObservation(name, offset));
+
+        public event EventHandler<WorldCoord>? PinAdded;
+
+        public void NotePinAdded(WorldCoord world) =>
+            PinAdded?.Invoke(this, world);
     }
 }


### PR DESCRIPTION
## Phase 4 of #454 — freehand pin calibration via `ProcessMapPinAdd`

> **Stacked on [#458](https://github.com/moumantai-gg/mithril/pull/458) (Phase 3)** → base `feat/454-processmapfx-absolute-placement`. Rebase/retarget to `main` as the stack lands.

The **cold-start-capable** calibration path. Landmark calibration (#443/#449) needs a *previously-explored* area — fog of war means a fresh area's map is blank, nothing to click. A dropped map pin works on a fogged/blank map because the pin's exact world coord comes from `Player.log`. This makes pin calibration the v1-primary path; landmark calibration stays as the complementary option for explored areas.

### Engine reuse — only the world-coord source changes
A synthetic `CalibrationReference` built from a live `ProcessMapPinAdd` coord flows through the **unchanged** `Placements` → `Solve` → `IAreaCalibrationService.CalibrateCurrentArea` path (the shipped #443/#449 solver/persist). Zero solver changes.

### Label-agnostic, by construction (hard rule #454)
`IAreaCalibrationService.PinAdded` carries a **bare `WorldCoord`** — there is structurally no label the VM could key off. The `ProcessMapPinAdd` label is parsed for diagnostics only. Pairing is the user's overlay click in **turn order**: each click pairs the *oldest unpaired* world point (place ≥3 in-game → click each on the overlay in the same order).

### Replay-arming gate
`ProcessMapPinAdd` **bulk-replays on area entry**. Pins are queued only while the user has explicitly armed pin calibration (`Begin pin calibration`); the area-entry replay arrives disarmed and is dropped. `ClearPlacements`/`Recalibrate` disarm + flush the queue.

### UI
`CalibrationOverlayView`: a "Begin pin calibration (cold-start)" toggle + an amber armed-status readout (`N pending`). All existing click/drag/nudge/Solve plumbing reused verbatim.

### Verification
`dotnet build Mithril.slnx` clean (0/0). New tests: parser `ProcessMapPinAdd` (real grammar, negative coords, **verb-like label proven ignored**); VM turn-order pairing → `Solve` receives `(world,pixel)` pairs in click order, disarmed-replay-dropped, `ClearPlacements` disarms; ingestion `ProcessMapPinAdd → NotePinAdded`. **283** Legolas tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
