### PR TITLE
feat(gamestate): live skill-state tracker from Player.log (#462)

### DIFF
--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -103,16 +103,16 @@ identically:
   `skills.json`; their level is derived from member sub-skills (Phrenology →
   Phrenology_Demons, …) and carried in `bonus` (`MaxBonusLevels` 125, `raw`
   stays 0). They never gain XP, so there is no per-level curve — hence
-  `max=0`, a **verified-exact runtime proxy** for `skills.json`'s
-  `IsUmbrellaSkill` / `XpTable:"None"` (`skills.json` is keyed by exactly the
-  log `type=` token, so the proxy maps 1:1). It is a proxy *only* because
-  `IReferenceDataService` doesn't yet surface a skill catalog (it parses
-  `skills.json` but exposes only the derived `AbilitiesBySkill`) — **not** an
-  "avoid reference data" rule: `Mithril.GameState` already depends on
-  `IReferenceDataService` (Inventory, Quests). Catalog + authoritative
-  enrichment tracked in #469 / #470. Kept in the snapshot — flagged, not
-  dropped — so a consumer decides; the leveling constraint set should exclude
-  them.
+  `max=0`, a **verified-exact runtime proxy** for the authoritative
+  `IReferenceDataService.Skills[key].XpTable == "None"` (`skills.json` is keyed
+  by exactly the log `type=` token, so it maps 1:1). That accessor **already
+  exists and is widely consumed** (Elrond, Celebrimbor, Silmarillion's own
+  Abilities tab, …) — the tracker uses the log proxy by **deliberate choice**
+  (keep the parser/service pure-string and unit-testable, no DI surface), not
+  because the data is unavailable. Optional reference-backed enrichment is the
+  independent follow-up #470 (no dependency on the Silmarillion-tab work
+  #469). Kept in the snapshot — flagged, not dropped — so a consumer decides;
+  the leveling constraint set should exclude them.
 - **`bonus` is gear/buff/form-derived for trainable skills, not progression** —
   volatile (moves as the player swaps equipment / shifts form); `Level` (raw)
   is the progression truth, and the projection keeps them separate and **never
@@ -221,8 +221,8 @@ lock — do non-trivial work off-thread.
   (verified: Augmentation/Performance/Phrenology all carry both; trainable
   skills like Tailoring/Endurance/NatureAppreciation have a real `XpTable` and
   no umbrella flag). `skills.json` is keyed by the same `type=` token, so the
-  proxy is 1:1 — no name list, no fuzzy mapping. The runtime predicate is
-  log-only for v1 because `IReferenceDataService` doesn't yet surface a skill
-  catalog (#469) — *not* an architectural rule (`Mithril.GameState` already
-  consumes `IReferenceDataService` in Inventory/Quests). Swapping the proxy for
-  the authoritative flag is tracked in #470.
+  proxy is 1:1 — no name list, no fuzzy mapping. `IReferenceDataService.Skills`
+  (with `XpTable`) already exists and is consumed elsewhere; the tracker uses
+  the log proxy by deliberate choice (pure-string, unit-testable), and swapping
+  in the authoritative value is the independent follow-up #470 (does **not**
+  depend on the Silmarillion-tab work #469).

--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -97,14 +97,23 @@ identically:
 
 - **Capped skills** (`raw == max`, max > 0) → `IsCapped == true`. `tnl`/`xp`
   are stale at the cap; do not present "N xp to next level" for them.
-- **Pseudo-skills** (`max == 0`, e.g. Augmentation / Performance / Phrenology,
-  reported `raw=0,bonus=N,max=0`) → `IsTrainable == false`. Kept in the
-  snapshot (flagged, not dropped) so a consumer decides; the leveling
-  constraint set should filter them out.
-- **`bonus` is gear/buff/form-derived, not progression.** It is volatile (it
-  moves as the player swaps equipment or shifts form). `Level` (raw) is the
-  progression truth. The projection keeps them as separate fields and **never
-  sums them** — consumers must not either.
+- **Umbrella skills** (`max == 0`, e.g. Augmentation / Performance /
+  Phrenology, reported `raw=0,bonus=N,max=0`) → `IsTrainable == false`. These
+  are **real skills**, flagged `IsUmbrellaSkill` with `XpTable:"None"` in
+  `skills.json`; their level is derived from member sub-skills (Phrenology →
+  Phrenology_Demons, …) and carried in `bonus` (`MaxBonusLevels` 125, `raw`
+  stays 0). They never gain XP, so there is no per-level curve — hence
+  `max=0`, which is the runtime proxy for the reference classification (this
+  service takes no reference-data dependency by design; `skills.json` is keyed
+  by exactly the log `type=` token, so the proxy maps 1:1). Kept in the
+  snapshot — flagged, not dropped — so a consumer decides; the leveling
+  constraint set should exclude them.
+- **`bonus` is gear/buff/form-derived for trainable skills, not progression** —
+  volatile (moves as the player swaps equipment / shifts form); `Level` (raw)
+  is the progression truth, and the projection keeps them separate and **never
+  sums them** (consumers must not either). The exception is umbrella skills
+  (above), where `raw` is always 0 and `bonus` *is* the derived level — which
+  is exactly why `IsTrainable == false` excludes them from XP-leveling logic.
 - **Timestamps are UTC.** `Player.log`'s `[HH:MM:SS]` prefix is UTC;
   `PlayerSkillSnapshot.MeasuredAt` is therefore UTC. Surface it for freshness:
   a *live* snapshot can still be minutes old if the player has idled in one
@@ -202,7 +211,10 @@ lock — do non-trivial work off-thread.
   (zone/relog) fires; whether it fires on *every* zone change is unconfirmed.
   The wholesale-replace design is robust either way (worst case: a slightly
   older but still-complete table until the next fire).
-- **Pseudo-skill set.** Only Augmentation / Performance / Phrenology observed
-  with `max==0`. The code uses the `max==0` predicate (not a name list), so a
-  new one is handled automatically — but enumerate against the skills
-  reference before relying on the exact set anywhere.
+- **Umbrella-skill classification — RESOLVED.** `max==0` in the log is the
+  exact runtime proxy for `skills.json`'s `IsUmbrellaSkill` / `XpTable:"None"`
+  (verified: Augmentation/Performance/Phrenology all carry both; trainable
+  skills like Tailoring/Endurance/NatureAppreciation have a real `XpTable` and
+  no umbrella flag). `skills.json` is keyed by the same `type=` token, so the
+  proxy is 1:1 — no name list, no fuzzy mapping. The runtime predicate stays
+  log-only by design (no reference-data dependency).

--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -1,0 +1,133 @@
+# Player skill-state service (`Mithril.GameState.Skills`)
+
+Shared, `Player.log`-fed live view of the player's current skill progression —
+every skill, without requiring a character re-export. Issue: #462.
+
+## Why it exists
+
+The neutral leveling input (`Mithril.Leveling.SkillState`) historically had a
+single producer: Elrond's `SnapshotPlanInput.ToSkillState(CharacterSnapshot)`,
+fed from the character **export**. That export is the only reason leveling
+advice goes stale until the player manually re-exports. `Player.log` already
+carries the whole picture continuously, so this service makes it the live
+source.
+
+## What it reads
+
+Two log lines, both built from the identical
+`{type=…,raw=…,bonus=…,xp=…,tnl=…,max=…}` struct grammar:
+
+| Line | Meaning | Service action |
+|---|---|---|
+| `LocalPlayer: ProcessLoadSkills({…}, {…}, …)` | Full skill-table dump (~125 rows). Emitted at login **and on every zone / session transition.** | **Wholesale replace** of tracked state. |
+| `LocalPlayer: ProcessUpdateSkill({…}, <bool>, <delta>, 0, 0)` | One skill's progression delta. | **Per-skill upsert** (copy-on-write). |
+
+### Field mapping (1:1, raw parse → projection)
+
+| Log field | `SkillProgressRecord` (raw) | `SkillProgressSnapshot` (projection) |
+|---|---|---|
+| `type` | `SkillKey` | the map key |
+| `raw` | `Level` | `Level` |
+| `bonus` | `BonusLevels` | `BonusLevels` |
+| `xp` | `XpTowardNextLevel` | `XpTowardNextLevel` |
+| `tnl` | `XpNeededForNextLevel` | `XpNeededForNextLevel` |
+| `max` | `MaxLevel` | `MaxLevel` + `IsCapped`/`IsTrainable` |
+
+## Data caveats (interpreted into predicates, not assumed away)
+
+These are encoded on `SkillProgressSnapshot` so every consumer applies them
+identically:
+
+- **Capped skills** (`raw == max`, max > 0) → `IsCapped == true`. `tnl`/`xp`
+  are stale at the cap; do not present "N xp to next level" for them.
+- **Pseudo-skills** (`max == 0`, e.g. Augmentation / Performance / Phrenology,
+  reported `raw=0,bonus=N,max=0`) → `IsTrainable == false`. Kept in the
+  snapshot (flagged, not dropped) so a consumer decides; the leveling
+  constraint set should filter them out.
+- **`bonus` is gear/buff/form-derived, not progression.** It is volatile (it
+  moves as the player swaps equipment or shifts form). `Level` (raw) is the
+  progression truth. The projection keeps them as separate fields and **never
+  sums them** — consumers must not either.
+- **Timestamps are UTC.** `Player.log`'s `[HH:MM:SS]` prefix is UTC;
+  `PlayerSkillSnapshot.MeasuredAt` is therefore UTC. Surface it for freshness:
+  a *live* snapshot can still be minutes old if the player has idled in one
+  zone.
+- **Skill keys are internal names** (`Anatomy_Bears`, `Performance_Dance`),
+  kept verbatim. UI resolves the key → display name (model keeps the key —
+  project-wide convention).
+
+## Self-heal / warm-up contract
+
+`ProcessLoadSkills` re-fires on every zone change, so a wholesale replace on
+each one keeps state correct **even when Mithril starts tailing mid-session** —
+the next zone transition re-establishes the full table (typically within
+minutes). Until the first `ProcessLoadSkills` of the session:
+
+- `Current` is `PlayerSkillSnapshot.Empty` (`Source == None`,
+  `MeasuredAt == null`); **or**
+- if isolated `ProcessUpdateSkill` lines arrive first, `Current` is a
+  deliberately **partial** snapshot (`Source == LiveLog`) — better than
+  nothing; the next `ProcessLoadSkills` makes it whole.
+
+This window is the documented behaviour, not a bug. No reverse-scan startup
+seed is built (the self-heal makes it unnecessary for v1); it remains a
+possible future enhancement.
+
+## Architecture decision: GameState-native type, no `Mithril.Leveling` dependency
+
+The service exposes a **GameState-native** `PlayerSkillSnapshot` /
+`SkillProgressSnapshot`, *not* `Mithril.Leveling.SkillState`. Rationale:
+
+- `Mithril.GameState` is neutral shared infrastructure; coupling it to the
+  leveling-math library for a consumer that isn't wired yet would be poor
+  hygiene and widen the dependency graph of every module that already depends
+  on game state.
+- The established pattern is **consumer-owned adapters**: Elrond's
+  `SnapshotPlanInput` already adapts the export's per-skill record → `SkillState`
+  with a flat field copy. A future live-source adapter mirrors that exactly
+  (`IPlayerSkillState` → `SkillState`) and lives on the consumer side.
+- This is a refinement of the #462 scope wording ("`SkillState Current`"),
+  recorded as a comment on the issue. It does not fork the neutral abstraction;
+  it keeps the adapter where the codebase already puts it.
+
+Consumer-side wiring (Elrond preferring live over export, freshness badges) is
+explicitly **out of scope** here — service work only.
+
+## Threading
+
+`Current` is a reference read of an immutable object (lock-free). The snapshot
+reference is swapped under an internal lock; `Subscribe` replays the current
+snapshot and attaches the handler **atomically under the same lock the
+ingestion loop fires under**, which closes the late-subscribe race (mirrors
+`InventoryService`). Handlers run synchronously under that lock — do
+non-trivial work off-thread.
+
+## Components
+
+- `Skills/Parsing/SkillEvents.cs` — `SkillProgressRecord` (raw parse),
+  `SkillsSnapshotEvent`, `SkillProgressUpdateEvent`.
+- `Skills/Parsing/SkillLogParser.cs` — `ILogParser`; `LoadSkillsRx` /
+  `UpdateSkillRx` guards + the `SkillTupleRx` workhorse. Catalogued in
+  `log-patterns.json` as `shared.SkillLogParser.*` (the `shared` module prefix
+  follows the precedent of the other `Mithril.GameState` parsers in the
+  catalog; parity asserted by `LogPatternCatalogParityTests`).
+- `Skills/IPlayerSkillState.cs` — interface + `PlayerSkillSnapshot` /
+  `SkillProgressSnapshot` / `SkillStateSource`.
+- `Skills/PlayerSkillStateService.cs` — `BackgroundService` + `IPlayerSkillState`,
+  registered in `GameStateServiceCollectionExtensions.AddMithrilGameState`.
+
+## Verification owed
+
+- **`ProcessUpdateSkill` trailing positionals** (announce bool, XP delta, two
+  zeros) are intentionally **not parsed** — semantics are only inferred from a
+  small sample. The leading struct is authoritative for state, so they are not
+  needed. Revisit if a consumer wants "last XP gain" telemetry; capture a
+  level-up sample first (all observed had the trailing `0, 0`).
+- **`ProcessLoadSkills` trigger.** Confirmed at login + several mid-session
+  (zone/relog) fires; whether it fires on *every* zone change is unconfirmed.
+  The wholesale-replace design is robust either way (worst case: a slightly
+  older but still-complete table until the next fire).
+- **Pseudo-skill set.** Only Augmentation / Performance / Phrenology observed
+  with `max==0`. The code uses the `max==0` predicate (not a name list), so a
+  new one is handled automatically — but enumerate against the skills
+  reference before relying on the exact set anywhere.

--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -48,8 +48,36 @@ Three exact matches across the offset. `arg3` is keyed by **internal name**
 (`type=Anatomy_Bears`) whereas the chat line is display-named ("Bear and
 Bugbear Anatomy") — so `Player.log` is the *better* ingestion source (no
 fragile display→key reverse lookup); chat is the verification oracle. The
-`<bool>` (announce / batch-vs-discrete) and the trailing `0, 0` are still not
-parsed.
+`<bool>` (announce / batch-vs-discrete) and the trailing `0, 0` are not parsed.
+
+### Live level-up capture (verification resolved)
+
+A captured Tailoring level-up:
+
+```
+[12:38:57] {type=Tailoring,raw=9, bonus=2,xp=199,tnl=210,max=50}, True, 160, 0, 0
+           chat: "You earned 160 XP in Tailoring."
+[12:39:02] {type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0
+           chat: "You earned 160 XP and reached level 12 in Tailoring!"
+```
+
+Settles the open questions:
+
+- **`arg3` is the *gross* XP gained, even across the rollover.** Tick 2
+  crossed the boundary and `arg3 = 160` = the chat value; the engine does
+  **not** split it pre/post-level. Summing `XpGained` stays correct through
+  level-ups (arithmetic: 39 → +160 = 199 (<210) → +160 = 359, overflow
+  359−210 = 149 into the new level, new `tnl` 420, `raw` 9→10). So
+  `XpGained` is authoritative across a single-level rollover, not
+  "best-effort."
+- **`args 4,5` stay `0, 0` through a level-up** — not a levels-gained /
+  skill-up count. Reserved/unused; no longer "verification owed."
+- **No dedicated level-up line in `Player.log`.** The level-up is conveyed
+  *only* by `raw` incrementing on the next `ProcessUpdateSkill` — exactly what
+  `SkillChange.Previous.Level < Current.Level` detects.
+- **Chat "reached level 12" = `raw(10) + bonus(2)`** (effective level);
+  `Player.log` `raw` is the base. Reconfirms keeping `Level`/`BonusLevels`
+  separate.
 
 ### Field mapping (1:1, raw parse → projection)
 
@@ -163,15 +191,13 @@ lock — do non-trivial work off-thread.
 
 ## Verification owed
 
-- **`XpGained` (`arg3`) at a level-up / cap-reaching tick.** `arg3` itself is
-  chat-corroborated within a level (see the triangulation table above), so it
-  is *not* wholesale unverified. What remains unobserved is its value on the
-  exact tick a skill levels or caps (every captured sample had trailing
-  `0, 0`, no level-up): treat `XpGained` as authoritative within a level,
-  best-effort across a boundary. Low impact — capped skills then go silent and
-  the next `ProcessLoadSkills` reasserts absolute state, so any cross-boundary
-  `XpGained`-sum drift self-heals. The `<bool>` and trailing `0, 0` remain
-  unparsed (informational only).
+- **`XpGained` (`arg3`) / trailing positionals — RESOLVED** by the live
+  level-up capture above. `arg3` is the gross XP gained, chat-matched, correct
+  across a single-level rollover; `args 4,5` stay `0, 0` through a level-up
+  (not levels-gained). Remaining unknown is narrow and low-impact: a
+  multi-level single tick (raw jumping by >1) is unobserved — the model still
+  holds (`raw` is taken from the struct, `XpGained` is the gross total), only
+  the per-level decomposition (which no consumer needs) is unverified.
 - **`ProcessLoadSkills` trigger.** Confirmed at login + several mid-session
   (zone/relog) fires; whether it fires on *every* zone change is unconfirmed.
   The wholesale-replace design is robust either way (worst case: a slightly

--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -20,7 +20,36 @@ Two log lines, both built from the identical
 | Line | Meaning | Service action |
 |---|---|---|
 | `LocalPlayer: ProcessLoadSkills({…}, {…}, …)` | Full skill-table dump (~125 rows). Emitted at login **and on every zone / session transition.** | **Wholesale replace** of tracked state. |
-| `LocalPlayer: ProcessUpdateSkill({…}, <bool>, <delta>, 0, 0)` | One skill's progression delta. | **Per-skill upsert** (copy-on-write). |
+| `LocalPlayer: ProcessUpdateSkill({…}, <bool>, <gained>, 0, 0)` | One skill's progression delta + XP earned this tick. | **Per-skill upsert** (copy-on-write) + a `Delta` change event carrying `XpGained`. |
+
+### Capped skills go silent
+
+Once a skill reaches its cap (`raw == max`), PG emits **no further
+`ProcessUpdateSkill`** for it. This needs no special-casing: the change
+channel simply stops producing `Delta` events for that skill; its absolute
+state still arrives in every `ProcessLoadSkills` (where it shows `raw == max`
+→ `IsCapped`). The *capping tick itself* is the last `Delta` for the skill and
+is where `Previous.IsCapped == false && Current.IsCapped == true`.
+
+### `XpGained` (the third positional) — chat-triangulated
+
+`arg3` of `ProcessUpdateSkill` is the XP earned on that tick. It was validated
+against the authoritative chat `[Status] You earned N XP in <Skill>.` line for
+the same events, lining the `Player.log` (UTC) and `ChatLogs` (local, +1h)
+timelines up:
+
+| Event | Chat `[Status]` | `ProcessUpdateSkill` `arg3` |
+|---|---|---|
+| 11:36:42 UTC | "earned 26 XP in Endurance" | `{type=Endurance,…}, True, **26**, …` |
+| 11:36:42 UTC | "earned 577 XP in Psychology" | `{type=Psychology,…}, False, **577**, …` |
+| 11:36:52 UTC | "earned 48 XP in Bear and Bugbear Anatomy" | `{type=Anatomy_Bears,…}, True, **48**, …` |
+
+Three exact matches across the offset. `arg3` is keyed by **internal name**
+(`type=Anatomy_Bears`) whereas the chat line is display-named ("Bear and
+Bugbear Anatomy") — so `Player.log` is the *better* ingestion source (no
+fragile display→key reverse lookup); chat is the verification oracle. The
+`<bool>` (announce / batch-vs-discrete) and the trailing `0, 0` are still not
+parsed.
 
 ### Field mapping (1:1, raw parse → projection)
 
@@ -93,36 +122,56 @@ The service exposes a **GameState-native** `PlayerSkillSnapshot` /
 Consumer-side wiring (Elrond preferring live over export, freshness badges) is
 explicitly **out of scope** here — service work only.
 
+## Two subscription channels
+
+- **`Subscribe(Action<PlayerSkillSnapshot>)`** — whole-state. Replays the
+  current snapshot on attach, then pushes the full snapshot on every change.
+  For "what is the player's skill state now" consumers.
+- **`SubscribeChanges(Action<SkillChange>)`** — granular. **No replay** (a
+  change is an event, not state — read `Current` for state). One `Delta` per
+  `ProcessUpdateSkill` carrying `XpGained`; one `SnapshotReplace` per skill
+  whose projection *actually differs* on a `ProcessLoadSkills` (a no-op re-sync
+  emits nothing; `XpGained == 0` for snapshot changes). Derived signals fall
+  out of `Previous`/`Current`: level-up = `Previous?.Level < Current.Level`;
+  just-hit-cap = `Previous is { IsCapped: false } && Current.IsCapped` (then
+  the skill goes silent — see above).
+
 ## Threading
 
 `Current` is a reference read of an immutable object (lock-free). The snapshot
-reference is swapped under an internal lock; `Subscribe` replays the current
-snapshot and attaches the handler **atomically under the same lock the
-ingestion loop fires under**, which closes the late-subscribe race (mirrors
-`InventoryService`). Handlers run synchronously under that lock — do
-non-trivial work off-thread.
+reference is swapped under an internal lock; both `Subscribe` (replay + attach)
+and live dispatch happen **atomically under the same lock the ingestion loop
+fires under**, which closes the late-subscribe race (mirrors
+`InventoryService`). Snapshot handlers then change handlers fire under that
+lock — do non-trivial work off-thread.
 
 ## Components
 
 - `Skills/Parsing/SkillEvents.cs` — `SkillProgressRecord` (raw parse),
-  `SkillsSnapshotEvent`, `SkillProgressUpdateEvent`.
+  `SkillsSnapshotEvent`, `SkillProgressUpdateEvent` (incl. `XpGained`).
 - `Skills/Parsing/SkillLogParser.cs` — `ILogParser`; `LoadSkillsRx` /
-  `UpdateSkillRx` guards + the `SkillTupleRx` workhorse. Catalogued in
-  `log-patterns.json` as `shared.SkillLogParser.*` (the `shared` module prefix
-  follows the precedent of the other `Mithril.GameState` parsers in the
-  catalog; parity asserted by `LogPatternCatalogParityTests`).
+  `UpdateSkillRx` guards, the `SkillTupleRx` workhorse, and `XpGainRx` for
+  `arg3`. Catalogued in `log-patterns.json` as `shared.SkillLogParser.*` (the
+  `shared` module prefix follows the precedent of the other `Mithril.GameState`
+  parsers in the catalog; parity asserted by `LogPatternCatalogParityTests`).
 - `Skills/IPlayerSkillState.cs` — interface + `PlayerSkillSnapshot` /
   `SkillProgressSnapshot` / `SkillStateSource`.
+- `Skills/SkillChange.cs` — `SkillChange` / `SkillChangeKind` (the
+  `SubscribeChanges` channel payload).
 - `Skills/PlayerSkillStateService.cs` — `BackgroundService` + `IPlayerSkillState`,
   registered in `GameStateServiceCollectionExtensions.AddMithrilGameState`.
 
 ## Verification owed
 
-- **`ProcessUpdateSkill` trailing positionals** (announce bool, XP delta, two
-  zeros) are intentionally **not parsed** — semantics are only inferred from a
-  small sample. The leading struct is authoritative for state, so they are not
-  needed. Revisit if a consumer wants "last XP gain" telemetry; capture a
-  level-up sample first (all observed had the trailing `0, 0`).
+- **`XpGained` (`arg3`) at a level-up / cap-reaching tick.** `arg3` itself is
+  chat-corroborated within a level (see the triangulation table above), so it
+  is *not* wholesale unverified. What remains unobserved is its value on the
+  exact tick a skill levels or caps (every captured sample had trailing
+  `0, 0`, no level-up): treat `XpGained` as authoritative within a level,
+  best-effort across a boundary. Low impact — capped skills then go silent and
+  the next `ProcessLoadSkills` reasserts absolute state, so any cross-boundary
+  `XpGained`-sum drift self-heals. The `<bool>` and trailing `0, 0` remain
+  unparsed (informational only).
 - **`ProcessLoadSkills` trigger.** Confirmed at login + several mid-session
   (zone/relog) fires; whether it fires on *every* zone change is unconfirmed.
   The wholesale-replace design is robust either way (worst case: a slightly

--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -103,11 +103,16 @@ identically:
   `skills.json`; their level is derived from member sub-skills (Phrenology →
   Phrenology_Demons, …) and carried in `bonus` (`MaxBonusLevels` 125, `raw`
   stays 0). They never gain XP, so there is no per-level curve — hence
-  `max=0`, which is the runtime proxy for the reference classification (this
-  service takes no reference-data dependency by design; `skills.json` is keyed
-  by exactly the log `type=` token, so the proxy maps 1:1). Kept in the
-  snapshot — flagged, not dropped — so a consumer decides; the leveling
-  constraint set should exclude them.
+  `max=0`, a **verified-exact runtime proxy** for `skills.json`'s
+  `IsUmbrellaSkill` / `XpTable:"None"` (`skills.json` is keyed by exactly the
+  log `type=` token, so the proxy maps 1:1). It is a proxy *only* because
+  `IReferenceDataService` doesn't yet surface a skill catalog (it parses
+  `skills.json` but exposes only the derived `AbilitiesBySkill`) — **not** an
+  "avoid reference data" rule: `Mithril.GameState` already depends on
+  `IReferenceDataService` (Inventory, Quests). Catalog + authoritative
+  enrichment tracked in #469 / #470. Kept in the snapshot — flagged, not
+  dropped — so a consumer decides; the leveling constraint set should exclude
+  them.
 - **`bonus` is gear/buff/form-derived for trainable skills, not progression** —
   volatile (moves as the player swaps equipment / shifts form); `Level` (raw)
   is the progression truth, and the projection keeps them separate and **never
@@ -216,5 +221,8 @@ lock — do non-trivial work off-thread.
   (verified: Augmentation/Performance/Phrenology all carry both; trainable
   skills like Tailoring/Endurance/NatureAppreciation have a real `XpTable` and
   no umbrella flag). `skills.json` is keyed by the same `type=` token, so the
-  proxy is 1:1 — no name list, no fuzzy mapping. The runtime predicate stays
-  log-only by design (no reference-data dependency).
+  proxy is 1:1 — no name list, no fuzzy mapping. The runtime predicate is
+  log-only for v1 because `IReferenceDataService` doesn't yet surface a skill
+  catalog (#469) — *not* an architectural rule (`Mithril.GameState` already
+  consumes `IReferenceDataService` in Inventory/Quests). Swapping the proxy for
+  the authoritative flag is tracked in #470.

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -5,6 +5,8 @@ using Mithril.GameState.Movement;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
 using Mithril.GameState.Sessions;
+using Mithril.GameState.Skills;
+using Mithril.GameState.Skills.Parsing;
 using Mithril.Shared.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -41,6 +43,15 @@ public static class GameStateServiceCollectionExtensions
         // one tracker, registered once here — consumers inject the tracker.
         services.AddSingleton<AreaTransitionParser>();
         services.AddSingleton<PlayerAreaTracker>();
+
+        // Shared live skill state from Player.log (ProcessLoadSkills /
+        // ProcessUpdateSkill) — no character re-export required. Single parser,
+        // single tracker; consumers inject IPlayerSkillState. See issue #462.
+        services.AddSingleton<SkillLogParser>();
+        services
+            .AddSingleton<PlayerSkillStateService>()
+            .AddSingleton<IPlayerSkillState>(sp => sp.GetRequiredService<PlayerSkillStateService>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerSkillStateService>());
 
         // Player position is shared live game-state (Palantir debug surface,
         // future overlay/positioning consumers). Self-feeding hosted service —

--- a/src/Mithril.GameState/Skills/IPlayerSkillState.cs
+++ b/src/Mithril.GameState/Skills/IPlayerSkillState.cs
@@ -159,4 +159,26 @@ public interface IPlayerSkillState
     /// subscription to stop receiving events.</para>
     /// </summary>
     IDisposable Subscribe(Action<PlayerSkillSnapshot> handler);
+
+    /// <summary>
+    /// Attach a handler that receives a granular <see cref="SkillChange"/> per
+    /// skill that actually moved — the channel for consumers that care
+    /// <em>which</em> skill changed (level-ups, XP feeds) rather than the whole
+    /// snapshot.
+    ///
+    /// <para>Unlike <see cref="Subscribe"/> there is <b>no replay</b>: a
+    /// <see cref="SkillChange"/> is an event, not state. A late subscriber sees
+    /// changes from the moment it attaches; for current state it reads
+    /// <see cref="Current"/>. A <c>ProcessLoadSkills</c> emits one
+    /// <see cref="SkillChangeKind.SnapshotReplace"/> only for skills whose
+    /// projection differs from (or is new vs.) the prior state — a no-op
+    /// re-sync produces nothing. A <c>ProcessUpdateSkill</c> emits one
+    /// <see cref="SkillChangeKind.Delta"/> carrying
+    /// <see cref="SkillChange.XpGained"/>.</para>
+    ///
+    /// <para>Same threading contract as <see cref="Subscribe"/>: the handler
+    /// runs synchronously under the tracker's lock on the ingestion thread —
+    /// do non-trivial work off-thread. Dispose to stop receiving.</para>
+    /// </summary>
+    IDisposable SubscribeChanges(Action<SkillChange> handler);
 }

--- a/src/Mithril.GameState/Skills/IPlayerSkillState.cs
+++ b/src/Mithril.GameState/Skills/IPlayerSkillState.cs
@@ -52,11 +52,16 @@ public readonly record struct SkillProgressSnapshot(
     int MaxLevel)
 {
     /// <summary>
-    /// True when the skill is a real trainable skill (<c>max &gt; 0</c>).
-    /// False for the pseudo-skills PG reports as <c>raw=0,bonus=N,max=0</c>
-    /// (Augmentation / Performance / Phrenology and similar). These are kept in
-    /// the snapshot — flagged rather than dropped — so a consumer can decide;
-    /// the leveling constraint set should filter them out.
+    /// True when the skill advances via an XP curve (<c>max &gt; 0</c>). False
+    /// for <b>umbrella skills</b> — real skills flagged <c>IsUmbrellaSkill</c>
+    /// /<c>XpTable:"None"</c> in <c>skills.json</c> (Augmentation / Performance /
+    /// Phrenology, …) whose level is derived from member sub-skills and carried
+    /// in <see cref="BonusLevels"/> (<see cref="Level"/> stays 0). They never
+    /// gain XP, so they have no per-level curve and report <c>max=0</c>; that is
+    /// the runtime proxy for the reference classification (this assembly takes
+    /// no reference-data dependency by design). Kept in the snapshot — flagged,
+    /// not dropped — so a consumer decides; the leveling constraint set should
+    /// exclude them.
     /// </summary>
     public bool IsTrainable => MaxLevel > 0;
 

--- a/src/Mithril.GameState/Skills/IPlayerSkillState.cs
+++ b/src/Mithril.GameState/Skills/IPlayerSkillState.cs
@@ -1,0 +1,162 @@
+using Mithril.GameState.Skills.Parsing;
+
+namespace Mithril.GameState.Skills;
+
+/// <summary>
+/// Where the current <see cref="PlayerSkillSnapshot"/> came from. Lets a
+/// consumer prefer live data and surface provenance / freshness.
+/// </summary>
+public enum SkillStateSource
+{
+    /// <summary>
+    /// Nothing observed yet — the tracker has not seen a <c>ProcessLoadSkills</c>
+    /// or <c>ProcessUpdateSkill</c> line this session. The snapshot is
+    /// <see cref="PlayerSkillSnapshot.Empty"/>.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Built by tailing <c>Player.log</c> (<c>ProcessLoadSkills</c> /
+    /// <c>ProcessUpdateSkill</c>). The default and, today, only populated
+    /// source. The enum is left open so a future export-fed source can be
+    /// distinguished without a breaking change.
+    /// </summary>
+    LiveLog = 1,
+}
+
+/// <summary>
+/// Consumer-facing projection of one skill's progression — the raw
+/// <see cref="SkillProgressRecord"/> with the data caveats from issue #462
+/// interpreted into intent-revealing predicates so every consumer applies them
+/// the same way.
+/// </summary>
+/// <param name="Level">Unbuffed base level (the log's <c>raw</c>). This is the
+/// progression-truth value the leveling constraint set keys off — never add
+/// <see cref="BonusLevels"/> to it for "level achieved".</param>
+/// <param name="BonusLevels">Gear / buff / form level bonus (the log's
+/// <c>bonus</c>). Volatile and <em>not</em> progression; surfaced so a consumer
+/// can show effective level if it wants, kept strictly separate from
+/// <see cref="Level"/>.</param>
+/// <param name="XpTowardNextLevel">XP into the current level (the log's
+/// <c>xp</c>). Only meaningful when <see cref="IsCapped"/> is false.</param>
+/// <param name="XpNeededForNextLevel">XP threshold for the next level (the
+/// log's <c>tnl</c>). PG leaves a stale value here at the cap — only meaningful
+/// when <see cref="IsCapped"/> is false.</param>
+/// <param name="MaxLevel">Level cap (the log's <c>max</c>). <c>0</c> for a
+/// non-trainable pseudo-skill.</param>
+public readonly record struct SkillProgressSnapshot(
+    int Level,
+    int BonusLevels,
+    long XpTowardNextLevel,
+    long XpNeededForNextLevel,
+    int MaxLevel)
+{
+    /// <summary>
+    /// True when the skill is a real trainable skill (<c>max &gt; 0</c>).
+    /// False for the pseudo-skills PG reports as <c>raw=0,bonus=N,max=0</c>
+    /// (Augmentation / Performance / Phrenology and similar). These are kept in
+    /// the snapshot — flagged rather than dropped — so a consumer can decide;
+    /// the leveling constraint set should filter them out.
+    /// </summary>
+    public bool IsTrainable => MaxLevel > 0;
+
+    /// <summary>
+    /// True when the skill has reached its cap (<c>raw &gt;= max</c>, max &gt; 0).
+    /// <see cref="XpTowardNextLevel"/> / <see cref="XpNeededForNextLevel"/> are
+    /// stale and meaningless once capped — do not present "N xp to next level"
+    /// for a capped skill.
+    /// </summary>
+    public bool IsCapped => MaxLevel > 0 && Level >= MaxLevel;
+}
+
+/// <summary>
+/// An immutable, atomically-consistent view of the player's whole skill table
+/// at one instant: the per-skill map plus when and from where it was measured.
+/// Returned by value so a consumer never observes a torn read (map updated but
+/// timestamp not, or vice versa).
+/// </summary>
+public sealed class PlayerSkillSnapshot
+{
+    /// <summary>The empty snapshot — no skills, never measured, source
+    /// <see cref="SkillStateSource.None"/>. The cold-start value.</summary>
+    public static PlayerSkillSnapshot Empty { get; } =
+        new(new Dictionary<string, SkillProgressSnapshot>(StringComparer.Ordinal), null, SkillStateSource.None);
+
+    internal PlayerSkillSnapshot(
+        IReadOnlyDictionary<string, SkillProgressSnapshot> skills,
+        DateTime? measuredAt,
+        SkillStateSource source)
+    {
+        Skills = skills;
+        MeasuredAt = measuredAt;
+        Source = source;
+    }
+
+    /// <summary>
+    /// Skill internal name → progression. Internal-name keyed (<c>"Vampirism"</c>,
+    /// <c>"Anatomy_Bears"</c>) — UI resolves the key to a display name, the
+    /// model keeps the key (project-wide convention). Ordinal-keyed.
+    /// </summary>
+    public IReadOnlyDictionary<string, SkillProgressSnapshot> Skills { get; }
+
+    /// <summary>
+    /// UTC timestamp of the log line that produced this snapshot, or
+    /// <c>null</c> if nothing has been observed yet. (Player.log timestamps are
+    /// UTC.) Surface this for freshness — a live snapshot can still be minutes
+    /// old if the player has been idle in one zone.
+    /// </summary>
+    public DateTime? MeasuredAt { get; }
+
+    /// <summary>Provenance of this snapshot.</summary>
+    public SkillStateSource Source { get; }
+
+    /// <summary>Convenience lookup for one skill.</summary>
+    public bool TryGet(string skillKey, out SkillProgressSnapshot progress)
+        => Skills.TryGetValue(skillKey, out progress);
+}
+
+/// <summary>
+/// Shared, <c>Player.log</c>-fed live view of the player's current skill
+/// progression — every skill, without requiring a character re-export.
+///
+/// <para>Built by tailing two log lines (<c>ProcessLoadSkills</c> = full
+/// snapshot at login / zone change; <c>ProcessUpdateSkill</c> = per-skill
+/// delta). Because <c>ProcessLoadSkills</c> re-fires on zone transitions, the
+/// tracker <b>self-heals</b>: even if Mithril starts tailing mid-session, the
+/// next zone change re-establishes the full table. Until the first
+/// <c>ProcessLoadSkills</c> of the session is observed, <see cref="Current"/>
+/// is <see cref="PlayerSkillSnapshot.Empty"/> (or partial, if only isolated
+/// <c>ProcessUpdateSkill</c> lines have been seen) — this warm-up window is the
+/// documented contract, not a bug.</para>
+///
+/// <para>This is neutral shared infrastructure (it does not know about leveling
+/// math or any module). A consumer that needs the leveling-engine
+/// <c>SkillState</c> shape adapts this projection itself — mirroring how
+/// Elrond's <c>SnapshotPlanInput</c> already adapts the character export — so
+/// <c>Mithril.GameState</c> takes no dependency on <c>Mithril.Leveling</c>.</para>
+/// </summary>
+public interface IPlayerSkillState
+{
+    /// <summary>
+    /// The current immutable snapshot. Atomically consistent: the map,
+    /// <see cref="PlayerSkillSnapshot.MeasuredAt"/>, and
+    /// <see cref="PlayerSkillSnapshot.Source"/> always belong to the same
+    /// observation. Never null — <see cref="PlayerSkillSnapshot.Empty"/> before
+    /// the first observation.
+    /// </summary>
+    PlayerSkillSnapshot Current { get; }
+
+    /// <summary>
+    /// Attach a handler that is invoked immediately with the
+    /// <see cref="Current"/> snapshot (replay) and then again on every
+    /// subsequent change. Replay + live-attach are atomic under an internal
+    /// lock, so a late subscriber cannot miss the snapshot that landed between
+    /// resolving the service and subscribing.
+    ///
+    /// <para>The handler runs synchronously under the tracker's lock — both for
+    /// the replay (on the caller's thread) and for live dispatch (on the log
+    /// ingestion thread). Do non-trivial work off-thread. Dispose the returned
+    /// subscription to stop receiving events.</para>
+    /// </summary>
+    IDisposable Subscribe(Action<PlayerSkillSnapshot> handler);
+}

--- a/src/Mithril.GameState/Skills/IPlayerSkillState.cs
+++ b/src/Mithril.GameState/Skills/IPlayerSkillState.cs
@@ -58,13 +58,13 @@ public readonly record struct SkillProgressSnapshot(
     /// Phrenology, …) whose level is derived from member sub-skills and carried
     /// in <see cref="BonusLevels"/> (<see cref="Level"/> stays 0). They never
     /// gain XP, so they have no per-level curve and report <c>max=0</c>; that is
-    /// a verified-exact runtime proxy for skills.json's
-    /// <c>IsUmbrellaSkill</c>/<c>XpTable:"None"</c> — a proxy only because
-    /// <c>IReferenceDataService</c> doesn't yet surface a skill catalog
-    /// (#469/#470), not an avoid-reference-data rule (this assembly already
-    /// uses <c>IReferenceDataService</c> elsewhere). Kept in the snapshot —
-    /// flagged, not dropped — so a consumer decides; the leveling constraint
-    /// set should exclude them.
+    /// a verified-exact runtime proxy for the authoritative
+    /// <c>IReferenceDataService.Skills[key].XpTable == "None"</c> (already
+    /// exposed and widely consumed). The tracker stays log-only by deliberate
+    /// choice — pure-string, unit-testable, no DI surface — with optional
+    /// reference-backed enrichment as the independent follow-up #470. Kept in
+    /// the snapshot — flagged, not dropped — so a consumer decides; the
+    /// leveling constraint set should exclude them.
     /// </summary>
     public bool IsTrainable => MaxLevel > 0;
 

--- a/src/Mithril.GameState/Skills/IPlayerSkillState.cs
+++ b/src/Mithril.GameState/Skills/IPlayerSkillState.cs
@@ -58,10 +58,13 @@ public readonly record struct SkillProgressSnapshot(
     /// Phrenology, …) whose level is derived from member sub-skills and carried
     /// in <see cref="BonusLevels"/> (<see cref="Level"/> stays 0). They never
     /// gain XP, so they have no per-level curve and report <c>max=0</c>; that is
-    /// the runtime proxy for the reference classification (this assembly takes
-    /// no reference-data dependency by design). Kept in the snapshot — flagged,
-    /// not dropped — so a consumer decides; the leveling constraint set should
-    /// exclude them.
+    /// a verified-exact runtime proxy for skills.json's
+    /// <c>IsUmbrellaSkill</c>/<c>XpTable:"None"</c> — a proxy only because
+    /// <c>IReferenceDataService</c> doesn't yet surface a skill catalog
+    /// (#469/#470), not an avoid-reference-data rule (this assembly already
+    /// uses <c>IReferenceDataService</c> elsewhere). Kept in the snapshot —
+    /// flagged, not dropped — so a consumer decides; the leveling constraint
+    /// set should exclude them.
     /// </summary>
     public bool IsTrainable => MaxLevel > 0;
 

--- a/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
@@ -65,14 +65,27 @@ public sealed record SkillsSnapshotEvent(DateTime Timestamp, IReadOnlyList<Skill
 
 /// <summary>
 /// A single skill's progression changed, parsed from a
-/// <c>ProcessUpdateSkill({…}, &lt;bool&gt;, &lt;delta&gt;, 0, 0)</c> line. Only
-/// the leading struct is consumed: it carries the new authoritative state, so
-/// the tracker upserts from it directly. The trailing positionals (announce
-/// bool, XP delta, two zeros) are intentionally <b>not</b> parsed — their
-/// semantics are only inferred from a small sample (verification owed, see the
-/// service docs / issue #462) and the struct alone is sufficient for state.
+/// <c>ProcessUpdateSkill({…}, &lt;bool&gt;, &lt;gained&gt;, 0, 0)</c> line. The
+/// leading struct carries the new authoritative absolute state; the third
+/// positional (<c>&lt;gained&gt;</c>) is the XP earned on this tick.
+///
+/// <para><b>Why we trust <see cref="XpGained"/>.</b> It was triangulated
+/// against the authoritative chat <c>[Status] You earned N XP in &lt;Skill&gt;</c>
+/// line for the same events across the Player.log(UTC)/ChatLogs(local) offset —
+/// e.g. Endurance 26, Psychology 577, Anatomy_Bears 48 all matched exactly. So
+/// it is authoritative <em>within a level</em>. The behaviour on the level-up /
+/// cap-reaching tick is still unobserved (every captured sample had trailing
+/// <c>0, 0</c> and no level-up): treat <see cref="XpGained"/> as best-effort
+/// across a level/cap boundary. This is low-impact — capped skills then go
+/// silent (PG emits no further <c>ProcessUpdateSkill</c> for them) and the next
+/// <c>ProcessLoadSkills</c> reasserts absolute state, so any cross-boundary
+/// drift self-heals. The remaining two positionals (announce bool, two zeros)
+/// are still not parsed; the bool's batch-vs-discrete meaning is informational
+/// only.</para>
 /// </summary>
 /// <param name="Timestamp">The source log line's timestamp (UTC).</param>
 /// <param name="Skill">The single skill record from the line's struct.</param>
-public sealed record SkillProgressUpdateEvent(DateTime Timestamp, SkillProgressRecord Skill)
+/// <param name="XpGained">The third positional — XP earned this tick,
+/// chat-corroborated within a level.</param>
+public sealed record SkillProgressUpdateEvent(DateTime Timestamp, SkillProgressRecord Skill, long XpGained)
     : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
@@ -33,8 +33,14 @@ namespace Mithril.GameState.Skills.Parsing;
 ///   ("to next level"): the threshold for the next level. Also stale at the
 ///   cap.</item>
 ///   <item><see cref="MaxLevel"/> — the struct's <c>max=</c>: the level cap.
-///   <c>0</c> marks a non-trainable pseudo-skill (Augmentation / Performance /
-///   Phrenology and similar, which report <c>raw=0,bonus=N,max=0</c>).</item>
+///   <c>0</c> marks an <b>umbrella skill</b> — a <em>real</em> skill flagged
+///   <c>IsUmbrellaSkill</c> with <c>XpTable:"None"</c> in <c>skills.json</c>
+///   (Augmentation / Performance / Phrenology, …). It never gains XP; its level
+///   is derived from member sub-skills and carried in <see cref="BonusLevels"/>
+///   (so it reports <c>raw=0,bonus=N,max=0</c>). <c>max==0</c> is the
+///   runtime proxy for that classification — <c>Mithril.GameState</c> has no
+///   reference-data dependency by design, and the proxy is exact (skills.json
+///   is keyed by this same <c>type=</c> token).</item>
 /// </list>
 /// </summary>
 public readonly record struct SkillProgressRecord(

--- a/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
@@ -38,14 +38,13 @@ namespace Mithril.GameState.Skills.Parsing;
 ///   (Augmentation / Performance / Phrenology, …). It never gains XP; its level
 ///   is derived from member sub-skills and carried in <see cref="BonusLevels"/>
 ///   (so it reports <c>raw=0,bonus=N,max=0</c>). <c>max==0</c> is a runtime
-///   <em>proxy</em> for skills.json's <c>IsUmbrellaSkill</c>/<c>XpTable:"None"</c>
-///   classification — verified exact (skills.json is keyed by this same
-///   <c>type=</c> token). It is a proxy only because
-///   <c>IReferenceDataService</c> does not yet surface a skill catalog (it
-///   parses skills.json but exposes only the derived <c>AbilitiesBySkill</c>);
-///   not because this assembly avoids reference data (it already consumes
-///   <c>IReferenceDataService</c> in Inventory/Quests). Authoritative
-///   enrichment is tracked in #470 (prereq #469).</item>
+///   <em>proxy</em> for the authoritative <c>SkillEntry.XpTable == "None"</c>,
+///   verified exact (skills.json is keyed by this same <c>type=</c> token). The
+///   tracker stays log-only by deliberate choice — the parser/service remain
+///   pure-string and unit-testable without a DI surface — even though
+///   <c>IReferenceDataService.Skills</c> is already available (this assembly
+///   already injects <c>IReferenceDataService</c> in Inventory/Quests).
+///   Optional authoritative enrichment is the independent follow-up #470.</item>
 /// </list>
 /// </summary>
 public readonly record struct SkillProgressRecord(

--- a/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
@@ -1,0 +1,78 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Skills.Parsing;
+
+/// <summary>
+/// One skill's progression facet exactly as Project Gorgon emits it inside the
+/// <c>{type=…,raw=…,bonus=…,xp=…,tnl=…,max=…}</c> struct shared by the
+/// <c>ProcessLoadSkills</c> (login / zone snapshot) and <c>ProcessUpdateSkill</c>
+/// (per-skill delta) log lines.
+///
+/// <para>This is the raw parse record — a faithful 1:1 of the log fields, before
+/// any caveat interpretation. <see cref="Mithril.GameState.Skills.SkillProgressSnapshot"/>
+/// is the consumer-facing projection that layers the capped / trainable rules on
+/// top.</para>
+///
+/// <list type="bullet">
+///   <item><see cref="SkillKey"/> — the skill's internal name (the struct's
+///   <c>type=</c>), e.g. <c>"Vampirism"</c>, <c>"Anatomy_Bears"</c>,
+///   <c>"Performance_Dance"</c>. Carries the underscore form verbatim; UI is
+///   responsible for resolving it to a display name (model keeps the key — the
+///   project-wide skill-key→display-name convention).</item>
+///   <item><see cref="Level"/> — the struct's <c>raw=</c>: the unbuffed base
+///   level. This is the progression-truth value; never sum it with
+///   <see cref="BonusLevels"/>.</item>
+///   <item><see cref="BonusLevels"/> — the struct's <c>bonus=</c>: levels added
+///   by gear / buffs / forms. Volatile (it moves as the player swaps equipment
+///   or shifts form — cf. the <c>ProcessSetActiveSkills</c> mount cycling) and is
+///   <em>not</em> progression.</item>
+///   <item><see cref="XpTowardNextLevel"/> — the struct's <c>xp=</c>: XP
+///   accumulated into the current level. Meaningless once
+///   <see cref="MaxLevel"/> is reached (PG leaves a stale value there).</item>
+///   <item><see cref="XpNeededForNextLevel"/> — the struct's <c>tnl=</c>
+///   ("to next level"): the threshold for the next level. Also stale at the
+///   cap.</item>
+///   <item><see cref="MaxLevel"/> — the struct's <c>max=</c>: the level cap.
+///   <c>0</c> marks a non-trainable pseudo-skill (Augmentation / Performance /
+///   Phrenology and similar, which report <c>raw=0,bonus=N,max=0</c>).</item>
+/// </list>
+/// </summary>
+public readonly record struct SkillProgressRecord(
+    string SkillKey,
+    int Level,
+    int BonusLevels,
+    long XpTowardNextLevel,
+    long XpNeededForNextLevel,
+    int MaxLevel);
+
+/// <summary>
+/// A full skill-table snapshot, parsed from a <c>ProcessLoadSkills(…)</c> line.
+/// Project Gorgon emits this right after <c>Logged in as character &lt;name&gt;</c>
+/// and again on zone / session transitions, so it is <b>authoritative and
+/// complete</b> — <see cref="Mithril.GameState.Skills.PlayerSkillStateService"/>
+/// treats it as a wholesale replace of the tracked state, never a merge. The
+/// re-fire on zone changes is what lets the tracker self-heal after a
+/// mid-session start (see the service docs).
+/// </summary>
+/// <param name="Timestamp">The source log line's timestamp (UTC — Player.log's
+/// <c>[HH:MM:SS]</c> prefix is UTC).</param>
+/// <param name="Skills">Every skill in the dump, in log order. ~125 entries in
+/// practice, including capped (<c>raw==max</c>) and pseudo (<c>max==0</c>)
+/// rows — the parser does not filter; interpretation is the snapshot layer's
+/// job.</param>
+public sealed record SkillsSnapshotEvent(DateTime Timestamp, IReadOnlyList<SkillProgressRecord> Skills)
+    : LogEvent(Timestamp);
+
+/// <summary>
+/// A single skill's progression changed, parsed from a
+/// <c>ProcessUpdateSkill({…}, &lt;bool&gt;, &lt;delta&gt;, 0, 0)</c> line. Only
+/// the leading struct is consumed: it carries the new authoritative state, so
+/// the tracker upserts from it directly. The trailing positionals (announce
+/// bool, XP delta, two zeros) are intentionally <b>not</b> parsed — their
+/// semantics are only inferred from a small sample (verification owed, see the
+/// service docs / issue #462) and the struct alone is sufficient for state.
+/// </summary>
+/// <param name="Timestamp">The source log line's timestamp (UTC).</param>
+/// <param name="Skill">The single skill record from the line's struct.</param>
+public sealed record SkillProgressUpdateEvent(DateTime Timestamp, SkillProgressRecord Skill)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
@@ -37,10 +37,15 @@ namespace Mithril.GameState.Skills.Parsing;
 ///   <c>IsUmbrellaSkill</c> with <c>XpTable:"None"</c> in <c>skills.json</c>
 ///   (Augmentation / Performance / Phrenology, …). It never gains XP; its level
 ///   is derived from member sub-skills and carried in <see cref="BonusLevels"/>
-///   (so it reports <c>raw=0,bonus=N,max=0</c>). <c>max==0</c> is the
-///   runtime proxy for that classification — <c>Mithril.GameState</c> has no
-///   reference-data dependency by design, and the proxy is exact (skills.json
-///   is keyed by this same <c>type=</c> token).</item>
+///   (so it reports <c>raw=0,bonus=N,max=0</c>). <c>max==0</c> is a runtime
+///   <em>proxy</em> for skills.json's <c>IsUmbrellaSkill</c>/<c>XpTable:"None"</c>
+///   classification — verified exact (skills.json is keyed by this same
+///   <c>type=</c> token). It is a proxy only because
+///   <c>IReferenceDataService</c> does not yet surface a skill catalog (it
+///   parses skills.json but exposes only the derived <c>AbilitiesBySkill</c>);
+///   not because this assembly avoids reference data (it already consumes
+///   <c>IReferenceDataService</c> in Inventory/Quests). Authoritative
+///   enrichment is tracked in #470 (prereq #469).</item>
 /// </list>
 /// </summary>
 public readonly record struct SkillProgressRecord(

--- a/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillEvents.cs
@@ -71,17 +71,21 @@ public sealed record SkillsSnapshotEvent(DateTime Timestamp, IReadOnlyList<Skill
 ///
 /// <para><b>Why we trust <see cref="XpGained"/>.</b> It was triangulated
 /// against the authoritative chat <c>[Status] You earned N XP in &lt;Skill&gt;</c>
-/// line for the same events across the Player.log(UTC)/ChatLogs(local) offset —
-/// e.g. Endurance 26, Psychology 577, Anatomy_Bears 48 all matched exactly. So
-/// it is authoritative <em>within a level</em>. The behaviour on the level-up /
-/// cap-reaching tick is still unobserved (every captured sample had trailing
-/// <c>0, 0</c> and no level-up): treat <see cref="XpGained"/> as best-effort
-/// across a level/cap boundary. This is low-impact — capped skills then go
-/// silent (PG emits no further <c>ProcessUpdateSkill</c> for them) and the next
-/// <c>ProcessLoadSkills</c> reasserts absolute state, so any cross-boundary
-/// drift self-heals. The remaining two positionals (announce bool, two zeros)
-/// are still not parsed; the bool's batch-vs-discrete meaning is informational
-/// only.</para>
+/// line across the Player.log(UTC)/ChatLogs(local) offset — Endurance 26,
+/// Psychology 577, Anatomy_Bears 48 all matched exactly. A live level-up
+/// capture then confirmed it holds <em>across the rollover</em>: Tailoring
+/// <c>raw=9,xp=199,tnl=210, …160</c> then <c>raw=10,xp=149,tnl=420, …160</c>,
+/// with chat "earned 160 XP and reached level 12 in Tailoring" — i.e.
+/// <see cref="XpGained"/> is the <b>gross</b> XP gained that tick (matching
+/// chat), the engine does <em>not</em> split it pre/post-level, so a consumer
+/// summing it stays correct through level-ups. The trailing
+/// <c>0, 0</c> positionals were observed to stay <c>0, 0</c> <em>through</em> a
+/// level-up — they are <b>not</b> a levels-gained / skill-up count; treat as
+/// reserved. The announce bool's batch-vs-discrete meaning is informational
+/// only and still not parsed. A level-up is conveyed solely by <c>raw</c>
+/// incrementing on the next event (PG emits no dedicated level-up line);
+/// the chat "reached level N" uses the <em>effective</em> level
+/// (<c>raw + bonus</c>), whereas <c>raw</c> here is the base.</para>
 /// </summary>
 /// <param name="Timestamp">The source log line's timestamp (UTC).</param>
 /// <param name="Skill">The single skill record from the line's struct.</param>

--- a/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
@@ -1,0 +1,103 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Skills.Parsing;
+
+/// <summary>
+/// Parses Project Gorgon's two skill-progression log lines into typed events:
+///
+/// <list type="bullet">
+///   <item><c>LocalPlayer: ProcessLoadSkills({type=…}, {type=…}, …)</c> — the
+///   full skill-table dump emitted at login and on zone / session transitions.
+///   Yields a <see cref="SkillsSnapshotEvent"/> carrying every parsed row.</item>
+///   <item><c>LocalPlayer: ProcessUpdateSkill({type=…}, &lt;bool&gt;, &lt;delta&gt;, 0, 0)</c>
+///   — a single skill's progression delta. Yields a
+///   <see cref="SkillProgressUpdateEvent"/> for the one row in the leading
+///   struct; the trailing positionals are deliberately ignored (see
+///   <see cref="SkillProgressUpdateEvent"/>).</item>
+/// </list>
+///
+/// Both lines share the identical <c>{type=…,raw=…,bonus=…,xp=…,tnl=…,max=…}</c>
+/// struct grammar; <see cref="SkillTupleRx"/> is the single workhorse applied
+/// over the whole line (one match for an update, ~125 for a snapshot).
+///
+/// <para>The regexes are unanchored — the same convention every other
+/// <c>Player.log</c> parser in the codebase uses — and the
+/// <see cref="LoadSkillsRx"/> / <see cref="UpdateSkillRx"/> guards both pin the
+/// <c>LocalPlayer:</c> prefix so an unrelated line that merely mentions the
+/// verb cannot trigger a parse. A cheap substring pre-check short-circuits the
+/// (overwhelmingly common) unrelated line before any regex runs.</para>
+///
+/// <para>This parser is independent of Samwise's
+/// <c>GardenLogParser.GardeningXpRx</c> (<c>ProcessUpdateSkill.*type=Gardening</c>):
+/// both can match the same Gardening update line; Samwise consumes it as a
+/// gardening heartbeat while this parser folds Gardening into the full skill
+/// state. There is no coupling or ordering dependency between them.</para>
+///
+/// <para>Catalogued in <c>log-patterns.json</c> as
+/// <c>shared.SkillLogParser.{LoadSkillsRx,UpdateSkillRx,SkillTupleRx}</c>
+/// (the <c>shared</c> module prefix matches the precedent set by the other
+/// <c>Mithril.GameState</c> parsers in the catalog).</para>
+/// </summary>
+public sealed partial class SkillLogParser : ILogParser
+{
+    // Guard: a real ProcessLoadSkills line (full-table dump). Pins the
+    // LocalPlayer: prefix so only the genuine emitter matches.
+    [GeneratedRegex(@"LocalPlayer: ProcessLoadSkills\(", RegexOptions.CultureInvariant)]
+    private static partial Regex LoadSkillsRx();
+
+    // Guard: a real ProcessUpdateSkill line. The trailing `\{` ensures the
+    // leading argument is the skill struct (not some other overload form).
+    [GeneratedRegex(@"LocalPlayer: ProcessUpdateSkill\(\{", RegexOptions.CultureInvariant)]
+    private static partial Regex UpdateSkillRx();
+
+    // Workhorse: one skill struct. Applied via Matches() over the whole line —
+    // exactly one for an update, the entire table for a snapshot. Skill keys
+    // carry underscores (Anatomy_Bears, Performance_Dance) so \w+ is correct;
+    // all numeric fields are non-negative integers in observed data.
+    [GeneratedRegex(
+        @"\{type=(?<type>\w+),raw=(?<raw>\d+),bonus=(?<bonus>\d+),xp=(?<xp>\d+),tnl=(?<tnl>\d+),max=(?<max>\d+)\}",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex SkillTupleRx();
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        // Fast path: the vast majority of Player.log lines are neither verb.
+        // Substring check before any regex, mirroring the other parsers.
+        if (!line.Contains("ProcessLoadSkills", StringComparison.Ordinal)
+            && !line.Contains("ProcessUpdateSkill", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (LoadSkillsRx().IsMatch(line))
+        {
+            var skills = new List<SkillProgressRecord>();
+            foreach (Match m in SkillTupleRx().Matches(line))
+            {
+                skills.Add(ToRecord(m));
+            }
+
+            // A ProcessLoadSkills line with no parseable struct is degenerate
+            // (truncated log, grammar drift). Emit nothing rather than a
+            // spurious empty snapshot that would wipe live state.
+            return skills.Count == 0 ? null : new SkillsSnapshotEvent(timestamp, skills);
+        }
+
+        if (UpdateSkillRx().IsMatch(line))
+        {
+            var m = SkillTupleRx().Match(line);
+            return m.Success ? new SkillProgressUpdateEvent(timestamp, ToRecord(m)) : null;
+        }
+
+        return null;
+    }
+
+    private static SkillProgressRecord ToRecord(Match m) => new(
+        SkillKey: m.Groups["type"].Value,
+        Level: int.Parse(m.Groups["raw"].ValueSpan),
+        BonusLevels: int.Parse(m.Groups["bonus"].ValueSpan),
+        XpTowardNextLevel: long.Parse(m.Groups["xp"].ValueSpan),
+        XpNeededForNextLevel: long.Parse(m.Groups["tnl"].ValueSpan),
+        MaxLevel: int.Parse(m.Groups["max"].ValueSpan));
+}

--- a/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
@@ -51,6 +51,14 @@ public sealed partial class SkillLogParser : ILogParser
     [GeneratedRegex(@"LocalPlayer: ProcessUpdateSkill\(\{", RegexOptions.CultureInvariant)]
     private static partial Regex UpdateSkillRx();
 
+    // ProcessUpdateSkill's third positional: XP earned this tick. Anchored on
+    // the verb + struct close so it can only match the genuine emitter. The
+    // value is chat-corroborated within a level (see SkillProgressUpdateEvent).
+    [GeneratedRegex(
+        @"ProcessUpdateSkill\(\{[^}]*\},\s*\w+,\s*(?<gained>\d+)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex XpGainRx();
+
     // Workhorse: one skill struct. Applied via Matches() over the whole line —
     // exactly one for an update, the entire table for a snapshot. Skill keys
     // carry underscores (Anatomy_Bears, Performance_Dance) so \w+ is correct;
@@ -87,7 +95,13 @@ public sealed partial class SkillLogParser : ILogParser
         if (UpdateSkillRx().IsMatch(line))
         {
             var m = SkillTupleRx().Match(line);
-            return m.Success ? new SkillProgressUpdateEvent(timestamp, ToRecord(m)) : null;
+            if (!m.Success) return null;
+
+            // arg3 = XP gained this tick. Defaults to 0 if the tail is absent
+            // (grammar drift) — the struct is still authoritative for state.
+            var g = XpGainRx().Match(line);
+            long gained = g.Success ? long.Parse(g.Groups["gained"].ValueSpan) : 0;
+            return new SkillProgressUpdateEvent(timestamp, ToRecord(m), gained);
         }
 
         return null;

--- a/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
+++ b/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
@@ -36,6 +36,7 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
 
     private readonly object _lock = new();
     private readonly List<Action<PlayerSkillSnapshot>> _handlers = new();
+    private readonly List<Action<SkillChange>> _changeHandlers = new();
     private volatile PlayerSkillSnapshot _current = PlayerSkillSnapshot.Empty;
 
     public PlayerSkillStateService(
@@ -57,7 +58,19 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         {
             Invoke(handler, _current);
             _handlers.Add(handler);
-            return new Subscription(this, handler);
+            return new Unsub(this, _handlers, handler);
+        }
+    }
+
+    public IDisposable SubscribeChanges(Action<SkillChange> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // No replay — a SkillChange is an event, not state. Current state
+            // is read via Current.
+            _changeHandlers.Add(handler);
+            return new Unsub(this, _changeHandlers, handler);
         }
     }
 
@@ -78,7 +91,10 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         }
     }
 
-    /// <summary>Wholesale replace from a <c>ProcessLoadSkills</c> dump.</summary>
+    /// <summary>Wholesale replace from a <c>ProcessLoadSkills</c> dump. Emits a
+    /// <see cref="SkillChangeKind.SnapshotReplace"/> only for skills whose
+    /// projection actually differs from (or is new vs.) the prior state — a
+    /// no-op re-sync produces no change events.</summary>
     private void ReplaceAll(SkillsSnapshotEvent snap)
     {
         var map = new Dictionary<string, SkillProgressSnapshot>(snap.Skills.Count, StringComparer.Ordinal);
@@ -91,30 +107,54 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
 
         lock (_lock)
         {
+            var prev = _current.Skills;
+            List<SkillChange>? changes = _changeHandlers.Count == 0 ? null : new();
+            if (changes is not null)
+            {
+                foreach (var (key, cur) in map)
+                {
+                    bool had = prev.TryGetValue(key, out var before);
+                    if (had && before.Equals(cur)) continue; // unchanged — skip
+                    changes.Add(new SkillChange(
+                        key, had ? before : null, cur, XpGained: 0,
+                        SkillChangeKind.SnapshotReplace, snap.Timestamp));
+                }
+            }
+
             _current = new PlayerSkillSnapshot(map, snap.Timestamp, SkillStateSource.LiveLog);
             _diag?.Trace("GameState.Skills",
                 $"Skill snapshot replaced: {map.Count} skills @ {snap.Timestamp:O}");
             Fire(_current);
+            if (changes is not null)
+                foreach (var c in changes) FireChange(c);
         }
     }
 
     /// <summary>Single-skill upsert from a <c>ProcessUpdateSkill</c> delta.
     /// Accepted even before the first full snapshot — the resulting partial
-    /// state is intentional (see the type docs).</summary>
+    /// state is intentional (see the type docs). Emits one
+    /// <see cref="SkillChangeKind.Delta"/> carrying the tick's XP.</summary>
     private void Upsert(SkillProgressUpdateEvent upd)
     {
         lock (_lock)
         {
+            var key = upd.Skill.SkillKey;
+            SkillProgressSnapshot? before =
+                _current.Skills.TryGetValue(key, out var b) ? b : null;
+            var cur = Project(upd.Skill);
+
             // Copy-on-write so any consumer holding the prior snapshot keeps a
             // stable, immutable view.
             var map = new Dictionary<string, SkillProgressSnapshot>(_current.Skills, StringComparer.Ordinal)
             {
-                [upd.Skill.SkillKey] = Project(upd.Skill),
+                [key] = cur,
             };
             _current = new PlayerSkillSnapshot(map, upd.Timestamp, SkillStateSource.LiveLog);
             _diag?.Trace("GameState.Skills",
-                $"Skill upsert: {upd.Skill.SkillKey} raw={upd.Skill.Level} @ {upd.Timestamp:O}");
+                $"Skill upsert: {key} raw={upd.Skill.Level} +{upd.XpGained}xp @ {upd.Timestamp:O}");
             Fire(_current);
+            FireChange(new SkillChange(
+                key, before, cur, upd.XpGained, SkillChangeKind.Delta, upd.Timestamp));
         }
     }
 
@@ -131,20 +171,39 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         foreach (var h in _handlers) Invoke(h, snapshot);
     }
 
+    /// <summary>MUST be called with <see cref="_lock"/> held.</summary>
+    private void FireChange(SkillChange change)
+    {
+        foreach (var h in _changeHandlers) InvokeChange(h, change);
+    }
+
     private void Invoke(Action<PlayerSkillSnapshot> handler, PlayerSkillSnapshot snapshot)
     {
         try { handler(snapshot); }
         catch (Exception ex) { _diag?.Warn("GameState.Skills", $"Subscriber threw: {ex.Message}"); }
     }
 
-    private sealed class Subscription : IDisposable
+    private void InvokeChange(Action<SkillChange> handler, SkillChange change)
+    {
+        try { handler(change); }
+        catch (Exception ex) { _diag?.Warn("GameState.Skills", $"Change subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Removes <paramref name="handler"/> from the list it was added to, under
+    /// the owner's lock. One implementation serves both the snapshot and the
+    /// change channels.
+    /// </summary>
+    private sealed class Unsub : IDisposable
     {
         private PlayerSkillStateService? _owner;
-        private readonly Action<PlayerSkillSnapshot> _handler;
+        private readonly System.Collections.IList _list;
+        private readonly object _handler;
 
-        public Subscription(PlayerSkillStateService owner, Action<PlayerSkillSnapshot> handler)
+        public Unsub(PlayerSkillStateService owner, System.Collections.IList list, object handler)
         {
             _owner = owner;
+            _list = list;
             _handler = handler;
         }
 
@@ -152,7 +211,7 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         {
             var owner = Interlocked.Exchange(ref _owner, null);
             if (owner is null) return;
-            lock (owner._lock) { owner._handlers.Remove(_handler); }
+            lock (owner._lock) { _list.Remove(_handler); }
         }
     }
 }

--- a/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
+++ b/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.Hosting;
+using Mithril.GameState.Skills.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Skills;
+
+/// <summary>
+/// Eagerly tails <see cref="IPlayerLogStream"/> at shell startup and maintains
+/// the canonical live <see cref="PlayerSkillSnapshot"/> from
+/// <c>ProcessLoadSkills</c> (full replace) and <c>ProcessUpdateSkill</c>
+/// (per-skill upsert) lines. The single owner of player skill state derived
+/// from the log — modules depend on <see cref="IPlayerSkillState"/> rather than
+/// re-parsing the stream.
+///
+/// <para><b>Self-heal / warm-up.</b> <c>ProcessLoadSkills</c> is emitted at
+/// login and again on every zone / session transition, so a wholesale replace
+/// on each one keeps state correct even when Mithril starts tailing
+/// mid-session. Before the first snapshot of the session,
+/// <see cref="Current"/> is <see cref="PlayerSkillSnapshot.Empty"/>; isolated
+/// <c>ProcessUpdateSkill</c> lines seen first produce a deliberately partial
+/// snapshot (better than nothing — the next <c>ProcessLoadSkills</c> makes it
+/// whole). This window is the documented contract.</para>
+///
+/// <para><b>Threading.</b> The snapshot reference is swapped under
+/// <see cref="_lock"/>; <see cref="Current"/> reads are lock-free (reference
+/// read of an immutable object). <see cref="Subscribe"/> replays and attaches
+/// atomically under the same lock the ingestion loop fires under, which closes
+/// the late-subscribe race exactly as <c>InventoryService</c> does.</para>
+/// </summary>
+public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillState
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly SkillLogParser _parser;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly List<Action<PlayerSkillSnapshot>> _handlers = new();
+    private volatile PlayerSkillSnapshot _current = PlayerSkillSnapshot.Empty;
+
+    public PlayerSkillStateService(
+        IPlayerLogStream stream,
+        SkillLogParser parser,
+        IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _parser = parser;
+        _diag = diag;
+    }
+
+    public PlayerSkillSnapshot Current => _current;
+
+    public IDisposable Subscribe(Action<PlayerSkillSnapshot> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            Invoke(handler, _current);
+            _handlers.Add(handler);
+            return new Subscription(this, handler);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Skills", "Subscribing to Player.log for skill-state events");
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            switch (_parser.TryParse(raw.Line, raw.Timestamp))
+            {
+                case SkillsSnapshotEvent snap:
+                    ReplaceAll(snap);
+                    break;
+                case SkillProgressUpdateEvent upd:
+                    Upsert(upd);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Wholesale replace from a <c>ProcessLoadSkills</c> dump.</summary>
+    private void ReplaceAll(SkillsSnapshotEvent snap)
+    {
+        var map = new Dictionary<string, SkillProgressSnapshot>(snap.Skills.Count, StringComparer.Ordinal);
+        foreach (var r in snap.Skills)
+        {
+            // Last-wins on the (not observed in practice) chance of a dup key —
+            // the indexer rather than Add avoids throwing on grammar drift.
+            map[r.SkillKey] = Project(r);
+        }
+
+        lock (_lock)
+        {
+            _current = new PlayerSkillSnapshot(map, snap.Timestamp, SkillStateSource.LiveLog);
+            _diag?.Trace("GameState.Skills",
+                $"Skill snapshot replaced: {map.Count} skills @ {snap.Timestamp:O}");
+            Fire(_current);
+        }
+    }
+
+    /// <summary>Single-skill upsert from a <c>ProcessUpdateSkill</c> delta.
+    /// Accepted even before the first full snapshot — the resulting partial
+    /// state is intentional (see the type docs).</summary>
+    private void Upsert(SkillProgressUpdateEvent upd)
+    {
+        lock (_lock)
+        {
+            // Copy-on-write so any consumer holding the prior snapshot keeps a
+            // stable, immutable view.
+            var map = new Dictionary<string, SkillProgressSnapshot>(_current.Skills, StringComparer.Ordinal)
+            {
+                [upd.Skill.SkillKey] = Project(upd.Skill),
+            };
+            _current = new PlayerSkillSnapshot(map, upd.Timestamp, SkillStateSource.LiveLog);
+            _diag?.Trace("GameState.Skills",
+                $"Skill upsert: {upd.Skill.SkillKey} raw={upd.Skill.Level} @ {upd.Timestamp:O}");
+            Fire(_current);
+        }
+    }
+
+    private static SkillProgressSnapshot Project(SkillProgressRecord r) => new(
+        Level: r.Level,
+        BonusLevels: r.BonusLevels,
+        XpTowardNextLevel: r.XpTowardNextLevel,
+        XpNeededForNextLevel: r.XpNeededForNextLevel,
+        MaxLevel: r.MaxLevel);
+
+    /// <summary>MUST be called with <see cref="_lock"/> held.</summary>
+    private void Fire(PlayerSkillSnapshot snapshot)
+    {
+        foreach (var h in _handlers) Invoke(h, snapshot);
+    }
+
+    private void Invoke(Action<PlayerSkillSnapshot> handler, PlayerSkillSnapshot snapshot)
+    {
+        try { handler(snapshot); }
+        catch (Exception ex) { _diag?.Warn("GameState.Skills", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private PlayerSkillStateService? _owner;
+        private readonly Action<PlayerSkillSnapshot> _handler;
+
+        public Subscription(PlayerSkillStateService owner, Action<PlayerSkillSnapshot> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
+        }
+    }
+}

--- a/src/Mithril.GameState/Skills/SkillChange.cs
+++ b/src/Mithril.GameState/Skills/SkillChange.cs
@@ -1,0 +1,58 @@
+namespace Mithril.GameState.Skills;
+
+/// <summary>How a <see cref="SkillChange"/> was produced.</summary>
+public enum SkillChangeKind
+{
+    /// <summary>
+    /// From a <c>ProcessUpdateSkill</c> delta — a live, in-session progression
+    /// tick. Carries a meaningful <see cref="SkillChange.XpGained"/>.
+    /// </summary>
+    Delta = 0,
+
+    /// <summary>
+    /// From a <c>ProcessLoadSkills</c> full snapshot — emitted only for skills
+    /// whose projection actually differs from (or is new vs.) the prior state.
+    /// A snapshot is not a gain event, so <see cref="SkillChange.XpGained"/> is
+    /// <c>0</c> here even though the level/xp may have moved (e.g. progression
+    /// that happened while Mithril wasn't tailing, or the periodic re-sync).
+    /// </summary>
+    SnapshotReplace = 1,
+}
+
+/// <summary>
+/// A single skill's progression changed. The granular companion to
+/// <see cref="IPlayerSkillState.Subscribe"/>'s whole-snapshot push: a consumer
+/// that cares <em>which</em> skill moved (level-ups, XP feeds) subscribes via
+/// <see cref="IPlayerSkillState.SubscribeChanges"/> instead of diffing
+/// snapshots itself.
+///
+/// <list type="bullet">
+///   <item><b>Level-up</b> is <c>Previous?.Level &lt; Current.Level</c>.</item>
+///   <item><b>Just hit cap</b> is
+///   <c>Previous is { IsCapped: false } &amp;&amp; Current.IsCapped</c> — and
+///   note PG then goes silent for that skill (no further
+///   <c>ProcessUpdateSkill</c>), so this is the last <see cref="Delta"/> you
+///   will see for it until a <see cref="SkillChangeKind.SnapshotReplace"/>.</item>
+/// </list>
+/// </summary>
+/// <param name="SkillKey">Skill internal name (the map key — e.g.
+/// <c>"Anatomy_Bears"</c>). UI resolves to a display name; the model keeps the
+/// key.</param>
+/// <param name="Previous">The skill's projection before this change, or
+/// <c>null</c> if it was previously unknown (first observation, or first time
+/// seen after a cold start).</param>
+/// <param name="Current">The skill's projection after this change.</param>
+/// <param name="XpGained">XP earned on this tick for a
+/// <see cref="SkillChangeKind.Delta"/> (chat-corroborated within a level; see
+/// <see cref="Parsing.SkillProgressUpdateEvent"/>). Always <c>0</c> for a
+/// <see cref="SkillChangeKind.SnapshotReplace"/>.</param>
+/// <param name="Kind">Whether this came from a live delta or a snapshot
+/// reconcile.</param>
+/// <param name="Timestamp">UTC timestamp of the source log line.</param>
+public readonly record struct SkillChange(
+    string SkillKey,
+    SkillProgressSnapshot? Previous,
+    SkillProgressSnapshot Current,
+    long XpGained,
+    SkillChangeKind Kind,
+    DateTime Timestamp);

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -315,6 +315,42 @@
         { "name": "name", "group": "name", "type": "string" }
       ]
     },
+    "shared.SkillLogParser.LoadSkillsRx": {
+      "pattern": "LocalPlayer: ProcessLoadSkills\\(",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Skills.Parsing.SkillLogParser", "method": "LoadSkillsRx" },
+      "eventType": "shared.SkillsSnapshot",
+      "kind": "marker",
+      "notes": "Guard for the full skill-table dump (login / zone-change). The per-skill rows are extracted by SkillTupleRx applied over the whole line; this entry only discriminates the line. Re-fires on zone transitions, which is what lets PlayerSkillStateService self-heal after a mid-session start. See issue #462.",
+      "fields": []
+    },
+    "shared.SkillLogParser.UpdateSkillRx": {
+      "pattern": "LocalPlayer: ProcessUpdateSkill\\(\\{",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Skills.Parsing.SkillLogParser", "method": "UpdateSkillRx" },
+      "eventType": "shared.SkillProgressUpdate",
+      "kind": "marker",
+      "notes": "Guard for a single-skill delta. The leading struct is extracted by SkillTupleRx; the trailing positionals (announce bool, xp delta, 0, 0) are intentionally not parsed (semantics verification-owed, see #462). Independent of samwise.GardenLogParser.GardeningXpRx — both may match a Gardening update; no ordering dependency.",
+      "fields": []
+    },
+    "shared.SkillLogParser.SkillTupleRx": {
+      "pattern": "\\{type=(?<type>\\w+),raw=(?<raw>\\d+),bonus=(?<bonus>\\d+),xp=(?<xp>\\d+),tnl=(?<tnl>\\d+),max=(?<max>\\d+)\\}",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Skills.Parsing.SkillLogParser", "method": "SkillTupleRx" },
+      "eventType": "shared.SkillProgressTuple",
+      "notes": "The shared {type=,raw=,bonus=,xp=,tnl=,max=} struct grammar emitted by both ProcessLoadSkills and ProcessUpdateSkill. Applied via Matches() over the whole line: one match for an update, the full table (~125) for a snapshot. raw=Level, bonus=BonusLevels, xp=XpTowardNextLevel, tnl=XpNeededForNextLevel, max=MaxLevel (0 = non-trainable pseudo-skill; raw>=max = capped, tnl stale).",
+      "fields": [
+        { "name": "type", "group": "type", "type": "string" },
+        { "name": "raw", "group": "raw", "type": "int" },
+        { "name": "bonus", "group": "bonus", "type": "int" },
+        { "name": "xp", "group": "xp", "type": "int" },
+        { "name": "tnl", "group": "tnl", "type": "int" },
+        { "name": "max", "group": "max", "type": "int" }
+      ]
+    },
     "shared.ActiveCharacterLogSynchronizer.AddPlayerRx": {
       "pattern": "LocalPlayer:\\s*ProcessAddPlayer\\([^,]+,\\s*[^,]+,\\s*\"[^\"]*\",\\s*\"([^\"]+)\"",
       "source": "player",

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -332,8 +332,19 @@
       "csharp": { "type": "Mithril.GameState.Skills.Parsing.SkillLogParser", "method": "UpdateSkillRx" },
       "eventType": "shared.SkillProgressUpdate",
       "kind": "marker",
-      "notes": "Guard for a single-skill delta. The leading struct is extracted by SkillTupleRx; the trailing positionals (announce bool, xp delta, 0, 0) are intentionally not parsed (semantics verification-owed, see #462). Independent of samwise.GardenLogParser.GardeningXpRx — both may match a Gardening update; no ordering dependency.",
+      "notes": "Guard for a single-skill delta. The leading struct is extracted by SkillTupleRx, the XP gained by XpGainRx. Independent of samwise.GardenLogParser.GardeningXpRx — both may match a Gardening update; no ordering dependency.",
       "fields": []
+    },
+    "shared.SkillLogParser.XpGainRx": {
+      "pattern": "ProcessUpdateSkill\\(\\{[^}]*\\},\\s*\\w+,\\s*(?<gained>\\d+)",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Skills.Parsing.SkillLogParser", "method": "XpGainRx" },
+      "eventType": "shared.SkillXpGained",
+      "notes": "ProcessUpdateSkill's third positional = XP earned this tick. Triangulated against the authoritative chat '[Status] You earned N XP in <Skill>' line across the Player.log(UTC)/ChatLogs(local) offset (Endurance 26, Psychology 577, Anatomy_Bears 48 matched exactly) — authoritative within a level. Level-up / cap-reaching tick behaviour is unobserved (verification owed, #462); best-effort across a boundary and self-healing via the next ProcessLoadSkills. The announce bool and trailing 0,0 are still not parsed.",
+      "fields": [
+        { "name": "gained", "group": "gained", "type": "int" }
+      ]
     },
     "shared.SkillLogParser.SkillTupleRx": {
       "pattern": "\\{type=(?<type>\\w+),raw=(?<raw>\\d+),bonus=(?<bonus>\\d+),xp=(?<xp>\\d+),tnl=(?<tnl>\\d+),max=(?<max>\\d+)\\}",

--- a/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
@@ -255,6 +255,39 @@ public sealed class PlayerSkillStateServiceTests
         try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
+    [Fact]
+    public async Task Real_Tailoring_level_up_emits_level_up_SkillChange_with_gross_XpGained()
+    {
+        // The captured Tailoring level-up, fed through the service. Asserts the
+        // level-up is detectable purely from raw incrementing (no dedicated
+        // log line) and XpGained is the gross 160 (chat-matched), not split.
+        var stream = new ScriptedStream(new RawLogLine(Ts(12, 38, 57),
+            "[12:38:57] LocalPlayer: ProcessUpdateSkill({type=Tailoring,raw=9,bonus=2,xp=199,tnl=210,max=50}, True, 160, 0, 0)"));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<SkillChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            stream.Push("[12:39:02] LocalPlayer: ProcessUpdateSkill({type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+        var c = changes[0];
+        c.Kind.Should().Be(SkillChangeKind.Delta);
+        c.SkillKey.Should().Be("Tailoring");
+        c.Previous!.Value.Level.Should().Be(9);
+        c.Current.Level.Should().Be(10);
+        (c.Previous!.Value.Level < c.Current.Level).Should().BeTrue(); // level-up signal
+        c.Current.XpTowardNextLevel.Should().Be(149);
+        c.XpGained.Should().Be(160); // gross gain across the rollover
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
     private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);
 
     private static async Task RunUntilDrainedAsync(PlayerSkillStateService svc, ScriptedStream stream)

--- a/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
@@ -1,0 +1,201 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Skills;
+using Mithril.GameState.Skills.Parsing;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Skills;
+
+public sealed class PlayerSkillStateServiceTests
+{
+    private const string LoadLine =
+        "[08:22:21] LocalPlayer: ProcessLoadSkills(" +
+        "{type=Toolcrafting,raw=15,bonus=0,xp=26,tnl=680,max=50}, " +
+        "{type=Tanning,raw=50,bonus=3,xp=0,tnl=5280,max=50}, " +
+        "{type=Augmentation,raw=0,bonus=2,xp=0,tnl=1,max=0})";
+
+    private static PlayerSkillStateService NewService(ScriptedStream stream)
+        => new(stream, new SkillLogParser());
+
+    [Fact]
+    public void Cold_start_is_Empty_with_no_measurement()
+    {
+        var svc = NewService(new ScriptedStream());
+        svc.Current.Should().BeSameAs(PlayerSkillSnapshot.Empty);
+        svc.Current.Source.Should().Be(SkillStateSource.None);
+        svc.Current.MeasuredAt.Should().BeNull();
+        svc.Current.Skills.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProcessLoadSkills_populates_full_snapshot_with_caveat_flags()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        var cur = svc.Current;
+        cur.Source.Should().Be(SkillStateSource.LiveLog);
+        cur.MeasuredAt.Should().Be(Ts(8, 22, 21));
+        cur.Skills.Should().HaveCount(3);
+
+        cur.TryGet("Tanning", out var tanning).Should().BeTrue();
+        tanning.IsTrainable.Should().BeTrue();
+        tanning.IsCapped.Should().BeTrue(); // raw == max == 50
+
+        cur.TryGet("Augmentation", out var aug).Should().BeTrue();
+        aug.IsTrainable.Should().BeFalse(); // max == 0 pseudo-skill
+        aug.IsCapped.Should().BeFalse();
+
+        cur.TryGet("Toolcrafting", out var tool).Should().BeTrue();
+        tool.IsCapped.Should().BeFalse();
+        tool.Level.Should().Be(15);
+        tool.BonusLevels.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ProcessLoadSkills_is_a_wholesale_replace_not_a_merge()
+    {
+        var stream = new ScriptedStream(
+            new RawLogLine(Ts(8, 0, 0),
+                "LocalPlayer: ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})"),
+            new RawLogLine(Ts(9, 0, 0),
+                "LocalPlayer: ProcessLoadSkills({type=Cooking,raw=20,bonus=0,xp=1,tnl=2,max=50})"));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.Skills.Keys.Should().Equal("Cooking"); // Sword gone
+        svc.Current.MeasuredAt.Should().Be(Ts(9, 0, 0));
+    }
+
+    [Fact]
+    public async Task ProcessUpdateSkill_upserts_one_skill_keeping_the_rest()
+    {
+        var stream = new ScriptedStream(
+            new RawLogLine(Ts(8, 22, 21), LoadLine),
+            new RawLogLine(Ts(8, 30, 0),
+                "LocalPlayer: ProcessUpdateSkill({type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)"));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.Skills.Should().HaveCount(3); // Tanning + Augmentation untouched
+        svc.Current.TryGet("Toolcrafting", out var tool).Should().BeTrue();
+        tool.Level.Should().Be(16);
+        tool.XpTowardNextLevel.Should().Be(5);
+        svc.Current.MeasuredAt.Should().Be(Ts(8, 30, 0));
+    }
+
+    [Fact]
+    public async Task ProcessUpdateSkill_before_any_snapshot_yields_partial_state()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 30, 0),
+            "LocalPlayer: ProcessUpdateSkill({type=NatureAppreciation,raw=26,bonus=2,xp=315,tnl=1350,max=50}, True, 110, 0, 0)"));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.Source.Should().Be(SkillStateSource.LiveLog);
+        svc.Current.Skills.Keys.Should().Equal("NatureAppreciation");
+    }
+
+    [Fact]
+    public async Task Subscribe_replays_current_then_delivers_live_changes()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var seen = new List<PlayerSkillSnapshot>();
+        using (svc.Subscribe(seen.Add))
+        {
+            seen.Should().HaveCount(1); // replay of current
+            seen[0].Skills.Should().HaveCount(3);
+
+            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        seen.Should().HaveCount(2);
+        seen[1].TryGet("Sword", out _).Should().BeTrue();
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Disposed_subscription_stops_receiving()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var seen = new List<PlayerSkillSnapshot>();
+        var sub = svc.Subscribe(seen.Add);
+        sub.Dispose();
+
+        stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
+        await stream.WaitForDrainAsync(cts.Token);
+
+        seen.Should().HaveCount(1); // only the replay; no live event after dispose
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);
+
+    private static async Task RunUntilDrainedAsync(PlayerSkillStateService svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public ScriptedStream(params RawLogLine[] lines)
+        {
+            if (lines.Length == 0)
+            {
+                _drained.TrySetResult();
+                return;
+            }
+            Interlocked.Add(ref _pending, lines.Length);
+            foreach (var line in lines) _channel.Writer.TryWrite(line);
+        }
+
+        public void Push(string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+        public Task WaitForDrainAsync(TimeSpan timeout) => _drained.Task.WaitAsync(timeout);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
@@ -144,6 +144,117 @@ public sealed class PlayerSkillStateServiceTests
         try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
+    [Fact]
+    public async Task SubscribeChanges_has_no_replay_then_delivers_Delta_with_XpGained()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<SkillChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            changes.Should().BeEmpty(); // no replay — a change is an event, not state
+
+            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().HaveCount(1);
+        var c = changes[0];
+        c.Kind.Should().Be(SkillChangeKind.Delta);
+        c.SkillKey.Should().Be("Toolcrafting");
+        c.Previous!.Value.Level.Should().Be(15); // from LoadLine
+        c.Current.Level.Should().Be(16);
+        c.XpGained.Should().Be(4);
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Delta_for_never_seen_skill_has_null_Previous()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+
+        var changes = new List<SkillChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+        changes[0].Previous.Should().BeNull();
+        changes[0].Current.Level.Should().Be(2);
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task SnapshotReplace_emits_only_skills_that_actually_changed()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0),
+            "LocalPlayer: ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})"));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<SkillChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            // Re-sync: Sword identical (no-op), Cooking new.
+            stream.Push("LocalPlayer: ProcessLoadSkills(" +
+                        "{type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50}, " +
+                        "{type=Cooking,raw=20,bonus=0,xp=3,tnl=4,max=50})");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle(); // Sword unchanged → suppressed
+        changes[0].Kind.Should().Be(SkillChangeKind.SnapshotReplace);
+        changes[0].SkillKey.Should().Be("Cooking");
+        changes[0].Previous.Should().BeNull();
+        changes[0].XpGained.Should().Be(0); // snapshot is not a gain event
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Capped_tick_emits_IsCapped_transition_then_skill_goes_silent()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0),
+            "LocalPlayer: ProcessLoadSkills({type=Sword,raw=49,bonus=0,xp=10,tnl=20,max=50})"));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<SkillChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            // The capping tick: raw reaches max. PG then emits no further
+            // ProcessUpdateSkill for Sword — modelled by a subsequent unrelated
+            // skill update producing no Sword change.
+            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=50,bonus=0,xp=0,tnl=20,max=50}, True, 5, 0, 0)");
+            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Cooking,raw=3,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        var swordChanges = changes.Where(c => c.SkillKey == "Sword").ToList();
+        swordChanges.Should().ContainSingle();
+        swordChanges[0].Previous!.Value.IsCapped.Should().BeFalse(); // 49 < 50
+        swordChanges[0].Current.IsCapped.Should().BeTrue();          // 50 == 50
+        // No further Sword event despite later activity — the "goes silent" contract.
+        changes.Count(c => c.SkillKey == "Sword").Should().Be(1);
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
     private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);
 
     private static async Task RunUntilDrainedAsync(PlayerSkillStateService svc, ScriptedStream stream)

--- a/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
@@ -67,6 +67,32 @@ public sealed class SkillLogParserTests
         upd.Skill.XpTowardNextLevel.Should().Be(315);
         upd.Skill.XpNeededForNextLevel.Should().Be(1350);
         upd.Skill.MaxLevel.Should().Be(50);
+        upd.XpGained.Should().Be(110); // arg3
+    }
+
+    // arg3 triangulated against the authoritative chat "[Status] You earned N
+    // XP in <Skill>." line for the same events across the Player.log (UTC) /
+    // ChatLogs (local, +1h) offset. These three matched exactly in the real
+    // logs; encoding them pins the semantic so a regression is visible.
+    [Theory]
+    [InlineData("{type=Endurance,raw=53,bonus=3,xp=11237,tnl=13140,max=60}", 26)]   // chat: "26 XP in Endurance"
+    [InlineData("{type=Psychology,raw=48,bonus=3,xp=38347,tnl=74953,max=50}", 577)] // chat: "577 XP in Psychology"
+    [InlineData("{type=Anatomy_Bears,raw=27,bonus=0,xp=1483,tnl=1500,max=50}", 48)] // chat: "48 XP in Bear and Bugbear Anatomy"
+    public void ProcessUpdateSkill_XpGained_matches_chat_Status_oracle(string structText, long gained)
+    {
+        var line = $"[11:36:42] LocalPlayer: ProcessUpdateSkill({structText}, False, {gained}, 0, 0)";
+        var upd = _parser.TryParse(line, Ts).Should().BeOfType<SkillProgressUpdateEvent>().Subject;
+        upd.XpGained.Should().Be(gained);
+    }
+
+    [Fact]
+    public void ProcessUpdateSkill_with_no_tail_defaults_XpGained_to_zero()
+    {
+        // Grammar drift / truncation: struct is still authoritative for state.
+        var line = "LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50})";
+        var upd = _parser.TryParse(line, Ts).Should().BeOfType<SkillProgressUpdateEvent>().Subject;
+        upd.Skill.Level.Should().Be(2);
+        upd.XpGained.Should().Be(0);
     }
 
     [Fact]

--- a/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Mithril.GameState.Skills.Parsing;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Skills;
+
+public sealed class SkillLogParserTests
+{
+    private readonly SkillLogParser _parser = new();
+    private static readonly DateTime Ts = new(2026, 5, 18, 10, 49, 51, DateTimeKind.Utc);
+
+    // Real capture (trimmed to 5 representative rows incl. a capped skill and a
+    // max=0 pseudo-skill) from Player.log's login dump.
+    private const string LoadSkillsLine =
+        "[08:22:21] LocalPlayer: ProcessLoadSkills(" +
+        "{type=Toolcrafting,raw=15,bonus=0,xp=26,tnl=680,max=50}, " +
+        "{type=Tanning,raw=50,bonus=3,xp=0,tnl=5280,max=50}, " +
+        "{type=Augmentation,raw=0,bonus=2,xp=0,tnl=1,max=0}, " +
+        "{type=Werewolf,raw=56,bonus=4,xp=13091,tnl=188650,max=70}, " +
+        "{type=Anatomy_Bears,raw=27,bonus=0,xp=1435,tnl=1500,max=50})";
+
+    private const string UpdateSkillLine =
+        "[10:49:51] LocalPlayer: ProcessUpdateSkill(" +
+        "{type=NatureAppreciation,raw=26,bonus=2,xp=315,tnl=1350,max=50}, True, 110, 0, 0)";
+
+    [Fact]
+    public void ProcessLoadSkills_yields_full_snapshot_in_log_order()
+    {
+        var evt = _parser.TryParse(LoadSkillsLine, Ts);
+
+        var snap = evt.Should().BeOfType<SkillsSnapshotEvent>().Subject;
+        snap.Timestamp.Should().Be(Ts);
+        snap.Skills.Select(s => s.SkillKey).Should().Equal(
+            "Toolcrafting", "Tanning", "Augmentation", "Werewolf", "Anatomy_Bears");
+    }
+
+    [Fact]
+    public void ProcessLoadSkills_maps_every_field_1to1()
+    {
+        var snap = (SkillsSnapshotEvent)_parser.TryParse(LoadSkillsLine, Ts)!;
+
+        // Underscore key parsed verbatim; large xp/tnl fit long.
+        var bears = snap.Skills.Single(s => s.SkillKey == "Anatomy_Bears");
+        bears.Level.Should().Be(27);
+        bears.BonusLevels.Should().Be(0);
+        bears.XpTowardNextLevel.Should().Be(1435);
+        bears.XpNeededForNextLevel.Should().Be(1500);
+        bears.MaxLevel.Should().Be(50);
+
+        var werewolf = snap.Skills.Single(s => s.SkillKey == "Werewolf");
+        werewolf.Level.Should().Be(56);
+        werewolf.BonusLevels.Should().Be(4);
+        werewolf.XpNeededForNextLevel.Should().Be(188650);
+        werewolf.MaxLevel.Should().Be(70);
+    }
+
+    [Fact]
+    public void ProcessUpdateSkill_yields_single_record_ignoring_trailing_args()
+    {
+        var evt = _parser.TryParse(UpdateSkillLine, Ts);
+
+        var upd = evt.Should().BeOfType<SkillProgressUpdateEvent>().Subject;
+        upd.Timestamp.Should().Be(Ts);
+        upd.Skill.SkillKey.Should().Be("NatureAppreciation");
+        upd.Skill.Level.Should().Be(26);
+        upd.Skill.BonusLevels.Should().Be(2);
+        upd.Skill.XpTowardNextLevel.Should().Be(315);
+        upd.Skill.XpNeededForNextLevel.Should().Be(1350);
+        upd.Skill.MaxLevel.Should().Be(50);
+    }
+
+    [Fact]
+    public void Gardening_update_still_parses_independently_of_Samwise()
+    {
+        // Samwise's GardenLogParser also matches this line; SkillLogParser must
+        // fold Gardening into skill state regardless — no ordering coupling.
+        var line = "[10:00:00] LocalPlayer: ProcessUpdateSkill(" +
+                   "{type=Gardening,raw=30,bonus=1,xp=100,tnl=900,max=50}, True, 50, 0, 0)";
+
+        var upd = _parser.TryParse(line, Ts).Should().BeOfType<SkillProgressUpdateEvent>().Subject;
+        upd.Skill.SkillKey.Should().Be("Gardening");
+        upd.Skill.Level.Should().Be(30);
+    }
+
+    [Theory]
+    [InlineData("[10:46:47] LocalPlayer: ProcessSetActiveSkills(Riding, Riding)")]
+    [InlineData("[10:46:47] entity_23984278: OnAttackHitMe(Big Cat Claw). Evaded = False")]
+    [InlineData("Loading preferences from C:/Users/x/GorgonSettings.txt")]
+    public void Unrelated_lines_return_null(string line)
+        => _parser.TryParse(line, Ts).Should().BeNull();
+
+    [Fact]
+    public void Degenerate_ProcessLoadSkills_with_no_struct_returns_null()
+    {
+        // Truncated / grammar-drift line: emit nothing rather than an empty
+        // snapshot that would wipe live state.
+        _parser.TryParse("[08:22:21] LocalPlayer: ProcessLoadSkills()", Ts).Should().BeNull();
+    }
+}

--- a/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
@@ -86,6 +86,21 @@ public sealed class SkillLogParserTests
     }
 
     [Fact]
+    public void ProcessUpdateSkill_level_up_tick_parses_gross_arg3_and_post_rollover_struct()
+    {
+        // Real captured Tailoring level-up (raw 9→10). arg3 is the GROSS gain
+        // (160, = chat "earned 160 XP and reached level 12"), NOT split across
+        // the rollover; struct xp/tnl are the post-level-up values.
+        var line = "[12:39:02] LocalPlayer: ProcessUpdateSkill(" +
+                   "{type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)";
+        var upd = _parser.TryParse(line, Ts).Should().BeOfType<SkillProgressUpdateEvent>().Subject;
+        upd.Skill.Level.Should().Be(10);
+        upd.Skill.XpTowardNextLevel.Should().Be(149); // overflow into the new level
+        upd.Skill.XpNeededForNextLevel.Should().Be(420); // new level's threshold
+        upd.XpGained.Should().Be(160); // gross, chat-matched, not pre/post split
+    }
+
+    [Fact]
     public void ProcessUpdateSkill_with_no_tail_defaults_XpGained_to_zero()
     {
         // Grammar drift / truncation: struct is still authoritative for state.


### PR DESCRIPTION
Closes #462.

## What

Shared, `Player.log`-fed live view of the player's current skill progression — all ~125 skills, **no character re-export required**. Service work only, no UI.

- **`SkillLogParser`** — `ProcessLoadSkills` (full snapshot, login + zone/relog) and `ProcessUpdateSkill` (per-skill delta), sharing the `{type,raw,bonus,xp,tnl,max}` grammar. Catalogued in `log-patterns.json` as `shared.SkillLogParser.*`; `LogPatternCatalogParityTests` asserts char-for-char parity with the `[GeneratedRegex]`.
- **`IPlayerSkillState` / `PlayerSkillStateService`** — `BackgroundService`: wholesale-replace on snapshot, copy-on-write upsert on delta, atomic `Subscribe` replay/attach (mirrors `InventoryService`). **Self-heals**: a mid-session start recovers full state on the next zone-change `ProcessLoadSkills`.
- **Caveats interpreted, not assumed away** — `SkillProgressSnapshot.IsCapped` (`raw==max`, stale `tnl`), `IsTrainable` (`max>0`; `max==0` pseudo-skills kept-but-flagged), `bonus` kept strictly separate from `raw`. UTC `MeasuredAt`. Internal-name keys kept verbatim.
- Thorough XML docs on all shared-infra types; design doc at `docs/player-skill-state-service.md`.

## Design refinement vs the issue (recorded on #462)

The issue wording said `SkillState Current`. Implemented as a **GameState-native** `PlayerSkillSnapshot` with **no `Mithril.Leveling` dependency**: a consumer adapts to `SkillState` the way Elrond's `SnapshotPlanInput` already adapts the export. Keeps shared infra dependency-minimal; does not fork the neutral abstraction. Consumer-side wiring (Elrond prefer-live, freshness badges) is out of scope as the issue states.

## Verification

- Full solution build clean (warnings-as-errors).
- `Mithril.GameState.Tests` 165/165 (15 new: parser 7, service 8); log-pattern parity 2/2.
- Branched off **latest main** (post-#461 player-position tracker, same file region) — post-merge re-verify green; #461's Movement registration preserved.
- ⚠️ Not run: 12-module shell boot. The change is an additive leaf hosted service in already-wired `Mithril.GameState` with only already-registered deps (`IPlayerLogStream`, `SkillLogParser`) — same shape as `InventoryService`/`PlayerPositionTracker`, so DI-cycle risk is minimal, but the boot smoke-test is not a substitute claim. Happy to run it on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
