### PR TITLE
feat(gamestate,legolas): promote player map-pins to a GameState service; calibrate from existing pins (#468)

### DIFF
--- a/docs/legolas-overview.md
+++ b/docs/legolas-overview.md
@@ -126,6 +126,27 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 
 There is no longer a `NoteSurveyDetected`/`CanAcceptSurvey`/`DescribeWhyDropped` drop path: absolute pins are added straight to `SessionState.Surveys` and the controller reacts via `OnSurveysChanged`. The cold-start "uncalibrated area" case is handled in the wizard (a `Calibrating` gate step — see #460), not the FSM.
 
+## Pin calibration: two routes & the label-agnostic reconciliation
+
+> **Read this before "fixing" the calibration UI back to label-agnostic.** The two halves below look contradictory and are not.
+
+Cold-start calibration pairs *(world coordinate ↔ overlay pixel)* points and feeds them to `LandmarkCalibrationSolver` via `IAreaCalibrationService.CalibrateCurrentArea`. The world coordinates come from the player's map pins.
+
+**Pin source (#468).** The pin set is owned by the GameState-tier `IPlayerPinTracker` (`Mithril.GameState.Pins`), *not* Legolas. It parses `ProcessMapPin{Add,Remove}` (the only two verbs PG has — a rename/move is Remove+Add; there is no clear/edit verb), is **area-scoped** (keyed off the shared `PlayerAreaTracker`, swapped on area change), and **owns the login/area-entry replay**: PG bulk-re-emits every pin as an `Add` burst on each entry, which the tracker folds into an idempotent upsert keyed by rounded coordinate. Consumers therefore no longer hand-roll a replay-arming gate — `PinCalibrationCoordinator` and the standalone `CalibrationSessionViewModel` both just subscribe. Legolas's `PlayerLogParser` keeps only `ProcessMapFx` (survey targets are Legolas-owned, not shared pins).
+
+`PinCalibrationCoordinator` exposes **two routes**, both ending in the *same* `(world ↔ pixel)` solve:
+
+1. **Existing-pins route.** When the area already has ≥3 well-spread pins (`HasUsableExistingPins`), the wizard lists them by in-game identity — `MapPin.DisplayName` + `Appearance` (colour/shape decoded from the pin args, e.g. *"Fire Magic 25 (red dot)"*). The user selects one and clicks where it is on the overlay. No re-dropping.
+2. **Freshly-dropped turn-order route.** The true cold-start case (fogged brand-new area, no usable pins). Pins dropped *after* arming queue up; each click pairs the oldest unpaired one — by interaction order, label-agnostic.
+
+**Why this does not violate #454's "never pair by name" rule.** The rule's intent is *no automatic name→point pairing* (the freshly-dropped flow has no reliable name↔point map). It is preserved because:
+
+- The **solve is purely `(WorldCoord ↔ PixelPoint)`** in both routes. Name/colour/shape **never** reach `LandmarkCalibrationSolver` or `CalibrateCurrentArea`.
+- In the existing-pins route, identity is used **only to help the human** decide which service-supplied world point they are about to click. The pairing is still the user's *deliberate select-then-click* — the system never infers a pairing from a label.
+- The turn-order route is **retained**, not replaced; it is the only path that works when no usable pins exist.
+
+So: identity is UX-only disambiguation; the pairing remains a human click against a service-supplied coordinate. Keep both routes and keep colour/shape out of the solver.
+
 ## SessionState
 
 [`SessionState`](../src/Legolas.Module/ViewModels/SessionState.cs) is the shared observable model. The fields that matter for Survey:

--- a/docs/player-pin-service.md
+++ b/docs/player-pin-service.md
@@ -1,0 +1,141 @@
+# Player map-pin service (`Mithril.GameState.Pins`)
+
+Shared, `Player.log`-fed live view of the player's **map pins** for the
+current area — the authoritative, replay-deduped, area-scoped pin set. Issue:
+[#468](https://github.com/moumantai-gg/mithril/issues/468).
+
+## Why it exists
+
+Pin parsing started life inside Legolas (`PlayerLogParser` →
+`MapPinAdded`, #459) purely to feed cold-start map calibration. But the pin
+set is general live game-state — several map-overlay modes (calibrate,
+verify, landmarks, motherlode) want "what pins does the player have here?" —
+and PG's pin log has two awkward properties every consumer otherwise
+re-implements:
+
+1. **It bulk-replays the whole set on every login / area entry** with no
+   "clear" beforehand. A naïve consumer either double-counts or has to
+   hand-roll an "arm" gate to discard the backlog (the old
+   `CalibrationSessionViewModel` and `PinCalibrationCoordinator` each did).
+2. **There is no edit/move/clear verb** — only `Add` and `Remove`. A rename
+   or move is `Remove`+`Add`. Lifecycle reconstruction is non-trivial.
+
+Promoting it to a GameState-tier service (mirroring the
+`AreaTransitionParser` → `Mithril.GameState.Areas` promotion in #456, and the
+`PlayerPositionTracker` shape from #461) makes the service own that lifecycle
+once, so consumers just read a correct current set.
+
+## What it reads
+
+Two log lines, the **only** two pin verbs PG emits:
+
+| Line | Meaning | Service action |
+|---|---|---|
+| `LocalPlayer: ProcessMapPinAdd(A, B, C, (X, 0.00, Z), "label")` | A pin was placed. Also **bulk-replayed** for the whole set on every login / area entry. | **Upsert** keyed by rounded `(X,Z)`. Idempotent — a replayed pin at an unchanged coordinate raises no event. |
+| `LocalPlayer: ProcessMapPinRemove(A, B, C, (X, 0.00, Z), "label")` | A pin was deleted. | **Remove** by coordinate key. |
+
+There is no `Edit`, `Move` or `Clear` verb. The client models those as:
+
+- **Rename:** `Remove(coord, oldLabel)` then `Add(coord, newLabel)` (same timestamp-second).
+- **Move:** `Add(newCoord, label)` then `Remove(oldCoord, label)`.
+
+So a pin's **identity is its coordinate**, never its label.
+
+### Argument grammar (decoded 2026-05-18)
+
+Decoded from three live captures (`Player.log`, `Player-prev.log`,
+`oldPlayer.log`) cross-referenced with the in-game pin-editor screenshot.
+
+| Arg | Meaning | Mapping |
+|---|---|---|
+| **A** | Opaque. Invariant `1` in every capture (pin-list / visible flag). | Surfaced verbatim as `MapPin.RawList`; never interpreted. |
+| **B** | **Shape** (the editor's "Design" row). | `0` = `Dot` (circle+dot), `1` = `Square` (square+dot). Out-of-range → `Unknown`. |
+| **C** | **Colour** (the 10-swatch palette). | Index left→right, top row then bottom: `0` White, `1` Red, `2` Orange, `3` Yellow, `4` Green, `5` Cyan, `6` Blue, `7` Purple, `8` Pink, `9` Black. Out-of-range → `Unknown`. |
+| `Y` (middle of triple) | Always `0.00` — pins are 2-D map markers. | Dropped. |
+
+`0`=White is user-confirmed; `1`=Red is empirical (the captured campfire
+pins, which the player had deliberately coloured red); `2–9` are ratified
+from the palette reading order. There is **no system-assigned colour or
+shape** — every value is the player's own choice, which is what makes them a
+good *human* disambiguator for the existing-pins calibration route.
+
+Coordinates are **signed** (negative X/Z common) and area-local — the same
+per-area engine-unit world frame as `npcs.json` `Pos` / `landmarks.json`
+`Loc` and the player's own position (memory: `pg_reference_coords_are_world_frame`).
+
+## Lifecycle model
+
+```
+                ┌─────────────── area change (PlayerAreaTracker key delta)
+                │                 → clear set, raise AreaChanged(empty)
+                ▼
+  ProcessMapPinAdd ──► upsert by rounded (X,Z)
+        │                 • new coord / changed label  → raise Added
+        │                 • identical re-add (replay)   → no-op, no event
+        ▼
+  ProcessMapPinRemove ──► remove by (X,Z) ──► raise Removed (if it existed)
+```
+
+- **Replay = idempotent upsert.** The login/area-entry burst is `Add`s with
+  no preceding clear; identical coordinates collapse, so the post-replay set
+  equals the pre-replay set and consumers stay quiet through the backlog.
+- **Area transition = swap.** Pins are area-local; on any
+  `PlayerAreaTracker.CurrentArea` change the set is dropped and an
+  `AreaChanged` (empty) notification is raised. The new area's replay burst —
+  which follows the `LOADING LEVEL` line that moved the key — repopulates it.
+- **No area reverse-scan seed** (unlike `PlayerAreaTracker`/`PlayerPositionTracker`):
+  the pin replay burst lands *inside* the live tail window (after the login
+  `ProcessAddPlayer` the window is seeded to), so the set self-populates.
+
+## Public API
+
+| Member | Purpose |
+|---|---|
+| `IPlayerPinTracker.CurrentArea` | The area key the tracked set belongs to, or `null`. |
+| `IPlayerPinTracker.CurrentAreaPins` | Immutable snapshot of the current area's pins. |
+| `IPlayerPinTracker.Subscribe(Action<PinSetChanged>)` | Replays a `Snapshot` synchronously, then live `Added`/`Removed`/`AreaChanged` deltas. Returns a disposable unsubscribe token. |
+| `MapPin` | `X`, `Z`, `Label`, `Shape`, `Color`, `RawList`; `Appearance` (`"red dot"`), `DisplayName` (label or `"Unnamed pin"`). |
+| `PinSetChanged` | `Kind`, `Area`, `Pin` (the single affected pin for Added/Removed), `Pins` (full post-change snapshot), `ObservedAt` (`DateTimeOffset`). |
+
+`MapPinLogEvent` (parser output) carries the `LogEvent`-mandated `DateTime`;
+the tracker converts it to a `DateTimeOffset` at the boundary via the
+established `ToOffset(ts) => new(DateTime.SpecifyKind(ts, DateTimeKind.Utc))`
+pattern, so every model/notification timestamp is an unambiguous UTC instant
+without widening `ILogParser`.
+
+## Threading
+
+`PlayerPinTracker` is a self-feeding `BackgroundService` (mirrors
+`PlayerPositionTracker`). Ingestion runs on the hosted-service loop thread;
+state mutation, `CurrentArea`/`CurrentAreaPins` reads and subscriber dispatch
+are serialised under one lock. Every notification carries an **immutable
+snapshot**, so a handler may hold `Pins` safely. Handlers run on the
+ingestion thread — non-trivial / UI work must marshal off (e.g. WPF consumers
+dispatch to the UI thread, exactly as the calibration coordinator does).
+
+## Consumers
+
+- **Legolas cold-start calibration** (`PinCalibrationCoordinator`,
+  `CalibrationSessionViewModel`). Two routes, one solve — see the
+  "Pin calibration: two routes & the label-agnostic reconciliation" section
+  of [`legolas-overview.md`](legolas-overview.md). The solve only ever sees
+  `(WorldCoord ↔ pixel)`; colour/shape/label are UX-only disambiguation.
+- Future map-overlay modes (verify / landmarks / motherlode) can read the
+  same area-scoped set instead of re-deriving it.
+
+## Owed verification / data ceiling
+
+- **Arg A** semantics are unknown (invariant `1`); intentionally opaque, no
+  risk. Surfaced as `RawList` in case a future capture varies it.
+- `PinShape.Square` (`B=1`) never appeared in any capture — its value is
+  screenshot-derived. Low risk; revisit if a varied capture disagrees.
+- The full colour map (`2–9`) is palette-order-ratified by the maintainer,
+  not separately log-confirmed per index — acceptable, not flagged as a
+  blocking unknown.
+
+## Related
+
+- Tier/pattern precedent: `Mithril.GameState.Movement` (#461),
+  `Mithril.GameState.Areas` parser promotion (#456).
+- Memory: `pg_map_pin_log_grammar`, `legolas_calibration_findings`,
+  `pg_reference_coords_are_world_frame`, `prefer_datetimeoffset`.

--- a/src/Legolas.Module/Controls/BoolToVisibilityConverter.cs
+++ b/src/Legolas.Module/Controls/BoolToVisibilityConverter.cs
@@ -6,10 +6,19 @@ namespace Legolas.Controls;
 
 public sealed class BoolToVisibilityConverter : IValueConverter
 {
-    public static readonly BoolToVisibilityConverter Instance = new();
+    public static readonly BoolToVisibilityConverter Instance = new(false);
+
+    /// <summary>Visible when the bound bool is <c>false</c> — used to collapse
+    /// the turn-order fallback guidance once the existing-pins route is
+    /// usable (#468).</summary>
+    public static readonly BoolToVisibilityConverter Inverse = new(true);
+
+    private readonly bool _invert;
+
+    private BoolToVisibilityConverter(bool invert) => _invert = invert;
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => value is true ? Visibility.Visible : Visibility.Collapsed;
+        => (value is true) != _invert ? Visibility.Visible : Visibility.Collapsed;
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -30,22 +30,10 @@ public sealed record MapTargetDetected(
     string Category,
     string Message) : GameEvent(Timestamp);
 
-/// <summary>
-/// Player.log <c>LocalPlayer: ProcessMapPinAdd(1, 0, 0, (X, 0.00, Z),
-/// "&lt;label&gt;")</c> — a user-dropped map pin's <b>exact world
-/// coordinate</b> (#454). Emitted live on placement <em>and bulk-replayed on
-/// area entry</em>, so consumers must gate on an explicit "begin calibration"
-/// arm to avoid ingesting the replay backlog.
-///
-/// <para><b>Label is diagnostic-only — never keyed off.</b> The
-/// (world↔overlay-pixel) pairing is established by the user's overlay click in
-/// turn order during the calibration flow, identified by interaction order,
-/// never by name (hard rule, #454).</para>
-/// </summary>
-public sealed record MapPinAdded(
-    DateTime Timestamp,
-    WorldCoord World,
-    string Label) : GameEvent(Timestamp);
+// Map-pin lifecycle (ProcessMapPin{Add,Remove}) is no longer a Legolas
+// GameEvent: it was promoted to the GameState-tier MapPinParser /
+// PlayerPinTracker (#468). Calibration consumers read the area-scoped pin
+// set from IPlayerPinTracker, not a Legolas log event.
 
 public sealed record ItemCollected(
     DateTime Timestamp,

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -74,17 +74,10 @@ public interface IAreaCalibrationService
     /// <summary>Raised for each <see cref="NoteSurvey"/> — the test-mode hook.</summary>
     event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
 
-    /// <summary>
-    /// Fed every <c>ProcessMapPinAdd</c> world coord by the Player.log
-    /// pipeline (#454). Re-raised as <see cref="PinAdded"/> so the calibration
-    /// window — and only when the user has armed pin calibration — can pair it
-    /// with an overlay click. A no-op for everyone else; this decouples the
-    /// ingestion service from the VM exactly like <see cref="NoteSurvey"/>.
-    /// </summary>
-    void NotePinAdded(WorldCoord world);
-
-    /// <summary>Raised for each <see cref="NotePinAdded"/> — the pin-calibration hook.</summary>
-    event EventHandler<WorldCoord>? PinAdded;
+    // Pin ingestion is no longer Legolas-owned: the map-pin lifecycle is the
+    // GameState-tier IPlayerPinTracker (#468), which both calibration
+    // consumers subscribe to directly. The old NotePinAdded/PinAdded relay
+    // (#454) was removed with that promotion.
 }
 
 /// <summary>
@@ -199,11 +192,6 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
 
     public void NoteSurvey(string name, MetreOffset offset) =>
         SurveyObserved?.Invoke(this, new CalibrationSurveyObservation(name, offset));
-
-    public event EventHandler<WorldCoord>? PinAdded;
-
-    public void NotePinAdded(WorldCoord world) =>
-        PinAdded?.Invoke(this, world);
 
     public void ClearCurrentAreaCalibration()
     {

--- a/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
+++ b/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
@@ -1,49 +1,88 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Legolas.Domain;
+using Mithril.GameState.Pins;
 
 namespace Legolas.Services;
 
 /// <summary>
-/// View-agnostic driver for #460 cold-start pin calibration done <b>through
-/// the map overlay</b> (not the messy standalone calibration window — that
-/// path is left untouched/redundant per the #460 decision). Reuses only the
-/// clean service core: subscribes to <see cref="IAreaCalibrationService.PinAdded"/>
-/// (fed by the Player.log <c>ProcessMapPinAdd</c> ingestion) and calls
-/// <see cref="IAreaCalibrationService.CalibrateCurrentArea"/> /
-/// <c>LandmarkCalibrationSolver</c>.
+/// View-agnostic driver for cold-start pin calibration done <b>through the
+/// map overlay</b>. Consumes the GameState-tier
+/// <see cref="IPlayerPinTracker"/> (#468) — the authoritative, area-scoped,
+/// replay-deduped player pin set — and feeds click-paired
+/// <c>(WorldCoord ↔ PixelPoint)</c> placements to
+/// <see cref="IAreaCalibrationService.CalibrateCurrentArea"/>.
 ///
-/// <para><b>Replay-arming.</b> <c>ProcessMapPinAdd</c> bulk-replays on area
-/// entry, so world points are queued <em>only while armed</em> (the wizard
-/// arms on entering the <c>Calibrating</c> step). The standalone window's
-/// own pin-cal consumer gates on its own arm independently — coexistence is
-/// safe.</para>
+/// <para><b>Two routes (both end in the same solve).</b></para>
+/// <list type="number">
+///   <item><b>Existing-pins route.</b> When the player already has ≥3
+///   well-spread pins in this area, they're listed by their in-game identity
+///   (<see cref="MapPin.Label"/> + <see cref="MapPin.Appearance"/>, e.g.
+///   "Fire Magic 25 (red dot)"). The user selects one and clicks where it is
+///   on the overlay — no re-dropping. The pairing is the user's
+///   <em>deliberate</em> select-then-click; name/colour/shape are
+///   <b>UX-only</b> and never reach the solver.</item>
+///   <item><b>Freshly-dropped turn-order route.</b> The true cold-start case
+///   (fogged brand-new area, no usable pins). Pins dropped <em>after</em>
+///   arming queue up; each overlay click pairs the oldest unpaired one —
+///   label-agnostic, by interaction order (hard rule #454).</item>
+/// </list>
 ///
-/// <para><b>Label-agnostic.</b> <see cref="IAreaCalibrationService.PinAdded"/>
-/// carries a bare <see cref="WorldCoord"/> — there is structurally no pin
-/// label here. Pairing is the user's overlay click in turn order: each click
-/// pairs the <em>oldest</em> unpaired world point (hard rule #454).</para>
+/// <para><b>Reconciliation of the #454 label-agnostic rule.</b> The solve is
+/// purely <c>(WorldCoord ↔ PixelPoint)</c> in both routes — labels/colours
+/// never feed <c>LandmarkCalibrationSolver</c>. The existing-pins route only
+/// uses identity to help the <em>human</em> pick which service-supplied world
+/// point they are clicking; the pairing is still a deliberate user click, so
+/// the rule's intent (no auto-pairing by name) is preserved. See
+/// docs/legolas-overview.md.</para>
+///
+/// <para><b>Replay is the service's job now.</b> <see cref="IPlayerPinTracker"/>
+/// owns the login/area-entry bulk-replay (idempotent upsert keyed by
+/// coordinate), so a backlog never reaches the turn-order queue: only genuine
+/// post-arm <see cref="PinSetChange.Added"/> notifications enqueue. The
+/// <see cref="IsArmed"/> gate additionally scopes the queue to "since the user
+/// started calibrating".</para>
 /// </summary>
 public sealed partial class PinCalibrationCoordinator : ObservableObject
 {
     private readonly IAreaCalibrationService _service;
+    private readonly IPlayerPinTracker _pins;
+    private readonly IDisposable _sub;
+
+    // Turn-order route: pins dropped after arming, not yet click-paired.
     private readonly Queue<WorldCoord> _pending = new();
+    // Accumulated solve pairs (both routes feed this).
     private readonly List<(WorldCoord World, PixelPoint Pixel)> _pairs = new();
 
-    public PinCalibrationCoordinator(IAreaCalibrationService service)
+    public PinCalibrationCoordinator(IAreaCalibrationService service, IPlayerPinTracker pins)
     {
         _service = service;
-        _service.PinAdded += OnPinAdded;
+        _pins = pins;
+        // Subscribe replays a Snapshot synchronously (seeds ExistingPins);
+        // live notifications arrive on the tracker's ingestion thread.
+        _sub = _pins.Subscribe(OnPinSetChanged);
     }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(StatusText))]
     private bool _isArmed;
 
-    /// <summary>World points dropped (via <c>ProcessMapPinAdd</c>) and not yet
-    /// paired with an overlay click.</summary>
+    /// <summary>The pin the user has selected to click next (existing-pins
+    /// route). Null falls back to the turn-order route.</summary>
+    [ObservableProperty]
+    private MapPin? _selectedExistingPin;
+
+    /// <summary>Current-area pins available to calibrate against, by their
+    /// in-game identity. Kept in sync with the GameState set.</summary>
+    public ObservableCollection<MapPin> ExistingPins { get; } = new();
+
+    /// <summary>≥3 well-spread existing pins ⇒ offer the friendlier route.</summary>
+    public bool HasUsableExistingPins => ExistingPins.Count >= 3;
+
+    /// <summary>Pins dropped post-arm and not yet paired (turn-order route).</summary>
     public int PendingCount => _pending.Count;
 
     /// <summary>Click-paired (world ↔ pixel) points accumulated so far.</summary>
@@ -55,18 +94,30 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
     /// <summary>Markers the map overlay renders at each paired click pixel.</summary>
     public ObservableCollection<PixelPoint> PlacedMarkers { get; } = new();
 
-    public string StatusText => IsArmed
-        ? $"Drop ≥3 well-spread map pins in-game, then click each on the map " +
-          $"in the same order. Paired: {PairedCount}  ·  awaiting click: {PendingCount}."
-        : "Pin calibration is off.";
+    public string StatusText
+    {
+        get
+        {
+            if (!IsArmed) return "Pin calibration is off.";
+            var tail = $"Paired: {PairedCount}.";
+            return HasUsableExistingPins
+                ? $"Pick a pin below, then click where it is on the map. " +
+                  $"You have {ExistingPins.Count} pins here. {tail}"
+                : $"Drop ≥3 well-spread map pins in-game, then click each on " +
+                  $"the map in the same order. Awaiting click: {PendingCount}. {tail}";
+        }
+    }
 
-    /// <summary>Arm capture and clear any stale state so the area-entry
-    /// replay backlog can't leak in.</summary>
+    /// <summary>Arm capture and clear any stale state. Seeds
+    /// <see cref="ExistingPins"/> from the current GameState set so the
+    /// existing-pins route is immediately usable.</summary>
     public void Arm()
     {
         _pending.Clear();
         _pairs.Clear();
         PlacedMarkers.Clear();
+        SelectedExistingPin = null;
+        SyncExistingPins(_pins.CurrentAreaPins);
         IsArmed = true;
         RaiseCounts();
     }
@@ -78,19 +129,41 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
         _pending.Clear();
         _pairs.Clear();
         PlacedMarkers.Clear();
+        SelectedExistingPin = null;
         IsArmed = false;
         RaiseCounts();
     }
 
     /// <summary>
-    /// Pair the next overlay click. Dequeues the oldest unpaired world point
-    /// (turn order) and binds it to <paramref name="pixel"/>. No-op when
-    /// disarmed or nothing is pending.
+    /// Pair an overlay click. Existing-pins route when a pin is selected
+    /// (pairs that pin's service-supplied world coord); otherwise the
+    /// turn-order route (oldest unpaired post-arm pin). No-op when disarmed,
+    /// nothing is selected, and nothing is pending. Degenerate duplicate
+    /// world points are rejected so the solve stays well-conditioned.
     /// </summary>
     public void PairClick(PixelPoint pixel)
     {
-        if (!IsArmed || _pending.Count == 0) return;
-        var world = _pending.Dequeue();
+        if (!IsArmed) return;
+
+        WorldCoord world;
+        if (SelectedExistingPin is { } sel)
+        {
+            world = new WorldCoord(sel.X, 0, sel.Z);
+            SelectedExistingPin = null;
+        }
+        else if (_pending.Count > 0)
+        {
+            world = _pending.Dequeue();
+        }
+        else
+        {
+            return;
+        }
+
+        // Reject a second click on the same world point (both routes share
+        // _pairs) — duplicates degrade the least-squares solve.
+        if (_pairs.Any(p => Same(p.World, world))) { RaiseCounts(); return; }
+
         _pairs.Add((world, pixel));
         PlacedMarkers.Add(pixel);
         RaiseCounts();
@@ -113,19 +186,46 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
         return result;
     }
 
-    private void OnPinAdded(object? sender, WorldCoord world)
+    private void OnPinSetChanged(PinSetChanged note)
     {
         var disp = Application.Current?.Dispatcher;
-        if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => Enqueue(world));
-        else Enqueue(world);
+        if (disp is not null && !disp.CheckAccess())
+            disp.Invoke(() => Apply(note));
+        else
+            Apply(note);
     }
 
-    private void Enqueue(WorldCoord world)
+    private void Apply(PinSetChanged note)
     {
-        if (!IsArmed) return; // disarmed → drop (this is how replay is discarded)
-        _pending.Enqueue(world);
-        RaiseCounts();
+        // Keep the existing-pins picker mirroring the live set in all cases.
+        SyncExistingPins(note.Pins);
+
+        // Turn-order route: only genuinely-new pins dropped while armed
+        // enqueue. The service already suppresses replay re-adds, so no
+        // backlog can leak; the IsArmed gate scopes to the active session.
+        if (note is { Kind: PinSetChange.Added, Pin: { } pin } && IsArmed)
+        {
+            _pending.Enqueue(new WorldCoord(pin.X, 0, pin.Z));
+            RaiseCounts();
+        }
     }
+
+    /// <summary>Rebuild <see cref="ExistingPins"/> from a snapshot, preserving
+    /// the current selection by value when the same pin survives.</summary>
+    private void SyncExistingPins(IReadOnlyList<MapPin> pins)
+    {
+        var prev = SelectedExistingPin;
+        ExistingPins.Clear();
+        foreach (var p in pins) ExistingPins.Add(p);
+        SelectedExistingPin = prev is null
+            ? null
+            : ExistingPins.FirstOrDefault(p => p == prev);
+        OnPropertyChanged(nameof(HasUsableExistingPins));
+        OnPropertyChanged(nameof(StatusText));
+    }
+
+    private static bool Same(WorldCoord a, WorldCoord b) =>
+        Math.Abs(a.X - b.X) < 0.01 && Math.Abs(a.Z - b.Z) < 0.01;
 
     private void RaiseCounts()
     {

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -20,10 +20,10 @@ namespace Legolas.Services;
 /// responsibility wired here is the area→calibration bridge: feed the shared
 /// <see cref="PlayerAreaTracker"/> and, whenever the player's area changes,
 /// apply that area's persisted <see cref="Domain.AreaCalibration"/> via
-/// <see cref="IAreaCalibrationService.SelectArea"/>. <c>ProcessMapFx</c>
-/// (absolute survey/treasure targets) and <c>ProcessMapPinAdd</c> (freehand
-/// pin calibration) parsing land in Phases 3 and 4 on this same subscription —
-/// one Player.log subscription, consistent with the other consumers.</para>
+/// <see cref="IAreaCalibrationService.SelectArea"/>, plus <c>ProcessMapFx</c>
+/// (absolute survey/treasure targets) placement. Map-pin lifecycle parsing was
+/// promoted out to the GameState-tier <c>PlayerPinTracker</c> (#468) — one
+/// Player.log subscription here, consistent with the other consumers.</para>
 ///
 /// <para>The shared tracker is reverse-scan-seeded at startup
 /// (<see cref="PlayerAreaTracker.SeedFromLog"/>) to close the gap where the
@@ -94,19 +94,11 @@ public sealed class PlayerLogIngestionService : BackgroundService
                 _areaTracker.Observe(raw);
                 ApplyAreaIfChanged();
 
-                switch (_parser.TryParse(raw.Line, raw.Timestamp))
-                {
-                    case MapTargetDetected mt:
-                        PostToUi(() => HandleMapTarget(mt));
-                        break;
-                    case MapPinAdded mp:
-                        // The calibration VM ignores this unless the user has
-                        // armed pin calibration (drops the area-entry replay
-                        // backlog). Label is never read — pairing is by the
-                        // user's overlay click in turn order.
-                        PostToUi(() => _areaCalibration.NotePinAdded(mp.World));
-                        break;
-                }
+                // Map pins (ProcessMapPin{Add,Remove}) are owned by the
+                // GameState-tier PlayerPinTracker (#468); this service only
+                // handles ProcessMapFx absolute targets now.
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is MapTargetDetected mt)
+                    PostToUi(() => HandleMapTarget(mt));
             }
             catch (Exception ex)
             {

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -7,9 +7,10 @@ namespace Legolas.Services;
 
 /// <summary>
 /// Player.log analog of <see cref="ChatLogParser"/> — pure line→event. #454:
-/// <c>ProcessMapFx</c> (absolute survey/treasure-map targets) and
-/// <c>ProcessMapPinAdd</c> (freehand pin-calibration world coords). One
-/// parser, many patterns, mirroring the ChatLog parser's shape.
+/// <c>ProcessMapFx</c> (absolute survey/treasure-map targets). Map-pin
+/// lifecycle parsing moved to the GameState-tier <c>MapPinParser</c> /
+/// <c>PlayerPinTracker</c> (#468) — same promotion pattern as
+/// <c>AreaTransitionParser</c> (#456); this parser is now MapFx-only.
 ///
 /// <para>Real captured grammar (live Player.log, 2026-05-18):</para>
 /// <code>
@@ -29,14 +30,6 @@ public sealed partial class PlayerLogParser : ILogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
     private static partial Regex MapFxRx();
 
-    // ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), "Calib 1")
-    // Leading three ints + the (x, y, z) triple + quoted label. The label is
-    // captured for diagnostics ONLY — pairing is turn-order, never by name.
-    [GeneratedRegex(
-        """ProcessMapPinAdd\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*\(\s*(?<x>-?\d+(?:\.\d+)?)\s*,\s*(?<y>-?\d+(?:\.\d+)?)\s*,\s*(?<z>-?\d+(?:\.\d+)?)\s*\)\s*,\s*"(?<label>[^"]*)"\s*\)""",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
-    private static partial Regex MapPinAddRx();
-
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
         if (string.IsNullOrEmpty(line)) return null;
@@ -53,18 +46,6 @@ public sealed partial class PlayerLogParser : ILogParser
                 m.Groups["short"].Value,
                 m.Groups["cat"].Value,
                 m.Groups["msg"].Value);
-        }
-
-        if (line.Contains("ProcessMapPinAdd", StringComparison.Ordinal)
-            && MapPinAddRx().Match(line) is { Success: true } p
-            && TryNum(p.Groups["x"].ValueSpan, out var px)
-            && TryNum(p.Groups["y"].ValueSpan, out var py)
-            && TryNum(p.Groups["z"].ValueSpan, out var pz))
-        {
-            return new MapPinAdded(
-                timestamp,
-                new WorldCoord(px, py, pz),
-                p.Groups["label"].Value);
         }
 
         return null;

--- a/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
+++ b/src/Legolas.Module/ViewModels/CalibrationSessionViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
 using Legolas.Services;
+using Mithril.GameState.Pins;
 using Mithril.Shared.Reference;
 
 namespace Legolas.ViewModels;
@@ -24,13 +25,17 @@ namespace Legolas.ViewModels;
 public sealed partial class CalibrationSessionViewModel : ObservableObject
 {
     private readonly IAreaCalibrationService _service;
+    private readonly IDisposable? _pinSub;
 
-    public CalibrationSessionViewModel(IAreaCalibrationService service)
+    public CalibrationSessionViewModel(IAreaCalibrationService service, IPlayerPinTracker? pins = null)
     {
         _service = service;
         _service.Changed += OnServiceChanged;
         _service.SurveyObserved += OnSurveyObserved;
-        _service.PinAdded += OnPinAdded;
+        // Pin lifecycle moved to the GameState tracker (#468). Subscribe for
+        // the turn-order route; the area-entry replay is service-deduped and
+        // additionally gated by PinCalibrationArmed below.
+        _pinSub = pins?.Subscribe(OnPinSetChanged);
         Refresh();
     }
 
@@ -610,8 +615,12 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
         RaiseDebug();
     }
 
-    private void OnPinAdded(object? sender, WorldCoord world)
+    private void OnPinSetChanged(PinSetChanged note)
     {
+        // Only genuinely-new drops feed the turn-order queue. The tracker
+        // suppresses login/area-entry replay re-adds, so no backlog leaks.
+        if (note is not { Kind: PinSetChange.Added, Pin: { } pin }) return;
+        var world = new WorldCoord(pin.X, 0, pin.Z);
         var disp = Application.Current?.Dispatcher;
         if (disp is not null && !disp.CheckAccess()) disp.Invoke(() => EnqueuePin(world));
         else EnqueuePin(world);
@@ -619,9 +628,9 @@ public sealed partial class CalibrationSessionViewModel : ObservableObject
 
     private void EnqueuePin(WorldCoord world)
     {
-        // Disarmed → ignore (this is how the bulk area-entry replay is
-        // discarded). The label is intentionally not part of MapPinAdded's
-        // contract here — pairing is the user's next overlay click, in order.
+        // Disarmed → ignore (the bulk area-entry replay is already
+        // service-deduped; this gate scopes to the active calibration).
+        // Label is never read — pairing is the user's next overlay click.
         if (!PinCalibrationArmed) return;
         _pendingPins.Enqueue(world);
         OnPropertyChanged(nameof(PendingPinCount));

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -83,7 +83,7 @@
                         Background="#CC0A2A3A" BorderBrush="#FF33C1FF" BorderThickness="1"
                         CornerRadius="4" MaxWidth="520" IsHitTestVisible="False"
                         Visibility="{Binding IsCalibrationCapturing, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                    <TextBlock Text="Calibration: click each dropped map pin here, in the order you dropped them."
+                    <TextBlock Text="Calibration: pick a pin in the wizard and click where it is here — or, if you dropped fresh pins, click them here in the order you dropped them."
                                Foreground="#FFE0F4FF" TextWrapping="Wrap" TextAlignment="Center" FontSize="13" />
                 </Border>
 

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -216,9 +216,40 @@
                     <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,12"
                                FontSize="{DynamicResource AppFontSizeBody}"
                                Foreground="{StaticResource TextSecondaryBrush}">
-                        <Run Text="This area isn't calibrated yet, so pins can't place. Calibrate by dropping map pins:" />
+                        <Run Text="This area isn't calibrated yet, so pins can't place. Calibrate it below:" />
                     </TextBlock>
-                    <StackPanel HorizontalAlignment="Center" Margin="0,0,0,12">
+
+                    <!-- #468 Existing-pins route: shown when the player already
+                         has ≥3 pins here. Identify each by name + colour/shape
+                         (UX only — the solve still pairs world↔pixel). -->
+                    <StackPanel Visibility="{Binding PinCalibration.HasUsableExistingPins, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                                Margin="0,0,0,12">
+                        <TextBlock Text="You already have pins here. Pick one, then click where it is on the map — repeat for ≥3 well-spread pins:"
+                                   TextWrapping="Wrap" TextAlignment="Center"
+                                   FontSize="{DynamicResource AppFontSizeBody}"
+                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,8" />
+                        <ListBox ItemsSource="{Binding PinCalibration.ExistingPins}"
+                                 SelectedItem="{Binding PinCalibration.SelectedExistingPin, Mode=TwoWay}"
+                                 MaxHeight="160" HorizontalAlignment="Center" MinWidth="240"
+                                 Background="Transparent" BorderThickness="0">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock FontSize="{DynamicResource AppFontSizeBody}"
+                                               Foreground="{StaticResource TextPrimaryBrush}">
+                                        <Run Text="{Binding DisplayName, Mode=OneWay}" FontWeight="SemiBold" />
+                                        <Run Text="{Binding Appearance, Mode=OneWay, StringFormat=({0})}"
+                                             Foreground="{StaticResource TextSecondaryBrush}" />
+                                    </TextBlock>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </StackPanel>
+
+                    <!-- Turn-order fallback: true cold-start (no usable pins /
+                         fogged brand-new area). Collapses once the existing-pins
+                         route is available. -->
+                    <StackPanel HorizontalAlignment="Center" Margin="0,0,0,12"
+                                Visibility="{Binding PinCalibration.HasUsableExistingPins, Converter={x:Static controls:BoolToVisibilityConverter.Inverse}}">
                         <TextBlock Text="1.  Drop ≥3 well-spread map pins in-game (works on a fogged/blank map)"
                                    FontSize="{DynamicResource AppFontSizeBody}"
                                    Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
+using Mithril.GameState.Pins;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
 using Mithril.GameState.Sessions;
@@ -62,6 +63,18 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<PlayerPositionTracker>()
             .AddSingleton<IPlayerPositionTracker>(sp => sp.GetRequiredService<PlayerPositionTracker>())
             .AddHostedService(sp => sp.GetRequiredService<PlayerPositionTracker>());
+
+        // Player map pins are shared live game-state (#468). PG bulk-replays
+        // ProcessMapPinAdd on every login / area entry and has no clear/edit
+        // verb, so the service owns the full lifecycle (replay = idempotent
+        // upsert, area change = swap) — Legolas's calibration consumes the
+        // area-scoped set instead of hand-rolling a replay-arming gate.
+        // Self-feeding; also warms PlayerAreaTracker (idempotent).
+        services.AddSingleton<MapPinParser>();
+        services
+            .AddSingleton<PlayerPinTracker>()
+            .AddSingleton<IPlayerPinTracker>(sp => sp.GetRequiredService<PlayerPinTracker>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerPinTracker>());
 
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();

--- a/src/Mithril.GameState/Pins/IPlayerPinTracker.cs
+++ b/src/Mithril.GameState/Pins/IPlayerPinTracker.cs
@@ -1,0 +1,83 @@
+namespace Mithril.GameState.Pins;
+
+/// <summary>How a <see cref="PinSetChanged"/> notification arose.</summary>
+public enum PinSetChange
+{
+    /// <summary>Replayed synchronously to a new subscriber — the full
+    /// current-area set as it already stands (mirrors
+    /// <c>IPlayerPositionTracker.Subscribe</c>'s replay).</summary>
+    Snapshot,
+
+    /// <summary>A single pin was placed (a genuinely new coordinate, or a
+    /// changed label/appearance at an existing one). Idempotent re-adds from
+    /// a login / area-entry replay burst do <b>not</b> raise this.</summary>
+    Added,
+
+    /// <summary>A single pin was removed.</summary>
+    Removed,
+
+    /// <summary>The player changed area: the previous area's set was dropped
+    /// and <see cref="PinSetChanged.Pins"/> is the new (initially empty)
+    /// set.</summary>
+    AreaChanged,
+}
+
+/// <summary>
+/// A change to the current area's pin set. <see cref="Pins"/> is always the
+/// full set <em>after</em> the change (an immutable snapshot, safe to hold);
+/// <see cref="Pin"/> is the single affected pin for
+/// <see cref="PinSetChange.Added"/>/<see cref="PinSetChange.Removed"/> and
+/// <c>null</c> otherwise. <see cref="ObservedAt"/> is the source log line's
+/// UTC instant as a <see cref="DateTimeOffset"/> (Snapshot replays use the
+/// subscribe instant).
+/// </summary>
+/// <param name="Kind">Why this notification arose.</param>
+/// <param name="Area">The area key the set belongs to (may be <c>null</c> if
+/// the player's area is unknown).</param>
+/// <param name="Pin">The single affected pin for
+/// <see cref="PinSetChange.Added"/>/<see cref="PinSetChange.Removed"/>;
+/// <c>null</c> for <see cref="PinSetChange.Snapshot"/> /
+/// <see cref="PinSetChange.AreaChanged"/>.</param>
+/// <param name="Pins">The full current-area set <em>after</em> the change —
+/// an immutable snapshot, safe to retain.</param>
+/// <param name="ObservedAt">UTC instant of the source log line (or the
+/// subscribe instant for a <see cref="PinSetChange.Snapshot"/> replay).</param>
+public sealed record PinSetChanged(
+    PinSetChange Kind,
+    string? Area,
+    MapPin? Pin,
+    IReadOnlyList<MapPin> Pins,
+    DateTimeOffset ObservedAt);
+
+/// <summary>
+/// Shared live game-state: the local player's <b>area-scoped</b> map-pin set,
+/// owned authoritatively here (#468). Mirrors
+/// <see cref="Mithril.GameState.Movement.IPlayerPositionTracker"/> — a current
+/// snapshot plus a replay-on-<see cref="Subscribe"/> handler so late
+/// subscribers see the same view already-attached ones do.
+///
+/// <para><b>Why the service owns the set.</b> <c>ProcessMapPinAdd</c>
+/// bulk-replays on every login / area entry and there is no clear/edit verb.
+/// Centralising lifecycle here (replay = idempotent upsert keyed by
+/// coordinate, area transition = swap) means every consumer reads a correct
+/// current set instead of each re-deriving it behind its own arm-gate.</para>
+/// </summary>
+public interface IPlayerPinTracker
+{
+    /// <summary>The area the tracked set belongs to (the shared
+    /// <c>PlayerAreaTracker</c> key), or <c>null</c> if unknown.</summary>
+    string? CurrentArea { get; }
+
+    /// <summary>The current area's pins — an immutable snapshot, empty before
+    /// the first observed pin / after an area change.</summary>
+    IReadOnlyList<MapPin> CurrentAreaPins { get; }
+
+    /// <summary>
+    /// Register a handler. The current set is replayed synchronously as a
+    /// <see cref="PinSetChange.Snapshot"/> before the call returns; subsequent
+    /// changes are delivered live until the returned token is disposed.
+    /// Handlers run on the ingestion thread — marshal off-thread for
+    /// non-trivial / UI work (mirrors the position tracker's contract).
+    /// </summary>
+    IDisposable Subscribe(Action<PinSetChanged> handler);
+}

--- a/src/Mithril.GameState/Pins/MapPin.cs
+++ b/src/Mithril.GameState/Pins/MapPin.cs
@@ -1,0 +1,57 @@
+namespace Mithril.GameState.Pins;
+
+/// <summary>
+/// A single player-placed map pin in the current area. The <see cref="X"/>/
+/// <see cref="Z"/> ground-plane coordinate is the same per-area engine-unit
+/// world frame as <c>npcs.json</c> <c>Pos</c> / <c>landmarks.json</c>
+/// <c>Loc</c> and the player's own position — verified signed, negatives are
+/// common. The log's <c>Y</c> argument is always <c>0.00</c> for pins (they
+/// are 2-D map markers) and is intentionally dropped.
+///
+/// <para><see cref="Label"/>, <see cref="Shape"/> and <see cref="Color"/> are
+/// the player's own choices. They are <b>identity/UX metadata only</b> — a
+/// pin is keyed by its coordinate, never by label (a rename keeps the
+/// coordinate; see <see cref="PlayerPinTracker"/>). <see cref="RawList"/> is
+/// the still-undecoded leading <c>A</c> argument (invariant <c>1</c> in every
+/// capture); surfaced verbatim rather than interpreted.</para>
+/// </summary>
+/// <param name="X">Ground-plane east/west world coordinate (signed; the
+/// log's first coordinate component).</param>
+/// <param name="Z">Ground-plane north/south world coordinate (signed; the
+/// log's third component — the middle <c>Y</c> is always 0 and dropped).</param>
+/// <param name="Label">The player-typed pin label; may be empty (see
+/// <see cref="DisplayName"/> for a non-blank fallback).</param>
+/// <param name="Shape">Decoded from log arg <c>B</c> (the editor's "Design").</param>
+/// <param name="Color">Decoded from log arg <c>C</c> (the editor's palette).</param>
+/// <param name="RawList">The opaque, undecoded leading log arg <c>A</c>
+/// (invariant <c>1</c> in every capture). Surfaced for forward-compat; do not
+/// interpret.</param>
+public sealed record MapPin(
+    double X,
+    double Z,
+    string Label,
+    PinShape Shape,
+    PinColor Color,
+    int RawList)
+{
+    /// <summary>
+    /// Human phrase for the calibration UX, e.g. <c>"red square"</c> /
+    /// <c>"dot"</c> (colour omitted when unknown). Lets the existing-pins
+    /// route say "click where <em>Fire Magic 25</em> (red dot) is" without
+    /// the colour/shape ever reaching the solver.
+    /// </summary>
+    public string Appearance
+    {
+        get
+        {
+            var c = Color.ToDisplayWord();
+            var s = Shape.ToDisplayWord();
+            return string.IsNullOrEmpty(c) ? s : $"{c} {s}";
+        }
+    }
+
+    /// <summary>The label, or a stable fallback for unlabeled pins, so the
+    /// calibration picker never shows a blank row.</summary>
+    public string DisplayName =>
+        string.IsNullOrWhiteSpace(Label) ? "Unnamed pin" : Label;
+}

--- a/src/Mithril.GameState/Pins/MapPinLogEvent.cs
+++ b/src/Mithril.GameState/Pins/MapPinLogEvent.cs
@@ -1,0 +1,50 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Pins;
+
+/// <summary>Whether a <see cref="MapPinLogEvent"/> places or removes a pin.</summary>
+public enum MapPinChange
+{
+    /// <summary><c>ProcessMapPinAdd</c> — pin placed (also bulk-replayed on
+    /// login / area entry).</summary>
+    Added,
+
+    /// <summary><c>ProcessMapPinRemove</c> — pin deleted. PG has <b>no</b>
+    /// edit/move verb: a rename or move is a <see cref="Removed"/> of the old
+    /// pin followed by an <see cref="Added"/> of the new one (same
+    /// timestamp-second).</summary>
+    Removed,
+}
+
+/// <summary>
+/// One parsed <c>LocalPlayer: ProcessMapPin{Add,Remove}(A, B, C, (X, 0.00, Z),
+/// "label")</c> line (#468). The pure line→event output of
+/// <see cref="MapPinParser"/>; <see cref="PlayerPinTracker"/> folds a stream
+/// of these into the area-scoped current set.
+///
+/// <para>Carries a <see cref="LogEvent"/>-mandated <see cref="DateTime"/>
+/// timestamp (Player.log <c>[HH:MM:SS]</c> is UTC). It is converted to a
+/// <see cref="DateTimeOffset"/> at the tracker boundary — model/notification
+/// surfaces use <see cref="DateTimeOffset"/>; the parser interface is not
+/// widened.</para>
+/// </summary>
+/// <param name="Timestamp">The source line's reconstructed UTC instant
+/// (Player.log <c>[HH:MM:SS]</c> is UTC).</param>
+/// <param name="Change">Whether this line places or removes a pin.</param>
+/// <param name="X">Ground-plane east/west world coordinate (signed).</param>
+/// <param name="Z">Ground-plane north/south world coordinate (signed; the
+/// log's third triple component — the middle <c>Y</c> is dropped).</param>
+/// <param name="Label">The player-typed label arg (may be empty).</param>
+/// <param name="Shape">Decoded log arg <c>B</c>.</param>
+/// <param name="Color">Decoded log arg <c>C</c>.</param>
+/// <param name="RawList">Opaque leading log arg <c>A</c> (invariant
+/// <c>1</c>); passed through unmodified.</param>
+public sealed record MapPinLogEvent(
+    DateTime Timestamp,
+    MapPinChange Change,
+    double X,
+    double Z,
+    string Label,
+    PinShape Shape,
+    PinColor Color,
+    int RawList) : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Pins/MapPinParser.cs
+++ b/src/Mithril.GameState/Pins/MapPinParser.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Pins;
+
+/// <summary>
+/// Parses the local player's map-pin lifecycle from Project Gorgon's
+/// <c>Player.log</c> (#468). Promoted out of Legolas's <c>PlayerLogParser</c>
+/// to <see cref="Mithril.GameState"/> — the same tier-promotion pattern as
+/// <c>AreaTransitionParser</c> (#456) — so a single GameState service owns the
+/// authoritative pin set and consumers stop hand-rolling replay-arming.
+///
+/// <para><b>Real captured grammar</b> (live Player.log, 3 captures,
+/// 2026-05-18):</para>
+/// <code>
+/// [10:10:03] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1425.06, 0.00, 2924.99), "South")
+/// [10:30:15] LocalPlayer: ProcessMapPinRemove(1, 0, 0, (784.74, 0.00, 3429.94), "")
+/// </code>
+/// Exactly two verbs exist — <c>Add</c> and <c>Remove</c>; there is no
+/// edit/move/clear verb (a rename/move is Remove+Add, a fresh login/area-entry
+/// is a bulk <c>Add</c> burst — both handled by <see cref="PlayerPinTracker"/>,
+/// not here). The three leading integers are <c>A</c> (opaque, invariant
+/// <c>1</c>), <c>B</c> = shape and <c>C</c> = colour. The middle <c>Y</c> of
+/// the coordinate triple is always <c>0.00</c> and is skipped — pins are 2-D.
+/// Coordinates are <b>signed</b>. Non-pin lines fast-path to null.
+/// </summary>
+public sealed partial class MapPinParser : ILogParser
+{
+    // ProcessMapPinAdd(1, 0, 0, (1425.06, 0.00, 2924.99), "South")
+    //                  A  B  C    x       (y, skipped)  z     label
+    [GeneratedRegex(
+        """ProcessMapPin(?<verb>Add|Remove)\(\s*(?<a>-?\d+)\s*,\s*(?<b>-?\d+)\s*,\s*(?<c>-?\d+)\s*,\s*\(\s*(?<x>-?\d+(?:\.\d+)?)\s*,\s*-?\d+(?:\.\d+)?\s*,\s*(?<z>-?\d+(?:\.\d+)?)\s*\)\s*,\s*"(?<label>[^"]*)"\s*\)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex MapPinRx();
+
+    /// <summary>
+    /// Parse one <c>Player.log</c> line. Pure and allocation-light: a
+    /// substring fast-path rejects non-pin lines before the regex runs, so it
+    /// is safe to call on every line of the stream.
+    /// </summary>
+    /// <param name="line">The raw log line (timestamp prefix already stripped
+    /// by the tail reader, though the regex is anchored on
+    /// <c>ProcessMapPin*</c> and tolerates a prefix).</param>
+    /// <param name="timestamp">The line's reconstructed UTC instant, passed
+    /// straight onto <see cref="MapPinLogEvent.Timestamp"/>.</param>
+    /// <returns>
+    /// A <see cref="MapPinLogEvent"/> for a well-formed
+    /// <c>ProcessMapPinAdd</c>/<c>ProcessMapPinRemove</c> line; <c>null</c>
+    /// for any other line, an empty/blank line, or a pin line whose numeric
+    /// fields fail to parse (defensive — never throws on malformed input).
+    /// </returns>
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(line)) return null;
+
+        if (!line.Contains("ProcessMapPin", StringComparison.Ordinal)) return null;
+
+        if (MapPinRx().Match(line) is not { Success: true } m) return null;
+        if (!TryNum(m.Groups["x"].ValueSpan, out var x)) return null;
+        if (!TryNum(m.Groups["z"].ValueSpan, out var z)) return null;
+        if (!TryInt(m.Groups["a"].ValueSpan, out var a)) return null;
+        if (!TryInt(m.Groups["b"].ValueSpan, out var b)) return null;
+        if (!TryInt(m.Groups["c"].ValueSpan, out var c)) return null;
+
+        var change = m.Groups["verb"].ValueSpan is "Remove"
+            ? MapPinChange.Removed
+            : MapPinChange.Added;
+
+        return new MapPinLogEvent(
+            timestamp,
+            change,
+            x,
+            z,
+            m.Groups["label"].Value,
+            b.ToPinShape(),
+            c.ToPinColor(),
+            a);
+    }
+
+    private static bool TryNum(ReadOnlySpan<char> s, out double v) =>
+        double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+
+    private static bool TryInt(ReadOnlySpan<char> s, out int v) =>
+        int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out v);
+}

--- a/src/Mithril.GameState/Pins/PinColor.cs
+++ b/src/Mithril.GameState/Pins/PinColor.cs
@@ -1,0 +1,49 @@
+namespace Mithril.GameState.Pins;
+
+/// <summary>
+/// A map pin's <em>colour</em> — freely chosen per pin in the in-game pin
+/// editor's "Color" palette. Decoded 2026-05-18 from the third positional
+/// argument of <c>ProcessMapPin{Add,Remove}(A, B, <b>C</b>, (X,0,Z), "label")</c>
+/// (#468). The palette is two rows of five; the index runs left→right, top
+/// row then bottom row. <c>0 = White</c> is user-confirmed, <c>1 = Red</c> is
+/// empirical (the captured campfire pins), <c>2–9</c> are ratified from the
+/// palette order. There is <b>no system-assigned colour</b> — every value is
+/// the player's deliberate choice, which is exactly what makes it a good
+/// human disambiguator for #468's existing-pins calibration route.
+/// </summary>
+public enum PinColor
+{
+    /// <summary>Argument <c>C</c> outside 0–9 — kept, not thrown.</summary>
+    Unknown = -1,
+
+    White = 0,
+    Red = 1,
+    Orange = 2,
+    Yellow = 3,
+    Green = 4,
+    Cyan = 5,
+    Blue = 6,
+    Purple = 7,
+    Pink = 8,
+    Black = 9,
+}
+
+/// <summary>Maps the raw <c>C</c> argument to a <see cref="PinColor"/>.</summary>
+public static class PinColorExtensions
+{
+    /// <summary>Decode log arg <c>C</c> into a colour.</summary>
+    /// <param name="rawColor">The palette index from
+    /// <c>ProcessMapPin*</c>.</param>
+    /// <returns>The matching <see cref="PinColor"/> for <c>0–9</c>, else
+    /// <see cref="PinColor.Unknown"/> (never throws).</returns>
+    public static PinColor ToPinColor(this int rawColor) =>
+        rawColor is >= 0 and <= 9 ? (PinColor)rawColor : PinColor.Unknown;
+
+    /// <summary>Lower-case human word for calibration UX ("<b>red</b> dot").</summary>
+    /// <param name="color">The colour to render.</param>
+    /// <returns>The lower-case colour name, or an <b>empty string</b> when
+    /// unknown — callers (e.g. <see cref="MapPin.Appearance"/>) treat empty as
+    /// "omit the colour word".</returns>
+    public static string ToDisplayWord(this PinColor color) =>
+        color == PinColor.Unknown ? "" : color.ToString().ToLowerInvariant();
+}

--- a/src/Mithril.GameState/Pins/PinShape.cs
+++ b/src/Mithril.GameState/Pins/PinShape.cs
@@ -1,0 +1,49 @@
+namespace Mithril.GameState.Pins;
+
+/// <summary>
+/// A map pin's <em>shape</em> — the in-game pin editor's "Design" row, which
+/// the player picks per pin. Decoded 2026-05-18 from the second positional
+/// argument of <c>ProcessMapPin{Add,Remove}(A, <b>B</b>, C, (X,0,Z), "label")</c>
+/// (#468): <c>B</c> is the design index. Only <see cref="Dot"/> ever appeared
+/// in the captured logs; <see cref="Square"/> is the editor's second design.
+/// </summary>
+public enum PinShape
+{
+    /// <summary>Argument <c>B</c> outside the known range — kept rather than
+    /// thrown so an unrecognised future design degrades gracefully.</summary>
+    Unknown = -1,
+
+    /// <summary><c>B = 0</c> — circle with a centre dot (the default).</summary>
+    Dot = 0,
+
+    /// <summary><c>B = 1</c> — square with a centre dot.</summary>
+    Square = 1,
+}
+
+/// <summary>Maps the raw <c>B</c> argument to a <see cref="PinShape"/>.</summary>
+public static class PinShapeExtensions
+{
+    /// <summary>Decode log arg <c>B</c> into a shape.</summary>
+    /// <param name="rawDesign">The leading "Design" integer from
+    /// <c>ProcessMapPin*</c>.</param>
+    /// <returns>The matching <see cref="PinShape"/>, or
+    /// <see cref="PinShape.Unknown"/> for an unrecognised value (never
+    /// throws).</returns>
+    public static PinShape ToPinShape(this int rawDesign) => rawDesign switch
+    {
+        0 => PinShape.Dot,
+        1 => PinShape.Square,
+        _ => PinShape.Unknown,
+    };
+
+    /// <summary>Lower-case human word for calibration UX ("red <b>dot</b>").</summary>
+    /// <param name="shape">The shape to render.</param>
+    /// <returns>"dot" / "square", or "pin" when unknown (never empty, so the
+    /// UX phrase always reads naturally).</returns>
+    public static string ToDisplayWord(this PinShape shape) => shape switch
+    {
+        PinShape.Dot => "dot",
+        PinShape.Square => "square",
+        _ => "pin",
+    };
+}

--- a/src/Mithril.GameState/Pins/PlayerPinTracker.cs
+++ b/src/Mithril.GameState/Pins/PlayerPinTracker.cs
@@ -1,0 +1,244 @@
+using Mithril.GameState.Areas;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Pins;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IPlayerPinTracker"/>. Tails
+/// <see cref="IPlayerLogStream"/>, parses <c>ProcessMapPin{Add,Remove}</c> via
+/// <see cref="MapPinParser"/>, and folds the stream into the current area's
+/// pin set (#468).
+///
+/// <para><b>Lifecycle the service owns</b> (so no consumer hand-rolls it):</para>
+/// <list type="bullet">
+///   <item><b>Login / area-entry replay = idempotent upsert.</b> PG re-emits
+///   the whole set as an <c>Add</c> burst on every entry with no preceding
+///   clear. Pins are keyed by rounded coordinate, so a replayed pin at an
+///   unchanged coordinate is a no-op and raises no <see cref="PinSetChange.Added"/>
+///   — consumers stay quiet through the backlog.</item>
+///   <item><b>No edit/move verb.</b> A rename/move is <c>Remove</c>+<c>Add</c>;
+///   it surfaces as a <see cref="PinSetChange.Removed"/> then
+///   <see cref="PinSetChange.Added"/>, which is faithful to the log.</item>
+///   <item><b>Area transition = swap.</b> Pins are area-local; on any
+///   <c>PlayerAreaTracker.CurrentArea</c> change the set is dropped and a
+///   <see cref="PinSetChange.AreaChanged"/> (empty set) is raised. The
+///   subsequent replay burst repopulates it for the new area.</item>
+/// </list>
+///
+/// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
+/// <see cref="Movement.PlayerPositionTracker"/> — shared live game-state must
+/// be available without any module being activated. It also calls
+/// <see cref="PlayerAreaTracker.Observe(RawLogLine)"/> to keep the shared area
+/// tracker warm (idempotent when the position tracker / Legolas also feed it).
+/// No area reverse-scan seed is needed: the pin replay burst lands inside the
+/// live window (after the login <c>ProcessAddPlayer</c> the window is seeded
+/// to), so the set self-populates.</para>
+///
+/// <para><b>Threading.</b> Ingestion runs on the hosted-service loop thread;
+/// <see cref="CurrentArea"/>/<see cref="CurrentAreaPins"/> reads, state
+/// mutation and subscriber dispatch are serialised under <c>_lock</c>; each
+/// notification carries an immutable snapshot, so handlers may hold it. They
+/// run on the ingestion thread — non-trivial / UI work must marshal off.</para>
+/// </summary>
+public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly MapPinParser _parser;
+    private readonly PlayerAreaTracker _areaTracker;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly List<Action<PinSetChanged>> _handlers = [];
+
+    // Keyed by rounded coordinate: a pin's identity is its position (a rename
+    // keeps the coordinate; a move is Remove+Add). Rounding only absorbs
+    // float repr — PG re-replays byte-identical coordinate strings.
+    private readonly Dictionary<PinKey, MapPin> _pins = new();
+    private string? _trackedArea;
+    private bool _areaInitialised;
+
+    /// <param name="stream">The shared Player.log line stream this service
+    /// tails (its live replay window already covers the login pin burst).</param>
+    /// <param name="parser">Stateless line→<see cref="MapPinLogEvent"/> parser.</param>
+    /// <param name="areaTracker">Shared area key source; also fed every line
+    /// here so it stays warm without another module being active.</param>
+    /// <param name="diag">Optional diagnostics sink (info on subscribe,
+    /// warnings on ingestion / subscriber faults).</param>
+    public PlayerPinTracker(
+        IPlayerLogStream stream,
+        MapPinParser parser,
+        PlayerAreaTracker areaTracker,
+        IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _parser = parser;
+        _areaTracker = areaTracker;
+        _diag = diag;
+    }
+
+    /// <inheritdoc/>
+    public string? CurrentArea
+    {
+        get { lock (_lock) return _trackedArea; }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<MapPin> CurrentAreaPins
+    {
+        get { lock (_lock) return Snapshot(); }
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(Action<PinSetChanged> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // Replay the current set before going live so a late subscriber
+            // observes the same view already-attached handlers see. Mirrors
+            // PlayerPositionTracker.Subscribe.
+            Invoke(handler, new PinSetChanged(
+                PinSetChange.Snapshot, _trackedArea, null, Snapshot(),
+                DateTimeOffset.UtcNow));
+            _handlers.Add(handler);
+            return new Subscription(this, handler);
+        }
+    }
+
+    /// <summary>
+    /// The hosted-service ingestion loop: for every Player.log line, warm the
+    /// shared area tracker, reconcile an area change, then fold a parsed
+    /// pin event into the set. Exits when <paramref name="stoppingToken"/> is
+    /// cancelled or the stream completes; per-line exceptions are logged and
+    /// swallowed so one bad line never stops ingestion.
+    /// </summary>
+    /// <param name="stoppingToken">Host shutdown signal.</param>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Pins", "Subscribing to Player.log for ProcessMapPin*");
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                // Same line stream carries area transitions; keep the shared
+                // tracker warm even when no other feeder is active.
+                _areaTracker.Observe(raw);
+                ReconcileArea();
+
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is MapPinLogEvent evt)
+                    Apply(evt);
+            }
+            catch (Exception ex)
+            {
+                _diag?.Warn("GameState.Pins", $"Ingestion error: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drop the set whenever the shared area key changes (including the first
+    /// time it becomes known). The set is area-local; the new area's replay
+    /// burst — which follows the <c>LOADING LEVEL</c> line that moved the key
+    /// — repopulates it.
+    /// </summary>
+    private void ReconcileArea()
+    {
+        var area = _areaTracker.CurrentArea;
+        PinSetChanged? note = null;
+        lock (_lock)
+        {
+            if (_areaInitialised && area == _trackedArea) return;
+            _areaInitialised = true;
+            _trackedArea = area;
+            _pins.Clear();
+            note = new PinSetChanged(
+                PinSetChange.AreaChanged, area, null, Snapshot(),
+                DateTimeOffset.UtcNow);
+        }
+        if (note is not null) Publish(note);
+    }
+
+    private void Apply(MapPinLogEvent evt)
+    {
+        var key = PinKey.From(evt.X, evt.Z);
+        PinSetChanged? note = null;
+        lock (_lock)
+        {
+            if (evt.Change == MapPinChange.Removed)
+            {
+                if (_pins.Remove(key, out var removed))
+                    note = new PinSetChanged(
+                        PinSetChange.Removed, _trackedArea, removed, Snapshot(),
+                        ToOffset(evt.Timestamp));
+            }
+            else
+            {
+                var pin = new MapPin(
+                    evt.X, evt.Z, evt.Label, evt.Shape, evt.Color, evt.RawList);
+                // Idempotent: a replay-burst re-add of an unchanged pin is a
+                // no-op and raises nothing. Only a new coordinate or a changed
+                // label/appearance notifies.
+                if (!_pins.TryGetValue(key, out var existing) || existing != pin)
+                {
+                    _pins[key] = pin;
+                    note = new PinSetChanged(
+                        PinSetChange.Added, _trackedArea, pin, Snapshot(),
+                        ToOffset(evt.Timestamp));
+                }
+            }
+        }
+        if (note is not null) Publish(note);
+    }
+
+    /// <summary>Immutable copy of the current set. Caller holds <c>_lock</c>.</summary>
+    private IReadOnlyList<MapPin> Snapshot() => _pins.Values.ToArray();
+
+    private void Publish(PinSetChanged note)
+    {
+        Action<PinSetChanged>[] toFire;
+        lock (_lock) toFire = _handlers.ToArray();
+        foreach (var h in toFire) Invoke(h, note);
+    }
+
+    private void Invoke(Action<PinSetChanged> handler, PinSetChanged note)
+    {
+        try { handler(note); }
+        catch (Exception ex) { _diag?.Warn("GameState.Pins", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Player.log timestamps are reconstructed as UTC <see cref="DateTime"/>s.
+    /// Stamp the kind defensively so the offset is +00:00 rather than the
+    /// host's local offset (mirrors PlayerPositionTracker.ToOffset).
+    /// </summary>
+    private static DateTimeOffset ToOffset(DateTime ts) =>
+        new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
+
+    private readonly record struct PinKey(long X100, long Z100)
+    {
+        public static PinKey From(double x, double z) => new(
+            (long)Math.Round(x * 100.0, MidpointRounding.AwayFromZero),
+            (long)Math.Round(z * 100.0, MidpointRounding.AwayFromZero));
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private PlayerPinTracker? _owner;
+        private readonly Action<PinSetChanged> _handler;
+
+        public Subscription(PlayerPinTracker owner, Action<PinSetChanged> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
+        }
+    }
+}

--- a/tests/Legolas.Tests/FakePlayerPinTracker.cs
+++ b/tests/Legolas.Tests/FakePlayerPinTracker.cs
@@ -1,0 +1,70 @@
+using Mithril.GameState.Pins;
+
+namespace Legolas.Tests;
+
+/// <summary>
+/// Test double for <see cref="IPlayerPinTracker"/> (#468). Lets a test seed a
+/// pre-existing area set (no event — mimics login replay already folded by
+/// the real service) and push live Added/Removed/AreaChanged notifications.
+/// <see cref="Subscribe"/> replays a Snapshot synchronously like the real one.
+/// </summary>
+public sealed class FakePlayerPinTracker : IPlayerPinTracker
+{
+    private readonly List<Action<PinSetChanged>> _handlers = new();
+    private readonly List<MapPin> _pins = new();
+
+    public string? CurrentArea { get; set; } = "AreaTest";
+    public IReadOnlyList<MapPin> CurrentAreaPins => _pins.ToArray();
+
+    public IDisposable Subscribe(Action<PinSetChanged> handler)
+    {
+        handler(new PinSetChanged(
+            PinSetChange.Snapshot, CurrentArea, null, CurrentAreaPins, DateTimeOffset.UtcNow));
+        _handlers.Add(handler);
+        return new Sub(this, handler);
+    }
+
+    /// <summary>Pre-existing pins present before the consumer subscribes /
+    /// arms — the existing-pins route's input. Raises no event.</summary>
+    public void SeedExisting(params MapPin[] pins)
+    {
+        _pins.Clear();
+        _pins.AddRange(pins);
+    }
+
+    public static MapPin Pin(double x, double z, string label = "",
+        PinShape shape = PinShape.Dot, PinColor color = PinColor.White) =>
+        new(x, z, label, shape, color, 1);
+
+    /// <summary>A genuinely-new pin drop (turn-order route input).</summary>
+    public MapPin Add(double x, double z, string label = "")
+    {
+        var p = Pin(x, z, label);
+        _pins.Add(p);
+        Raise(new PinSetChanged(PinSetChange.Added, CurrentArea, p, CurrentAreaPins, DateTimeOffset.UtcNow));
+        return p;
+    }
+
+    public void Remove(MapPin p)
+    {
+        _pins.Remove(p);
+        Raise(new PinSetChanged(PinSetChange.Removed, CurrentArea, p, CurrentAreaPins, DateTimeOffset.UtcNow));
+    }
+
+    public void ChangeArea(string? area)
+    {
+        CurrentArea = area;
+        _pins.Clear();
+        Raise(new PinSetChanged(PinSetChange.AreaChanged, area, null, CurrentAreaPins, DateTimeOffset.UtcNow));
+    }
+
+    private void Raise(PinSetChanged n)
+    {
+        foreach (var h in _handlers.ToArray()) h(n);
+    }
+
+    private sealed class Sub(FakePlayerPinTracker owner, Action<PinSetChanged> handler) : IDisposable
+    {
+        public void Dispose() => owner._handlers.Remove(handler);
+    }
+}

--- a/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
@@ -65,26 +65,12 @@ public class PlayerLogParserTests
         _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
     }
 
-    // Real captured ProcessMapPinAdd lines (live Player.log, 2026-05-18).
+    // Map-pin lifecycle parsing was promoted to the GameState-tier
+    // MapPinParser (#468); this parser is MapFx-only now and must ignore
+    // ProcessMapPin{Add,Remove}.
     [Theory]
-    [InlineData(
-        "[08:22:22] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), \"\")",
-        -521.96, 368.39, "")]
-    [InlineData(
-        "[08:32:20] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")",
-        1145.39, 1323.40, "Calib 1")]
-    // A label that looks like an area/verb must STILL just be a label —
-    // pairing is turn-order, never by name (hard rule #454).
-    [InlineData(
-        "[08:32:38] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-355.16, 0.00, -392.82), \"AreaEltibule Check Survey\")",
-        -355.16, -392.82, "AreaEltibule Check Survey")]
-    public void Parses_ProcessMapPinAdd_world_coord_and_label(
-        string line, double x, double z, string label)
-    {
-        var evt = (MapPinAdded?)_parser.TryParse(line, DateTime.UtcNow);
-        evt.Should().NotBeNull();
-        evt!.World.X.Should().Be(x);
-        evt.World.Z.Should().Be(z);
-        evt.Label.Should().Be(label); // captured for diagnostics only
-    }
+    [InlineData("[08:22:22] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, 368.39), \"\")")]
+    [InlineData("[10:30:15] LocalPlayer: ProcessMapPinRemove(1, 0, 0, (784.74, 0.00, 3429.94), \"\")")]
+    public void Ignores_map_pin_lines(string line)
+        => _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
 }

--- a/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
@@ -1,53 +1,54 @@
 using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Services;
+using Mithril.GameState.Pins;
 using Mithril.Shared.Reference;
 using Xunit;
+using PinShape = Mithril.GameState.Pins.PinShape;
+using PinColor = Mithril.GameState.Pins.PinColor;
 
 namespace Legolas.Tests.Services;
 
 /// <summary>
-/// #460: the view-agnostic cold-start pin-calibration driver. Mirrors the
-/// Phase-4 pin-cal invariants but against the coordinator, not the (untouched,
-/// redundant) standalone calibration VM.
+/// #468: the cold-start pin-calibration driver now consumes the GameState
+/// <see cref="IPlayerPinTracker"/>. Two routes, one solve — and the #454
+/// label-agnostic rule is preserved (the solve only ever sees world↔pixel).
 /// </summary>
 public class PinCalibrationCoordinatorTests
 {
-    private static (PinCalibrationCoordinator coord, FakeCalib calib) Build()
+    private static (PinCalibrationCoordinator coord, FakeCalib calib, FakePlayerPinTracker pins) Build()
     {
         var calib = new FakeCalib();
-        return (new PinCalibrationCoordinator(calib), calib);
+        var pins = new FakePlayerPinTracker();
+        return (new PinCalibrationCoordinator(calib, pins), calib, pins);
     }
 
+    // ---- Turn-order (freshly-dropped) route ----
+
     [Fact]
-    public void Disarmed_pins_are_dropped_so_area_entry_replay_cannot_leak()
+    public void Pre_arm_drops_are_ignored_so_replay_cannot_leak()
     {
-        var (coord, calib) = Build();
-        // Bulk area-entry replay arrives BEFORE arming → must be ignored.
-        calib.NotePinAdded(new WorldCoord(-521, 0, 368));
-        calib.NotePinAdded(new WorldCoord(367, 0, 2798));
+        var (coord, _, pins) = Build();
+        pins.Add(-521, 368);
+        pins.Add(367, 2798);
 
         coord.PendingCount.Should().Be(0);
-        coord.PairClick(new PixelPoint(1, 1)); // nothing pending → no-op
+        coord.PairClick(new PixelPoint(1, 1));
         coord.PairedCount.Should().Be(0);
     }
 
     [Fact]
-    public void Armed_pins_queue_and_pair_in_turn_order()
+    public void Armed_fresh_drops_queue_and_pair_in_turn_order()
     {
-        var (coord, calib) = Build();
+        var (coord, calib, pins) = Build();
         coord.Arm();
 
-        var w0 = new WorldCoord(-521, 0, 368);
-        var w1 = new WorldCoord(367, 0, 2798);
-        var w2 = new WorldCoord(1145, 0, 1323);
-        calib.NotePinAdded(w0);
-        calib.NotePinAdded(w1);
-        calib.NotePinAdded(w2);
+        var w0 = pins.Add(-521, 368);
+        var w1 = pins.Add(367, 2798);
+        var w2 = pins.Add(1145, 1323);
         coord.PendingCount.Should().Be(3);
         coord.CanSolve.Should().BeFalse();
 
-        // Oldest-first pairing, irrespective of anything else.
         coord.PairClick(new PixelPoint(10, 11));
         coord.PairClick(new PixelPoint(20, 22));
         coord.PairClick(new PixelPoint(30, 33));
@@ -59,18 +60,79 @@ public class PinCalibrationCoordinatorTests
 
         coord.Solve().Should().NotBeNull();
         calib.LastPairs.Should().Equal(
-            (w0, new PixelPoint(10, 11)),
-            (w1, new PixelPoint(20, 22)),
-            (w2, new PixelPoint(30, 33)));
+            (new WorldCoord(w0.X, 0, w0.Z), new PixelPoint(10, 11)),
+            (new WorldCoord(w1.X, 0, w1.Z), new PixelPoint(20, 22)),
+            (new WorldCoord(w2.X, 0, w2.Z), new PixelPoint(30, 33)));
         coord.IsArmed.Should().BeFalse("a successful solve disarms");
     }
+
+    // ---- Existing-pins route ----
+
+    [Fact]
+    public void Existing_pins_are_offered_and_pair_by_deliberate_selection()
+    {
+        var (coord, calib, pins) = Build();
+        var a = FakePlayerPinTracker.Pin(10, 20, "Fire Magic 25", PinShape.Dot, PinColor.Red);
+        var b = FakePlayerPinTracker.Pin(30, 40, "North", PinShape.Square, PinColor.White);
+        var c = FakePlayerPinTracker.Pin(50, 60, "");
+        pins.SeedExisting(a, b, c);
+
+        coord.Arm();
+        coord.HasUsableExistingPins.Should().BeTrue();
+        coord.ExistingPins.Should().HaveCount(3);
+        // UX identity is derivable (used only to help the human pick).
+        a.Appearance.Should().Be("red dot");
+
+        coord.SelectedExistingPin = b;
+        coord.PairClick(new PixelPoint(1, 1));
+        coord.SelectedExistingPin = a;
+        coord.PairClick(new PixelPoint(2, 2));
+        coord.SelectedExistingPin = c;
+        coord.PairClick(new PixelPoint(3, 3));
+
+        coord.PairedCount.Should().Be(3);
+        coord.Solve().Should().NotBeNull();
+        // Pairs follow the user's selection order — not list/turn order — and
+        // carry only world↔pixel (no label/colour reaches the solver).
+        calib.LastPairs.Should().Equal(
+            (new WorldCoord(30, 0, 40), new PixelPoint(1, 1)),
+            (new WorldCoord(10, 0, 20), new PixelPoint(2, 2)),
+            (new WorldCoord(50, 0, 60), new PixelPoint(3, 3)));
+    }
+
+    [Fact]
+    public void Snapshot_seeds_existing_pins_before_arming()
+    {
+        var calib = new FakeCalib();
+        var pins = new FakePlayerPinTracker();
+        pins.SeedExisting(FakePlayerPinTracker.Pin(1, 2), FakePlayerPinTracker.Pin(3, 4));
+
+        var coord = new PinCalibrationCoordinator(calib, pins); // Subscribe → Snapshot
+        coord.ExistingPins.Should().HaveCount(2);
+        coord.HasUsableExistingPins.Should().BeFalse("only 2 < 3");
+    }
+
+    [Fact]
+    public void Duplicate_world_point_is_rejected_to_keep_the_solve_conditioned()
+    {
+        var (coord, _, _) = Build();
+        var p = FakePlayerPinTracker.Pin(10, 20, "A");
+        coord.Arm();
+        coord.SelectedExistingPin = p;
+        coord.PairClick(new PixelPoint(1, 1));
+        coord.SelectedExistingPin = p; // same pin again
+        coord.PairClick(new PixelPoint(9, 9));
+        coord.PairedCount.Should().Be(1);
+    }
+
+    // ---- Shared invariants ----
 
     [Fact]
     public void Solve_below_three_pairs_is_null_and_does_not_call_service()
     {
-        var (coord, calib) = Build();
+        var (coord, calib, pins) = Build();
         coord.Arm();
-        calib.NotePinAdded(new WorldCoord(1, 0, 2));
+        pins.Add(1, 2);
         coord.PairClick(new PixelPoint(5, 5));
 
         coord.CanSolve.Should().BeFalse();
@@ -81,24 +143,23 @@ public class PinCalibrationCoordinatorTests
     [Fact]
     public void Arm_clears_stale_state_then_Disarm_flushes()
     {
-        var (coord, calib) = Build();
+        var (coord, _, pins) = Build();
         coord.Arm();
-        calib.NotePinAdded(new WorldCoord(1, 0, 2));
+        pins.Add(1, 2);
         coord.PairClick(new PixelPoint(5, 5));
         coord.PairedCount.Should().Be(1);
 
-        coord.Arm(); // re-arm = fresh attempt
+        coord.Arm();
         coord.PairedCount.Should().Be(0);
         coord.PendingCount.Should().Be(0);
         coord.PlacedMarkers.Should().BeEmpty();
 
-        calib.NotePinAdded(new WorldCoord(3, 0, 4));
+        pins.Add(3, 4);
         coord.PendingCount.Should().Be(1);
         coord.Disarm();
         coord.IsArmed.Should().BeFalse();
         coord.PendingCount.Should().Be(0);
-        // Disarmed again → replay ignored.
-        calib.NotePinAdded(new WorldCoord(7, 0, 8));
+        pins.Add(7, 8);
         coord.PendingCount.Should().Be(0);
     }
 
@@ -112,9 +173,6 @@ public class PinCalibrationCoordinatorTests
             LastPairs = placements.Select(p => (p.World, p.Pixel)).ToList();
             return new AreaCalibration(1, 0, 0, 0, placements.Count, 0);
         }
-
-        public event EventHandler<WorldCoord>? PinAdded;
-        public void NotePinAdded(WorldCoord world) => PinAdded?.Invoke(this, world);
 
         public string? CurrentAreaKey => "AreaTest";
         public string? CurrentAreaFriendlyName => "Test";

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -230,20 +230,19 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ProcessMapPinAdd_is_forwarded_to_NotePinAdded()
+    public async Task ProcessMapPin_lines_are_ignored_by_this_service()
     {
-        var (svc, stream, spy, session) = Build(calibration: Identity());
+        // Map-pin lifecycle is GameState-owned now (#468); the Legolas
+        // Player.log consumer only handles ProcessMapFx targets.
+        var (svc, stream, _, session) = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
         {
             stream.Push("[08:32:20] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")");
+            stream.Push("[08:32:21] LocalPlayer: ProcessMapPinRemove(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")");
             await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => spy.NotedPins.Count > 0, cts.Token);
 
-            spy.NotedPins.Should().ContainSingle()
-                .Which.Should().Be(new WorldCoord(1145.39, 0.00, 1323.40));
-            // It's a pin, not a target — no survey pin placed by ingestion.
             session.Surveys.Should().BeEmpty();
         }
         finally { await Stop(svc, run, cts); }
@@ -281,10 +280,6 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
 
         public List<string> SelectedAreas { get; } = new();
         public void SelectArea(string areaKey) => SelectedAreas.Add(areaKey);
-
-        public List<WorldCoord> NotedPins { get; } = new();
-        public void NotePinAdded(WorldCoord world) => NotedPins.Add(world);
-        public event EventHandler<WorldCoord>? PinAdded { add { } remove { } }
 
         public AreaCalibration? CurrentCalibration => _cal;
         public bool IsCurrentAreaCalibrated => _cal is not null;

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Services;
+using Legolas.Tests;
 using Legolas.ViewModels;
 using Mithril.Shared.Reference;
 
@@ -655,7 +656,7 @@ public class CalibrationSessionViewModelTests
 
     // ---- #454 freehand pin calibration ----------------------------------
 
-    private static CalibrationSessionViewModel ArmedPinVm(out FakeService svc)
+    private static CalibrationSessionViewModel ArmedPinVm(out FakeService svc, out FakePlayerPinTracker pins)
     {
         svc = new FakeService
         {
@@ -663,7 +664,8 @@ public class CalibrationSessionViewModelTests
             CurrentAreaKey = "AreaEltibule",
             SolveResult = new AreaCalibration(0.4, 0.1, 5, 6, 3, 0.0),
         };
-        var vm = new CalibrationSessionViewModel(svc);
+        pins = new FakePlayerPinTracker();
+        var vm = new CalibrationSessionViewModel(svc, pins);
         vm.TogglePinCalibrationCommand.Execute(null);
         vm.PinCalibrationArmed.Should().BeTrue();
         return vm;
@@ -673,11 +675,12 @@ public class CalibrationSessionViewModelTests
     public void Disarmed_pins_are_dropped_so_area_entry_replay_cannot_leak()
     {
         var svc = new FakeService { CurrentAreaKey = "AreaEltibule" };
-        var vm = new CalibrationSessionViewModel(svc);
+        var pins = new FakePlayerPinTracker();
+        var vm = new CalibrationSessionViewModel(svc, pins);
 
         // Bulk area-entry replay arrives BEFORE the user arms — must be ignored.
-        svc.NotePinAdded(new WorldCoord(-521.96, 0, 368.39));
-        svc.NotePinAdded(new WorldCoord(367.28, 0, 2798.03));
+        pins.Add(-521.96, 368.39);
+        pins.Add(367.28, 2798.03);
         vm.PendingPinCount.Should().Be(0);
 
         // A click while disarmed/empty doesn't fabricate a placement.
@@ -688,16 +691,16 @@ public class CalibrationSessionViewModelTests
     [Fact]
     public void Pins_pair_with_overlay_clicks_in_turn_order_never_by_label()
     {
-        var vm = ArmedPinVm(out var svc);
+        var vm = ArmedPinVm(out var svc, out var pins);
 
-        // The PinAdded contract is a bare WorldCoord — there is structurally
+        // The tracker hands the VM a bare world point — there is structurally
         // no label the VM could key off. Drop three distinct world points…
         var w0 = new WorldCoord(-521.96, 0, 368.39);
         var w1 = new WorldCoord(367.28, 0, 2798.03);
         var w2 = new WorldCoord(1145.39, 0, 1323.40);
-        svc.NotePinAdded(w0);
-        svc.NotePinAdded(w1);
-        svc.NotePinAdded(w2);
+        pins.Add(w0.X, w0.Z);
+        pins.Add(w1.X, w1.Z);
+        pins.Add(w2.X, w2.Z);
         vm.PendingPinCount.Should().Be(3);
 
         // …then click three overlay spots. Pairing is OLDEST-first (turn
@@ -720,8 +723,8 @@ public class CalibrationSessionViewModelTests
     [Fact]
     public void ClearPlacements_disarms_and_drops_pending_pins()
     {
-        var vm = ArmedPinVm(out var svc);
-        svc.NotePinAdded(new WorldCoord(1, 0, 2));
+        var vm = ArmedPinVm(out _, out var pins);
+        pins.Add(1, 2);
         vm.PendingPinCount.Should().Be(1);
 
         vm.ClearPlacementsCommand.Execute(null);
@@ -729,7 +732,7 @@ public class CalibrationSessionViewModelTests
         vm.PinCalibrationArmed.Should().BeFalse();
         vm.PendingPinCount.Should().Be(0);
         // A pin arriving now is ignored again (disarmed).
-        svc.NotePinAdded(new WorldCoord(3, 0, 4));
+        pins.Add(3, 4);
         vm.PendingPinCount.Should().Be(0);
     }
 
@@ -784,10 +787,5 @@ public class CalibrationSessionViewModelTests
 
         public void NoteSurvey(string name, MetreOffset offset) =>
             SurveyObserved?.Invoke(this, new CalibrationSurveyObservation(name, offset));
-
-        public event EventHandler<WorldCoord>? PinAdded;
-
-        public void NotePinAdded(WorldCoord world) =>
-            PinAdded?.Invoke(this, world);
     }
 }

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.Services;
+using Legolas.Tests;
 using Legolas.ViewModels;
 
 namespace Legolas.Tests.ViewModels;
@@ -42,12 +43,11 @@ public class LegolasWizardViewModelTests
         public void ClearCurrentAreaCalibration() { }
         public void NoteSurvey(string name, MetreOffset offset) { }
         public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
-        public void NotePinAdded(WorldCoord world) => PinAdded?.Invoke(this, world);
-        public event EventHandler<WorldCoord>? PinAdded;
     }
 
     private static (LegolasWizardViewModel wizard, SessionState session, SurveyFlowController surveyFlow,
-        MotherlodeFlowController motherlodeFlow, LegolasSettings settings) BuildSut(FakeAreaCalib? calib = null)
+        MotherlodeFlowController motherlodeFlow, LegolasSettings settings) BuildSut(
+        FakeAreaCalib? calib = null, FakePlayerPinTracker? pins = null)
     {
         var session = new SessionState();
         var settings = new LegolasSettings();
@@ -59,7 +59,7 @@ public class LegolasWizardViewModelTests
         var projector = new CoordinateProjector();
         var brushes = new LegolasBrushes(settings);
         var areaCalib = calib ?? new FakeAreaCalib();
-        var pinCal = new PinCalibrationCoordinator(areaCalib);
+        var pinCal = new PinCalibrationCoordinator(areaCalib, pins ?? new FakePlayerPinTracker());
         var motherlode = new MotherlodeViewModel(trilat, optimizer, session, motherlodeFlow);
         var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings, pinCal);
         var nudgePad = new NudgePadViewModel(session, mapOverlay, settings);
@@ -375,13 +375,14 @@ public class LegolasWizardViewModelTests
     public void SolveCalibration_persists_and_leaves_the_gate()
     {
         var calib = new FakeAreaCalib { Calibrated = false };
-        var (wizard, _, _, _, _) = BuildSut(calib);
+        var pins = new FakePlayerPinTracker();
+        var (wizard, _, _, _, _) = BuildSut(calib, pins);
         wizard.PickSurveyModeCommand.Execute(null);
 
-        // Three click-paired pins, then Solve.
-        calib.NotePinAdded(new WorldCoord(1, 0, 2));
-        calib.NotePinAdded(new WorldCoord(3, 0, 4));
-        calib.NotePinAdded(new WorldCoord(5, 0, 6));
+        // Three fresh pin drops, then click-pair + Solve.
+        pins.Add(1, 2);
+        pins.Add(3, 4);
+        pins.Add(5, 6);
         wizard.MapOverlay.PairCalibrationClick(new PixelPoint(10, 10));
         wizard.MapOverlay.PairCalibrationClick(new PixelPoint(20, 20));
         wizard.MapOverlay.PairCalibrationClick(new PixelPoint(30, 30));

--- a/tests/Mithril.GameState.Tests/Pins/MapPinParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Pins/MapPinParserTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using Mithril.GameState.Pins;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Pins;
+
+public sealed class MapPinParserTests
+{
+    private readonly MapPinParser _parser = new();
+    private static readonly DateTime Stamp = new(2026, 5, 18, 10, 10, 3, DateTimeKind.Utc);
+
+    [Fact]
+    public void Parses_Add_with_coords_label_shape_color()
+    {
+        // Real captured line: A=1, B=0 (dot), C=0 (white).
+        var evt = (MapPinLogEvent?)_parser.TryParse(
+            "[10:10:03] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1425.06, 0.00, 2924.99), \"South\")",
+            Stamp);
+
+        evt.Should().NotBeNull();
+        evt!.Change.Should().Be(MapPinChange.Added);
+        evt.X.Should().Be(1425.06);
+        evt.Z.Should().Be(2924.99);
+        evt.Label.Should().Be("South");
+        evt.Shape.Should().Be(PinShape.Dot);
+        evt.Color.Should().Be(PinColor.White);
+        evt.RawList.Should().Be(1);
+    }
+
+    [Fact]
+    public void Parses_Remove_verb()
+    {
+        var evt = (MapPinLogEvent?)_parser.TryParse(
+            "[10:30:15] LocalPlayer: ProcessMapPinRemove(1, 0, 0, (784.74, 0.00, 3429.94), \"\")",
+            Stamp);
+
+        evt.Should().NotBeNull();
+        evt!.Change.Should().Be(MapPinChange.Removed);
+        evt.X.Should().Be(784.74);
+        evt.Label.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Decodes_color_index_one_as_red()
+    {
+        // The captured "campfire" preset pins logged C=1 (a deliberate red).
+        var evt = (MapPinLogEvent?)_parser.TryParse(
+            "[10:19:43] LocalPlayer: ProcessMapPinAdd(1, 0, 1, (1606.78, 0.00, 2838.42), \"Campfire\")",
+            Stamp);
+
+        evt!.Color.Should().Be(PinColor.Red);
+        evt.Shape.Should().Be(PinShape.Dot);
+    }
+
+    [Theory]
+    [InlineData(1, PinShape.Square)]
+    [InlineData(9, PinShape.Unknown)]
+    public void Maps_shape_argument_including_out_of_range(int b, PinShape expected)
+    {
+        var evt = (MapPinLogEvent?)_parser.TryParse(
+            $"[10:10:03] LocalPlayer: ProcessMapPinAdd(1, {b}, 0, (1.0, 0.00, 2.0), \"x\")",
+            Stamp);
+        evt!.Shape.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(9, PinColor.Black)]
+    [InlineData(42, PinColor.Unknown)]
+    public void Maps_color_argument_including_out_of_range(int c, PinColor expected)
+    {
+        var evt = (MapPinLogEvent?)_parser.TryParse(
+            $"[10:10:03] LocalPlayer: ProcessMapPinAdd(1, 0, {c}, (1.0, 0.00, 2.0), \"x\")",
+            Stamp);
+        evt!.Color.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Coordinates_are_signed()
+    {
+        var evt = (MapPinLogEvent?)_parser.TryParse(
+            "[08:22:22] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (-521.96, 0.00, -322.68), \"\")",
+            Stamp);
+
+        evt!.X.Should().Be(-521.96);
+        evt.Z.Should().Be(-322.68);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("[10:10:03] LocalPlayer: ProcessAddItem(Barley(1), 0, False)")]
+    [InlineData("[10:10:03] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, \"x is here\", ImportantInfo, \"msg\")")]
+    public void Non_pin_lines_return_null(string line)
+        => _parser.TryParse(line, Stamp).Should().BeNull();
+}

--- a/tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs
@@ -1,0 +1,236 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Pins;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Pins;
+
+public sealed class PlayerPinTrackerTests
+{
+    private static readonly DateTime Stamp = new(2026, 5, 18, 10, 10, 3, DateTimeKind.Utc);
+
+    private static PlayerPinTracker NewTracker(ScriptedStream stream, PlayerAreaTracker? area = null) =>
+        new(stream, new MapPinParser(),
+            area ?? new PlayerAreaTracker(new AreaTransitionParser()));
+
+    private static string Area(string key) => $"[10:00:00] LOADING LEVEL {key}";
+    private static string Add(double x, double z, string label, int b = 0, int c = 0) =>
+        $"[10:10:03] LocalPlayer: ProcessMapPinAdd(1, {b}, {c}, ({x:0.00}, 0.00, {z:0.00}), \"{label}\")";
+    private static string Remove(double x, double z, string label) =>
+        $"[10:10:03] LocalPlayer: ProcessMapPinRemove(1, 0, 0, ({x:0.00}, 0.00, {z:0.00}), \"{label}\")";
+
+    [Fact]
+    public async Task Add_populates_current_area_pins_with_decoded_appearance()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Add(1425.06, 2924.99, "South", b: 1, c: 1));
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.CurrentArea.Should().Be("AreaSerbule");
+            var pin = svc.CurrentAreaPins.Should().ContainSingle().Subject;
+            pin.Label.Should().Be("South");
+            pin.X.Should().Be(1425.06);
+            pin.Z.Should().Be(2924.99);
+            pin.Shape.Should().Be(PinShape.Square);
+            pin.Color.Should().Be(PinColor.Red);
+            pin.Appearance.Should().Be("red square");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Replay_burst_is_idempotent_no_duplicates_no_extra_events()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            var seen = new List<PinSetChanged>();
+            using var sub = svc.Subscribe(seen.Add);
+
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Add(10, 20, "A"));
+            stream.Push(Stamp, Add(30, 40, "B"));
+            await stream.WaitForDrainAsync(cts.Token);
+            // Login/area-entry re-emits the whole set verbatim.
+            stream.Push(Stamp, Add(10, 20, "A"));
+            stream.Push(Stamp, Add(30, 40, "B"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            svc.CurrentAreaPins.Should().HaveCount(2);
+            seen.Count(n => n.Kind == PinSetChange.Added).Should().Be(2);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Remove_deletes_by_coordinate()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Add(10, 20, "A"));
+            stream.Push(Stamp, Remove(10, 20, "A"));
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.CurrentAreaPins.Should().BeEmpty();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Rename_is_remove_then_add_at_same_coord()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Add(10, 20, ""));
+            stream.Push(Stamp, Remove(10, 20, ""));
+            stream.Push(Stamp, Add(10, 20, "Calib 1"));
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.CurrentAreaPins.Should().ContainSingle()
+                .Which.Label.Should().Be("Calib 1");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Area_change_swaps_the_set_and_raises_AreaChanged()
+    {
+        var stream = new ScriptedStream();
+        var area = new PlayerAreaTracker(new AreaTransitionParser());
+        var svc = NewTracker(stream, area);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Add(10, 20, "A"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<PinSetChanged>();
+            using var sub = svc.Subscribe(seen.Add); // Snapshot replay first
+            stream.Push(Stamp, Area("AreaEltibule"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            svc.CurrentArea.Should().Be("AreaEltibule");
+            svc.CurrentAreaPins.Should().BeEmpty();
+            seen.Should().Contain(n => n.Kind == PinSetChange.AreaChanged && n.Area == "AreaEltibule");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Subscribe_replays_snapshot_synchronously_then_delivers_live()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Add(10, 20, "A"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<PinSetChanged>();
+            using var sub = svc.Subscribe(seen.Add);
+            seen.Should().ContainSingle()
+                .Which.Should().Match<PinSetChanged>(n =>
+                    n.Kind == PinSetChange.Snapshot && n.Pins.Count == 1);
+
+            stream.Push(Stamp, Add(30, 40, "B"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var added = seen.Last();
+            added.Kind.Should().Be(PinSetChange.Added);
+            added.Pin!.Label.Should().Be("B");
+            added.ObservedAt.Offset.Should().Be(TimeSpan.Zero);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    private static async Task RunUntilDrainedAsync(PlayerPinTracker svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(PlayerPinTracker svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public ScriptedStream() => _drained.TrySetResult();
+
+        public void Push(DateTime ts, string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(ts, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}


### PR DESCRIPTION
Closes #468.

Promotes player **map-pin ownership** to a `Mithril.GameState` live-state service and reworks Legolas calibration to consume it — including a friendlier route that calibrates from pins the player already has.

## Part 1 — `Mithril.GameState.Pins`

- `MapPinParser` — parses **both** `ProcessMapPinAdd` and `ProcessMapPinRemove` (the only two pin verbs PG has; rename/move = Remove+Add, no clear/edit verb).
- `PlayerPinTracker` — self-feeding `BackgroundService` mirroring `PlayerPositionTracker`: **area-scoped**, **idempotent login/area-entry replay** (upsert keyed by rounded coordinate → no backlog leak, consumers stop hand-rolling arm-gates), area transition swaps the set, `Subscribe` replays a `Snapshot` then live deltas.
- `PinShape`/`PinColor` decode: arg **A** opaque (`RawList`), **B** = shape, **C** = colour (palette `0–9`); out-of-range → `Unknown`, never throws. `MapPin` model + `Appearance`/`DisplayName` UX helpers.
- Registered in `AddMithrilGameState`. Retired the Legolas-side pin parsing (`PlayerLogParser` is MapFx-only), the `MapPinAdded` GameEvent, and the `IAreaCalibrationService.NotePinAdded`/`PinAdded` relay. Same tier-promotion pattern as `AreaTransitionParser` → `Mithril.GameState.Areas` (#456).

## Part 2 — Legolas consumes the service

- `PinCalibrationCoordinator` + `CalibrationSessionViewModel` now read `IPlayerPinTracker`. **Two routes, one solve:**
  1. **Existing-pins** — when ≥3 well-spread pins already exist, pick one by `label (colour shape)` and click where it is. No re-dropping.
  2. **Freshly-dropped turn-order** — retained cold-start fallback (fogged brand-new area).
- The solve still receives only `(WorldCoord ↔ pixel)`; name/colour/shape are **UX-only** human disambiguation, so #454's label-agnostic rule's intent is preserved. Wizard `Calibrating` step gains the picker; turn-order steps collapse when the existing-pins route is usable.

## Docs & conventions

- New `docs/player-pin-service.md` (service design + full log-grammar decode table + lifecycle diagram).
- `legolas-overview.md`: "two routes & the label-agnostic reconciliation" section so the next contributor doesn't revert it.
- Detailed xmldoc across the new public surface. Model/event timestamps are `DateTimeOffset`, converted at the `ILogParser` boundary.

## Verification

- Full solution builds warnings-as-errors clean.
- **GameState.Tests 192/192**, **Legolas.Tests 268/268** green. New `MapPinParserTests`/`PlayerPinTrackerTests`, shared `FakePlayerPinTracker`; all 5 affected Legolas test files reworked.
- Branch rebased onto `origin/main` (#467 `PinCalibrationCoordinator` is a prerequisite).

**Residual manual check:** `PlayerPinTracker` introduces no new DI dependency *types* (strict subset of `PlayerPositionTracker`'s deps) so a DI cycle is structurally impossible — but a shell launch to watch boot.log clear module-load, plus an in-game eyeball of the existing-pins picker, is the honest confirmation not yet done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
