### PR TITLE
Legolas: Survey player-GPS (#476) + overlay-topmost regression fix

### DIFF
--- a/docs/legolas-overview.md
+++ b/docs/legolas-overview.md
@@ -11,6 +11,8 @@ Companion docs:
 Project Gorgon's survey/treasure items (gated on **Geology**, **Mining**, or **Treasure Cartography** — "Surveying" is loose shorthand here) go in the player's inventory. Using one prints a chat line like `[Status] The Iron Vein is 50m east and 30m north`. The item is consumed (and grants XP) only when used while *standing on* the target spot.
 
 > **As-built — [#454](https://github.com/moumantai-gg/mithril/issues/454) landed.** Survey/treasure placement is now **absolute**: Legolas consumes `IPlayerLogStream` and keys off Player.log `LocalPlayer: ProcessMapFx((X,Y,Z), …)`, which carries the target's exact world coordinate. The relative-offset model, the anchor click, `CoordinateProjector.Refit`, the `AwaitingPosition`/`Ready` FSM states, and the `Gathering` survey-drop are **retired for Survey**. `SessionState.PlayerPosition` / `CoordinateProjector` survive but are **Motherlode-only** now (its triangulation records the player position from a map click). Sections below that still describe the relative/anchor model are flagged inline; the FSM and coordinate sections are updated. Cold-start calibration moved to a wizard `Calibrating` step driven by the map overlay — see [#460](https://github.com/moumantai-gg/mithril/issues/460).
+>
+> **As-built — [#476](https://github.com/moumantai-gg/mithril/issues/476) landed.** The anchor click was *also* (undesigned) the player-position reference for Survey: the "you are here" marker, the route start, and the initial "head here next" segment. #460 collateral-removed all three. #476 restores them from a **better source** — the GameState `IPlayerPositionTracker` world coordinate projected through the area calibration (`AreaCalibration.ProjectWorld`, the same transform `ProcessMapFx` pins use), **not** a manual click. Placement stays absolute; the relative/anchor model does not return. The signal is sparse (zone-in / teleport only — there is no per-tick movement feed in Player.log), so it is freshest at Optimize time and goes stale as the player walks; `MeasuredAt`/`Source` are surfaced (`MapOverlayViewModel.PlayerAnchorStatus`, shown in the overlay header) and it is never drawn as live. **Option C also landed**: a *manual override* — the optional `SurveyFlowState.SettingPosition` detour ("Set my position" in the wizard → click the map) corrects a stale anchor. The auto GPS is still the zero-click default; a manual pixel wins until the next *fresh* tracker fix (zone-in / teleport) supersedes it.
 
 Legolas tails the chat log, parses these offsets, and:
 
@@ -106,13 +108,14 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 
 ## SurveyFlowController FSM
 
-[`SurveyFlowController`](../src/Legolas.Module/Flow/SurveyFlowController.cs). **#454 collapsed this to three states** — `ProcessMapFx` targets are absolute, so there is no anchor click and no `AwaitingPosition`/`Ready` bootstrap. Initial state is `Listening`.
+[`SurveyFlowController`](../src/Legolas.Module/Flow/SurveyFlowController.cs). **#454 collapsed this to three states** — `ProcessMapFx` targets are absolute, so there is no anchor click and no `AwaitingPosition`/`Ready` bootstrap. **#476 added one optional state**, `SettingPosition`, for the manual position-override detour (Option C). Initial state is `Listening`.
 
 | State | Meaning |
 |---|---|
 | `Listening` | Default working state. Absolute pins auto-place as `ProcessMapFx` arrives. The first pin of a cycle stamps `SessionState.StartedAt`. |
 | `Gathering` | Route optimised; user is walking it. New targets are **accepted** (the old position-anchor "drop new surveys" constraint is retired with the relative model). |
 | `Done` | All surveys collected. If `AutoResetWhenAllCollected`, `Reset()` immediately follows. |
+| `SettingPosition` | **#476, optional.** The manual player-GPS override is active: the overlay awaits a "click where you are" and the wizard shows a Cancel affordance. Entered on demand from `Listening`/`Gathering`; returns to whichever it came from (`ReturnState`). The auto tracker GPS is the zero-click default — this state only exists to *correct a stale anchor*, so users who never invoke it never see it. |
 
 ### Transitions
 
@@ -121,10 +124,13 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 | `Listening` | `Surveys.Add` (first pin, count 0→1) | `Listening` | No transition — **stamps `SessionState.StartedAt`** (the canonical "session started" time). Re-stamps every cycle since `Reset` returns to `Listening`. |
 | `Listening` | `OptimizeRoute()` | `Gathering` | Caller has assigned `RouteOrder`s. `CanOptimize` = `Listening && Surveys.Count > 0` (the non-empty precondition is now explicit, not structural). |
 | `Listening` \| `Gathering` | `AllCollected` event (auto) | `Done` | Fires when the last uncollected survey is marked. |
+| `Listening` \| `Gathering` | `RequestSetPosition()` | `SettingPosition` | #476. Parks the current state in `ReturnState`. No-op from any other state. The auto anchor is untouched until the click confirms. |
+| `SettingPosition` | `ConfirmPosition()` (map click) | `ReturnState` | #476. `MapOverlayViewModel` writes the manual pixel to the session *before* this call (`SurveyPlayerIsManual = true`); the FSM only owns the phase. |
+| `SettingPosition` | `CancelSetPosition()` | `ReturnState` | #476. Returns with the anchor unchanged. |
 | `Done` | `Reset()` (auto, if `AutoResetWhenAllCollected`) | `Listening` | Clears `Surveys` + `StartedAt`. |
-| any | `Reset()` | `Listening` | Always — there is no anchor precondition. Clears `Surveys` + `StartedAt`. |
+| any | `Reset()` | `Listening` | Always — there is no anchor precondition. Clears `Surveys` + `StartedAt` (also exits `SettingPosition`). |
 
-There is no longer a `NoteSurveyDetected`/`CanAcceptSurvey`/`DescribeWhyDropped` drop path: absolute pins are added straight to `SessionState.Surveys` and the controller reacts via `OnSurveysChanged`. The cold-start "uncalibrated area" case is handled in the wizard (a `Calibrating` gate step — see #460), not the FSM.
+There is no longer a `NoteSurveyDetected`/`CanAcceptSurvey`/`DescribeWhyDropped` drop path: absolute pins are added straight to `SessionState.Surveys` and the controller reacts via `OnSurveysChanged`. The cold-start "uncalibrated area" case is handled in the wizard (a `Calibrating` gate step — see #460), not the FSM. The `SettingPosition` detour is *not* surfaced as its own `WizardStep` — `RecomputeStep` maps it back to its `ReturnState`'s step so the wizard panel stays put while the overlay collects the click.
 
 ## Pin calibration: two routes & the label-agnostic reconciliation
 
@@ -154,15 +160,19 @@ So: identity is UX-only disambiguation; the pairing remains a human click agains
 | Field | Lifetime | Notes |
 |---|---|---|
 | `Surveys : ObservableCollection<SurveyItemViewModel>` | Session | Cleared by `Reset()`. Fires `AllCollected` event when last uncollected is marked. |
-| `PlayerPosition : PixelPoint` | Session | The projector anchor in pixel space. Initially set by the user's click; updated to follow `_projector.Origin` after every Refit. Mutating this re-fires `RebuildRouteGeometry` + wedges. |
-| `HasPlayerPosition : bool` | Session | True once `SetPlayerPosition` runs. |
-| `IsAnchorEditable : bool` | Derived | `HasPlayerPosition && Surveys.Count == 0`. See below. |
+| `PlayerPosition : PixelPoint` | Session | **Motherlode-only** (#454). The manual map-click position its triangulation records. Mutating it re-fires `RebuildRouteGeometry` + wedges. Survey never reads it. |
+| `HasPlayerPosition : bool` | Session | True once `SetPlayerPosition` runs (Motherlode click). |
+| `SurveyPlayerPixel : PixelPoint?` | Session | **Survey-only** (#476). The `IPlayerPositionTracker` world fix projected through the current area's calibration. Null until a fix lands in a calibrated area. Route start + rendered marker + pre-first-collection segment. Set by `MapOverlayViewModel`; distinct from `PlayerPosition` so the two modes can't cross-contaminate. |
+| `SurveyPlayerMeasuredAt : DateTimeOffset?`, `SurveyPlayerSource : PlayerPositionSource?` | Session | Staleness of `SurveyPlayerPixel`. Surfaced via `MapOverlayViewModel.PlayerAnchorStatus` — never drawn as live. (`Source` is null for a manual override.) |
+| `SurveyPlayerIsManual : bool` | Session | **#476 Option C.** True when `SurveyPlayerPixel` came from the user's "set my position" click (the `SettingPosition` detour), not the tracker projection. A manual pixel is calibration-independent, survives a calibration re-apply, and is superseded by the next *fresh* tracker fix. `PlayerAnchorStatus` shows `"You — set manually"`. |
 | `SelectedSurvey : SurveyItemViewModel?` | UI | Drives nudge-command targeting. Auto-set to the most-recently-placed survey by `LogIngestionService` so arrow-key adjustments target the new pin. |
 | `IsMapVisible`, `IsInventoryVisible : bool` | UI | Overlay visibility intent — `OverlayController` reacts. `IsInventoryVisible` is set true by `NoteSurveyDetected` so the user sees which slot to pick next. |
 | `MapOpacity`, `InventoryOpacity : double` | **Persisted** | Bidirectionally synced with `LegolasSettings` in [`LegolasModule.Register`](../src/Legolas.Module/LegolasModule.cs). |
 | `Mode : SessionMode` | Session | `Survey \| Motherlode`. |
 
 ### `IsAnchorEditable` (issue #120)
+
+> **Retired by [#454](https://github.com/moumantai-gg/mithril/issues/454).** There is no editable Survey anchor any more — `IsAnchorEditable` no longer exists and the player marker is non-interactive. [#476](https://github.com/moumantai-gg/mithril/issues/476) reinstated a *non-editable* Survey player marker sourced from `IPlayerPositionTracker` (see the `SurveyPlayerPixel` row above and the #476 banner near the top), not a click the user can drag. The paragraphs below describe the pre-#454 model and are kept only as history.
 
 The anchor is editable — i.e. draggable via the player thumb, nudgeable via hotkeys — **only** while:
 
@@ -300,6 +310,8 @@ The FSM's `Gathering` state is the explicit mitigation: once the route is optimi
 ~~This is not a heuristic; it's a hard constraint. Don't relax it without solving the position-tracking problem.~~
 
 > **Superseded — [#454](https://github.com/moumantai-gg/mithril/issues/454).** The position-tracking problem *is* solved by the game itself: every survey/treasure-map use emits Player.log `ProcessMapFx` with the target's absolute world coordinate (verified: `Check Survey` 4/4 in a live log; `Check Map`/Treasure Cartography shares the same item template). Once Legolas reads `ProcessMapFx`, targets are absolute, movement no longer invalidates anything, and the `Gathering` survey-drop mitigation is unnecessary for placement. This paragraph describes the current code only.
+>
+> **[#476](https://github.com/moumantai-gg/mithril/issues/476) caveat — this only solved *target* placement, not *player* tracking.** The Survey "you are here" marker / route-start (`SurveyPlayerPixel`) comes from `IPlayerPositionTracker`, whose fixes are *also* sparse (`ProcessAddPlayer`/`ProcessNewPosition` = zone-in / teleport only — there is genuinely no per-tick footstep feed in Player.log). The marker is therefore accurate at zone-in and goes stale as the player walks the route — by design, not a bug to "fix". Do not relax the staleness surfacing (`PlayerAnchorStatus` / `MeasuredAt` / `Source`); never present the marker as live. The user's recourse when it *is* stale is the Option C manual override (`SurveyFlowState.SettingPosition`) — that is the designed answer, not making the auto signal pretend to be denser than it is. Target *pins* are unaffected (they're absolute identities).
 
 ### Anchor is "manually editable" only before the first survey
 

--- a/src/Legolas.Module/Controls/ClickThrough.cs
+++ b/src/Legolas.Module/Controls/ClickThrough.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Threading;
 
 namespace Legolas.Controls;
 
@@ -49,5 +50,50 @@ internal static class ClickThrough
         var hwnd = new WindowInteropHelper(window).Handle;
         if (hwnd == IntPtr.Zero) return;
         SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    }
+
+    /// <summary>
+    /// Keeps an overlay reliably TOPMOST for its whole visible lifetime.
+    /// <para><see cref="ForceTopmost"/> alone is wired only to
+    /// <c>Loaded</c> (fires once) and <c>Activated</c> (fires only when the OS
+    /// actually activates the window). The overlays are cached and driven by
+    /// <c>Hide()</c>/<c>Show()</c>, and a <c>Show()</c> issued while the game
+    /// owns the foreground does <b>not</b> activate the window — so the
+    /// re-assert was being skipped and the window came back at ordinary
+    /// z-order (behind the game). This re-asserts on every show
+    /// (<see cref="UIElement.IsVisibleChanged"/> → visible) and, because a
+    /// fullscreen-borderless game can reclaim z-order with no event at all,
+    /// also on a low-frequency timer while the window is visible.</para>
+    /// </summary>
+    public static void KeepTopmost(Window window)
+    {
+        // Background priority + a coarse interval: one SetWindowPos every
+        // couple seconds is negligible and 2 s is a fine worst-case recovery
+        // window for the (rare) silent z-order steal.
+        var timer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromSeconds(2),
+        };
+        timer.Tick += (_, _) => ForceTopmost(window);
+
+        window.IsVisibleChanged += (_, _) =>
+        {
+            if (window.IsVisible)
+            {
+                ForceTopmost(window);
+                timer.Start();
+            }
+            else
+            {
+                timer.Stop();
+            }
+        };
+        window.Closed += (_, _) => timer.Stop();
+
+        if (window.IsVisible)
+        {
+            ForceTopmost(window);
+            timer.Start();
+        }
     }
 }

--- a/src/Legolas.Module/Flow/SurveyFlowController.cs
+++ b/src/Legolas.Module/Flow/SurveyFlowController.cs
@@ -11,12 +11,21 @@ namespace Legolas.Flow;
 /// so the old <c>AwaitingPosition</c>/<c>Ready</c> anchor-bootstrap states are
 /// gone. The map-click anchor + <see cref="SessionState.PlayerPosition"/>
 /// survive but are now <b>Motherlode-only</b> (Survey never reads them).
+///
+/// <para>#476 added <see cref="SettingPosition"/>: an <em>optional</em>
+/// manual-override sub-state for the Survey player-GPS. It is not a bootstrap
+/// — the auto tracker anchor remains the zero-click default; this is the
+/// "correct a stale anchor" escape hatch (Option&#160;C). It is entered on
+/// demand from <see cref="Listening"/> or <see cref="Gathering"/> and returns
+/// to whichever of those it came from, so the normal flow is unchanged for
+/// users who never invoke it.</para>
 /// </summary>
 public enum SurveyFlowState
 {
     Listening,
     Gathering,
     Done,
+    SettingPosition,
 }
 
 public sealed record SurveyTransition(
@@ -32,12 +41,27 @@ public sealed record SurveyTransition(
 /// surveys" constraint is retired with the relative model). Calibration is
 /// FSM-independent (per-area, persisted) — it is gated in the wizard
 /// step-machine, not here.
+///
+/// <para>#476 adds an optional <c>{Listening|Gathering} ⇄ SettingPosition</c>
+/// detour: <see cref="RequestSetPosition"/> parks the current state and
+/// switches to <see cref="SurveyFlowState.SettingPosition"/>;
+/// <see cref="ConfirmPosition"/> / <see cref="CancelSetPosition"/> return to
+/// it. The FSM only owns the <em>phase</em> — the actual manual pixel is
+/// recorded by <c>MapOverlayViewModel</c> before it calls
+/// <see cref="ConfirmPosition"/>. The auto tracker GPS is unaffected and
+/// remains the default; this detour is the stale-anchor override only.</para>
 /// </summary>
 public sealed partial class SurveyFlowController : ObservableObject
 {
     private readonly SessionState _session;
     private readonly LegolasSettings _settings;
     private readonly TimeProvider _clock;
+
+    /// <summary>The state <see cref="RequestSetPosition"/> parked, so
+    /// <see cref="ConfirmPosition"/>/<see cref="CancelSetPosition"/> can
+    /// restore it. Only meaningful while <see cref="CurrentState"/> is
+    /// <see cref="SurveyFlowState.SettingPosition"/>.</summary>
+    private SurveyFlowState _returnState = SurveyFlowState.Listening;
 
     public SurveyFlowController(SessionState session, LegolasSettings settings, TimeProvider? clock = null)
     {
@@ -73,6 +97,7 @@ public sealed partial class SurveyFlowController : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(PhaseDescription))]
     [NotifyPropertyChangedFor(nameof(CanOptimize))]
+    [NotifyPropertyChangedFor(nameof(IsSettingPosition))]
     private SurveyFlowState _currentState = SurveyFlowState.Listening;
 
     /// <summary>Fires after every successful state change.</summary>
@@ -84,8 +109,18 @@ public sealed partial class SurveyFlowController : ObservableObject
         SurveyFlowState.Listening => "Listening for surveys",
         SurveyFlowState.Gathering => "Walk the route to each target",
         SurveyFlowState.Done => "All surveys collected",
+        SurveyFlowState.SettingPosition => "Click the map where you are",
         _ => "",
     };
+
+    /// <summary>The state a <see cref="SurveyFlowState.SettingPosition"/>
+    /// detour will return to. Lets the wizard keep its panel anchored to the
+    /// originating step (Listening vs Gathering) during the override.</summary>
+    public SurveyFlowState ReturnState => _returnState;
+
+    /// <summary>True while the optional manual position-override detour
+    /// (#476) is active.</summary>
+    public bool IsSettingPosition => CurrentState == SurveyFlowState.SettingPosition;
 
     /// <summary>
     /// True when <see cref="OptimizeRoute"/> would be accepted: Listening with
@@ -106,6 +141,45 @@ public sealed partial class SurveyFlowController : ObservableObject
             return;
         }
         TransitionTo(SurveyFlowState.Gathering, nameof(OptimizeRoute));
+    }
+
+    /// <summary>
+    /// Enter the optional manual position-override detour (#476). Parks the
+    /// current phase so <see cref="ConfirmPosition"/>/<see cref="CancelSetPosition"/>
+    /// can restore it. Valid only from <c>Listening</c> or <c>Gathering</c>
+    /// (the two phases where a "where am I?" correction is meaningful) — no-op
+    /// otherwise, and an idempotent no-op if already setting position. The
+    /// auto tracker GPS is untouched; this only overrides it on confirm.
+    /// </summary>
+    public void RequestSetPosition()
+    {
+        if (CurrentState is not (SurveyFlowState.Listening or SurveyFlowState.Gathering))
+        {
+            _session.LastLogEvent = $"Set position ignored — state is {CurrentState}";
+            return;
+        }
+        _returnState = CurrentState;
+        TransitionTo(SurveyFlowState.SettingPosition, nameof(RequestSetPosition));
+    }
+
+    /// <summary>
+    /// Commit the manual override and return to the parked phase. The pixel
+    /// itself is written to the session by <c>MapOverlayViewModel</c> before
+    /// this call — the FSM only owns the phase. No-op unless currently
+    /// <c>SettingPosition</c>.
+    /// </summary>
+    public void ConfirmPosition()
+    {
+        if (CurrentState != SurveyFlowState.SettingPosition) return;
+        TransitionTo(_returnState, nameof(ConfirmPosition));
+    }
+
+    /// <summary>Abandon the detour and return to the parked phase without
+    /// changing the anchor. No-op unless currently <c>SettingPosition</c>.</summary>
+    public void CancelSetPosition()
+    {
+        if (CurrentState != SurveyFlowState.SettingPosition) return;
+        TransitionTo(_returnState, nameof(CancelSetPosition));
     }
 
     /// <summary>

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -433,6 +433,15 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
             SurveyFlowState.Listening => WizardStep.Listening,
             SurveyFlowState.Gathering => WizardStep.Gathering,
             SurveyFlowState.Done => WizardStep.Done,
+            // #476: the manual-override detour is transient — keep the panel
+            // anchored to the step it was launched from (Listening vs
+            // Gathering) rather than flashing a different step. The Set/Cancel
+            // affordance toggles on MapOverlay.IsSettingPosition within those
+            // same panels.
+            SurveyFlowState.SettingPosition =>
+                _surveyFlow.ReturnState == SurveyFlowState.Gathering
+                    ? WizardStep.Gathering
+                    : WizardStep.Listening,
             _ => WizardStep.Listening,
         };
     }

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -1,11 +1,13 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.Services;
+using Mithril.GameState.Movement;
 
 namespace Legolas.ViewModels;
 
@@ -18,11 +20,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     private readonly SurveyFlowController _surveyFlow;
     private readonly LegolasBrushes _brushes;
     private readonly PinCalibrationCoordinator? _pinCal;
+    private readonly IPlayerPositionTracker? _positionTracker;
+    private readonly IAreaCalibrationService? _areaCalibration;
 
     public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes)
         : this(session, projector, optimizer, surveyFlow, brushes, settings: null) { }
 
-    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes, LegolasSettings? settings, PinCalibrationCoordinator? pinCalibration = null)
+    public MapOverlayViewModel(SessionState session, ICoordinateProjector projector, IRouteOptimizer optimizer, SurveyFlowController surveyFlow, LegolasBrushes brushes, LegolasSettings? settings, PinCalibrationCoordinator? pinCalibration = null, IPlayerPositionTracker? positionTracker = null, IAreaCalibrationService? areaCalibration = null)
     {
         _session = session;
         _projector = projector;
@@ -31,6 +35,8 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         _brushes = brushes;
         _settings = settings;
         _pinCal = pinCalibration;
+        _positionTracker = positionTracker;
+        _areaCalibration = areaCalibration;
         if (_pinCal is not null)
             _pinCal.PropertyChanged += (_, e) =>
             {
@@ -55,8 +61,29 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             if (e.PropertyName is nameof(SessionState.PlayerPosition))
             {
                 OnPropertyChanged(nameof(PlayerPosition));
+                OnPropertyChanged(nameof(PlayerMarkerPixel));
                 RebuildRouteGeometry();
                 RebuildAllWedges();
+            }
+            else if (e.PropertyName is nameof(SessionState.HasPlayerPosition))
+            {
+                OnPropertyChanged(nameof(PlayerMarkerPixel));
+            }
+            else if (e.PropertyName is nameof(SessionState.SurveyPlayerPixel))
+            {
+                // #476: the Survey GPS moved (zone-in / teleport / calibration
+                // (re)applied). It is the route start + the rendered marker +
+                // the pre-first-collection guidance segment, so rebuild all
+                // three.
+                OnPropertyChanged(nameof(PlayerMarkerPixel));
+                RebuildRouteGeometry();
+            }
+            else if (e.PropertyName is nameof(SessionState.SurveyPlayerMeasuredAt)
+                     or nameof(SessionState.SurveyPlayerSource)
+                     or nameof(SessionState.SurveyPlayerIsManual))
+            {
+                OnPropertyChanged(nameof(PlayerAnchorStatus));
+                OnPropertyChanged(nameof(IsPlayerAnchorStatusVisible));
             }
             else if (e.PropertyName is nameof(SessionState.ShowRouteLines))
             {
@@ -70,7 +97,11 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             else if (e.PropertyName is nameof(SessionState.Mode))
             {
                 // Switching between Survey and Motherlode flips wedge
-                // visibility wholesale — Survey hides them, Motherlode shows.
+                // visibility wholesale — Survey hides them, Motherlode shows —
+                // and swaps which player pixel the marker reads (#476).
+                OnPropertyChanged(nameof(PlayerMarkerPixel));
+                OnPropertyChanged(nameof(PlayerAnchorStatus));
+                OnPropertyChanged(nameof(IsPlayerAnchorStatusVisible));
                 RebuildAllWedges();
             }
         };
@@ -83,14 +114,125 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             if (e.PropertyName == nameof(SurveyFlowController.CurrentState))
             {
                 OnPropertyChanged(nameof(IsListening));
+                OnPropertyChanged(nameof(IsSettingPosition));
                 OnPropertyChanged(nameof(OverlayHint));
                 OnPropertyChanged(nameof(IsOverlayHintVisible));
+                SetPositionCommand.NotifyCanExecuteChanged();
+                CancelSetPositionCommand.NotifyCanExecuteChanged();
             }
         };
+
+        // #476: Survey player-GPS. The tracker fix and the area calibration
+        // are two independent inputs to the same projection — either changing
+        // re-resolves the anchor. Subscribe replays Current synchronously, so
+        // a fix already seen at startup is picked up immediately; the
+        // calibration Changed event covers the (common) case where the area's
+        // calibration is applied after the overlay VM is constructed.
+        if (_positionTracker is not null && _areaCalibration is not null)
+        {
+            _positionTracker.Subscribe(_ => PostToUi(() => RefreshSurveyPlayerAnchor(fromTrackerFix: true)));
+            _areaCalibration.Changed += (_, _) => PostToUi(() => RefreshSurveyPlayerAnchor(fromTrackerFix: false));
+            RefreshSurveyPlayerAnchor(fromTrackerFix: false);
+        }
+    }
+
+    /// <summary>
+    /// Re-project the tracker's last world fix to a pixel through the current
+    /// area's calibration and publish it (plus its age/source) onto the
+    /// session. No tracker fix or no calibrated area ⇒ clear it (degrade
+    /// silently — same "no marker" behaviour as before #476). The projection
+    /// is <see cref="AreaCalibration.ProjectWorld"/> — the exact transform the
+    /// <c>ProcessMapFx</c> pins use, so the marker lands in the same frame as
+    /// the pins (subject to the ±10% non-affine map ceiling — it is "near you",
+    /// not pixel-exact, and that is expected).
+    ///
+    /// <para>#476 Option&#160;C — manual-override interaction:
+    /// <list type="bullet">
+    /// <item><paramref name="fromTrackerFix"/> = a genuinely new fix
+    /// (zone-in / teleport). Fresh data is authoritative again, so it
+    /// supersedes a manual override (the override only existed to fix a
+    /// <em>stale</em> anchor).</item>
+    /// <item><paramref name="fromTrackerFix"/> = false (calibration
+    /// re-applied). A manual override is a raw screen pixel that does not
+    /// depend on the calibration, so leave it untouched; otherwise
+    /// re-project auto.</item>
+    /// </list></para>
+    /// </summary>
+    private void RefreshSurveyPlayerAnchor(bool fromTrackerFix)
+    {
+        if (_session.SurveyPlayerIsManual && !fromTrackerFix)
+            return; // a deliberate correction outlives a calibration re-apply
+
+        var fix = _positionTracker?.Current;
+        var cal = _areaCalibration?.CurrentCalibration;
+        if (fix is null || cal is null)
+        {
+            // Either no anchor possible (no fix / uncalibrated, not manual),
+            // or a fresh tracker fix that supersedes a manual override but
+            // can't be projected (uncalibrated area) — the player moved, so
+            // the stale manual pixel is wrong now regardless. Clear everything.
+            _session.SurveyPlayerPixel = null;
+            _session.SurveyPlayerMeasuredAt = null;
+            _session.SurveyPlayerSource = null;
+            _session.SurveyPlayerIsManual = false;
+            return;
+        }
+
+        _session.SurveyPlayerPixel = cal.ProjectWorld(new WorldCoord(fix.X, fix.Y, fix.Z));
+        _session.SurveyPlayerMeasuredAt = fix.MeasuredAt;
+        _session.SurveyPlayerSource = fix.Source;
+        _session.SurveyPlayerIsManual = false;
+    }
+
+    /// <summary>
+    /// Record the user's "set my position" map click (#476 Option&#160;C,
+    /// the stale-anchor override). A raw screen pixel — independent of the
+    /// area calibration, no log <c>Source</c>, stamped with the click time —
+    /// that wins over the projected auto anchor until the next fresh tracker
+    /// fix (zone-in / teleport) takes over again.
+    /// </summary>
+    private void RecordManualPosition(PixelPoint where)
+    {
+        _session.SurveyPlayerPixel = where;
+        _session.SurveyPlayerMeasuredAt = DateTimeOffset.UtcNow;
+        _session.SurveyPlayerSource = null;
+        _session.SurveyPlayerIsManual = true;
+    }
+
+    /// <summary>
+    /// Marshal to the WPF dispatcher — the tracker fires from the Player.log
+    /// ingestion thread and we mutate observable session state bound to the
+    /// overlay. Falls back to a direct call in headless/test contexts. Mirrors
+    /// <c>PlayerLogIngestionService.PostToUi</c>.
+    /// </summary>
+    private static void PostToUi(Action action)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null) action();
+        else dispatcher.InvokeAsync(action);
     }
 
     /// <summary>True iff the survey FSM is in <c>Listening</c>.</summary>
     public bool IsListening => _surveyFlow.CurrentState == SurveyFlowState.Listening;
+
+    /// <summary>#476 Option&#160;C: true while the optional manual
+    /// position-override detour is active — the overlay routes the next
+    /// viewport click to <see cref="RecordManualPosition"/> and the wizard
+    /// shows the cancel affordance.</summary>
+    public bool IsSettingPosition => _surveyFlow.CurrentState == SurveyFlowState.SettingPosition;
+
+    /// <summary>Enter the manual position-override detour (#476). Enabled
+    /// only from Listening/Gathering — the FSM guards it too, but gating the
+    /// command keeps the button disabled rather than a silent no-op.</summary>
+    [RelayCommand(CanExecute = nameof(CanSetPosition))]
+    private void SetPosition() => _surveyFlow.RequestSetPosition();
+
+    private bool CanSetPosition() =>
+        _surveyFlow.CurrentState is SurveyFlowState.Listening or SurveyFlowState.Gathering;
+
+    /// <summary>Abandon the detour without changing the anchor (#476).</summary>
+    [RelayCommand(CanExecute = nameof(IsSettingPosition))]
+    private void CancelSetPosition() => _surveyFlow.CancelSetPosition();
 
     /// <summary>#460: true while the wizard <c>Calibrating</c> step has armed
     /// pin-capture on this overlay. The view routes viewport clicks to
@@ -197,9 +339,12 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     /// Hidden in Gathering/Done where the route geometry speaks for itself.
     /// </summary>
     // #454 retired the anchor-bootstrap states this hint coached through.
-    // Absolute placement needs no setup, so there's no stall to rescue — kept
-    // as an always-empty property so the view binding stays valid.
-    public string OverlayHint => string.Empty;
+    // Absolute placement needs no setup. #476 reuses the (still-empty by
+    // default) hint to coach the optional manual position-override click.
+    public string OverlayHint =>
+        IsSettingPosition
+            ? "Click the map where your character is standing now."
+            : string.Empty;
 
     public bool IsOverlayHintVisible => !string.IsNullOrEmpty(OverlayHint);
 
@@ -207,6 +352,63 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     {
         get => _session.PlayerPosition;
         set => _session.PlayerPosition = value;
+    }
+
+    /// <summary>
+    /// The "you are here" pixel the overlay renderer should draw, or null for
+    /// no marker. Mode-routed (#476): Motherlode keeps its manual-click anchor
+    /// (only when one has been recorded); Survey uses the projected tracker
+    /// GPS (null until a fix lands in a calibrated area — degrades silently,
+    /// same as pre-#476). Never presented as live: pair it with
+    /// <see cref="PlayerAnchorStatus"/> so the staleness is honest.
+    /// </summary>
+    public PixelPoint? PlayerMarkerPixel =>
+        _session.Mode == SessionMode.Motherlode
+            ? (_session.HasPlayerPosition ? _session.PlayerPosition : null)
+            : _session.SurveyPlayerPixel;
+
+    /// <summary>
+    /// Short staleness label for the Survey player-GPS, e.g.
+    /// <c>"You — zone-in, 4m ago"</c>, or <c>"You — set manually"</c> for the
+    /// #476 Option&#160;C override. Empty outside Survey mode or when no
+    /// anchor has resolved. The auto signal is sparse (zone-in / teleport
+    /// only); this exists so the UI never implies the marker is live.
+    /// </summary>
+    public string PlayerAnchorStatus
+    {
+        get
+        {
+            if (_session.Mode != SessionMode.Survey || !_session.SurveyPlayerPixel.HasValue)
+                return string.Empty;
+            if (_session.SurveyPlayerIsManual)
+                return "You — set manually";
+            return _session.SurveyPlayerMeasuredAt is { } at && _session.SurveyPlayerSource is { } src
+                ? FormatAnchorStatus(at, src, DateTimeOffset.UtcNow)
+                : string.Empty;
+        }
+    }
+
+    public bool IsPlayerAnchorStatusVisible => !string.IsNullOrEmpty(PlayerAnchorStatus);
+
+    /// <summary>
+    /// Pure staleness formatter (testable without a clock dependency). Source
+    /// names the freshness class — <c>Spawn</c> is the zone-in/login anchor
+    /// (freshest, the typical Optimize-time state), <c>Movement</c> a sparse
+    /// teleport. The age is "as of <paramref name="now"/>"; it grows between
+    /// the sparse fixes, which is the honest signal that the player has likely
+    /// walked away from it.
+    /// </summary>
+    public static string FormatAnchorStatus(DateTimeOffset measuredAt, PlayerPositionSource source, DateTimeOffset now)
+    {
+        var kind = source == PlayerPositionSource.Spawn ? "zone-in" : "teleport";
+        var age = now - measuredAt;
+        if (age < TimeSpan.Zero) age = TimeSpan.Zero;
+        string ago = age.TotalSeconds < 60
+            ? "just now"
+            : age.TotalMinutes < 60
+                ? $"{(int)age.TotalMinutes}m ago"
+                : $"{(int)age.TotalHours}h ago";
+        return $"You — {kind}, {ago}";
     }
 
     public bool ShowBearingWedges
@@ -220,11 +422,13 @@ public sealed partial class MapOverlayViewModel : ObservableObject
 
     /// <summary>
     /// Two-point polyline drawn on top of the static route line: from the
-    /// most-recently-collected pin (or the player anchor if nothing's been
-    /// collected yet) to the current <see cref="SurveyItemViewModel.IsActiveTarget"/>
-    /// pin. We can't read the player's live position — we only know the anchor —
-    /// so the last-collected pin is the closest available proxy for "where the
-    /// player physically is right now". Empty when there's no active target.
+    /// most-recently-collected pin — or, before the first collection, the
+    /// player's projected GPS anchor (#476) — to the current
+    /// <see cref="SurveyItemViewModel.IsActiveTarget"/> pin. The GPS is sparse
+    /// (zone-in / teleport only), so once the player is walking the route the
+    /// last-collected pin is the better proxy for "where they are now"; the
+    /// anchor only seeds the very first segment. Empty when there's no active
+    /// target, or before the first collection in an uncalibrated area.
     /// </summary>
     [ObservableProperty]
     private IReadOnlyList<PixelPoint> _activeSegmentPoints = Array.Empty<PixelPoint>();
@@ -248,11 +452,22 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     [RelayCommand]
     public void HandleMapClick(PixelPoint where)
     {
-        // Survey placement is automatic + absolute (ProcessMapFx) — map clicks
-        // do nothing in Survey mode. In Motherlode mode the click records the
-        // player position for triangulation.
+        // Motherlode: the click records the player position for triangulation.
         if (_session.Mode == SessionMode.Motherlode)
+        {
             SetPlayerPosition(where);
+            return;
+        }
+
+        // Survey: placement is automatic + absolute (ProcessMapFx), so a click
+        // normally does nothing. The one exception is the #476 Option C
+        // manual-override detour: while SettingPosition, the click is the
+        // stale-anchor correction. Record it and return to the parked phase.
+        if (IsSettingPosition)
+        {
+            RecordManualPosition(where);
+            _surveyFlow.ConfirmPosition();
+        }
     }
 
     public double Scale => _projector.Scale;
@@ -292,9 +507,14 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         }
         if (points.Count == 0) return;
 
-        // #454: no player anchor — the tour starts at the first uncollected
-        // pin (the optimiser still finds the best order through the rest).
-        var order = _optimizer.Optimize(points[0], points);
+        // #476: start the tour from the player's projected GPS when one has
+        // resolved (calibrated area + a tracker fix) — "nearest node to me
+        // first", parity with Motherlode. Falls back to the first uncollected
+        // pin when there's no anchor (uncalibrated area / no fix yet), which
+        // is the #454 behaviour. `start` is a separate origin, not a member of
+        // `points`, so `order`/`indices` are unaffected by the choice.
+        var start = _session.SurveyPlayerPixel ?? points[0];
+        var order = _optimizer.Optimize(start, points);
         for (var i = 0; i < Surveys.Count; i++)
         {
             Surveys[i].UpdateModel(Surveys[i].Model with { RouteOrder = null });
@@ -388,17 +608,21 @@ public sealed partial class MapOverlayViewModel : ObservableObject
             return;
         }
 
-        // #454: no player anchor. The live segment runs from the
-        // most-recently-collected pin (best available "where the player is
-        // now" proxy) to the active target. Before the first collection
-        // there's no start point — just highlight the target, no segment.
+        // The live segment runs from the most-recently-collected pin (best
+        // available "where the player is now" proxy once they're walking the
+        // route) to the active target. #476: before the first collection,
+        // start from the player's projected GPS if one resolved — restores the
+        // "from you → first node" guidance segment at run start. With neither
+        // (uncalibrated area / no fix, nothing collected) there's no start
+        // point, so just highlight the target (the #454 fallback).
         var lastCollected = Surveys
             .Where(s => s.Collected && s.RouteOrder.HasValue && s.EffectivePixel.HasValue)
             .OrderByDescending(s => s.RouteOrder!.Value)
             .FirstOrDefault();
 
-        ActiveSegmentPoints = lastCollected?.EffectivePixel is { } start
-            ? new[] { start, active.EffectivePixel.Value }
+        PixelPoint? start = lastCollected?.EffectivePixel ?? _session.SurveyPlayerPixel;
+        ActiveSegmentPoints = start is { } s0
+            ? new[] { s0, active.EffectivePixel.Value }
             : Array.Empty<PixelPoint>();
     }
 }

--- a/src/Legolas.Module/ViewModels/SessionState.cs
+++ b/src/Legolas.Module/ViewModels/SessionState.cs
@@ -104,6 +104,26 @@ public sealed partial class SessionState : ObservableObject
     // is retired.
     [ObservableProperty] private PixelPoint _playerPosition = new(400, 300);
     [ObservableProperty] private bool _hasPlayerPosition;
+
+    // #476: Survey's player-position GPS. Distinct from the Motherlode-only
+    // PlayerPosition above so the two modes can't cross-contaminate (Motherlode
+    // writes a manual click; Survey writes a projected world coord). This is
+    // the IPlayerPositionTracker world coordinate projected through the current
+    // area's calibration — set by MapOverlayViewModel, null when no tracker fix
+    // or no calibrated area. Sparse by nature (zone-in / teleport only): goes
+    // stale as the player walks the route, which is why MeasuredAt/Source ride
+    // alongside it and are surfaced honestly rather than drawn as if live.
+    //
+    // SurveyPlayerIsManual (#476 Option C): true when the pixel came from the
+    // user's "set my position" map click (the stale-anchor override), not the
+    // tracker projection. A manual pixel is a raw screen coordinate (no
+    // Source; MeasuredAt = when the user clicked), survives calibration
+    // re-applies, and is superseded by the next *fresh* tracker fix
+    // (zone-in / teleport) — a new fix is authoritative again.
+    [ObservableProperty] private PixelPoint? _surveyPlayerPixel;
+    [ObservableProperty] private DateTimeOffset? _surveyPlayerMeasuredAt;
+    [ObservableProperty] private Mithril.GameState.Movement.PlayerPositionSource? _surveyPlayerSource;
+    [ObservableProperty] private bool _surveyPlayerIsManual;
     [ObservableProperty] private string _lastLogEvent = "(waiting)";
     [ObservableProperty] private bool _showBearingWedges = true;
     [ObservableProperty] private bool _showRouteLines = true;

--- a/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/CalibrationOverlayView.xaml.cs
@@ -14,8 +14,8 @@ namespace Legolas.Views;
 /// <see cref="CalibrationSessionViewModel"/> (no survey-FSM coupling).
 ///
 /// Deliberately NOT click-through (unlike the survey overlay's optional mode):
-/// the whole point is to capture clicks. <see cref="ClickThrough.ForceTopmost"/>
-/// only keeps it above the game while it's open.
+/// the whole point is to capture clicks. <see cref="ClickThrough.KeepTopmost"/>
+/// keeps it above the game for its whole visible lifetime.
 /// </summary>
 public partial class CalibrationOverlayView : Window
 {
@@ -27,8 +27,10 @@ public partial class CalibrationOverlayView : Window
     public CalibrationOverlayView(LegolasSettings settings, SettingsAutoSaver<LegolasSettings> saver) : this()
     {
         WindowLayoutBinder.Bind(this, settings.CalibrationOverlay, saver.Touch);
-        Loaded += (_, _) => ClickThrough.ForceTopmost(this);
-        Activated += (_, _) => ClickThrough.ForceTopmost(this);
+        // Re-assert TOPMOST on every show + on a low-frequency timer while
+        // visible — Loaded/Activated alone miss the Hide()/Show() cycle the
+        // OverlayController drives when the game holds the foreground.
+        ClickThrough.KeepTopmost(this);
     }
 
     private void Viewport_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/Legolas.Module/Views/InventoryOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/InventoryOverlayView.xaml.cs
@@ -26,9 +26,11 @@ public partial class InventoryOverlayView : Window
         {
             partial = PartialClickThrough.Attach(this, resizeBorderThickness: 6, HeaderRegion);
             partial.SetActive(settings.ClickThroughInventory);
-            ClickThrough.ForceTopmost(this);
         };
-        Activated += (_, _) => ClickThrough.ForceTopmost(this);
+        // Re-assert TOPMOST on every show + on a low-frequency timer while
+        // visible — Loaded/Activated alone miss the Hide()/Show() cycle the
+        // OverlayController drives when the game holds the foreground.
+        ClickThrough.KeepTopmost(this);
         settings.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(LegolasSettings.ClickThroughInventory))

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -36,6 +36,13 @@
                     <TextBlock Text=" px/m, Rot: " Foreground="#FF888888" />
                     <TextBlock Text="{Binding RotationDegrees, StringFormat=0.0}" Foreground="#FFCCCCCC" />
                     <TextBlock Text="°" Foreground="#FF888888" />
+                    <!-- #476: Survey player-GPS staleness. Sparse signal
+                         (zone-in / teleport only) — surfaced honestly so the
+                         marker is never read as live. -->
+                    <TextBlock Text=" | " Foreground="#FF888888"
+                               Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
+                    <TextBlock Text="{Binding PlayerAnchorStatus}" Foreground="#FFCCCCCC"
+                               Visibility="{Binding IsPlayerAnchorStatusVisible, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
                 </StackPanel>
             </Border>
 

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -54,12 +54,11 @@ public partial class MapOverlayView : Window
         // arrives, so Command/IsChecked bindings inside the pad always work.
         OverlayNudgePad.DataContext = nudgePad;
         WindowLayoutBinder.Bind(this, settings.MapOverlay, saver.Touch);
-        Loaded += (_, _) =>
-        {
-            ClickThrough.Apply(this, settings.ClickThroughMap);
-            ClickThrough.ForceTopmost(this);
-        };
-        Activated += (_, _) => ClickThrough.ForceTopmost(this);
+        Loaded += (_, _) => ClickThrough.Apply(this, settings.ClickThroughMap);
+        // Re-assert TOPMOST on every show + on a low-frequency timer while
+        // visible — Loaded/Activated alone miss the Hide()/Show() cycle the
+        // OverlayController drives when the game holds the foreground.
+        ClickThrough.KeepTopmost(this);
         settings.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(LegolasSettings.ClickThroughMap))

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -157,7 +157,7 @@ public partial class MapOverlayView : Window
             SurveyOuter: outerStyle,
             SurveyCenter: centerStyle,
             SurveyOuterDiameter: vm.PinDiameter,
-            PlayerPosition: vm.Session.HasPlayerPosition ? vm.PlayerPosition : null,
+            PlayerPosition: vm.PlayerMarkerPixel,
             PlayerOuter: playerOuterStyle,
             PlayerCenter: playerCenterStyle,
             RouteLineColor: vm.Brushes.RouteLine.Color,

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -30,6 +30,31 @@
                 <Setter Property="Text" Value="›" />
                 <Setter Property="Margin" Value="10,0" />
             </Style>
+
+            <!-- #476 Option C: shared "set my position" affordance, hosted in
+                 both the Listening and Gathering panels (the two phases the
+                 SurveyFlow SettingPosition detour returns to). DataContext is
+                 the wizard VM, so MapOverlay.* binds through. -->
+            <DataTemplate x:Key="SetPositionAffordance">
+                <Grid>
+                    <Button Content="Set my position…"
+                            HorizontalAlignment="Center"
+                            Command="{Binding MapOverlay.SetPositionCommand}"
+                            Visibility="{Binding MapOverlay.IsSettingPosition, Converter={x:Static controls:BoolToVisibilityConverter.Inverse}}"
+                            ToolTip="Override the auto position marker — click the map where you're standing. Use this if the marker looks stale or wrong." />
+                    <Border Visibility="{Binding MapOverlay.IsSettingPosition, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                            Background="{StaticResource AccentSoftBrush}" CornerRadius="3" Padding="12,8">
+                        <StackPanel>
+                            <TextBlock Text="Click the map where your character is standing now."
+                                       TextAlignment="Center" TextWrapping="Wrap" MaxWidth="320"
+                                       Foreground="{StaticResource AccentSoftTextBrush}"
+                                       FontSize="{DynamicResource AppFontSizeBody}" Margin="0,0,0,8" />
+                            <Button Content="Cancel" HorizontalAlignment="Center"
+                                    Command="{Binding MapOverlay.CancelSetPositionCommand}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -359,6 +384,12 @@
                             </ListBox>
                         </DockPanel>
                     </Border>
+                    <!-- #476 Option C: optional manual position override. The
+                         auto GPS marker is the zero-click default; this is the
+                         "marker looks wrong / area uncalibrated" escape hatch. -->
+                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource SetPositionAffordance}"
+                                    HorizontalAlignment="Center" Margin="0,0,0,12" />
+
                     <Button Content="Go!" Style="{StaticResource WizardPrimaryButton}"
                             HorizontalAlignment="Center" Margin="0"
                             Command="{Binding MapOverlay.OptimizeRouteCommand}"
@@ -396,6 +427,10 @@
                     <Button Content="Mark current collected" Style="{StaticResource WizardPrimaryButton}"
                             HorizontalAlignment="Center" Margin="0"
                             Command="{Binding ControlPanel.MarkCurrentCollectedCommand}" />
+
+                    <!-- #476 Option C: correct a stale anchor mid-route. -->
+                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource SetPositionAffordance}"
+                                    HorizontalAlignment="Center" Margin="0,12,0,0" />
                 </StackPanel>
 
                 <!-- Done -->

--- a/tests/Legolas.Tests/FakeAreaCalibrationService.cs
+++ b/tests/Legolas.Tests/FakeAreaCalibrationService.cs
@@ -1,0 +1,41 @@
+using Legolas.Domain;
+using Legolas.Services;
+using Mithril.Shared.Reference;
+
+namespace Legolas.Tests;
+
+/// <summary>
+/// Minimal <see cref="IAreaCalibrationService"/> double for the #476 Survey
+/// player-GPS tests. Only <see cref="CurrentCalibration"/> + <see cref="Changed"/>
+/// are exercised (those are the inputs <see cref="Legolas.ViewModels.MapOverlayViewModel"/>
+/// reads to project the tracker fix); everything else is an inert stub.
+/// </summary>
+public sealed class FakeAreaCalibrationService : IAreaCalibrationService
+{
+    private AreaCalibration? _calibration;
+
+    /// <summary>Set the calibration and raise <see cref="Changed"/> (mimics a
+    /// calibrated area being applied on entry).</summary>
+    public void SetCalibration(AreaCalibration? calibration)
+    {
+        _calibration = calibration;
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public AreaCalibration? CurrentCalibration => _calibration;
+    public bool IsCurrentAreaCalibrated => _calibration is not null;
+    public string? CurrentAreaKey => _calibration is null ? null : "AreaTest";
+    public string? CurrentAreaFriendlyName => _calibration is null ? null : "Test Area";
+    public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
+    public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
+
+    public event EventHandler? Changed;
+    public event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
+
+    public void OnAreaEntered(string areaFriendlyName) { }
+    public void SelectArea(string areaKey) { }
+    public AreaCalibration? CalibrateCurrentArea(
+        IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0) => null;
+    public void ClearCurrentAreaCalibration() { }
+    public void NoteSurvey(string name, MetreOffset offset) => SurveyObserved?.Invoke(this, new(name, offset));
+}

--- a/tests/Legolas.Tests/FakePlayerPositionTracker.cs
+++ b/tests/Legolas.Tests/FakePlayerPositionTracker.cs
@@ -1,0 +1,41 @@
+using Mithril.GameState.Movement;
+
+namespace Legolas.Tests;
+
+/// <summary>
+/// Test double for <see cref="IPlayerPositionTracker"/> (#461/#465). Lets a
+/// test seed a fix before the consumer subscribes (replayed synchronously on
+/// <see cref="Subscribe"/>, like the real tracker's replay-on-subscribe) and
+/// push later fixes to simulate a zone-in / teleport.
+/// </summary>
+public sealed class FakePlayerPositionTracker : IPlayerPositionTracker
+{
+    private readonly List<Action<PlayerPosition>> _handlers = new();
+
+    public PlayerPosition? Current { get; private set; }
+
+    public IDisposable Subscribe(Action<PlayerPosition> handler)
+    {
+        if (Current is { } c) handler(c);
+        _handlers.Add(handler);
+        return new Sub(this, handler);
+    }
+
+    /// <summary>Seed a fix with no notification (pre-subscribe state).</summary>
+    public void Seed(double x, double y, double z,
+        PlayerPositionSource source = PlayerPositionSource.Spawn, DateTimeOffset? measuredAt = null)
+        => Current = new PlayerPosition(x, y, z, measuredAt ?? DateTimeOffset.UtcNow, source);
+
+    /// <summary>A new fix (zone-in / teleport) — notifies live subscribers.</summary>
+    public void Push(double x, double y, double z,
+        PlayerPositionSource source = PlayerPositionSource.Movement, DateTimeOffset? measuredAt = null)
+    {
+        Current = new PlayerPosition(x, y, z, measuredAt ?? DateTimeOffset.UtcNow, source);
+        foreach (var h in _handlers.ToArray()) h(Current);
+    }
+
+    private sealed class Sub(FakePlayerPositionTracker owner, Action<PlayerPosition> handler) : IDisposable
+    {
+        public void Dispose() => owner._handlers.Remove(handler);
+    }
+}

--- a/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
+++ b/tests/Legolas.Tests/Flow/SurveyFlowControllerTests.cs
@@ -201,4 +201,88 @@ public class SurveyFlowControllerTests
 
         flow.CurrentState.Should().Be(SurveyFlowState.Done);
     }
+
+    // ─── #476 SettingPosition detour (Option C) ──────────────────────────
+
+    [Fact]
+    public void RequestSetPosition_from_Listening_parks_and_returns_on_confirm()
+    {
+        var (flow, _, _, transitions, _) = BuildSut();
+
+        flow.RequestSetPosition();
+        flow.CurrentState.Should().Be(SurveyFlowState.SettingPosition);
+        flow.IsSettingPosition.Should().BeTrue();
+        flow.ReturnState.Should().Be(SurveyFlowState.Listening);
+
+        flow.ConfirmPosition();
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        transitions.Select(t => (t.From, t.To)).Should().Equal(
+            (SurveyFlowState.Listening, SurveyFlowState.SettingPosition),
+            (SurveyFlowState.SettingPosition, SurveyFlowState.Listening));
+    }
+
+    [Fact]
+    public void RequestSetPosition_from_Gathering_returns_to_Gathering()
+    {
+        var (flow, session, _, _, _) = BuildSut();
+        session.Surveys.Add(Pin());
+        flow.OptimizeRoute();
+        flow.CurrentState.Should().Be(SurveyFlowState.Gathering);
+
+        flow.RequestSetPosition();
+        flow.ReturnState.Should().Be(SurveyFlowState.Gathering);
+
+        flow.ConfirmPosition();
+        flow.CurrentState.Should().Be(SurveyFlowState.Gathering, "the detour returns to where it was launched");
+    }
+
+    [Fact]
+    public void CancelSetPosition_returns_to_parked_state()
+    {
+        var (flow, _, _, _, _) = BuildSut();
+        flow.RequestSetPosition();
+
+        flow.CancelSetPosition();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+    }
+
+    [Fact]
+    public void RequestSetPosition_is_ignored_from_Done()
+    {
+        var (flow, session, settings, _, _) = BuildSut();
+        settings.AutoResetWhenAllCollected = false;
+        var s1 = Pin("Diamond");
+        session.Surveys.Add(s1);
+        s1.UpdateModel(s1.Model with { Collected = true });
+        flow.CurrentState.Should().Be(SurveyFlowState.Done);
+
+        flow.RequestSetPosition();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Done, "no-op from a state with no anchor to correct");
+    }
+
+    [Fact]
+    public void Confirm_and_Cancel_are_noops_outside_SettingPosition()
+    {
+        var (flow, _, _, transitions, _) = BuildSut();
+
+        flow.ConfirmPosition();
+        flow.CancelSetPosition();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        transitions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Reset_exits_SettingPosition()
+    {
+        var (flow, _, _, _, _) = BuildSut();
+        flow.RequestSetPosition();
+
+        flow.Reset();
+
+        flow.CurrentState.Should().Be(SurveyFlowState.Listening);
+        flow.IsSettingPosition.Should().BeFalse();
+    }
 }

--- a/tests/Legolas.Tests/ViewModels/SurveyPlayerGpsTests.cs
+++ b/tests/Legolas.Tests/ViewModels/SurveyPlayerGpsTests.cs
@@ -1,0 +1,286 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+using Mithril.GameState.Movement;
+
+namespace Legolas.Tests.ViewModels;
+
+/// <summary>
+/// #476 — Survey player-GPS restored from <see cref="IPlayerPositionTracker"/>:
+/// the route start, the rendered marker, and the pre-first-collection segment,
+/// projected through the area calibration. Asserts the regression is fixed and
+/// the degrade-silently fallback (uncalibrated area / no fix) is preserved.
+/// </summary>
+public class SurveyPlayerGpsTests
+{
+    private sealed class CapturingOptimizer : IRouteOptimizer
+    {
+        public PixelPoint? LastStart { get; private set; }
+        public IReadOnlyList<int> Optimize(PixelPoint start, IReadOnlyList<PixelPoint> points,
+            CancellationToken cancellationToken = default)
+        {
+            LastStart = start;
+            return Enumerable.Range(0, points.Count).ToList();
+        }
+    }
+
+    // Scale 1, no rotation, origin (0,0): ProjectWorld(x,_,z) → (x, -z).
+    private static readonly AreaCalibration Calib = new(
+        Scale: 1.0, RotationRadians: 0.0, OriginX: 0.0, OriginY: 0.0,
+        ReferenceCount: 3, ResidualPixels: 0.5);
+
+    private static (SessionState session, MapOverlayViewModel map,
+        FakePlayerPositionTracker tracker, FakeAreaCalibrationService areaCal, CapturingOptimizer opt)
+        BuildSut(bool calibrated, double px = 40, double pz = -25,
+            PlayerPositionSource source = PlayerPositionSource.Spawn)
+    {
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var opt = new CapturingOptimizer();
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(settings);
+        var tracker = new FakePlayerPositionTracker();
+        tracker.Seed(px, 0, pz, source);
+        var areaCal = new FakeAreaCalibrationService();
+        if (calibrated) areaCal.SetCalibration(Calib);
+
+        var map = new MapOverlayViewModel(
+            session, projector, opt, surveyFlow, brushes, settings,
+            pinCalibration: null, positionTracker: tracker, areaCalibration: areaCal);
+        return (session, map, tracker, areaCal, opt);
+    }
+
+    private static SurveyItemViewModel SeedSurveyAt(SessionState session, string name,
+        double x, double y, int routeOrder)
+    {
+        var s = Survey.Create(name, new MetreOffset(x, y), gridIndex: routeOrder)
+            with { ManualOverride = new PixelPoint(x, y), RouteOrder = routeOrder };
+        var vm = new SurveyItemViewModel(s);
+        session.Surveys.Add(vm);
+        return vm;
+    }
+
+    // ─── Route start ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void OptimizeRoute_starts_from_projected_player_pixel_when_calibrated()
+    {
+        var (session, map, _, _, opt) = BuildSut(calibrated: true, px: 40, pz: -25);
+        var expected = Calib.ProjectWorld(new WorldCoord(40, 0, -25));
+        SeedSurveyAt(session, "A", 200, 200, 0);
+        SeedSurveyAt(session, "B", 300, 300, 1);
+
+        map.OptimizeRouteCommand.Execute(null);
+
+        session.SurveyPlayerPixel.Should().Be(expected);
+        opt.LastStart.Should().Be(expected, "the tour must start from the player's GPS, not pin[0]");
+    }
+
+    [Fact]
+    public void OptimizeRoute_falls_back_to_first_pin_when_uncalibrated()
+    {
+        var (session, map, _, _, opt) = BuildSut(calibrated: false);
+        var first = SeedSurveyAt(session, "A", 210, 220, 0);
+        SeedSurveyAt(session, "B", 300, 300, 1);
+
+        map.OptimizeRouteCommand.Execute(null);
+
+        session.SurveyPlayerPixel.Should().BeNull("no calibration ⇒ no projected anchor");
+        opt.LastStart.Should().Be(first.EffectivePixel!.Value, "#454 fallback preserved");
+    }
+
+    // ─── Marker ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Marker_resolves_only_when_a_player_pixel_exists()
+    {
+        var calibrated = BuildSut(calibrated: true, px: 12, pz: -8);
+        calibrated.map.PlayerMarkerPixel.Should()
+            .Be(Calib.ProjectWorld(new WorldCoord(12, 0, -8)));
+
+        var uncalibrated = BuildSut(calibrated: false);
+        uncalibrated.map.PlayerMarkerPixel.Should()
+            .BeNull("no regression vs pre-#476: uncalibrated ⇒ no marker");
+    }
+
+    [Fact]
+    public void Marker_is_motherlode_anchor_in_motherlode_mode()
+    {
+        var (session, map, _, _, _) = BuildSut(calibrated: true);
+        session.Mode = SessionMode.Motherlode;
+
+        map.PlayerMarkerPixel.Should().BeNull("Motherlode marker needs a recorded click");
+
+        session.PlayerPosition = new PixelPoint(77, 88);
+        session.HasPlayerPosition = true;
+        map.PlayerMarkerPixel.Should().Be(new PixelPoint(77, 88));
+    }
+
+    [Fact]
+    public void Live_fix_updates_the_anchor_on_zone_or_teleport()
+    {
+        var (session, _, tracker, _, _) = BuildSut(calibrated: true, px: 5, pz: -5);
+        session.SurveyPlayerPixel.Should().Be(Calib.ProjectWorld(new WorldCoord(5, 0, -5)));
+
+        tracker.Push(60, 0, -70, PlayerPositionSource.Movement);
+
+        session.SurveyPlayerPixel.Should().Be(Calib.ProjectWorld(new WorldCoord(60, 0, -70)));
+        session.SurveyPlayerSource.Should().Be(PlayerPositionSource.Movement);
+    }
+
+    [Fact]
+    public void Anchor_resolves_when_calibration_applied_after_construction()
+    {
+        // Mirrors the live order: the overlay VM is built, then the area's
+        // calibration is applied on zone-in (AreaCalibrationService.Changed).
+        var (session, _, _, areaCal, _) = BuildSut(calibrated: false, px: 9, pz: -3);
+        session.SurveyPlayerPixel.Should().BeNull();
+
+        areaCal.SetCalibration(Calib);
+
+        session.SurveyPlayerPixel.Should().Be(Calib.ProjectWorld(new WorldCoord(9, 0, -3)));
+    }
+
+    // ─── Initial guidance segment ────────────────────────────────────────
+
+    [Fact]
+    public void Initial_segment_runs_from_player_pixel_before_first_collection()
+    {
+        var (session, map, _, _, _) = BuildSut(calibrated: true, px: 10, pz: -10);
+        var start = Calib.ProjectWorld(new WorldCoord(10, 0, -10));
+        SeedSurveyAt(session, "First", 200, 200, 0);
+        SeedSurveyAt(session, "Second", 300, 300, 1);
+
+        map.ActiveSegmentPoints.Count.Should().Be(2);
+        map.ActiveSegmentPoints[0].Should().Be(start);
+        map.ActiveSegmentPoints[1].Should().Be(new PixelPoint(200, 200));
+    }
+
+    [Fact]
+    public void Initial_segment_absent_before_first_collection_when_uncalibrated()
+    {
+        // #454 parity: no anchor, nothing collected ⇒ no segment.
+        var (session, map, _, _, _) = BuildSut(calibrated: false);
+        SeedSurveyAt(session, "First", 200, 200, 0);
+        SeedSurveyAt(session, "Second", 300, 300, 1);
+
+        map.ActiveSegmentPoints.Count.Should().Be(0);
+    }
+
+    // ─── Staleness surface ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(PlayerPositionSource.Spawn, 0, "You — zone-in, just now")]
+    [InlineData(PlayerPositionSource.Spawn, 240, "You — zone-in, 4m ago")]
+    [InlineData(PlayerPositionSource.Movement, 7200, "You — teleport, 2h ago")]
+    public void FormatAnchorStatus_reflects_source_and_age(
+        PlayerPositionSource source, int ageSeconds, string expected)
+    {
+        var now = DateTimeOffset.UnixEpoch + TimeSpan.FromHours(10);
+        var measuredAt = now - TimeSpan.FromSeconds(ageSeconds);
+
+        MapOverlayViewModel.FormatAnchorStatus(measuredAt, source, now).Should().Be(expected);
+    }
+
+    [Fact]
+    public void PlayerAnchorStatus_is_empty_until_an_anchor_resolves_and_only_in_survey_mode()
+    {
+        var (session, map, _, _, _) = BuildSut(calibrated: false);
+        map.PlayerAnchorStatus.Should().BeEmpty("no anchor yet");
+        map.IsPlayerAnchorStatusVisible.Should().BeFalse();
+
+        var (s2, m2, _, _, _) = BuildSut(calibrated: true);
+        m2.PlayerAnchorStatus.Should().NotBeEmpty("anchor resolved in Survey mode");
+        m2.IsPlayerAnchorStatusVisible.Should().BeTrue();
+
+        s2.Mode = SessionMode.Motherlode;
+        m2.PlayerAnchorStatus.Should().BeEmpty("staleness label is Survey-only");
+    }
+
+    // ─── #476 Option C: manual override ──────────────────────────────────
+
+    [Fact]
+    public void Map_click_records_a_manual_override_only_while_setting_position()
+    {
+        var (session, map, _, _, _) = BuildSut(calibrated: true, px: 1, pz: -1);
+        var auto = Calib.ProjectWorld(new WorldCoord(1, 0, -1));
+        session.SurveyPlayerPixel.Should().Be(auto);
+
+        // A click outside the detour does nothing in Survey mode.
+        map.HandleMapClick(new PixelPoint(500, 600));
+        session.SurveyPlayerPixel.Should().Be(auto);
+        session.SurveyPlayerIsManual.Should().BeFalse();
+
+        map.SetPositionCommand.Execute(null);
+        map.IsSettingPosition.Should().BeTrue();
+        map.OverlayHint.Should().NotBeEmpty("the detour coaches the click");
+
+        map.HandleMapClick(new PixelPoint(500, 600));
+
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(500, 600));
+        session.SurveyPlayerIsManual.Should().BeTrue();
+        session.SurveyPlayerSource.Should().BeNull("a manual pixel has no log source");
+        map.PlayerMarkerPixel.Should().Be(new PixelPoint(500, 600));
+        map.PlayerAnchorStatus.Should().Be("You — set manually");
+        map.IsSettingPosition.Should().BeFalse("the click confirms and returns");
+    }
+
+    [Fact]
+    public void Manual_override_survives_a_calibration_reapply_but_a_fresh_fix_supersedes_it()
+    {
+        var (session, map, tracker, areaCal, _) = BuildSut(calibrated: true, px: 2, pz: -2);
+
+        map.SetPositionCommand.Execute(null);
+        map.HandleMapClick(new PixelPoint(123, 456));
+        session.SurveyPlayerIsManual.Should().BeTrue();
+
+        // Calibration re-applied on the same area (e.g. recalibrate): the
+        // manual pixel is calibration-independent, so it stays.
+        areaCal.SetCalibration(Calib);
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(123, 456));
+        session.SurveyPlayerIsManual.Should().BeTrue();
+
+        // A fresh tracker fix (zone-in / teleport) is authoritative again.
+        tracker.Push(80, 0, -90, PlayerPositionSource.Movement);
+        session.SurveyPlayerIsManual.Should().BeFalse();
+        session.SurveyPlayerPixel.Should().Be(Calib.ProjectWorld(new WorldCoord(80, 0, -90)));
+    }
+
+    [Fact]
+    public void Manual_override_works_even_when_area_is_uncalibrated()
+    {
+        // The whole point of Option C: an uncalibrated area has no auto
+        // anchor, but the user can still place one by hand.
+        var (session, map, _, _, opt) = BuildSut(calibrated: false);
+        session.SurveyPlayerPixel.Should().BeNull();
+
+        map.SetPositionCommand.Execute(null);
+        map.HandleMapClick(new PixelPoint(42, 99));
+
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(42, 99));
+        session.SurveyPlayerIsManual.Should().BeTrue();
+
+        SeedSurveyAt(session, "A", 300, 300, 0);
+        map.OptimizeRouteCommand.Execute(null);
+        opt.LastStart.Should().Be(new PixelPoint(42, 99),
+            "the manual anchor seeds the route start even with no calibration");
+    }
+
+    [Fact]
+    public void Cancel_leaves_the_anchor_unchanged()
+    {
+        var (session, map, _, _, _) = BuildSut(calibrated: true, px: 3, pz: -4);
+        var auto = Calib.ProjectWorld(new WorldCoord(3, 0, -4));
+
+        map.SetPositionCommand.Execute(null);
+        map.IsSettingPosition.Should().BeTrue();
+        map.CancelSetPositionCommand.Execute(null);
+
+        map.IsSettingPosition.Should().BeFalse();
+        session.SurveyPlayerPixel.Should().Be(auto, "cancel makes no change");
+        session.SurveyPlayerIsManual.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- **#476 — restore Survey player-GPS.** #460 collateral-removed the "you are here" marker, route-start, and initial guidance segment when it retired the anchor click. Restored from a better source: the GameState `IPlayerPositionTracker` world fix projected through the area calibration (`AreaCalibration.ProjectWorld` — the same transform `ProcessMapFx` pins use), not a manual click. Placement stays absolute; the relative/anchor model does not return. The signal is sparse (zone-in / teleport only), so `MeasuredAt`/`Source` are surfaced via `MapOverlayViewModel.PlayerAnchorStatus` and the marker is never drawn as live.
- **#476 Option C — manual override.** A new optional `SurveyFlowState.SettingPosition` detour ("Set my position" in the wizard -> click the map) corrects a stale anchor. A manual pixel is calibration-independent, survives a recalibration, and is superseded by the next fresh tracker fix. Entered on demand from Listening/Gathering and returns there; the zero-click auto GPS remains the default.
- **Overlay-topmost regression fix.** `ForceTopmost` was only re-asserted on `Loaded` (fires once) and `Activated` (fires only on real OS activation). `OverlayController` drives visibility with `Hide()`/`Show()`, and a `Show()` while the game holds the foreground does not activate the window — so the overlay came back behind the game. New `ClickThrough.KeepTopmost` re-asserts on `IsVisibleChanged` -> visible plus a low-frequency timer while visible; wired into all three overlays.

## Notes

- Two commits: the topmost fix is isolated from the #476 feature work.
- Tracking issue: moumantai-gg/mithril#476. Follow-up deliberately deferred: making the manual anchor *nudgeable* is now **Part C of moumantai-gg/mithril#477** (it reuses that issue's shared marker hit-test/select/nudge layer); the stale `MapOverlayViewModel.Nudge` XML doc is fixed there.

## Test plan

- [x] `dotnet build Mithril.Shell` clean (warnings-as-errors, 0 warnings)
- [x] `dotnet test tests/Legolas.Tests` — 291 passing (6 new FSM transition tests + Option C VM tests + the player-GPS suite)
- [x] Rebased onto latest `origin/main` (incl. #482 overlay-rendering fix); no conflicts
- [ ] Manual: live session in a calibrated area — marker at zone-in, route starts from nearest node, staleness label updates on zone/teleport
- [ ] Manual: "Set my position" -> click corrects the anchor; a fresh zone-in then snaps back to auto
- [ ] Manual: overlays stay on top across auto-hide/show and the wizard's Done->next-cycle hide/show

🤖 Generated with [Claude Code](https://claude.com/claude-code)