### PR TITLE
feat(gamestate): live recipe-state tracker from Player.log (#473)

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@ using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
+using Mithril.GameState.Recipes;
+using Mithril.GameState.Recipes.Parsing;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
 using Mithril.GameState.Sessions;
@@ -53,6 +55,18 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<PlayerSkillStateService>()
             .AddSingleton<IPlayerSkillState>(sp => sp.GetRequiredService<PlayerSkillStateService>())
             .AddHostedService(sp => sp.GetRequiredService<PlayerSkillStateService>());
+
+        // Shared live recipe state from Player.log (ProcessLoadRecipes /
+        // ProcessUpdateRecipe) — known recipes + per-recipe completion counts,
+        // no character re-export required. The recipe sibling of the skill
+        // tracker above; together they eliminate the planner's export
+        // dependency. Single parser, single tracker; consumers inject
+        // IPlayerRecipeState. See issue #473.
+        services.AddSingleton<RecipeLogParser>();
+        services
+            .AddSingleton<PlayerRecipeStateService>()
+            .AddSingleton<IPlayerRecipeState>(sp => sp.GetRequiredService<PlayerRecipeStateService>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerRecipeStateService>());
 
         // Player position is shared live game-state (Palantir debug surface,
         // future overlay/positioning consumers). Self-feeding hosted service —

--- a/src/Mithril.GameState/Recipes/IPlayerRecipeState.cs
+++ b/src/Mithril.GameState/Recipes/IPlayerRecipeState.cs
@@ -1,0 +1,173 @@
+using Mithril.GameState.Recipes.Parsing;
+
+namespace Mithril.GameState.Recipes;
+
+/// <summary>
+/// Where the current <see cref="PlayerRecipeSnapshot"/> came from. Lets a
+/// consumer prefer live data and surface provenance / freshness.
+/// </summary>
+public enum RecipeStateSource
+{
+    /// <summary>
+    /// Nothing observed yet — the tracker has not seen a
+    /// <c>ProcessLoadRecipes</c> or <c>ProcessUpdateRecipe</c> line this
+    /// session. The snapshot is <see cref="PlayerRecipeSnapshot.Empty"/>.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Built by tailing <c>Player.log</c> (<c>ProcessLoadRecipes</c> /
+    /// <c>ProcessUpdateRecipe</c>). The default and, today, only populated
+    /// source. The enum is left open so a future export-fed source can be
+    /// distinguished without a breaking change.
+    /// </summary>
+    LiveLog = 1,
+}
+
+/// <summary>
+/// Consumer-facing projection of one recipe's state — the raw
+/// <see cref="RecipeCompletionRecord"/> with the known / crafted distinction
+/// interpreted into intent-revealing predicates so every consumer applies them
+/// the same way.
+///
+/// <para>Membership of a recipe id in <see cref="PlayerRecipeSnapshot.Recipes"/>
+/// is itself the "known" signal: a recipe is in the map iff the player has
+/// learned it (it appeared in a <c>ProcessLoadRecipes</c> dump or any
+/// <c>ProcessUpdateRecipe</c>). <see cref="Completions"/> then says whether it
+/// has ever been crafted.</para>
+/// </summary>
+/// <param name="Completions">Lifetime times this recipe has been crafted by
+/// this character (PG's <c>RecipeCompletions</c> ledger). <c>0</c> = known but
+/// never crafted.</param>
+public readonly record struct RecipeProgressSnapshot(int Completions)
+{
+    /// <summary>
+    /// True once the recipe has been crafted at least once
+    /// (<see cref="Completions"/> &gt;= 1). False for a learned-only recipe.
+    /// </summary>
+    public bool IsCrafted => Completions >= 1;
+}
+
+/// <summary>
+/// An immutable, atomically-consistent view of the player's whole known-recipe
+/// table at one instant: the per-recipe map plus when and from where it was
+/// measured. Returned by value so a consumer never observes a torn read.
+/// </summary>
+public sealed class PlayerRecipeSnapshot
+{
+    /// <summary>The empty snapshot — no recipes, never measured, source
+    /// <see cref="RecipeStateSource.None"/>. The cold-start value.</summary>
+    public static PlayerRecipeSnapshot Empty { get; } =
+        new(new Dictionary<int, RecipeProgressSnapshot>(), null, RecipeStateSource.None);
+
+    internal PlayerRecipeSnapshot(
+        IReadOnlyDictionary<int, RecipeProgressSnapshot> recipes,
+        DateTime? measuredAt,
+        RecipeStateSource source)
+    {
+        Recipes = recipes;
+        MeasuredAt = measuredAt;
+        Source = source;
+    }
+
+    /// <summary>
+    /// Recipe id → progression. Keyed by the numeric <c>recipe_&lt;id&gt;</c>
+    /// id the log carries — a consumer (or a reference-enrichment follow-up,
+    /// the recipe analogue of #470) resolves the id to <c>InternalName</c> /
+    /// <c>Name</c> / <c>Skill</c>. Presence of a key == the recipe is known.
+    /// </summary>
+    public IReadOnlyDictionary<int, RecipeProgressSnapshot> Recipes { get; }
+
+    /// <summary>
+    /// UTC timestamp of the log line that produced this snapshot, or
+    /// <c>null</c> if nothing has been observed yet. (Player.log timestamps are
+    /// UTC.) Surface this for freshness — a live snapshot can still be minutes
+    /// old if the player has been idle in one zone.
+    /// </summary>
+    public DateTime? MeasuredAt { get; }
+
+    /// <summary>Provenance of this snapshot.</summary>
+    public RecipeStateSource Source { get; }
+
+    /// <summary>True if the recipe is known (learned and/or crafted).</summary>
+    public bool IsKnown(int recipeId) => Recipes.ContainsKey(recipeId);
+
+    /// <summary>Convenience lookup for one recipe.</summary>
+    public bool TryGet(int recipeId, out RecipeProgressSnapshot progress)
+        => Recipes.TryGetValue(recipeId, out progress);
+}
+
+/// <summary>
+/// Shared, <c>Player.log</c>-fed live view of the player's current recipe
+/// state — every known recipe and its lifetime completion count, without
+/// requiring a character re-export.
+///
+/// <para>Built by tailing two log lines (<c>ProcessLoadRecipes</c> = full
+/// known-recipe snapshot at login / zone change; <c>ProcessUpdateRecipe</c> =
+/// per-recipe delta — learn when count is 0, craft when &gt;=1). Because
+/// <c>ProcessLoadRecipes</c> re-fires on zone transitions (verified live: a
+/// full <c>[ids],[counts]</c> dump 8× in one session, structurally identical
+/// to <c>ProcessLoadSkills</c>), the tracker <b>self-heals</b>: even if Mithril
+/// starts tailing mid-session, the next zone change re-establishes the full
+/// known set including never-crafted recipes. Until the first
+/// <c>ProcessLoadRecipes</c> of the session is observed, <see cref="Current"/>
+/// is <see cref="PlayerRecipeSnapshot.Empty"/> (or partial, if only isolated
+/// <c>ProcessUpdateRecipe</c> lines have been seen) — this warm-up window is
+/// the documented contract, not a bug. The existence of a full dump is what
+/// makes the character export's recipe half fully eliminable (resolving the
+/// open question in #473).</para>
+///
+/// <para>This is neutral shared infrastructure (it does not know about leveling
+/// math, the first-time XP bonus, or any module). A consumer that needs the
+/// leveling-engine <c>RecipeHistory</c> shape adapts this projection itself —
+/// mirroring how Elrond's <c>SnapshotPlanInput</c> already adapts the character
+/// export — so <c>Mithril.GameState</c> takes no dependency on
+/// <c>Mithril.Leveling</c>.</para>
+/// </summary>
+public interface IPlayerRecipeState
+{
+    /// <summary>
+    /// The current immutable snapshot. Atomically consistent: the map,
+    /// <see cref="PlayerRecipeSnapshot.MeasuredAt"/>, and
+    /// <see cref="PlayerRecipeSnapshot.Source"/> always belong to the same
+    /// observation. Never null — <see cref="PlayerRecipeSnapshot.Empty"/>
+    /// before the first observation.
+    /// </summary>
+    PlayerRecipeSnapshot Current { get; }
+
+    /// <summary>
+    /// Attach a handler that is invoked immediately with the
+    /// <see cref="Current"/> snapshot (replay) and then again on every
+    /// subsequent change. Replay + live-attach are atomic under an internal
+    /// lock, so a late subscriber cannot miss the snapshot that landed between
+    /// resolving the service and subscribing.
+    ///
+    /// <para>The handler runs synchronously under the tracker's lock — both for
+    /// the replay (on the caller's thread) and for live dispatch (on the log
+    /// ingestion thread). Do non-trivial work off-thread. Dispose the returned
+    /// subscription to stop receiving events.</para>
+    /// </summary>
+    IDisposable Subscribe(Action<PlayerRecipeSnapshot> handler);
+
+    /// <summary>
+    /// Attach a handler that receives a granular <see cref="RecipeChange"/> per
+    /// recipe that actually moved — the channel for consumers that care
+    /// <em>which</em> recipe changed (learned / crafted feeds) rather than the
+    /// whole snapshot.
+    ///
+    /// <para>Unlike <see cref="Subscribe"/> there is <b>no replay</b>: a
+    /// <see cref="RecipeChange"/> is an event, not state. A late subscriber
+    /// sees changes from the moment it attaches; for current state it reads
+    /// <see cref="Current"/>. A <c>ProcessLoadRecipes</c> emits one
+    /// <see cref="RecipeChangeKind.SnapshotReplace"/> only for recipes whose
+    /// projection differs from (or is new vs.) the prior state — a no-op
+    /// re-sync produces nothing. A <c>ProcessUpdateRecipe</c> emits one
+    /// <see cref="RecipeChangeKind.Learned"/> (count 0, previously unknown) or
+    /// <see cref="RecipeChangeKind.Completed"/> (count increased).</para>
+    ///
+    /// <para>Same threading contract as <see cref="Subscribe"/>: the handler
+    /// runs synchronously under the tracker's lock on the ingestion thread —
+    /// do non-trivial work off-thread. Dispose to stop receiving.</para>
+    /// </summary>
+    IDisposable SubscribeChanges(Action<RecipeChange> handler);
+}

--- a/src/Mithril.GameState/Recipes/Parsing/RecipeEvents.cs
+++ b/src/Mithril.GameState/Recipes/Parsing/RecipeEvents.cs
@@ -1,0 +1,79 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Recipes.Parsing;
+
+/// <summary>
+/// One recipe's completion facet exactly as Project Gorgon emits it: the
+/// numeric recipe id paired with its lifetime completion count. Both the
+/// <c>ProcessLoadRecipes([ids],[counts])</c> (login / zone snapshot) and
+/// <c>ProcessUpdateRecipe(id, count)</c> (per-recipe delta) log lines reduce to
+/// this pair.
+///
+/// <para>This is the raw parse record — a faithful 1:1 of the log fields, before
+/// any caveat interpretation.
+/// <see cref="Mithril.GameState.Recipes.RecipeProgressSnapshot"/> is the
+/// consumer-facing projection that layers the known / crafted predicates on
+/// top.</para>
+///
+/// <list type="bullet">
+///   <item><see cref="RecipeId"/> — the recipe's numeric id: the
+///   <c>recipe_&lt;id&gt;</c> key in <c>recipes.json</c>. Kept as the integer
+///   the log carries; a consumer (or a reference-enrichment follow-up, the
+///   recipe analogue of #470) resolves it to <c>InternalName</c> / <c>Name</c>
+///   / <c>Skill</c>. The model keeps the key — the project-wide
+///   key→display-name convention, recipe edition. The tracker stays log-only by
+///   deliberate choice (pure-int, unit-testable, no reference-data DI surface),
+///   exactly mirroring the #462 skill tracker.</item>
+///   <item><see cref="Completions"/> — lifetime times this recipe has been
+///   crafted by this character (PG's per-recipe <c>RecipeCompletions</c>
+///   ledger). Monotonic non-decreasing in practice. <c>0</c> means the recipe
+///   is <b>known but never crafted</b> — a learned-only recipe; presence of the
+///   id at all (in a snapshot, or via any update) is what makes it
+///   <em>known</em>.</item>
+/// </list>
+/// </summary>
+public readonly record struct RecipeCompletionRecord(int RecipeId, int Completions);
+
+/// <summary>
+/// A full known-recipe table snapshot, parsed from a
+/// <c>ProcessLoadRecipes([id,…], [count,…])</c> line — two parallel,
+/// equal-length integer arrays (ids ‖ completion counts). Project Gorgon emits
+/// this at login and again on every zone / session transition, so it is
+/// <b>authoritative and complete</b> —
+/// <see cref="Mithril.GameState.Recipes.PlayerRecipeStateService"/> treats it
+/// as a wholesale replace of the tracked state, never a merge. The re-fire on
+/// zone changes is what lets the tracker self-heal after a mid-session start
+/// (mirrors <c>ProcessLoadSkills</c> / #462 exactly — there <em>is</em> a full
+/// dump, so the export's recipe half is fully eliminable, not merely
+/// reducible; this resolved the open research question in #473).
+/// </summary>
+/// <param name="Timestamp">The source log line's timestamp (UTC — Player.log's
+/// <c>[HH:MM:SS]</c> prefix is UTC).</param>
+/// <param name="Recipes">Every recipe in the dump, in log order, including
+/// <c>Completions==0</c> known-but-never-crafted rows — the parser does not
+/// filter; interpretation is the snapshot layer's job.</param>
+public sealed record RecipesSnapshotEvent(DateTime Timestamp, IReadOnlyList<RecipeCompletionRecord> Recipes)
+    : LogEvent(Timestamp);
+
+/// <summary>
+/// A single recipe's state changed, parsed from a
+/// <c>ProcessUpdateRecipe(id, count)</c> line. <paramref name="Recipe"/> carries
+/// the new <b>absolute</b> completion count (not a delta — verified live:
+/// snapshot 255 → <c>ProcessUpdateRecipe(7026, 256)</c> → next snapshot 256).
+///
+/// <para>The same verb conveys two distinct in-session events, disambiguated by
+/// the count: <c>count == 0</c> for a previously-unknown recipe is a
+/// <b>learn</b> (the discrete, recipe-specific signal that has no skill
+/// analogue — verified live against trainer learns); <c>count &gt;= 1</c> is a
+/// <b>craft completion</b>. PG emits no separate learn/first-time verb; the
+/// classification is <see cref="Mithril.GameState.Recipes.PlayerRecipeStateService"/>'s
+/// job from the prior state. A trainer learn is also accompanied by an
+/// unrelated <c>ProcessTrainingScreenRemoveId(handle, slot)</c> whose slot
+/// index is opaque (the offered list logs only as <c>TrainingInfo[]</c>); this
+/// parser deliberately ignores it — <c>ProcessUpdateRecipe(id,0)</c> is the
+/// authoritative learn signal.</para>
+/// </summary>
+/// <param name="Timestamp">The source log line's timestamp (UTC).</param>
+/// <param name="Recipe">The single recipe id + new absolute completion count.</param>
+public sealed record RecipeUpdateEvent(DateTime Timestamp, RecipeCompletionRecord Recipe)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Recipes/Parsing/RecipeLogParser.cs
+++ b/src/Mithril.GameState/Recipes/Parsing/RecipeLogParser.cs
@@ -1,0 +1,108 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Recipes.Parsing;
+
+/// <summary>
+/// Parses Project Gorgon's two recipe-state log lines into typed events:
+///
+/// <list type="bullet">
+///   <item><c>LocalPlayer: ProcessLoadRecipes([id,…], [count,…])</c> — the full
+///   known-recipe dump emitted at login and on zone / session transitions: two
+///   parallel, equal-length integer arrays (recipe ids ‖ lifetime completion
+///   counts). Yields a <see cref="RecipesSnapshotEvent"/> carrying every
+///   parsed row.</item>
+///   <item><c>LocalPlayer: ProcessUpdateRecipe(id, count)</c> — a single
+///   recipe's new <em>absolute</em> completion count (<c>0</c> for a just-learned
+///   recipe, <c>&gt;=1</c> for a craft). Yields a
+///   <see cref="RecipeUpdateEvent"/>.</item>
+/// </list>
+///
+/// <para>The regexes are unanchored — the convention every other
+/// <c>Player.log</c> parser uses — and the guards pin the <c>LocalPlayer:</c>
+/// prefix so an unrelated line that merely mentions the verb cannot trigger a
+/// parse. A cheap substring pre-check short-circuits the (overwhelmingly
+/// common) unrelated line before any regex runs. The arrays' trailing comma
+/// (PG emits <c>[1,2,3,]</c>) is absorbed by splitting with empty-entry
+/// removal.</para>
+///
+/// <para>Mirrors <see cref="Mithril.GameState.Skills.Parsing.SkillLogParser"/>
+/// (the #462 template). Catalogued in <c>log-patterns.json</c> as
+/// <c>shared.RecipeLogParser.{LoadRecipesRx,UpdateRecipeRx,LoadRecipesPayloadRx}</c>
+/// (the <c>shared</c> module prefix matches the other <c>Mithril.GameState</c>
+/// parsers in the catalog).</para>
+/// </summary>
+public sealed partial class RecipeLogParser : ILogParser
+{
+    // Guard: a real ProcessLoadRecipes line (full known-recipe dump). Pins the
+    // LocalPlayer: prefix so only the genuine emitter matches.
+    [GeneratedRegex(@"LocalPlayer: ProcessLoadRecipes\(", RegexOptions.CultureInvariant)]
+    private static partial Regex LoadRecipesRx();
+
+    // Guard: a real ProcessUpdateRecipe line.
+    [GeneratedRegex(@"LocalPlayer: ProcessUpdateRecipe\(", RegexOptions.CultureInvariant)]
+    private static partial Regex UpdateRecipeRx();
+
+    // ProcessLoadRecipes payload: the two bracketed integer lists. PG separates
+    // them with ", " but tolerate any whitespace. Recipe ids and counts are
+    // non-negative integers; the lists carry a trailing comma.
+    [GeneratedRegex(
+        @"ProcessLoadRecipes\(\[(?<ids>[\d,]*)\]\s*,\s*\[(?<counts>[\d,]*)\]\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex LoadRecipesPayloadRx();
+
+    // ProcessUpdateRecipe(id, count) — both non-negative integers.
+    [GeneratedRegex(
+        @"ProcessUpdateRecipe\((?<id>\d+)\s*,\s*(?<count>\d+)\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex UpdateRecipePayloadRx();
+
+    private static readonly char[] Comma = [','];
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        // Fast path: the vast majority of Player.log lines are neither verb.
+        if (!line.Contains("ProcessLoadRecipes", StringComparison.Ordinal)
+            && !line.Contains("ProcessUpdateRecipe", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (LoadRecipesRx().IsMatch(line))
+        {
+            var m = LoadRecipesPayloadRx().Match(line);
+            if (!m.Success) return null;
+
+            var ids = Split(m.Groups["ids"].Value);
+            var counts = Split(m.Groups["counts"].Value);
+
+            // The two arrays are parallel and must be equal length. A
+            // mismatched or empty payload is degenerate (truncation / grammar
+            // drift) — emit nothing rather than a spurious / lopsided snapshot
+            // that would wipe or corrupt live state.
+            if (ids.Length == 0 || ids.Length != counts.Length) return null;
+
+            var recipes = new List<RecipeCompletionRecord>(ids.Length);
+            for (int i = 0; i < ids.Length; i++)
+            {
+                recipes.Add(new RecipeCompletionRecord(
+                    int.Parse(ids[i]), int.Parse(counts[i])));
+            }
+            return new RecipesSnapshotEvent(timestamp, recipes);
+        }
+
+        if (UpdateRecipeRx().IsMatch(line))
+        {
+            var m = UpdateRecipePayloadRx().Match(line);
+            if (!m.Success) return null;
+            return new RecipeUpdateEvent(timestamp, new RecipeCompletionRecord(
+                int.Parse(m.Groups["id"].ValueSpan),
+                int.Parse(m.Groups["count"].ValueSpan)));
+        }
+
+        return null;
+    }
+
+    private static string[] Split(string list) =>
+        list.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs
+++ b/src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs
@@ -1,0 +1,240 @@
+using Microsoft.Extensions.Hosting;
+using Mithril.GameState.Recipes.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Recipes;
+
+/// <summary>
+/// Eagerly tails <see cref="IPlayerLogStream"/> at shell startup and maintains
+/// the canonical live <see cref="PlayerRecipeSnapshot"/> from
+/// <c>ProcessLoadRecipes</c> (full replace) and <c>ProcessUpdateRecipe</c>
+/// (per-recipe upsert) lines. The single owner of player recipe state derived
+/// from the log — modules depend on <see cref="IPlayerRecipeState"/> rather
+/// than re-parsing the stream or requiring a character re-export.
+///
+/// <para><b>Self-heal / warm-up.</b> <c>ProcessLoadRecipes</c> is emitted at
+/// login and again on every zone / session transition, so a wholesale replace
+/// on each one keeps state correct (including never-crafted known recipes)
+/// even when Mithril starts tailing mid-session. Before the first snapshot of
+/// the session, <see cref="Current"/> is
+/// <see cref="PlayerRecipeSnapshot.Empty"/>; isolated
+/// <c>ProcessUpdateRecipe</c> lines seen first produce a deliberately partial
+/// snapshot (better than nothing — the next <c>ProcessLoadRecipes</c> makes it
+/// whole). This window is the documented contract.</para>
+///
+/// <para><b>Threading.</b> The snapshot reference is swapped under
+/// <see cref="_lock"/>; <see cref="Current"/> reads are lock-free (reference
+/// read of an immutable object). <see cref="Subscribe"/> replays and attaches
+/// atomically under the same lock the ingestion loop fires under, which closes
+/// the late-subscribe race exactly as <c>PlayerSkillStateService</c> does.</para>
+/// </summary>
+public sealed class PlayerRecipeStateService : BackgroundService, IPlayerRecipeState
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly RecipeLogParser _parser;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly List<Action<PlayerRecipeSnapshot>> _handlers = new();
+    private readonly List<Action<RecipeChange>> _changeHandlers = new();
+    private volatile PlayerRecipeSnapshot _current = PlayerRecipeSnapshot.Empty;
+
+    public PlayerRecipeStateService(
+        IPlayerLogStream stream,
+        RecipeLogParser parser,
+        IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _parser = parser;
+        _diag = diag;
+    }
+
+    public PlayerRecipeSnapshot Current => _current;
+
+    public IDisposable Subscribe(Action<PlayerRecipeSnapshot> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            Invoke(handler, _current);
+            _handlers.Add(handler);
+            return new Unsub(this, _handlers, handler);
+        }
+    }
+
+    public IDisposable SubscribeChanges(Action<RecipeChange> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // No replay — a RecipeChange is an event, not state. Current state
+            // is read via Current.
+            _changeHandlers.Add(handler);
+            return new Unsub(this, _changeHandlers, handler);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Recipes", "Subscribing to Player.log for recipe-state events");
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            switch (_parser.TryParse(raw.Line, raw.Timestamp))
+            {
+                case RecipesSnapshotEvent snap:
+                    ReplaceAll(snap);
+                    break;
+                case RecipeUpdateEvent upd:
+                    Upsert(upd);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Wholesale replace from a <c>ProcessLoadRecipes</c> dump. Emits a
+    /// <see cref="RecipeChangeKind.SnapshotReplace"/> only for recipes whose
+    /// projection actually differs from (or is new vs.) the prior state — a
+    /// no-op re-sync produces no change events.</summary>
+    private void ReplaceAll(RecipesSnapshotEvent snap)
+    {
+        var map = new Dictionary<int, RecipeProgressSnapshot>(snap.Recipes.Count);
+        foreach (var r in snap.Recipes)
+        {
+            // Last-wins on the (not observed in practice) chance of a dup id —
+            // the indexer rather than Add avoids throwing on grammar drift.
+            map[r.RecipeId] = Project(r);
+        }
+
+        lock (_lock)
+        {
+            var prev = _current.Recipes;
+            List<RecipeChange>? changes = _changeHandlers.Count == 0 ? null : new();
+            if (changes is not null)
+            {
+                foreach (var (id, cur) in map)
+                {
+                    bool had = prev.TryGetValue(id, out var before);
+                    if (had && before.Equals(cur)) continue; // unchanged — skip
+                    changes.Add(new RecipeChange(
+                        id, had ? before : null, cur, CompletionsGained: 0,
+                        RecipeChangeKind.SnapshotReplace, snap.Timestamp));
+                }
+            }
+
+            _current = new PlayerRecipeSnapshot(map, snap.Timestamp, RecipeStateSource.LiveLog);
+            _diag?.Trace("GameState.Recipes",
+                $"Recipe snapshot replaced: {map.Count} recipes @ {snap.Timestamp:O}");
+            Fire(_current);
+            if (changes is not null)
+                foreach (var c in changes) FireChange(c);
+        }
+    }
+
+    /// <summary>Single-recipe upsert from a <c>ProcessUpdateRecipe</c> delta.
+    /// Accepted even before the first full snapshot — the resulting partial
+    /// state is intentional (see the type docs). Classifies the change as a
+    /// <see cref="RecipeChangeKind.Learned"/> (newly known, count 0) or a
+    /// <see cref="RecipeChangeKind.Completed"/> (count increased); an
+    /// idempotent re-emit that moves nothing is dropped entirely (PG re-emits
+    /// learn/count lines — unlike <c>ProcessUpdateSkill</c>, which only fires on
+    /// real movement, so the skill tracker need not guard this).</summary>
+    private void Upsert(RecipeUpdateEvent upd)
+    {
+        lock (_lock)
+        {
+            var id = upd.Recipe.RecipeId;
+            RecipeProgressSnapshot? before =
+                _current.Recipes.TryGetValue(id, out var b) ? b : null;
+            var cur = Project(upd.Recipe);
+
+            // True no-op (already known at this exact count — a duplicate
+            // learn/count re-emit): nothing changed, so don't churn the
+            // snapshot or fire spurious events.
+            if (before is { } bv && bv.Equals(cur)) return;
+
+            RecipeChangeKind kind;
+            int gained;
+            if (before is null)
+            {
+                // No baseline. count 0 = a fresh learn; count >=1 = a craft we
+                // joined mid-history (don't attribute a gain — honest contract).
+                kind = cur.Completions == 0 ? RecipeChangeKind.Learned : RecipeChangeKind.Completed;
+                gained = 0;
+            }
+            else
+            {
+                // Known already; the count moved. Counts are monotonic in
+                // practice — a decrease (grammar drift) still upserts last-wins
+                // but reports no gain.
+                kind = RecipeChangeKind.Completed;
+                gained = Math.Max(0, cur.Completions - before.Value.Completions);
+            }
+
+            // Copy-on-write so any consumer holding the prior snapshot keeps a
+            // stable, immutable view.
+            var map = new Dictionary<int, RecipeProgressSnapshot>(_current.Recipes)
+            {
+                [id] = cur,
+            };
+            _current = new PlayerRecipeSnapshot(map, upd.Timestamp, RecipeStateSource.LiveLog);
+            _diag?.Trace("GameState.Recipes",
+                $"Recipe upsert: {id} completions={cur.Completions} ({kind}) @ {upd.Timestamp:O}");
+            Fire(_current);
+            FireChange(new RecipeChange(id, before, cur, gained, kind, upd.Timestamp));
+        }
+    }
+
+    private static RecipeProgressSnapshot Project(RecipeCompletionRecord r) =>
+        new(Completions: r.Completions);
+
+    /// <summary>MUST be called with <see cref="_lock"/> held.</summary>
+    private void Fire(PlayerRecipeSnapshot snapshot)
+    {
+        foreach (var h in _handlers) Invoke(h, snapshot);
+    }
+
+    /// <summary>MUST be called with <see cref="_lock"/> held.</summary>
+    private void FireChange(RecipeChange change)
+    {
+        foreach (var h in _changeHandlers) InvokeChange(h, change);
+    }
+
+    private void Invoke(Action<PlayerRecipeSnapshot> handler, PlayerRecipeSnapshot snapshot)
+    {
+        try { handler(snapshot); }
+        catch (Exception ex) { _diag?.Warn("GameState.Recipes", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    private void InvokeChange(Action<RecipeChange> handler, RecipeChange change)
+    {
+        try { handler(change); }
+        catch (Exception ex) { _diag?.Warn("GameState.Recipes", $"Change subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Removes <paramref name="handler"/> from the list it was added to, under
+    /// the owner's lock. One implementation serves both the snapshot and the
+    /// change channels.
+    /// </summary>
+    private sealed class Unsub : IDisposable
+    {
+        private PlayerRecipeStateService? _owner;
+        private readonly System.Collections.IList _list;
+        private readonly object _handler;
+
+        public Unsub(PlayerRecipeStateService owner, System.Collections.IList list, object handler)
+        {
+            _owner = owner;
+            _list = list;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { _list.Remove(_handler); }
+        }
+    }
+}

--- a/src/Mithril.GameState/Recipes/RecipeChange.cs
+++ b/src/Mithril.GameState/Recipes/RecipeChange.cs
@@ -1,0 +1,86 @@
+namespace Mithril.GameState.Recipes;
+
+/// <summary>How a <see cref="RecipeChange"/> was produced.</summary>
+public enum RecipeChangeKind
+{
+    /// <summary>
+    /// From a <c>ProcessUpdateRecipe(id, 0)</c> for a previously-unknown
+    /// recipe — the player just <b>learned</b> it (from a trainer or a scroll)
+    /// but has not crafted it. The discrete learn signal that has no skill
+    /// analogue. <see cref="RecipeChange.CompletionsGained"/> is <c>0</c>.
+    /// </summary>
+    Learned = 0,
+
+    /// <summary>
+    /// From a <c>ProcessUpdateRecipe(id, N)</c> whose count increased — a craft
+    /// completion. <see cref="RecipeChange.CompletionsGained"/> carries the
+    /// increment (when a prior count was known);
+    /// <see cref="RecipeChange.IsFirstCompletion"/> marks the observed
+    /// <c>0 → ≥1</c> transition.
+    /// </summary>
+    Completed = 1,
+
+    /// <summary>
+    /// From a <c>ProcessLoadRecipes</c> full snapshot — emitted only for
+    /// recipes whose projection actually differs from (or is new vs.) the prior
+    /// state. A snapshot is not a gain event, so
+    /// <see cref="RecipeChange.CompletionsGained"/> is <c>0</c> here even though
+    /// the count may have moved (progression while Mithril wasn't tailing, or
+    /// the periodic re-sync).
+    /// </summary>
+    SnapshotReplace = 2,
+}
+
+/// <summary>
+/// A single recipe's state changed. The granular companion to
+/// <see cref="IPlayerRecipeState.Subscribe"/>'s whole-snapshot push: a consumer
+/// that cares <em>which</em> recipe moved (a "you learned X" / craft-count feed)
+/// subscribes via <see cref="IPlayerRecipeState.SubscribeChanges"/> instead of
+/// diffing snapshots itself.
+///
+/// <list type="bullet">
+///   <item><b>Just learned</b> is <see cref="Kind"/> ==
+///   <see cref="RecipeChangeKind.Learned"/>.</item>
+///   <item><b>First-ever craft</b> is <see cref="IsFirstCompletion"/> — the
+///   observed <c>0 → ≥1</c> transition. Only flagged when a prior count was
+///   known (<see cref="Previous"/> is not null); a craft seen before any
+///   baseline is a <see cref="RecipeChangeKind.Completed"/> with null
+///   <see cref="Previous"/> and is deliberately <em>not</em> flagged first —
+///   the honest warm-up contract (the next <c>ProcessLoadRecipes</c>
+///   reconciles).</item>
+/// </list>
+/// </summary>
+/// <param name="RecipeId">The recipe's numeric id (the map key). A consumer
+/// resolves it to a display name; the model keeps the id.</param>
+/// <param name="Previous">The recipe's projection before this change, or
+/// <c>null</c> if it was previously unknown (first observation, or first time
+/// seen after a cold start).</param>
+/// <param name="Current">The recipe's projection after this change.</param>
+/// <param name="CompletionsGained">Completions added on this tick for a
+/// <see cref="RecipeChangeKind.Completed"/> when a prior count was known;
+/// <c>0</c> for <see cref="RecipeChangeKind.Learned"/>,
+/// <see cref="RecipeChangeKind.SnapshotReplace"/>, and a craft seen with no
+/// baseline.</param>
+/// <param name="Kind">Whether this came from a learn, a craft, or a snapshot
+/// reconcile.</param>
+/// <param name="Timestamp">UTC timestamp of the source log line.</param>
+public readonly record struct RecipeChange(
+    int RecipeId,
+    RecipeProgressSnapshot? Previous,
+    RecipeProgressSnapshot Current,
+    int CompletionsGained,
+    RecipeChangeKind Kind,
+    DateTime Timestamp)
+{
+    /// <summary>
+    /// True for the observed first-ever craft of this recipe — a
+    /// <see cref="RecipeChangeKind.Completed"/> whose known prior count was
+    /// <c>0</c> (covers the in-session learn-then-craft: a
+    /// <see cref="RecipeChangeKind.Learned"/> at <c>0</c> followed by this
+    /// <c>0 → 1</c>). Not flagged when there was no baseline
+    /// (<see cref="Previous"/> null) — PG emits no first-time verb, so without
+    /// a prior count we do not guess.
+    /// </summary>
+    public bool IsFirstCompletion =>
+        Kind == RecipeChangeKind.Completed && Previous is { Completions: 0 };
+}

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -362,6 +362,50 @@
         { "name": "max", "group": "max", "type": "int" }
       ]
     },
+    "shared.RecipeLogParser.LoadRecipesRx": {
+      "pattern": "LocalPlayer: ProcessLoadRecipes\\(",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Recipes.Parsing.RecipeLogParser", "method": "LoadRecipesRx" },
+      "eventType": "shared.RecipesSnapshot",
+      "kind": "marker",
+      "notes": "Guard for the full known-recipe dump (login / zone-change). The two parallel [ids],[counts] arrays are extracted by LoadRecipesPayloadRx; this entry only discriminates the line. Re-fires on zone transitions, which is what lets PlayerRecipeStateService self-heal after a mid-session start and makes the export's recipe half fully eliminable. See issue #473.",
+      "fields": []
+    },
+    "shared.RecipeLogParser.UpdateRecipeRx": {
+      "pattern": "LocalPlayer: ProcessUpdateRecipe\\(",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Recipes.Parsing.RecipeLogParser", "method": "UpdateRecipeRx" },
+      "eventType": "shared.RecipeUpdate",
+      "kind": "marker",
+      "notes": "Guard for a single-recipe delta. The (id, count) payload is extracted by UpdateRecipePayloadRx. count==0 for a previously-unknown recipe is a learn (the discrete signal with no skill analogue; PG emits no separate learn/first-time verb); count>=1 is the new absolute craft-completion total (verified live: not a delta).",
+      "fields": []
+    },
+    "shared.RecipeLogParser.LoadRecipesPayloadRx": {
+      "pattern": "ProcessLoadRecipes\\(\\[(?<ids>[\\d,]*)\\]\\s*,\\s*\\[(?<counts>[\\d,]*)\\]\\)",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Recipes.Parsing.RecipeLogParser", "method": "LoadRecipesPayloadRx" },
+      "eventType": "shared.RecipesSnapshotPayload",
+      "notes": "The two parallel, equal-length integer arrays of ProcessLoadRecipes: ids (recipe_<id> in recipes.json) zipped with lifetime completion counts (0 = known but never crafted). Lists carry a trailing comma; split with empty-entry removal. A length mismatch or empty payload is treated as degenerate and yields no event (don't wipe live state).",
+      "fields": [
+        { "name": "ids", "group": "ids", "type": "string" },
+        { "name": "counts", "group": "counts", "type": "string" }
+      ]
+    },
+    "shared.RecipeLogParser.UpdateRecipePayloadRx": {
+      "pattern": "ProcessUpdateRecipe\\((?<id>\\d+)\\s*,\\s*(?<count>\\d+)\\)",
+      "source": "player",
+      "module": "shared",
+      "csharp": { "type": "Mithril.GameState.Recipes.Parsing.RecipeLogParser", "method": "UpdateRecipePayloadRx" },
+      "eventType": "shared.RecipeUpdatePayload",
+      "notes": "ProcessUpdateRecipe(id, count): id = recipe_<id>; count = the new ABSOLUTE lifetime completion count for this character (verified live — snapshot 255 → ProcessUpdateRecipe(7026,256) → next snapshot 256, not a delta). 0 = just-learned.",
+      "fields": [
+        { "name": "id", "group": "id", "type": "int" },
+        { "name": "count", "group": "count", "type": "int" }
+      ]
+    },
     "shared.ActiveCharacterLogSynchronizer.AddPlayerRx": {
       "pattern": "LocalPlayer:\\s*ProcessAddPlayer\\([^,]+,\\s*[^,]+,\\s*\"[^\"]*\",\\s*\"([^\"]+)\"",
       "source": "player",

--- a/tests/Mithril.GameState.Tests/Recipes/PlayerRecipeStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Recipes/PlayerRecipeStateServiceTests.cs
@@ -1,0 +1,388 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Recipes;
+using Mithril.GameState.Recipes.Parsing;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Recipes;
+
+public sealed class PlayerRecipeStateServiceTests
+{
+    // Real trimmed login dump: Butter=7, BoneMeal1=607, recipe_7026=255,
+    // CraftedClothPants2(13103)=0 (known, never crafted at session start).
+    private const string LoadLine =
+        "[10:10:03] LocalPlayer: ProcessLoadRecipes([1,7025,7026,13103,], [7,607,255,0,])";
+
+    private static PlayerRecipeStateService NewService(ScriptedStream stream)
+        => new(stream, new RecipeLogParser());
+
+    [Fact]
+    public void Cold_start_is_Empty_with_no_measurement()
+    {
+        var svc = NewService(new ScriptedStream());
+        svc.Current.Should().BeSameAs(PlayerRecipeSnapshot.Empty);
+        svc.Current.Source.Should().Be(RecipeStateSource.None);
+        svc.Current.MeasuredAt.Should().BeNull();
+        svc.Current.Recipes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProcessLoadRecipes_populates_full_snapshot_with_known_and_crafted_flags()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        var cur = svc.Current;
+        cur.Source.Should().Be(RecipeStateSource.LiveLog);
+        cur.MeasuredAt.Should().Be(Ts(10, 10, 3));
+        cur.Recipes.Should().HaveCount(4);
+
+        cur.TryGet(7025, out var boneMeal).Should().BeTrue();
+        boneMeal.Completions.Should().Be(607);
+        boneMeal.IsCrafted.Should().BeTrue();
+
+        cur.IsKnown(13103).Should().BeTrue();             // present == known
+        cur.TryGet(13103, out var pants).Should().BeTrue();
+        pants.Completions.Should().Be(0);
+        pants.IsCrafted.Should().BeFalse();               // learned, never crafted
+
+        cur.IsKnown(999999).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessLoadRecipes_is_a_wholesale_replace_not_a_merge()
+    {
+        var stream = new ScriptedStream(
+            new RawLogLine(Ts(10, 0, 0), "LocalPlayer: ProcessLoadRecipes([1,2], [3,4])"),
+            new RawLogLine(Ts(11, 0, 0), "LocalPlayer: ProcessLoadRecipes([9], [1])"));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.Recipes.Keys.Should().Equal(9); // 1 & 2 gone
+        svc.Current.MeasuredAt.Should().Be(Ts(11, 0, 0));
+    }
+
+    [Fact]
+    public async Task ProcessUpdateRecipe_upserts_one_recipe_keeping_the_rest()
+    {
+        var stream = new ScriptedStream(
+            new RawLogLine(Ts(10, 10, 3), LoadLine),
+            new RawLogLine(Ts(10, 22, 39), "LocalPlayer: ProcessUpdateRecipe(7026, 256)"));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.Recipes.Should().HaveCount(4); // others untouched
+        svc.Current.TryGet(7026, out var r).Should().BeTrue();
+        r.Completions.Should().Be(256);
+        svc.Current.MeasuredAt.Should().Be(Ts(10, 22, 39));
+    }
+
+    [Fact]
+    public async Task ProcessUpdateRecipe_before_any_snapshot_yields_partial_state()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(13, 32, 20),
+            "LocalPlayer: ProcessUpdateRecipe(13104, 0)"));
+        var svc = NewService(stream);
+        await RunUntilDrainedAsync(svc, stream);
+
+        svc.Current.Source.Should().Be(RecipeStateSource.LiveLog);
+        svc.Current.Recipes.Keys.Should().Equal(13104);
+    }
+
+    [Fact]
+    public async Task Learn_of_previously_unknown_recipe_emits_Learned_change()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<RecipeChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            // Real trainer learn of CraftedClothPants2E (count 0, not in dump).
+            stream.Push("LocalPlayer: ProcessUpdateRecipe(13104, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+        var c = changes[0];
+        c.Kind.Should().Be(RecipeChangeKind.Learned);
+        c.RecipeId.Should().Be(13104);
+        c.Previous.Should().BeNull();
+        c.Current.Completions.Should().Be(0);
+        c.CompletionsGained.Should().Be(0);
+        c.IsFirstCompletion.Should().BeFalse();
+        svc.Current.IsKnown(13104).Should().BeTrue();
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task First_craft_of_a_known_zero_count_recipe_is_Completed_and_IsFirstCompletion()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<RecipeChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            // 13103 is known at count 0 in the dump; real first craft → 1.
+            stream.Push("[13:30:36] LocalPlayer: ProcessUpdateRecipe(13103, 1)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+        var c = changes[0];
+        c.Kind.Should().Be(RecipeChangeKind.Completed);
+        c.RecipeId.Should().Be(13103);
+        c.Previous!.Value.Completions.Should().Be(0);
+        c.Current.Completions.Should().Be(1);
+        c.CompletionsGained.Should().Be(1);
+        c.IsFirstCompletion.Should().BeTrue();
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Subsequent_craft_is_Completed_with_increment_and_not_first()
+    {
+        var stream = new ScriptedStream(
+            new RawLogLine(Ts(10, 10, 3), LoadLine),
+            new RawLogLine(Ts(10, 22, 39), "LocalPlayer: ProcessUpdateRecipe(7026, 256)")); // 255→256
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<RecipeChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            stream.Push("LocalPlayer: ProcessUpdateRecipe(7026, 258)"); // +2
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+        var c = changes[0];
+        c.Kind.Should().Be(RecipeChangeKind.Completed);
+        c.Previous!.Value.Completions.Should().Be(256);
+        c.Current.Completions.Should().Be(258);
+        c.CompletionsGained.Should().Be(2);
+        c.IsFirstCompletion.Should().BeFalse(); // prior count was 256, not 0
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Craft_with_no_baseline_is_Completed_but_not_flagged_first()
+    {
+        // Mid-session start: first thing seen for this recipe is a craft, no
+        // prior snapshot. Honest contract — we don't claim "first ever".
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+
+        var changes = new List<RecipeChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            stream.Push("LocalPlayer: ProcessUpdateRecipe(7026, 256)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+        var c = changes[0];
+        c.Kind.Should().Be(RecipeChangeKind.Completed);
+        c.Previous.Should().BeNull();
+        c.CompletionsGained.Should().Be(0);    // no baseline → no attributed gain
+        c.IsFirstCompletion.Should().BeFalse(); // no baseline → not flagged
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Idempotent_re_emit_at_same_count_produces_no_change_and_no_snapshot_churn()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var snaps = new List<PlayerRecipeSnapshot>();
+        var changes = new List<RecipeChange>();
+        using (svc.Subscribe(snaps.Add))
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            snaps.Should().ContainSingle(); // replay only
+            // 7026 is already known at 255 in the dump; re-emit same value.
+            stream.Push("LocalPlayer: ProcessUpdateRecipe(7026, 255)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().BeEmpty();      // no movement → no change event
+        snaps.Should().ContainSingle();  // no spurious snapshot push
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task SnapshotReplace_emits_only_recipes_that_actually_changed()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 0, 0),
+            "LocalPlayer: ProcessLoadRecipes([1,7026], [7,255])"));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<RecipeChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            // Re-sync: 1 identical (no-op), 7026 moved 255→256, 13103 new.
+            stream.Push("LocalPlayer: ProcessLoadRecipes([1,7026,13103], [7,256,0])");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().HaveCount(2); // recipe 1 unchanged → suppressed
+        changes.Should().AllSatisfy(c => c.Kind.Should().Be(RecipeChangeKind.SnapshotReplace));
+        changes.Should().AllSatisfy(c => c.CompletionsGained.Should().Be(0)); // snapshot not a gain
+
+        var moved = changes.Single(c => c.RecipeId == 7026);
+        moved.Previous!.Value.Completions.Should().Be(255);
+        moved.Current.Completions.Should().Be(256);
+
+        var added = changes.Single(c => c.RecipeId == 13103);
+        added.Previous.Should().BeNull();
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Subscribe_replays_current_then_delivers_live_changes()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var seen = new List<PlayerRecipeSnapshot>();
+        using (svc.Subscribe(seen.Add))
+        {
+            seen.Should().HaveCount(1); // replay of current
+            seen[0].Recipes.Should().HaveCount(4);
+
+            stream.Push("LocalPlayer: ProcessUpdateRecipe(13104, 0)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        seen.Should().HaveCount(2);
+        seen[1].IsKnown(13104).Should().BeTrue();
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task SubscribeChanges_has_no_replay()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var changes = new List<RecipeChange>();
+        using (svc.SubscribeChanges(changes.Add))
+        {
+            changes.Should().BeEmpty(); // a change is an event, not state
+            stream.Push("LocalPlayer: ProcessUpdateRecipe(7026, 256)");
+            await stream.WaitForDrainAsync(cts.Token);
+        }
+
+        changes.Should().ContainSingle();
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Disposed_subscription_stops_receiving()
+    {
+        var stream = new ScriptedStream(new RawLogLine(Ts(10, 10, 3), LoadLine));
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+
+        var seen = new List<PlayerRecipeSnapshot>();
+        var sub = svc.Subscribe(seen.Add);
+        sub.Dispose();
+
+        stream.Push("LocalPlayer: ProcessUpdateRecipe(13104, 0)");
+        await stream.WaitForDrainAsync(cts.Token);
+
+        seen.Should().HaveCount(1); // only the replay; nothing after dispose
+
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);
+
+    private static async Task RunUntilDrainedAsync(PlayerRecipeStateService svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public ScriptedStream(params RawLogLine[] lines)
+        {
+            if (lines.Length == 0)
+            {
+                _drained.TrySetResult();
+                return;
+            }
+            Interlocked.Add(ref _pending, lines.Length);
+            foreach (var line in lines) _channel.Writer.TryWrite(line);
+        }
+
+        public void Push(string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Recipes/RecipeLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Recipes/RecipeLogParserTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Mithril.GameState.Recipes.Parsing;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Recipes;
+
+public sealed class RecipeLogParserTests
+{
+    private readonly RecipeLogParser _parser = new();
+    private static readonly DateTime Ts = new(2026, 5, 18, 10, 10, 3, DateTimeKind.Utc);
+
+    // Real capture (trimmed to 5 representative rows incl. a high-count, a
+    // mid-count, and two never-crafted count=0 rows) from Player.log's login
+    // dump. Note PG's trailing comma in both arrays.
+    private const string LoadRecipesLine =
+        "[10:10:03] LocalPlayer: ProcessLoadRecipes(" +
+        "[1,7025,8002,7026,13103,], [7,607,397,255,0,])";
+
+    [Fact]
+    public void ProcessLoadRecipes_yields_full_snapshot_in_log_order()
+    {
+        var evt = _parser.TryParse(LoadRecipesLine, Ts);
+
+        var snap = evt.Should().BeOfType<RecipesSnapshotEvent>().Subject;
+        snap.Timestamp.Should().Be(Ts);
+        snap.Recipes.Select(r => r.RecipeId).Should().Equal(1, 7025, 8002, 7026, 13103);
+    }
+
+    [Fact]
+    public void ProcessLoadRecipes_zips_ids_with_counts_1to1_absorbing_trailing_comma()
+    {
+        var snap = (RecipesSnapshotEvent)_parser.TryParse(LoadRecipesLine, Ts)!;
+
+        snap.Recipes.Single(r => r.RecipeId == 7025).Completions.Should().Be(607);  // BoneMeal1
+        snap.Recipes.Single(r => r.RecipeId == 8002).Completions.Should().Be(397);  // LeatherRoll2
+        snap.Recipes.Single(r => r.RecipeId == 1).Completions.Should().Be(7);       // Butter
+        snap.Recipes.Single(r => r.RecipeId == 13103).Completions.Should().Be(0);   // learned, never crafted
+        snap.Recipes.Should().HaveCount(5);
+    }
+
+    [Theory]
+    [InlineData("[10:22:39] LocalPlayer: ProcessUpdateRecipe(7026, 256)", 7026, 256)] // real craft
+    [InlineData("[13:30:36] LocalPlayer: ProcessUpdateRecipe(13103, 1)", 13103, 1)]   // real first craft
+    [InlineData("[13:32:20] LocalPlayer: ProcessUpdateRecipe(13104, 0)", 13104, 0)]   // real trainer learn
+    public void ProcessUpdateRecipe_yields_single_record(string line, int id, int count)
+    {
+        var upd = _parser.TryParse(line, Ts).Should().BeOfType<RecipeUpdateEvent>().Subject;
+        upd.Timestamp.Should().Be(Ts);
+        upd.Recipe.RecipeId.Should().Be(id);
+        upd.Recipe.Completions.Should().Be(count);
+    }
+
+    [Fact]
+    public void ProcessLoadRecipes_tolerates_no_space_between_arrays()
+    {
+        var snap = _parser.TryParse(
+            "LocalPlayer: ProcessLoadRecipes([1,2],[3,4])", Ts)
+            .Should().BeOfType<RecipesSnapshotEvent>().Subject;
+        snap.Recipes.Should().BeEquivalentTo(new[]
+        {
+            new RecipeCompletionRecord(1, 3),
+            new RecipeCompletionRecord(2, 4),
+        });
+    }
+
+    [Fact]
+    public void Mismatched_array_lengths_returns_null_rather_than_corrupt_snapshot()
+    {
+        // Degenerate (truncation / grammar drift): a lopsided snapshot would
+        // mis-pair ids with counts — emit nothing, let state stand.
+        _parser.TryParse("LocalPlayer: ProcessLoadRecipes([1,2,3], [9,9])", Ts)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Degenerate_ProcessLoadRecipes_with_empty_arrays_returns_null()
+    {
+        // Emit nothing rather than an empty snapshot that would wipe live state.
+        _parser.TryParse("[10:10:03] LocalPlayer: ProcessLoadRecipes([], [])", Ts)
+            .Should().BeNull();
+        _parser.TryParse("[10:10:03] LocalPlayer: ProcessLoadRecipes()", Ts)
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("[10:46:47] LocalPlayer: ProcessSetActiveSkills(Riding, Riding)")]
+    [InlineData("[10:46:47] entity_23984278: OnAttackHitMe(Big Cat Claw). Evaded = False")]
+    [InlineData("[13:32:20] LocalPlayer: ProcessTrainingScreenRemoveId(9376, 16)")]
+    [InlineData("[11:54:19] LocalPlayer: ProcessShowRecipes(Teleportation)")]
+    [InlineData("[10:10:03] LocalPlayer: ProcessSetStarredRecipes(System.Collections.Generic.HashSet`1[System.Int32])")]
+    public void Unrelated_lines_return_null(string line)
+        => _parser.TryParse(line, Ts).Should().BeNull();
+}


### PR DESCRIPTION
Part of #473 — the tracker portion (acceptance bullets 1 + 3). Issue stays open until the consumer switch (#472) lands; intentionally NOT auto-closing.

## What

`Mithril.GameState.Recipes` — `IPlayerRecipeState`, a `Player.log`-fed live view of **known recipes + per-recipe lifetime completion counts**, the recipe sibling of the #462/#465 skill tracker. Together they eliminate the planner's character-export dependency: #462 made *skill state* live, this makes *recipe state* live.

## The finding that de-risked #473

#473 flagged a central open question: *"there may be no full 'here are all your known recipes' dump on login/zone … if so the export remains the only complete bootstrap and this tracker is incremental-on-top, not a full replacement."*

Live-log investigation **resolved it**: there **is** a full dump. `ProcessLoadRecipes([ids],[counts])` is two parallel, equal-length integer arrays (recipe ids ‖ lifetime completion counts) emitted at login **and every zone/relog** (verified 8× in one session) — structurally identical to `ProcessLoadSkills`, and it **includes `count=0` known-but-never-crafted rows**. So the tracker fully self-heals and the export's recipe half is **truly eliminable**, not merely reducible.

Also decoded and verified live:
- `ProcessUpdateRecipe(id, newCount)` — `newCount` is the **new absolute** count, *not* a delta (snapshot 255 → `ProcessUpdateRecipe(7026,256)` → next snapshot 256).
- A **learn** is `ProcessUpdateRecipe(id, 0)` for a previously-unknown recipe (the discrete signal with no skill analogue; PG emits no separate learn/first-time verb). A trainer learn is also accompanied by an opaque `ProcessTrainingScreenRemoveId` (the offered list logs only as `TrainingInfo[]`) — deliberately ignored.

## Shape (mirrors #462 exactly)

- **Parsing/** — `RecipeLogParser` (guarded, substring fast-path, trailing-comma tolerant, length-mismatch/empty → no event so live state is never wiped), `RecipeCompletionRecord` + `RecipesSnapshotEvent` / `RecipeUpdateEvent`.
- **`IPlayerRecipeState`** — immutable `PlayerRecipeSnapshot` (`int recipeId → RecipeProgressSnapshot`), atomic `Subscribe` (replay-on-attach) + `SubscribeChanges` (no replay), documented warm-up/self-heal contract. **Neutral**: keyed by the numeric `recipe_<id>` the log carries, **no `Mithril.Leveling` / reference-data dependency** — consumers adapt to `RecipeHistory` themselves (mirroring `SnapshotPlanInput`). int-key + raw-vs-projection split chosen so a #470-style reference enrichment can layer on with **no breaking change**.
- **`RecipeChange`** — `Learned` / `Completed` / `SnapshotReplace`; `IsFirstCompletion` = the observed `0 → ≥1` transition (honest: **not** flagged without a baseline, since PG emits no first-time verb — the next `ProcessLoadRecipes` reconciles).
- DI registration in `AddMithrilGameState` + `log-patterns.json` catalog (`shared.RecipeLogParser.*`).

## Tests

27 tests over **real captured `Player.log` craft/learn fixtures** (BoneMeal1=607, the verified `7026` 255→256 craft, the `13103` 0→1 first craft, the `13104` trainer learn). Full `Mithril.GameState.Tests` suite green (**202**). Clean build (warnings-as-errors).

## Scope

Tracker only. The consumer switch (planner `RecipeHistory` → live source, Celebrimbor `PlanExecutor`) is the separate follow-up **#472**, as agreed — mirrors #462 deferring its consumers.

— drafted by Claude (Opus 4.7), posted by @arthur-conde