### PR TITLE
feat(silmarillion): surface item keywords + numeric id (recipes' ItemCode) in shared ItemDetailView (#517)

### DIFF
--- a/src/Mithril.Shared.Wpf/ItemDetailView.xaml
+++ b/src/Mithril.Shared.Wpf/ItemDetailView.xaml
@@ -96,6 +96,18 @@
                     </TextBlock>
                 </StackPanel>
 
+                <!-- Keywords — the item's raw classification tags as a second
+                     inert Fact strip (matrix #3, same idiom as the StatStrip
+                     above). Item keywords are non-navigable classification
+                     (no Keyword entity) ⇒ Fact tier, not a Link, even though
+                     the query engine can filter on them. Section (label +
+                     strip) self-hides when the item declares no keywords. -->
+                <StackPanel Margin="0,0,0,10"
+                            Visibility="{Binding KeywordStrip.Pairs.Count, Converter={StaticResource PositiveIntToVis}}">
+                    <TextBlock Text="Keywords" Style="{StaticResource StructureSectionLabelStyle}"/>
+                    <c:FactTable DataContext="{Binding KeywordStrip}" HorizontalAlignment="Left"/>
+                </StackPanel>
+
                 <!-- Sources (vendor / drop / quest reward / …). ItemSourceChip →
                      Link enumeration (Density="List"; provenance suffix rides
                      from the source Detail via LinkVm.From). -->

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -155,13 +155,26 @@ public sealed partial class ItemDetailViewModel
             ? null
             : new SetRefVm("Used as", MatchCount: ConsumedAsKeywordInTotal, IsActionable: true);
 
-        // Footer ID (matrix #14 · G-a · ratified E5). The Item InternalName is a
-        // cross-entity reference KEY — recipes/quests/NPCs resolve items by it —
-        // ⇒ the copyable `KEY` cell (NOT the inert storage-only `ROW`; cf.
-        // EffectDetailView's EnvelopeKey). None() self-hides when absent.
-        Footer = string.IsNullOrEmpty(InternalName)
+        // Footer ID (matrix #14 · G-a · ratified E5). Two cells (G-a caps at 2):
+        //   • InternalName — the cross-entity reference KEY (recipes / quests /
+        //     NPCs resolve items by it) ⇒ copyable.
+        //   • `item_{Id}` — the JSON envelope from which Id was lifted; a
+        //     storage-only key (sources_items.json / itemuses.json reference items
+        //     this way alongside InternalName, but the envelope is the record
+        //     position, not the named identifier) ⇒ the inert `ROW` cell, exactly
+        //     EffectDetailView's `effect_XXXX` EnvelopeKey path. Rebuilt from Id
+        //     verbatim — the deserializer lifts the envelope key into Id, so
+        //     `$"item_{Id}"` recovers the JSON form.
+        // None() self-hides when both are absent; a missing InternalName still
+        // surfaces the ROW (and vice-versa).
+        var footerIds = new List<FactFooterId>(2);
+        if (!string.IsNullOrEmpty(InternalName))
+            footerIds.Add(new FactFooterId("KEY", InternalName, copyable: true));
+        if (Item.Id > 0)
+            footerIds.Add(new FactFooterId("ROW", $"item_{Item.Id}", copyable: false));
+        Footer = footerIds.Count == 0
             ? FactFooterVm.None()
-            : FactFooterVm.Key(InternalName);
+            : FactFooterVm.Of(footerIds.ToArray());
     }
 
     public Item Item { get; }
@@ -397,10 +410,12 @@ public sealed partial class ItemDetailViewModel
     public SetRefVm? ConsumedAsKeywordInSetRef { get; }
 
     /// <summary>
-    /// Footer identifier strip (matrix #14 · G-a · ratified E5). The Item
-    /// <see cref="InternalName"/> is a cross-entity reference KEY (recipes /
-    /// quests / NPCs resolve items by it) ⇒ a single copyable <c>KEY</c> cell;
-    /// <c>None()</c> (the strip self-hides) when the item has no internal name.
+    /// Footer identifier strip (matrix #14 · G-a · ratified E5). Up to two
+    /// cells (G-a caps at 2): the cross-entity reference <c>KEY</c>
+    /// (<see cref="InternalName"/> — copyable) and the inert <c>ROW</c>
+    /// (<c>item_{Id}</c> — the JSON envelope from which <see cref="Item.Id"/>
+    /// was lifted; mirrors EffectDetailView's <c>effect_XXXX</c> EnvelopeKey).
+    /// <see cref="FactFooterVm.None"/> (self-hides) when both are absent.
     /// </summary>
     public FactFooterVm Footer { get; }
 

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Input;
@@ -155,23 +156,28 @@ public sealed partial class ItemDetailViewModel
             ? null
             : new SetRefVm("Used as", MatchCount: ConsumedAsKeywordInTotal, IsActionable: true);
 
-        // Footer ID (matrix #14 · G-a · ratified E5). Two cells (G-a caps at 2):
-        //   • InternalName — the cross-entity reference KEY (recipes / quests /
-        //     NPCs resolve items by it) ⇒ copyable.
-        //   • `item_{Id}` — the JSON envelope from which Id was lifted; a
-        //     storage-only key (sources_items.json / itemuses.json reference items
-        //     this way alongside InternalName, but the envelope is the record
-        //     position, not the named identifier) ⇒ the inert `ROW` cell, exactly
-        //     EffectDetailView's `effect_XXXX` EnvelopeKey path. Rebuilt from Id
-        //     verbatim — the deserializer lifts the envelope key into Id, so
-        //     `$"item_{Id}"` recovers the JSON form.
-        // None() self-hides when both are absent; a missing InternalName still
-        // surfaces the ROW (and vice-versa).
+        // Footer ID (matrix #14 · G-a · ratified E5). Two cells (G-a caps at 2),
+        // BOTH `KEY`/copyable — items have two distinct cross-entity reference
+        // identifiers and E5 demands both be copyable:
+        //   • InternalName — the named cross-entity reference (recipes /
+        //     quests / NPCs that resolve items by name use this form).
+        //   • Item.Id rendered as a bare integer — recipes index every
+        //     ingredient and result by `{"ItemCode": <int>}`, so the numeric
+        //     id IS the primary cross-entity reference from the recipe graph.
+        //     Bare int (not the `item_XXXX` envelope wrapper) matches the
+        //     recipe ItemCode form verbatim, which is the most useful copy
+        //     payload (recipe analysis tools, planner inputs).
+        // The Effect precedent (single inert ROW for `effect_XXXX`) is NOT a
+        // template — Effect lacks a clean InternalName, so its envelope is the
+        // only handle; for Item both identifiers exist and are cross-referenced.
+        // None() self-hides when both are absent; each cell is independently
+        // gated so a missing InternalName still surfaces the id cell, and
+        // vice-versa.
         var footerIds = new List<FactFooterId>(2);
         if (!string.IsNullOrEmpty(InternalName))
             footerIds.Add(new FactFooterId("KEY", InternalName, copyable: true));
         if (Item.Id > 0)
-            footerIds.Add(new FactFooterId("ROW", $"item_{Item.Id}", copyable: false));
+            footerIds.Add(new FactFooterId("KEY", Item.Id.ToString(CultureInfo.InvariantCulture), copyable: true));
         Footer = footerIds.Count == 0
             ? FactFooterVm.None()
             : FactFooterVm.Of(footerIds.ToArray());
@@ -411,10 +417,16 @@ public sealed partial class ItemDetailViewModel
 
     /// <summary>
     /// Footer identifier strip (matrix #14 · G-a · ratified E5). Up to two
-    /// cells (G-a caps at 2): the cross-entity reference <c>KEY</c>
-    /// (<see cref="InternalName"/> — copyable) and the inert <c>ROW</c>
-    /// (<c>item_{Id}</c> — the JSON envelope from which <see cref="Item.Id"/>
-    /// was lifted; mirrors EffectDetailView's <c>effect_XXXX</c> EnvelopeKey).
+    /// cells (G-a caps at 2), both <c>KEY</c>/copyable — items have two
+    /// distinct cross-entity reference identifiers:
+    /// <list type="bullet">
+    /// <item><see cref="InternalName"/> — the named cross-entity reference
+    /// (recipe / quest / NPC consumers that resolve items by name).</item>
+    /// <item><see cref="Item.Id"/> as a bare integer — recipes index every
+    /// ingredient and result by <c>{"ItemCode": &lt;int&gt;}</c>, so the id
+    /// IS the cross-entity reference from the recipe graph; bare-int form
+    /// matches the <c>ItemCode</c> payload verbatim.</item>
+    /// </list>
     /// <see cref="FactFooterVm.None"/> (self-hides) when both are absent.
     /// </summary>
     public FactFooterVm Footer { get; }

--- a/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
+++ b/src/Mithril.Shared.Wpf/ItemDetailViewModel.cs
@@ -112,6 +112,24 @@ public sealed partial class ItemDetailViewModel
             stat.Add(new FactPair(null, req));
         StatStrip = FactTableVm.Strip(stat);
 
+        // The item's raw classification keywords as a second inert Fact strip
+        // (same matrix #3 / StatStrip idiom). Item keywords are non-navigable
+        // classification — there is no Keyword entity to open — so they are a
+        // Fact tier, NOT a Link, even though the query engine can filter on
+        // them (Keywords CONTAINS 'X'): the shared/popup detail contract
+        // carries no host filter command, so the strip stays inert (G-b — no
+        // box/gold, the FactTable Strip Style owns the inert pigment). Raw
+        // verbatim JSON form per tag — "Tag" or "Tag=Quality" when Quality > 0
+        // (NOT camel-split; the maintainer chose the data-true token). Built
+        // from Item.Keywords directly (not ItemKeywordSynthesis.Enrich, which
+        // is matching machinery). Empty list ⇒ an empty strip and the section
+        // self-hides via KeywordStrip.Pairs.Count.
+        KeywordStrip = FactTableVm.Strip(
+            (Item.Keywords ?? [])
+                .Select(kw => new FactPair(
+                    null, kw.Quality > 0 ? $"{kw.Tag}={kw.Quality}" : kw.Tag))
+                .ToList());
+
         // Cross-link sections → the unified Link (matrix #6/#9/#10/#12), via the
         // ratified EntityChip/ItemSourceChip adapters; the view renders them
         // Density="List" (the canonical pilot enumeration pattern). Glyph is
@@ -309,6 +327,17 @@ public sealed partial class ItemDetailViewModel
     /// all-empty strip renders nothing.
     /// </summary>
     public FactTableVm StatStrip { get; }
+
+    /// <summary>
+    /// The item's raw <see cref="Item.Keywords"/> classification tags as one
+    /// inert Fact strip (the same StatStrip / matrix #3 idiom). Verbatim JSON
+    /// form per tag (<c>Tag</c>, or <c>Tag=Quality</c> when Quality &gt; 0).
+    /// Item keywords have no Keyword entity to navigate to ⇒ a Fact, not a
+    /// Link, even though the query engine can filter on them. Empty when the
+    /// item declares no keywords — the section self-hides via
+    /// <see cref="FactTableVm.Pairs"/>.<c>Count</c> (G-b: no box/gold).
+    /// </summary>
+    public FactTableVm KeywordStrip { get; }
 
     /// <summary>"Sources" rows as the unified <see cref="LinkVm"/> (matrix #9 —
     /// provenance suffix rides from <see cref="ItemSourceChipVm.Detail"/>).</summary>

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -562,6 +562,55 @@ public sealed class ItemsTabViewModelTests
         vm.DetailViewModel.TreasureProfileLink.Should().BeNull();
     }
 
+    // ── Keywords — raw classification tags as an inert Fact strip ──────────────
+    // Item keywords are non-navigable (no Keyword entity) ⇒ Fact tier, not a
+    // Link, even though the query engine can filter on them. Verbatim JSON form
+    // per tag, order preserved; the section self-hides when there are none.
+
+    [Fact]
+    public void Keywords_ItemWithKeywords_StripIsVerbatimAndOrdered()
+    {
+        var salad = new Item
+        {
+            Id = 1,
+            InternalName = "GardenSalad",
+            Name = "Garden Salad",
+            Keywords =
+            [
+                new ItemKeyword("Loot", 0),
+                new ItemKeyword("VegetarianDish", 84),
+                new ItemKeyword("Salad", 0),
+            ],
+        };
+        var refData = new StubReferenceData { ItemsByName = { ["GardenSalad"] = salad } };
+        var vm = new ItemsTabViewModel(refData,
+            new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedItem = salad;
+
+        var strip = vm.DetailViewModel!.KeywordStrip;
+        strip.Pairs.Select(p => p.Label).Should().AllBeEquivalentTo((string?)null,
+            "keywords render value-only — the inert StatStrip idiom");
+        strip.Pairs.Select(p => p.Value).Should().Equal(
+            "Loot", "VegetarianDish=84", "Salad");
+    }
+
+    [Fact]
+    public void Keywords_ItemWithoutKeywords_StripEmpty_SectionHidden()
+    {
+        var plain = new Item { Id = 1, InternalName = "PlainRock", Name = "Plain Rock" };
+        var refData = new StubReferenceData { ItemsByName = { ["PlainRock"] = plain } };
+        var vm = new ItemsTabViewModel(refData,
+            new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedItem = plain;
+
+        vm.DetailViewModel!.KeywordStrip.Pairs.Should().BeEmpty(
+            "no keywords ⇒ empty strip and the section self-hides");
+    }
+
     private static SilmarillionReferenceNavigator NavWithRecipe() =>
         new(new IReferenceKindTarget[] { new StubKindTarget(EntityKind.Recipe) });
 

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -562,6 +562,55 @@ public sealed class ItemsTabViewModelTests
         vm.DetailViewModel.TreasureProfileLink.Should().BeNull();
     }
 
+    // ── Footer — InternalName KEY + item_{Id} ROW ──────────────────────────────
+    // Matrix #14 · G-a · ratified E5. The named identifier is the copyable KEY;
+    // the JSON envelope (recovered as `item_{Id}` from the lifted Id) is the
+    // inert storage-only ROW, mirroring Effect's `effect_XXXX` envelope path.
+
+    [Fact]
+    public void Footer_ItemWithIdAndInternalName_HasKeyAndRowCells()
+    {
+        var item = new Item { Id = 5010, InternalName = "GardenSalad", Name = "Garden Salad" };
+        var refData = new StubReferenceData { ItemsByName = { ["GardenSalad"] = item } };
+        var vm = new ItemsTabViewModel(refData,
+            new SilmarillionReferenceNavigator(Array.Empty<IReferenceKindTarget>()),
+            new ReferenceDataEntityNameResolver(refData));
+
+        vm.SelectedItem = item;
+
+        var footer = vm.DetailViewModel!.Footer;
+        footer.HasIds.Should().BeTrue();
+        footer.Ids.Should().HaveCount(2);
+
+        footer.Ids[0].LabelTag.Should().Be("KEY");
+        footer.Ids[0].Value.Should().Be("GardenSalad");
+        footer.Ids[0].Copyable.Should().BeTrue(
+            "InternalName is the cross-entity reference key (E5)");
+
+        footer.Ids[1].LabelTag.Should().Be("ROW");
+        footer.Ids[1].Value.Should().Be("item_5010",
+            "the ROW cell rebuilds the JSON envelope from the lifted Id");
+        footer.Ids[1].Copyable.Should().BeFalse(
+            "the envelope is a storage-only key, not a cross-entity reference (E5)");
+    }
+
+    [Fact]
+    public void Footer_ItemWithIdButNoInternalName_ShowsOnlyRow()
+    {
+        // Belt-and-braces: a missing InternalName must not suppress the ROW
+        // cell — each cell is independently gated. Reached via direct VM
+        // construction since ItemsTab keys on Name.
+        var item = new Item { Id = 5010, Name = "Mystery Item" };
+        var refData = new StubReferenceData();
+
+        var detail = new ItemDetailViewModel(item, refData);
+
+        detail.Footer.Ids.Should().HaveCount(1);
+        detail.Footer.Ids[0].LabelTag.Should().Be("ROW");
+        detail.Footer.Ids[0].Value.Should().Be("item_5010");
+        detail.Footer.Ids[0].Copyable.Should().BeFalse();
+    }
+
     // ── Keywords — raw classification tags as an inert Fact strip ──────────────
     // Item keywords are non-navigable (no Keyword entity) ⇒ Fact tier, not a
     // Link, even though the query engine can filter on them. Verbatim JSON form

--- a/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
+++ b/tests/Silmarillion.Tests/ViewModels/ItemsTabViewModelTests.cs
@@ -562,13 +562,16 @@ public sealed class ItemsTabViewModelTests
         vm.DetailViewModel.TreasureProfileLink.Should().BeNull();
     }
 
-    // ── Footer — InternalName KEY + item_{Id} ROW ──────────────────────────────
-    // Matrix #14 · G-a · ratified E5. The named identifier is the copyable KEY;
-    // the JSON envelope (recovered as `item_{Id}` from the lifted Id) is the
-    // inert storage-only ROW, mirroring Effect's `effect_XXXX` envelope path.
+    // ── Footer — InternalName + Id, both KEY/copyable ──────────────────────────
+    // Matrix #14 · G-a · ratified E5. Items have two cross-entity reference
+    // identifiers: InternalName (used by name-keyed consumers) and the numeric
+    // Id (recipes index ingredients/results by {"ItemCode": <int>}, so the id
+    // is the primary cross-reference from the recipe graph). E5 demands both
+    // are copyable — neither is storage-only. NOT the Effect precedent (which
+    // uses ROW because its envelope is the only handle, no clean InternalName).
 
     [Fact]
-    public void Footer_ItemWithIdAndInternalName_HasKeyAndRowCells()
+    public void Footer_ItemWithIdAndInternalName_BothCellsAreCopyableKey()
     {
         var item = new Item { Id = 5010, InternalName = "GardenSalad", Name = "Garden Salad" };
         var refData = new StubReferenceData { ItemsByName = { ["GardenSalad"] = item } };
@@ -585,19 +588,19 @@ public sealed class ItemsTabViewModelTests
         footer.Ids[0].LabelTag.Should().Be("KEY");
         footer.Ids[0].Value.Should().Be("GardenSalad");
         footer.Ids[0].Copyable.Should().BeTrue(
-            "InternalName is the cross-entity reference key (E5)");
+            "InternalName is a cross-entity reference (named-key consumers — E5)");
 
-        footer.Ids[1].LabelTag.Should().Be("ROW");
-        footer.Ids[1].Value.Should().Be("item_5010",
-            "the ROW cell rebuilds the JSON envelope from the lifted Id");
-        footer.Ids[1].Copyable.Should().BeFalse(
-            "the envelope is a storage-only key, not a cross-entity reference (E5)");
+        footer.Ids[1].LabelTag.Should().Be("KEY");
+        footer.Ids[1].Value.Should().Be("5010",
+            "bare-int Id matches recipes' ItemCode cross-reference form");
+        footer.Ids[1].Copyable.Should().BeTrue(
+            "Id is a cross-entity reference (recipes index by ItemCode — E5)");
     }
 
     [Fact]
-    public void Footer_ItemWithIdButNoInternalName_ShowsOnlyRow()
+    public void Footer_ItemWithIdButNoInternalName_ShowsOnlyIdCell()
     {
-        // Belt-and-braces: a missing InternalName must not suppress the ROW
+        // Belt-and-braces: a missing InternalName must not suppress the id
         // cell — each cell is independently gated. Reached via direct VM
         // construction since ItemsTab keys on Name.
         var item = new Item { Id = 5010, Name = "Mystery Item" };
@@ -606,9 +609,9 @@ public sealed class ItemsTabViewModelTests
         var detail = new ItemDetailViewModel(item, refData);
 
         detail.Footer.Ids.Should().HaveCount(1);
-        detail.Footer.Ids[0].LabelTag.Should().Be("ROW");
-        detail.Footer.Ids[0].Value.Should().Be("item_5010");
-        detail.Footer.Ids[0].Copyable.Should().BeFalse();
+        detail.Footer.Ids[0].LabelTag.Should().Be("KEY");
+        detail.Footer.Ids[0].Value.Should().Be("5010");
+        detail.Footer.Ids[0].Copyable.Should().BeTrue();
     }
 
     // ── Keywords — raw classification tags as an inert Fact strip ──────────────


### PR DESCRIPTION
Closes #517.

## What

Two skipped `Item` fields surfaced in the shared `ItemDetailView` (`src/Mithril.Shared.Wpf`):

1. **`Item.Keywords`** — classification tags (`Loot`, `VegetarianDish=84`, …) parsed onto the model but never projected/rendered.
2. **`Item.Id`** — recipes index ingredients/results by `{"ItemCode": <int>}`; the id was never surfaced anywhere on the pane.

Both were invisible to every consumer of the shared pane (Silmarillion Items tab, Celebrimbor popup, deep links).

## Approach (owner-confirmed)

### Keywords
- **Fact tier, not a Link** — non-navigable classification (no Keyword entity). Inert Fact strip, same idiom as the existing `StatStrip` (G-b: no box/gold). They're query-filterable via `Keywords CONTAINS 'X'`, but that acts on a list; the shared pane has no host filter command in popup/deep-link contexts.
- **Raw verbatim tags** — `Tag`, or `Tag=Quality` when `Quality > 0`; order preserved.
- **Raw `Item.Keywords` only** — not `ItemKeywordSynthesis.Enrich` (matching machinery).
- Dedicated "Keywords" section between Description and Sources; self-hides when none.

### `Item.Id` footer cell
- G-a footer second cell, **both cells `KEY`/copyable**: `InternalName` (named cross-reference) + bare-int `Id` (recipes' `ItemCode` cross-reference). E5: copyable iff a cross-entity reference key — both qualify.
- **Bare integer** `"5010"`, not the `item_XXXX` envelope wrapper — matches `recipes.json` `ItemCode` payload verbatim, the useful form for recipe / planner / log analysis tools.
- **Not the Effect `ROW` precedent.** Effect uses inert ROW because its envelope is its only handle; Item has two distinct cross-references, both copyable.
- Each cell independently gated (missing `InternalName` still surfaces id).

Pure VM-property + XAML addition — no `ItemDetailContext` plumbing (both fields are on `Item` directly).

## Tests

- `ItemsTabViewModelTests` — 4 new (keyword strip verbatim/ordered, empty→section-hidden; footer two-`KEY`-cell shape, missing-InternalName id-only).
- Full `ItemsTabViewModelTests` (30) green — cross-module detail-contract unaffected.

## Note for reviewer — commit history

Three commits on the branch; the last (`fix: item id is a cross-entity KEY, not ROW`) corrects the second-commit choice after a reviewer correction surfaced that recipes index items by `ItemCode`. The net diff is what gets squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
