### PR TITLE
feat(legolas): cold-start pin calibration via the map overlay (#460)

### DIFF
--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -59,6 +59,10 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<ITrilaterationSolver, TrilaterationSolver>();
         services.AddSingleton<ICoordinateProjector, CoordinateProjector>();
         services.AddSingleton<IAreaCalibrationService, AreaCalibrationService>();
+        // #460: cold-start pin calibration driven through the map overlay
+        // (not the standalone window). View-agnostic; shared by the wizard
+        // Calibrating step and the map-overlay capture branch.
+        services.AddSingleton<PinCalibrationCoordinator>();
 
         // Session + flow controllers + VMs.
         // Session.MapOpacity / InventoryOpacity hydrate from persisted settings on

--- a/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
+++ b/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Legolas.Domain;
+
+namespace Legolas.Services;
+
+/// <summary>
+/// View-agnostic driver for #460 cold-start pin calibration done <b>through
+/// the map overlay</b> (not the messy standalone calibration window — that
+/// path is left untouched/redundant per the #460 decision). Reuses only the
+/// clean service core: subscribes to <see cref="IAreaCalibrationService.PinAdded"/>
+/// (fed by the Player.log <c>ProcessMapPinAdd</c> ingestion) and calls
+/// <see cref="IAreaCalibrationService.CalibrateCurrentArea"/> /
+/// <c>LandmarkCalibrationSolver</c>.
+///
+/// <para><b>Replay-arming.</b> <c>ProcessMapPinAdd</c> bulk-replays on area
+/// entry, so world points are queued <em>only while armed</em> (the wizard
+/// arms on entering the <c>Calibrating</c> step). The standalone window's
+/// own pin-cal consumer gates on its own arm independently — coexistence is
+/// safe.</para>
+///
+/// <para><b>Label-agnostic.</b> <see cref="IAreaCalibrationService.PinAdded"/>
+/// carries a bare <see cref="WorldCoord"/> — there is structurally no pin
+/// label here. Pairing is the user's overlay click in turn order: each click
+/// pairs the <em>oldest</em> unpaired world point (hard rule #454).</para>
+/// </summary>
+public sealed partial class PinCalibrationCoordinator : ObservableObject
+{
+    private readonly IAreaCalibrationService _service;
+    private readonly Queue<WorldCoord> _pending = new();
+    private readonly List<(WorldCoord World, PixelPoint Pixel)> _pairs = new();
+
+    public PinCalibrationCoordinator(IAreaCalibrationService service)
+    {
+        _service = service;
+        _service.PinAdded += OnPinAdded;
+    }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    private bool _isArmed;
+
+    /// <summary>World points dropped (via <c>ProcessMapPinAdd</c>) and not yet
+    /// paired with an overlay click.</summary>
+    public int PendingCount => _pending.Count;
+
+    /// <summary>Click-paired (world ↔ pixel) points accumulated so far.</summary>
+    public int PairedCount => _pairs.Count;
+
+    /// <summary>≥3 well-spread pairs are needed for a stable solve.</summary>
+    public bool CanSolve => _pairs.Count >= 3;
+
+    /// <summary>Markers the map overlay renders at each paired click pixel.</summary>
+    public ObservableCollection<PixelPoint> PlacedMarkers { get; } = new();
+
+    public string StatusText => IsArmed
+        ? $"Drop ≥3 well-spread map pins in-game, then click each on the map " +
+          $"in the same order. Paired: {PairedCount}  ·  awaiting click: {PendingCount}."
+        : "Pin calibration is off.";
+
+    /// <summary>Arm capture and clear any stale state so the area-entry
+    /// replay backlog can't leak in.</summary>
+    public void Arm()
+    {
+        _pending.Clear();
+        _pairs.Clear();
+        PlacedMarkers.Clear();
+        IsArmed = true;
+        RaiseCounts();
+    }
+
+    /// <summary>Disarm and flush — leaving the calibration step, or after a
+    /// solve/clear.</summary>
+    public void Disarm()
+    {
+        _pending.Clear();
+        _pairs.Clear();
+        PlacedMarkers.Clear();
+        IsArmed = false;
+        RaiseCounts();
+    }
+
+    /// <summary>
+    /// Pair the next overlay click. Dequeues the oldest unpaired world point
+    /// (turn order) and binds it to <paramref name="pixel"/>. No-op when
+    /// disarmed or nothing is pending.
+    /// </summary>
+    public void PairClick(PixelPoint pixel)
+    {
+        if (!IsArmed || _pending.Count == 0) return;
+        var world = _pending.Dequeue();
+        _pairs.Add((world, pixel));
+        PlacedMarkers.Add(pixel);
+        RaiseCounts();
+    }
+
+    /// <summary>
+    /// Solve + persist + apply the area calibration from the accumulated
+    /// pairs (reuses the shipped solver verbatim). Returns the calibration,
+    /// or null if &lt;3 pairs / the solve failed. On success the area becomes
+    /// calibrated (<see cref="IAreaCalibrationService.Changed"/> fires) and
+    /// the coordinator disarms.
+    /// </summary>
+    public AreaCalibration? Solve()
+    {
+        if (!CanSolve) return null;
+        // Zoom OCR/CV is deferred (#460) — calibrate at the default zoom
+        // stamp, consistent with the standalone window's unset-zoom path.
+        var result = _service.CalibrateCurrentArea(_pairs.ToList(), calibrationZoom: 1.0);
+        if (result is not null) Disarm();
+        return result;
+    }
+
+    private void OnPinAdded(object? sender, WorldCoord world)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => Enqueue(world));
+        else Enqueue(world);
+    }
+
+    private void Enqueue(WorldCoord world)
+    {
+        if (!IsArmed) return; // disarmed → drop (this is how replay is discarded)
+        _pending.Enqueue(world);
+        RaiseCounts();
+    }
+
+    private void RaiseCounts()
+    {
+        OnPropertyChanged(nameof(PendingCount));
+        OnPropertyChanged(nameof(PairedCount));
+        OnPropertyChanged(nameof(CanSolve));
+        OnPropertyChanged(nameof(StatusText));
+    }
+}

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
 using Legolas.Flow;
+using Legolas.Services;
 using Legolas.Sharing;
 using Mithril.Shared.Character;
 using Mithril.Shared.Reference;
@@ -19,6 +20,7 @@ namespace Legolas.ViewModels;
 public enum WizardStep
 {
     PickMode,
+    Calibrating,
     Listening,
     Gathering,
     Done,
@@ -35,6 +37,7 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
     private readonly SessionState _session;
     private readonly SurveyFlowController _surveyFlow;
     private readonly MotherlodeFlowController _motherlodeFlow;
+    private readonly IAreaCalibrationService _areaCalibration;
     private readonly LegolasSettings _settings;
     private readonly LegolasReportService? _reportService;
     private readonly LegolasShareCardRenderer? _renderer;
@@ -50,6 +53,8 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         MotherlodeViewModel motherlode,
         MapOverlayViewModel mapOverlay,
         NudgePadViewModel nudgePad,
+        IAreaCalibrationService areaCalibration,
+        PinCalibrationCoordinator pinCalibration,
         LegolasSettings settings,
         LegolasReportService? reportService = null,
         LegolasShareCardRenderer? renderer = null,
@@ -66,6 +71,8 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _activeChar = activeChar;
         _refData = refData;
         _dialogs = dialogs;
+        _areaCalibration = areaCalibration;
+        PinCalibration = pinCalibration;
         ControlPanel = controlPanel;
         Motherlode = motherlode;
         MapOverlay = mapOverlay;
@@ -76,6 +83,9 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _session.Surveys.CollectionChanged += OnSurveysChangedForOverlays;
         _motherlodeFlow.PropertyChanged += OnMotherlodeFlowChanged;
         _session.PropertyChanged += OnSessionChanged;
+        // #460: once the area becomes calibrated (Solve persisted it), leave
+        // the Calibrating gate.
+        _areaCalibration.Changed += (_, _) => RecomputeStep();
         if (_reportService is not null)
             _reportService.ReportGenerated += OnReportGenerated;
         RecomputeStep();
@@ -163,11 +173,22 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
 
     partial void OnCurrentStepChanged(WizardStep value)
     {
+        // #460: the Calibrating gate arms pin-capture on the map overlay
+        // (which it opens); any other step disarms (flushes pending/pairs).
+        if (value == WizardStep.Calibrating)
+        {
+            PinCalibration.Arm();
+            _session.IsMapVisible = true;
+        }
+        else if (PinCalibration.IsArmed)
+        {
+            PinCalibration.Disarm();
+        }
+
         // #454: no AwaitingPosition step. Entering Listening auto-opens the
-        // map (so absolute pins are visible by default — replaces the map
-        // auto-open the old anchor step provided) and the inventory (the user
-        // is picking which survey to use). Gathering keeps the inventory open
-        // as a walk-the-route checklist.
+        // map (so absolute pins are visible by default) and the inventory
+        // (the user is picking which survey to use). Gathering keeps the
+        // inventory open as a walk-the-route checklist.
         if (value is WizardStep.Listening or WizardStep.Gathering)
         {
             _session.IsInventoryVisible = true;
@@ -180,6 +201,7 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
     public string CurrentStepTitle => CurrentStep switch
     {
         WizardStep.PickMode => "What are you doing?",
+        WizardStep.Calibrating => "Calibrate this area",
         WizardStep.Listening => "Use a survey",
         WizardStep.Gathering => "Walk your route",
         WizardStep.Done => "All collected",
@@ -191,6 +213,10 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
     public MotherlodeViewModel Motherlode { get; }
     public MapOverlayViewModel MapOverlay { get; }
     public NudgePadViewModel NudgePad { get; }
+
+    /// <summary>#460 cold-start pin-calibration driver — the Calibrating step
+    /// binds its status/Solve to this.</summary>
+    public PinCalibrationCoordinator PinCalibration { get; }
 
     public SessionState Session => _session;
     public SurveyFlowController SurveyFlow => _surveyFlow;
@@ -216,6 +242,21 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _surveyFlow.Reset();
     }
 
+    /// <summary>#460 Calibrating step: solve + persist from the click-paired
+    /// pins. On success the area is calibrated, <c>Changed</c> fires, and the
+    /// wizard advances out of Calibrating (RecomputeStep).</summary>
+    [RelayCommand]
+    private void SolveCalibration()
+    {
+        PinCalibration.Solve();
+        RecomputeStep();
+    }
+
+    /// <summary>#460 Calibrating step: discard placed pairs and re-arm
+    /// capture for a fresh attempt.</summary>
+    [RelayCommand]
+    private void ClearCalibrationPins() => PinCalibration.Arm();
+
     /// <summary>
     /// Step-wise back. From the first post-pick step, returns to mode pick
     /// (delegates to <see cref="ChangeMode"/>). From mid-flow steps, undoes
@@ -228,6 +269,7 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
     {
         switch (CurrentStep)
         {
+            case WizardStep.Calibrating:
             case WizardStep.Listening:
             case WizardStep.MotherlodeMeasuring:
                 // First post-pick step → back to mode pick.
@@ -368,18 +410,30 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
             return;
         }
 
-        // #454 collapsed the Survey FSM (no AwaitingPosition/Ready — absolute
-        // placement needs no anchor). Listening is the resting/default step;
-        // its UI already adapts to an empty Surveys list. (The cold-start
-        // Calibrating gate is added in the follow-up PR — see #460.)
-        CurrentStep = _session.Mode == SessionMode.Motherlode
-            ? WizardStep.MotherlodeMeasuring
-            : _surveyFlow.CurrentState switch
-            {
-                SurveyFlowState.Listening => WizardStep.Listening,
-                SurveyFlowState.Gathering => WizardStep.Gathering,
-                SurveyFlowState.Done => WizardStep.Done,
-                _ => WizardStep.Listening,
-            };
+        if (_session.Mode == SessionMode.Motherlode)
+        {
+            CurrentStep = WizardStep.MotherlodeMeasuring;
+            return;
+        }
+
+        // #460: cold-start gate. An uncalibrated area places nothing
+        // (placement is absolute) — route the user through Calibrating until
+        // the area has a calibration; IAreaCalibrationService.Changed
+        // re-runs this once Solve persists one. #454 collapsed the rest of
+        // the Survey FSM (no AwaitingPosition/Ready); Listening is the
+        // resting/default step and its UI adapts to an empty Surveys list.
+        if (!_areaCalibration.IsCurrentAreaCalibrated)
+        {
+            CurrentStep = WizardStep.Calibrating;
+            return;
+        }
+
+        CurrentStep = _surveyFlow.CurrentState switch
+        {
+            SurveyFlowState.Listening => WizardStep.Listening,
+            SurveyFlowState.Gathering => WizardStep.Gathering,
+            SurveyFlowState.Done => WizardStep.Done,
+            _ => WizardStep.Listening,
+        };
     }
 }

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -17,11 +17,12 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     private readonly LegolasSettings? _settings;
     private readonly SurveyFlowController _surveyFlow;
     private readonly LegolasBrushes _brushes;
+    private readonly PinCalibrationCoordinator? _pinCal;
 
     public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes)
         : this(session, projector, optimizer, surveyFlow, brushes, settings: null) { }
 
-    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes, LegolasSettings? settings)
+    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes, LegolasSettings? settings, PinCalibrationCoordinator? pinCalibration = null)
     {
         _session = session;
         _projector = projector;
@@ -29,6 +30,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         _surveyFlow = surveyFlow;
         _brushes = brushes;
         _settings = settings;
+        _pinCal = pinCalibration;
+        if (_pinCal is not null)
+            _pinCal.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(PinCalibrationCoordinator.IsArmed))
+                    OnPropertyChanged(nameof(IsCalibrationCapturing));
+            };
         if (_settings is not null)
         {
             _settings.PropertyChanged += (_, e) =>
@@ -83,6 +91,21 @@ public sealed partial class MapOverlayViewModel : ObservableObject
 
     /// <summary>True iff the survey FSM is in <c>Listening</c>.</summary>
     public bool IsListening => _surveyFlow.CurrentState == SurveyFlowState.Listening;
+
+    /// <summary>#460: true while the wizard <c>Calibrating</c> step has armed
+    /// pin-capture on this overlay. The view routes viewport clicks to
+    /// <see cref="PairCalibrationClick"/> while this holds.</summary>
+    public bool IsCalibrationCapturing => _pinCal?.IsArmed == true;
+
+    /// <summary>Pair a calibration overlay-click with the next pending
+    /// <c>ProcessMapPinAdd</c> world coord (turn order). No-op when not
+    /// capturing.</summary>
+    public void PairCalibrationClick(PixelPoint pixel) => _pinCal?.PairClick(pixel);
+
+    /// <summary>Click-paired calibration markers to render on the overlay
+    /// (null when no coordinator — e.g. the test ctor).</summary>
+    public System.Collections.ObjectModel.ObservableCollection<PixelPoint>? CalibrationMarkers
+        => _pinCal?.PlacedMarkers;
 
     /// <summary>
     /// Move the currently-nudgeable target by <c>(dx, dy) * step</c>. Routes

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -53,6 +53,40 @@
                      on hover are not reproduced — see commit history. -->
                 <rendering:D2DOverlaySurface x:Name="MapSurface" IsHitTestVisible="False" />
 
+                <!-- #460: calibration capture. While the wizard Calibrating
+                     step has armed capture, viewport clicks pair with pending
+                     ProcessMapPinAdd coords; each paired click drops a marker
+                     here. IsHitTestVisible=False so clicks reach the Viewport
+                     handler. Zero-size Canvas + negative offsets so the dot
+                     sits exactly on the click (WPF Grid would re-centre it). -->
+                <ItemsControl ItemsSource="{Binding CalibrationMarkers}" IsHitTestVisible="False"
+                              Visibility="{Binding IsCalibrationCapturing, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Ellipse Width="12" Height="12" Margin="-6,-6,0,0"
+                                     Fill="#CC33C1FF" Stroke="White" StrokeThickness="1.5" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Border HorizontalAlignment="Center" VerticalAlignment="Top"
+                        Margin="0,12,0,0" Padding="14,8"
+                        Background="#CC0A2A3A" BorderBrush="#FF33C1FF" BorderThickness="1"
+                        CornerRadius="4" MaxWidth="520" IsHitTestVisible="False"
+                        Visibility="{Binding IsCalibrationCapturing, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                    <TextBlock Text="Calibration: click each dropped map pin here, in the order you dropped them."
+                               Foreground="#FFE0F4FF" TextWrapping="Wrap" TextAlignment="Center" FontSize="13" />
+                </Border>
+
                 <!-- Optional on-overlay nudge pad (toggle in settings). Same VM as
                      the wizard panel's pad, so step-size selection stays in sync. -->
                 <Border HorizontalAlignment="Right" VerticalAlignment="Bottom"

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -208,6 +208,16 @@ public partial class MapOverlayView : Window
         var canvasPos = Mouse.GetPosition(Viewport);
         var clickPoint = new PixelPoint(canvasPos.X, canvasPos.Y);
 
+        // #460: while the wizard Calibrating step has armed capture, a
+        // viewport click pairs with the next pending ProcessMapPinAdd world
+        // coord (turn order). Consumes the click — no placement / mode logic.
+        if (vm.IsCalibrationCapturing)
+        {
+            vm.PairCalibrationClick(clickPoint);
+            e.Handled = true;
+            return;
+        }
+
         // Motherlode records the player position from the click; Survey
         // ignores it (placement is automatic + absolute). The VM mode-gates.
         vm.HandleMapClickCommand.Execute(clickPoint);

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -63,7 +63,21 @@
                             Visibility="{Binding Session.Mode, Converter={x:Static controls:EnumMatchConverter.ToVisibility}, ConverterParameter=Survey}">
                     <TextBlock Text="Mode" Style="{StaticResource WizardBreadcrumbStep}" />
                     <TextBlock Style="{StaticResource WizardBreadcrumbSeparator}" />
-                    <!-- #454: no "Position" step — placement is absolute. -->
+                    <!-- #460: cold-start calibration gate (skipped when the
+                         area is already calibrated). -->
+                    <TextBlock Text="Calibrate">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource WizardBreadcrumbStep}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CurrentStep}" Value="Calibrating">
+                                        <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
+                                        <Setter Property="FontWeight" Value="SemiBold" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBlock Style="{StaticResource WizardBreadcrumbSeparator}" />
                     <TextBlock Text="Listen">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource WizardBreadcrumbStep}">
@@ -192,6 +206,39 @@
                                 Command="{Binding PickSurveyModeCommand}" />
                         <Button Content="Motherlode" Style="{StaticResource WizardPrimaryButton}" Margin="0"
                                 Command="{Binding PickMotherlodeModeCommand}" />
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- Calibrating (#460: cold-start gate — uncalibrated area.
+                     Capture happens on the map overlay, not a separate
+                     window; this panel is just guidance + status + Solve. -->
+                <StackPanel Visibility="{Binding CurrentStep, Converter={x:Static controls:EnumMatchConverter.ToVisibility}, ConverterParameter=Calibrating}">
+                    <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,12"
+                               FontSize="{DynamicResource AppFontSizeBody}"
+                               Foreground="{StaticResource TextSecondaryBrush}">
+                        <Run Text="This area isn't calibrated yet, so pins can't place. Calibrate by dropping map pins:" />
+                    </TextBlock>
+                    <StackPanel HorizontalAlignment="Center" Margin="0,0,0,12">
+                        <TextBlock Text="1.  Drop ≥3 well-spread map pins in-game (works on a fogged/blank map)"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
+                        <TextBlock Text="2.  Click each pin's spot on the map overlay, in the same order"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
+                        <TextBlock Text="3.  Solve — the area calibrates and the wizard continues"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
+                    </StackPanel>
+                    <TextBlock Text="{Binding PinCalibration.StatusText}"
+                               TextWrapping="Wrap" TextAlignment="Center" Margin="0,0,0,12"
+                               FontSize="{DynamicResource AppFontSizeBody}"
+                               Foreground="{StaticResource AccentBrush}" />
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button Content="Solve" Style="{StaticResource WizardPrimaryButton}"
+                                Command="{Binding SolveCalibrationCommand}"
+                                IsEnabled="{Binding PinCalibration.CanSolve}" />
+                        <Button Content="Clear pins" Style="{StaticResource WizardPrimaryButton}" Margin="0"
+                                Command="{Binding ClearCalibrationPinsCommand}" />
                     </StackPanel>
                 </StackPanel>
 

--- a/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Services;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Legolas.Tests.Services;
+
+/// <summary>
+/// #460: the view-agnostic cold-start pin-calibration driver. Mirrors the
+/// Phase-4 pin-cal invariants but against the coordinator, not the (untouched,
+/// redundant) standalone calibration VM.
+/// </summary>
+public class PinCalibrationCoordinatorTests
+{
+    private static (PinCalibrationCoordinator coord, FakeCalib calib) Build()
+    {
+        var calib = new FakeCalib();
+        return (new PinCalibrationCoordinator(calib), calib);
+    }
+
+    [Fact]
+    public void Disarmed_pins_are_dropped_so_area_entry_replay_cannot_leak()
+    {
+        var (coord, calib) = Build();
+        // Bulk area-entry replay arrives BEFORE arming → must be ignored.
+        calib.NotePinAdded(new WorldCoord(-521, 0, 368));
+        calib.NotePinAdded(new WorldCoord(367, 0, 2798));
+
+        coord.PendingCount.Should().Be(0);
+        coord.PairClick(new PixelPoint(1, 1)); // nothing pending → no-op
+        coord.PairedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Armed_pins_queue_and_pair_in_turn_order()
+    {
+        var (coord, calib) = Build();
+        coord.Arm();
+
+        var w0 = new WorldCoord(-521, 0, 368);
+        var w1 = new WorldCoord(367, 0, 2798);
+        var w2 = new WorldCoord(1145, 0, 1323);
+        calib.NotePinAdded(w0);
+        calib.NotePinAdded(w1);
+        calib.NotePinAdded(w2);
+        coord.PendingCount.Should().Be(3);
+        coord.CanSolve.Should().BeFalse();
+
+        // Oldest-first pairing, irrespective of anything else.
+        coord.PairClick(new PixelPoint(10, 11));
+        coord.PairClick(new PixelPoint(20, 22));
+        coord.PairClick(new PixelPoint(30, 33));
+
+        coord.PairedCount.Should().Be(3);
+        coord.PendingCount.Should().Be(0);
+        coord.CanSolve.Should().BeTrue();
+        coord.PlacedMarkers.Should().HaveCount(3);
+
+        coord.Solve().Should().NotBeNull();
+        calib.LastPairs.Should().Equal(
+            (w0, new PixelPoint(10, 11)),
+            (w1, new PixelPoint(20, 22)),
+            (w2, new PixelPoint(30, 33)));
+        coord.IsArmed.Should().BeFalse("a successful solve disarms");
+    }
+
+    [Fact]
+    public void Solve_below_three_pairs_is_null_and_does_not_call_service()
+    {
+        var (coord, calib) = Build();
+        coord.Arm();
+        calib.NotePinAdded(new WorldCoord(1, 0, 2));
+        coord.PairClick(new PixelPoint(5, 5));
+
+        coord.CanSolve.Should().BeFalse();
+        coord.Solve().Should().BeNull();
+        calib.LastPairs.Should().BeNull();
+    }
+
+    [Fact]
+    public void Arm_clears_stale_state_then_Disarm_flushes()
+    {
+        var (coord, calib) = Build();
+        coord.Arm();
+        calib.NotePinAdded(new WorldCoord(1, 0, 2));
+        coord.PairClick(new PixelPoint(5, 5));
+        coord.PairedCount.Should().Be(1);
+
+        coord.Arm(); // re-arm = fresh attempt
+        coord.PairedCount.Should().Be(0);
+        coord.PendingCount.Should().Be(0);
+        coord.PlacedMarkers.Should().BeEmpty();
+
+        calib.NotePinAdded(new WorldCoord(3, 0, 4));
+        coord.PendingCount.Should().Be(1);
+        coord.Disarm();
+        coord.IsArmed.Should().BeFalse();
+        coord.PendingCount.Should().Be(0);
+        // Disarmed again → replay ignored.
+        calib.NotePinAdded(new WorldCoord(7, 0, 8));
+        coord.PendingCount.Should().Be(0);
+    }
+
+    private sealed class FakeCalib : IAreaCalibrationService
+    {
+        public List<(WorldCoord, PixelPoint)>? LastPairs { get; private set; }
+
+        public AreaCalibration? CalibrateCurrentArea(
+            IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0)
+        {
+            LastPairs = placements.Select(p => (p.World, p.Pixel)).ToList();
+            return new AreaCalibration(1, 0, 0, 0, placements.Count, 0);
+        }
+
+        public event EventHandler<WorldCoord>? PinAdded;
+        public void NotePinAdded(WorldCoord world) => PinAdded?.Invoke(this, world);
+
+        public string? CurrentAreaKey => "AreaTest";
+        public string? CurrentAreaFriendlyName => "Test";
+        public bool IsCurrentAreaCalibrated => false;
+        public AreaCalibration? CurrentCalibration => null;
+        public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
+        public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
+        public event EventHandler? Changed { add { } remove { } }
+        public void OnAreaEntered(string areaFriendlyName) { }
+        public void SelectArea(string areaKey) { }
+        public void ClearCurrentAreaCalibration() { }
+        public void NoteSurvey(string name, MetreOffset offset) { }
+        public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -14,8 +14,40 @@ namespace Legolas.Tests.ViewModels;
 /// </summary>
 public class LegolasWizardViewModelTests
 {
+    // #460: a minimal IAreaCalibrationService. Defaults to *calibrated* so
+    // the existing flow tests bypass the Calibrating gate; gate tests pass
+    // one with Calibrated=false and flip it + RaiseChanged().
+    private sealed class FakeAreaCalib : IAreaCalibrationService
+    {
+        public bool Calibrated { get; set; } = true;
+        public bool IsCurrentAreaCalibrated => Calibrated;
+        public void RaiseChanged() => Changed?.Invoke(this, EventArgs.Empty);
+
+        public string? CurrentAreaKey => "AreaTest";
+        public string? CurrentAreaFriendlyName => "Test";
+        public AreaCalibration? CurrentCalibration => null;
+        public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
+        public IReadOnlyList<Mithril.Shared.Reference.AreaEntry> AllAreas => Array.Empty<Mithril.Shared.Reference.AreaEntry>();
+        public event EventHandler? Changed;
+        public void OnAreaEntered(string areaFriendlyName) { }
+        public void SelectArea(string areaKey) { }
+        public AreaCalibration? CalibrateCurrentArea(
+            IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0)
+        {
+            Calibrated = true;
+            var c = new AreaCalibration(1, 0, 0, 0, placements.Count, 0);
+            Changed?.Invoke(this, EventArgs.Empty);
+            return c;
+        }
+        public void ClearCurrentAreaCalibration() { }
+        public void NoteSurvey(string name, MetreOffset offset) { }
+        public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
+        public void NotePinAdded(WorldCoord world) => PinAdded?.Invoke(this, world);
+        public event EventHandler<WorldCoord>? PinAdded;
+    }
+
     private static (LegolasWizardViewModel wizard, SessionState session, SurveyFlowController surveyFlow,
-        MotherlodeFlowController motherlodeFlow, LegolasSettings settings) BuildSut()
+        MotherlodeFlowController motherlodeFlow, LegolasSettings settings) BuildSut(FakeAreaCalib? calib = null)
     {
         var session = new SessionState();
         var settings = new LegolasSettings();
@@ -26,11 +58,13 @@ public class LegolasWizardViewModelTests
         var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
         var projector = new CoordinateProjector();
         var brushes = new LegolasBrushes(settings);
+        var areaCalib = calib ?? new FakeAreaCalib();
+        var pinCal = new PinCalibrationCoordinator(areaCalib);
         var motherlode = new MotherlodeViewModel(trilat, optimizer, session, motherlodeFlow);
-        var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings);
+        var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings, pinCal);
         var nudgePad = new NudgePadViewModel(session, mapOverlay, settings);
         var wizard = new LegolasWizardViewModel(session, surveyFlow, motherlodeFlow,
-            controlPanel, motherlode, mapOverlay, nudgePad, settings);
+            controlPanel, motherlode, mapOverlay, nudgePad, areaCalib, pinCal, settings);
         return (wizard, session, surveyFlow, motherlodeFlow, settings);
     }
 
@@ -306,5 +340,70 @@ public class LegolasWizardViewModelTests
         session.IsInventoryVisible = true;
 
         notifications.Should().BeGreaterOrEqualTo(2);
+    }
+
+    // ─── #460 cold-start Calibrating gate ────────────────────────────────
+
+    [Fact]
+    public void PickSurveyMode_on_uncalibrated_area_goes_to_Calibrating()
+    {
+        var calib = new FakeAreaCalib { Calibrated = false };
+        var (wizard, _, _, _, _) = BuildSut(calib);
+
+        wizard.PickSurveyModeCommand.Execute(null);
+
+        wizard.CurrentStep.Should().Be(WizardStep.Calibrating);
+        wizard.PinCalibration.IsArmed.Should().BeTrue("entering Calibrating arms map-overlay capture");
+    }
+
+    [Fact]
+    public void Calibrating_advances_to_Listening_when_area_becomes_calibrated()
+    {
+        var calib = new FakeAreaCalib { Calibrated = false };
+        var (wizard, _, _, _, _) = BuildSut(calib);
+        wizard.PickSurveyModeCommand.Execute(null);
+        wizard.CurrentStep.Should().Be(WizardStep.Calibrating);
+
+        calib.Calibrated = true;
+        calib.RaiseChanged(); // IAreaCalibrationService.Changed → RecomputeStep
+
+        wizard.CurrentStep.Should().Be(WizardStep.Listening);
+        wizard.PinCalibration.IsArmed.Should().BeFalse("leaving Calibrating disarms capture");
+    }
+
+    [Fact]
+    public void SolveCalibration_persists_and_leaves_the_gate()
+    {
+        var calib = new FakeAreaCalib { Calibrated = false };
+        var (wizard, _, _, _, _) = BuildSut(calib);
+        wizard.PickSurveyModeCommand.Execute(null);
+
+        // Three click-paired pins, then Solve.
+        calib.NotePinAdded(new WorldCoord(1, 0, 2));
+        calib.NotePinAdded(new WorldCoord(3, 0, 4));
+        calib.NotePinAdded(new WorldCoord(5, 0, 6));
+        wizard.MapOverlay.PairCalibrationClick(new PixelPoint(10, 10));
+        wizard.MapOverlay.PairCalibrationClick(new PixelPoint(20, 20));
+        wizard.MapOverlay.PairCalibrationClick(new PixelPoint(30, 30));
+        wizard.PinCalibration.CanSolve.Should().BeTrue();
+
+        wizard.SolveCalibrationCommand.Execute(null);
+
+        calib.Calibrated.Should().BeTrue();
+        wizard.CurrentStep.Should().Be(WizardStep.Listening);
+    }
+
+    [Fact]
+    public void Back_from_Calibrating_returns_to_PickMode()
+    {
+        var calib = new FakeAreaCalib { Calibrated = false };
+        var (wizard, _, _, _, _) = BuildSut(calib);
+        wizard.PickSurveyModeCommand.Execute(null);
+        wizard.CurrentStep.Should().Be(WizardStep.Calibrating);
+
+        wizard.BackCommand.Execute(null);
+
+        wizard.CurrentStep.Should().Be(WizardStep.PickMode);
+        wizard.PinCalibration.IsArmed.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## #460 PR-B — cold-start pin calibration via the map overlay

Second of two PRs for #460. Adds the cold-start `Calibrating` wizard step, driven through the **existing map overlay** — explicitly **not** the messy standalone calibration window, which is left **untouched/redundant** per the #460 decision.

> **Stacked on [#466](https://github.com/moumantai-gg/mithril/pull/466)** (PR-A, FSM collapse — adds `WizardStep`, the collapsed wizard, etc.). Rebase/retarget to `main` as #466 merges.

### What it adds
- **`PinCalibrationCoordinator`** — view-agnostic. Subscribes to `IAreaCalibrationService.PinAdded` (the shipped `ProcessMapPinAdd` channel), turn-order-pairs world coords with overlay clicks, calls `CalibrateCurrentArea` + the existing solver. **Replay-arming:** queues only while armed (area-entry replay dropped when disarmed). **Label-agnostic by construction** — `PinAdded` carries a bare `WorldCoord`.
- **Wizard `Calibrating` gate** — `RecomputeStep` routes Survey to `Calibrating` when `!IsCurrentAreaCalibrated`; `IAreaCalibrationService.Changed` auto-advances out once `Solve` persists. Entering arms the coordinator + opens the map; leaving disarms. `Back → PickMode`. `Solve`/`Clear` commands, breadcrumb segment, step body.
- **Map overlay = capture surface.** `MapOverlayViewModel` exposes `IsCalibrationCapturing` / `PairCalibrationClick` / `CalibrationMarkers` (optional coordinator dep — test ctors unaffected). Viewport `MouseDown` routes clicks to `PairCalibrationClick` while capturing; placed markers + a capture banner render on the overlay. `CalibrationOverlayView`/`CalibrationSessionViewModel` **untouched** (redundant second pin-cal path, accepted).

### Verification
- `dotnet build Mithril.slnx` — **0/0**; `XamlResourceLint` OK (121 keys).
- **266** Legolas tests green: new `PinCalibrationCoordinatorTests` (replay-drop, turn-order pairing, ≥3 solve, arm/disarm flush) + wizard Calibrating-gate tests (uncalibrated→Calibrating, Changed→Listening, Solve persists, Back).
- Shell boots to **"Application started"** (DI resolves the coordinator + new wizard/map-overlay deps).
- ⚠️ Interactive click-through (PickMode → Calibrating → drop pins in-game → click each on the overlay → Solve → Listening) is not automatable here — a hands-on pass is recommended before merge (with #466).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
