### PR TITLE
feat(gamestate): reference-enrich PlayerSkillSnapshot (#470)

### DIFF
--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -103,16 +103,14 @@ identically:
   `skills.json`; their level is derived from member sub-skills (Phrenology →
   Phrenology_Demons, …) and carried in `bonus` (`MaxBonusLevels` 125, `raw`
   stays 0). They never gain XP, so there is no per-level curve — hence
-  `max=0`, a **verified-exact runtime proxy** for the authoritative
-  `IReferenceDataService.Skills[key].XpTable == "None"` (`skills.json` is keyed
-  by exactly the log `type=` token, so it maps 1:1). That accessor **already
-  exists and is widely consumed** (Elrond, Celebrimbor, Silmarillion's own
-  Abilities tab, …) — the tracker uses the log proxy by **deliberate choice**
-  (keep the parser/service pure-string and unit-testable, no DI surface), not
-  because the data is unavailable. Optional reference-backed enrichment is the
-  independent follow-up #470 (no dependency on the Silmarillion-tab work
-  #469). Kept in the snapshot — flagged, not dropped — so a consumer decides;
-  the leveling constraint set should exclude them.
+  `max=0`, a **verified-exact log proxy** for the authoritative
+  `SkillEntry.XpTable == "None"`. **#470 (shipped):** when
+  `IReferenceDataService` is available the snapshot carries a `SkillReference`
+  (`DisplayName`, `XpTable`, `MaxBonusLevels`) and `IsTrainable` uses the
+  authoritative `XpTable != "None"`; when absent it degrades to the `max>0`
+  proxy (the two agree 1:1 on all observed data — the reference just removes
+  the inference). Kept in the snapshot — flagged, not dropped — so a consumer
+  decides; the leveling constraint set should exclude them.
 - **`bonus` is gear/buff/form-derived for trainable skills, not progression** —
   volatile (moves as the player swaps equipment / shifts form); `Level` (raw)
   is the progression truth, and the projection keeps them separate and **never
@@ -197,11 +195,29 @@ lock — do non-trivial work off-thread.
   `shared` module prefix follows the precedent of the other `Mithril.GameState`
   parsers in the catalog; parity asserted by `LogPatternCatalogParityTests`).
 - `Skills/IPlayerSkillState.cs` — interface + `PlayerSkillSnapshot` /
-  `SkillProgressSnapshot` / `SkillStateSource`.
+  `SkillProgressSnapshot` / `SkillStateSource` / `SkillReference` (#470).
 - `Skills/SkillChange.cs` — `SkillChange` / `SkillChangeKind` (the
   `SubscribeChanges` channel payload).
 - `Skills/PlayerSkillStateService.cs` — `BackgroundService` + `IPlayerSkillState`,
   registered in `GameStateServiceCollectionExtensions.AddMithrilGameState`.
+  Takes an **optional** `IReferenceDataService?` (#470, mirrors
+  `InventoryService`) — DI auto-injects the registered singleton (already
+  required by `QuestService` in the same extension, so no new boot risk);
+  absent in unit tests → proxy fallback.
+
+## Reference enrichment (#470)
+
+When `IReferenceDataService` is present, `Project` resolves
+`Skills[skillKey]` and attaches a `SkillReference(DisplayName, XpTable,
+MaxBonusLevels)` to every `SkillProgressSnapshot`. Effects:
+
+- `IsTrainable` becomes **authoritative** (`XpTable != "None"`) instead of the
+  `max>0` log proxy; `DisplayName` is resolved at source (key →
+  human-readable). Both flow through `SkillChange.Previous`/`Current` for free.
+- When reference data is absent (tests, or not yet loaded) `Reference` is
+  `null` and the snapshot keeps the verified proxies — behaviour identical to
+  pre-#470. Optional by construction; no hard dependency, no parser change
+  (the log layer stays pure-string and unit-testable).
 
 ## Verification owed
 
@@ -221,8 +237,7 @@ lock — do non-trivial work off-thread.
   (verified: Augmentation/Performance/Phrenology all carry both; trainable
   skills like Tailoring/Endurance/NatureAppreciation have a real `XpTable` and
   no umbrella flag). `skills.json` is keyed by the same `type=` token, so the
-  proxy is 1:1 — no name list, no fuzzy mapping. `IReferenceDataService.Skills`
-  (with `XpTable`) already exists and is consumed elsewhere; the tracker uses
-  the log proxy by deliberate choice (pure-string, unit-testable), and swapping
-  in the authoritative value is the independent follow-up #470 (does **not**
-  depend on the Silmarillion-tab work #469).
+  proxy is 1:1 — no name list, no fuzzy mapping. **#470 shipped:** the snapshot
+  now also carries the authoritative `SkillEntry` value when reference data is
+  present (`IsTrainable` uses `XpTable != "None"`), with the proxy as the
+  no-reference-data fallback. See *Reference enrichment* above.

--- a/src/Mithril.GameState/Skills/IPlayerSkillState.cs
+++ b/src/Mithril.GameState/Skills/IPlayerSkillState.cs
@@ -25,10 +25,29 @@ public enum SkillStateSource
 }
 
 /// <summary>
+/// Authoritative skill metadata projected from
+/// <c>IReferenceDataService.Skills</c> (<c>SkillEntry</c>) and attached to a
+/// <see cref="SkillProgressSnapshot"/> when reference data is available. Lets a
+/// consumer use the real classification / display name instead of the log-only
+/// proxies. #470.
+/// </summary>
+/// <param name="DisplayName">In-game display name (<c>SkillEntry.DisplayName</c>),
+/// e.g. <c>"Bear and Bugbear Anatomy"</c>.</param>
+/// <param name="XpTable">The skill's XP-curve id (<c>SkillEntry.XpTable</c>);
+/// the literal <c>"None"</c> marks an umbrella skill — this is the
+/// authoritative source the <c>max==0</c> log heuristic only proxied.</param>
+/// <param name="MaxBonusLevels">Reference cap on derived/bonus levels
+/// (<c>SkillEntry.MaxBonusLevels</c>) — for umbrella skills this is the real
+/// ceiling of the <see cref="SkillProgressSnapshot.BonusLevels"/> the level
+/// lives in.</param>
+public sealed record SkillReference(string DisplayName, string XpTable, int MaxBonusLevels);
+
+/// <summary>
 /// Consumer-facing projection of one skill's progression — the raw
 /// <see cref="SkillProgressRecord"/> with the data caveats from issue #462
 /// interpreted into intent-revealing predicates so every consumer applies them
-/// the same way.
+/// the same way. When reference data is available it also carries authoritative
+/// <see cref="Reference"/> metadata (#470).
 /// </summary>
 /// <param name="Level">Unbuffed base level (the log's <c>raw</c>). This is the
 /// progression-truth value the leveling constraint set keys off — never add
@@ -42,31 +61,45 @@ public enum SkillStateSource
 /// <param name="XpNeededForNextLevel">XP threshold for the next level (the
 /// log's <c>tnl</c>). PG leaves a stale value here at the cap — only meaningful
 /// when <see cref="IsCapped"/> is false.</param>
-/// <param name="MaxLevel">Level cap (the log's <c>max</c>). <c>0</c> for a
-/// non-trainable pseudo-skill.</param>
+/// <param name="MaxLevel">Level cap (the log's <c>max</c>). <c>0</c> for an
+/// umbrella skill (see <see cref="IsTrainable"/>).</param>
+/// <param name="Reference">Authoritative skill metadata resolved from
+/// <c>IReferenceDataService.Skills</c> when reference data is available, else
+/// <c>null</c> (the tracker degrades to the log-only proxies). #470.</param>
 public readonly record struct SkillProgressSnapshot(
     int Level,
     int BonusLevels,
     long XpTowardNextLevel,
     long XpNeededForNextLevel,
-    int MaxLevel)
+    int MaxLevel,
+    SkillReference? Reference = null)
 {
     /// <summary>
-    /// True when the skill advances via an XP curve (<c>max &gt; 0</c>). False
-    /// for <b>umbrella skills</b> — real skills flagged <c>IsUmbrellaSkill</c>
-    /// /<c>XpTable:"None"</c> in <c>skills.json</c> (Augmentation / Performance /
-    /// Phrenology, …) whose level is derived from member sub-skills and carried
-    /// in <see cref="BonusLevels"/> (<see cref="Level"/> stays 0). They never
-    /// gain XP, so they have no per-level curve and report <c>max=0</c>; that is
-    /// a verified-exact runtime proxy for the authoritative
-    /// <c>IReferenceDataService.Skills[key].XpTable == "None"</c> (already
-    /// exposed and widely consumed). The tracker stays log-only by deliberate
-    /// choice — pure-string, unit-testable, no DI surface — with optional
-    /// reference-backed enrichment as the independent follow-up #470. Kept in
-    /// the snapshot — flagged, not dropped — so a consumer decides; the
-    /// leveling constraint set should exclude them.
+    /// True when the skill advances via an XP curve. <b>Authoritative when
+    /// <see cref="Reference"/> is present</b> (<c>XpTable != "None"</c>);
+    /// otherwise the verified-exact log proxy <c>max &gt; 0</c>.
+    ///
+    /// <para>False for <b>umbrella skills</b> — real skills flagged
+    /// <c>IsUmbrellaSkill</c>/<c>XpTable:"None"</c> in <c>skills.json</c>
+    /// (Augmentation / Performance / Phrenology, …) whose level is derived from
+    /// member sub-skills and carried in <see cref="BonusLevels"/>
+    /// (<see cref="Level"/> stays 0). Kept in the snapshot — flagged, not
+    /// dropped — so a consumer decides; the leveling constraint set should
+    /// exclude them. The proxy and the authoritative value agree 1:1 on all
+    /// observed data; <see cref="Reference"/> just removes the inference.</para>
     /// </summary>
-    public bool IsTrainable => MaxLevel > 0;
+    public bool IsTrainable => Reference is { } r
+        ? !string.Equals(r.XpTable, "None", StringComparison.Ordinal)
+        : MaxLevel > 0;
+
+    /// <summary>
+    /// Human-readable skill name from reference data (e.g.
+    /// <c>"Bear and Bugbear Anatomy"</c> for key <c>Anatomy_Bears</c>), or
+    /// <c>null</c> when reference data was unavailable — in which case the
+    /// consumer falls back to resolving the key itself (the model always keeps
+    /// the internal-name key regardless).
+    /// </summary>
+    public string? DisplayName => Reference?.DisplayName;
 
     /// <summary>
     /// True when the skill has reached its cap (<c>raw &gt;= max</c>, max &gt; 0).

--- a/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
+++ b/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Hosting;
 using Mithril.GameState.Skills.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
+using Mithril.Shared.Reference;
 
 namespace Mithril.GameState.Skills;
 
@@ -32,6 +33,7 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
 {
     private readonly IPlayerLogStream _stream;
     private readonly SkillLogParser _parser;
+    private readonly IReferenceDataService? _refData;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly object _lock = new();
@@ -39,13 +41,21 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
     private readonly List<Action<SkillChange>> _changeHandlers = new();
     private volatile PlayerSkillSnapshot _current = PlayerSkillSnapshot.Empty;
 
+    /// <param name="refData">Optional (#470). When present, each projected
+    /// <see cref="SkillProgressSnapshot"/> is enriched with authoritative
+    /// <see cref="SkillReference"/> metadata (display name, XpTable/umbrella).
+    /// Absent (tests, or reference data not yet loaded) → the snapshot keeps
+    /// the verified log-only proxies. Mirrors <c>InventoryService</c>'s
+    /// optional <c>IReferenceDataService?</c> dependency.</param>
     public PlayerSkillStateService(
         IPlayerLogStream stream,
         SkillLogParser parser,
+        IReferenceDataService? refData = null,
         IDiagnosticsSink? diag = null)
     {
         _stream = stream;
         _parser = parser;
+        _refData = refData;
         _diag = diag;
     }
 
@@ -158,12 +168,21 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         }
     }
 
-    private static SkillProgressSnapshot Project(SkillProgressRecord r) => new(
+    private SkillProgressSnapshot Project(SkillProgressRecord r) => new(
         Level: r.Level,
         BonusLevels: r.BonusLevels,
         XpTowardNextLevel: r.XpTowardNextLevel,
         XpNeededForNextLevel: r.XpNeededForNextLevel,
-        MaxLevel: r.MaxLevel);
+        MaxLevel: r.MaxLevel,
+        Reference: ResolveReference(r.SkillKey));
+
+    /// <summary>Authoritative metadata from reference data, or <c>null</c> when
+    /// reference data is absent or the skill isn't in the catalog (then the
+    /// snapshot falls back to the verified log-only proxies).</summary>
+    private SkillReference? ResolveReference(string skillKey)
+        => _refData is not null && _refData.Skills.TryGetValue(skillKey, out var e)
+            ? new SkillReference(e.DisplayName, e.XpTable, e.MaxBonusLevels)
+            : null;
 
     /// <summary>MUST be called with <see cref="_lock"/> held.</summary>
     private void Fire(PlayerSkillSnapshot snapshot)

--- a/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using Mithril.GameState.Skills;
 using Mithril.GameState.Skills.Parsing;
 using Mithril.Shared.Logging;
+using Mithril.Shared.Reference;
+using Mithril.TestSupport;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Skills;
@@ -17,6 +19,20 @@ public sealed class PlayerSkillStateServiceTests
 
     private static PlayerSkillStateService NewService(ScriptedStream stream)
         => new(stream, new SkillLogParser());
+
+    private static PlayerSkillStateService NewService(ScriptedStream stream, IReferenceDataService refData)
+        => new(stream, new SkillLogParser(), refData);
+
+    private static SkillEntry SkillRef(string key, string display, string xpTable, int maxBonus = 25)
+        => new(key, display, Id: 0, Combat: false, XpTable: xpTable, MaxBonusLevels: maxBonus,
+               Parents: [], Rewards: new Dictionary<string, SkillRewardEntry>());
+
+    private static FakeReferenceData RefDataWith(params SkillEntry[] skills)
+    {
+        var f = new FakeReferenceData();
+        foreach (var s in skills) f.SkillsRaw[s.Key] = s;
+        return f;
+    }
 
     [Fact]
     public void Cold_start_is_Empty_with_no_measurement()
@@ -286,6 +302,90 @@ public sealed class PlayerSkillStateServiceTests
         c.XpGained.Should().Be(160); // gross gain across the rollover
 
         try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    // ── #470: reference-data enrichment ───────────────────────────────────
+
+    private const string ProxyVsAuthLine =
+        "LocalPlayer: ProcessLoadSkills(" +
+        // log proxy (max==0) → not trainable, but reference says it IS:
+        "{type=Foo,raw=0,bonus=2,xp=0,tnl=1,max=0}, " +
+        // log proxy (max>0) → trainable, but reference says umbrella:
+        "{type=Bar,raw=10,bonus=0,xp=1,tnl=2,max=50})";
+
+    [Fact]
+    public async Task Reference_enrichment_makes_IsTrainable_authoritative_over_the_log_proxy()
+    {
+        var refData = RefDataWith(
+            SkillRef("Foo", "Foocraft", xpTable: "TypicalNoncombatSkill", maxBonus: 25),
+            SkillRef("Bar", "Bar (umbrella)", xpTable: "None", maxBonus: 125));
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0), ProxyVsAuthLine));
+        var svc = NewService(stream, refData);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.TryGet("Foo", out var foo).Should().BeTrue();
+        foo.MaxLevel.Should().Be(0);          // log proxy would say not trainable…
+        foo.IsTrainable.Should().BeTrue();    // …reference (XpTable != None) overrides
+        foo.DisplayName.Should().Be("Foocraft");
+        foo.Reference!.XpTable.Should().Be("TypicalNoncombatSkill");
+
+        svc.Current.TryGet("Bar", out var bar).Should().BeTrue();
+        bar.MaxLevel.Should().Be(50);         // log proxy would say trainable…
+        bar.IsTrainable.Should().BeFalse();   // …reference (XpTable == None) overrides
+        bar.DisplayName.Should().Be("Bar (umbrella)");
+        bar.Reference!.MaxBonusLevels.Should().Be(125);
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Without_reference_data_falls_back_to_the_verified_log_proxy()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0), ProxyVsAuthLine));
+        var svc = NewService(stream); // no refData
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.TryGet("Foo", out var foo).Should().BeTrue();
+        foo.Reference.Should().BeNull();
+        foo.DisplayName.Should().BeNull();
+        foo.IsTrainable.Should().BeFalse(); // proxy: max==0
+
+        svc.Current.TryGet("Bar", out var bar).Should().BeTrue();
+        bar.IsTrainable.Should().BeTrue();  // proxy: max>0
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Skill_absent_from_catalog_falls_back_to_proxy()
+    {
+        // refData present but doesn't know "Foo"/"Bar" → null Reference, proxy used.
+        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0), ProxyVsAuthLine));
+        var svc = NewService(stream, RefDataWith(SkillRef("Unrelated", "Unrelated", "None")));
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.TryGet("Foo", out var foo).Should().BeTrue();
+        foo.Reference.Should().BeNull();
+        foo.IsTrainable.Should().BeFalse(); // proxy fallback
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Real_skill_delta_carries_authoritative_DisplayName_and_Reference()
+    {
+        var refData = RefDataWith(
+            SkillRef("Tailoring", "Tailoring", xpTable: "TypicalNoncombatSkill", maxBonus: 25));
+        var stream = new ScriptedStream(new RawLogLine(Ts(12, 39, 2),
+            "[12:39:02] LocalPlayer: ProcessUpdateSkill({type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)"));
+        var svc = NewService(stream, refData);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.TryGet("Tailoring", out var t).Should().BeTrue();
+        t.DisplayName.Should().Be("Tailoring");
+        t.IsTrainable.Should().BeTrue();
+        t.Reference!.XpTable.Should().Be("TypicalNoncombatSkill");
+        t.Level.Should().Be(10); // log progression untouched by enrichment
     }
 
     private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);

--- a/tests/TestSupport/FakeReferenceData.cs
+++ b/tests/TestSupport/FakeReferenceData.cs
@@ -38,7 +38,10 @@ internal sealed class FakeReferenceData : IReferenceDataService
     public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
     public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
     public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
-    public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+    /// <summary>Mutable in tests that need skill-metadata resolution
+    /// (display name, XpTable/umbrella classification).</summary>
+    public Dictionary<string, SkillEntry> SkillsRaw { get; } = new(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, SkillEntry> Skills => SkillsRaw;
     public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
     public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
     /// <summary>Mutable in tests that need area-friendly-name resolution.</summary>


### PR DESCRIPTION
Closes #470. Builds on #465 (merged).

## What

`PlayerSkillStateService` takes an **optional** `IReferenceDataService?` (mirrors `InventoryService`). When present, every `SkillProgressSnapshot` carries a `SkillReference(DisplayName, XpTable, MaxBonusLevels)` resolved from the already-existing `IReferenceDataService.Skills`:

- **`IsTrainable` becomes authoritative** — `XpTable != "None"` instead of the `max>0` log proxy. (Tests prove the override both directions: a log-`max=0` skill that reference says is trainable → `true`; a log-`max>0` skill that reference says is umbrella → `false`.)
- **`DisplayName`** resolved at source (key → human-readable, e.g. `Anatomy_Bears` → "Bear and Bugbear Anatomy").
- Flows through `SkillChange.Previous`/`Current` for free.
- **Absent** (unit tests / reference data not yet loaded) → `Reference == null`, verified log proxies retained — behaviour identical to pre-#470.

No parser change (the log layer stays pure-string/unit-testable); no hard dependency.

## Independent of #469

Consumes the already-existing `IReferenceDataService.Skills` accessor — does **not** depend on the Silmarillion Skills-tab work (#469). (That false dependency was a bad-grep artifact, corrected earlier.)

## DI / boot

DI auto-injects the registered `IReferenceDataService` singleton. `QuestService` in the *same* `AddMithrilGameState` extension already takes `IReferenceDataService` (required) and boots, so adding the same (optional) dependency to another hosted service introduces **no new DI-cycle surface** — strong static argument that the boot is unaffected. Boot smoke-test not re-run here (consistent with #465's stance); happy to run on request.

## Verification

- Branched off post-#465 `main` (`d94f670`); mandatory post-merge re-verify was green before changes.
- Full solution build clean; `Mithril.GameState.Tests` **179/179** (+4 enrichment tests); log-pattern parity 2/2.
- Shared `Mithril.TestSupport.FakeReferenceData.Skills` made seedable via `SkillsRaw` (mirrors existing `AreasRaw`/`StringsRaw`; non-breaking — no ctor change, existing callers unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
