### PR TITLE
feat(gamestate): live lunar-phase producer + Palantir readout

### DIFF
--- a/src/Mithril.GameState/Celestial/IPlayerCelestialState.cs
+++ b/src/Mithril.GameState/Celestial/IPlayerCelestialState.cs
@@ -1,0 +1,42 @@
+namespace Mithril.GameState.Celestial;
+
+/// <summary>
+/// The local player's last-known lunar phase, plus the instant it was
+/// measured. PG emits <c>ProcessSetCelestialInfo</c> on login and on every
+/// phase roll-over, so this is far less stale than position — but it can
+/// still lag if a phase boundary passed while the log wasn't being tailed.
+/// <see cref="MeasuredAt"/> is the log line's UTC instant (Player.log
+/// <c>[HH:MM:SS]</c> prefixes are UTC), exposed as a
+/// <see cref="DateTimeOffset"/>. <see cref="RawPhase"/> is the verbatim log
+/// token; <see cref="Phase"/> is its canonical mapping
+/// (<see cref="MoonPhase.Unknown"/> ⇒ the token was unrecognised but
+/// <see cref="RawPhase"/> is still authoritative).
+/// </summary>
+public sealed record CelestialInfo(MoonPhase Phase, string RawPhase, DateTimeOffset MeasuredAt)
+{
+    /// <summary>Human phrase — fixed name for a recognised phase, otherwise a
+    /// CamelCase-split of the raw token.</summary>
+    public string DisplayName => Phase.DisplayName(RawPhase);
+}
+
+/// <summary>
+/// Shared live game-state: the player's last-known lunar phase. Mirrors
+/// <see cref="Mithril.GameState.Movement.IPlayerPositionTracker"/> —
+/// <see cref="Current"/> plus a replay-on-<see cref="Subscribe"/> handler so
+/// late subscribers see the same view already-attached ones do.
+/// </summary>
+public interface IPlayerCelestialState
+{
+    /// <summary>
+    /// Last lunar phase observed, or <c>null</c> before the first
+    /// <c>ProcessSetCelestialInfo</c> line of the session is seen.
+    /// </summary>
+    CelestialInfo? Current { get; }
+
+    /// <summary>
+    /// Register a handler. If a phase is already known it is replayed
+    /// synchronously before the call returns; subsequent phases are delivered
+    /// live until the returned token is disposed.
+    /// </summary>
+    IDisposable Subscribe(Action<CelestialInfo> handler);
+}

--- a/src/Mithril.GameState/Celestial/MoonPhase.cs
+++ b/src/Mithril.GameState/Celestial/MoonPhase.cs
@@ -1,0 +1,115 @@
+using System.Text;
+
+namespace Mithril.GameState.Celestial;
+
+/// <summary>
+/// Project Gorgon's lunar cycle — the standard eight phases. The game's
+/// <c>ProcessSetCelestialInfo</c> Player.log line carries one of these as a
+/// token (e.g. <c>WaxingCrescentMoon</c>); the cycle gates a handful of
+/// recipes / quests (<c>MoonPhase</c> / <c>FullMoon</c> requirements) and the
+/// mushroom-circle recall cooldowns.
+///
+/// <para><b>Vocabulary caveat.</b> Three spellings of the same phase are in
+/// play: the Player.log token has a trailing <c>Moon</c>
+/// (<c>WaxingCrescentMoon</c>); reference-data discriminator values do not
+/// (<c>WaxingCrescent</c> / <c>FullMoon</c> / <c>NewMoon</c>);
+/// <c>strings_all</c> carries prose only. The six non-quarter phases are
+/// confirmed from a live capture + the strings table; the two quarter tokens
+/// (<see cref="FirstQuarter"/> / <see cref="ThirdQuarter"/>) are the standard
+/// astronomical names and are <b>not yet confirmed against a live Player.log</b>
+/// — if PG emits a different token there it maps to <see cref="Unknown"/> and
+/// the raw string still surfaces verbatim (no data loss). See the
+/// <c>ProcessSetCelestialInfo</c> investigation.</para>
+/// </summary>
+public enum MoonPhase
+{
+    /// <summary>Token not recognised — the raw log string is still retained
+    /// on <see cref="CelestialInfo.RawPhase"/> and surfaced verbatim.</summary>
+    Unknown = 0,
+    NewMoon,
+    WaxingCrescent,
+    FirstQuarter,
+    WaxingGibbous,
+    FullMoon,
+    WaningGibbous,
+    ThirdQuarter,
+    WaningCrescent,
+}
+
+public static class MoonPhaseExtensions
+{
+    // Keyed by a normalised form: letters only, lower-cased, with a trailing
+    // "moon" stripped. This collapses all three observed spellings onto one
+    // key — log `WaxingCrescentMoon` → "waxingcrescent", reference
+    // `WaxingCrescent` → "waxingcrescent", `FullMoon`/`NewMoon` → "full"/"new".
+    // `LastQuarter` is accepted as a synonym for the third quarter.
+    private static readonly Dictionary<string, MoonPhase> ByToken = new(StringComparer.Ordinal)
+    {
+        ["new"] = MoonPhase.NewMoon,
+        ["waxingcrescent"] = MoonPhase.WaxingCrescent,
+        ["firstquarter"] = MoonPhase.FirstQuarter,
+        ["waxinggibbous"] = MoonPhase.WaxingGibbous,
+        ["full"] = MoonPhase.FullMoon,
+        ["waninggibbous"] = MoonPhase.WaningGibbous,
+        ["thirdquarter"] = MoonPhase.ThirdQuarter,
+        ["lastquarter"] = MoonPhase.ThirdQuarter,
+        ["waningcrescent"] = MoonPhase.WaningCrescent,
+    };
+
+    /// <summary>
+    /// Map a raw celestial token (any of the three observed spellings) to a
+    /// canonical <see cref="MoonPhase"/>. Unrecognised tokens yield
+    /// <see cref="MoonPhase.Unknown"/> — the caller keeps the raw string.
+    /// </summary>
+    public static MoonPhase ParsePhase(string? rawToken)
+    {
+        if (string.IsNullOrWhiteSpace(rawToken)) return MoonPhase.Unknown;
+        return ByToken.TryGetValue(Normalise(rawToken), out var p) ? p : MoonPhase.Unknown;
+    }
+
+    private static string Normalise(string token)
+    {
+        var sb = new StringBuilder(token.Length);
+        foreach (var c in token)
+            if (char.IsLetter(c)) sb.Append(char.ToLowerInvariant(c));
+        var s = sb.ToString();
+        // "new"/"full" rather than "newmoon"/"fullmoon"; "waxingcrescent"
+        // rather than "waxingcrescentmoon". "moon" is never a phase by itself.
+        if (s.Length > 4 && s.EndsWith("moon", StringComparison.Ordinal))
+            s = s[..^4];
+        return s;
+    }
+
+    /// <summary>
+    /// Human phrase for display: a fixed name for a recognised phase,
+    /// otherwise a CamelCase-split of the raw token so an unconfirmed /
+    /// future token still reads as a phrase ("WaxingCrescentMoon" →
+    /// "Waxing Crescent Moon") rather than a blank.
+    /// </summary>
+    public static string DisplayName(this MoonPhase phase, string rawFallback) => phase switch
+    {
+        MoonPhase.NewMoon => "New Moon",
+        MoonPhase.WaxingCrescent => "Waxing Crescent",
+        MoonPhase.FirstQuarter => "First Quarter",
+        MoonPhase.WaxingGibbous => "Waxing Gibbous",
+        MoonPhase.FullMoon => "Full Moon",
+        MoonPhase.WaningGibbous => "Waning Gibbous",
+        MoonPhase.ThirdQuarter => "Third Quarter",
+        MoonPhase.WaningCrescent => "Waning Crescent",
+        _ => SplitCamelCase(rawFallback),
+    };
+
+    private static string SplitCamelCase(string raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return "(unknown)";
+        var sb = new StringBuilder(raw.Length + 8);
+        for (var i = 0; i < raw.Length; i++)
+        {
+            var c = raw[i];
+            if (i > 0 && char.IsUpper(c) && !char.IsUpper(raw[i - 1]) && sb.Length > 0 && sb[^1] != ' ')
+                sb.Append(' ');
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Mithril.GameState/Celestial/Parsing/CelestialEvents.cs
+++ b/src/Mithril.GameState/Celestial/Parsing/CelestialEvents.cs
@@ -1,0 +1,14 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Celestial.Parsing;
+
+/// <summary>
+/// The local player's current lunar phase, parsed from
+/// <c>LocalPlayer: ProcessSetCelestialInfo(&lt;token&gt;)</c>. PG emits this on
+/// login and again whenever the phase rolls over. <see cref="RawPhase"/> is
+/// the verbatim log token; <see cref="Phase"/> is its canonical mapping
+/// (<see cref="MoonPhase.Unknown"/> if the token is unrecognised — the raw
+/// string is still authoritative).
+/// </summary>
+public sealed record CelestialInfoEvent(DateTime Timestamp, MoonPhase Phase, string RawPhase)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Celestial/Parsing/CelestialLogParser.cs
+++ b/src/Mithril.GameState/Celestial/Parsing/CelestialLogParser.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Celestial.Parsing;
+
+/// <summary>
+/// Parses the local player's lunar phase from Project Gorgon's
+/// <c>Player.log</c>. One line carries it:
+///
+/// <code>
+/// [19:50:42] LocalPlayer: ProcessSetCelestialInfo(WaxingCrescentMoon)
+/// </code>
+///
+/// <para>The actor token must be exactly <c>LocalPlayer</c> — the negative
+/// lookbehind for a letter rejects <c>NonLocalPlayer:</c> /
+/// <c>RemoteLocalPlayer:</c> etc. (mirrors
+/// <c>PlayerPositionParser</c>'s boundary discipline). The single argument is
+/// a phase token of one of three observed spellings; mapping to a canonical
+/// <see cref="MoonPhase"/> is total (unrecognised ⇒
+/// <see cref="MoonPhase.Unknown"/>, raw token retained). Unrelated lines
+/// fast-path to <c>null</c>; the parser never throws.</para>
+/// </summary>
+public sealed partial class CelestialLogParser : ILogParser
+{
+    [GeneratedRegex(
+        """(?<![A-Za-z])LocalPlayer:\s*ProcessSetCelestialInfo\(\s*(?<phase>[A-Za-z]+)\s*\)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex CelestialRx();
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(line)) return null;
+        if (!line.Contains("ProcessSetCelestialInfo", StringComparison.Ordinal)) return null;
+
+        if (CelestialRx().Match(line) is not { Success: true } m) return null;
+
+        var raw = m.Groups["phase"].Value;
+        return new CelestialInfoEvent(timestamp, MoonPhaseExtensions.ParsePhase(raw), raw);
+    }
+}

--- a/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
+++ b/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
@@ -1,0 +1,133 @@
+using Mithril.GameState.Celestial.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Celestial;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IPlayerCelestialState"/>.
+/// Tails <see cref="IPlayerLogStream"/>, parses
+/// <c>ProcessSetCelestialInfo</c> via <see cref="CelestialLogParser"/>, and
+/// holds the latest <see cref="CelestialInfo"/> (phase + the line's UTC
+/// instant). Last-writer-wins keeps it advancing across phase roll-overs and
+/// relogs.
+///
+/// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
+/// <see cref="Movement.PlayerPositionTracker"/>: the lunar phase is shared
+/// live game-state and must be available to consumers (Palantir's debug
+/// surface today; potential Silmarillion "active now" / Gandalf phase alarms
+/// later) without depending on any other module being activated. Unlike
+/// position, there is no second source line and no area to warm, so the loop
+/// is a plain parse-and-publish.</para>
+///
+/// <para><b>Threading.</b> Ingestion runs on the hosted-service loop thread;
+/// <see cref="Current"/> reads and subscriber dispatch happen under
+/// <c>_lock</c>. Subscribers doing non-trivial work should marshal off-thread
+/// immediately (the Palantir VM dispatches to the UI thread).</para>
+/// </summary>
+public sealed class PlayerCelestialStateService : BackgroundService, IPlayerCelestialState
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly CelestialLogParser _parser;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly List<Action<CelestialInfo>> _handlers = [];
+    private CelestialInfo? _current;
+
+    public PlayerCelestialStateService(
+        IPlayerLogStream stream,
+        CelestialLogParser parser,
+        IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _parser = parser;
+        _diag = diag;
+    }
+
+    public CelestialInfo? Current
+    {
+        get { lock (_lock) return _current; }
+    }
+
+    public IDisposable Subscribe(Action<CelestialInfo> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // Replay the current phase before going live so a late subscriber
+            // observes the same view already-attached handlers see. Mirrors
+            // PlayerPositionTracker.Subscribe.
+            if (_current is not null) Invoke(handler, _current);
+            _handlers.Add(handler);
+            return new Subscription(this, handler);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Celestial", "Subscribing to Player.log for ProcessSetCelestialInfo");
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is CelestialInfoEvent evt)
+                {
+                    Publish(new CelestialInfo(evt.Phase, evt.RawPhase, ToOffset(evt.Timestamp)));
+                    _diag?.Trace("GameState.Celestial",
+                        $"Moon phase: {evt.RawPhase} ({evt.Phase}) @ {evt.Timestamp:O}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _diag?.Warn("GameState.Celestial", $"Ingestion error: {ex.Message}");
+            }
+        }
+    }
+
+    private void Publish(CelestialInfo info)
+    {
+        Action<CelestialInfo>[] toFire;
+        lock (_lock)
+        {
+            _current = info;
+            toFire = _handlers.ToArray();
+        }
+        foreach (var h in toFire) Invoke(h, info);
+    }
+
+    private void Invoke(Action<CelestialInfo> handler, CelestialInfo info)
+    {
+        try { handler(info); }
+        catch (Exception ex) { _diag?.Warn("GameState.Celestial", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Player.log timestamps are reconstructed as UTC <see cref="DateTime"/>s
+    /// by <c>LogLineTimestampSequencer</c>. Stamp the kind defensively in case
+    /// a caller passes an Unspecified-kind value (tests), so the offset is
+    /// always +00:00 rather than the host's local offset.
+    /// </summary>
+    private static DateTimeOffset ToOffset(DateTime ts) =>
+        new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
+
+    private sealed class Subscription : IDisposable
+    {
+        private PlayerCelestialStateService? _owner;
+        private readonly Action<CelestialInfo> _handler;
+
+        public Subscription(PlayerCelestialStateService owner, Action<CelestialInfo> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
+        }
+    }
+}

--- a/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
+++ b/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
@@ -34,6 +34,7 @@ public sealed class PlayerCelestialStateService : BackgroundService, IPlayerCele
 
     private readonly object _lock = new();
     private readonly List<Action<CelestialInfo>> _handlers = [];
+    private readonly HashSet<string> _reportedUnknownTokens = new(StringComparer.Ordinal);
     private CelestialInfo? _current;
 
     public PlayerCelestialStateService(
@@ -74,6 +75,9 @@ public sealed class PlayerCelestialStateService : BackgroundService, IPlayerCele
             {
                 if (_parser.TryParse(raw.Line, raw.Timestamp) is CelestialInfoEvent evt)
                 {
+                    if (evt.Phase == MoonPhase.Unknown)
+                        ReportUnknownToken(evt.RawPhase);
+
                     Publish(new CelestialInfo(evt.Phase, evt.RawPhase, ToOffset(evt.Timestamp)));
                     _diag?.Trace("GameState.Celestial",
                         $"Moon phase: {evt.RawPhase} ({evt.Phase}) @ {evt.Timestamp:O}");
@@ -84,6 +88,28 @@ public sealed class PlayerCelestialStateService : BackgroundService, IPlayerCele
                 _diag?.Warn("GameState.Celestial", $"Ingestion error: {ex.Message}");
             }
         }
+    }
+
+    /// <summary>
+    /// PG emitted a celestial token that maps to no <see cref="MoonPhase"/>
+    /// member — the canonical enum / token map is missing a case (a game
+    /// patch added a phase, or a quarter token's spelling differs from the
+    /// assumed astronomical name). Logged at <see cref="DiagnosticLevel.Error"/>
+    /// because it is a code-level gap we want surfaced loudly, not a transient
+    /// runtime hiccup. Deduped per distinct raw token: PG re-emits
+    /// <c>ProcessSetCelestialInfo</c> on every login + phase roll-over, so an
+    /// unmapped token would otherwise flood the Error log indefinitely.
+    /// </summary>
+    private void ReportUnknownToken(string rawToken)
+    {
+        bool firstSighting;
+        lock (_lock) { firstSighting = _reportedUnknownTokens.Add(rawToken); }
+        if (!firstSighting) return;
+
+        _diag?.Error("GameState.Celestial",
+            $"Unmapped celestial token '{rawToken}' — no MoonPhase enum member. " +
+            "Add it to MoonPhase + MoonPhaseExtensions.ByToken / DisplayName " +
+            "(value preserved as raw passthrough until then).");
     }
 
     private void Publish(CelestialInfo info)

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Celestial;
+using Mithril.GameState.Celestial.Parsing;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
@@ -89,6 +91,18 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<PlayerPinTracker>()
             .AddSingleton<IPlayerPinTracker>(sp => sp.GetRequiredService<PlayerPinTracker>())
             .AddHostedService(sp => sp.GetRequiredService<PlayerPinTracker>());
+
+        // Shared live lunar phase from Player.log (ProcessSetCelestialInfo) —
+        // emitted on login + every phase roll-over. Backs the planner-punted
+        // MoonPhase / FullMoon recipe & quest gates (currently surfaced only
+        // statically by Silmarillion) and the moon-dependent recall cooldowns.
+        // Self-feeding; consumers inject IPlayerCelestialState. See the
+        // ProcessSetCelestialInfo investigation.
+        services.AddSingleton<CelestialLogParser>();
+        services
+            .AddSingleton<PlayerCelestialStateService>()
+            .AddSingleton<IPlayerCelestialState>(sp => sp.GetRequiredService<PlayerCelestialStateService>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerCelestialStateService>());
 
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();

--- a/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
+++ b/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mithril.GameState.Areas;
+using Mithril.GameState.Celestial;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
 using Mithril.Shared.Reference;
@@ -26,19 +27,25 @@ namespace Palantir.ViewModels;
 /// <para>Pins are push-driven: <see cref="IPlayerPinTracker.Subscribe"/>
 /// replays the current set synchronously then delivers add / remove / area
 /// swap live (PG bulk-replays the set on every login / zone, idempotently).
-/// Both tracker subscriptions fire on the GameState ingestion thread, so
+/// All tracker subscriptions fire on the GameState ingestion thread, so
 /// every handler marshals through <see cref="_dispatch"/> before touching
 /// bound state.</para>
+///
+/// <para>The lunar phase (<see cref="IPlayerCelestialState"/>) is push-driven
+/// too — replayed on subscribe, then delivered live on every phase
+/// roll-over.</para>
 /// </summary>
 public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
 {
     private readonly IPlayerPositionTracker _positionTracker;
     private readonly PlayerAreaTracker _areaTracker;
     private readonly IPlayerPinTracker _pinTracker;
+    private readonly IPlayerCelestialState _celestial;
     private readonly IReferenceDataService? _refData;
     private readonly Action<Action> _dispatch;
     private IDisposable? _subscription;
     private IDisposable? _pinSubscription;
+    private IDisposable? _celestialSubscription;
 
     [ObservableProperty] private string _areaKey = "(unknown)";
     [ObservableProperty] private string _areaFriendlyName = "(area not yet known)";
@@ -54,6 +61,11 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     [ObservableProperty] private bool _hasPins;
     [ObservableProperty] private string _pinsObservedAtText = "—";
 
+    [ObservableProperty] private bool _hasMoonPhase;
+    [ObservableProperty] private string _moonPhaseText = "(no celestial info observed yet)";
+    [ObservableProperty] private string _moonPhaseRawText = "—";
+    [ObservableProperty] private string _moonMeasuredAtText = "—";
+
     /// <summary>The current area's pins as presentation rows. Mutated only
     /// on the dispatched (UI) thread — see <see cref="OnPins"/>.</summary>
     public ObservableCollection<MapPinRow> Pins { get; } = [];
@@ -62,8 +74,9 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         IPlayerPositionTracker positionTracker,
         PlayerAreaTracker areaTracker,
         IPlayerPinTracker pinTracker,
+        IPlayerCelestialState celestial,
         IReferenceDataService? refData = null)
-        : this(positionTracker, areaTracker, pinTracker, refData, dispatch: null)
+        : this(positionTracker, areaTracker, pinTracker, celestial, refData, dispatch: null)
     { }
 
     /// <summary>
@@ -74,19 +87,23 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         IPlayerPositionTracker positionTracker,
         PlayerAreaTracker areaTracker,
         IPlayerPinTracker pinTracker,
+        IPlayerCelestialState celestial,
         IReferenceDataService? refData,
         Action<Action>? dispatch)
     {
         _positionTracker = positionTracker;
         _areaTracker = areaTracker;
         _pinTracker = pinTracker;
+        _celestial = celestial;
         _refData = refData;
         _dispatch = dispatch ?? DefaultDispatch;
 
         RefreshArea();
-        // Replay-on-subscribe seeds position / the pin set if already known.
+        // Replay-on-subscribe seeds position / the pin set / the phase if
+        // already known.
         _subscription = _positionTracker.Subscribe(OnPosition);
         _pinSubscription = _pinTracker.Subscribe(OnPins);
+        _celestialSubscription = _celestial.Subscribe(OnCelestial);
     }
 
     private void OnPosition(PlayerPosition p) => _dispatch(() =>
@@ -132,6 +149,23 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         });
     }
 
+    /// <summary>
+    /// Surface the current lunar phase. <see cref="CelestialInfo"/> is an
+    /// immutable record — safe to read off the ingestion thread before
+    /// dispatching. The raw token is shown alongside the friendly name so an
+    /// unrecognised / future phase token is still inspectable on this debug
+    /// surface.
+    /// </summary>
+    private void OnCelestial(CelestialInfo c) => _dispatch(() =>
+    {
+        HasMoonPhase = true;
+        MoonPhaseText = c.DisplayName;
+        MoonPhaseRawText = c.Phase == MoonPhase.Unknown
+            ? $"{c.RawPhase} (unrecognised token)"
+            : c.RawPhase;
+        MoonMeasuredAtText = c.MeasuredAt.UtcDateTime.ToString("u", CultureInfo.InvariantCulture);
+    });
+
     [RelayCommand]
     private void Refresh() => _dispatch(RefreshArea);
 
@@ -171,6 +205,8 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         _subscription = null;
         _pinSubscription?.Dispose();
         _pinSubscription = null;
+        _celestialSubscription?.Dispose();
+        _celestialSubscription = null;
     }
 
     private static void DefaultDispatch(Action action)

--- a/src/Palantir.Module/Views/WorldStateView.xaml
+++ b/src/Palantir.Module/Views/WorldStateView.xaml
@@ -38,7 +38,10 @@
                 set. Position is sparse — it only updates on teleport /
                 zone-in, so the measured instant can lag wall-clock by a long
                 way. Pins are push-driven and area-local: PG idempotently
-                replays the whole set on every login / zone change.
+                replays the whole set on every login / zone change. The lunar
+                phase comes from Player.log ProcessSetCelestialInfo (login +
+                every phase roll-over) and backs the moon-gated recipes /
+                quests.
             </TextBlock>
 
             <!-- Map / area -->
@@ -166,6 +169,38 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <!-- Moon / celestial -->
+            <TextBlock Text="MOON" Foreground="#88FFFFFF"
+                       FontSize="{DynamicResource AppFontSizeHint}"
+                       FontWeight="SemiBold" Margin="0,16,0,4"/>
+            <Border Background="#FF252525" CornerRadius="4" Padding="14,10">
+                <StackPanel>
+                    <DockPanel Margin="0,0,0,6">
+                        <TextBlock DockPanel.Dock="Left" Text="Phase"
+                                   Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding MoonPhaseText}"
+                                   Foreground="#FFFFFFFF" FontWeight="SemiBold"/>
+                    </DockPanel>
+                    <DockPanel Margin="0,0,0,6">
+                        <TextBlock DockPanel.Dock="Left" Text="Raw token"
+                                   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding MoonPhaseRawText}"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   Foreground="#88FFFFFF"/>
+                    </DockPanel>
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Left" Text="Measured (UTC)"
+                                   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding MoonMeasuredAtText}"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   Foreground="#88FFFFFF"/>
+                    </DockPanel>
                 </StackPanel>
             </Border>
 

--- a/tests/Mithril.GameState.Tests/Celestial/CelestialLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Celestial/CelestialLogParserTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Mithril.GameState.Celestial;
+using Mithril.GameState.Celestial.Parsing;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Celestial;
+
+public sealed class CelestialLogParserTests
+{
+    private static readonly CelestialLogParser Parser = new();
+    private static readonly DateTime Ts = new(2026, 5, 18, 19, 50, 42, DateTimeKind.Utc);
+
+    // Byte-exact from a real Player.log (this machine, 2026-05-18).
+    private const string RealLine =
+        "[19:50:42] LocalPlayer: ProcessSetCelestialInfo(WaxingCrescentMoon)";
+
+    [Fact]
+    public void Real_line_parses_to_canonical_phase_and_keeps_raw_token()
+    {
+        var evt = Parser.TryParse(RealLine, Ts)
+            .Should().BeOfType<CelestialInfoEvent>().Subject;
+
+        evt.Phase.Should().Be(MoonPhase.WaxingCrescent);
+        evt.RawPhase.Should().Be("WaxingCrescentMoon");
+        evt.Timestamp.Should().Be(Ts);
+    }
+
+    [Theory]
+    // Player.log token spelling (trailing "Moon").
+    [InlineData("NewMoon", MoonPhase.NewMoon)]
+    [InlineData("WaxingCrescentMoon", MoonPhase.WaxingCrescent)]
+    [InlineData("FirstQuarterMoon", MoonPhase.FirstQuarter)]
+    [InlineData("WaxingGibbousMoon", MoonPhase.WaxingGibbous)]
+    [InlineData("FullMoon", MoonPhase.FullMoon)]
+    [InlineData("WaningGibbousMoon", MoonPhase.WaningGibbous)]
+    [InlineData("ThirdQuarterMoon", MoonPhase.ThirdQuarter)]
+    [InlineData("LastQuarterMoon", MoonPhase.ThirdQuarter)]
+    [InlineData("WaningCrescentMoon", MoonPhase.WaningCrescent)]
+    // Reference-data discriminator spelling (no suffix) maps the same way.
+    [InlineData("WaxingCrescent", MoonPhase.WaxingCrescent)]
+    [InlineData("NewMoon ", MoonPhase.NewMoon)]
+    public void Maps_all_observed_token_spellings(string token, MoonPhase expected)
+    {
+        var line = $"[19:50:42] LocalPlayer: ProcessSetCelestialInfo({token})";
+        var evt = Parser.TryParse(line, Ts).Should().BeOfType<CelestialInfoEvent>().Subject;
+
+        evt.Phase.Should().Be(expected);
+        evt.RawPhase.Should().Be(token.Trim());
+    }
+
+    [Fact]
+    public void Unrecognised_token_yields_Unknown_but_retains_raw_string()
+    {
+        var line = "[19:50:42] LocalPlayer: ProcessSetCelestialInfo(BloodMoonEclipse)";
+        var evt = Parser.TryParse(line, Ts).Should().BeOfType<CelestialInfoEvent>().Subject;
+
+        evt.Phase.Should().Be(MoonPhase.Unknown);
+        evt.RawPhase.Should().Be("BloodMoonEclipse");
+        // Display still reads as a phrase rather than a blank.
+        evt.Phase.DisplayName(evt.RawPhase).Should().Be("Blood Moon Eclipse");
+    }
+
+    [Fact]
+    public void Rejects_non_local_actor_token()
+    {
+        // A bare substring check would be fooled — the boundary lookbehind
+        // must reject this (mirrors PlayerPositionParser's discipline).
+        Parser.TryParse(
+                "[19:50:42] NonLocalPlayer: ProcessSetCelestialInfo(FullMoon)", Ts)
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("[19:50:42] LocalPlayer: ProcessAddItem(Barley(1), 0, False)")]
+    [InlineData("LOADING LEVEL AreaSerbule")]
+    [InlineData("[19:50:42] LocalPlayer: ProcessSetCelestialInfo()")]
+    public void Returns_null_for_unrelated_or_malformed_lines(string line)
+    {
+        Parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void DisplayName_is_fixed_for_every_recognised_phase()
+    {
+        MoonPhase.NewMoon.DisplayName("x").Should().Be("New Moon");
+        MoonPhase.WaxingCrescent.DisplayName("x").Should().Be("Waxing Crescent");
+        MoonPhase.FirstQuarter.DisplayName("x").Should().Be("First Quarter");
+        MoonPhase.WaxingGibbous.DisplayName("x").Should().Be("Waxing Gibbous");
+        MoonPhase.FullMoon.DisplayName("x").Should().Be("Full Moon");
+        MoonPhase.WaningGibbous.DisplayName("x").Should().Be("Waning Gibbous");
+        MoonPhase.ThirdQuarter.DisplayName("x").Should().Be("Third Quarter");
+        MoonPhase.WaningCrescent.DisplayName("x").Should().Be("Waning Crescent");
+    }
+}

--- a/tests/Mithril.GameState.Tests/Celestial/PlayerCelestialStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Celestial/PlayerCelestialStateServiceTests.cs
@@ -1,0 +1,203 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Celestial;
+using Mithril.GameState.Celestial.Parsing;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Celestial;
+
+public sealed class PlayerCelestialStateServiceTests
+{
+    private static readonly DateTime Stamp = new(2026, 5, 18, 19, 50, 42, DateTimeKind.Utc);
+
+    private const string CrescentLine =
+        "[19:50:42] LocalPlayer: ProcessSetCelestialInfo(WaxingCrescentMoon)";
+    private const string FullLine =
+        "[20:30:00] LocalPlayer: ProcessSetCelestialInfo(FullMoon)";
+
+    private static PlayerCelestialStateService NewService(ScriptedStream stream) =>
+        new(stream, new CelestialLogParser());
+
+    [Fact]
+    public async Task Cold_start_Current_is_null()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            stream.Push(Stamp, "[19:50:42] LocalPlayer: ProcessAddItem(Barley(1), 0, False)");
+            await RunUntilDrainedAsync(svc, stream);
+            svc.Current.Should().BeNull();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Celestial_line_populates_Current_with_phase_and_utc_instant()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            stream.Push(Stamp, CrescentLine);
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Phase.Should().Be(MoonPhase.WaxingCrescent);
+            svc.Current.RawPhase.Should().Be("WaxingCrescentMoon");
+            svc.Current.DisplayName.Should().Be("Waxing Crescent");
+            svc.Current.MeasuredAt.Should().Be(new DateTimeOffset(Stamp));
+            svc.Current.MeasuredAt.Offset.Should().Be(TimeSpan.Zero);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Latest_phase_wins_on_rollover()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            stream.Push(Stamp, CrescentLine);
+            stream.Push(Stamp.AddMinutes(40), FullLine);
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.Current!.Phase.Should().Be(MoonPhase.FullMoon);
+            svc.Current.RawPhase.Should().Be("FullMoon");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Subscribe_after_observed_replays_synchronously_then_delivers_live()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, CrescentLine);
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<CelestialInfo>();
+            using var sub = svc.Subscribe(seen.Add);
+            seen.Should().ContainSingle().Which.Phase.Should().Be(MoonPhase.WaxingCrescent);
+
+            stream.Push(Stamp.AddMinutes(40), FullLine);
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().HaveCount(2);
+            seen[1].Phase.Should().Be(MoonPhase.FullMoon);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Subscribe_with_no_phase_does_not_invoke_handler()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var runTask = svc.StartAsync(cts.Token);
+
+            var seen = 0;
+            using var sub = svc.Subscribe(_ => seen++);
+            seen.Should().Be(0);
+
+            await cts.CancelAsync();
+            _ = runTask;
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Disposed_subscription_stops_receiving()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            var seen = new List<CelestialInfo>();
+            var sub = svc.Subscribe(seen.Add);
+            sub.Dispose();
+
+            stream.Push(Stamp, CrescentLine);
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().BeEmpty();
+            svc.Current.Should().NotBeNull("the service still tracks state even with no subscribers");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    private static async Task RunUntilDrainedAsync(PlayerCelestialStateService svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(PlayerCelestialStateService svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public ScriptedStream() => _drained.TrySetResult();
+
+        public void Push(DateTime ts, string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(ts, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Celestial/PlayerCelestialStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Celestial/PlayerCelestialStateServiceTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using FluentAssertions;
 using Mithril.GameState.Celestial;
 using Mithril.GameState.Celestial.Parsing;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Xunit;
 
@@ -16,8 +17,9 @@ public sealed class PlayerCelestialStateServiceTests
     private const string FullLine =
         "[20:30:00] LocalPlayer: ProcessSetCelestialInfo(FullMoon)";
 
-    private static PlayerCelestialStateService NewService(ScriptedStream stream) =>
-        new(stream, new CelestialLogParser());
+    private static PlayerCelestialStateService NewService(
+        ScriptedStream stream, IDiagnosticsSink? diag = null) =>
+        new(stream, new CelestialLogParser(), diag);
 
     [Fact]
     public async Task Cold_start_Current_is_null()
@@ -147,6 +149,56 @@ public sealed class PlayerCelestialStateServiceTests
             _ = runTask;
             svc.Dispose();
         }
+    }
+
+    [Fact]
+    public async Task Unmapped_token_writes_an_Error_diagnostic_once_per_distinct_token()
+    {
+        var stream = new ScriptedStream();
+        var diag = new DiagnosticsSink();
+        var svc = NewService(stream, diag);
+        try
+        {
+            // Same unmapped token replayed 3× (login + roll-overs); a second,
+            // different unmapped token once.
+            stream.Push(Stamp, "[19:50:42] LocalPlayer: ProcessSetCelestialInfo(BloodMoonEclipse)");
+            stream.Push(Stamp.AddMinutes(40), "[20:30:00] LocalPlayer: ProcessSetCelestialInfo(BloodMoonEclipse)");
+            stream.Push(Stamp.AddHours(1), "[20:50:00] LocalPlayer: ProcessSetCelestialInfo(BloodMoonEclipse)");
+            stream.Push(Stamp.AddHours(2), "[21:50:00] LocalPlayer: ProcessSetCelestialInfo(VoidMoon)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            var errors = diag.Snapshot()
+                .Where(e => e.Level == DiagnosticLevel.Error
+                            && e.Category == "GameState.Celestial")
+                .ToArray();
+
+            errors.Should().HaveCount(2, "one Error per distinct unmapped token, deduped on replay");
+            errors.Should().ContainSingle(e => e.Message.Contains("'BloodMoonEclipse'"));
+            errors.Should().ContainSingle(e => e.Message.Contains("'VoidMoon'"));
+            errors[0].Message.Should().Contain("no MoonPhase enum member");
+
+            // The value is still tracked despite being unmapped.
+            svc.Current!.Phase.Should().Be(MoonPhase.Unknown);
+            svc.Current.RawPhase.Should().Be("VoidMoon");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Recognised_tokens_emit_no_Error_diagnostic()
+    {
+        var stream = new ScriptedStream();
+        var diag = new DiagnosticsSink();
+        var svc = NewService(stream, diag);
+        try
+        {
+            stream.Push(Stamp, CrescentLine);
+            stream.Push(Stamp.AddMinutes(40), FullLine);
+            await RunUntilDrainedAsync(svc, stream);
+
+            diag.Snapshot().Should().NotContain(e => e.Level == DiagnosticLevel.Error);
+        }
+        finally { await StopAsync(svc); }
     }
 
     private static async Task RunUntilDrainedAsync(PlayerCelestialStateService svc, ScriptedStream stream)

--- a/tests/Palantir.Tests/WorldStateViewModelTests.cs
+++ b/tests/Palantir.Tests/WorldStateViewModelTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Celestial;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
 using Mithril.Reference.Models.Items;
@@ -92,7 +93,7 @@ public sealed class WorldStateViewModelTests
         pos.PreloadAsCurrent(new PlayerPosition(1, 2, 3, T, PlayerPositionSource.Spawn));
         using var vm = new WorldStateViewModel(
             pos, new PlayerAreaTracker(new AreaTransitionParser()),
-            new FakePinTracker(), null, a => a());
+            new FakePinTracker(), new FakeCelestialState(), null, a => a());
 
         vm.HasPosition.Should().BeTrue();
         vm.PositionText.Should().Be("X 1.00   Y 2.00   Z 3.00");
@@ -122,7 +123,7 @@ public sealed class WorldStateViewModelTests
             Pin(10, -20, "Vendor"), Pin(-5.5, 99.25, ""));
         using var vm = new WorldStateViewModel(
             new FakePositionTracker(), new PlayerAreaTracker(new AreaTransitionParser()),
-            pins, null, a => a());
+            pins, new FakeCelestialState(), null, a => a());
 
         vm.HasPins.Should().BeTrue();
         vm.PinCount.Should().Be(2);
@@ -203,19 +204,87 @@ public sealed class WorldStateViewModelTests
         vm.HasPins.Should().BeFalse("the disposed VM must unsubscribe from pins");
     }
 
+    // --- Moon phase -------------------------------------------------------
+
+    [Fact]
+    public void No_celestial_info_shows_default()
+    {
+        using var vm = NewVm(out _, out _, out _, out _);
+
+        vm.HasMoonPhase.Should().BeFalse();
+        vm.MoonPhaseText.Should().Contain("no celestial");
+        vm.MoonMeasuredAtText.Should().Be("—");
+    }
+
+    [Fact]
+    public void Celestial_event_surfaces_phase_raw_token_and_instant()
+    {
+        using var vm = NewVm(out _, out _, out _, out var celestial);
+
+        celestial.Fire(new CelestialInfo(MoonPhase.WaxingCrescent, "WaxingCrescentMoon", T));
+
+        vm.HasMoonPhase.Should().BeTrue();
+        vm.MoonPhaseText.Should().Be("Waxing Crescent");
+        vm.MoonPhaseRawText.Should().Be("WaxingCrescentMoon");
+        vm.MoonMeasuredAtText.Should().Be("2026-05-18 10:45:47Z");
+    }
+
+    [Fact]
+    public void Unrecognised_phase_token_is_flagged_but_still_shown()
+    {
+        using var vm = NewVm(out _, out _, out _, out var celestial);
+
+        celestial.Fire(new CelestialInfo(MoonPhase.Unknown, "BloodMoonEclipse", T));
+
+        vm.HasMoonPhase.Should().BeTrue();
+        vm.MoonPhaseText.Should().Be("Blood Moon Eclipse");
+        vm.MoonPhaseRawText.Should().Be("BloodMoonEclipse (unrecognised token)");
+    }
+
+    [Fact]
+    public void Replay_on_subscribe_seeds_existing_phase()
+    {
+        var celestial = new FakeCelestialState();
+        celestial.PreloadAsCurrent(new CelestialInfo(MoonPhase.FullMoon, "FullMoon", T));
+        using var vm = new WorldStateViewModel(
+            new FakePositionTracker(), new PlayerAreaTracker(new AreaTransitionParser()),
+            new FakePinTracker(), celestial, null, a => a());
+
+        vm.HasMoonPhase.Should().BeTrue();
+        vm.MoonPhaseText.Should().Be("Full Moon");
+    }
+
+    [Fact]
+    public void Dispose_stops_observing_celestial()
+    {
+        using var vm = NewVm(out _, out _, out _, out var celestial);
+        vm.Dispose();
+
+        celestial.Fire(new CelestialInfo(MoonPhase.FullMoon, "FullMoon", T));
+
+        vm.HasMoonPhase.Should().BeFalse("the disposed VM must unsubscribe from celestial");
+    }
+
     private static WorldStateViewModel NewVm(
         out FakePositionTracker pos, out PlayerAreaTracker area, IReferenceDataService? refData = null)
-        => NewVm(out pos, out area, out _, refData);
+        => NewVm(out pos, out area, out _, out _, refData);
 
     private static WorldStateViewModel NewVm(
         out FakePositionTracker pos, out PlayerAreaTracker area,
         out FakePinTracker pins, IReferenceDataService? refData = null)
+        => NewVm(out pos, out area, out pins, out _, refData);
+
+    private static WorldStateViewModel NewVm(
+        out FakePositionTracker pos, out PlayerAreaTracker area,
+        out FakePinTracker pins, out FakeCelestialState celestial,
+        IReferenceDataService? refData = null)
     {
         pos = new FakePositionTracker();
         area = new PlayerAreaTracker(new AreaTransitionParser());
         pins = new FakePinTracker();
+        celestial = new FakeCelestialState();
         // Synchronous dispatcher: test thread is the WPF thread.
-        return new WorldStateViewModel(pos, area, pins, refData, a => a());
+        return new WorldStateViewModel(pos, area, pins, celestial, refData, a => a());
     }
 
     private sealed class FakePositionTracker : IPlayerPositionTracker
@@ -279,6 +348,34 @@ public sealed class WorldStateViewModelTests
         }
 
         private sealed class Sub(FakePinTracker owner) : IDisposable
+        {
+            public void Dispose() => owner._handler = null;
+        }
+    }
+
+    private sealed class FakeCelestialState : IPlayerCelestialState
+    {
+        private CelestialInfo? _current;
+        private Action<CelestialInfo>? _handler;
+
+        public CelestialInfo? Current => _current;
+
+        public void PreloadAsCurrent(CelestialInfo c) => _current = c;
+
+        public void Fire(CelestialInfo c)
+        {
+            _current = c;
+            _handler?.Invoke(c);
+        }
+
+        public IDisposable Subscribe(Action<CelestialInfo> handler)
+        {
+            if (_current is not null) handler(_current);
+            _handler = handler;
+            return new Sub(this);
+        }
+
+        private sealed class Sub(FakeCelestialState owner) : IDisposable
         {
             public void Dispose() => owner._handler = null;
         }


### PR DESCRIPTION
## What

Adds a **live lunar-phase GameState producer** and surfaces it read-only on Palantir's **World State** debug tab.

The Player.log line `LocalPlayer: ProcessSetCelestialInfo(<phase>)` (emitted on login + every phase roll-over) was previously dropped on the floor — moon phase was unobservable to Mithril even though `GameClock` models in-game time-of-day. Silmarillion surfaces `MoonPhase`/`FullMoon` recipe & quest gates *statically* and the planner deliberately punts on cyclical gates on the basis that "the player can see the gate somewhere"; this is the live half of that signal.

## How

New `Mithril.GameState/Celestial/` (inside the existing `Mithril.GameState` lib — no new shared lib, so no Shell-ProjectReference boot-stall risk):

- **`CelestialLogParser`** (`ILogParser`) — substring fast-path + boundary-checked `LocalPlayer:` regex (rejects `NonLocalPlayer:`, mirrors `PlayerPositionParser`'s discipline).
- **`MoonPhase`** — canonical 8-phase enum + a tolerant token mapper. Collapses the **three observed spellings** (log `WaxingCrescentMoon`, reference-data `WaxingCrescent`/`FullMoon`/`NewMoon`, prose) onto one key. **Unrecognised tokens → `Unknown` but the verbatim raw string is always retained and still displayed** — robust to the vocabulary uncertainty flagged in the investigation.
- **`PlayerCelestialStateService`** — self-feeding `BackgroundService` implementing `IPlayerCelestialState` (`Current` + replay-on-subscribe), a near-exact clone of `PlayerPositionTracker` (single-value state, `IDiagnosticsSink` instrumentation under category `GameState.Celestial`). Registered in `GameStateServiceCollectionExtensions` the same way as the position/recipe/skill producers.
- **Palantir** — `WorldStateViewModel` gains a celestial subscription (UI-thread-marshalled like the existing position/pin handlers); `WorldStateView` gains a **MOON** section showing the friendly phase, the raw token (flagged when unrecognised), and the measured-at UTC instant.

## Caveat (carried from the investigation)

The six non-quarter phases are confirmed from a live capture + `strings_all`. The two **quarter tokens (`FirstQuarter`/`ThirdQuarter`) are the standard astronomical names and are *not yet confirmed against a live Player.log***. If PG emits a different token there it maps to `Unknown` and the raw string still surfaces verbatim — no data loss, just a missing friendly name until confirmed. `LastQuarter` is accepted as a `ThirdQuarter` synonym defensively.

## Tests

- `CelestialLogParserTests` — real captured line, all three spellings, unrecognised-token fallback, non-local rejection, malformed/unrelated → null, every phase's DisplayName.
- `PlayerCelestialStateServiceTests` — cold-start null, populate, roll-over last-writer-wins, replay-on-subscribe + live delivery, no-phase no-invoke, disposed-subscription.
- `WorldStateViewModelTests` — default state, event surfacing, unrecognised-token flagging, replay-on-subscribe seeding, dispose-unsubscribe; existing pin/position tests updated for the new ctor arg.

Full solution builds clean (0 warnings). **248** `Mithril.GameState.Tests` + **25** `Palantir.Tests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
