### PR TITLE
feat(palantir): surface GameState player map-pins in the World State tab

### DIFF
--- a/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
+++ b/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
@@ -1,8 +1,10 @@
+using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.GameState.Areas;
 using Mithril.GameState.Movement;
+using Mithril.GameState.Pins;
 using Mithril.Shared.Reference;
 
 namespace Palantir.ViewModels;
@@ -11,22 +13,32 @@ namespace Palantir.ViewModels;
 /// Debug surface over <b>Mithril.GameState</b>'s live map + position state:
 /// the current area (<see cref="PlayerAreaTracker"/>) resolved through
 /// <c>areas.json</c> (<see cref="IReferenceDataService.Areas"/>) to its
-/// friendly names, plus the player's last-known <see cref="PlayerPosition"/>
+/// friendly names, the player's last-known <see cref="PlayerPosition"/>
 /// (coords + the UTC instant it was measured) from
-/// <see cref="IPlayerPositionTracker"/>.
+/// <see cref="IPlayerPositionTracker"/>, and the area-scoped player map-pin
+/// set from <see cref="IPlayerPinTracker"/>.
 ///
 /// <para>Position is event-driven (sparse — teleport / zone-in only). The
 /// area tracker exposes no change event, so it is re-read on every position
 /// update (area changes coincide with the teleport that emits a position)
 /// and on the manual <see cref="RefreshCommand"/>.</para>
+///
+/// <para>Pins are push-driven: <see cref="IPlayerPinTracker.Subscribe"/>
+/// replays the current set synchronously then delivers add / remove / area
+/// swap live (PG bulk-replays the set on every login / zone, idempotently).
+/// Both tracker subscriptions fire on the GameState ingestion thread, so
+/// every handler marshals through <see cref="_dispatch"/> before touching
+/// bound state.</para>
 /// </summary>
 public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
 {
     private readonly IPlayerPositionTracker _positionTracker;
     private readonly PlayerAreaTracker _areaTracker;
+    private readonly IPlayerPinTracker _pinTracker;
     private readonly IReferenceDataService? _refData;
     private readonly Action<Action> _dispatch;
     private IDisposable? _subscription;
+    private IDisposable? _pinSubscription;
 
     [ObservableProperty] private string _areaKey = "(unknown)";
     [ObservableProperty] private string _areaFriendlyName = "(area not yet known)";
@@ -38,11 +50,20 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     [ObservableProperty] private string _measuredAtText = "—";
     [ObservableProperty] private string _positionSourceText = "—";
 
+    [ObservableProperty] private int _pinCount;
+    [ObservableProperty] private bool _hasPins;
+    [ObservableProperty] private string _pinsObservedAtText = "—";
+
+    /// <summary>The current area's pins as presentation rows. Mutated only
+    /// on the dispatched (UI) thread — see <see cref="OnPins"/>.</summary>
+    public ObservableCollection<MapPinRow> Pins { get; } = [];
+
     public WorldStateViewModel(
         IPlayerPositionTracker positionTracker,
         PlayerAreaTracker areaTracker,
+        IPlayerPinTracker pinTracker,
         IReferenceDataService? refData = null)
-        : this(positionTracker, areaTracker, refData, dispatch: null)
+        : this(positionTracker, areaTracker, pinTracker, refData, dispatch: null)
     { }
 
     /// <summary>
@@ -52,17 +73,20 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     public WorldStateViewModel(
         IPlayerPositionTracker positionTracker,
         PlayerAreaTracker areaTracker,
+        IPlayerPinTracker pinTracker,
         IReferenceDataService? refData,
         Action<Action>? dispatch)
     {
         _positionTracker = positionTracker;
         _areaTracker = areaTracker;
+        _pinTracker = pinTracker;
         _refData = refData;
         _dispatch = dispatch ?? DefaultDispatch;
 
         RefreshArea();
-        // Replay-on-subscribe seeds position if one is already known.
+        // Replay-on-subscribe seeds position / the pin set if already known.
         _subscription = _positionTracker.Subscribe(OnPosition);
+        _pinSubscription = _pinTracker.Subscribe(OnPins);
     }
 
     private void OnPosition(PlayerPosition p) => _dispatch(() =>
@@ -80,6 +104,33 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         // A new position implies a possible zone change — re-resolve the area.
         RefreshArea();
     });
+
+    /// <summary>
+    /// Rebuild the pin list from the post-change snapshot. The set is tiny
+    /// (a handful per area) and replay-on-login is idempotent at the tracker,
+    /// so a clear-and-refill is simpler than diffing and correct for every
+    /// <see cref="PinSetChange"/> kind (Snapshot / Added / Removed /
+    /// AreaChanged). <see cref="PinSetChanged.Pins"/> is an immutable
+    /// snapshot — safe to read off the ingestion thread before dispatching.
+    /// </summary>
+    private void OnPins(PinSetChanged change)
+    {
+        var rows = change.Pins.Select(MapPinRow.From).ToArray();
+        // A Snapshot replay reflects the existing set, not a fresh
+        // observation — keep the "—" placeholder until a real change lands.
+        var stamp = change.Kind == PinSetChange.Snapshot
+            ? null
+            : change.ObservedAt.UtcDateTime.ToString("u", CultureInfo.InvariantCulture);
+
+        _dispatch(() =>
+        {
+            Pins.Clear();
+            foreach (var r in rows) Pins.Add(r);
+            PinCount = rows.Length;
+            HasPins = rows.Length > 0;
+            if (stamp is not null) PinsObservedAtText = stamp;
+        });
+    }
 
     [RelayCommand]
     private void Refresh() => _dispatch(RefreshArea);
@@ -118,6 +169,8 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     {
         _subscription?.Dispose();
         _subscription = null;
+        _pinSubscription?.Dispose();
+        _pinSubscription = null;
     }
 
     private static void DefaultDispatch(Action action)
@@ -126,4 +179,24 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         if (d is null || d.CheckAccess()) action();
         else d.InvokeAsync(action);
     }
+}
+
+/// <summary>
+/// Presentation-only projection of a <see cref="MapPin"/> for the World
+/// State debug list — formatting lives here, not in the XAML.
+/// </summary>
+/// <param name="Label">The pin label, or "Unnamed pin" for blank labels
+/// (<see cref="MapPin.DisplayName"/>).</param>
+/// <param name="Appearance">Human appearance phrase, e.g. "red dot"
+/// (<see cref="MapPin.Appearance"/>).</param>
+/// <param name="Coords">Signed engine-unit ground-plane coordinate, formatted
+/// to match the POSITION row (Y is intentionally dropped for pins).</param>
+/// <param name="Detail">Raw enum names — debug-surface extra.</param>
+public sealed record MapPinRow(string Label, string Appearance, string Coords, string Detail)
+{
+    public static MapPinRow From(MapPin p) => new(
+        p.DisplayName,
+        p.Appearance,
+        string.Format(CultureInfo.InvariantCulture, "X {0:0.00}   Z {1:0.00}", p.X, p.Z),
+        $"{p.Color} · {p.Shape}");
 }

--- a/src/Palantir.Module/Views/WorldStateView.xaml
+++ b/src/Palantir.Module/Views/WorldStateView.xaml
@@ -33,10 +33,12 @@
                        FontSize="{DynamicResource AppFontSizeHint}"
                        Margin="0,0,0,16">
                 Live Mithril.GameState projection: the current area resolved
-                through areas.json, and the player's last-known position from
-                Player.log ProcessNewPosition. Position is sparse — it only
-                updates on teleport / zone-in, so the measured instant can
-                lag wall-clock by a long way.
+                through areas.json, the player's last-known position from
+                Player.log ProcessNewPosition, and the area-scoped map-pin
+                set. Position is sparse — it only updates on teleport /
+                zone-in, so the measured instant can lag wall-clock by a long
+                way. Pins are push-driven and area-local: PG idempotently
+                replays the whole set on every login / zone change.
             </TextBlock>
 
             <!-- Map / area -->
@@ -100,6 +102,70 @@
                                    Text="{Binding PositionSourceText}"
                                    Foreground="#88FFFFFF"/>
                     </DockPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Pins -->
+            <TextBlock Text="PINS" Foreground="#88FFFFFF"
+                       FontSize="{DynamicResource AppFontSizeHint}"
+                       FontWeight="SemiBold" Margin="0,16,0,4"/>
+            <Border Background="#FF252525" CornerRadius="4" Padding="14,10">
+                <StackPanel>
+                    <DockPanel Margin="0,0,0,6">
+                        <TextBlock DockPanel.Dock="Left" Text="Pins (this area)"
+                                   Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding PinCount, StringFormat={}{0} pin(s)}"
+                                   Foreground="#FFFFFFFF" FontWeight="SemiBold"/>
+                    </DockPanel>
+                    <DockPanel Margin="0,0,0,6">
+                        <TextBlock DockPanel.Dock="Left" Text="Last change (UTC)"
+                                   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding PinsObservedAtText}"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   Foreground="#88FFFFFF"/>
+                    </DockPanel>
+
+                    <TextBlock Text="(no pins in this area)"
+                               Foreground="#66FFFFFF" FontStyle="Italic"
+                               Margin="0,4,0,0"
+                               Visibility="{Binding HasPins, Converter={StaticResource InverseBoolToVis}}"/>
+
+                    <ItemsControl ItemsSource="{Binding Pins}"
+                                  Margin="0,4,0,0"
+                                  Visibility="{Binding HasPins, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="#FF2E2E2E" CornerRadius="3"
+                                        Padding="10,7" Margin="0,0,0,5">
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock HorizontalAlignment="Right"
+                                                       Text="{Binding Appearance}"
+                                                       Foreground="#CCFFFFFF"
+                                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBlock Text="{Binding Label}"
+                                                       Foreground="#FFFFFFFF"
+                                                       FontWeight="SemiBold"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </DockPanel>
+                                        <DockPanel Margin="0,3,0,0">
+                                            <TextBlock HorizontalAlignment="Right"
+                                                       Text="{Binding Detail}"
+                                                       Foreground="#66FFFFFF"
+                                                       FontSize="{DynamicResource AppFontSizeHint}"
+                                                       VerticalAlignment="Center"/>
+                                            <TextBlock Text="{Binding Coords}"
+                                                       FontFamily="{DynamicResource AppMonoFontFamily}"
+                                                       Foreground="#88FFFFFF"/>
+                                        </DockPanel>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </Border>
 

--- a/tests/Palantir.Tests/WorldStateViewModelTests.cs
+++ b/tests/Palantir.Tests/WorldStateViewModelTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Movement;
+using Mithril.GameState.Pins;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
@@ -90,7 +91,8 @@ public sealed class WorldStateViewModelTests
         var pos = new FakePositionTracker();
         pos.PreloadAsCurrent(new PlayerPosition(1, 2, 3, T, PlayerPositionSource.Spawn));
         using var vm = new WorldStateViewModel(
-            pos, new PlayerAreaTracker(new AreaTransitionParser()), null, a => a());
+            pos, new PlayerAreaTracker(new AreaTransitionParser()),
+            new FakePinTracker(), null, a => a());
 
         vm.HasPosition.Should().BeTrue();
         vm.PositionText.Should().Be("X 1.00   Y 2.00   Z 3.00");
@@ -108,13 +110,112 @@ public sealed class WorldStateViewModelTests
         vm.HasPosition.Should().BeFalse("the disposed VM must unsubscribe");
     }
 
+    private static MapPin Pin(double x, double z, string label,
+        PinShape shape = PinShape.Dot, PinColor color = PinColor.Red)
+        => new(x, z, label, shape, color, RawList: 1);
+
+    [Fact]
+    public void Replay_on_subscribe_seeds_existing_pin_set()
+    {
+        var pins = new FakePinTracker();
+        pins.Preload("AreaSerbule",
+            Pin(10, -20, "Vendor"), Pin(-5.5, 99.25, ""));
+        using var vm = new WorldStateViewModel(
+            new FakePositionTracker(), new PlayerAreaTracker(new AreaTransitionParser()),
+            pins, null, a => a());
+
+        vm.HasPins.Should().BeTrue();
+        vm.PinCount.Should().Be(2);
+        vm.Pins.Should().HaveCount(2);
+        // Snapshot replay reflects an existing set, not a fresh observation.
+        vm.PinsObservedAtText.Should().Be("—");
+    }
+
+    [Fact]
+    public void Added_pin_appends_row_and_stamps_observed_at()
+    {
+        using var vm = NewVm(out _, out _, out var pins);
+        var pin = Pin(123.4, -567.8, "Camp", PinShape.Square, PinColor.Green);
+
+        pins.Fire(new PinSetChanged(
+            PinSetChange.Added, "AreaSerbule", pin, [pin], T));
+
+        vm.HasPins.Should().BeTrue();
+        vm.PinCount.Should().Be(1);
+        var row = vm.Pins.Single();
+        row.Label.Should().Be("Camp");
+        row.Appearance.Should().Be("green square");
+        row.Coords.Should().Be("X 123.40   Z -567.80");
+        row.Detail.Should().Be("Green · Square");
+        vm.PinsObservedAtText.Should().Be("2026-05-18 10:45:47Z");
+    }
+
+    [Fact]
+    public void Removed_pin_drops_the_row()
+    {
+        using var vm = NewVm(out _, out _, out var pins);
+        var a = Pin(1, 1, "A");
+        var b = Pin(2, 2, "B");
+        pins.Fire(new PinSetChanged(PinSetChange.Added, "X", b, [a, b], T));
+
+        pins.Fire(new PinSetChanged(PinSetChange.Removed, "X", a, [b], T));
+
+        vm.Pins.Select(r => r.Label).Should().ContainSingle().Which.Should().Be("B");
+    }
+
+    [Fact]
+    public void Area_change_clears_the_pin_set()
+    {
+        using var vm = NewVm(out _, out _, out var pins);
+        var p = Pin(1, 1, "Gone");
+        pins.Fire(new PinSetChanged(PinSetChange.Added, "AreaA", p, [p], T));
+
+        pins.Fire(new PinSetChanged(PinSetChange.AreaChanged, "AreaB", null, [], T));
+
+        vm.HasPins.Should().BeFalse();
+        vm.PinCount.Should().Be(0);
+        vm.Pins.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Unlabeled_pin_falls_back_to_placeholder_name()
+    {
+        using var vm = NewVm(out _, out _, out var pins);
+        var p = Pin(-3.14, 0, "  ", PinShape.Unknown, PinColor.Unknown);
+
+        pins.Fire(new PinSetChanged(PinSetChange.Added, "X", p, [p], T));
+
+        var row = vm.Pins.Single();
+        row.Label.Should().Be("Unnamed pin");
+        row.Appearance.Should().Be("pin"); // unknown colour omitted, unknown shape → "pin"
+        row.Coords.Should().Be("X -3.14   Z 0.00");
+    }
+
+    [Fact]
+    public void Dispose_stops_observing_pins()
+    {
+        using var vm = NewVm(out _, out _, out var pins);
+        vm.Dispose();
+
+        var p = Pin(9, 9, "Late");
+        pins.Fire(new PinSetChanged(PinSetChange.Added, "X", p, [p], T));
+
+        vm.HasPins.Should().BeFalse("the disposed VM must unsubscribe from pins");
+    }
+
     private static WorldStateViewModel NewVm(
         out FakePositionTracker pos, out PlayerAreaTracker area, IReferenceDataService? refData = null)
+        => NewVm(out pos, out area, out _, refData);
+
+    private static WorldStateViewModel NewVm(
+        out FakePositionTracker pos, out PlayerAreaTracker area,
+        out FakePinTracker pins, IReferenceDataService? refData = null)
     {
         pos = new FakePositionTracker();
         area = new PlayerAreaTracker(new AreaTransitionParser());
+        pins = new FakePinTracker();
         // Synchronous dispatcher: test thread is the WPF thread.
-        return new WorldStateViewModel(pos, area, refData, a => a());
+        return new WorldStateViewModel(pos, area, pins, refData, a => a());
     }
 
     private sealed class FakePositionTracker : IPlayerPositionTracker
@@ -140,6 +241,44 @@ public sealed class WorldStateViewModelTests
         }
 
         private sealed class Sub(FakePositionTracker owner) : IDisposable
+        {
+            public void Dispose() => owner._handler = null;
+        }
+    }
+
+    private sealed class FakePinTracker : IPlayerPinTracker
+    {
+        private string? _area;
+        private IReadOnlyList<MapPin> _pins = [];
+        private Action<PinSetChanged>? _handler;
+
+        public string? CurrentArea => _area;
+        public IReadOnlyList<MapPin> CurrentAreaPins => _pins;
+
+        /// <summary>Seed the set so the Subscribe replay (Snapshot) carries it.</summary>
+        public void Preload(string area, params MapPin[] pins)
+        {
+            _area = area;
+            _pins = pins;
+        }
+
+        public void Fire(PinSetChanged change)
+        {
+            _area = change.Area;
+            _pins = change.Pins;
+            _handler?.Invoke(change);
+        }
+
+        public IDisposable Subscribe(Action<PinSetChanged> handler)
+        {
+            // Mirror PlayerPinTracker: synchronous Snapshot replay first.
+            handler(new PinSetChanged(
+                PinSetChange.Snapshot, _area, null, _pins, DateTimeOffset.UnixEpoch));
+            _handler = handler;
+            return new Sub(this);
+        }
+
+        private sealed class Sub(FakePinTracker owner) : IDisposable
         {
             public void Dispose() => owner._handler = null;
         }


### PR DESCRIPTION
Closes #479.

Surfaces **GameState's player map-pins** in Palantir's World State debug tab. `Mithril.GameState.Pins.IPlayerPinTracker` shipped with #468 (closed) as the authoritative area-scoped owner of the player's pins; nothing rendered it. Palantir is the debug/inspector surface over `Mithril.GameState` (per its charter), and the World State tab already projects area + position from GameState — pins are area-local map state that reads naturally alongside them.

**Placement** (owner decision): a PINS section *inside* the existing World State tab, not a new tab — no extra VM, the area context it needs is already shown there.

## Changes

- **`WorldStateViewModel`** — injects `IPlayerPinTracker`, subscribes in the ctor (synchronous replay-on-subscribe seeds an existing set), rebuilds an `ObservableCollection<MapPinRow>` on every `PinSetChanged` through the existing `_dispatch` marshal (tracker handlers fire on the GameState ingestion thread). Clear-and-refill: the set is a handful of pins and login/zone replay is idempotent *at the tracker*, so diffing buys nothing and a refill is correct for all four change kinds. `Snapshot` replays keep the `—` last-change placeholder (an existing set isn't a fresh observation). `Dispose` unsubscribes (parallel to the position subscription).
- **`WorldStateView.xaml`** — a PINS `Border` mirroring the MAP/POSITION visual grammar: count + last-change-UTC stamp, an `ItemsControl` of `label / appearance / signed coords / raw enum detail`, `BoolToVis`/`InverseBoolToVis` for the empty-state. Blurb updated.
- **Tests** — `FakePinTracker` (mirrors `PlayerPinTracker`'s synchronous `Snapshot` replay) + 6 cases: replay-seed, add (+observed-at stamp), remove, area-swap clear, unlabeled/unknown-enum fallback, dispose-unsubscribe. Existing ctor / `NewVm` call sites updated for the new required dependency.

## Verification

- `dotnet build Mithril.slnx` — clean (0 warnings, warnings-as-errors).
- `dotnet test Mithril.slnx` — all green (Palantir 20/20; full suite incl. the `Mithril.Shell` boot guard, 552 Silmarillion, 1140 Shared).
- Palantir stays debug-only (`IsDeveloperOnly`, lazy) — the VM is resolved on first tab open, not at boot, so the new required `IPlayerPinTracker` ctor dependency carries no boot-time DI risk (it's an already-registered GameState singleton).
- No GameState / Shared / Shell changes.

## Non-goals (per #479)

No map/overlay rendering (Legolas's overlay charter), no pin editing (PG has no inbound path; pins are read-only state), no new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
