### PR TITLE
feat(gamestate): live per-map weather producer + Palantir surface

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Mithril.GameState.Quests.Parsing;
 using Mithril.GameState.Sessions;
 using Mithril.GameState.Skills;
 using Mithril.GameState.Skills.Parsing;
+using Mithril.GameState.Weather;
 using Mithril.Shared.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -103,6 +104,22 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<PlayerCelestialStateService>()
             .AddSingleton<IPlayerCelestialState>(sp => sp.GetRequiredService<PlayerCelestialStateService>())
             .AddHostedService(sp => sp.GetRequiredService<PlayerCelestialStateService>());
+
+        // Shared live weather state from Player.log (ProcessSetWeather). PG's
+        // Vampirism skill makes the player take sun damage, so the ambient
+        // condition is a real game-mechanic input for a future sun-damage
+        // consumer; Palantir is the immediate debug surface. Weather is
+        // per-map (owner-confirmed), so the tracker is area-scoped exactly
+        // like PlayerPinTracker — self-feeding, drops on map change,
+        // idempotent on zone-entry replay. Single parser, single tracker;
+        // consumers inject IPlayerWeatherTracker. The log grammar is not yet
+        // corpus-verified, so it is deliberately kept out of log-patterns.json
+        // until characterised (see WeatherLogParser).
+        services.AddSingleton<WeatherLogParser>();
+        services
+            .AddSingleton<PlayerWeatherTracker>()
+            .AddSingleton<IPlayerWeatherTracker>(sp => sp.GetRequiredService<PlayerWeatherTracker>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerWeatherTracker>());
 
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();

--- a/src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs
+++ b/src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs
@@ -1,0 +1,108 @@
+namespace Mithril.GameState.Weather;
+
+/// <summary>
+/// The local player's ambient weather <em>for the current map</em>, plus the
+/// instant it was observed. <see cref="MeasuredAt"/> is the source log line's
+/// UTC instant (Player.log <c>[HH:MM:SS]</c> prefixes are UTC), exposed as a
+/// <see cref="DateTimeOffset"/>.
+///
+/// <para><see cref="Condition"/> is the game's verb argument verbatim
+/// (e.g. <c>"Foggy"</c>) — deliberately <em>not</em> classified into
+/// sunny/overcast here. The <c>Vampirism</c> sun-damage consumer owns that
+/// interpretation; this record is the faithful raw signal (the same
+/// dumb-producer split as the pin tracker surfacing raw pin appearance).</para>
+/// </summary>
+/// <param name="Condition">The weather condition string verbatim from the
+/// <c>ProcessSetWeather</c> first argument.</param>
+/// <param name="Flag">The line's opaque second boolean — passed through
+/// unmodified; semantics unverified (Verification owed, see
+/// <see cref="WeatherChangedEvent.Flag"/>).</param>
+/// <param name="MeasuredAt">UTC instant of the source log line.</param>
+public sealed record WeatherState(
+    string Condition, bool Flag, DateTimeOffset MeasuredAt);
+
+/// <summary>How a <see cref="WeatherChanged"/> notification arose.</summary>
+public enum WeatherChangeKind
+{
+    /// <summary>Replayed synchronously to a new subscriber — the current
+    /// map's weather as it already stands (<see cref="WeatherChanged.State"/>
+    /// is <c>null</c> if none has been observed for this map yet). Mirrors
+    /// <c>PinSetChange.Snapshot</c>.</summary>
+    Snapshot,
+
+    /// <summary>A genuine weather change for the current map. An idempotent
+    /// re-emit of the same condition/flag (e.g. a zone-entry replay) does
+    /// <b>not</b> raise this.</summary>
+    Changed,
+
+    /// <summary>The player changed map: the previous map's weather was dropped
+    /// (it is per-map and does not carry across) and
+    /// <see cref="WeatherChanged.State"/> is <c>null</c> until the new map's
+    /// <c>ProcessSetWeather</c> arrives. Mirrors
+    /// <c>PinSetChange.AreaChanged</c>.</summary>
+    AreaChanged,
+}
+
+/// <summary>
+/// A change to the current map's weather. <see cref="State"/> is the full
+/// weather <em>after</em> the change (an immutable record, safe to hold), or
+/// <c>null</c> when the current map's weather is not yet known — after an
+/// <see cref="WeatherChangeKind.AreaChanged"/>, or a
+/// <see cref="WeatherChangeKind.Snapshot"/> replay before any weather has been
+/// observed for the map. For the <c>Vampirism</c> consumer, <c>null</c> means
+/// "weather unknown" — distinct from a known clear/sunny condition.
+/// </summary>
+/// <param name="Kind">Why this notification arose.</param>
+/// <param name="Area">The map key the weather belongs to (the shared
+/// <c>PlayerAreaTracker</c> key; may be <c>null</c> if the area is
+/// unknown).</param>
+/// <param name="State">The current map's weather after the change, or
+/// <c>null</c> if not yet known for this map.</param>
+/// <param name="ObservedAt">UTC instant of the source log line (or the
+/// subscribe instant for a <see cref="WeatherChangeKind.Snapshot"/> replay /
+/// the area-transition instant for <see cref="WeatherChangeKind.AreaChanged"/>).</param>
+public sealed record WeatherChanged(
+    WeatherChangeKind Kind,
+    string? Area,
+    WeatherState? State,
+    DateTimeOffset ObservedAt);
+
+/// <summary>
+/// Shared live game-state: the local player's <b>per-map</b> ambient weather,
+/// owned authoritatively here. Mirrors
+/// <see cref="Mithril.GameState.Pins.IPlayerPinTracker"/> — weather is
+/// map-scoped (it does not carry from one map to the next, which matters for
+/// the <c>Vampirism</c> sun-damage consumer), so this exposes a
+/// <see cref="CurrentArea"/> + the map's <see cref="Current"/> weather plus a
+/// replay-on-<see cref="Subscribe"/> handler so late subscribers see the same
+/// view already-attached ones do.
+///
+/// <para><b>Why the service owns the lifecycle.</b> Weather belongs to the
+/// map; on a map change the previous map's value is stale and is dropped, and
+/// the new map's <c>ProcessSetWeather</c> repopulates it (an unchanged re-emit
+/// is idempotent). Centralising this here means every consumer reads a correct
+/// current-map weather instead of each re-deriving the area gate.</para>
+/// </summary>
+public interface IPlayerWeatherTracker
+{
+    /// <summary>The map the tracked weather belongs to (the shared
+    /// <c>PlayerAreaTracker</c> key), or <c>null</c> if unknown.</summary>
+    string? CurrentArea { get; }
+
+    /// <summary>
+    /// The current map's weather, or <c>null</c> before the first
+    /// <c>ProcessSetWeather</c> for this map is seen / immediately after a map
+    /// change. <c>null</c> means "weather unknown for this map" — for the
+    /// <c>Vampirism</c> consumer that is distinct from a known clear sky.
+    /// </summary>
+    WeatherState? Current { get; }
+
+    /// <summary>
+    /// Register a handler. The current state is replayed synchronously as a
+    /// <see cref="WeatherChangeKind.Snapshot"/> before the call returns;
+    /// subsequent changes are delivered live until the returned token is
+    /// disposed. Handlers run on the ingestion thread — marshal off-thread for
+    /// non-trivial / UI work (mirrors the pin tracker's contract).
+    /// </summary>
+    IDisposable Subscribe(Action<WeatherChanged> handler);
+}

--- a/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
+++ b/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
@@ -1,0 +1,228 @@
+using Mithril.GameState.Areas;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Weather;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IPlayerWeatherTracker"/>. Tails
+/// <see cref="IPlayerLogStream"/>, parses <c>ProcessSetWeather</c> via
+/// <see cref="WeatherLogParser"/>, and holds the current <b>map's</b>
+/// <see cref="WeatherState"/> (condition + opaque flag + the line's UTC
+/// instant).
+///
+/// <para><b>Lifecycle the service owns</b> (so no consumer hand-rolls it) —
+/// the same area-scoped shape as <see cref="Pins.PlayerPinTracker"/> because
+/// weather is per-map (owner-confirmed):</para>
+/// <list type="bullet">
+///   <item><b>Map change = drop.</b> Weather belongs to the map; on any
+///   <c>PlayerAreaTracker.CurrentArea</c> change the value is cleared and a
+///   <see cref="WeatherChangeKind.AreaChanged"/> (<c>State == null</c>) is
+///   raised. <c>null</c> reads as "weather unknown for this map" — for the
+///   <c>Vampirism</c> consumer that is distinct from a known clear sky, so a
+///   stale foggy/sunny value never bleeds across a zone.</item>
+///   <item><b>Genuine change = update + notify.</b> A new condition/flag for
+///   the current map updates <see cref="Current"/> and raises
+///   <see cref="WeatherChangeKind.Changed"/>.</item>
+///   <item><b>Idempotent re-emit.</b> If PG re-emits the current weather on
+///   zone entry (replay — unverified but plausible), the repeat is a no-op and
+///   raises nothing, so consumers stay quiet through a backlog (the same
+///   idempotence stance as <c>PlayerPinTracker</c>'s replay burst).</item>
+/// </list>
+///
+/// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
+/// <see cref="Pins.PlayerPinTracker"/> / <see cref="Movement.PlayerPositionTracker"/>:
+/// shared live game-state must be available to consumers (the future
+/// <c>Vampirism</c> sun-damage feature; Palantir's debug surface) without
+/// depending on any module being activated. It also calls
+/// <see cref="PlayerAreaTracker.Observe(RawLogLine)"/> to keep the shared area
+/// tracker warm (idempotent when the position/pin trackers also feed it). No
+/// reverse-scan seed is needed here: the shared <see cref="PlayerAreaTracker"/>
+/// singleton is already seeded at startup by the position tracker, and a
+/// per-map weather emit lands inside the live window after its
+/// <c>LOADING LEVEL</c> line.</para>
+///
+/// <para><b>Threading.</b> Ingestion runs on the hosted-service loop thread;
+/// <see cref="CurrentArea"/>/<see cref="Current"/> reads, state mutation and
+/// subscriber dispatch are serialised under <c>_lock</c>; each notification
+/// carries an immutable record, so handlers may hold it. They run on the
+/// ingestion thread — non-trivial / UI work must marshal off (mirrors
+/// PlayerPinTracker).</para>
+/// </summary>
+public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTracker
+{
+    private readonly IPlayerLogStream _stream;
+    private readonly WeatherLogParser _parser;
+    private readonly PlayerAreaTracker _areaTracker;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly List<Action<WeatherChanged>> _handlers = [];
+    private WeatherState? _current;
+    private string? _trackedArea;
+    private bool _areaInitialised;
+
+    /// <param name="stream">The shared Player.log line stream this service tails.</param>
+    /// <param name="parser">Stateless line→<see cref="WeatherChangedEvent"/> parser.</param>
+    /// <param name="areaTracker">Shared map key source; also fed every line
+    /// here so it stays warm without another module being active.</param>
+    /// <param name="diag">Optional diagnostics sink (info on subscribe,
+    /// warnings on ingestion / subscriber faults).</param>
+    public PlayerWeatherTracker(
+        IPlayerLogStream stream,
+        WeatherLogParser parser,
+        PlayerAreaTracker areaTracker,
+        IDiagnosticsSink? diag = null)
+    {
+        _stream = stream;
+        _parser = parser;
+        _areaTracker = areaTracker;
+        _diag = diag;
+    }
+
+    /// <inheritdoc/>
+    public string? CurrentArea
+    {
+        get { lock (_lock) return _trackedArea; }
+    }
+
+    /// <inheritdoc/>
+    public WeatherState? Current
+    {
+        get { lock (_lock) return _current; }
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(Action<WeatherChanged> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // Replay the current state before going live so a late subscriber
+            // observes the same view already-attached handlers see. Mirrors
+            // PlayerPinTracker.Subscribe.
+            Invoke(handler, new WeatherChanged(
+                WeatherChangeKind.Snapshot, _trackedArea, _current,
+                DateTimeOffset.UtcNow));
+            _handlers.Add(handler);
+            return new Subscription(this, handler);
+        }
+    }
+
+    /// <summary>
+    /// The hosted-service ingestion loop: for every Player.log line, warm the
+    /// shared area tracker, reconcile a map change, then fold a parsed weather
+    /// event into the current map's state. Exits when
+    /// <paramref name="stoppingToken"/> is cancelled or the stream completes;
+    /// per-line exceptions are logged and swallowed so one bad line never
+    /// stops ingestion.
+    /// </summary>
+    /// <param name="stoppingToken">Host shutdown signal.</param>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Weather", "Subscribing to Player.log for ProcessSetWeather");
+        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                // Same line stream carries map transitions; keep the shared
+                // tracker warm even when no other feeder is active.
+                _areaTracker.Observe(raw);
+                ReconcileArea();
+
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is WeatherChangedEvent evt)
+                    Apply(evt);
+            }
+            catch (Exception ex)
+            {
+                _diag?.Warn("GameState.Weather", $"Ingestion error: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drop the weather whenever the shared map key changes (including the
+    /// first time it becomes known). Weather is per-map; the new map's
+    /// <c>ProcessSetWeather</c> — which follows the <c>LOADING LEVEL</c> line
+    /// that moved the key — repopulates it.
+    /// </summary>
+    private void ReconcileArea()
+    {
+        var area = _areaTracker.CurrentArea;
+        WeatherChanged? note = null;
+        lock (_lock)
+        {
+            if (_areaInitialised && area == _trackedArea) return;
+            _areaInitialised = true;
+            _trackedArea = area;
+            _current = null;
+            note = new WeatherChanged(
+                WeatherChangeKind.AreaChanged, area, null,
+                DateTimeOffset.UtcNow);
+        }
+        if (note is not null) Publish(note);
+    }
+
+    private void Apply(WeatherChangedEvent evt)
+    {
+        WeatherChanged? note = null;
+        lock (_lock)
+        {
+            // Idempotent: a replay re-emit of the unchanged weather for the
+            // current map is a no-op and notifies nothing.
+            if (_current is { } cur
+                && string.Equals(cur.Condition, evt.Condition, StringComparison.Ordinal)
+                && cur.Flag == evt.Flag)
+            {
+                return;
+            }
+
+            _current = new WeatherState(evt.Condition, evt.Flag, ToOffset(evt.Timestamp));
+            note = new WeatherChanged(
+                WeatherChangeKind.Changed, _trackedArea, _current,
+                ToOffset(evt.Timestamp));
+        }
+        if (note is not null) Publish(note);
+    }
+
+    private void Publish(WeatherChanged note)
+    {
+        Action<WeatherChanged>[] toFire;
+        lock (_lock) toFire = _handlers.ToArray();
+        foreach (var h in toFire) Invoke(h, note);
+    }
+
+    private void Invoke(Action<WeatherChanged> handler, WeatherChanged note)
+    {
+        try { handler(note); }
+        catch (Exception ex) { _diag?.Warn("GameState.Weather", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Player.log timestamps are reconstructed as UTC <see cref="DateTime"/>s.
+    /// Stamp the kind defensively so the offset is +00:00 rather than the
+    /// host's local offset (mirrors PlayerPinTracker.ToOffset).
+    /// </summary>
+    private static DateTimeOffset ToOffset(DateTime ts) =>
+        new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
+
+    private sealed class Subscription : IDisposable
+    {
+        private PlayerWeatherTracker? _owner;
+        private readonly Action<WeatherChanged> _handler;
+
+        public Subscription(PlayerWeatherTracker owner, Action<WeatherChanged> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock) { owner._handlers.Remove(_handler); }
+        }
+    }
+}

--- a/src/Mithril.GameState/Weather/WeatherChangedEvent.cs
+++ b/src/Mithril.GameState/Weather/WeatherChangedEvent.cs
@@ -1,0 +1,39 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Weather;
+
+/// <summary>
+/// One parsed <c>LocalPlayer: ProcessSetWeather("&lt;condition&gt;", &lt;flag&gt;)</c>
+/// line. The pure line→event output of <see cref="WeatherLogParser"/>;
+/// <see cref="PlayerWeatherTracker"/> folds a stream of these into the
+/// last-known weather state.
+///
+/// <para>Carries a <see cref="LogEvent"/>-mandated <see cref="DateTime"/>
+/// timestamp (Player.log <c>[HH:MM:SS]</c> is UTC). It is converted to a
+/// <see cref="DateTimeOffset"/> at the tracker boundary — model/notification
+/// surfaces use <see cref="DateTimeOffset"/>; the parser interface is not
+/// widened (mirrors <c>MapPinLogEvent</c>).</para>
+///
+/// <para><b>Why this exists.</b> Project Gorgon's <c>Vampirism</c> skill makes
+/// the player take damage in sunlight; the ambient weather condition gates
+/// whether that is happening. This event is the raw, faithful signal. It does
+/// <em>not</em> interpret which conditions are "sunny" / damaging — that
+/// classification is a consuming feature's job (the same dumb-producer split
+/// as <c>MapPinLogEvent</c> carrying a raw <c>RawList</c> arg).</para>
+/// </summary>
+/// <param name="Timestamp">The source line's reconstructed UTC instant
+/// (Player.log <c>[HH:MM:SS]</c> is UTC).</param>
+/// <param name="Condition">The weather condition string verbatim from the
+/// first argument (e.g. <c>"Foggy"</c>). Surfaced unmodified — no normalisation
+/// or sunny/overcast classification here.</param>
+/// <param name="Flag">The line's opaque second boolean argument, passed
+/// through unmodified (the same convention as <c>MapPinLogEvent.RawList</c>).
+/// <b>Semantics unverified — Verification owed:</b> from the single captured
+/// sample <c>ProcessSetWeather("Foggy", True)</c> the meaning is unknown
+/// (plausibly a crossfade-vs-instant flag, or a login-resync vs. live-change
+/// flag — neither confirmed against a live corpus). Consumers should not depend
+/// on an interpretation of this bit until the grammar is characterised.</param>
+public sealed record WeatherChangedEvent(
+    DateTime Timestamp,
+    string Condition,
+    bool Flag) : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Weather/WeatherLogParser.cs
+++ b/src/Mithril.GameState/Weather/WeatherLogParser.cs
@@ -1,0 +1,76 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Weather;
+
+/// <summary>
+/// Parses the local player's ambient weather from Project Gorgon's
+/// <c>Player.log</c>. The same tier-promotion / single-verb shape as
+/// <c>MapPinParser</c> (#468) and <c>PlayerPositionParser</c> — a single
+/// GameState service owns the authoritative state and consumers stop
+/// hand-rolling the parse.
+///
+/// <para><b>Captured grammar</b> (single sample, 2026-05-18 — <b>not yet
+/// corpus-verified</b>):</para>
+/// <code>
+/// [19:50:42] LocalPlayer: ProcessSetWeather("Foggy", True)
+/// </code>
+/// One verb (<c>ProcessSetWeather</c>); the first argument is a quoted
+/// condition string surfaced verbatim, the second is an opaque boolean
+/// (<see cref="WeatherChangedEvent.Flag"/> — semantics Verification owed).
+/// Non-weather lines fast-path to <c>null</c>; a malformed weather line never
+/// throws (defensive, mirrors <c>MapPinParser</c>).
+///
+/// <para>Weather is <b>per-map</b> (owner-confirmed) — it does not carry from
+/// one map to the next; <see cref="PlayerWeatherTracker"/> drops it on a map
+/// change and the new map's <c>ProcessSetWeather</c> repopulates it (the same
+/// area-scoped lifecycle as <c>PlayerPinTracker</c>).</para>
+///
+/// <para><b>Verification owed</b> (needs a live Player.log pass before this
+/// grammar can be promoted into <c>log-patterns.json</c>): the meaning of the
+/// boolean; whether a <c>False</c> form exists; whether weather is re-emitted
+/// on zone entry (replay) or only on genuine transitions. The tracker's
+/// per-map, idempotent, drop-on-map-change stance is correct under every one
+/// of those remaining hypotheses.</para>
+/// </summary>
+public sealed partial class WeatherLogParser : ILogParser
+{
+    // ProcessSetWeather("Foggy", True)
+    //                    condition  flag
+    [GeneratedRegex(
+        """ProcessSetWeather\(\s*"(?<condition>[^"]*)"\s*,\s*(?<flag>True|False)\s*\)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex WeatherRx();
+
+    /// <summary>
+    /// Parse one <c>Player.log</c> line. Pure and allocation-light: a substring
+    /// fast-path rejects non-weather lines before the regex runs, so it is safe
+    /// to call on every line of the stream.
+    /// </summary>
+    /// <param name="line">The raw log line (the regex is anchored on
+    /// <c>ProcessSetWeather</c> and tolerates the timestamp/<c>LocalPlayer:</c>
+    /// prefix).</param>
+    /// <param name="timestamp">The line's reconstructed UTC instant, passed
+    /// straight onto <see cref="WeatherChangedEvent.Timestamp"/>.</param>
+    /// <returns>
+    /// A <see cref="WeatherChangedEvent"/> for a well-formed
+    /// <c>ProcessSetWeather</c> line; <c>null</c> for any other line, an
+    /// empty/blank line, or a weather line that fails the shape (defensive —
+    /// never throws on malformed input).
+    /// </returns>
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(line)) return null;
+
+        if (!line.Contains("ProcessSetWeather", StringComparison.Ordinal)) return null;
+
+        if (WeatherRx().Match(line) is not { Success: true } m) return null;
+
+        var flag = m.Groups["flag"].ValueSpan is "True";
+
+        return new WeatherChangedEvent(
+            timestamp,
+            m.Groups["condition"].Value,
+            flag);
+    }
+}

--- a/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
+++ b/src/Palantir.Module/ViewModels/WorldStateViewModel.cs
@@ -6,6 +6,7 @@ using Mithril.GameState.Areas;
 using Mithril.GameState.Celestial;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
+using Mithril.GameState.Weather;
 using Mithril.Shared.Reference;
 
 namespace Palantir.ViewModels;
@@ -17,7 +18,8 @@ namespace Palantir.ViewModels;
 /// friendly names, the player's last-known <see cref="PlayerPosition"/>
 /// (coords + the UTC instant it was measured) from
 /// <see cref="IPlayerPositionTracker"/>, and the area-scoped player map-pin
-/// set from <see cref="IPlayerPinTracker"/>.
+/// set from <see cref="IPlayerPinTracker"/>, and the per-map ambient weather
+/// from <see cref="IPlayerWeatherTracker"/>.
 ///
 /// <para>Position is event-driven (sparse — teleport / zone-in only). The
 /// area tracker exposes no change event, so it is re-read on every position
@@ -41,11 +43,13 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     private readonly PlayerAreaTracker _areaTracker;
     private readonly IPlayerPinTracker _pinTracker;
     private readonly IPlayerCelestialState _celestial;
+    private readonly IPlayerWeatherTracker _weatherTracker;
     private readonly IReferenceDataService? _refData;
     private readonly Action<Action> _dispatch;
     private IDisposable? _subscription;
     private IDisposable? _pinSubscription;
     private IDisposable? _celestialSubscription;
+    private IDisposable? _weatherSubscription;
 
     [ObservableProperty] private string _areaKey = "(unknown)";
     [ObservableProperty] private string _areaFriendlyName = "(area not yet known)";
@@ -66,6 +70,11 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
     [ObservableProperty] private string _moonPhaseRawText = "—";
     [ObservableProperty] private string _moonMeasuredAtText = "—";
 
+    [ObservableProperty] private bool _hasWeather;
+    [ObservableProperty] private string _weatherConditionText = "(weather unknown for this map)";
+    [ObservableProperty] private string _weatherFlagText = "—";
+    [ObservableProperty] private string _weatherObservedAtText = "—";
+
     /// <summary>The current area's pins as presentation rows. Mutated only
     /// on the dispatched (UI) thread — see <see cref="OnPins"/>.</summary>
     public ObservableCollection<MapPinRow> Pins { get; } = [];
@@ -75,8 +84,9 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         PlayerAreaTracker areaTracker,
         IPlayerPinTracker pinTracker,
         IPlayerCelestialState celestial,
+        IPlayerWeatherTracker weatherTracker,
         IReferenceDataService? refData = null)
-        : this(positionTracker, areaTracker, pinTracker, celestial, refData, dispatch: null)
+        : this(positionTracker, areaTracker, pinTracker, celestial, weatherTracker, refData, dispatch: null)
     { }
 
     /// <summary>
@@ -88,6 +98,7 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         PlayerAreaTracker areaTracker,
         IPlayerPinTracker pinTracker,
         IPlayerCelestialState celestial,
+        IPlayerWeatherTracker weatherTracker,
         IReferenceDataService? refData,
         Action<Action>? dispatch)
     {
@@ -95,15 +106,17 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         _areaTracker = areaTracker;
         _pinTracker = pinTracker;
         _celestial = celestial;
+        _weatherTracker = weatherTracker;
         _refData = refData;
         _dispatch = dispatch ?? DefaultDispatch;
 
         RefreshArea();
-        // Replay-on-subscribe seeds position / the pin set / the phase if
-        // already known.
+        // Replay-on-subscribe seeds position / the pin set / the phase /
+        // weather if already known.
         _subscription = _positionTracker.Subscribe(OnPosition);
         _pinSubscription = _pinTracker.Subscribe(OnPins);
         _celestialSubscription = _celestial.Subscribe(OnCelestial);
+        _weatherSubscription = _weatherTracker.Subscribe(OnWeather);
     }
 
     private void OnPosition(PlayerPosition p) => _dispatch(() =>
@@ -166,6 +179,32 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         MoonMeasuredAtText = c.MeasuredAt.UtcDateTime.ToString("u", CultureInfo.InvariantCulture);
     });
 
+    /// <summary>
+    /// Project the current map's weather. <see cref="WeatherChanged.State"/>
+    /// is <c>null</c> for an <see cref="WeatherChangeKind.AreaChanged"/> reset
+    /// (or a pre-known Snapshot) — surfaced as "weather unknown for this map",
+    /// deliberately distinct from a known clear sky (the Vampirism-relevant
+    /// distinction). Stamping mirrors <see cref="OnPins"/>: a Snapshot replay
+    /// reflects existing state, not a fresh observation, so the "—" placeholder
+    /// is kept until a real change lands; a map change resets it.
+    /// </summary>
+    private void OnWeather(WeatherChanged change)
+    {
+        var state = change.State;
+        var stamp = state is null || change.Kind == WeatherChangeKind.Snapshot
+            ? null
+            : change.ObservedAt.UtcDateTime.ToString("u", CultureInfo.InvariantCulture);
+
+        _dispatch(() =>
+        {
+            HasWeather = state is not null;
+            WeatherConditionText = state?.Condition ?? "(weather unknown for this map)";
+            WeatherFlagText = state is null ? "—" : (state.Flag ? "True" : "False");
+            if (stamp is not null) WeatherObservedAtText = stamp;
+            else if (change.Kind == WeatherChangeKind.AreaChanged) WeatherObservedAtText = "—";
+        });
+    }
+
     [RelayCommand]
     private void Refresh() => _dispatch(RefreshArea);
 
@@ -207,6 +246,8 @@ public sealed partial class WorldStateViewModel : ObservableObject, IDisposable
         _pinSubscription = null;
         _celestialSubscription?.Dispose();
         _celestialSubscription = null;
+        _weatherSubscription?.Dispose();
+        _weatherSubscription = null;
     }
 
     private static void DefaultDispatch(Action action)

--- a/src/Palantir.Module/Views/WorldStateView.xaml
+++ b/src/Palantir.Module/Views/WorldStateView.xaml
@@ -41,7 +41,10 @@
                 replays the whole set on every login / zone change. The lunar
                 phase comes from Player.log ProcessSetCelestialInfo (login +
                 every phase roll-over) and backs the moon-gated recipes /
-                quests.
+                quests. Weather is per-map (ProcessSetWeather) — it is dropped
+                on a map change and reads "unknown" until the new map reports,
+                so a foggy/sunny value never bleeds across a zone (the
+                Vampirism-relevant case).
             </TextBlock>
 
             <!-- Map / area -->
@@ -201,6 +204,43 @@
                                    FontFamily="{DynamicResource AppMonoFontFamily}"
                                    Foreground="#88FFFFFF"/>
                     </DockPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Weather -->
+            <TextBlock Text="WEATHER" Foreground="#88FFFFFF"
+                       FontSize="{DynamicResource AppFontSizeHint}"
+                       FontWeight="SemiBold" Margin="0,16,0,4"/>
+            <Border Background="#FF252525" CornerRadius="4" Padding="14,10">
+                <StackPanel>
+                    <DockPanel Margin="0,0,0,6">
+                        <TextBlock DockPanel.Dock="Left" Text="Condition (this map)"
+                                   Foreground="#CCFFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding WeatherConditionText}"
+                                   Foreground="#FFFFFFFF" FontWeight="SemiBold"/>
+                    </DockPanel>
+                    <DockPanel Margin="0,0,0,6">
+                        <TextBlock DockPanel.Dock="Left" Text="Flag (raw, unverified)"
+                                   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding WeatherFlagText}"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   Foreground="#88FFFFFF"/>
+                    </DockPanel>
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Left" Text="Last change (UTC)"
+                                   Foreground="#88FFFFFF" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding WeatherObservedAtText}"
+                                   FontFamily="{DynamicResource AppMonoFontFamily}"
+                                   Foreground="#88FFFFFF"/>
+                    </DockPanel>
+
+                    <TextBlock Text="(weather unknown — left the map, or not yet reported)"
+                               Foreground="#66FFFFFF" FontStyle="Italic"
+                               Margin="0,4,0,0"
+                               Visibility="{Binding HasWeather, Converter={StaticResource InverseBoolToVis}}"/>
                 </StackPanel>
             </Border>
 

--- a/tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs
@@ -1,0 +1,263 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Weather;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Weather;
+
+public sealed class PlayerWeatherTrackerTests
+{
+    private static readonly DateTime Stamp = new(2026, 5, 18, 19, 50, 42, DateTimeKind.Utc);
+
+    private static PlayerWeatherTracker NewTracker(ScriptedStream stream, PlayerAreaTracker? area = null) =>
+        new(stream, new WeatherLogParser(),
+            area ?? new PlayerAreaTracker(new AreaTransitionParser()));
+
+    private static string Area(string key) => $"[10:00:00] LOADING LEVEL {key}";
+    private static string Set(string condition, bool flag = true) =>
+        $"[19:50:42] LocalPlayer: ProcessSetWeather(\"{condition}\", {(flag ? "True" : "False")})";
+
+    [Fact]
+    public async Task First_weather_line_populates_Current_for_the_map()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Set("Foggy"));
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.CurrentArea.Should().Be("AreaSerbule");
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Condition.Should().Be("Foggy");
+            svc.Current.Flag.Should().BeTrue();
+            svc.Current.MeasuredAt.Offset.Should().Be(TimeSpan.Zero);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Last_writer_wins_on_a_genuine_change()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Set("Foggy"));
+            stream.Push(Stamp, Set("Clear", flag: false));
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.Current!.Condition.Should().Be("Clear");
+            svc.Current.Flag.Should().BeFalse();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Map_change_drops_weather_until_the_new_map_reports()
+    {
+        var stream = new ScriptedStream();
+        var area = new PlayerAreaTracker(new AreaTransitionParser());
+        var svc = NewTracker(stream, area);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Set("Foggy"));
+            await stream.WaitForDrainAsync(cts.Token);
+            svc.Current!.Condition.Should().Be("Foggy");
+
+            var seen = new List<WeatherChanged>();
+            using var sub = svc.Subscribe(seen.Add); // Snapshot replay first
+
+            // Leave the foggy map: weather must not bleed into the next map.
+            stream.Push(Stamp, Area("AreaEltibule"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            svc.CurrentArea.Should().Be("AreaEltibule");
+            svc.Current.Should().BeNull(); // unknown — NOT still Foggy
+            seen.Should().Contain(n =>
+                n.Kind == WeatherChangeKind.AreaChanged
+                && n.Area == "AreaEltibule"
+                && n.State == null);
+
+            // New map reports its own weather.
+            stream.Push(Stamp, Set("Clear", flag: false));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            svc.Current!.Condition.Should().Be("Clear");
+            seen.Last().Should().Match<WeatherChanged>(n =>
+                n.Kind == WeatherChangeKind.Changed
+                && n.Area == "AreaEltibule"
+                && n.State!.Condition == "Clear");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Replay_of_unchanged_weather_is_idempotent_no_extra_events()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Set("Foggy"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<WeatherChanged>();
+            using var sub = svc.Subscribe(seen.Add); // Snapshot
+            seen.Should().ContainSingle()
+                .Which.Should().Match<WeatherChanged>(n =>
+                    n.Kind == WeatherChangeKind.Snapshot && n.State!.Condition == "Foggy");
+
+            // Zone re-emits the current weather verbatim.
+            stream.Push(Stamp, Set("Foggy"));
+            stream.Push(Stamp, Set("Foggy"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().ContainSingle(); // no further notifications
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Subscribe_replays_snapshot_synchronously_then_delivers_live()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            stream.Push(Stamp, Set("Foggy"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<WeatherChanged>();
+            using var sub = svc.Subscribe(seen.Add);
+            seen.Should().ContainSingle()
+                .Which.Should().Match<WeatherChanged>(n =>
+                    n.Kind == WeatherChangeKind.Snapshot && n.State!.Condition == "Foggy");
+
+            stream.Push(Stamp, Set("Rainy"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var last = seen.Last();
+            last.Kind.Should().Be(WeatherChangeKind.Changed);
+            last.State!.Condition.Should().Be("Rainy");
+            last.ObservedAt.Offset.Should().Be(TimeSpan.Zero);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Disposed_subscription_stops_receiving_but_state_advances()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewTracker(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp, Area("AreaSerbule"));
+            var seen = new List<WeatherChanged>();
+            var sub = svc.Subscribe(seen.Add);
+            stream.Push(Stamp, Set("Foggy"));
+            await stream.WaitForDrainAsync(cts.Token);
+            var countAtDispose = seen.Count;
+            sub.Dispose();
+
+            stream.Push(Stamp, Set("Rainy"));
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().HaveCount(countAtDispose); // no further delivery
+            svc.Current!.Condition.Should().Be("Rainy"); // state still advances
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    private static async Task RunUntilDrainedAsync(PlayerWeatherTracker svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(PlayerWeatherTracker svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+
+    private sealed class ScriptedStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcs();
+
+        public ScriptedStream() => _drained.TrySetResult();
+
+        public void Push(DateTime ts, string line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new RawLogLine(ts, line));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_channel.Reader.TryRead(out var line))
+                {
+                    yield return line;
+                    if (Interlocked.Decrement(ref _pending) == 0)
+                        _drained.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Weather/WeatherLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Weather/WeatherLogParserTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Mithril.GameState.Weather;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Weather;
+
+public sealed class WeatherLogParserTests
+{
+    private readonly WeatherLogParser _parser = new();
+    private static readonly DateTime Ts = new(2026, 5, 18, 19, 50, 42, DateTimeKind.Utc);
+
+    // The single real captured sample (2026-05-18).
+    private const string FoggyLine =
+        "[19:50:42] LocalPlayer: ProcessSetWeather(\"Foggy\", True)";
+
+    [Fact]
+    public void Captured_sample_parses_condition_flag_and_timestamp()
+    {
+        var evt = _parser.TryParse(FoggyLine, Ts)
+            .Should().BeOfType<WeatherChangedEvent>().Subject;
+
+        evt.Timestamp.Should().Be(Ts);
+        evt.Condition.Should().Be("Foggy");
+        evt.Flag.Should().BeTrue();
+    }
+
+    [Fact]
+    public void False_flag_form_parses()
+    {
+        var evt = _parser.TryParse(
+                "[19:50:42] LocalPlayer: ProcessSetWeather(\"Clear\", False)", Ts)
+            .Should().BeOfType<WeatherChangedEvent>().Subject;
+
+        evt.Condition.Should().Be("Clear");
+        evt.Flag.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Rainy")]
+    [InlineData("Snowy")]
+    [InlineData("Overcast")]
+    [InlineData("")] // tolerate an empty condition rather than throw
+    public void Condition_string_is_surfaced_verbatim(string condition)
+    {
+        var line = $"[19:50:42] LocalPlayer: ProcessSetWeather(\"{condition}\", True)";
+        _parser.TryParse(line, Ts)
+            .Should().BeOfType<WeatherChangedEvent>()
+            .Which.Condition.Should().Be(condition);
+    }
+
+    [Fact]
+    public void Tolerates_whitespace_variation_inside_the_arg_list()
+    {
+        var evt = _parser.TryParse(
+                "[19:50:42] LocalPlayer: ProcessSetWeather( \"Foggy\" ,  False )", Ts)
+            .Should().BeOfType<WeatherChangedEvent>().Subject;
+
+        evt.Condition.Should().Be("Foggy");
+        evt.Flag.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("[19:50:42] LocalPlayer: ProcessNewPosition((1.0, 2.0, 3.0), 0)")]
+    [InlineData("[19:50:42] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1.0, 0.00, 2.0), \"x\")")]
+    [InlineData("Loading preferences from C:/Users/x/GorgonSettings.txt")]
+    [InlineData("")]
+    public void Unrelated_or_blank_lines_return_null(string line)
+        => _parser.TryParse(line, Ts).Should().BeNull();
+
+    [Theory]
+    [InlineData("[19:50:42] LocalPlayer: ProcessSetWeather(\"Foggy\")")]            // missing flag
+    [InlineData("[19:50:42] LocalPlayer: ProcessSetWeather(\"Foggy\", Maybe)")]     // non-bool flag
+    [InlineData("[19:50:42] LocalPlayer: ProcessSetWeather(Foggy, True)")]          // unquoted condition
+    public void Malformed_weather_line_returns_null_without_throwing(string line)
+    {
+        var act = () => _parser.TryParse(line, Ts);
+        act.Should().NotThrow();
+        act().Should().BeNull();
+    }
+}

--- a/tests/Palantir.Tests/WorldStateViewModelTests.cs
+++ b/tests/Palantir.Tests/WorldStateViewModelTests.cs
@@ -4,6 +4,7 @@ using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Celestial;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
+using Mithril.GameState.Weather;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using Mithril.Shared.Reference;
@@ -93,7 +94,7 @@ public sealed class WorldStateViewModelTests
         pos.PreloadAsCurrent(new PlayerPosition(1, 2, 3, T, PlayerPositionSource.Spawn));
         using var vm = new WorldStateViewModel(
             pos, new PlayerAreaTracker(new AreaTransitionParser()),
-            new FakePinTracker(), new FakeCelestialState(), null, a => a());
+            new FakePinTracker(), new FakeCelestialState(), new FakeWeatherTracker(), null, a => a());
 
         vm.HasPosition.Should().BeTrue();
         vm.PositionText.Should().Be("X 1.00   Y 2.00   Z 3.00");
@@ -123,7 +124,7 @@ public sealed class WorldStateViewModelTests
             Pin(10, -20, "Vendor"), Pin(-5.5, 99.25, ""));
         using var vm = new WorldStateViewModel(
             new FakePositionTracker(), new PlayerAreaTracker(new AreaTransitionParser()),
-            pins, new FakeCelestialState(), null, a => a());
+            pins, new FakeCelestialState(), new FakeWeatherTracker(), null, a => a());
 
         vm.HasPins.Should().BeTrue();
         vm.PinCount.Should().Be(2);
@@ -248,7 +249,7 @@ public sealed class WorldStateViewModelTests
         celestial.PreloadAsCurrent(new CelestialInfo(MoonPhase.FullMoon, "FullMoon", T));
         using var vm = new WorldStateViewModel(
             new FakePositionTracker(), new PlayerAreaTracker(new AreaTransitionParser()),
-            new FakePinTracker(), celestial, null, a => a());
+            new FakePinTracker(), celestial, new FakeWeatherTracker(), null, a => a());
 
         vm.HasMoonPhase.Should().BeTrue();
         vm.MoonPhaseText.Should().Be("Full Moon");
@@ -265,26 +266,98 @@ public sealed class WorldStateViewModelTests
         vm.HasMoonPhase.Should().BeFalse("the disposed VM must unsubscribe from celestial");
     }
 
+    // --- Weather ----------------------------------------------------------
+
+    [Fact]
+    public void Replay_on_subscribe_seeds_existing_weather()
+    {
+        var weather = new FakeWeatherTracker();
+        weather.Preload("AreaSerbule", new WeatherState("Foggy", true, T));
+        using var vm = new WorldStateViewModel(
+            new FakePositionTracker(), new PlayerAreaTracker(new AreaTransitionParser()),
+            new FakePinTracker(), new FakeCelestialState(), weather, null, a => a());
+
+        vm.HasWeather.Should().BeTrue();
+        vm.WeatherConditionText.Should().Be("Foggy");
+        vm.WeatherFlagText.Should().Be("True");
+        // Snapshot replay reflects existing state, not a fresh observation.
+        vm.WeatherObservedAtText.Should().Be("—");
+    }
+
+    [Fact]
+    public void Changed_weather_populates_condition_flag_and_observed_at()
+    {
+        using var vm = NewVm(out _, out _, out _, out _, out var weather);
+
+        weather.Fire(new WeatherChanged(
+            WeatherChangeKind.Changed, "AreaSerbule",
+            new WeatherState("Rainy", false, T), T));
+
+        vm.HasWeather.Should().BeTrue();
+        vm.WeatherConditionText.Should().Be("Rainy");
+        vm.WeatherFlagText.Should().Be("False");
+        vm.WeatherObservedAtText.Should().Be("2026-05-18 10:45:47Z");
+    }
+
+    [Fact]
+    public void Map_change_resets_weather_to_unknown_not_stale()
+    {
+        using var vm = NewVm(out _, out _, out _, out _, out var weather);
+        weather.Fire(new WeatherChanged(
+            WeatherChangeKind.Changed, "AreaA", new WeatherState("Foggy", true, T), T));
+
+        weather.Fire(new WeatherChanged(
+            WeatherChangeKind.AreaChanged, "AreaB", null, T));
+
+        vm.HasWeather.Should().BeFalse();
+        vm.WeatherConditionText.Should().Be("(weather unknown for this map)");
+        vm.WeatherFlagText.Should().Be("—");
+        vm.WeatherObservedAtText.Should().Be("—");
+    }
+
+    [Fact]
+    public void Dispose_stops_observing_weather()
+    {
+        using var vm = NewVm(out _, out _, out _, out _, out var weather);
+        vm.Dispose();
+
+        weather.Fire(new WeatherChanged(
+            WeatherChangeKind.Changed, "X", new WeatherState("Foggy", true, T), T));
+
+        vm.HasWeather.Should().BeFalse("the disposed VM must unsubscribe from weather");
+    }
+
     private static WorldStateViewModel NewVm(
         out FakePositionTracker pos, out PlayerAreaTracker area, IReferenceDataService? refData = null)
-        => NewVm(out pos, out area, out _, out _, refData);
+        => NewVm(out pos, out area, out _, out _, out _, refData);
 
     private static WorldStateViewModel NewVm(
         out FakePositionTracker pos, out PlayerAreaTracker area,
         out FakePinTracker pins, IReferenceDataService? refData = null)
-        => NewVm(out pos, out area, out pins, out _, refData);
+        => NewVm(out pos, out area, out pins, out _, out _, refData);
+
+    // 4-out (celestial) — kept so the moon-phase tests' call sites stay
+    // unchanged after the weather param was stacked on; delegates to the
+    // 5-out base discarding weather.
+    private static WorldStateViewModel NewVm(
+        out FakePositionTracker pos, out PlayerAreaTracker area,
+        out FakePinTracker pins, out FakeCelestialState celestial,
+        IReferenceDataService? refData = null)
+        => NewVm(out pos, out area, out pins, out celestial, out _, refData);
 
     private static WorldStateViewModel NewVm(
         out FakePositionTracker pos, out PlayerAreaTracker area,
         out FakePinTracker pins, out FakeCelestialState celestial,
+        out FakeWeatherTracker weather,
         IReferenceDataService? refData = null)
     {
         pos = new FakePositionTracker();
         area = new PlayerAreaTracker(new AreaTransitionParser());
         pins = new FakePinTracker();
         celestial = new FakeCelestialState();
+        weather = new FakeWeatherTracker();
         // Synchronous dispatcher: test thread is the WPF thread.
-        return new WorldStateViewModel(pos, area, pins, celestial, refData, a => a());
+        return new WorldStateViewModel(pos, area, pins, celestial, weather, refData, a => a());
     }
 
     private sealed class FakePositionTracker : IPlayerPositionTracker
@@ -376,6 +449,44 @@ public sealed class WorldStateViewModelTests
         }
 
         private sealed class Sub(FakeCelestialState owner) : IDisposable
+        {
+            public void Dispose() => owner._handler = null;
+        }
+    }
+
+    private sealed class FakeWeatherTracker : IPlayerWeatherTracker
+    {
+        private string? _area;
+        private WeatherState? _current;
+        private Action<WeatherChanged>? _handler;
+
+        public string? CurrentArea => _area;
+        public WeatherState? Current => _current;
+
+        /// <summary>Seed so the Subscribe replay (Snapshot) carries it.</summary>
+        public void Preload(string area, WeatherState? state)
+        {
+            _area = area;
+            _current = state;
+        }
+
+        public void Fire(WeatherChanged change)
+        {
+            _area = change.Area;
+            _current = change.State;
+            _handler?.Invoke(change);
+        }
+
+        public IDisposable Subscribe(Action<WeatherChanged> handler)
+        {
+            // Mirror PlayerWeatherTracker: synchronous Snapshot replay first.
+            handler(new WeatherChanged(
+                WeatherChangeKind.Snapshot, _area, _current, DateTimeOffset.UnixEpoch));
+            _handler = handler;
+            return new Sub(this);
+        }
+
+        private sealed class Sub(FakeWeatherTracker owner) : IDisposable
         {
             public void Dispose() => owner._handler = null;
         }


### PR DESCRIPTION
## What

Adds a live **per-map weather** producer to `Mithril.GameState` and surfaces it in Palantir's debug panel.

PG's **Vampirism** skill makes the player take sun damage; the ambient weather gates whether that's happening, so weather is a real game-mechanic input for a future Vampirism-safety consumer.

### Producer — `Mithril.GameState/Weather/`
- `WeatherLogParser` — `ProcessSetWeather("<condition>", <bool>)`, substring fast-path + `[GeneratedRegex]`, defensive (never throws).
- `WeatherChangedEvent`, `WeatherState`, `IPlayerWeatherTracker` (`Snapshot` / `Changed` / `AreaChanged` notifications).
- `PlayerWeatherTracker` — self-feeding `BackgroundService`, **area-scoped exactly like `PlayerPinTracker`**: weather is per-map (owner-confirmed), so it drops on a map change and repopulates from the new map; idempotent on zone-entry replay.
- DI registration in `GameStateServiceCollectionExtensions`.

### Surface — Palantir
- `WorldStateViewModel` / `WorldStateView` gain a **WEATHER section** (mirrors the pins pattern: dispatched handler, disposable subscription). An `AreaChanged` reset reads **"weather unknown for this map"**, not a stale value.

## Key design decision: the producer is deliberately *dumb*

It surfaces the raw condition string + the opaque flag and does **no** sun-damage classification. Verified in-game: condition strings are **tiered** (`Cloudy 1`, `Cloudy 3`), and sun damage is decided by the **tier number, not the family name** — `Cloudy 1` damages, `Cloudy 3` is safe. A name-based rule (`contains "Cloudy"` ⇒ safe) would be wrong for half the tiers. The `(family, tier) → takes-damage` map is the future Vampirism consumer's job, against an empirically-built table.

## Deliberately *not* in this PR
- **No `log-patterns.json` entry.** The grammar is held out of the cross-tool catalog until corpus-verified (follows the Pins/Position/Skills precedent — the catalog is the settled contract; an unverified pattern must not cement a guess).
- **No Vampirism consumer.** Producer + debug surface only.

## Verification owed (documented, not blocking)
Captured in the wiki [Player-Log-Signals → Weather](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#weather-vampirism-sun-damage): the opaque flag's meaning, whether a `False` form / zone-entry replay occurs, the full condition+tier vocabulary, and the `Cloudy 2` damage boundary. The tracker's per-map + idempotent + drop-on-map-change stance is correct under every remaining hypothesis. The Palantir WEATHER row doubles as the live capture tool.

## Tests
- `Mithril.GameState.Tests` — **243/243** (12 parser + 8 tracker incl. map-change-drop).
- `Palantir.Tests` — **24/24** (4 new weather VM tests + ctor-arity ripple).
- Clean under warnings-as-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
