### PR TITLE
Legolas: guided two-phase calibration walkthrough + recalibration + nudgeable anchor (#477)

### DIFF
--- a/docs/legolas-overview.md
+++ b/docs/legolas-overview.md
@@ -132,26 +132,34 @@ The map uses `atan2(East, North)` (not `atan2(N, E)`) for the offset bearing, pa
 
 There is no longer a `NoteSurveyDetected`/`CanAcceptSurvey`/`DescribeWhyDropped` drop path: absolute pins are added straight to `SessionState.Surveys` and the controller reacts via `OnSurveysChanged`. The cold-start "uncalibrated area" case is handled in the wizard (a `Calibrating` gate step — see #460), not the FSM. The `SettingPosition` detour is *not* surfaced as its own `WizardStep` — `RecomputeStep` maps it back to its `ReturnState`'s step so the wizard panel stays put while the overlay collects the click.
 
-## Pin calibration: two routes & the label-agnostic reconciliation
+## Pin calibration: the guided two-phase walkthrough & the label-agnostic reconciliation
 
-> **Read this before "fixing" the calibration UI back to label-agnostic.** The two halves below look contradictory and are not.
+> **Read this before "fixing" the calibration UI.** The label-agnostic rule and the named-pin prompt look contradictory and are not.
+
+> **As-built — [#477](https://github.com/moumantai-gg/mithril/issues/477) Part A landed.** The in-flow (#460) calibration is now a **guided, two-phase, correctable** walkthrough driven by `PinCalibrationCoordinator`. The earlier "existing-pins route vs. freshly-dropped turn-order route" branch and the per-pin turn-order queue are **retired** — there is one model with two explicit phases. The paragraphs below describe the current code; the standalone `CalibrationSessionViewModel` (landmark window) still uses its own turn-order queue and is unchanged.
 
 Cold-start calibration pairs *(world coordinate ↔ overlay pixel)* points and feeds them to `LandmarkCalibrationSolver` via `IAreaCalibrationService.CalibrateCurrentArea`. The world coordinates come from the player's map pins.
 
-**Pin source (#468).** The pin set is owned by the GameState-tier `IPlayerPinTracker` (`Mithril.GameState.Pins`), *not* Legolas. It parses `ProcessMapPin{Add,Remove}` (the only two verbs PG has — a rename/move is Remove+Add; there is no clear/edit verb), is **area-scoped** (keyed off the shared `PlayerAreaTracker`, swapped on area change), and **owns the login/area-entry replay**: PG bulk-re-emits every pin as an `Add` burst on each entry, which the tracker folds into an idempotent upsert keyed by rounded coordinate. Consumers therefore no longer hand-roll a replay-arming gate — `PinCalibrationCoordinator` and the standalone `CalibrationSessionViewModel` both just subscribe. Legolas's `PlayerLogParser` keeps only `ProcessMapFx` (survey targets are Legolas-owned, not shared pins).
+**Pin source (#468).** The pin set is owned by the GameState-tier `IPlayerPinTracker` (`Mithril.GameState.Pins`), *not* Legolas. It parses `ProcessMapPin{Add,Remove}` (the only two verbs PG has — a rename/move is Remove+Add; there is no clear/edit verb), is **area-scoped** (keyed off the shared `PlayerAreaTracker`, swapped on area change), and **owns the login/area-entry replay**: PG bulk-re-emits every pin as an `Add` burst on each entry, which the tracker folds into an idempotent upsert keyed by rounded coordinate. Consumers just subscribe. Legolas's `PlayerLogParser` keeps only `ProcessMapFx` (survey targets are Legolas-owned, not shared pins).
 
-`PinCalibrationCoordinator` exposes **two routes**, both ending in the *same* `(world ↔ pixel)` solve:
+### The two phases
 
-1. **Existing-pins route.** When the area already has ≥3 well-spread pins (`HasUsableExistingPins`), the wizard lists them by in-game identity — `MapPin.DisplayName` + `Appearance` (colour/shape decoded from the pin args, e.g. *"Fire Magic 25 (red dot)"*). The user selects one and clicks where it is on the overlay. No re-dropping.
-2. **Freshly-dropped turn-order route.** The true cold-start case (fogged brand-new area, no usable pins). Pins dropped *after* arming queue up; each click pairs the oldest unpaired one — by interaction order, label-agnostic.
+A transparent overlay's click-through is **all-or-nothing** — it either passes a right-click to the game *or* captures the user's left-click, never both. So calibration is two **explicit, user-toggled** phases (`CalibrationPhase`), never an automatic FSM edge. The phase trigger lives on the **wizard panel** (a normal, always-clickable window) plus an optional unbound `IHotkeyCommand` — *not* on the transparent overlay.
 
-**Why this does not violate #454's "never pair by name" rule.** The rule's intent is *no automatic name→point pairing* (the freshly-dropped flow has no reliable name↔point map). It is preserved because:
+- **Drop.** Overlay click-through ON. The user right-clicks the in-game map to place ≥3 well-spread pins (or relies on ones already there); Legolas only *observes* the live count (`PinsAvailable`). Entry starts here only when <3 usable pins exist.
+- **Pair.** Overlay captures clicks. The coordinator names **one pin at a time** (`SuggestedPin`) by its in-game identity (`MapPin.DisplayName` + `Appearance`, e.g. *"red dot — 'Fire Magic 25'"*), chosen for **spread** (farthest-point from already-paired). The user left-clicks that pin's game-rendered dot through the overlay. **Advance is implicit** — pairing the next named pin *is* the advance; there is no per-pin confirm key. A pin can be **skipped** (deferred) or **overridden** (`OverridePin` — pick any pin). Entry starts here when ≥3 usable pins already exist (the common case).
 
-- The **solve is purely `(WorldCoord ↔ PixelPoint)`** in both routes. Name/colour/shape **never** reach `LandmarkCalibrationSolver` or `CalibrateCurrentArea`.
-- In the existing-pins route, identity is used **only to help the human** decide which service-supplied world point they are about to click. The pairing is still the user's *deliberate select-then-click* — the system never infers a pairing from a label.
-- The turn-order route is **retained**, not replaced; it is the only path that works when no usable pins exist.
+**Correction.** Placed pairs are `CalibrationMarker` VMs (not bare points), so a marker can be selected (`TrySelectMarkerAt`), dragged (`DragSelectedTo`), or arrow-nudged (`NudgeSelected`) — the default nudge target is the just-placed marker. Correction edits **only the pixel half**; the world coord is tracker-supplied and never mutated. (`CalibrationMarker` is also the single marker model #478 reshapes for per-marker styling.)
 
-So: identity is UX-only disambiguation; the pairing remains a human click against a service-supplied coordinate. Keep both routes and keep colour/shape out of the solver.
+**Live, non-persisting residual.** Once ≥3 pairs exist, every add/nudge/drag re-runs the pure `LandmarkCalibrationSolver` *in-process* (`PreviewResidual`) — no persist, no `IAreaCalibrationService.Changed`. Only the terminal **Confirm** / **Finish anyway** calls the persisting `CalibrateCurrentArea`. Confirm is gated on `≥3 pairs && residual ≤ LegolasSettings.CalibrationGoodResidualPx` (12 px default); "Finish anyway" persists despite a high residual so the user is never trapped at the non-affine ±10% map ceiling.
+
+**Gesture/phase table.** Right-click = in-game pin drop (Drop; observed, never captured). Left-click on overlay = pair the named pin / grab a marker to drag (Pair; overlay captures). Arrow keys = nudge the selected/just-placed marker. Wizard-panel button (+ optional hotkey) = phase toggle / terminal Confirm. The view drives the overlay's click-through from the phase (`IsCalibrationDropping` ⇒ ON, `IsCalibrationCapturing` ⇒ OFF), overriding the user's `ClickThroughMap` preference for the duration.
+
+**Why this does not violate #454's "never pair by name" rule.** The rule's intent is *no automatic name→point pairing*. It holds because the **solve is purely `(WorldCoord ↔ PixelPoint)`** — name/colour/shape never reach `LandmarkCalibrationSolver`; identity is used **only to help the human** decide which service-supplied world point they are deliberately clicking. The pairing is always a human click against a named target, never an inferred name→point map.
+
+### In-flow recalibration (#477 Part B)
+
+`IAreaCalibrationService.ClearCurrentAreaCalibration()` removes + persists the deletion and fires `Changed`. The Listening step offers a **"Recalibrate this area"** affordance (only when `CanRecalibrate` — i.e. the area is already calibrated) behind a **confirm guard** (`IsConfirmingRecalibrate`) so a misclick can't wipe a good calibration. Confirming clears the calibration → `Changed` → `RecomputeStep` routes back into `WizardStep.Calibrating` via the *same pin route as cold start* (`OnCurrentStepChanged` re-arms `PinCalibration`), so Part A's guided correctable flow applies on the redo. No new top-level FSM state — the existing edges are reused. The standalone window's Recalibrate (landmark route) is left as the alternative.
 
 ## SessionState
 
@@ -217,15 +225,18 @@ Auto-save is wired through [`SettingsAutoSaver<LegolasSettings>`](../src/Mithril
 
 None ship with a default key binding. Arrow keys would collide with in-game movement, so the user opts into specific bindings via `Settings → Hotkeys`.
 
-### Pin-nudge fallback to anchor (issues #119, #120)
+### Pin-nudge target precedence (issues #119, #120; #477 A/C)
 
-`NudgePinCommandBase.ExecuteAsync` ([Commands.cs:206](../src/Legolas.Module/Hotkeys/Commands.cs)):
+`NudgePinCommandBase.ExecuteAsync` and the on-screen nudge pad both call the **single** `MapOverlayViewModel.Nudge(dx, dy, step)` so the keyboard and pad can't diverge. Precedence:
 
-1. If `SessionState.SelectedSurvey` is non-null and has a pixel position → nudge it via `MapOverlayViewModel.CorrectSurveyCommand`.
-2. Else if `SessionState.IsAnchorEditable` → nudge the anchor via `MapOverlayViewModel.MoveAnchor`.
-3. Else → no-op.
+1. A selected **calibration marker** (#477A — the guided walkthrough's just-placed/selected marker) → `PinCalibrationCoordinator.NudgeSelected`.
+2. The selected `SessionState.SelectedSurvey` pin → `CorrectSurveyCommand` (a survey always wins over the manual anchor).
+3. The **manual** Survey player anchor (#477C) — only when no survey is selected and `SurveyPlayerIsManual`: mutate `SurveyPlayerPixel` only, keep the manual flag (a fresh tracker fix still supersedes it per #476), never touch the Motherlode `PlayerPosition` or the retired `MoveAnchor`/`IsAnchorEditable` model.
+4. Else → no-op.
 
-This means the same arrow keys that nudge a selected pin will fall through to the anchor when no pin is selected and the anchor is still editable — the "fine-tune what I just clicked" workflow.
+The auto/tracker-projected anchor is intentionally **non-interactive** — nudging a data-sourced fix would mask staleness. `NudgePinCommandBase.IsRegistrable` and `NudgePadViewModel.IsAvailable` track all of (1)–(3) so the arrow keys aren't eaten system-wide when there's nothing to nudge (#139).
+
+> The pre-#454 `IsAnchorEditable`/`MoveAnchor` fall-through is gone. The #477C manual anchor is *not* that model — it is a raw screen pixel on the shared marker layer, superseded by the next fresh tracker fix.
 
 ### Click-through
 

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -301,6 +301,29 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
         }
     }
 
+    private double _calibrationGoodResidualPx = 12.0;
+    /// <summary>
+    /// RMS pixel-residual at or below which an in-flow (#460) pin calibration
+    /// is considered "good" and the guided walkthrough's terminal Confirm is
+    /// ungated. Above it the user must explicitly "finish anyway" (the
+    /// non-affine ±10% map ceiling means a high residual is sometimes
+    /// unavoidable — the user is never trapped). 12 px mirrors the long-standing
+    /// "good" notion the standalone calibration window's Solve already uses;
+    /// exposed here so it is one configurable value, not a hardcoded constant.
+    /// Additive — old settings JSON without it loads the 12 px default.
+    /// </summary>
+    public double CalibrationGoodResidualPx
+    {
+        get => _calibrationGoodResidualPx;
+        set
+        {
+            var clamped = value > 0 ? value : 12.0;
+            if (Math.Abs(_calibrationGoodResidualPx - clamped) < 1e-6) return;
+            _calibrationGoodResidualPx = clamped;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CalibrationGoodResidualPx)));
+        }
+    }
+
     private double _nudgeStepDefault = 1.0;
     public double NudgeStepDefault
     {

--- a/src/Legolas.Module/Hotkeys/Commands.cs
+++ b/src/Legolas.Module/Hotkeys/Commands.cs
@@ -3,6 +3,7 @@ using Mithril.Shared.Hotkeys;
 using Legolas.Diagnostics;
 using Legolas.Domain;
 using Legolas.Flow;
+using Legolas.Services;
 using Legolas.ViewModels;
 
 namespace Legolas.Hotkeys;
@@ -223,9 +224,11 @@ public abstract class NudgePinCommandBase : IGatedHotkeyCommand
         _session = session;
         _map = map;
         _settings = settings;
-        // #454 retired the editable anchor — Pin Nudge now only ever targets a
-        // selected survey pin, so registrability tracks SelectedSurvey alone.
+        // Pin Nudge targets, in precedence order (see MapOverlayViewModel.Nudge):
+        // a selected #477A calibration marker, the selected survey pin, or the
+        // #477C manual player anchor. Registrability tracks all three inputs.
         _session.PropertyChanged += OnSessionPropertyChanged;
+        _map.PropertyChanged += OnMapPropertyChanged;
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -236,16 +239,31 @@ public abstract class NudgePinCommandBase : IGatedHotkeyCommand
     public HotkeyBinding? DefaultBinding => null;
 
     /// <summary>
-    /// Pin Nudge only matters when a survey pin is selected. Outside that
-    /// window arrow keys are dead weight that would otherwise be eaten
-    /// system-wide (#139). The Execute body re-checks, so a registration that
-    /// briefly outraces a state change is harmless.
+    /// Pin Nudge matters when there's something to nudge: a selected survey
+    /// pin, a selected #477A calibration marker, or the #477C manual player
+    /// anchor. Outside those windows arrow keys are dead weight that would
+    /// otherwise be eaten system-wide (#139). The Execute body re-checks, so a
+    /// registration that briefly outraces a state change is harmless.
     /// </summary>
-    public bool IsRegistrable => _session.SelectedSurvey is not null;
+    public bool IsRegistrable =>
+        _session.SelectedSurvey is not null
+        || _map.HasSelectedCalibrationMarker
+        || (_session.Mode == SessionMode.Survey
+            && _session.SurveyPlayerIsManual
+            && _session.SurveyPlayerPixel is not null);
 
     private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(SessionState.SelectedSurvey))
+        if (e.PropertyName is nameof(SessionState.SelectedSurvey)
+                           or nameof(SessionState.SurveyPlayerIsManual)
+                           or nameof(SessionState.SurveyPlayerPixel)
+                           or nameof(SessionState.Mode))
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsRegistrable)));
+    }
+
+    private void OnMapPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MapOverlayViewModel.HasSelectedCalibrationMarker))
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsRegistrable)));
     }
 
@@ -262,15 +280,10 @@ public abstract class NudgePinCommandBase : IGatedHotkeyCommand
     public Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var (dx, dy) = Direction;
-        var step = Step;
-
-        var selected = _session.SelectedSurvey;
-        if (selected is not null && selected.EffectivePixel.HasValue)
-        {
-            var p = selected.EffectivePixel.Value;
-            _map.CorrectSurveyCommand.Execute(
-                new CorrectionArgs(selected, new PixelPoint(p.X + dx * step, p.Y + dy * step)));
-        }
+        // Single path: MapOverlayViewModel.Nudge applies the #477A marker /
+        // survey / #477C manual-anchor precedence, so the keyboard hotkeys and
+        // the on-screen nudge pad can't diverge.
+        _map.Nudge(dx, dy, Step);
         return Task.CompletedTask;
     }
 }
@@ -522,5 +535,72 @@ public sealed class RunSurveyPerfHarnessTreatmentSweepCommand : IHotkeyCommand
         {
             _session.LastLogEvent = "Perf sweep cancelled.";
         }
+    }
+}
+
+// ─── Calibration (#477A) ─────────────────────────────────────────────────────
+// Optional bindable mirrors of the wizard-panel phase trigger / Confirm, for
+// users who don't want to look away from the game. No default binding (the
+// Legolas convention — game-movement collision avoidance). Gated so the keys
+// aren't eaten system-wide outside an armed walkthrough.
+
+/// <summary>Flip the guided calibration walkthrough between the Drop and Pair
+/// phases (mirror of the wizard-panel button).</summary>
+public sealed class ToggleCalibrationPhaseCommand : IGatedHotkeyCommand
+{
+    private readonly PinCalibrationCoordinator _cal;
+
+    public ToggleCalibrationPhaseCommand(PinCalibrationCoordinator cal)
+    {
+        _cal = cal;
+        _cal.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(PinCalibrationCoordinator.IsArmed))
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsRegistrable)));
+        };
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public string Id => "legolas.calibration.phase.toggle";
+    public string DisplayName => "Calibration: Toggle Drop/Pair Phase";
+    public string? Category => "Legolas · Calibration";
+    public HotkeyBinding? DefaultBinding => null;
+    public bool IsRegistrable => _cal.IsArmed;
+    public Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _cal.TogglePhase();
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Terminal Confirm of the guided calibration (mirror of the
+/// wizard-panel Confirm; gated on ≥3 pairs and a good residual — "finish
+/// anyway" stays panel-only so a stray keypress can't persist a loose fit).</summary>
+public sealed class ConfirmCalibrationCommand : IGatedHotkeyCommand
+{
+    private readonly PinCalibrationCoordinator _cal;
+
+    public ConfirmCalibrationCommand(PinCalibrationCoordinator cal)
+    {
+        _cal = cal;
+        _cal.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(PinCalibrationCoordinator.IsArmed)
+                               or nameof(PinCalibrationCoordinator.CanConfirm)
+                               or nameof(PinCalibrationCoordinator.IsResidualGood))
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsRegistrable)));
+        };
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public string Id => "legolas.calibration.confirm";
+    public string DisplayName => "Calibration: Confirm";
+    public string? Category => "Legolas · Calibration";
+    public HotkeyBinding? DefaultBinding => null;
+    public bool IsRegistrable => _cal.IsArmed && _cal.CanConfirm && _cal.IsResidualGood;
+    public Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _cal.Confirm();
+        return Task.CompletedTask;
     }
 }

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -204,6 +204,10 @@ public sealed class LegolasModule : IMithrilModule
         services.AddSingleton<IHotkeyCommand, NudgePinRightCommand>();
         services.AddSingleton<IHotkeyCommand, NudgePinRightFastCommand>();
         services.AddSingleton<IHotkeyCommand, NudgePinRightFineCommand>();
+        // #477A: optional bindable mirrors of the guided-calibration panel
+        // controls (no default binding — Legolas convention).
+        services.AddSingleton<IHotkeyCommand, ToggleCalibrationPhaseCommand>();
+        services.AddSingleton<IHotkeyCommand, ConfirmCalibrationCommand>();
 
         // Chat-log ingestion (relative [Status] survey/collect lines).
         services.AddHostedService<LogIngestionService>();

--- a/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
+++ b/src/Legolas.Module/Services/PinCalibrationCoordinator.cs
@@ -8,182 +8,454 @@ using Mithril.GameState.Pins;
 
 namespace Legolas.Services;
 
+/// <summary>The two explicit phases of the guided in-flow (#460) calibration
+/// walkthrough. They are explicit because a transparent overlay's click-through
+/// is all-or-nothing: <see cref="Drop"/> passes right-clicks to the game (drop
+/// pins), <see cref="Pair"/> captures left-clicks (pair them) — never both at
+/// once. The phase is toggled by the user (wizard-panel button / hotkey), never
+/// an automatic FSM edge.</summary>
+public enum CalibrationPhase
+{
+    /// <summary>Overlay click-through ON. The user right-clicks the in-game map
+    /// to place well-spread pins (or relies on ones already there). Legolas
+    /// only observes the live count — it captures nothing.</summary>
+    Drop,
+
+    /// <summary>Overlay captures clicks. The wizard names one pin at a time;
+    /// the user left-clicks that pin's game-rendered dot through the
+    /// transparent overlay to pair it, and may select / drag / nudge a placed
+    /// marker to correct it.</summary>
+    Pair,
+}
+
 /// <summary>
-/// View-agnostic driver for cold-start pin calibration done <b>through the
-/// map overlay</b>. Consumes the GameState-tier
-/// <see cref="IPlayerPinTracker"/> (#468) — the authoritative, area-scoped,
-/// replay-deduped player pin set — and feeds click-paired
-/// <c>(WorldCoord ↔ PixelPoint)</c> placements to
+/// A placed calibration marker — the overlay-pixel half of one
+/// <c>(WorldCoord ↔ PixelPoint)</c> solve pair, promoted from a bare
+/// <c>PixelPoint</c> to an observable VM so it can be selected, dragged and
+/// nudged after placement (the dominant accuracy bottleneck is click
+/// precision — see #443/#449). The marker's <see cref="Pixel"/> and its
+/// <c>_pairs[<see cref="PairIndex"/>]</c> entry move in lockstep; the world
+/// coordinate is tracker-supplied and never mutated.
+///
+/// <para>Kept appearance-free on purpose: this is the single mutable marker
+/// model #478 reshapes to drive per-marker <c>LegolasPinStyle</c> styling, so
+/// the interaction state (pixel / selection / pair back-ref) lives here and
+/// styling drops in there without touching this contract.</para>
+/// </summary>
+public sealed partial class CalibrationMarker : ObservableObject
+{
+    public CalibrationMarker(PixelPoint pixel, int pairIndex)
+    {
+        _pixel = pixel;
+        PairIndex = pairIndex;
+    }
+
+    [ObservableProperty] private PixelPoint _pixel;
+    [ObservableProperty] private bool _isSelected;
+
+    /// <summary>Index into the coordinator's pair list. Stable: pairs only ever
+    /// grow (until a full Clear/Arm), so no re-indexing is needed.</summary>
+    public int PairIndex { get; }
+
+    partial void OnPixelChanged(PixelPoint value)
+    {
+        OnPropertyChanged(nameof(X));
+        OnPropertyChanged(nameof(Y));
+    }
+
+    public double X => Pixel.X;
+    public double Y => Pixel.Y;
+}
+
+/// <summary>
+/// View-agnostic driver for the <b>guided two-phase correctable</b> cold-start
+/// pin calibration done through the survey map overlay (#460 → #477 Part A).
+/// Consumes the GameState-tier <see cref="IPlayerPinTracker"/> (#468) — the
+/// authoritative, area-scoped, replay-deduped player pin set — and feeds
+/// click-paired <c>(WorldCoord ↔ PixelPoint)</c> placements to
 /// <see cref="IAreaCalibrationService.CalibrateCurrentArea"/>.
 ///
-/// <para><b>Two routes (both end in the same solve).</b></para>
-/// <list type="number">
-///   <item><b>Existing-pins route.</b> When the player already has ≥3
-///   well-spread pins in this area, they're listed by their in-game identity
-///   (<see cref="MapPin.Label"/> + <see cref="MapPin.Appearance"/>, e.g.
-///   "Fire Magic 25 (red dot)"). The user selects one and clicks where it is
-///   on the overlay — no re-dropping. The pairing is the user's
-///   <em>deliberate</em> select-then-click; name/colour/shape are
-///   <b>UX-only</b> and never reach the solver.</item>
-///   <item><b>Freshly-dropped turn-order route.</b> The true cold-start case
-///   (fogged brand-new area, no usable pins). Pins dropped <em>after</em>
-///   arming queue up; each overlay click pairs the oldest unpaired one —
-///   label-agnostic, by interaction order (hard rule #454).</item>
-/// </list>
+/// <para><b>The flow.</b> One model, two phases (see
+/// <see cref="CalibrationPhase"/>). Entry starts in <see cref="CalibrationPhase.Pair"/>
+/// when the area already has ≥3 usable pins (the common case — PG players
+/// accumulate them), else <see cref="CalibrationPhase.Drop"/>. In Pair the
+/// coordinator names <em>one pin at a time</em> by its in-game identity
+/// (<see cref="SuggestedPin"/>, chosen for spread via a farthest-point
+/// heuristic), the user clicks that pin's game-rendered dot, and advance is
+/// <em>implicit</em> — pairing the next named pin is the advance. A pin can be
+/// skipped (deferred) or overridden (pick any pin).</para>
 ///
-/// <para><b>Reconciliation of the #454 label-agnostic rule.</b> The solve is
-/// purely <c>(WorldCoord ↔ PixelPoint)</c> in both routes — labels/colours
-/// never feed <c>LandmarkCalibrationSolver</c>. The existing-pins route only
-/// uses identity to help the <em>human</em> pick which service-supplied world
-/// point they are clicking; the pairing is still a deliberate user click, so
-/// the rule's intent (no auto-pairing by name) is preserved. See
-/// docs/legolas-overview.md.</para>
+/// <para><b>#454 label-agnostic preserved.</b> Identity (label/colour/shape) is
+/// UX-only — it only helps the human decide which service-supplied world coord
+/// they are clicking. The solve is purely <c>(WorldCoord ↔ PixelPoint)</c>;
+/// colour/shape/label never reach <c>LandmarkCalibrationSolver</c>. Correction
+/// edits only the <em>pixel</em> half.</para>
 ///
-/// <para><b>Replay is the service's job now.</b> <see cref="IPlayerPinTracker"/>
-/// owns the login/area-entry bulk-replay (idempotent upsert keyed by
-/// coordinate), so a backlog never reaches the turn-order queue: only genuine
-/// post-arm <see cref="PinSetChange.Added"/> notifications enqueue. The
-/// <see cref="IsArmed"/> gate additionally scopes the queue to "since the user
-/// started calibrating".</para>
+/// <para><b>Non-persisting residual.</b> Once ≥3 pairs exist, each add / nudge
+/// / drag re-runs the pure <c>LandmarkCalibrationSolver</c> in-process (no
+/// persist, no <see cref="IAreaCalibrationService.Changed"/>) to surface a live
+/// <see cref="PreviewResidual"/>. Only <see cref="Confirm"/> /
+/// <see cref="ConfirmAnyway"/> call the persisting
+/// <see cref="IAreaCalibrationService.CalibrateCurrentArea"/>.</para>
 /// </summary>
 public sealed partial class PinCalibrationCoordinator : ObservableObject
 {
     private readonly IAreaCalibrationService _service;
     private readonly IPlayerPinTracker _pins;
+    private readonly LegolasSettings _settings;
     private readonly IDisposable _sub;
 
-    // Turn-order route: pins dropped after arming, not yet click-paired.
-    private readonly Queue<WorldCoord> _pending = new();
-    // Accumulated solve pairs (both routes feed this).
-    private readonly List<(WorldCoord World, PixelPoint Pixel)> _pairs = new();
+    // The accumulated solve pairs. Keyed by the MapPin (for spread + identity);
+    // only (WorldCoord, Pixel) ever reaches the solver.
+    private readonly List<(MapPin Pin, PixelPoint Pixel)> _pairs = new();
+    // Pins the user deferred ("skip") — excluded from the next suggestion until
+    // everything else is paired (then recycled, so the user is never stuck).
+    private readonly List<MapPin> _skipped = new();
 
-    public PinCalibrationCoordinator(IAreaCalibrationService service, IPlayerPinTracker pins)
+    public PinCalibrationCoordinator(
+        IAreaCalibrationService service, IPlayerPinTracker pins, LegolasSettings settings)
     {
         _service = service;
         _pins = pins;
+        _settings = settings;
         // Subscribe replays a Snapshot synchronously (seeds ExistingPins);
         // live notifications arrive on the tracker's ingestion thread.
         _sub = _pins.Subscribe(OnPinSetChanged);
+        _settings.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(LegolasSettings.CalibrationGoodResidualPx))
+                OnPropertyChanged(nameof(IsResidualGood));
+        };
     }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(StatusText))]
     private bool _isArmed;
 
-    /// <summary>The pin the user has selected to click next (existing-pins
-    /// route). Null falls back to the turn-order route.</summary>
     [ObservableProperty]
-    private MapPin? _selectedExistingPin;
+    [NotifyPropertyChangedFor(nameof(IsPairing))]
+    [NotifyPropertyChangedFor(nameof(IsDropping))]
+    [NotifyPropertyChangedFor(nameof(PhaseToggleLabel))]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    private CalibrationPhase _phase;
 
-    /// <summary>Current-area pins available to calibrate against, by their
-    /// in-game identity. Kept in sync with the GameState set.</summary>
+    /// <summary>Overlay capture is desired (Pair phase + armed). The view
+    /// routes left-clicks to <see cref="PairClick"/> / marker selection only
+    /// while this holds; Drop phase wants click-through so right-clicks reach
+    /// the game.</summary>
+    public bool IsPairing => IsArmed && Phase == CalibrationPhase.Pair;
+
+    /// <summary>Drop phase + armed — click-through ON, no pixel capture.</summary>
+    public bool IsDropping => IsArmed && Phase == CalibrationPhase.Drop;
+
+    partial void OnIsArmedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsPairing));
+        OnPropertyChanged(nameof(IsDropping));
+    }
+
+    /// <summary>The pin the user explicitly chose to pair next (override the
+    /// spread suggestion). Cleared once paired or skipped.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SuggestedPin))]
+    [NotifyPropertyChangedFor(nameof(PromptText))]
+    private MapPin? _overridePin;
+
+    /// <summary>Current-area pins by in-game identity — the override picker's
+    /// source. Kept in sync with the GameState set.</summary>
     public ObservableCollection<MapPin> ExistingPins { get; } = new();
 
-    /// <summary>≥3 well-spread existing pins ⇒ offer the friendlier route.</summary>
-    public bool HasUsableExistingPins => ExistingPins.Count >= 3;
+    /// <summary>Markers the overlay renders, one per accumulated pair (parallel
+    /// to <c>_pairs</c> by <see cref="CalibrationMarker.PairIndex"/>).</summary>
+    public ObservableCollection<CalibrationMarker> PlacedMarkers { get; } = new();
 
-    /// <summary>Pins dropped post-arm and not yet paired (turn-order route).</summary>
-    public int PendingCount => _pending.Count;
+    /// <summary>The currently-selected marker (for drag / nudge correction), or
+    /// null. Defaults to the just-placed marker after a pair.</summary>
+    [ObservableProperty] private CalibrationMarker? _selectedMarker;
 
-    /// <summary>Click-paired (world ↔ pixel) points accumulated so far.</summary>
+    /// <summary>Live count of current-area pins available to pair against.</summary>
+    public int PinsAvailable => _pins.CurrentAreaPins.Count;
+
+    /// <summary>≥3 pins exist ⇒ Pair phase is workable without dropping more.</summary>
+    public bool HasUsablePins => PinsAvailable >= 3;
+
+    /// <summary>Click-paired points accumulated so far.</summary>
     public int PairedCount => _pairs.Count;
 
-    /// <summary>≥3 well-spread pairs are needed for a stable solve.</summary>
-    public bool CanSolve => _pairs.Count >= 3;
+    /// <summary>Hard floor: ≥3 pairs before any finalize.</summary>
+    public bool CanConfirm => _pairs.Count >= 3;
 
-    /// <summary>Markers the map overlay renders at each paired click pixel.</summary>
-    public ObservableCollection<PixelPoint> PlacedMarkers { get; } = new();
+    /// <summary>Non-persisting RMS residual of the current pairs (≥3), or null.
+    /// Recomputed on every pair add / nudge / drag.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ResidualText))]
+    [NotifyPropertyChangedFor(nameof(IsResidualGood))]
+    private double? _previewResidual;
+
+    /// <summary>Confirm is ungated once the preview residual is at or below the
+    /// configured "good" threshold; otherwise the user must "finish anyway".</summary>
+    public bool IsResidualGood =>
+        PreviewResidual is { } r && r <= _settings.CalibrationGoodResidualPx;
+
+    public string ResidualText => PreviewResidual is { } r
+        ? $"Fit residual: {r:0.0} px (target ≤ {_settings.CalibrationGoodResidualPx:0} px)."
+        : "Pair ≥3 pins to see the fit quality.";
+
+    /// <summary>The next pin the user should pair: the explicit override if
+    /// set, else the spread suggestion (farthest-point from already-paired,
+    /// excluding skipped). Null when nothing is left to pair.</summary>
+    public MapPin? SuggestedPin
+    {
+        get
+        {
+            if (OverridePin is { } o && !IsPaired(o)) return o;
+            return ComputeSuggestion();
+        }
+    }
+
+    /// <summary>Label for the phase-toggle button.</summary>
+    public string PhaseToggleLabel =>
+        Phase == CalibrationPhase.Drop ? "Done dropping — pair them" : "Drop more pins";
 
     public string StatusText
     {
         get
         {
             if (!IsArmed) return "Pin calibration is off.";
-            var tail = $"Paired: {PairedCount}.";
-            return HasUsableExistingPins
-                ? $"Pick a pin below, then click where it is on the map. " +
-                  $"You have {ExistingPins.Count} pins here. {tail}"
-                : $"Drop ≥3 well-spread map pins in-game, then click each on " +
-                  $"the map in the same order. Awaiting click: {PendingCount}. {tail}";
+            if (Phase == CalibrationPhase.Drop)
+                return $"Right-click the in-game map to place ≥3 well-spread pins. " +
+                       $"You have {PinsAvailable}. " +
+                       (HasUsablePins ? "Enough — pair them when ready." : "Drop a few more.");
+            return $"Paired {PairedCount}. " + PromptText;
         }
     }
 
-    /// <summary>Arm capture and clear any stale state. Seeds
-    /// <see cref="ExistingPins"/> from the current GameState set so the
-    /// existing-pins route is immediately usable.</summary>
+    /// <summary>Per-phase guidance. In Pair, names the suggested pin by its
+    /// in-game identity (UX-only — never reaches the solver).</summary>
+    public string PromptText
+    {
+        get
+        {
+            if (Phase == CalibrationPhase.Drop)
+                return "Drop ≥3 well-spread map pins in-game (works on a fogged/blank map).";
+            if (SuggestedPin is { } p)
+                return $"Click where this pin is: {p.Appearance} — “{p.DisplayName}”.";
+            return PairedCount >= 3
+                ? "All pins paired. Check the fit, then Confirm."
+                : "No more pins to pair — drop more, or Confirm if you have ≥3.";
+        }
+    }
+
+    /// <summary>Arm capture and clear stale state. Seeds
+    /// <see cref="ExistingPins"/> and picks the entry phase: straight to
+    /// <see cref="CalibrationPhase.Pair"/> when ≥3 usable pins already exist
+    /// (the common case), else <see cref="CalibrationPhase.Drop"/>.</summary>
     public void Arm()
     {
-        _pending.Clear();
         _pairs.Clear();
+        _skipped.Clear();
         PlacedMarkers.Clear();
-        SelectedExistingPin = null;
+        SelectedMarker = null;
+        OverridePin = null;
+        PreviewResidual = null;
         SyncExistingPins(_pins.CurrentAreaPins);
+        Phase = HasUsablePins ? CalibrationPhase.Pair : CalibrationPhase.Drop;
         IsArmed = true;
-        RaiseCounts();
+        RaiseAll();
     }
 
     /// <summary>Disarm and flush — leaving the calibration step, or after a
-    /// solve/clear.</summary>
+    /// confirm.</summary>
     public void Disarm()
     {
-        _pending.Clear();
         _pairs.Clear();
+        _skipped.Clear();
         PlacedMarkers.Clear();
-        SelectedExistingPin = null;
+        SelectedMarker = null;
+        OverridePin = null;
+        PreviewResidual = null;
         IsArmed = false;
-        RaiseCounts();
+        RaiseAll();
+    }
+
+    /// <summary>Flip Drop ⇄ Pair. The wizard-panel button (and optional
+    /// hotkey) drives this — an explicit, user-driven toggle, never an
+    /// automatic transition. Idempotent intent: re-reading <see cref="Phase"/>
+    /// is the source of truth for the overlay's capture mode.</summary>
+    public void TogglePhase()
+    {
+        if (!IsArmed) return;
+        Phase = Phase == CalibrationPhase.Drop ? CalibrationPhase.Pair : CalibrationPhase.Drop;
+        RaiseAll();
     }
 
     /// <summary>
-    /// Pair an overlay click. Existing-pins route when a pin is selected
-    /// (pairs that pin's service-supplied world coord); otherwise the
-    /// turn-order route (oldest unpaired post-arm pin). No-op when disarmed,
-    /// nothing is selected, and nothing is pending. Degenerate duplicate
-    /// world points are rejected so the solve stays well-conditioned.
+    /// Pair an overlay click with the currently-named pin (override or spread
+    /// suggestion) — the implicit advance: the next call pairs the next named
+    /// pin. No-op when disarmed, not pairing, or nothing is left to pair.
+    /// Degenerate duplicate world points are rejected so the solve stays
+    /// well-conditioned. The just-placed marker becomes the selection so an
+    /// immediate nudge corrects it.
     /// </summary>
     public void PairClick(PixelPoint pixel)
     {
-        if (!IsArmed) return;
+        if (!IsArmed || Phase != CalibrationPhase.Pair) return;
+        if (SuggestedPin is not { } pin) return;
 
-        WorldCoord world;
-        if (SelectedExistingPin is { } sel)
-        {
-            world = new WorldCoord(sel.X, 0, sel.Z);
-            SelectedExistingPin = null;
-        }
-        else if (_pending.Count > 0)
-        {
-            world = _pending.Dequeue();
-        }
-        else
-        {
-            return;
-        }
+        // Reject a second click on the same world point — duplicates degrade
+        // the least-squares solve.
+        if (_pairs.Any(p => SameWorld(p.Pin, pin))) { OverridePin = null; RaiseAll(); return; }
 
-        // Reject a second click on the same world point (both routes share
-        // _pairs) — duplicates degrade the least-squares solve.
-        if (_pairs.Any(p => Same(p.World, world))) { RaiseCounts(); return; }
-
-        _pairs.Add((world, pixel));
-        PlacedMarkers.Add(pixel);
-        RaiseCounts();
+        var index = _pairs.Count;
+        _pairs.Add((pin, pixel));
+        var marker = new CalibrationMarker(pixel, index);
+        PlacedMarkers.Add(marker);
+        SelectMarker(marker);
+        OverridePin = null;
+        // The pin is paired now; drop it from the skip list if it was deferred.
+        _skipped.RemoveAll(s => SameWorld(s, pin));
+        RecomputeResidual();
+        RaiseAll();
     }
 
-    /// <summary>
-    /// Solve + persist + apply the area calibration from the accumulated
-    /// pairs (reuses the shipped solver verbatim). Returns the calibration,
-    /// or null if &lt;3 pairs / the solve failed. On success the area becomes
-    /// calibrated (<see cref="IAreaCalibrationService.Changed"/> fires) and
-    /// the coordinator disarms.
-    /// </summary>
-    public AreaCalibration? Solve()
+    /// <summary>Defer the suggested pin: it is excluded from the next
+    /// suggestion (a different, still-spread pin is offered) until everything
+    /// else is paired. No pair is recorded.</summary>
+    public void SkipSuggestion()
     {
-        if (!CanSolve) return null;
-        // Zoom OCR/CV is deferred (#460) — calibrate at the default zoom
-        // stamp, consistent with the standalone window's unset-zoom path.
-        var result = _service.CalibrateCurrentArea(_pairs.ToList(), calibrationZoom: 1.0);
+        if (!IsArmed || Phase != CalibrationPhase.Pair) return;
+        if (SuggestedPin is not { } pin) return;
+        OverridePin = null;
+        if (!_skipped.Any(s => SameWorld(s, pin))) _skipped.Add(pin);
+        RaiseAll();
+    }
+
+    /// <summary>Mouse-down hit-test: select the nearest marker within
+    /// <paramref name="radius"/> px (so the view starts a drag) and return
+    /// true; else false → the click falls through to <see cref="PairClick"/>.</summary>
+    public bool TrySelectMarkerAt(PixelPoint at, double radius)
+    {
+        CalibrationMarker? best = null;
+        var bestD = radius;
+        foreach (var m in PlacedMarkers)
+        {
+            var d = m.Pixel.DistanceTo(at);
+            if (d <= bestD) { bestD = d; best = m; }
+        }
+        if (best is null) return false;
+        SelectMarker(best);
+        return true;
+    }
+
+    /// <summary>Drag the selected marker to an absolute pixel. Mutates only the
+    /// pixel half of its pair; the world coord is untouched.</summary>
+    public void DragSelectedTo(PixelPoint at)
+    {
+        if (SelectedMarker is not { } m) return;
+        m.Pixel = at;
+        _pairs[m.PairIndex] = (_pairs[m.PairIndex].Pin, at);
+        RecomputeResidual();
+    }
+
+    /// <summary>Arrow-key nudge of the selected (default: just-placed) marker
+    /// by a pixel delta. Magnitude is resolved by the caller from
+    /// <c>LegolasSettings.NudgeStep*</c>.</summary>
+    public void NudgeSelected(double dx, double dy)
+    {
+        if (SelectedMarker is not { } m) return;
+        var moved = new PixelPoint(m.Pixel.X + dx, m.Pixel.Y + dy);
+        m.Pixel = moved;
+        _pairs[m.PairIndex] = (_pairs[m.PairIndex].Pin, moved);
+        RecomputeResidual();
+    }
+
+    public void ClearSelection() => SelectMarker(null);
+
+    /// <summary>Terminal confirm — solve + persist + apply, gated on ≥3 pairs
+    /// AND a good residual. Returns the calibration or null if the gate fails /
+    /// the solve failed. On success the area becomes calibrated
+    /// (<see cref="IAreaCalibrationService.Changed"/> fires) and the
+    /// coordinator disarms.</summary>
+    public AreaCalibration? Confirm()
+    {
+        if (!CanConfirm || !IsResidualGood) return null;
+        return Persist();
+    }
+
+    /// <summary>"Finish anyway" — persist with a high residual (still ≥3
+    /// pairs). The non-affine ±10% map ceiling means a high residual is
+    /// sometimes unavoidable; the user is never trapped.</summary>
+    public AreaCalibration? ConfirmAnyway()
+    {
+        if (!CanConfirm) return null;
+        return Persist();
+    }
+
+    private AreaCalibration? Persist()
+    {
+        var pairs = _pairs
+            .Select(p => (new WorldCoord(p.Pin.X, 0, p.Pin.Z), p.Pixel))
+            .ToList();
+        // Zoom OCR/CV is deferred (#460) — calibrate at the default zoom stamp,
+        // consistent with the standalone window's unset-zoom path.
+        var result = _service.CalibrateCurrentArea(pairs, calibrationZoom: 1.0);
         if (result is not null) Disarm();
         return result;
+    }
+
+    private void SelectMarker(CalibrationMarker? m)
+    {
+        if (ReferenceEquals(SelectedMarker, m)) return;
+        if (SelectedMarker is { } prev) prev.IsSelected = false;
+        SelectedMarker = m;
+        if (m is not null) m.IsSelected = true;
+    }
+
+    private MapPin? ComputeSuggestion()
+    {
+        var candidates = _pins.CurrentAreaPins
+            .Where(p => !IsPaired(p) && !_skipped.Any(s => SameWorld(s, p)))
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            // Everything left is skipped — recycle so the user is never stuck.
+            candidates = _pins.CurrentAreaPins.Where(p => !IsPaired(p)).ToList();
+        }
+        if (candidates.Count == 0) return null;
+        if (_pairs.Count == 0) return candidates[0];
+
+        // Farthest-point: maximise the minimum world-distance to already-paired
+        // pins, so each new pair widens the geometric spread (a well-spread set
+        // conditions the similarity solve far better than a clustered one).
+        MapPin? best = null;
+        var bestMin = double.NegativeInfinity;
+        foreach (var c in candidates)
+        {
+            var min = _pairs.Min(p => WorldDist(p.Pin, c));
+            if (min > bestMin) { bestMin = min; best = c; }
+        }
+        return best;
+    }
+
+    private bool IsPaired(MapPin p) => _pairs.Any(q => SameWorld(q.Pin, p));
+
+    private static bool SameWorld(MapPin a, MapPin b) =>
+        Math.Abs(a.X - b.X) < 0.01 && Math.Abs(a.Z - b.Z) < 0.01;
+
+    private static double WorldDist(MapPin a, MapPin b)
+    {
+        var dx = a.X - b.X;
+        var dz = a.Z - b.Z;
+        return Math.Sqrt(dx * dx + dz * dz);
+    }
+
+    private void RecomputeResidual()
+    {
+        if (_pairs.Count < 3) { PreviewResidual = null; return; }
+        var refs = _pairs
+            .Select(p => new LandmarkCalibrationSolver.Reference(p.Pin.X, p.Pin.Z, p.Pixel))
+            .ToList();
+        PreviewResidual = LandmarkCalibrationSolver.Solve(refs)?.ResidualPixels;
     }
 
     private void OnPinSetChanged(PinSetChanged note)
@@ -195,43 +467,36 @@ public sealed partial class PinCalibrationCoordinator : ObservableObject
             Apply(note);
     }
 
-    private void Apply(PinSetChanged note)
-    {
-        // Keep the existing-pins picker mirroring the live set in all cases.
-        SyncExistingPins(note.Pins);
-
-        // Turn-order route: only genuinely-new pins dropped while armed
-        // enqueue. The service already suppresses replay re-adds, so no
-        // backlog can leak; the IsArmed gate scopes to the active session.
-        if (note is { Kind: PinSetChange.Added, Pin: { } pin } && IsArmed)
-        {
-            _pending.Enqueue(new WorldCoord(pin.X, 0, pin.Z));
-            RaiseCounts();
-        }
-    }
+    private void Apply(PinSetChanged note) => SyncExistingPins(note.Pins);
 
     /// <summary>Rebuild <see cref="ExistingPins"/> from a snapshot, preserving
-    /// the current selection by value when the same pin survives.</summary>
+    /// the override selection by value when the same pin survives.</summary>
     private void SyncExistingPins(IReadOnlyList<MapPin> pins)
     {
-        var prev = SelectedExistingPin;
+        var prevOverride = OverridePin;
         ExistingPins.Clear();
         foreach (var p in pins) ExistingPins.Add(p);
-        SelectedExistingPin = prev is null
+        OverridePin = prevOverride is null
             ? null
-            : ExistingPins.FirstOrDefault(p => p == prev);
-        OnPropertyChanged(nameof(HasUsableExistingPins));
+            : ExistingPins.FirstOrDefault(p => p == prevOverride);
+        OnPropertyChanged(nameof(PinsAvailable));
+        OnPropertyChanged(nameof(HasUsablePins));
+        OnPropertyChanged(nameof(SuggestedPin));
+        OnPropertyChanged(nameof(PromptText));
         OnPropertyChanged(nameof(StatusText));
     }
 
-    private static bool Same(WorldCoord a, WorldCoord b) =>
-        Math.Abs(a.X - b.X) < 0.01 && Math.Abs(a.Z - b.Z) < 0.01;
-
-    private void RaiseCounts()
+    private void RaiseAll()
     {
-        OnPropertyChanged(nameof(PendingCount));
+        OnPropertyChanged(nameof(PinsAvailable));
+        OnPropertyChanged(nameof(HasUsablePins));
         OnPropertyChanged(nameof(PairedCount));
-        OnPropertyChanged(nameof(CanSolve));
+        OnPropertyChanged(nameof(CanConfirm));
+        OnPropertyChanged(nameof(SuggestedPin));
+        OnPropertyChanged(nameof(PromptText));
         OnPropertyChanged(nameof(StatusText));
+        OnPropertyChanged(nameof(ResidualText));
+        OnPropertyChanged(nameof(IsResidualGood));
+        OnPropertyChanged(nameof(PhaseToggleLabel));
     }
 }

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.ViewModels;
 using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
@@ -45,39 +46,60 @@ public sealed class PlayerLogIngestionService : BackgroundService
     private readonly PlayerLogParser _parser;
     private readonly PlayerAreaTracker _areaTracker;
     private readonly IAreaCalibrationService _areaCalibration;
+    private readonly SurveyFlowController _flow;
     private readonly SessionState _session;
     private readonly LegolasSettings _settings;
     private readonly ModuleGates _gates;
     private readonly GameConfig _config;
+    private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
 
     private string? _lastAppliedArea;
+
+    /// <summary>
+    /// UTC instant this consumer went live. <c>ProcessMapFx</c> lines stamped
+    /// before it are the session-replay backlog (PG/the stream replays from
+    /// session start so the area→calibration bridge and the #468 pin tracker
+    /// can catch up) — they must NOT auto-populate stale survey pins from a run
+    /// the user already finished before opening Legolas. Set once when
+    /// ingestion starts.
+    /// </summary>
+    private DateTime _liveSince = DateTime.MinValue;
 
     public PlayerLogIngestionService(
         IPlayerLogStream stream,
         PlayerLogParser parser,
         PlayerAreaTracker areaTracker,
         IAreaCalibrationService areaCalibration,
+        SurveyFlowController flow,
         SessionState session,
         LegolasSettings settings,
         ModuleGates gates,
         GameConfig config,
+        TimeProvider? time = null,
         IDiagnosticsSink? diag = null)
     {
         _stream = stream;
         _parser = parser;
         _areaTracker = areaTracker;
         _areaCalibration = areaCalibration;
+        _flow = flow;
         _session = session;
         _settings = settings;
         _gates = gates;
         _config = config;
+        _time = time ?? TimeProvider.System;
         _diag = diag;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await _gates.For("legolas").WaitAsync(stoppingToken).ConfigureAwait(false);
+
+        // Everything already in Player.log at this point is replay/backlog —
+        // anchor the live cutoff before the stream yields the session-replay
+        // buffer, so a finished run's targets don't repopulate as fresh pins.
+        _liveSince = _time.GetUtcNow().UtcDateTime;
 
         // One-shot reverse-scan for the most recent LOADING LEVEL Area* line
         // before the live tail kicks in — best-effort, never blocks ingestion.
@@ -123,6 +145,31 @@ public sealed class PlayerLogIngestionService : BackgroundService
             _session.LastLogEvent = $"Map target: {Describe(mt)} → ignored (mode is Motherlode)";
             return;
         }
+
+        // Replay/backlog guard: the Player.log stream replays from session
+        // start (the area/calibration bridge and #468 pin tracker need it).
+        // A target stamped before this consumer went live is a pin from a run
+        // the user already finished — placing it would resurrect stale surveys
+        // on startup. Only genuinely-live uses (after Legolas opened) place.
+        if (mt.Timestamp < _liveSince)
+        {
+            _session.LastLogEvent =
+                $"Map target: {Describe(mt)} → ignored (log replay / pre-session backlog)";
+            return;
+        }
+
+        // FSM gate: a target only places while the survey flow is actually
+        // accepting one. Listening (resting/default) and Gathering (route in
+        // progress — new targets welcome, #454) accept; Done (run finished,
+        // awaiting reset) and SettingPosition (transient position-override
+        // detour) do not.
+        if (_flow.CurrentState is not (SurveyFlowState.Listening or SurveyFlowState.Gathering))
+        {
+            _session.LastLogEvent =
+                $"Map target: {Describe(mt)} → ignored (survey flow is {_flow.CurrentState})";
+            return;
+        }
+
         if (_areaCalibration.CurrentCalibration is not { } cal)
         {
             _session.LastLogEvent =

--- a/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
+++ b/src/Legolas.Module/ViewModels/LegolasWizardViewModel.cs
@@ -83,9 +83,16 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _session.Surveys.CollectionChanged += OnSurveysChangedForOverlays;
         _motherlodeFlow.PropertyChanged += OnMotherlodeFlowChanged;
         _session.PropertyChanged += OnSessionChanged;
-        // #460: once the area becomes calibrated (Solve persisted it), leave
-        // the Calibrating gate.
-        _areaCalibration.Changed += (_, _) => RecomputeStep();
+        // #460: once the area becomes calibrated (Confirm persisted it), leave
+        // the Calibrating gate. #477B: a clear/(re)calibrate also flips
+        // CanRecalibrate and must reset the confirm guard so a stale "are you
+        // sure?" can't carry across areas.
+        _areaCalibration.Changed += (_, _) =>
+        {
+            IsConfirmingRecalibrate = false;
+            OnPropertyChanged(nameof(CanRecalibrate));
+            RecomputeStep();
+        };
         if (_reportService is not null)
             _reportService.ReportGenerated += OnReportGenerated;
         RecomputeStep();
@@ -242,20 +249,73 @@ public sealed partial class LegolasWizardViewModel : ObservableObject
         _surveyFlow.Reset();
     }
 
-    /// <summary>#460 Calibrating step: solve + persist from the click-paired
-    /// pins. On success the area is calibrated, <c>Changed</c> fires, and the
-    /// wizard advances out of Calibrating (RecomputeStep).</summary>
+    /// <summary>#477A: flip the guided walkthrough between the Drop and Pair
+    /// phases. Lives on the wizard panel (a normal, always-clickable window) —
+    /// the transparent overlay can't host the trigger while click-through.</summary>
     [RelayCommand]
-    private void SolveCalibration()
+    private void ToggleCalibrationPhase() => PinCalibration.TogglePhase();
+
+    /// <summary>#477A: defer the currently-named pin and get the next
+    /// spread suggestion (no pair recorded).</summary>
+    [RelayCommand]
+    private void SkipCalibrationPin() => PinCalibration.SkipSuggestion();
+
+    /// <summary>#477A terminal Confirm: solve + persist, gated on ≥3 pairs and
+    /// a good residual. On success the area is calibrated, <c>Changed</c>
+    /// fires, and the wizard advances out of Calibrating (RecomputeStep).</summary>
+    [RelayCommand]
+    private void ConfirmCalibration()
     {
-        PinCalibration.Solve();
+        PinCalibration.Confirm();
         RecomputeStep();
     }
 
-    /// <summary>#460 Calibrating step: discard placed pairs and re-arm
-    /// capture for a fresh attempt.</summary>
+    /// <summary>#477A "finish anyway": persist despite a high residual (still
+    /// ≥3 pairs) — the non-affine ±10% ceiling means the user is never
+    /// trapped.</summary>
+    [RelayCommand]
+    private void ConfirmCalibrationAnyway()
+    {
+        PinCalibration.ConfirmAnyway();
+        RecomputeStep();
+    }
+
+    /// <summary>#477A: discard placed pairs and re-arm for a fresh attempt.</summary>
     [RelayCommand]
     private void ClearCalibrationPins() => PinCalibration.Arm();
+
+    /// <summary>#477B: true once the user has clicked "Recalibrate this area"
+    /// and we are waiting on the confirm guard (a misclick would wipe a good,
+    /// persisted calibration).</summary>
+    [ObservableProperty]
+    private bool _isConfirmingRecalibrate;
+
+    /// <summary>#477B: in-flow recalibration entry — only meaningful when the
+    /// current area is already calibrated. Arms the confirm guard rather than
+    /// destroying immediately.</summary>
+    [RelayCommand]
+    private void Recalibrate() => IsConfirmingRecalibrate = true;
+
+    /// <summary>#477B: confirmed recalibrate. Clears the current area's
+    /// persisted calibration; <see cref="IAreaCalibrationService.Changed"/>
+    /// makes <see cref="RecomputeStep"/> route back into
+    /// <see cref="WizardStep.Calibrating"/> via the same pin route as cold
+    /// start (<see cref="OnCurrentStepChanged"/> re-arms PinCalibration), so
+    /// Part A's guided correctable flow applies on the redo.</summary>
+    [RelayCommand]
+    private void ConfirmRecalibrate()
+    {
+        IsConfirmingRecalibrate = false;
+        _areaCalibration.ClearCurrentAreaCalibration();
+    }
+
+    /// <summary>#477B: back out of the recalibrate confirm guard.</summary>
+    [RelayCommand]
+    private void CancelRecalibrate() => IsConfirmingRecalibrate = false;
+
+    /// <summary>#477B: a "Recalibrate this area" affordance is offered only
+    /// when there is a persisted calibration to redo (Listening step).</summary>
+    public bool CanRecalibrate => _areaCalibration.IsCurrentAreaCalibrated;
 
     /// <summary>
     /// Step-wise back. From the first post-pick step, returns to mode pick

--- a/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MapOverlayViewModel.cs
@@ -40,8 +40,21 @@ public sealed partial class MapOverlayViewModel : ObservableObject
         if (_pinCal is not null)
             _pinCal.PropertyChanged += (_, e) =>
             {
-                if (e.PropertyName == nameof(PinCalibrationCoordinator.IsArmed))
+                if (e.PropertyName is nameof(PinCalibrationCoordinator.IsPairing)
+                                   or nameof(PinCalibrationCoordinator.IsDropping)
+                                   or nameof(PinCalibrationCoordinator.IsArmed))
+                {
                     OnPropertyChanged(nameof(IsCalibrationCapturing));
+                    OnPropertyChanged(nameof(IsCalibrationDropping));
+                }
+                else if (e.PropertyName is nameof(PinCalibrationCoordinator.PromptText))
+                {
+                    OnPropertyChanged(nameof(CalibrationPrompt));
+                }
+                else if (e.PropertyName is nameof(PinCalibrationCoordinator.SelectedMarker))
+                {
+                    OnPropertyChanged(nameof(HasSelectedCalibrationMarker));
+                }
             };
         if (_settings is not null)
         {
@@ -234,37 +247,93 @@ public sealed partial class MapOverlayViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(IsSettingPosition))]
     private void CancelSetPosition() => _surveyFlow.CancelSetPosition();
 
-    /// <summary>#460: true while the wizard <c>Calibrating</c> step has armed
-    /// pin-capture on this overlay. The view routes viewport clicks to
-    /// <see cref="PairCalibrationClick"/> while this holds.</summary>
-    public bool IsCalibrationCapturing => _pinCal?.IsArmed == true;
+    /// <summary>#460/#477A: true while the guided calibration walkthrough is in
+    /// its <see cref="CalibrationPhase.Pair"/> phase — the overlay captures
+    /// left-clicks (pair the named pin / select+drag a marker), so it must NOT
+    /// be click-through. The view routes viewport clicks to
+    /// <see cref="PairCalibrationClick"/> / marker selection while this holds.</summary>
+    public bool IsCalibrationCapturing => _pinCal?.IsPairing == true;
 
-    /// <summary>Pair a calibration overlay-click with the next pending
-    /// <c>ProcessMapPinAdd</c> world coord (turn order). No-op when not
-    /// capturing.</summary>
+    /// <summary>#477A: true while the walkthrough is in
+    /// <see cref="CalibrationPhase.Drop"/> — the overlay must be click-through
+    /// so right-clicks reach the game to drop pins. Drives the view's
+    /// phase-aware click-through override (the panel button toggles the phase,
+    /// not the overlay directly — the separate-window assumption).</summary>
+    public bool IsCalibrationDropping => _pinCal?.IsDropping == true;
+
+    /// <summary>Pair a calibration overlay-click with the currently-named
+    /// (suggested/overridden) pin. No-op when not in the Pair phase.</summary>
     public void PairCalibrationClick(PixelPoint pixel) => _pinCal?.PairClick(pixel);
+
+    /// <summary>Mouse-down hit-test against placed calibration markers
+    /// (select-then-drag correction). False ⇒ the click should pair instead.</summary>
+    public bool TrySelectCalibrationMarkerAt(PixelPoint at, double radius) =>
+        _pinCal?.TrySelectMarkerAt(at, radius) == true;
+
+    /// <summary>Drag the selected calibration marker to an absolute pixel.</summary>
+    public void DragCalibrationMarkerTo(PixelPoint at) => _pinCal?.DragSelectedTo(at);
+
+    /// <summary>True iff a calibration marker is currently selected (so the
+    /// nudge keys/pad target it ahead of survey pins / the manual anchor).</summary>
+    public bool HasSelectedCalibrationMarker => _pinCal?.SelectedMarker is not null;
+
+    /// <summary>Deselect any calibration marker (Escape, or starting a fresh
+    /// pair). No-op without a coordinator.</summary>
+    public void ClearCalibrationSelection() => _pinCal?.ClearSelection();
+
+    /// <summary>The guided walkthrough's current on-overlay prompt (names the
+    /// pin to click next, etc.). Empty without a coordinator.</summary>
+    public string CalibrationPrompt => _pinCal?.PromptText ?? string.Empty;
 
     /// <summary>Click-paired calibration markers to render on the overlay
     /// (null when no coordinator — e.g. the test ctor).</summary>
-    public System.Collections.ObjectModel.ObservableCollection<PixelPoint>? CalibrationMarkers
+    public System.Collections.ObjectModel.ObservableCollection<CalibrationMarker>? CalibrationMarkers
         => _pinCal?.PlacedMarkers;
 
     /// <summary>
-    /// Move the currently-nudgeable target by <c>(dx, dy) * step</c>. Routes
-    /// to <see cref="SessionState.SelectedSurvey"/> when one is selected and
-    /// has a pixel position; falls back to the player anchor while it's still
-    /// editable. No-op otherwise. Shared between the keyboard hotkey commands
-    /// (NudgePinCommandBase) and the on-screen nudge pad — same semantics, same
-    /// commit path through CorrectSurveyCommand / MoveAnchor.
+    /// Move the currently-nudgeable target by <c>(dx, dy) * step</c>. Precedence:
+    /// <list type="number">
+    /// <item>a selected <b>calibration marker</b> (#477A — the guided
+    /// walkthrough's just-placed/selected marker, correcting the dominant
+    /// click-precision error);</item>
+    /// <item>the selected <see cref="SessionState.SelectedSurvey"/> pin
+    /// (a survey still wins over the manual anchor);</item>
+    /// <item>the <b>manual</b> Survey player anchor (#477C) — only when no
+    /// survey is selected and <see cref="SessionState.SurveyPlayerIsManual"/>;
+    /// the auto/tracker-projected anchor is intentionally non-interactive
+    /// (nudging a data-sourced fix would mask staleness).</item>
+    /// </list>
+    /// No-op otherwise. Shared by the keyboard hotkeys (NudgePinCommandBase)
+    /// and the on-screen nudge pad.
     /// </summary>
     public void Nudge(double dx, double dy, double step)
     {
+        if (_pinCal?.SelectedMarker is not null)
+        {
+            _pinCal.NudgeSelected(dx * step, dy * step);
+            return;
+        }
+
         var selected = _session.SelectedSurvey;
         if (selected is not null && selected.EffectivePixel.HasValue)
         {
             var p = selected.EffectivePixel.Value;
             CorrectSurveyCommand.Execute(
                 new CorrectionArgs(selected, new PixelPoint(p.X + dx * step, p.Y + dy * step)));
+            return;
+        }
+
+        // #477C: the manual "Set my position" anchor is selectable/nudgeable on
+        // this same shared layer. Mutate only SurveyPlayerPixel and keep the
+        // manual flag (a fresh tracker fix still supersedes it per #476); never
+        // touch the Motherlode PlayerPosition or the retired MoveAnchor model.
+        if (_session.Mode == SessionMode.Survey
+            && _session.SurveyPlayerIsManual
+            && _session.SurveyPlayerPixel is { } anchor)
+        {
+            _session.SurveyPlayerPixel =
+                new PixelPoint(anchor.X + dx * step, anchor.Y + dy * step);
+            _session.SurveyPlayerIsManual = true;
         }
     }
 

--- a/src/Legolas.Module/ViewModels/NudgePadViewModel.cs
+++ b/src/Legolas.Module/ViewModels/NudgePadViewModel.cs
@@ -24,16 +24,28 @@ public sealed partial class NudgePadViewModel : ObservableObject
         _map = map;
         _settings = settings;
 
-        // The pad is "available" iff there's something to nudge: a selected
-        // survey, OR the player anchor while it's still editable. Recompute
-        // when either input changes so buttons enable/disable live.
+        // The pad is "available" iff there's something to nudge — the same
+        // precedence MapOverlayViewModel.Nudge applies: a selected #477A
+        // calibration marker, the selected survey, or the #477C manual player
+        // anchor. Recompute when any of those inputs change so the d-pad
+        // enables/disables live (its root binds IsEnabled to IsAvailable).
         _session.PropertyChanged += OnSessionChanged;
         _session.Surveys.CollectionChanged += (_, _) => RaiseAvailability();
+        _map.PropertyChanged += OnMapChanged;
     }
 
     private void OnSessionChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(SessionState.SelectedSurvey))
+        if (e.PropertyName is nameof(SessionState.SelectedSurvey)
+                           or nameof(SessionState.SurveyPlayerIsManual)
+                           or nameof(SessionState.SurveyPlayerPixel)
+                           or nameof(SessionState.Mode))
+            RaiseAvailability();
+    }
+
+    private void OnMapChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MapOverlayViewModel.HasSelectedCalibrationMarker))
             RaiseAvailability();
     }
 
@@ -43,20 +55,31 @@ public sealed partial class NudgePadViewModel : ObservableObject
         OnPropertyChanged(nameof(NudgeTargetLabel));
     }
 
-    /// <summary>True iff a survey pin is selected to nudge (#454: the
-    /// editable anchor is retired).</summary>
-    public bool IsAvailable => _session.SelectedSurvey is not null;
+    private bool IsManualAnchorNudgeable =>
+        _session.Mode == SessionMode.Survey
+        && _session.SurveyPlayerIsManual
+        && _session.SurveyPlayerPixel is not null;
+
+    /// <summary>True iff there is a nudge target: a selected calibration
+    /// marker (#477A), a selected survey pin, or the manual player anchor
+    /// (#477C).</summary>
+    public bool IsAvailable =>
+        _map.HasSelectedCalibrationMarker
+        || _session.SelectedSurvey is not null
+        || IsManualAnchorNudgeable;
 
     /// <summary>
-    /// Short human label of what the buttons will move. Used by the panel-side
-    /// pad so the user can tell at a glance which pin they're nudging.
+    /// Short human label of what the buttons will move. Mirrors the
+    /// <see cref="MapOverlayViewModel.Nudge"/> precedence.
     /// </summary>
     public string NudgeTargetLabel
     {
         get
         {
-            var sel = _session.SelectedSurvey;
-            return sel is not null ? $"Pin: {sel.Name}" : "(no target — select a pin)";
+            if (_map.HasSelectedCalibrationMarker) return "Calibration pin";
+            if (_session.SelectedSurvey is { } sel) return $"Pin: {sel.Name}";
+            if (IsManualAnchorNudgeable) return "Your position";
+            return "(no target — select a pin)";
         }
     }
 

--- a/src/Legolas.Module/Views/MapOverlayView.xaml
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml
@@ -60,12 +60,14 @@
                      on hover are not reproduced — see commit history. -->
                 <rendering:D2DOverlaySurface x:Name="MapSurface" IsHitTestVisible="False" />
 
-                <!-- #460: calibration capture. While the wizard Calibrating
-                     step has armed capture, viewport clicks pair with pending
-                     ProcessMapPinAdd coords; each paired click drops a marker
-                     here. IsHitTestVisible=False so clicks reach the Viewport
+                <!-- #460/#477A: guided calibration, Pair phase. Viewport clicks
+                     pair the wizard-named pin or grab a placed marker for
+                     drag/nudge correction (hit-test is VM-side). Markers are
+                     IsHitTestVisible=False so clicks reach the Viewport
                      handler. Zero-size Canvas + negative offsets so the dot
-                     sits exactly on the click (WPF Grid would re-centre it). -->
+                     sits exactly on the click (WPF Grid would re-centre it).
+                     #478 will drive this marker's appearance from
+                     LegolasPinStyle; today it is a fixed dot + selection ring. -->
                 <ItemsControl ItemsSource="{Binding CalibrationMarkers}" IsHitTestVisible="False"
                               Visibility="{Binding IsCalibrationCapturing, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
                     <ItemsControl.ItemsPanel>
@@ -79,8 +81,21 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Ellipse Width="12" Height="12" Margin="-6,-6,0,0"
-                                     Fill="#CC33C1FF" Stroke="White" StrokeThickness="1.5" />
+                            <!-- Zero-size Canvas so the dot's screen position
+                                 is independent of the selection ring: a Grid
+                                 auto-resizes 12→22px when IsSelected flips,
+                                 which slid already-placed dots down/right as
+                                 selection moved to the next pin. Canvas pins
+                                 each ellipse at a fixed offset from (X,Y). -->
+                            <Canvas Width="0" Height="0">
+                                <Ellipse Canvas.Left="-11" Canvas.Top="-11"
+                                         Width="22" Height="22"
+                                         Stroke="#FFFFD23F" StrokeThickness="2"
+                                         Visibility="{Binding IsSelected, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}" />
+                                <Ellipse Canvas.Left="-6" Canvas.Top="-6"
+                                         Width="12" Height="12"
+                                         Fill="#CC33C1FF" Stroke="White" StrokeThickness="1.5" />
+                            </Canvas>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -90,7 +105,7 @@
                         Background="#CC0A2A3A" BorderBrush="#FF33C1FF" BorderThickness="1"
                         CornerRadius="4" MaxWidth="520" IsHitTestVisible="False"
                         Visibility="{Binding IsCalibrationCapturing, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
-                    <TextBlock Text="Calibration: pick a pin in the wizard and click where it is here — or, if you dropped fresh pins, click them here in the order you dropped them."
+                    <TextBlock Text="{Binding CalibrationPrompt}"
                                Foreground="#FFE0F4FF" TextWrapping="Wrap" TextAlignment="Center" FontSize="13" />
                 </Border>
 

--- a/src/Legolas.Module/Views/MapOverlayView.xaml.cs
+++ b/src/Legolas.Module/Views/MapOverlayView.xaml.cs
@@ -30,6 +30,10 @@ public partial class MapOverlayView : Window
     //  * Drag moves SessionState.SelectedSurvey (picked from the wizard
     //    panel's survey list) — a local pixel correction, no recalibration.
     private SurveyItemViewModel? _draggingPinFromViewport;
+    // #477A: a placed calibration marker grabbed for drag-correction.
+    private bool _draggingCalibrationMarker;
+    // Hit-radius (px) for grabbing a calibration marker before a click pairs.
+    private const double CalibrationMarkerGrabRadius = 14;
 
     private readonly D2DBrushCache _brushCache = new();
     private readonly MarchingAntsClock _antsClock = new();
@@ -54,7 +58,7 @@ public partial class MapOverlayView : Window
         // arrives, so Command/IsChecked bindings inside the pad always work.
         OverlayNudgePad.DataContext = nudgePad;
         WindowLayoutBinder.Bind(this, settings.MapOverlay, saver.Touch);
-        Loaded += (_, _) => ClickThrough.Apply(this, settings.ClickThroughMap);
+        Loaded += (_, _) => ApplyClickThrough();
         // Re-assert TOPMOST on every show + on a low-frequency timer while
         // visible — Loaded/Activated alone miss the Hide()/Show() cycle the
         // OverlayController drives when the game holds the foreground.
@@ -62,7 +66,20 @@ public partial class MapOverlayView : Window
         settings.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(LegolasSettings.ClickThroughMap))
-                ClickThrough.Apply(this, settings.ClickThroughMap);
+                ApplyClickThrough();
+        };
+        // #477A: the calibration phase overrides the user's click-through
+        // preference — Drop must pass right-clicks to the game (click-through
+        // ON), Pair must capture left-clicks (OFF). The wizard-panel button
+        // toggles the phase; the overlay reacts here (it can't host the trigger
+        // — it's a transparent, possibly click-through window).
+        DataContextChanged += (_, e) =>
+        {
+            if (e.OldValue is MapOverlayViewModel oldVm)
+                oldVm.PropertyChanged -= OnOverlayVmPropertyChanged;
+            if (e.NewValue is MapOverlayViewModel newVm)
+                newVm.PropertyChanged += OnOverlayVmPropertyChanged;
+            ApplyClickThrough();
         };
         Closed += (_, _) =>
         {
@@ -168,6 +185,28 @@ public partial class MapOverlayView : Window
         PinSceneRenderer.Render(scene, e.RenderTarget, e.Factory, _brushCache);
     }
 
+    private void OnOverlayVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MapOverlayViewModel.IsCalibrationCapturing)
+                           or nameof(MapOverlayViewModel.IsCalibrationDropping))
+            ApplyClickThrough();
+    }
+
+    /// <summary>The calibration phase overrides the user's click-through
+    /// preference: Drop ⇒ click-through ON (right-clicks reach the game), Pair
+    /// ⇒ OFF (the overlay captures the pairing/correction left-clicks). Outside
+    /// calibration, honour <see cref="LegolasSettings.ClickThroughMap"/>.</summary>
+    private void ApplyClickThrough()
+    {
+        var clickThrough = Settings?.ClickThroughMap ?? false;
+        if (DataContext is MapOverlayViewModel vm)
+        {
+            if (vm.IsCalibrationDropping) clickThrough = true;
+            else if (vm.IsCalibrationCapturing) clickThrough = false;
+        }
+        ClickThrough.Apply(this, clickThrough);
+    }
+
     private static Color ParseColor(string hex) => LegolasBrushes.Parse(hex);
 
     private void Header_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -185,6 +224,8 @@ public partial class MapOverlayView : Window
         // focus. Local handler now only clears the active selection on Escape.
         if (DataContext is MapOverlayViewModel vm && e.Key == Key.Escape)
         {
+            // Clear whichever selection is live so a stray arrow does nothing.
+            vm.ClearCalibrationSelection();
             vm.Session.SelectedSurvey = null;
             e.Handled = true;
             return;
@@ -207,12 +248,20 @@ public partial class MapOverlayView : Window
         var canvasPos = Mouse.GetPosition(Viewport);
         var clickPoint = new PixelPoint(canvasPos.X, canvasPos.Y);
 
-        // #460: while the wizard Calibrating step has armed capture, a
-        // viewport click pairs with the next pending ProcessMapPinAdd world
-        // coord (turn order). Consumes the click — no placement / mode logic.
+        // #460/#477A: in the guided walkthrough's Pair phase the overlay
+        // captures clicks. A click first tries to grab a placed marker for
+        // drag-correction; if none is near, it pairs the currently-named pin.
         if (vm.IsCalibrationCapturing)
         {
-            vm.PairCalibrationClick(clickPoint);
+            if (vm.TrySelectCalibrationMarkerAt(clickPoint, CalibrationMarkerGrabRadius))
+            {
+                _draggingCalibrationMarker = true;
+                Viewport.CaptureMouse();
+            }
+            else
+            {
+                vm.PairCalibrationClick(clickPoint);
+            }
             e.Handled = true;
             return;
         }
@@ -240,6 +289,12 @@ public partial class MapOverlayView : Window
         if (DataContext is not MapOverlayViewModel vm) return;
         var canvasPos = Mouse.GetPosition(Viewport);
 
+        if (_draggingCalibrationMarker)
+        {
+            vm.DragCalibrationMarkerTo(new PixelPoint(canvasPos.X, canvasPos.Y));
+            return;
+        }
+
         if (_draggingPinFromViewport is not null)
         {
             ApplyDraggedPinPosition(canvasPos);
@@ -250,6 +305,14 @@ public partial class MapOverlayView : Window
     {
         if (!Viewport.IsMouseCaptured) return;
         Viewport.ReleaseMouseCapture();
+
+        if (_draggingCalibrationMarker)
+        {
+            // The drag already committed live via DragCalibrationMarkerTo;
+            // just end the gesture (the marker stays selected for nudging).
+            _draggingCalibrationMarker = false;
+            return;
+        }
 
         if (_draggingPinFromViewport is not null && DataContext is MapOverlayViewModel vm)
         {

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -234,28 +234,47 @@
                     </StackPanel>
                 </StackPanel>
 
-                <!-- Calibrating (#460: cold-start gate — uncalibrated area.
-                     Capture happens on the map overlay, not a separate
-                     window; this panel is just guidance + status + Solve. -->
+                <!-- Calibrating (#460/#477A: guided two-phase correctable
+                     walkthrough. Capture happens on the map overlay, not a
+                     separate window; this always-clickable panel hosts the
+                     phase trigger, the named-pin prompt, the live residual,
+                     and the terminal Confirm. -->
                 <StackPanel Visibility="{Binding CurrentStep, Converter={x:Static controls:EnumMatchConverter.ToVisibility}, ConverterParameter=Calibrating}">
                     <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,12"
                                FontSize="{DynamicResource AppFontSizeBody}"
                                Foreground="{StaticResource TextSecondaryBrush}">
-                        <Run Text="This area isn't calibrated yet, so pins can't place. Calibrate it below:" />
+                        <Run Text="This area isn't calibrated yet, so pins can't place. Two steps: drop well-spread map pins in-game, then click each one through the overlay to pair it." />
                     </TextBlock>
 
-                    <!-- #468 Existing-pins route: shown when the player already
-                         has ≥3 pins here. Identify each by name + colour/shape
-                         (UX only — the solve still pairs world↔pixel). -->
-                    <StackPanel Visibility="{Binding PinCalibration.HasUsableExistingPins, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                    <!-- Live status (drop count / named-pin prompt). -->
+                    <TextBlock Text="{Binding PinCalibration.StatusText}"
+                               TextWrapping="Wrap" TextAlignment="Center" Margin="0,0,0,12"
+                               FontSize="{DynamicResource AppFontSizeBody}"
+                               Foreground="{StaticResource AccentBrush}" />
+
+                    <!-- Phase trigger: "Done dropping — pair them" / "Drop more
+                         pins". Always clickable (this panel is not the
+                         transparent overlay). An optional hotkey mirrors it. -->
+                    <Button Content="{Binding PinCalibration.PhaseToggleLabel}"
+                            Style="{StaticResource WizardPrimaryButton}"
+                            HorizontalAlignment="Center" Margin="0,0,0,12"
+                            Command="{Binding ToggleCalibrationPhaseCommand}" />
+
+                    <!-- Pair-phase controls: skip the named pin, or override
+                         to any pin by identity (UX only — solve stays
+                         world↔pixel). -->
+                    <StackPanel Visibility="{Binding PinCalibration.IsPairing, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
                                 Margin="0,0,0,12">
-                        <TextBlock Text="You already have pins here. Pick one, then click where it is on the map — repeat for ≥3 well-spread pins:"
-                                   TextWrapping="Wrap" TextAlignment="Center"
-                                   FontSize="{DynamicResource AppFontSizeBody}"
-                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,8" />
+                        <Button Content="Skip this pin" Style="{StaticResource WizardPrimaryButton}"
+                                HorizontalAlignment="Center" Margin="0,0,0,8"
+                                Command="{Binding SkipCalibrationPinCommand}" />
+                        <TextBlock Text="Or pick the pin you're clicking (optional):"
+                                   TextAlignment="Center"
+                                   FontSize="{DynamicResource AppFontSize}"
+                                   Foreground="{StaticResource TextTertiaryBrush}" Margin="0,0,0,4" />
                         <ListBox ItemsSource="{Binding PinCalibration.ExistingPins}"
-                                 SelectedItem="{Binding PinCalibration.SelectedExistingPin, Mode=TwoWay}"
-                                 MaxHeight="160" HorizontalAlignment="Center" MinWidth="240"
+                                 SelectedItem="{Binding PinCalibration.OverridePin, Mode=TwoWay}"
+                                 MaxHeight="140" HorizontalAlignment="Center" MinWidth="240"
                                  Background="Transparent" BorderThickness="0">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
@@ -270,29 +289,39 @@
                         </ListBox>
                     </StackPanel>
 
-                    <!-- Turn-order fallback: true cold-start (no usable pins /
-                         fogged brand-new area). Collapses once the existing-pins
-                         route is available. -->
-                    <StackPanel HorizontalAlignment="Center" Margin="0,0,0,12"
-                                Visibility="{Binding PinCalibration.HasUsableExistingPins, Converter={x:Static controls:BoolToVisibilityConverter.Inverse}}">
-                        <TextBlock Text="1.  Drop ≥3 well-spread map pins in-game (works on a fogged/blank map)"
-                                   FontSize="{DynamicResource AppFontSizeBody}"
-                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
-                        <TextBlock Text="2.  Click each pin's spot on the map overlay, in the same order"
-                                   FontSize="{DynamicResource AppFontSizeBody}"
-                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
-                        <TextBlock Text="3.  Solve — the area calibrates and the wizard continues"
-                                   FontSize="{DynamicResource AppFontSizeBody}"
-                                   Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
-                    </StackPanel>
-                    <TextBlock Text="{Binding PinCalibration.StatusText}"
+                    <!-- Live, non-persisting fit quality (≥3 pairs). -->
+                    <TextBlock Text="{Binding PinCalibration.ResidualText}"
                                TextWrapping="Wrap" TextAlignment="Center" Margin="0,0,0,12"
                                FontSize="{DynamicResource AppFontSizeBody}"
-                               Foreground="{StaticResource AccentBrush}" />
+                               Foreground="{StaticResource TextSecondaryBrush}" />
+
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button Content="Solve" Style="{StaticResource WizardPrimaryButton}"
-                                Command="{Binding SolveCalibrationCommand}"
-                                IsEnabled="{Binding PinCalibration.CanSolve}" />
+                        <Button Content="Confirm" Style="{StaticResource WizardPrimaryButton}"
+                                Command="{Binding ConfirmCalibrationCommand}"
+                                ToolTip="Save this calibration and continue"
+                                IsEnabled="{Binding PinCalibration.IsResidualGood}" />
+                        <!-- finish anyway: only when ≥3 pairs but the residual
+                             is above target (never trap the user at the ±10%
+                             ceiling). -->
+                        <Button Content="Finish anyway"
+                                Command="{Binding ConfirmCalibrationAnywayCommand}"
+                                ToolTip="The fit is loose (the in-game map isn't perfectly affine) — save it regardless"
+                                IsEnabled="{Binding PinCalibration.CanConfirm}">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource WizardPrimaryButton}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding PinCalibration.CanConfirm}" Value="True" />
+                                                <Condition Binding="{Binding PinCalibration.IsResidualGood}" Value="False" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
                         <Button Content="Clear pins" Style="{StaticResource WizardPrimaryButton}" Margin="0"
                                 Command="{Binding ClearCalibrationPinsCommand}" />
                     </StackPanel>
@@ -319,11 +348,35 @@
                                        FontSize="{DynamicResource AppFontSizeBody}"
                                        Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,2" />
                         </StackPanel>
-                        <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0,12,0,0"
-                                   FontSize="{DynamicResource AppFontSizeBody}"
-                                   Foreground="{StaticResource TextTertiaryBrush}">
-                            <Run Text="No pins appearing? This area isn't calibrated yet — open Calibration (crosshair, top-right) and drop a few calib pins. (Guided cold-start calibration is coming.)" />
-                        </TextBlock>
+                        <!-- #477B: in-flow recalibration. Offered only when the
+                             area is already calibrated; the guided cold-start
+                             path (Part A) handles the uncalibrated case before
+                             this step is ever reached. A confirm guard protects
+                             the persisted calibration from a misclick. -->
+                        <StackPanel Margin="0,12,0,0"
+                                    Visibility="{Binding CanRecalibrate, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}">
+                            <Button Content="Recalibrate this area"
+                                    HorizontalAlignment="Center"
+                                    Command="{Binding RecalibrateCommand}"
+                                    Visibility="{Binding IsConfirmingRecalibrate, Converter={x:Static controls:BoolToVisibilityConverter.Inverse}}"
+                                    ToolTip="Pins landing wrong? Drop this area's saved calibration and redo it with the guided flow." />
+                            <Border Visibility="{Binding IsConfirmingRecalibrate, Converter={x:Static controls:BoolToVisibilityConverter.Instance}}"
+                                    Background="{StaticResource AccentSoftBrush}" CornerRadius="3" Padding="12,8"
+                                    HorizontalAlignment="Center">
+                                <StackPanel>
+                                    <TextBlock Text="This deletes the saved calibration for this area and restarts the guided flow. Continue?"
+                                               TextAlignment="Center" TextWrapping="Wrap" MaxWidth="320"
+                                               Foreground="{StaticResource AccentSoftTextBrush}"
+                                               FontSize="{DynamicResource AppFontSizeBody}" Margin="0,0,0,8" />
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                        <Button Content="Recalibrate" Margin="0,0,8,0"
+                                                Command="{Binding ConfirmRecalibrateCommand}" />
+                                        <Button Content="Cancel"
+                                                Command="{Binding CancelRecalibrateCommand}" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
                         <TextBlock TextWrapping="Wrap" TextAlignment="Center" Margin="0,12,0,0"
                                    FontSize="{DynamicResource AppFontSizeBody}"
                                    Foreground="{StaticResource TextTertiaryBrush}">

--- a/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Services;
-using Mithril.GameState.Pins;
 using Mithril.Shared.Reference;
 using Xunit;
 using PinShape = Mithril.GameState.Pins.PinShape;
@@ -10,167 +9,333 @@ using PinColor = Mithril.GameState.Pins.PinColor;
 namespace Legolas.Tests.Services;
 
 /// <summary>
-/// #468: the cold-start pin-calibration driver now consumes the GameState
-/// <see cref="IPlayerPinTracker"/>. Two routes, one solve — and the #454
-/// label-agnostic rule is preserved (the solve only ever sees world↔pixel).
+/// #477 Part A: the guided two-phase correctable walkthrough. One model, two
+/// phases; spread-suggested pairing with skip/override; non-persisting residual
+/// preview; correction (select/drag/nudge); terminal Confirm. The #454
+/// label-agnostic rule still holds — only (world↔pixel) reaches the solver.
 /// </summary>
 public class PinCalibrationCoordinatorTests
 {
-    private static (PinCalibrationCoordinator coord, FakeCalib calib, FakePlayerPinTracker pins) Build()
+    private static (PinCalibrationCoordinator coord, FakeCalib calib, FakePlayerPinTracker pins, LegolasSettings settings) Build()
     {
         var calib = new FakeCalib();
         var pins = new FakePlayerPinTracker();
-        return (new PinCalibrationCoordinator(calib, pins), calib, pins);
+        var settings = new LegolasSettings();
+        return (new PinCalibrationCoordinator(calib, pins, settings), calib, pins, settings);
     }
 
-    // ---- Turn-order (freshly-dropped) route ----
+    // A well-conditioned scale-only transform: pixel = (100 + 2X, 100 - 2Z),
+    // i.e. AreaCalibration{scale=2, origin=(100,100), no rotation, north=+Z}.
+    private static PixelPoint Project(double x, double z) => new(100 + 2 * x, 100 - 2 * z);
 
-    [Fact]
-    public void Pre_arm_drops_are_ignored_so_replay_cannot_leak()
+    // Pair every remaining pin at its own perfect projection, in whatever
+    // spread order the coordinator suggests (the no-correction baseline).
+    private static void PairAllPerfectly(PinCalibrationCoordinator coord)
     {
-        var (coord, _, pins) = Build();
-        pins.Add(-521, 368);
-        pins.Add(367, 2798);
-
-        coord.PendingCount.Should().Be(0);
-        coord.PairClick(new PixelPoint(1, 1));
-        coord.PairedCount.Should().Be(0);
+        while (coord.SuggestedPin is { } s)
+            coord.PairClick(Project(s.X, s.Z));
     }
 
+    // ---- Phase model ----
+
     [Fact]
-    public void Armed_fresh_drops_queue_and_pair_in_turn_order()
+    public void Arm_starts_in_Drop_when_under_three_pins_else_Pair()
     {
-        var (coord, calib, pins) = Build();
+        var (coord, _, pins, _) = Build();
         coord.Arm();
+        coord.Phase.Should().Be(CalibrationPhase.Drop, "no pins yet");
 
-        var w0 = pins.Add(-521, 368);
-        var w1 = pins.Add(367, 2798);
-        var w2 = pins.Add(1145, 1323);
-        coord.PendingCount.Should().Be(3);
-        coord.CanSolve.Should().BeFalse();
-
-        coord.PairClick(new PixelPoint(10, 11));
-        coord.PairClick(new PixelPoint(20, 22));
-        coord.PairClick(new PixelPoint(30, 33));
-
-        coord.PairedCount.Should().Be(3);
-        coord.PendingCount.Should().Be(0);
-        coord.CanSolve.Should().BeTrue();
-        coord.PlacedMarkers.Should().HaveCount(3);
-
-        coord.Solve().Should().NotBeNull();
-        calib.LastPairs.Should().Equal(
-            (new WorldCoord(w0.X, 0, w0.Z), new PixelPoint(10, 11)),
-            (new WorldCoord(w1.X, 0, w1.Z), new PixelPoint(20, 22)),
-            (new WorldCoord(w2.X, 0, w2.Z), new PixelPoint(30, 33)));
-        coord.IsArmed.Should().BeFalse("a successful solve disarms");
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(1, 2), FakePlayerPinTracker.Pin(3, 4), FakePlayerPinTracker.Pin(5, 6));
+        coord.Arm();
+        coord.Phase.Should().Be(CalibrationPhase.Pair, "≥3 usable pins → skip Drop");
     }
 
-    // ---- Existing-pins route ----
+    [Fact]
+    public void Phase_toggle_flips_capture_intent_and_is_idempotent()
+    {
+        var (coord, _, _, _) = Build();
+        coord.Arm(); // Drop
+        coord.IsDropping.Should().BeTrue();
+        coord.IsPairing.Should().BeFalse();
+
+        coord.TogglePhase();
+        coord.Phase.Should().Be(CalibrationPhase.Pair);
+        coord.IsPairing.Should().BeTrue();
+        coord.IsDropping.Should().BeFalse();
+
+        coord.TogglePhase();
+        coord.Phase.Should().Be(CalibrationPhase.Drop, "toggle is a clean flip-back");
+    }
 
     [Fact]
-    public void Existing_pins_are_offered_and_pair_by_deliberate_selection()
+    public void Phase1_live_count_reflects_PinSetChanged_Added()
     {
-        var (coord, calib, pins) = Build();
-        var a = FakePlayerPinTracker.Pin(10, 20, "Fire Magic 25", PinShape.Dot, PinColor.Red);
-        var b = FakePlayerPinTracker.Pin(30, 40, "North", PinShape.Square, PinColor.White);
-        var c = FakePlayerPinTracker.Pin(50, 60, "");
+        var (coord, _, pins, _) = Build();
+        coord.Arm();
+        coord.PinsAvailable.Should().Be(0);
+        pins.Add(1, 2);
+        pins.Add(3, 4);
+        coord.PinsAvailable.Should().Be(2);
+        coord.HasUsablePins.Should().BeFalse();
+        pins.Add(5, 6);
+        coord.HasUsablePins.Should().BeTrue();
+    }
+
+    // ---- Spread suggestion + skip/override ----
+
+    [Fact]
+    public void Suggestion_is_the_farthest_unpaired_pin_from_already_paired()
+    {
+        var (coord, _, pins, _) = Build();
+        var near = FakePlayerPinTracker.Pin(11, 10);
+        var far = FakePlayerPinTracker.Pin(900, 900);
+        pins.SeedExisting(FakePlayerPinTracker.Pin(10, 10), near, far);
+        coord.Arm(); // Pair (3 pins)
+
+        // First suggestion (no pairs yet) is deterministic: list head.
+        coord.SuggestedPin!.X.Should().Be(10);
+        coord.PairClick(Project(10, 10));
+
+        // Now the farthest-from-(10,10) unpaired pin wins.
+        coord.SuggestedPin.Should().Be(far);
+    }
+
+    [Fact]
+    public void Skip_defers_the_pin_without_recording_a_pair()
+    {
+        var (coord, _, pins, _) = Build();
+        var a = FakePlayerPinTracker.Pin(10, 10);
+        var b = FakePlayerPinTracker.Pin(20, 20);
+        var c = FakePlayerPinTracker.Pin(30, 30);
         pins.SeedExisting(a, b, c);
-
         coord.Arm();
-        coord.HasUsableExistingPins.Should().BeTrue();
-        coord.ExistingPins.Should().HaveCount(3);
-        // UX identity is derivable (used only to help the human pick).
-        a.Appearance.Should().Be("red dot");
 
-        coord.SelectedExistingPin = b;
-        coord.PairClick(new PixelPoint(1, 1));
-        coord.SelectedExistingPin = a;
-        coord.PairClick(new PixelPoint(2, 2));
-        coord.SelectedExistingPin = c;
-        coord.PairClick(new PixelPoint(3, 3));
-
-        coord.PairedCount.Should().Be(3);
-        coord.Solve().Should().NotBeNull();
-        // Pairs follow the user's selection order — not list/turn order — and
-        // carry only world↔pixel (no label/colour reaches the solver).
-        calib.LastPairs.Should().Equal(
-            (new WorldCoord(30, 0, 40), new PixelPoint(1, 1)),
-            (new WorldCoord(10, 0, 20), new PixelPoint(2, 2)),
-            (new WorldCoord(50, 0, 60), new PixelPoint(3, 3)));
+        var first = coord.SuggestedPin;
+        coord.SkipSuggestion();
+        coord.PairedCount.Should().Be(0, "skip records nothing");
+        coord.SuggestedPin.Should().NotBe(first, "a different pin is offered");
     }
 
     [Fact]
-    public void Snapshot_seeds_existing_pins_before_arming()
+    public void Override_pin_takes_precedence_over_the_spread_suggestion()
     {
-        var calib = new FakeCalib();
-        var pins = new FakePlayerPinTracker();
-        pins.SeedExisting(FakePlayerPinTracker.Pin(1, 2), FakePlayerPinTracker.Pin(3, 4));
+        var (coord, _, pins, _) = Build();
+        var a = FakePlayerPinTracker.Pin(10, 10);
+        var b = FakePlayerPinTracker.Pin(20, 20);
+        var c = FakePlayerPinTracker.Pin(30, 30);
+        pins.SeedExisting(a, b, c);
+        coord.Arm();
 
-        var coord = new PinCalibrationCoordinator(calib, pins); // Subscribe → Snapshot
-        coord.ExistingPins.Should().HaveCount(2);
-        coord.HasUsableExistingPins.Should().BeFalse("only 2 < 3");
+        coord.OverridePin = c;
+        coord.SuggestedPin.Should().Be(c);
+        coord.PairClick(Project(30, 30));
+        // Solver only ever sees (world↔pixel) — verified on Confirm below.
+        coord.PairedCount.Should().Be(1);
+        coord.OverridePin.Should().BeNull("cleared once paired");
+    }
+
+    // ---- Pairing (implicit advance) + finalize floor ----
+
+    [Fact]
+    public void Pairing_is_implicit_advance_and_under_three_cannot_finalize()
+    {
+        var (coord, calib, pins, _) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        coord.Arm();
+
+        coord.PairClick(Project(10, 10));
+        coord.PairClick(Project(50, 60));
+        coord.PairedCount.Should().Be(2);
+        coord.CanConfirm.Should().BeFalse();
+        coord.Confirm().Should().BeNull("≥3 pairs is a hard floor");
+        coord.ConfirmAnyway().Should().BeNull();
+        calib.LastPairs.Should().BeNull("nothing persisted below the floor");
+
+        coord.PairClick(Project(90, 20));
+        coord.CanConfirm.Should().BeTrue();
     }
 
     [Fact]
     public void Duplicate_world_point_is_rejected_to_keep_the_solve_conditioned()
     {
-        var (coord, _, _) = Build();
+        var (coord, _, pins, _) = Build();
         var p = FakePlayerPinTracker.Pin(10, 20, "A");
+        pins.SeedExisting(p);
         coord.Arm();
-        coord.SelectedExistingPin = p;
+        coord.TogglePhase(); // 1 pin → entered in Drop; move to Pair
+        coord.OverridePin = p;
         coord.PairClick(new PixelPoint(1, 1));
-        coord.SelectedExistingPin = p; // same pin again
+        coord.OverridePin = p; // same pin again
         coord.PairClick(new PixelPoint(9, 9));
         coord.PairedCount.Should().Be(1);
     }
 
-    // ---- Shared invariants ----
+    // ---- Correction (select / drag / nudge) ----
 
     [Fact]
-    public void Solve_below_three_pairs_is_null_and_does_not_call_service()
+    public void Hit_test_selects_nearest_marker_and_drag_moves_only_that_pixel()
     {
-        var (coord, calib, pins) = Build();
+        var (coord, calib, pins, _) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
         coord.Arm();
-        pins.Add(1, 2);
-        coord.PairClick(new PixelPoint(5, 5));
+        PairAllPerfectly(coord); // marker[0] is the first-suggested pin = (10,10)
 
-        coord.CanSolve.Should().BeFalse();
-        coord.Solve().Should().BeNull();
-        calib.LastPairs.Should().BeNull();
+        var other = coord.PlacedMarkers[1];
+        var otherPixel = other.Pixel;
+
+        coord.TrySelectMarkerAt(new PixelPoint(121, 81), radius: 14).Should().BeTrue();
+        coord.SelectedMarker!.PairIndex.Should().Be(0);
+        coord.SelectedMarker.Pixel.Should().Be(Project(10, 10));
+
+        coord.DragSelectedTo(new PixelPoint(500, 500));
+        coord.PlacedMarkers[0].Pixel.Should().Be(new PixelPoint(500, 500));
+        other.Pixel.Should().Be(otherPixel, "other markers are untouched");
+
+        coord.NudgeSelected(3, -2);
+        coord.PlacedMarkers[0].Pixel.Should().Be(new PixelPoint(503, 498));
+
+        // The world half is never mutated — Confirm proves the pairs carry the
+        // dragged pixel against the ORIGINAL world coords.
+        coord.Confirm(); // residual high after the drag → gated; force anyway
+        coord.ConfirmAnyway();
+        calib.LastPairs!.Should().Contain(p =>
+            p.Item1 == new WorldCoord(10, 0, 10) && p.Item2 == new PixelPoint(503, 498));
+        calib.LastPairs!.Should().Contain(p =>
+            p.Item1 == new WorldCoord(50, 0, 60) && p.Item2 == Project(50, 60));
     }
 
     [Fact]
-    public void Arm_clears_stale_state_then_Disarm_flushes()
+    public void Miss_returns_false_so_the_click_pairs_instead()
     {
-        var (coord, _, pins) = Build();
+        var (coord, _, pins, _) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
         coord.Arm();
-        pins.Add(1, 2);
-        coord.PairClick(new PixelPoint(5, 5));
+        coord.PairClick(Project(10, 10));
+        coord.TrySelectMarkerAt(new PixelPoint(9999, 9999), radius: 14).Should().BeFalse();
+    }
+
+    // ---- Non-persisting residual preview ----
+
+    [Fact]
+    public void Residual_preview_is_non_persisting_and_equals_a_direct_solve()
+    {
+        var (coord, calib, pins, _) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        coord.Arm();
+
+        coord.PreviewResidual.Should().BeNull("under 3 pairs");
+        PairAllPerfectly(coord);
+
+        coord.PreviewResidual.Should().NotBeNull();
+        calib.LastPairs.Should().BeNull("preview must not persist");
+        calib.ChangedCount.Should().Be(0, "preview must not fire Changed");
+
+        // Equals a direct solve of the same (world↔pixel) pairs. Residual is
+        // order-independent, so the suggestion order doesn't matter.
+        var refs = new[]
+        {
+            new LandmarkCalibrationSolver.Reference(10, 10, Project(10, 10)),
+            new LandmarkCalibrationSolver.Reference(50, 60, Project(50, 60)),
+            new LandmarkCalibrationSolver.Reference(90, 20, Project(90, 20)),
+        };
+        var direct = LandmarkCalibrationSolver.Solve(refs)!.ResidualPixels;
+        coord.PreviewResidual!.Value.Should().BeApproximately(direct, 1e-6);
+    }
+
+    [Fact]
+    public void Confirm_gate_flips_at_the_configured_threshold_and_finish_anyway_persists()
+    {
+        var (coord, calib, pins, settings) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        coord.Arm();
+
+        coord.PairClick(Project(10, 10));
+        coord.PairClick(Project(50, 60));
+        // One badly misplaced click → a large residual.
+        coord.PairClick(new PixelPoint(Project(90, 20).X + 400, Project(90, 20).Y));
+
+        coord.IsResidualGood.Should().BeFalse();
+        coord.Confirm().Should().BeNull("gated on a good residual");
+        calib.LastPairs.Should().BeNull();
+
+        // Raise the threshold above the residual → the gate opens.
+        settings.CalibrationGoodResidualPx = coord.PreviewResidual!.Value + 10;
+        coord.IsResidualGood.Should().BeTrue();
+        coord.Confirm().Should().NotBeNull();
+        coord.IsArmed.Should().BeFalse("a successful confirm disarms");
+    }
+
+    [Fact]
+    public void No_correction_run_solves_equivalently_and_only_Confirm_persists()
+    {
+        var (coord, calib, pins, _) = Build();
+        var a = FakePlayerPinTracker.Pin(10, 10);
+        var b = FakePlayerPinTracker.Pin(50, 60);
+        var c = FakePlayerPinTracker.Pin(90, 20);
+        pins.SeedExisting(a, b, c);
+        coord.Arm();
+
+        // Click each named dot precisely (the regression baseline).
+        while (coord.SuggestedPin is { } s)
+            coord.PairClick(Project(s.X, s.Z));
+
+        calib.LastPairs.Should().BeNull("only Confirm persists");
+        coord.Confirm().Should().NotBeNull();
+        // Pure (world↔pixel); no label/colour/shape ever reaches the solver.
+        calib.LastPairs.Should().BeEquivalentTo(new[]
+        {
+            (new WorldCoord(10, 0, 10), Project(10, 10)),
+            (new WorldCoord(50, 0, 60), Project(50, 60)),
+            (new WorldCoord(90, 0, 20), Project(90, 20)),
+        });
+    }
+
+    [Fact]
+    public void Arm_clears_stale_state()
+    {
+        var (coord, _, pins, _) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        coord.Arm();
+        coord.PairClick(Project(10, 10));
         coord.PairedCount.Should().Be(1);
 
         coord.Arm();
         coord.PairedCount.Should().Be(0);
-        coord.PendingCount.Should().Be(0);
         coord.PlacedMarkers.Should().BeEmpty();
-
-        pins.Add(3, 4);
-        coord.PendingCount.Should().Be(1);
-        coord.Disarm();
-        coord.IsArmed.Should().BeFalse();
-        coord.PendingCount.Should().Be(0);
-        pins.Add(7, 8);
-        coord.PendingCount.Should().Be(0);
+        coord.PreviewResidual.Should().BeNull();
+        coord.SelectedMarker.Should().BeNull();
     }
 
     private sealed class FakeCalib : IAreaCalibrationService
     {
         public List<(WorldCoord, PixelPoint)>? LastPairs { get; private set; }
+        public int ChangedCount { get; private set; }
 
         public AreaCalibration? CalibrateCurrentArea(
             IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0)
         {
             LastPairs = placements.Select(p => (p.World, p.Pixel)).ToList();
+            ChangedCount++;
+            Changed?.Invoke(this, EventArgs.Empty);
             return new AreaCalibration(1, 0, 0, 0, placements.Count, 0);
         }
 
@@ -180,7 +345,7 @@ public class PinCalibrationCoordinatorTests
         public AreaCalibration? CurrentCalibration => null;
         public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
         public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
-        public event EventHandler? Changed { add { } remove { } }
+        public event EventHandler? Changed;
         public void OnAreaEntered(string areaFriendlyName) { }
         public void SelectArea(string areaKey) { }
         public void ClearCurrentAreaCalibration() { }

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Channels;
 using FluentAssertions;
 using Legolas.Domain;
+using Legolas.Flow;
 using Legolas.Services;
 using Legolas.ViewModels;
 using Mithril.GameState.Areas;
@@ -36,19 +37,34 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 67m west and 1181m south.\")";
 
     private static (PlayerLogIngestionService svc, ScriptedStream stream, SpyAreaCalibration spy,
-        SessionState session) Build(AreaCalibration? calibration = null, GameConfig? config = null)
+        SessionState session, SurveyFlowController flow) Build(
+        AreaCalibration? calibration = null, GameConfig? config = null)
     {
         var stream = new ScriptedStream();
         var tracker = new PlayerAreaTracker(new AreaTransitionParser());
         var spy = new SpyAreaCalibration(calibration);
         var session = new SessionState();
         var settings = new LegolasSettings();
+        var flow = new SurveyFlowController(session, settings);
         var gates = new ModuleGates();
         gates.For("legolas").Open();
+        // Freeze the live-cutoff at construction time. The real
+        // ModuleGate.WaitAsync yields, so the after-gate _liveSince capture
+        // would otherwise race ahead of the test's pushes (every live line
+        // would look like replay). A frozen clock makes the cutoff
+        // deterministic: pushes that use real UtcNow are "live"; a push with
+        // an explicit older timestamp is "replay".
+        var clock = new FrozenClock(DateTime.UtcNow);
         var svc = new PlayerLogIngestionService(
-            stream, new PlayerLogParser(), tracker, spy, session, settings, gates,
-            config ?? new GameConfig());
-        return (svc, stream, spy, session);
+            stream, new PlayerLogParser(), tracker, spy, flow, session, settings, gates,
+            config ?? new GameConfig(), time: clock);
+        return (svc, stream, spy, session, flow);
+    }
+
+    private sealed class FrozenClock(DateTime utc) : TimeProvider
+    {
+        private readonly DateTimeOffset _now = new(utc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
     }
 
     // ---- area→calibration bridge (Phase 2) -------------------------------
@@ -56,7 +72,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Area_load_line_applies_that_area_calibration_once()
     {
-        var (svc, stream, spy, _) = Build();
+        var (svc, stream, spy, _, _) = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -72,7 +88,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Area_change_applies_each_distinct_area_in_order()
     {
-        var (svc, stream, spy, _) = Build();
+        var (svc, stream, spy, _, _) = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -88,7 +104,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task ChooseCharacter_resets_latch_so_same_area_re_applies()
     {
-        var (svc, stream, spy, _) = Build();
+        var (svc, stream, spy, _, _) = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -113,7 +129,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             "LocalPlayer: ProcessAddPlayer(...)\n",
             new UTF8Encoding(false));
 
-        var (svc, _, spy, _) = Build(config: new GameConfig { GameRoot = _tempDir });
+        var (svc, _, spy, _, _) = Build(config: new GameConfig { GameRoot = _tempDir });
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -129,7 +145,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Calibrated_area_places_one_absolute_pin_at_projected_pixel()
     {
-        var (svc, stream, _, session) = Build(calibration: Identity());
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -156,7 +172,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Duplicate_world_coord_within_radius_does_not_stack()
     {
-        var (svc, stream, _, session) = Build(calibration: Identity());
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -176,7 +192,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Distinct_targets_place_separate_pins()
     {
-        var (svc, stream, _, session) = Build(calibration: Identity());
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -196,7 +212,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Uncalibrated_area_does_not_place_and_reports_diagnostic()
     {
-        var (svc, stream, _, session) = Build(calibration: null);
+        var (svc, stream, _, session, _) = Build(calibration: null);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -214,7 +230,7 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Motherlode_mode_ignores_absolute_targets()
     {
-        var (svc, stream, _, session) = Build(calibration: Identity());
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
         session.Mode = SessionMode.Motherlode;
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
@@ -229,12 +245,92 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         finally { await Stop(svc, run, cts); }
     }
 
+    // ---- replay / FSM gating (#477 follow-up) ----------------------------
+
+    [Fact]
+    public async Task Replayed_pre_session_target_is_not_placed()
+    {
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            // Stamped well before this consumer went live → session-replay
+            // backlog from a run the user already finished.
+            stream.Push(MapFx, DateTime.UtcNow.AddMinutes(-5));
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.LastLogEvent?.Contains("log replay") == true, cts.Token);
+
+            session.Surveys.Should().BeEmpty("replayed backlog must not repopulate stale pins");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Live_target_after_startup_is_still_placed()
+    {
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx); // default = DateTime.UtcNow → live
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.Surveys.Count == 1, cts.Token);
+
+            session.Surveys.Should().HaveCount(1);
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Non_accepting_flow_state_does_not_place()
+    {
+        var (svc, stream, _, session, flow) = Build(calibration: Identity());
+        flow.RequestSetPosition(); // Listening → SettingPosition (a non-accept state)
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx); // live, but the flow isn't accepting
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.LastLogEvent?.Contains("survey flow is") == true, cts.Token);
+
+            session.Surveys.Should().BeEmpty();
+            session.LastLogEvent.Should().Contain("SettingPosition");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
+    [Fact]
+    public async Task Gathering_still_accepts_new_targets()
+    {
+        var (svc, stream, _, session, flow) = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(MapFx);
+            await WaitUntil(() => session.Surveys.Count == 1, cts.Token);
+            flow.OptimizeRoute(); // Listening + 1 pin → Gathering
+
+            stream.Push(
+                "[08:33:17] LocalPlayer: ProcessMapFx((1666.00, 36.95, 2620.00), 25, 1, " +
+                "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")");
+            await stream.WaitForDrainAsync(cts.Token);
+            await WaitUntil(() => session.Surveys.Count == 2, cts.Token);
+
+            session.Surveys.Should().HaveCount(2, "#454: Gathering accepts new targets");
+        }
+        finally { await Stop(svc, run, cts); }
+    }
+
     [Fact]
     public async Task ProcessMapPin_lines_are_ignored_by_this_service()
     {
         // Map-pin lifecycle is GameState-owned now (#468); the Legolas
         // Player.log consumer only handles ProcessMapFx targets.
-        var (svc, stream, _, session) = Build(calibration: Identity());
+        var (svc, stream, _, session, _) = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
@@ -305,11 +401,15 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         private long _pending;
         private TaskCompletionSource _drained = NewDrainTcs();
 
-        public void Push(string line)
+        public void Push(string line) => Push(line, DateTime.UtcNow);
+
+        /// <summary>Push a line with an explicit UTC timestamp — used to
+        /// simulate the session-replay backlog (pre-live timestamps).</summary>
+        public void Push(string line, DateTime timestampUtc)
         {
             Interlocked.Increment(ref _pending);
             Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+            _channel.Writer.TryWrite(new RawLogLine(timestampUtc, line));
         }
 
         public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -40,7 +40,12 @@ public class LegolasWizardViewModelTests
             Changed?.Invoke(this, EventArgs.Empty);
             return c;
         }
-        public void ClearCurrentAreaCalibration() { }
+        public void ClearCurrentAreaCalibration()
+        {
+            if (!Calibrated) return;
+            Calibrated = false;
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
         public void NoteSurvey(string name, MetreOffset offset) { }
         public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
     }
@@ -59,7 +64,7 @@ public class LegolasWizardViewModelTests
         var projector = new CoordinateProjector();
         var brushes = new LegolasBrushes(settings);
         var areaCalib = calib ?? new FakeAreaCalib();
-        var pinCal = new PinCalibrationCoordinator(areaCalib, pins ?? new FakePlayerPinTracker());
+        var pinCal = new PinCalibrationCoordinator(areaCalib, pins ?? new FakePlayerPinTracker(), settings);
         var motherlode = new MotherlodeViewModel(trilat, optimizer, session, motherlodeFlow);
         var mapOverlay = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings, pinCal);
         var nudgePad = new NudgePadViewModel(session, mapOverlay, settings);
@@ -372,23 +377,25 @@ public class LegolasWizardViewModelTests
     }
 
     [Fact]
-    public void SolveCalibration_persists_and_leaves_the_gate()
+    public void ConfirmCalibration_persists_and_leaves_the_gate()
     {
         var calib = new FakeAreaCalib { Calibrated = false };
         var pins = new FakePlayerPinTracker();
         var (wizard, _, _, _, _) = BuildSut(calib, pins);
         wizard.PickSurveyModeCommand.Execute(null);
 
-        // Three fresh pin drops, then click-pair + Solve.
+        // Drop three pins in-game, switch to the Pair phase, click each named
+        // pin's spot, then Confirm. FakeAreaCalib returns residual 0 ⇒ good.
         pins.Add(1, 2);
         pins.Add(3, 4);
         pins.Add(5, 6);
+        wizard.ToggleCalibrationPhaseCommand.Execute(null); // Drop → Pair
         wizard.MapOverlay.PairCalibrationClick(new PixelPoint(10, 10));
         wizard.MapOverlay.PairCalibrationClick(new PixelPoint(20, 20));
         wizard.MapOverlay.PairCalibrationClick(new PixelPoint(30, 30));
-        wizard.PinCalibration.CanSolve.Should().BeTrue();
+        wizard.PinCalibration.CanConfirm.Should().BeTrue();
 
-        wizard.SolveCalibrationCommand.Execute(null);
+        wizard.ConfirmCalibrationCommand.Execute(null);
 
         calib.Calibrated.Should().BeTrue();
         wizard.CurrentStep.Should().Be(WizardStep.Listening);
@@ -406,5 +413,52 @@ public class LegolasWizardViewModelTests
 
         wizard.CurrentStep.Should().Be(WizardStep.PickMode);
         wizard.PinCalibration.IsArmed.Should().BeFalse();
+    }
+
+    // ─── #477B in-flow recalibration re-entry ────────────────────────────
+
+    [Fact]
+    public void Recalibrate_is_offered_only_when_the_area_is_calibrated()
+    {
+        var calibrated = new FakeAreaCalib { Calibrated = true };
+        var (wizard, _, _, _, _) = BuildSut(calibrated);
+        wizard.PickSurveyModeCommand.Execute(null);
+        wizard.CurrentStep.Should().Be(WizardStep.Listening);
+        wizard.CanRecalibrate.Should().BeTrue();
+
+        var uncal = new FakeAreaCalib { Calibrated = false };
+        var (w2, _, _, _, _) = BuildSut(uncal);
+        w2.PickSurveyModeCommand.Execute(null);
+        w2.CanRecalibrate.Should().BeFalse("nothing to redo on an uncalibrated area");
+    }
+
+    [Fact]
+    public void Recalibrate_is_guarded_then_clears_and_routes_back_into_Calibrating()
+    {
+        var calib = new FakeAreaCalib { Calibrated = true };
+        var (wizard, _, _, _, _) = BuildSut(calib);
+        wizard.PickSurveyModeCommand.Execute(null);
+        wizard.CurrentStep.Should().Be(WizardStep.Listening);
+
+        // First click only arms the confirm guard — no destruction.
+        wizard.RecalibrateCommand.Execute(null);
+        wizard.IsConfirmingRecalibrate.Should().BeTrue();
+        calib.Calibrated.Should().BeTrue("a misclick must not wipe a good calibration");
+        wizard.CurrentStep.Should().Be(WizardStep.Listening);
+
+        // Cancel backs out cleanly.
+        wizard.CancelRecalibrateCommand.Execute(null);
+        wizard.IsConfirmingRecalibrate.Should().BeFalse();
+        calib.Calibrated.Should().BeTrue();
+
+        // Confirmed: clears the persisted calibration; Changed → RecomputeStep
+        // routes back into Calibrating via the same pin route as cold start,
+        // and OnCurrentStepChanged re-arms PinCalibration.
+        wizard.RecalibrateCommand.Execute(null);
+        wizard.ConfirmRecalibrateCommand.Execute(null);
+        calib.Calibrated.Should().BeFalse();
+        wizard.IsConfirmingRecalibrate.Should().BeFalse();
+        wizard.CurrentStep.Should().Be(WizardStep.Calibrating);
+        wizard.PinCalibration.IsArmed.Should().BeTrue("re-entry arms the guided flow");
     }
 }

--- a/tests/Legolas.Tests/ViewModels/ManualAnchorNudgeTests.cs
+++ b/tests/Legolas.Tests/ViewModels/ManualAnchorNudgeTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+using Mithril.GameState.Movement;
+using Xunit;
+
+namespace Legolas.Tests.ViewModels;
+
+/// <summary>
+/// #477 Part C: the #476 manual "Set my position" anchor is selectable +
+/// nudgeable on Part A's shared marker-interaction layer. Nudging mutates only
+/// <see cref="SessionState.SurveyPlayerPixel"/> (flag preserved), never the
+/// Motherlode <c>PlayerPosition</c>; the auto/tracker anchor stays
+/// non-interactive; a fresh tracker fix still supersedes (the #476 rule).
+/// </summary>
+public class ManualAnchorNudgeTests
+{
+    // Scale 1, no rotation, origin (0,0): ProjectWorld(x,_,z) → (x, -z).
+    private static readonly AreaCalibration Calib = new(
+        Scale: 1.0, RotationRadians: 0.0, OriginX: 0.0, OriginY: 0.0,
+        ReferenceCount: 3, ResidualPixels: 0.5);
+
+    private static (SessionState session, MapOverlayViewModel map, FakePlayerPositionTracker tracker)
+        BuildSut()
+    {
+        var session = new SessionState { Mode = SessionMode.Survey };
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(settings);
+        var tracker = new FakePlayerPositionTracker();
+        var areaCal = new FakeAreaCalibrationService();
+        areaCal.SetCalibration(Calib);
+        var map = new MapOverlayViewModel(
+            session, projector, optimizer, surveyFlow, brushes, settings,
+            pinCalibration: null, positionTracker: tracker, areaCalibration: areaCal);
+        return (session, map, tracker);
+    }
+
+    [Fact]
+    public void Manual_anchor_nudge_moves_only_SurveyPlayerPixel_and_keeps_the_flag()
+    {
+        var (session, map, _) = BuildSut();
+        session.PlayerPosition = new PixelPoint(7, 7); // Motherlode anchor
+        session.SurveyPlayerPixel = new PixelPoint(100, 100);
+        session.SurveyPlayerIsManual = true;
+
+        map.Nudge(1, -1, step: 5);
+
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(105, 95));
+        session.SurveyPlayerIsManual.Should().BeTrue();
+        session.PlayerPosition.Should().Be(new PixelPoint(7, 7), "Motherlode anchor is untouched");
+    }
+
+    [Fact]
+    public void Auto_tracker_anchor_is_not_nudgeable()
+    {
+        var (session, map, _) = BuildSut();
+        session.SurveyPlayerPixel = new PixelPoint(50, 50);
+        session.SurveyPlayerIsManual = false; // projected fix, not manual
+
+        map.Nudge(1, 0, step: 5);
+
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(50, 50), "a data-sourced fix is read-only");
+    }
+
+    [Fact]
+    public void A_fresh_tracker_fix_after_a_nudge_still_supersedes()
+    {
+        var (session, map, tracker) = BuildSut();
+        session.SurveyPlayerPixel = new PixelPoint(100, 100);
+        session.SurveyPlayerIsManual = true;
+        map.Nudge(2, 0, step: 5); // → (110, 100)
+
+        tracker.Push(33, 0, 11, PlayerPositionSource.Movement);
+
+        session.SurveyPlayerIsManual.Should().BeFalse("a zone-in/teleport wins");
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(33, -11), "reprojected from the fresh fix");
+    }
+
+    [Fact]
+    public void A_selected_survey_still_wins_over_the_manual_anchor()
+    {
+        var (session, map, _) = BuildSut();
+        session.SurveyPlayerPixel = new PixelPoint(100, 100);
+        session.SurveyPlayerIsManual = true;
+
+        var survey = new SurveyItemViewModel(
+            Survey.CreateAbsolute("Diamond", new WorldCoord(10, 0, 20), new PixelPoint(10, 20), 0));
+        session.Surveys.Add(survey);
+        session.SelectedSurvey = survey;
+
+        map.Nudge(1, 0, step: 4);
+
+        survey.EffectivePixel.Should().Be(new PixelPoint(14, 20), "the selected survey takes precedence");
+        session.SurveyPlayerPixel.Should().Be(new PixelPoint(100, 100), "the manual anchor is untouched");
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/NudgePadViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/NudgePadViewModelTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+using Mithril.Shared.Reference;
+using Xunit;
+
+namespace Legolas.Tests.ViewModels;
+
+/// <summary>
+/// The on-screen nudge pad (wizard panel + overlay) binds its root
+/// <c>IsEnabled</c> to <see cref="NudgePadViewModel.IsAvailable"/>. It must be
+/// live for every <see cref="MapOverlayViewModel.Nudge"/> target — not just a
+/// selected survey — or calibration-marker / manual-anchor nudging silently
+/// no-ops (the pad stays disabled).
+/// </summary>
+public class NudgePadViewModelTests
+{
+    private static PixelPoint Project(double x, double z) => new(100 + 2 * x, 100 - 2 * z);
+
+    private static (NudgePadViewModel pad, SessionState session, PinCalibrationCoordinator cal,
+        FakePlayerPinTracker pins) Build()
+    {
+        var session = new SessionState { Mode = SessionMode.Survey };
+        var settings = new LegolasSettings();
+        var surveyFlow = new SurveyFlowController(session, settings);
+        var optimizer = new AdaptiveRouteOptimizer(new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var projector = new CoordinateProjector();
+        var brushes = new LegolasBrushes(settings);
+        var pins = new FakePlayerPinTracker();
+        var cal = new PinCalibrationCoordinator(new FakeCalib(), pins, settings);
+        var map = new MapOverlayViewModel(session, projector, optimizer, surveyFlow, brushes, settings, cal);
+        var pad = new NudgePadViewModel(session, map, settings);
+        return (pad, session, cal, pins);
+    }
+
+    [Fact]
+    public void Pad_is_unavailable_with_no_target()
+    {
+        var (pad, _, _, _) = Build();
+        pad.IsAvailable.Should().BeFalse();
+        pad.NudgeTargetLabel.Should().Be("(no target — select a pin)");
+    }
+
+    [Fact]
+    public void Pad_becomes_available_when_a_calibration_marker_is_selected()
+    {
+        var (pad, _, cal, pins) = Build();
+        pins.SeedExisting(
+            FakePlayerPinTracker.Pin(10, 10),
+            FakePlayerPinTracker.Pin(50, 60),
+            FakePlayerPinTracker.Pin(90, 20));
+        cal.Arm(); // ≥3 pins → Pair phase
+
+        bool raised = false;
+        pad.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(pad.IsAvailable)) raised = true; };
+
+        // Pairing selects the just-placed marker.
+        cal.PairClick(Project(10, 10));
+
+        raised.Should().BeTrue("availability must re-raise so the d-pad enables live");
+        pad.IsAvailable.Should().BeTrue();
+        pad.NudgeTargetLabel.Should().Be("Calibration pin");
+    }
+
+    [Fact]
+    public void Pad_is_available_for_the_manual_player_anchor()
+    {
+        var (pad, session, _, _) = Build();
+        session.SurveyPlayerPixel = new PixelPoint(100, 100);
+        session.SurveyPlayerIsManual = true;
+
+        pad.IsAvailable.Should().BeTrue();
+        pad.NudgeTargetLabel.Should().Be("Your position");
+
+        // The auto/tracker anchor (not manual) is not nudgeable.
+        session.SurveyPlayerIsManual = false;
+        pad.IsAvailable.Should().BeFalse();
+    }
+
+    private sealed class FakeCalib : IAreaCalibrationService
+    {
+        public AreaCalibration? CalibrateCurrentArea(
+            IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0)
+            => new(1, 0, 0, 0, placements.Count, 0);
+        public string? CurrentAreaKey => "AreaTest";
+        public string? CurrentAreaFriendlyName => "Test";
+        public bool IsCurrentAreaCalibrated => false;
+        public AreaCalibration? CurrentCalibration => null;
+        public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
+        public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
+        public event EventHandler? Changed { add { } remove { } }
+        public void OnAreaEntered(string areaFriendlyName) { }
+        public void SelectArea(string areaKey) { }
+        public void ClearCurrentAreaCalibration() { }
+        public void NoteSurvey(string name, MetreOffset offset) { }
+        public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
+    }
+}


### PR DESCRIPTION
Closes #477.

## Summary

Implements all three parts of #477 (one branch, marker VM built #478-ready):

- **Part A — guided two-phase correctable calibration.** Replaces the in-flow (#460) cold-start step with a single model in two explicit, user-toggled phases (`Drop`/`Pair`). Pairing is spread-suggested one named pin at a time (farthest-point heuristic) with skip/override; advance is implicit. `PlacedMarkers` promoted to a `CalibrationMarker` observable VM (select/drag/arrow-nudge correction, edits the pixel half only — world coord untouched, #454 label-agnostic preserved). Live **non-persisting** residual preview (pure solver in-process, no `Changed`); terminal **Confirm** gated on ≥3 pairs + `LegolasSettings.CalibrationGoodResidualPx` (12px default) with a **Finish anyway** escape for the ±10% non-affine ceiling. Phase trigger + Confirm also exposed as unbound `IHotkeyCommand`s.
- **Part B — in-flow recalibration re-entry.** "Recalibrate this area" on the Listening step (only when calibrated) behind a confirm guard; reuses the existing `ClearCurrentAreaCalibration → Changed → RecomputeStep` edges (no new FSM state). Standalone landmark window left as the alternative.
- **Part C — nudgeable manual player anchor.** The #476 manual anchor is selectable/nudgeable on the shared marker layer. `MapOverlayViewModel.Nudge` precedence is calibration marker → selected survey → manual anchor, via a single path shared by the hotkeys and the on-screen pad (mutates `SurveyPlayerPixel` only, flag preserved, fresh tracker fix still supersedes). Stale `Nudge` XML doc fixed.

## Follow-up fix included

`PlayerLogIngestionService` now gates `ProcessMapFx` placement: it ignores the session-replay backlog (pre-live timestamps) and only places while the survey FSM is `Listening`/`Gathering` — fixes log replay flooding stale surveys when the Legolas tab is first opened.

## Docs

`docs/legolas-overview.md` updated: two-phase walkthrough, gesture/phase table, in-flow recalibration, and the nudge-target precedence (replacing the retired `IsAnchorEditable`/`MoveAnchor` fall-through).

## Test plan

- [x] Rewritten `PinCalibrationCoordinatorTests` — two-phase entry, spread suggestion, skip/override, hit-test/drag/nudge correction, non-persisting residual == direct solve, Confirm gate + finish-anyway, no-correction regression baseline.
- [x] New `ManualAnchorNudgeTests` (Part C), `NudgePadViewModelTests` (pad availability for marker/manual anchor), wizard recalibrate-re-entry tests (Part B), `AreaCalibrationService` clear test.
- [x] New `PlayerLogIngestionServiceTests` — replay backlog suppressed, live placed, non-accepting FSM state rejected, `Gathering` still accepts (#454 regression guard).
- [x] Full Legolas suite **311/311**; full solution builds; smoke-tested in-app (nudgeable pins confirmed).

### Verification owed (live-game, not unit-testable)
- PG renders player pins through the transparent overlay at all zooms (the pairing click target).
- Clean click-through ↔ capture toggling between phases without disturbing the Motherlode/survey left-click paths.
- Calibrated→cleared re-entry behaves identically to a true cold start across zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)