### PR TITLE
Legolas Motherlode: locked model (create-on-use, area scoping, dig-counted summary) + multi-level undo

### DIFF
--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -63,11 +63,14 @@ public sealed record MotherlodeDistance(
 /// "Using … Motherlode Map", …)</c> — the player clicked a carried metal-slab
 /// (Motherlode) map. The <b>use gesture</b> the measurement coordinator
 /// temporally correlates a position feeder fix and the following ChatLog
-/// <see cref="MotherlodeDistance"/> line(s) against (#488, label-agnostic
-/// pairing — the map's name is never used to bind, only the timestamp).
+/// <see cref="MotherlodeDistance"/> line(s) against (#488). Pairing/binding is
+/// still order-based, not name-based — the use-line name is the map <i>type</i>
+/// (identical across a same-type stack, no per-map identity), carried only as a
+/// display label for the working slot it creates (create-on-use).
 /// </summary>
 public sealed record MotherlodeUseDetected(
-    DateTime Timestamp) : GameEvent(Timestamp);
+    DateTime Timestamp,
+    string? MapName = null) : GameEvent(Timestamp);
 
 /// <summary>
 /// The chat-log area banner (<c>"******* Entering Area: Eltibule"</c>). Carries

--- a/src/Legolas.Module/Domain/LegolasSettings.cs
+++ b/src/Legolas.Module/Domain/LegolasSettings.cs
@@ -226,6 +226,31 @@ public sealed class LegolasSettings : INotifyPropertyChanged, IVersionedState<Le
     }
 
     /// <summary>
+    /// Motherlode multi-map mode (#488). Default <c>true</c> — carrying several
+    /// motherlode maps is the common case. ON declares the read-order contract:
+    /// after re-locating, the player reads map 1, map 2, … map N in the same
+    /// fixed order at every spot, so the k-th reading at a spot binds to the
+    /// k-th tracked treasure (the log carries no per-read identity). OFF =
+    /// single-active-treasure serial mode. Persisted but surfaced/edited on the
+    /// Motherlode panel, not the settings tab (an operational toggle flipped
+    /// mid-run — see <c>MotherlodeViewModel.MultiMapMode</c>). Additive: old
+    /// settings JSON without this key deserializes to the <c>true</c> default,
+    /// so no <see cref="SchemaVersion"/> bump / <see cref="Migrate"/> branch is
+    /// needed (same additive convention as <see cref="MapTargetDedupRadiusMetres"/>).
+    /// </summary>
+    private bool _motherlodeMultiMapMode = true;
+    public bool MotherlodeMultiMapMode
+    {
+        get => _motherlodeMultiMapMode;
+        set
+        {
+            if (_motherlodeMultiMapMode == value) return;
+            _motherlodeMultiMapMode = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MotherlodeMultiMapMode)));
+        }
+    }
+
+    /// <summary>
     /// Hide both overlays on Done→Ready (session ends) and re-show them on
     /// Ready→Listening (next survey lands). Lets the user keep the game
     /// window uncluttered between cycles without manual toggling. Default on

--- a/src/Legolas.Module/Domain/MotherlodeSurvey.cs
+++ b/src/Legolas.Module/Domain/MotherlodeSurvey.cs
@@ -59,10 +59,13 @@ public readonly record struct MotherlodePositionSample(
 /// One motherlode treasure being located. <see cref="DistancesByLocation"/> is
 /// parallel to the shared <see cref="MotherlodeSession.LocationSamples"/> list:
 /// element <c>k</c> is the ChatLog distance read at location <c>k</c> for this
-/// slot. The k-th distance line emitted at a location binds to slot k — the
-/// batching contract (no per-target identity exists in the log; a player
-/// carries an inventory of maps and clicks them in a stable order at every
-/// spot). Slots are solved independently against the shared samples.
+/// slot. Slots are <b>created on use/read</b> (never from holding inventory):
+/// the k-th read at the defining (first) spot creates working slot k; later
+/// spots re-read the same working set in the same order — the declared-order
+/// contract (no per-target identity exists in the log; Survey/Treasure-
+/// Cartography assumptions: same order every spot, maps arranged sequentially).
+/// Serial mode is the degenerate single-active-slot case. Slots are solved
+/// independently against the shared samples.
 /// </summary>
 public sealed record MotherlodeSurvey(
     Guid Id,
@@ -81,6 +84,15 @@ public sealed record MotherlodeSurvey(
     /// the slot has been solved at least once.
     /// </summary>
     public Services.MultilaterationQuality? Quality { get; init; }
+
+    /// <summary>
+    /// Map <i>type</i> display label this slot was created from (e.g.
+    /// "Kur Mountains Simple Metal Motherlode Map"), taken from the
+    /// <c>ProcessDoDelayLoop</c> use line. A label only — identical across a
+    /// same-type stack; binding stays order-based. Null when the use line
+    /// carried no name (carryover / fallback).
+    /// </summary>
+    public string? MapName { get; init; }
 
     public static MotherlodeSurvey Create() =>
         new(Guid.NewGuid(), Array.Empty<int>(), null, null, null, false, null);

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -4,6 +4,8 @@ using Mithril.Shared.DependencyInjection;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Hotkeys;
 using Mithril.Shared.Icons;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
 using Mithril.Shared.Logging;
@@ -112,8 +114,19 @@ public sealed class LegolasModule : IMithrilModule
                 sp.GetRequiredService<MotherlodeFlowController>(),
                 sp.GetRequiredService<IPlayerPositionTracker>(),
                 sp.GetRequiredService<IPlayerPinTracker>(),
-                sp.GetService<IDiagnosticsSink>(),
-                sp.GetService<ICharacterPinAnchor>()));
+                // #488 inventory-instance identity + exact completion;
+                // IReferenceDataService resolves the motherlode-map predicate;
+                // LegolasSettings carries the Multi-map mode toggle (read live).
+                sp.GetService<IInventoryService>(),
+                sp.GetService<IReferenceDataService>(),
+                sp.GetRequiredService<LegolasSettings>(),
+                // #497 @me/character-named pin = high-confidence self position.
+                sp.GetService<ICharacterPinAnchor>(),
+                // Shared GameState current-area: a confirmed area change
+                // invalidates the area-local-frame measurement (maps are
+                // area-specific). Same tracker Gandalf consumes.
+                sp.GetService<PlayerAreaTracker>(),
+                sp.GetService<IDiagnosticsSink>()));
 
         // End-of-run report (text + PNG + JSON + share link). Singleton so the
         // latest snapshot survives FSM resets and is available for the wizard's

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -81,9 +81,11 @@ public sealed class LogIngestionService : BackgroundService
                     HandleSurveyDetected(sd);
                     break;
                 case ItemAddedToInventory ia:
-                    if (_session.Mode == SessionMode.Motherlode)
-                        _motherlode.OnItemCollected(ia.Name);   // "… Metal Slab" gates progression
-                    else
+                    // Motherlode no longer infers completion from a "Metal Slab"
+                    // add: the dig is the map's IInventoryService Deleted event
+                    // (authoritative, exact), and loot is decoupled (the dig
+                    // spawns a mining node — no log link). Survey still uses it.
+                    if (_session.Mode != SessionMode.Motherlode)
                         HandleItemAddedToInventory(ia);
                     break;
                 case ItemCollected ic:

--- a/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
+++ b/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
@@ -1,67 +1,99 @@
 using Legolas.Domain;
 using Legolas.Flow;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
 using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Reference;
 
 namespace Legolas.Services;
 
 /// <summary>
 /// Immutable view of the in-flight Motherlode solve for the VM. <see cref="Surveys"/>
 /// and <see cref="Locations"/> are snapshots (safe to bind/iterate off-thread);
-/// <see cref="Guidance"/> is the single most relevant actionable hint (GDOP /
-/// missing-fix), or null when nothing needs saying.
+/// <see cref="Guidance"/> is the single most relevant actionable hint.
 /// </summary>
 /// <param name="Locations">The shared ordered Pᵢ set — one entry per spot the
-/// player measured at, in click order. Surfaced (not just counted) so the UI
-/// can phrase a solved treasure relative to "your spot #N" (#113 Layer 1, the
-/// zero-standoff reference tier). Includes fix-less rows (Confidence 0) so a
-/// row index lines up with <see cref="MotherlodeSurvey.DistancesByLocation"/>.</param>
+/// player measured at. Includes fix-less rows (Confidence 0) so a row index
+/// lines up with <see cref="MotherlodeSurvey.DistancesByLocation"/>.</param>
+/// <param name="ReadsPerLocation">Per-spot count of bound distance readings
+/// (parallel to <see cref="Locations"/>) — the passive multi-map shape
+/// surface ("Spot 1: 5 · Spot 2: 4").</param>
+/// <param name="MapsDug">Count of motherlode maps consumed this session (each
+/// <c>ProcessDeleteItem</c> of a motherlode map = one treasure found). The
+/// session summary is this + elapsed time; loot is a documented data ceiling
+/// (the dig spawns a mining node — yield is decoupled, no log link).</param>
 public sealed record MotherlodeStatus(
     int LocationCount,
     int LocationsWithFix,
     WorldCoord? LastPlayerWorld,
     IReadOnlyList<MotherlodeSurvey> Surveys,
     IReadOnlyList<MotherlodePositionSample> Locations,
-    string? Guidance);
+    string? Guidance,
+    IReadOnlyList<int> ReadsPerLocation,
+    int MapsDug);
 
 /// <summary>
-/// Owns the rebuilt Motherlode mechanic (#488): correlates the
-/// <see cref="MotherlodeUseDetected"/> use gesture, a position feeder fix
-/// (#1 opportunistic log position / #2 map pin — source-agnostic), and the
-/// following ChatLog <see cref="MotherlodeDistance"/> line(s) into a shared
-/// location-sample set, then runs <see cref="IMultilaterationSolver"/> per
-/// motherlode slot.
+/// Owns the rebuilt Motherlode mechanic (#488). Confirmed empirically from the
+/// live Player.log: <b>one map = one treasure</b>; the read line carries no
+/// per-map identity (type name only) and the inventory slot ≠ the grid the
+/// player arranges by, so read→treasure binding cannot be derived from the log.
 ///
-/// <para><b>Pairing is label-agnostic and temporal</b> (hard rule, mirrors
-/// #454): a use opens/extends a location; the feeder fix nearest in time to
-/// the use (within <see cref="MaxFeederGapSeconds"/>) is that location's Pᵢ;
-/// distance lines arriving within <see cref="DistanceWindowSeconds"/> of the
-/// last use bind in arrival order — the k-th to slot k (the batching contract:
-/// a player carries an inventory of maps and clicks them in a stable order at
-/// every spot; the log carries no per-target identity). The ingestion services
-/// already gate Motherlode mode and the session-replay backlog
-/// (<c>_liveSince</c>), so a finished run can't repopulate here.</para>
+/// <para><b>Create-on-use, not on stock.</b> A working slot is created lazily
+/// by a <i>reading</i>, never by holding inventory — so carrying 100+ maps
+/// costs nothing until measured. The map <i>type</i> name from the
+/// <c>ProcessDoDelayLoop</c> use line is a display label only.</para>
+///
+/// <para><b>Multi-map (default, toggle) vs serial.</b> With the
+/// <see cref="LegolasSettings.MotherlodeMultiMapMode"/> toggle on (other tools'
+/// posture, and the evidenced primary workflow — a stack read in a fixed order,
+/// the same set re-read at each spot), the k-th read at the defining (first)
+/// spot creates working slot k; later spots re-read that working set in order
+/// (the Survey/Treasure-Cartography assumptions: same order every spot, maps
+/// arranged sequentially). Off ⇒ serial single-active-treasure. The contract is
+/// validated against cross-spot read counts (<see cref="DetectBatchDivergence"/>),
+/// never silently authoritative.</para>
+///
+/// <para><b>Completion.</b> A motherlode-map <c>Deleted</c> (the dig; it spawns
+/// a mining node, loot decoupled) increments <see cref="MotherlodeStatus.MapsDug"/>
+/// and retires the next uncollected slot. Position is temporally paired from
+/// the highest-confidence feeder; the <c>@me</c>/character-named pin (#497) is
+/// the intended high-accuracy per-read source.</para>
 /// </summary>
 public sealed class MotherlodeMeasurementCoordinator : IDisposable
 {
-    // ---- #488 "decide during build" knobs (conservative; tune empirically) --
+    // ---- #488 knobs (conservative; tune empirically) ---------------------
 
     // A feeder fix older than this vs the use is too stale to be "where I am
-    // now". Comfortably exceeds the ~15–30 s relog load of the max-accuracy
-    // ProcessAddPlayer procedure.
+    // now". Comfortably exceeds the ~15–30 s relog of the max-accuracy
+    // ProcessAddPlayer procedure and the @me-pin→read latency.
     private const double MaxFeederGapSeconds = 120;
 
-    // Uses within this window of the previous use are the same physical spot
-    // (the player clicking several carried maps); a later use starts a new
-    // location.
+    // Uses within this window of the previous use are the same physical spot.
     private const double LocationClusterSeconds = 30;
 
     // A distance line must follow its use within this window to bind.
     private const double DistanceWindowSeconds = 20;
 
+    // Risk-1: when the time gate trips but the feeder fix is within this many
+    // metres of the open location's *committed first* anchor, the player is
+    // still standing there (a slow re-read), not at a new spot — keep the
+    // location so a >30 s same-spot pause can't fork a phantom row / desync.
+    // 12 m covers MapPin↔LogPosition feeder standoff while staying >2× below
+    // the solver's ~30 m distinct-spot guidance.
+    private const double SameSpotRadiusMetres = 12;
+
+    // A ProcessDeleteItem lands ~1 s after the completing use; far tighter
+    // than the distance window so an unrelated deletion can't be mistaken for
+    // a completion.
+    private const double MapConsumeWindowSeconds = 5;
+
     // Inverse-variance-ish confidence per feeder (→ solver weight). Accuracy
-    // ordering is load-bearing (#488 table); the exact values are an open knob.
+    // ordering is load-bearing (#488 table); exact values are an open knob.
+    // The @me/character-named pin (#497) is the player's own location (the
+    // intended high-accuracy per-read path), so it ranks well above a generic
+    // hand-placed map pin.
     private static double Confidence(MotherlodePositionSource src, PlayerPositionSource? pos) => src switch
     {
         MotherlodePositionSource.LogPosition => pos == PlayerPositionSource.Spawn ? 1.0 : 0.8,
@@ -75,12 +107,30 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     private readonly IMultilaterationSolver _solver;
     private readonly MotherlodeFlowController _flow;
     private readonly ICharacterPinAnchor? _characterPin;
+    private readonly PlayerAreaTracker? _areaTracker;
     private readonly IDiagnosticsSink? _diag;
+    private readonly IReferenceDataService? _refData;
+    private readonly LegolasSettings? _settings;
     private readonly IDisposable? _posSub;
     private readonly IDisposable? _pinSub;
+    private readonly IDisposable? _invSub;
+
+    // The area the in-flight measurement is anchored in. Multilateration is in
+    // the area-local engine frame and maps are area-specific, so crossing
+    // areas invalidates every position fix / slot — the measurement is cleared
+    // (the session-cumulative dug count is kept; it isn't frame-bound).
+    private string? _sessionArea;
 
     private readonly object _gate = new();
     private readonly MotherlodeSession _session = new();
+
+    // Maps consumed this session (each motherlode-map Deleted = a dig). The
+    // summary is this + elapsed time; no per-completed entity is retained.
+    private int _dugMaps;
+
+    // The map-type label from the most recent use, applied to a slot the next
+    // read creates (display only — identical across a same-type stack).
+    private string? _pendingUseName;
 
     // Latest feeder fix seen from a tracker (cross-thread; value-only).
     private (WorldCoord World, MotherlodePositionSource Src, PlayerPositionSource? Pos, DateTimeOffset At)? _latestFix;
@@ -91,9 +141,10 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         public MotherlodePositionSample? Sample;
         public DateTimeOffset LastUseAt;
         public int RowIndex = -1;            // index into _session.LocationSamples once committed
-        public int DistanceCount;            // distances bound so far (→ slot index)
+        public int DistanceCount;            // distances bound at this spot so far (per-spot ordinal)
     }
     private OpenLocation? _open;
+    private DateTimeOffset? _lastUseAt;
     private string? _guidance;
 
     public event Action? Changed;
@@ -103,17 +154,26 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         MotherlodeFlowController flow,
         IPlayerPositionTracker positionTracker,
         IPlayerPinTracker pinTracker,
-        IDiagnosticsSink? diag = null,
-        ICharacterPinAnchor? characterPin = null)
+        IInventoryService? inventory = null,
+        IReferenceDataService? refData = null,
+        LegolasSettings? settings = null,
+        ICharacterPinAnchor? characterPin = null,
+        PlayerAreaTracker? areaTracker = null,
+        IDiagnosticsSink? diag = null)
     {
         _solver = solver;
         _flow = flow;
         _characterPin = characterPin;
+        _areaTracker = areaTracker;
+        _refData = refData;
+        _settings = settings;
         _diag = diag;
-        // Replay-on-subscribe is fine: a fix only matters once a use references
-        // it within MaxFeederGap, so a stale replayed fix self-expires.
+        // Replay-on-subscribe is fine: a position fix only matters once a use
+        // references it within MaxFeederGap. Inventory is consumed for the
+        // *Deleted* completion signal only — never to create slots from stock.
         _posSub = positionTracker.Subscribe(OnPlayerPosition);
         _pinSub = pinTracker.Subscribe(OnPinChanged);
+        _invSub = inventory?.Subscribe(OnInventory);
     }
 
     // ---- Feeder inputs (tracker thread) ----------------------------------
@@ -128,7 +188,9 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     private void OnPinChanged(PinSetChanged c)
     {
         // Only a genuinely new pin is a feeder; Snapshot/AreaChanged replays
-        // carry no single Pin and must not move the fix.
+        // carry no single Pin and must not move the fix. The @me /
+        // character-named pin dropped at the read spot is the intended
+        // high-accuracy position source.
         if (c.Kind != PinSetChange.Added || c.Pin is not { } pin) return;
         // #497: a pin the player named after their character / "@me" is an
         // explicit "I am here" — prefer it over an arbitrary waypoint.
@@ -139,17 +201,129 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
             _latestFix = (new WorldCoord(pin.X, 0, pin.Z), src, null, c.ObservedAt);
     }
 
-    // ---- Use / distance / collection (UI thread, via ingestion PostToUi) --
+    // ---- Completion (inventory thread) -----------------------------------
+
+    /// <summary>
+    /// A motherlode-map <c>Deleted</c> is the dig: it consumed the map (and
+    /// spawned a mining node — loot is decoupled). Count it and retire the next
+    /// uncollected slot. The <c>Added</c> branch is intentionally absent —
+    /// holding stock must create nothing (the 100-maps pathology).
+    /// </summary>
+    private void OnInventory(InventoryEvent e)
+    {
+        if (e.Kind != InventoryEventKind.Deleted || !IsMotherlodeMap(e.InternalName)) return;
+        bool changed = false;
+        lock (_gate)
+        {
+            _dugMaps++;
+
+            // If this delete is the completing use (a use that opened a
+            // location which never received a distance, within the tight
+            // window), discard that ephemeral location so it doesn't pollute
+            // the solve / trip divergence.
+            var at = new DateTimeOffset(DateTime.SpecifyKind(e.Timestamp, DateTimeKind.Utc));
+            if (_open is { } o && o.DistanceCount == 0
+                && _lastUseAt is { } lu
+                && (at - lu).TotalSeconds <= MapConsumeWindowSeconds)
+            {
+                DiscardOpenLocation(o);
+                _open = null;
+            }
+
+            // Retire the next uncollected slot (lowest route order, else
+            // creation order) — order-based, mirrors the dig-the-cluster flow.
+            MotherlodeSurvey? best = null;
+            var bestOrder = int.MaxValue;
+            var bestIdx = -1;
+            for (var i = 0; i < _session.Surveys.Count; i++)
+            {
+                var s = _session.Surveys[i];
+                if (s.Collected) continue;
+                var ord = s.RouteOrder ?? i;
+                if (best is null || ord < bestOrder) { best = s; bestOrder = ord; bestIdx = i; }
+            }
+            if (best is { } b)
+            {
+                _session.Surveys[bestIdx] = b with { Collected = true };
+                _diag?.Info("Legolas.Motherlode",
+                    $"Map consumed ({e.InternalName}) — slot {bestIdx} collected; dug={_dugMaps}.");
+            }
+            else
+            {
+                _diag?.Info("Legolas.Motherlode",
+                    $"Map consumed ({e.InternalName}) — dug={_dugMaps} (no measured slot to retire).");
+            }
+            changed = true;
+        }
+        if (changed) Raise();
+    }
+
+    private bool IsMotherlodeMap(string internalName) =>
+        _refData is { } rd
+        && rd.ItemsByInternalName.TryGetValue(internalName, out var item)
+        && item.Name is { } n
+        && n.EndsWith("Motherlode Map", StringComparison.OrdinalIgnoreCase);
+
+    // A committed-but-distance-less location was a completing gesture, not a
+    // measurement: roll its row out of the shared sample set so it weighs on
+    // no solve and counts toward no divergence check.
+    private void DiscardOpenLocation(OpenLocation o)
+    {
+        if (o.RowIndex < 0 || o.RowIndex != _session.LocationSamples.Count - 1) return;
+        _session.LocationSamples.RemoveAt(o.RowIndex);
+        for (var i = 0; i < _session.Surveys.Count; i++)
+        {
+            var s = _session.Surveys[i];
+            if (s.DistancesByLocation.Count <= o.RowIndex) continue;
+            var d = s.DistancesByLocation.ToList();
+            d.RemoveAt(o.RowIndex);
+            _session.Surveys[i] = s with { DistancesByLocation = d };
+        }
+    }
+
+    // ---- Use / distance (UI thread, via ingestion PostToUi) --------------
 
     /// <summary>The player clicked a Motherlode map. Opens or extends the
-    /// current location and binds the feeder fix nearest in time.</summary>
-    public void OnUse(DateTimeOffset at)
+    /// current location; binds the feeder fix nearest in time. Risk-1: a use
+    /// after the time gate but still within <see cref="SameSpotRadiusMetres"/>
+    /// of the frozen anchor keeps the same location (slow same-spot re-read).
+    /// <paramref name="mapName"/> is the use-line map <i>type</i> label applied
+    /// to a slot the next read creates (display only).</summary>
+    public void OnUse(DateTimeOffset at, string? mapName = null)
     {
         bool changed;
         lock (_gate)
         {
+            // Area scoping: multilateration is area-local-frame and maps are
+            // area-specific. A confirmed area change invalidates every in-flight
+            // fix/slot — clear the measurement (keep the session dug count).
+            // Null = area unknown (char-select / pre-transition) → don't reset;
+            // self-heals on the next confirmed area.
+            var cur = _areaTracker?.CurrentArea;
+            if (cur is not null)
+            {
+                if (_sessionArea is not null && cur != _sessionArea)
+                {
+                    _diag?.Info("Legolas.Motherlode",
+                        $"Area {_sessionArea} → {cur}: clearing in-flight measurement (dug count kept).");
+                    ClearMeasurement();
+                }
+                _sessionArea = cur;
+            }
+
+            _pendingUseName = mapName;
+
             if (_open is { } o && (at - o.LastUseAt).TotalSeconds > LocationClusterSeconds)
-                _open = null;                       // player moved on — new spot
+            {
+                // Position-primary: compare the *current* fix to the committed
+                // first anchor only — never chain-compare to the previous fix,
+                // never refresh o.Sample (that would drift-walk the anchor).
+                var nf = NearestFix(at);
+                var sameSpot = o.Sample is { } anchor && anchor.Confidence > 0
+                    && nf is { } f
+                    && PlanarDist(anchor.World, f.World) <= SameSpotRadiusMetres;
+                if (!sameSpot) _open = null;     // genuine move, or no fix to compare
+            }
 
             if (_open is null)
             {
@@ -162,20 +336,21 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
                 }
                 else
                 {
-                    _guidance = "No recent position fix for that reading — relog " +
-                                "at the spot (best) or drop a map pin before using.";
+                    _guidance = "No position for that reading — drop an @me pin " +
+                                "at the spot (best) before using, or relog.";
                     _diag?.Info("Legolas.Motherlode", "Use with no feeder fix in window.");
                 }
             }
             _open.LastUseAt = at;
+            _lastUseAt = at;
             changed = true;
         }
         _flow.NoteMeasurement("motherlode-use");
         if (changed) Raise();
     }
 
-    /// <summary>A ChatLog distance reading. Binds to the open location's next
-    /// slot (arrival order = slot index) and re-solves that slot.</summary>
+    /// <summary>A ChatLog distance reading. Creates/binds the slot the current
+    /// mode + per-spot ordinal selects, then re-solves it.</summary>
     public void OnDistance(int metres, DateTimeOffset at)
     {
         lock (_gate)
@@ -192,51 +367,71 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
             }
 
             EnsureCommitted(o);
-            var slot = o.DistanceCount;
+            var slot = SelectSlot(o);
+            if (slot < 0)
+            {
+                _diag?.Trace("Legolas.Motherlode", $"Distance {metres}m — no slot to bind — dropped.");
+                return;
+            }
             o.DistanceCount++;
             SetDistance(o.RowIndex, slot, metres);
             ResolveSlot(slot);
+            if (DetectBatchDivergence() is { } div) _guidance = div;
         }
         _flow.NoteMeasurement("motherlode-distance");
         Raise();
     }
 
-    /// <summary>Collection-gated progression: a "<c>… Metal Slab</c>" entering
-    /// inventory marks the next uncollected motherlode collected.</summary>
-    public void OnItemCollected(string name)
+    /// <summary>
+    /// Which slot the k-th reading at this spot binds to. Multi-map (default):
+    /// the defining (first) spot creates slot k as the stack is read; later
+    /// spots re-read the same working set in order (divergence flags a
+    /// shortfall). Serial / toggle off: the single active uncollected treasure.
+    /// </summary>
+    private int SelectSlot(OpenLocation o)
     {
-        if (name.IndexOf("Metal Slab", StringComparison.OrdinalIgnoreCase) < 0) return;
-        bool changed = false;
-        lock (_gate)
+        var k = o.DistanceCount;                       // 0-based per-spot ordinal
+        var multiMap = _settings?.MotherlodeMultiMapMode ?? true;
+        var count = _session.Surveys.Count;
+
+        if (!multiMap)
         {
-            MotherlodeSurvey? best = null;
-            var bestOrder = int.MaxValue;
-            for (var i = 0; i < _session.Surveys.Count; i++)
-            {
-                var s = _session.Surveys[i];
-                if (s.Collected) continue;
-                var ord = s.RouteOrder ?? i;
-                if (best is null || ord < bestOrder) { best = s; bestOrder = ord; }
-            }
-            if (best is { } b)
-            {
-                var idx = _session.Surveys.IndexOf(b);
-                _session.Surveys[idx] = b with { Collected = true };
-                changed = true;
-            }
+            // Serial: the single active treasure = lowest-index uncollected
+            // slot; if none (all dug / none yet), a new one is created.
+            for (var i = 0; i < count; i++)
+                if (!_session.Surveys[i].Collected) return i;
+            return count;                              // SetDistance grows one
         }
-        if (changed) Raise();
+
+        // Multi-map declared-order. Defining pass (first measured spot) grows
+        // the working set lazily; later spots re-read it in the same order,
+        // clamped so an over/under-read can't throw — divergence surfaces it.
+        var definingPass = o.RowIndex == 0;
+        if (definingPass) return k;
+        if (count == 0) return 0;
+        return Math.Min(k, count - 1);
+    }
+
+    // Clears the in-flight measurement (area-local frames) — NOT the
+    // session-cumulative dug count, which isn't frame-bound. Caller holds _gate.
+    private void ClearMeasurement()
+    {
+        _session.LocationSamples.Clear();
+        _session.Surveys.Clear();
+        _open = null;
+        _lastUseAt = null;
+        _latestFix = null;
+        _guidance = null;
+        _pendingUseName = null;
     }
 
     public void Reset()
     {
         lock (_gate)
         {
-            _session.LocationSamples.Clear();
-            _session.Surveys.Clear();
-            _open = null;
-            _latestFix = null;
-            _guidance = null;
+            ClearMeasurement();
+            _dugMaps = 0;
+            _sessionArea = null;
         }
         _flow.Reset();
         Raise();
@@ -246,24 +441,27 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     {
         lock (_gate)
         {
+            var rows = _session.LocationSamples.Count;
             var withFix = _session.LocationSamples.Count(s => s.Confidence > 0);
             WorldCoord? last = null;
-            for (var i = _session.LocationSamples.Count - 1; i >= 0; i--)
+            for (var i = rows - 1; i >= 0; i--)
                 if (_session.LocationSamples[i].Confidence > 0)
                 { last = _session.LocationSamples[i].World; break; }
+
+            var reads = ReadsPerLocation(rows);
             return new MotherlodeStatus(
-                _session.LocationSamples.Count,
+                rows,
                 withFix,
                 last,
                 _session.Surveys.ToArray(),
                 _session.LocationSamples.ToArray(),
-                _guidance);
+                _guidance,
+                reads,
+                _dugMaps);
         }
     }
 
-    /// <summary>Persist the optimized visit order computed by the VM (route
-    /// optimization is calibration-free — world (X,Z) ordering is invariant
-    /// under the display similarity transform).</summary>
+    /// <summary>Persist the optimized visit order computed by the VM.</summary>
     public void ApplyRouteOrder(IReadOnlyList<Guid> orderedIds)
     {
         lock (_gate)
@@ -287,6 +485,13 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
 
     // ---- internals (all under _gate) -------------------------------------
 
+    private static double PlanarDist(WorldCoord a, WorldCoord b)
+    {
+        var dx = a.X - b.X;
+        var dz = a.Z - b.Z;
+        return Math.Sqrt(dx * dx + dz * dz);
+    }
+
     private (WorldCoord World, MotherlodePositionSource Src, PlayerPositionSource? Pos, DateTimeOffset At)? NearestFix(DateTimeOffset useAt)
     {
         if (_latestFix is not { } f) return null;
@@ -306,7 +511,9 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     private void SetDistance(int row, int slot, int metres)
     {
         while (_session.Surveys.Count <= slot)
-            _session.Surveys.Add(MotherlodeSurvey.Create());
+            // Create-on-read: a new working slot, labelled with the type name
+            // from the use that produced this read (display only).
+            _session.Surveys.Add(MotherlodeSurvey.Create() with { MapName = _pendingUseName });
 
         var s = _session.Surveys[slot];
         var d = s.DistancesByLocation.ToList();
@@ -351,11 +558,51 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         else if (r.Quality == MultilaterationQuality.Solved) _guidance = null;
     }
 
+    private int[] ReadsPerLocation(int rows)
+    {
+        var reads = new int[rows];
+        foreach (var s in _session.Surveys)
+            for (var r = 0; r < rows && r < s.DistancesByLocation.Count; r++)
+                if (s.DistancesByLocation[r] > 0) reads[r]++;
+        return reads;
+    }
+
+    /// <summary>
+    /// Validate the declared read-order contract by cross-spot consistency: a
+    /// committed, closed (non-open) spot that read fewer maps than a later
+    /// closed spot is very likely misaligned. Excludes the still-open final
+    /// batch (it legitimately trails). Working-set based — never keyed off
+    /// inventory-held stock. Returns the actionable message for the first
+    /// offending spot, else null.
+    /// </summary>
+    private string? DetectBatchDivergence()
+    {
+        var rows = _session.LocationSamples.Count;
+        if (rows == 0) return null;
+        var reads = ReadsPerLocation(rows);
+        var openRow = _open?.RowIndex ?? -1;
+
+        var maxClosed = 0;
+        for (var r = 0; r < rows; r++)
+            if (r != openRow) maxClosed = Math.Max(maxClosed, reads[r]);
+
+        for (var r = 0; r < rows; r++)
+        {
+            if (r == openRow) continue;
+            if (reads[r] == 0) continue;            // not yet read here at all
+            if (reads[r] < maxClosed)
+                return $"Spot #{r + 1} read fewer maps than a later spot — readings " +
+                       "may be misaligned; re-read that spot in the same order, or Reset.";
+        }
+        return null;
+    }
+
     private void Raise() => Changed?.Invoke();
 
     public void Dispose()
     {
         _posSub?.Dispose();
         _pinSub?.Dispose();
+        _invSub?.Dispose();
     }
 }

--- a/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
+++ b/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
@@ -32,7 +32,8 @@ public sealed record MotherlodeStatus(
     IReadOnlyList<MotherlodePositionSample> Locations,
     string? Guidance,
     IReadOnlyList<int> ReadsPerLocation,
-    int MapsDug);
+    int MapsDug,
+    bool CanUndo);
 
 /// <summary>
 /// Owns the rebuilt Motherlode mechanic (#488). Confirmed empirically from the
@@ -131,6 +132,14 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     // The map-type label from the most recent use, applied to a slot the next
     // read creates (display only — identical across a same-type stack).
     private string? _pendingUseName;
+
+    // Multi-level undo for an "oops, I accidentally checked a map" misclick.
+    // Each bound reading pushes enough to fully reverse it (LIFO): the row/slot
+    // it hit, the prior value there, and whether this read *created* that slot
+    // and/or that location row. Cleared whenever the measurement is cleared.
+    private readonly record struct ReadUndo(
+        int Row, int Slot, int PrevDistance, bool CreatedSlot, bool CreatedRow);
+    private readonly Stack<ReadUndo> _undo = new();
 
     // Latest feeder fix seen from a tracker (cross-thread; value-only).
     private (WorldCoord World, MotherlodePositionSource Src, PlayerPositionSource? Pos, DateTimeOffset At)? _latestFix;
@@ -267,16 +276,22 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
     // A committed-but-distance-less location was a completing gesture, not a
     // measurement: roll its row out of the shared sample set so it weighs on
     // no solve and counts toward no divergence check.
-    private void DiscardOpenLocation(OpenLocation o)
+    private void DiscardOpenLocation(OpenLocation o) => DiscardRow(o.RowIndex);
+
+    // Roll a (last) location row out of the shared sample set: drop its Pᵢ and
+    // trim every survey's parallel slot, so it weighs on no solve and counts
+    // toward no divergence check. Only the final row is removable (interior
+    // removal would renumber every slot's parallel array).
+    private void DiscardRow(int row)
     {
-        if (o.RowIndex < 0 || o.RowIndex != _session.LocationSamples.Count - 1) return;
-        _session.LocationSamples.RemoveAt(o.RowIndex);
+        if (row < 0 || row != _session.LocationSamples.Count - 1) return;
+        _session.LocationSamples.RemoveAt(row);
         for (var i = 0; i < _session.Surveys.Count; i++)
         {
             var s = _session.Surveys[i];
-            if (s.DistancesByLocation.Count <= o.RowIndex) continue;
+            if (s.DistancesByLocation.Count <= row) continue;
             var d = s.DistancesByLocation.ToList();
-            d.RemoveAt(o.RowIndex);
+            d.RemoveAt(row);
             _session.Surveys[i] = s with { DistancesByLocation = d };
         }
     }
@@ -366,6 +381,7 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
                 return;
             }
 
+            var createdRow = o.RowIndex < 0;          // EnsureCommitted will add it
             EnsureCommitted(o);
             var slot = SelectSlot(o);
             if (slot < 0)
@@ -373,9 +389,14 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
                 _diag?.Trace("Legolas.Motherlode", $"Distance {metres}m — no slot to bind — dropped.");
                 return;
             }
+            var createdSlot = slot >= _session.Surveys.Count;
+            var prev = !createdSlot && o.RowIndex < _session.Surveys[slot].DistancesByLocation.Count
+                ? _session.Surveys[slot].DistancesByLocation[o.RowIndex]
+                : 0;
             o.DistanceCount++;
             SetDistance(o.RowIndex, slot, metres);
             ResolveSlot(slot);
+            _undo.Push(new ReadUndo(o.RowIndex, slot, prev, createdSlot, createdRow));
             if (DetectBatchDivergence() is { } div) _guidance = div;
         }
         _flow.NoteMeasurement("motherlode-distance");
@@ -423,6 +444,7 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         _latestFix = null;
         _guidance = null;
         _pendingUseName = null;
+        _undo.Clear();
     }
 
     public void Reset()
@@ -435,6 +457,62 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         }
         _flow.Reset();
         Raise();
+    }
+
+    /// <summary>
+    /// "Oops, I accidentally checked a map." Reverses the most recently bound
+    /// reading (multi-level, LIFO): restores the prior distance, drops the slot
+    /// and/or location row if this read created it, decrements the open spot's
+    /// per-spot ordinal so the *next* real read re-takes that position (this is
+    /// what re-aligns the multi-map declared-order contract — without it the
+    /// desync persists), re-solves, and recomputes divergence. Returns false
+    /// when there is nothing to undo.
+    /// </summary>
+    public bool UndoLastReading()
+    {
+        lock (_gate)
+        {
+            if (_undo.Count == 0) return false;
+            var u = _undo.Pop();
+
+            if (u.Slot < _session.Surveys.Count)
+            {
+                var s = _session.Surveys[u.Slot];
+                if (u.Row < s.DistancesByLocation.Count)
+                {
+                    var d = s.DistancesByLocation.ToList();
+                    d[u.Row] = u.PrevDistance;
+                    _session.Surveys[u.Slot] = s = s with { DistancesByLocation = d };
+                }
+                // LIFO ⇒ a slot this read created is the last one and has no
+                // other readings now: drop it. Otherwise just re-solve.
+                if (u.CreatedSlot && s.DistancesByLocation.All(v => v <= 0) && !s.Collected
+                    && u.Slot == _session.Surveys.Count - 1)
+                    _session.Surveys.RemoveAt(u.Slot);
+                else
+                    ResolveSlot(u.Slot);
+            }
+
+            // Re-open the ordinal so the next read at this spot re-takes it.
+            if (_open is { } o && o.RowIndex == u.Row && o.DistanceCount > 0)
+                o.DistanceCount--;
+
+            // A row this read created, now empty, rolls out (and the open
+            // location must re-commit a fresh row on its next reading).
+            if (u.CreatedRow && u.Row == _session.LocationSamples.Count - 1
+                && _session.Surveys.All(s => s.DistancesByLocation.Count <= u.Row
+                                             || s.DistancesByLocation[u.Row] <= 0))
+            {
+                DiscardRow(u.Row);
+                if (_open is { } op && op.RowIndex == u.Row) op.RowIndex = -1;
+            }
+
+            // Recompute the contract warning (clears a stale one the bad read
+            // raised; null = no issue).
+            _guidance = DetectBatchDivergence();
+        }
+        Raise();
+        return true;
     }
 
     public MotherlodeStatus Snapshot()
@@ -457,7 +535,8 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
                 _session.LocationSamples.ToArray(),
                 _guidance,
                 reads,
-                _dugMaps);
+                _dugMaps,
+                _undo.Count > 0);
         }
     }
 

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -134,7 +134,8 @@ public sealed class PlayerLogIngestionService : BackgroundService
                              && use.Timestamp >= _liveSince:
                         var at = new DateTimeOffset(
                             DateTime.SpecifyKind(use.Timestamp, DateTimeKind.Utc));
-                        PostToUi(() => _motherlode.OnUse(at));
+                        var useName = use.MapName;
+                        PostToUi(() => _motherlode.OnUse(at, useName));
                         break;
                 }
             }

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -32,23 +32,35 @@ public sealed partial class PlayerLogParser : ILogParser
     private static partial Regex MapFxRx();
 
     // Motherlode-map use gesture: ProcessDoDelayLoop whose quoted action text
-    // mentions a Motherlode map. Label-agnostic — only the fact + timestamp are
-    // used for pairing (#488); the map's full name is intentionally not
-    // captured. Grammar mirrors Gandalf's InteractionDelayLoopParser (no
-    // cross-module dependency taken).
+    // mentions a Motherlode map. The quoted text is captured for its map *type*
+    // name (e.g. "Kur Mountains Simple Metal Motherlode Map") — a display label
+    // only; binding stays order-based (the type is identical across a same-type
+    // stack, no per-map identity). Grammar mirrors Gandalf's
+    // InteractionDelayLoopParser (no cross-module dependency taken).
     [GeneratedRegex(
-        """LocalPlayer:\s*ProcessDoDelayLoop\(\s*\d+(?:\.\d+)?\s*,\s*\w+\s*,\s*"[^"]*Motherlode Map[^"]*"\s*,""",
+        """LocalPlayer:\s*ProcessDoDelayLoop\(\s*\d+(?:\.\d+)?\s*,\s*\w+\s*,\s*"(?<map>[^"]*Motherlode Map[^"]*)"\s*,""",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
     private static partial Regex MotherlodeUseRx();
+
+    private static string? NormalizeMapName(string raw)
+    {
+        var s = raw.Trim();
+        // PG action text is "Using <Item Name>"; strip the verb prefix so the
+        // label is the bare map name.
+        if (s.StartsWith("Using ", StringComparison.OrdinalIgnoreCase))
+            s = s["Using ".Length..].Trim();
+        return s.Length == 0 ? null : s;
+    }
 
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
         if (string.IsNullOrEmpty(line)) return null;
 
         if (line.Contains("ProcessDoDelayLoop(", StringComparison.Ordinal)
-            && MotherlodeUseRx().IsMatch(line))
+            && MotherlodeUseRx().Match(line) is { Success: true } use)
         {
-            return new MotherlodeUseDetected(timestamp);
+            return new MotherlodeUseDetected(
+                timestamp, NormalizeMapName(use.Groups["map"].Value));
         }
 
         if (line.Contains("ProcessMapFx", StringComparison.Ordinal)

--- a/src/Legolas.Module/ViewModels/InventoryOverlayViewModel.cs
+++ b/src/Legolas.Module/ViewModels/InventoryOverlayViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Data;
@@ -10,11 +12,14 @@ namespace Legolas.ViewModels;
 public sealed partial class InventoryOverlayViewModel : ObservableObject
 {
     private readonly SessionState _session;
+    private readonly MotherlodeViewModel? _motherlode;
 
-    public InventoryOverlayViewModel(InventoryGridSettings grid, SessionState session)
+    public InventoryOverlayViewModel(InventoryGridSettings grid, SessionState session,
+        MotherlodeViewModel? motherlode = null)
     {
         Grid = grid;
         _session = session;
+        _motherlode = motherlode;
         Slots = CollectionViewSource.GetDefaultView(_session.Surveys);
         Slots.Filter = item => item is SurveyItemViewModel s && !s.Collected;
 
@@ -23,6 +28,51 @@ public sealed partial class InventoryOverlayViewModel : ObservableObject
         _session.Surveys.CollectionChanged += OnSurveysChanged;
         foreach (var s in _session.Surveys)
             s.PropertyChanged += OnItemChanged;
+
+        // #488: in Motherlode mode the overlay guides the multi-map read-order
+        // contract — it lists the tracked motherlode maps (name + 1-based read
+        // ordinal) so the player lays them in inventory in that order and reads
+        // top-to-bottom at every spot. Sourced from the Motherlode coordinator
+        // (via MotherlodeViewModel), kept entirely separate from Survey state.
+        if (_motherlode is not null)
+            _motherlode.Slots.CollectionChanged += (_, _) => RebuildMotherlodeSlots();
+        _session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(SessionState.Mode))
+            {
+                RebuildMotherlodeSlots();
+                OnPropertyChanged(nameof(ActiveSlots));
+            }
+        };
+        RebuildMotherlodeSlots();
+    }
+
+    /// <summary>Motherlode read-order guidance items (uncollected tracked maps,
+    /// in stable ordinal order). Reuses <see cref="SurveyItemViewModel"/> so the
+    /// existing inventory tile template renders them unchanged: Name = map
+    /// display name, GridIndex = 1-based read ordinal, IsActiveTarget = the
+    /// next map to read.</summary>
+    public ObservableCollection<SurveyItemViewModel> MotherlodeSlots { get; } = new();
+
+    /// <summary>The collection the overlay binds to — Survey pins or, in
+    /// Motherlode mode, the read-order map list.</summary>
+    public IEnumerable ActiveSlots =>
+        _session.Mode == SessionMode.Motherlode ? MotherlodeSlots : Slots;
+
+    private void RebuildMotherlodeSlots()
+    {
+        MotherlodeSlots.Clear();
+        if (_motherlode is null || _session.Mode != SessionMode.Motherlode) return;
+
+        var ordinal = 0;
+        foreach (var m in _motherlode.Slots)
+        {
+            if (m.Collected) continue;                       // mirrors the Survey "uncollected only" filter
+            var name = string.IsNullOrWhiteSpace(m.MapName) ? $"Map {ordinal + 1}" : m.MapName!;
+            var survey = Survey.Create(name, MetreOffset.Zero, ordinal) with { Collected = false };
+            MotherlodeSlots.Add(new SurveyItemViewModel(survey) { IsActiveTarget = m.IsNextUp });
+            ordinal++;
+        }
     }
 
     private void OnSurveysChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Legolas.Module/ViewModels/MotherlodeViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MotherlodeViewModel.cs
@@ -128,6 +128,10 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
     /// the FSM stays coarse — this is purely a snapshot projection.</summary>
     [ObservableProperty] private MotherlodeStage _stage;
 
+    /// <summary>True when there is a bound reading the player can undo (the
+    /// "oops" button is enabled). Multi-level.</summary>
+    [ObservableProperty] private bool _canUndo;
+
     /// <summary>Treasures with a confident fix so far — the headline number.</summary>
     public int SolvedCount => Slots.Count(s => s.HasFix);
 
@@ -170,6 +174,7 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
         Guidance = snap.Guidance;
         ReadsPerLocation = snap.ReadsPerLocation;
         MapsDug = snap.MapsDug;
+        CanUndo = snap.CanUndo;
         RecomputeContractText();
         OnPropertyChanged(nameof(SolvedCount));
 
@@ -200,6 +205,12 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
         var order = _optimizer.Optimize(start, points);
         _coordinator.ApplyRouteOrder(order.Select(i => ids[i]).ToList());
     }
+
+    /// <summary>"Oops, I accidentally checked a map" — reverse the last bound
+    /// reading (multi-level). Cheap correction vs. nuking the batch with
+    /// Reset.</summary>
+    [RelayCommand]
+    private void UndoLastReading() => _coordinator.UndoLastReading();
 
     [RelayCommand]
     private void Reset() => _coordinator.Reset();

--- a/src/Legolas.Module/ViewModels/MotherlodeViewModel.cs
+++ b/src/Legolas.Module/ViewModels/MotherlodeViewModel.cs
@@ -33,6 +33,7 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
     private readonly MotherlodeFlowController _flow;
     private readonly IPlayerPinTracker? _pinTracker;
     private readonly IAreaCalibrationService? _areaCalibration;
+    private readonly LegolasSettings? _settings;
 
     private static readonly IReadOnlyList<MapPin> NoPins = Array.Empty<MapPin>();
     private static readonly IReadOnlyList<CalibrationReference> NoReferences = Array.Empty<CalibrationReference>();
@@ -42,15 +43,46 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
         IRouteOptimizer optimizer,
         MotherlodeFlowController flow,
         IPlayerPinTracker? pinTracker = null,
-        IAreaCalibrationService? areaCalibration = null)
+        IAreaCalibrationService? areaCalibration = null,
+        LegolasSettings? settings = null)
     {
         _coordinator = coordinator;
         _optimizer = optimizer;
         _flow = flow;
         _pinTracker = pinTracker;
         _areaCalibration = areaCalibration;
+        _settings = settings;
         _coordinator.Changed += OnCoordinatorChanged;
+        if (_settings is not null)
+            _settings.PropertyChanged += OnSettingsChanged;
         Rebuild();
+    }
+
+    private void OnSettingsChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(LegolasSettings.MotherlodeMultiMapMode))
+        {
+            OnPropertyChanged(nameof(MultiMapMode));
+            RecomputeContractText();
+        }
+    }
+
+    /// <summary>
+    /// #488 Multi-map mode. Two-way, setting-backed (not a snapshot
+    /// projection) — this is an operational control the player flips mid-run,
+    /// deliberately surfaced on the Motherlode panel rather than the Legolas
+    /// settings tab (it belongs where the action is; the value still persists
+    /// via <see cref="LegolasSettings.MotherlodeMultiMapMode"/>). Default true
+    /// when no settings instance is available (tests).
+    /// </summary>
+    public bool MultiMapMode
+    {
+        get => _settings?.MotherlodeMultiMapMode ?? true;
+        set
+        {
+            if (_settings is null || _settings.MotherlodeMultiMapMode == value) return;
+            _settings.MotherlodeMultiMapMode = value;   // OnSettingsChanged raises the notification
+        }
     }
 
     public MotherlodeFlowController Flow => _flow;
@@ -60,6 +92,36 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
     [ObservableProperty] private int _locationCount;
     [ObservableProperty] private int _locationsWithFix;
     [ObservableProperty] private string? _guidance;
+
+    /// <summary>Per-spot bound-reading tally, parallel to the measured spots —
+    /// the passive multi-map shape surface ("Spot 1: 5 · Spot 2: 4").</summary>
+    [ObservableProperty] private IReadOnlyList<int> _readsPerLocation = Array.Empty<int>();
+
+    /// <summary>Session summary: motherlode maps dug (treasures found). Loot is
+    /// a documented data ceiling (dig spawns a node — yield decoupled), so the
+    /// summary is this + elapsed time only.</summary>
+    [ObservableProperty] private int _mapsDug;
+
+    /// <summary>Preformatted per-spot tally ("Spot 1: 5 · Spot 2: 4"), or null
+    /// when nothing has been read yet.</summary>
+    [ObservableProperty] private string? _readsSummary;
+
+    /// <summary>Multi-map contract hint ("expecting N maps per spot"), or null
+    /// when single-map / serial / inventory unknown.</summary>
+    [ObservableProperty] private string? _contractHint;
+
+    private void RecomputeContractText()
+    {
+        var reads = ReadsPerLocation;
+        ReadsSummary = reads.Count == 0 || reads.All(r => r == 0)
+            ? null
+            : string.Join("  ·  ", reads.Select((r, i) => $"Spot {i + 1}: {r}"));
+        // Working-set based (never inventory-held): hint only once a multi-map
+        // batch is actually in progress (≥2 active slots).
+        ContractHint = MultiMapMode && Slots.Count > 1
+            ? "Multi-map mode — read your maps in the same order at every spot"
+            : null;
+    }
 
     /// <summary>#113 Layer 4: the derived progress stage the wizard projects
     /// onto its Motherlode sub-steps. Recomputed every <see cref="Rebuild"/>;
@@ -90,9 +152,13 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
             .Select(s => (Guid?)s.Id)
             .FirstOrDefault();
 
+        // Active-only projection: a retired (dug) slot drops out immediately —
+        // the list is the working set, never a completed graveyard, so cost is
+        // O(active) regardless of how many were farmed this session.
         Slots.Clear();
         foreach (var s in snap.Surveys)
         {
+            if (s.Collected) continue;
             var bearing = s.SolvedWorld is { } w
                 ? MotherlodeReferenceLocator.Nearest(w, snap.Locations, pins, gazetteer)
                 : null;
@@ -102,10 +168,13 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
         LocationCount = snap.LocationCount;
         LocationsWithFix = snap.LocationsWithFix;
         Guidance = snap.Guidance;
+        ReadsPerLocation = snap.ReadsPerLocation;
+        MapsDug = snap.MapsDug;
+        RecomputeContractText();
         OnPropertyChanged(nameof(SolvedCount));
 
         Stage =
-            Slots.Count > 0 && Slots.All(s => s.Collected) ? MotherlodeStage.Done
+            MapsDug > 0 && Slots.Count == 0 ? MotherlodeStage.Done
             : Slots.Any(s => s.HasFix) ? MotherlodeStage.Walk
             : LocationCount > 0 || Slots.Count > 0 ? MotherlodeStage.Locating
             : MotherlodeStage.Measuring;
@@ -135,7 +204,12 @@ public sealed partial class MotherlodeViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void Reset() => _coordinator.Reset();
 
-    public void Dispose() => _coordinator.Changed -= OnCoordinatorChanged;
+    public void Dispose()
+    {
+        _coordinator.Changed -= OnCoordinatorChanged;
+        if (_settings is not null)
+            _settings.PropertyChanged -= OnSettingsChanged;
+    }
 }
 
 /// <summary>Derived Motherlode progress stage (#113 Layer 4). Projected onto
@@ -160,14 +234,17 @@ public sealed class MotherlodeSlotViewModel
         RouteText = m.RouteOrder is { } r ? $"{r + 1}." : "•";
         DistanceCount = m.DistancesByLocation.Count(d => d > 0);
         HasFix = m.SolvedWorld is not null;
+        MapName = m.MapName;
 
         // Headline: the actionable relative phrase when solved; otherwise the
-        // progress toward the 3-reading minimum.
-        HeadlineText = HasFix
+        // progress toward the 3-reading minimum. Prefixed with the inventory
+        // map name when known (#488) so juggled multi-map slots are legible.
+        var core = HasFix
             ? bearing?.ToDisplayString() ?? "located — no nearby reference"
             : DistanceCount < 3
                 ? $"locating… ({DistanceCount}/3 readings)"
                 : "locating…";
+        HeadlineText = string.IsNullOrWhiteSpace(MapName) ? core : $"{MapName} — {core}";
 
         Quality = m.Quality switch
         {
@@ -200,6 +277,7 @@ public sealed class MotherlodeSlotViewModel
     public string RouteText { get; }
     public int DistanceCount { get; }
     public bool HasFix { get; }
+    public string? MapName { get; }
     public string HeadlineText { get; }
     public MotherlodeFixQuality Quality { get; }
     public string? QualityText { get; }

--- a/src/Legolas.Module/Views/InventoryOverlayView.xaml
+++ b/src/Legolas.Module/Views/InventoryOverlayView.xaml
@@ -26,7 +26,7 @@
                 <TextBlock Text="Inventory" Foreground="White" FontWeight="SemiBold" />
             </Border>
 
-            <ItemsControl ItemsSource="{Binding Slots}" Margin="0,6,0,0">
+            <ItemsControl ItemsSource="{Binding ActiveSlots}" Margin="0,6,0,0">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <controls:InventoryGridPanel

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -168,6 +168,52 @@
                                    FontSize="{DynamicResource AppFontSizeBody}" VerticalAlignment="Center" />
                     </StackPanel>
 
+                    <!-- #488 Multi-map mode. DELIBERATELY surfaced here on the
+                         Motherlode panel, NOT in the Legolas settings tab:
+                         it's an operational control the player flips mid-run
+                         (one map vs a carried batch), so it belongs where the
+                         action is. It is still a persisted setting
+                         (LegolasSettings.MotherlodeMultiMapMode); the panel is
+                         just its edit+display surface. Do not relocate to
+                         settings. -->
+                    <CheckBox IsChecked="{Binding MultiMapMode, Mode=TwoWay}"
+                              HorizontalAlignment="Center" Margin="0,0,0,4"
+                              Content="Multi-map mode — I read my maps in the same order at every spot" />
+                    <TextBlock Text="{Binding ContractHint}" TextWrapping="Wrap"
+                               HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,8"
+                               FontSize="{DynamicResource AppFontSizeSmall}"
+                               Foreground="{StaticResource TextTertiaryBrush}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ContractHint}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- Passive per-spot read tally — the multi-map shape at a
+                         glance; the actionable warning lives in the Guidance
+                         border below. -->
+                    <TextBlock Text="{Binding ReadsSummary}" TextWrapping="Wrap"
+                               HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,10"
+                               FontSize="{DynamicResource AppFontSizeBody}"
+                               Foreground="{StaticResource TextTertiaryBrush}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ReadsSummary}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
                     <Border Margin="0,0,0,12" Padding="10,8" CornerRadius="4"
                             Background="{StaticResource AccentSoftBrush}">
                         <Border.Style>

--- a/src/Legolas.Module/Views/WizardView.xaml
+++ b/src/Legolas.Module/Views/WizardView.xaml
@@ -860,8 +860,14 @@
                                TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,20"
                                FontSize="{DynamicResource AppFontSizeBody}"
                                Foreground="{StaticResource TextSecondaryBrush}" />
-                    <Button Content="Reset" Padding="14,6" HorizontalAlignment="Center"
-                            Command="{Binding Motherlode.ResetCommand}" />
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button Content="Oops — undo last check" Padding="14,6" Margin="0,0,8,0"
+                                ToolTip="Accidentally checked a map? Reverse the last reading (multi-level)."
+                                IsEnabled="{Binding Motherlode.CanUndo}"
+                                Command="{Binding Motherlode.UndoLastReadingCommand}" />
+                        <Button Content="Reset" Padding="14,6"
+                                Command="{Binding Motherlode.ResetCommand}" />
+                    </StackPanel>
                 </StackPanel>
 
                 <!-- MotherlodeLocating — readings in, nothing solved yet. -->
@@ -872,8 +878,14 @@
                                Foreground="{StaticResource TextSecondaryBrush}" />
                     <ContentControl Content="{Binding Motherlode}" ContentTemplate="{StaticResource MotherlodeProgressBody}"
                                     HorizontalAlignment="Center" />
-                    <Button Content="Reset" Padding="14,6" HorizontalAlignment="Center" Margin="0,4,0,0"
-                            Command="{Binding Motherlode.ResetCommand}" />
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4,0,0">
+                        <Button Content="Oops — undo last check" Padding="14,6" Margin="0,0,8,0"
+                                ToolTip="Accidentally checked a map? Reverse the last reading (multi-level)."
+                                IsEnabled="{Binding Motherlode.CanUndo}"
+                                Command="{Binding Motherlode.UndoLastReadingCommand}" />
+                        <Button Content="Reset" Padding="14,6"
+                                Command="{Binding Motherlode.ResetCommand}" />
+                    </StackPanel>
                 </StackPanel>
 
                 <!-- MotherlodeWalk — ≥1 treasure located: relative guidance +

--- a/tests/Legolas.Tests/FakeInventoryService.cs
+++ b/tests/Legolas.Tests/FakeInventoryService.cs
@@ -1,0 +1,130 @@
+using Mithril.GameState.Inventory;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Reference;
+
+namespace Legolas.Tests;
+
+/// <summary>
+/// Test double for <see cref="IInventoryService"/> (#488). <see cref="Subscribe"/>
+/// atomically replays the current live (non-deleted) items as
+/// <see cref="InventoryEventKind.Added"/> then delivers live add/delete, like
+/// the real service. <see cref="Add"/>/<see cref="Delete"/> drive the stream.
+/// </summary>
+public sealed class FakeInventoryService : IInventoryService
+{
+    private readonly record struct Entry(string InternalName, bool Deleted);
+
+    private readonly List<long> _order = new();
+    private readonly Dictionary<long, Entry> _map = new();
+    private readonly List<Action<InventoryEvent>> _handlers = new();
+
+    public IDisposable Subscribe(Action<InventoryEvent> handler)
+    {
+        foreach (var id in _order)
+        {
+            var e = _map[id];
+            if (e.Deleted) continue;
+            handler(new InventoryEvent(InventoryEventKind.Added, id, e.InternalName,
+                DateTime.UtcNow, 1, true));
+        }
+        _handlers.Add(handler);
+        return new Sub(this, handler);
+    }
+
+    public bool TryResolve(long instanceId, out string internalName)
+    {
+        if (_map.TryGetValue(instanceId, out var e)) { internalName = e.InternalName; return true; }
+        internalName = string.Empty;
+        return false;
+    }
+
+    public bool TryGetStackSize(long instanceId, out int stackSize)
+    {
+        stackSize = _map.ContainsKey(instanceId) ? 1 : 0;
+        return _map.ContainsKey(instanceId);
+    }
+
+    /// <summary>Seed an item already in inventory before anyone subscribes
+    /// (mimics login replay) — raises no live event.</summary>
+    public void Seed(long instanceId, string internalName)
+    {
+        if (_map.ContainsKey(instanceId)) return;
+        _order.Add(instanceId);
+        _map[instanceId] = new Entry(internalName, false);
+    }
+
+    public void Add(long instanceId, string internalName, DateTime? at = null)
+    {
+        if (!_map.ContainsKey(instanceId)) _order.Add(instanceId);
+        _map[instanceId] = new Entry(internalName, false);
+        Raise(new InventoryEvent(InventoryEventKind.Added, instanceId, internalName,
+            at ?? DateTime.UtcNow, 1, true));
+    }
+
+    public void Delete(long instanceId, DateTime at)
+    {
+        if (!_map.TryGetValue(instanceId, out var e)) return;
+        _map[instanceId] = e with { Deleted = true };
+        Raise(new InventoryEvent(InventoryEventKind.Deleted, instanceId, e.InternalName,
+            at, e.Deleted ? 0 : 1, true));
+    }
+
+    private void Raise(InventoryEvent e)
+    {
+        foreach (var h in _handlers.ToArray()) h(e);
+    }
+
+    private sealed class Sub(FakeInventoryService owner, Action<InventoryEvent> handler) : IDisposable
+    {
+        public void Dispose() => owner._handlers.Remove(handler);
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="IReferenceDataService"/> for the motherlode-map
+/// predicate: only <see cref="ItemsByInternalName"/> is populated (the
+/// coordinator resolves an InternalName to an item whose display Name ends
+/// with "Motherlode Map"). Other members are empty/no-op.
+/// </summary>
+public sealed class FakeMotherlodeRefData : IReferenceDataService
+{
+    public FakeMotherlodeRefData(params (string InternalName, string Name)[] items)
+    {
+        var byName = new Dictionary<string, Item>(StringComparer.Ordinal);
+        var byId = new Dictionary<long, Item>();
+        long id = 1;
+        foreach (var (intern, name) in items)
+        {
+            var it = new Item { Id = id++, InternalName = intern, Name = name };
+            byName[intern] = it;
+            byId[it.Id] = it;
+        }
+        ItemsByInternalName = byName;
+        Items = byId;
+    }
+
+    public IReadOnlyList<string> Keys { get; } = [];
+    public IReadOnlyDictionary<long, Item> Items { get; }
+    public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; }
+    public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+    public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+    public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+    public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+    public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+    public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+    public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+    public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+    public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+    public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> Quests { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
+    public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> QuestsByInternalName { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
+    public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public event EventHandler<string>? FileUpdated;
+    public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+    public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+    public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+    public void BeginBackgroundRefresh() { }
+    private void Suppress() => FileUpdated?.Invoke(this, "");
+}

--- a/tests/Legolas.Tests/Services/MotherlodeMeasurementCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/MotherlodeMeasurementCoordinatorTests.cs
@@ -566,6 +566,79 @@ public class MotherlodeMeasurementCoordinatorTests
         snap.Surveys.Should().ContainSingle();                 // old slots cleared
     }
 
+    // ---- undo last reading ("oops, accidentally checked a map") ----------
+
+    [Fact]
+    public void Undo_pops_readings_LIFO_then_clears_can_undo()
+    {
+        var (coord, pos, _) = Build();                 // multi-map default
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0);
+        coord.OnUse(T0);                       coord.OnDistance(500, T0.AddSeconds(1));   // slot 0
+        coord.OnUse(T0.AddSeconds(2));         coord.OnDistance(600, T0.AddSeconds(3));   // slot 1
+
+        var s = coord.Snapshot();
+        s.Surveys.Should().HaveCount(2);
+        s.CanUndo.Should().BeTrue();
+
+        coord.UndoLastReading().Should().BeTrue();
+        coord.Snapshot().Surveys.Should().ContainSingle();      // slot 1 (created+empty) dropped
+
+        coord.UndoLastReading().Should().BeTrue();
+        var s2 = coord.Snapshot();
+        s2.Surveys.Should().BeEmpty();
+        s2.LocationCount.Should().Be(0);                        // the row this read created rolled out
+        s2.CanUndo.Should().BeFalse();
+
+        coord.UndoLastReading().Should().BeFalse();             // nothing left
+    }
+
+    [Fact]
+    public void Undo_rewinds_the_ordinal_so_the_corrected_read_re_takes_the_slot()
+    {
+        var (coord, pos, _) = Build();                 // multi-map default
+
+        // Spot 1 defines a 2-map working set (slots 0, 1).
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0);
+        coord.OnUse(T0);               coord.OnDistance(100, T0.AddSeconds(1));   // slot 0
+        coord.OnUse(T0.AddSeconds(2)); coord.OnDistance(200, T0.AddSeconds(3));   // slot 1
+
+        // Spot 2: accidentally check a map first → garbage binds slot 0 @ row 1.
+        var t2 = T0.AddMinutes(2);
+        pos.Push(900, 0, 0, PlayerPositionSource.Spawn, t2);
+        coord.OnUse(t2);               coord.OnDistance(9999, t2.AddSeconds(1));
+        coord.Snapshot().Surveys[0].DistancesByLocation[1].Should().Be(9999);
+
+        coord.UndoLastReading();                                                 // oops
+
+        // The garbage is gone and the ordinal rewound: the *next* read at this
+        // spot re-takes slot 0 (k0), not slot 1 — the contract re-aligns.
+        coord.OnUse(t2.AddSeconds(4)); coord.OnDistance(480, t2.AddSeconds(5));
+
+        var sv = coord.Snapshot().Surveys;
+        sv.Should().HaveCount(2);
+        sv[0].DistancesByLocation[1].Should().Be(480);    // corrected read landed on slot 0
+        (sv[1].DistancesByLocation.Count <= 1
+            || sv[1].DistancesByLocation[1] == 0).Should().BeTrue();   // slot 1 untouched here
+    }
+
+    [Fact]
+    public void Undo_stack_is_cleared_by_reset_and_area_change()
+    {
+        var (coord, pos, inv, area) = BuildAreaInv();
+        area.Observe("LOADING LEVEL AreaKurMountains", T0.UtcDateTime);
+        Spot(coord, pos, 0, 0, T0, 500, 600);
+        coord.Snapshot().CanUndo.Should().BeTrue();
+
+        area.Observe("LOADING LEVEL AreaEltibule", T0.AddMinutes(5).UtcDateTime);
+        coord.OnUse(T0.AddMinutes(6));                  // first use in new area clears measurement
+        coord.Snapshot().CanUndo.Should().BeFalse();    // stale undo history dropped
+
+        Spot(coord, pos, 0, 0, T0.AddMinutes(7), 700);
+        coord.Snapshot().CanUndo.Should().BeTrue();
+        coord.Reset();
+        coord.Snapshot().CanUndo.Should().BeFalse();
+    }
+
     [Fact]
     public void Same_area_re_observed_does_not_reset()
     {

--- a/tests/Legolas.Tests/Services/MotherlodeMeasurementCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/MotherlodeMeasurementCoordinatorTests.cs
@@ -1,14 +1,20 @@
 using FluentAssertions;
+using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.Services;
 using Legolas.ViewModels;
+using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Movement;
 
 namespace Legolas.Tests.Services;
 
 /// <summary>
-/// #488 — label-agnostic temporal pairing of the use gesture, a position
-/// feeder fix, and the ChatLog distance line; collection-gated progression.
+/// #488 (locked model): create-on-use working slots, declared-order multi-map
+/// (default) vs serial toggle, dig = motherlode-map <c>Deleted</c> →
+/// <c>MapsDug</c> + next-uncollected retire, cross-spot divergence, Risk-1
+/// same-spot clustering, #497 NamedMapPin confidence. Holding inventory stock
+/// creates nothing.
 /// </summary>
 public class MotherlodeMeasurementCoordinatorTests
 {
@@ -97,9 +103,21 @@ public class MotherlodeMeasurementCoordinatorTests
     }
 
     [Fact]
-    public void Multiple_maps_at_one_spot_fan_out_to_independent_slots()
+    public void Use_line_name_labels_the_created_slot()
     {
         var (coord, pos, _) = Build();
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0);
+        coord.OnUse(T0, "Kur Mountains Simple Metal Motherlode Map");
+        coord.OnDistance(500, T0.AddSeconds(2));
+
+        coord.Snapshot().Surveys.Should().ContainSingle()
+             .Which.MapName.Should().Be("Kur Mountains Simple Metal Motherlode Map");
+    }
+
+    [Fact]
+    public void Multiple_maps_at_one_spot_fan_out_to_independent_slots()
+    {
+        var (coord, pos, _) = Build();          // multi-map default
         (double X, double Z) a = (300, 300);
         (double X, double Z) b = (-150, 480);
 
@@ -127,27 +145,10 @@ public class MotherlodeMeasurementCoordinatorTests
     }
 
     [Fact]
-    public void Metal_slab_collection_marks_the_next_treasure_collected()
-    {
-        var (coord, pos, _) = Build();
-        (double X, double Z) target = (420, -260);
-        Measure(coord, pos, 0, 0, (int)Math.Round(D(0, 0, target.X, target.Z)), T0);
-        Measure(coord, pos, 800, 0, (int)Math.Round(D(800, 0, target.X, target.Z)), T0.AddMinutes(2));
-        Measure(coord, pos, 0, -800, (int)Math.Round(D(0, -800, target.X, target.Z)), T0.AddMinutes(4));
-
-        coord.OnItemCollected("Good Metal Slab");
-
-        coord.Snapshot().Surveys.Should().ContainSingle()
-             .Which.Collected.Should().BeTrue();
-    }
-
-    [Fact]
     public void A_map_pin_drop_is_an_accepted_position_feeder()
     {
         var (coord, _, pins) = Build();
         (double X, double Z) target = (100, 100);
-        // The pin fake stamps ObservedAt with the real clock, so anchor the
-        // use timeline on now (within MaxFeederGap of the pin event).
         var now = DateTimeOffset.UtcNow;
 
         void PinSpot(double x, double z, DateTimeOffset at)
@@ -157,8 +158,6 @@ public class MotherlodeMeasurementCoordinatorTests
             coord.OnDistance((int)Math.Round(D(x, z, target.X, target.Z)), at.AddSeconds(2));
         }
 
-        // 40 s apart: > LocationClusterSeconds (new spot each) but each use is
-        // still within MaxFeederGap of its pin event.
         PinSpot(0, 0, now);
         PinSpot(400, 0, now.AddSeconds(40));
         PinSpot(0, 400, now.AddSeconds(80));
@@ -172,10 +171,6 @@ public class MotherlodeMeasurementCoordinatorTests
     [Fact]
     public void A_character_named_pin_is_an_accepted_preferred_feeder()
     {
-        // #497: wire a real CharacterPinAnchor so the coordinator tags a
-        // self-labelled pin as the preferred feeder. Exercises the NamedMapPin
-        // branch end-to-end (IsSelfPin is a pure label rule — subscription
-        // order vs the coordinator is irrelevant).
         var pos = new FakePlayerPositionTracker();
         var pins = new FakePlayerPinTracker();
         var chr = new FakeActiveCharacterService();
@@ -183,7 +178,7 @@ public class MotherlodeMeasurementCoordinatorTests
         var charPin = new CharacterPinAnchor(pins, chr);
         var coord = new MotherlodeMeasurementCoordinator(
             new MultilaterationSolver(), new MotherlodeFlowController(new SessionState()),
-            pos, pins, diag: null, characterPin: charPin);
+            pos, pins, characterPin: charPin);
 
         (double X, double Z) target = (100, 100);
         var now = DateTimeOffset.UtcNow;
@@ -217,5 +212,370 @@ public class MotherlodeMeasurementCoordinatorTests
         snap.LocationCount.Should().Be(0);
         snap.Surveys.Should().BeEmpty();
         snap.Guidance.Should().BeNull();
+        snap.ReadsPerLocation.Should().BeEmpty();
+        snap.MapsDug.Should().Be(0);
+    }
+
+    // ---- create-on-use / completion / toggle / divergence ----------------
+
+    private const string KurSimple = "MiningSurveyKurMountains1X";
+    private const string KurBasic = "MiningSurveyKurMountains2X";
+    private const string KurGood = "MiningSurveyKurMountains3X";
+
+    private static FakeMotherlodeRefData RefData() => new(
+        (KurSimple, "Kur Mountains Simple Metal Motherlode Map"),
+        (KurBasic, "Kur Mountains Basic Metal Motherlode Map"),
+        (KurGood, "Kur Mountains Good Metal Motherlode Map"),
+        ("RawGem_Diamond", "Diamond"));
+
+    private static (MotherlodeMeasurementCoordinator coord, FakePlayerPositionTracker pos,
+        FakeInventoryService inv) BuildInv(bool multiMap)
+    {
+        var pos = new FakePlayerPositionTracker();
+        var pins = new FakePlayerPinTracker();
+        var inv = new FakeInventoryService();
+        var flow = new MotherlodeFlowController(new SessionState());
+        var settings = new LegolasSettings { MotherlodeMultiMapMode = multiMap };
+        var coord = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), flow, pos, pins, inv, RefData(), settings);
+        return (coord, pos, inv);
+    }
+
+    /// <summary>One spot: Spawn fix, use, then the listed distances in order.</summary>
+    private static void Spot(MotherlodeMeasurementCoordinator coord, FakePlayerPositionTracker pos,
+        double x, double z, DateTimeOffset at, params int[] dists)
+    {
+        pos.Push(x, 0, z, PlayerPositionSource.Spawn, at);
+        coord.OnUse(at);
+        var t = at;
+        foreach (var d in dists)
+            coord.OnDistance(d, t = t.AddSeconds(1));
+    }
+
+    [Fact]
+    public void Holding_stock_creates_no_slots()
+    {
+        var (coord, _, inv) = BuildInv(multiMap: true);
+        for (var i = 1; i <= 120; i++) inv.Add(i, KurSimple);   // a fat carried stack
+
+        var snap = coord.Snapshot();
+        snap.Surveys.Should().BeEmpty();        // create-on-use: holding ≠ measuring
+        snap.MapsDug.Should().Be(0);
+    }
+
+    [Fact]
+    public void Single_treasure_create_on_use_solves()
+    {
+        var (coord, pos, inv) = BuildInv(multiMap: true);
+        inv.Add(100, KurSimple);                                // held — irrelevant
+        (double X, double Z) target = (420, -260);
+
+        Spot(coord, pos, 0, 0, T0, (int)Math.Round(D(0, 0, target.X, target.Z)));
+        Spot(coord, pos, 800, 0, T0.AddMinutes(2), (int)Math.Round(D(800, 0, target.X, target.Z)));
+        Spot(coord, pos, 0, -800, T0.AddMinutes(4), (int)Math.Round(D(0, -800, target.X, target.Z)));
+
+        var s = coord.Snapshot().Surveys.Should().ContainSingle().Subject;
+        s.SolvedWorld!.Value.X.Should().BeApproximately(target.X, 3.0);
+        s.SolvedWorld!.Value.Z.Should().BeApproximately(target.Z, 3.0);
+    }
+
+    [Fact]
+    public void Motherlode_map_delete_counts_a_dig_and_retires_next_slot()
+    {
+        var (coord, pos, inv) = BuildInv(multiMap: true);
+        inv.Add(1, KurSimple);                                  // register (no slot — Added ignored)
+        inv.Add(2, KurBasic);
+        // Two treasures measured (create-on-use), then the cluster is dug.
+        Spot(coord, pos, 0, 0, T0, 500, 600);
+        Spot(coord, pos, 900, 0, T0.AddMinutes(2), 480, 470);
+        Spot(coord, pos, 0, 900, T0.AddMinutes(4), 450, 460);
+
+        coord.Snapshot().Surveys.Count(s => !s.Collected).Should().Be(2);
+
+        inv.Delete(1, T0.AddMinutes(6).UtcDateTime);
+        inv.Delete(2, T0.AddMinutes(6).AddSeconds(5).UtcDateTime);
+
+        var snap = coord.Snapshot();
+        snap.MapsDug.Should().Be(2);
+        snap.Surveys.All(s => s.Collected).Should().BeTrue();   // both retired in order
+    }
+
+    [Fact]
+    public void Completing_use_then_delete_discards_the_ephemeral_location()
+    {
+        var (coord, pos, inv) = BuildInv(multiMap: true);
+        inv.Add(1, KurSimple);                 // register (no slot)
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0);
+
+        coord.OnUse(T0);                       // opens a location, no distance (completing use)
+        inv.Delete(1, T0.AddSeconds(1).UtcDateTime);
+
+        var snap = coord.Snapshot();
+        snap.LocationCount.Should().Be(0);     // ephemeral location discarded
+        snap.MapsDug.Should().Be(1);
+        snap.Surveys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Non_motherlode_delete_does_not_count_as_a_dig()
+    {
+        var (coord, _, inv) = BuildInv(multiMap: true);
+        inv.Add(9, "RawGem_Diamond");
+        inv.Delete(9, DateTime.UtcNow);
+
+        var snap = coord.Snapshot();
+        snap.Surveys.Should().BeEmpty();
+        snap.MapsDug.Should().Be(0);
+    }
+
+    [Fact]
+    public void Toggle_off_serial_binds_one_active_treasure()
+    {
+        var (coord, pos, _) = BuildInv(multiMap: false);
+        (double X, double Z) target = (420, -260);
+
+        // Serial = one read per position (re-read while moving); even with the
+        // toggle off the single active treasure solves across the 3 spots.
+        Spot(coord, pos, 0, 0, T0, (int)Math.Round(D(0, 0, target.X, target.Z)));
+        Spot(coord, pos, 800, 0, T0.AddMinutes(2), (int)Math.Round(D(800, 0, target.X, target.Z)));
+        Spot(coord, pos, 0, -800, T0.AddMinutes(4), (int)Math.Round(D(0, -800, target.X, target.Z)));
+
+        var surveys = coord.Snapshot().Surveys;
+        surveys.Should().ContainSingle();                       // never fanned out
+        surveys[0].SolvedWorld!.Value.X.Should().BeApproximately(target.X, 3.0);
+        surveys[0].SolvedWorld!.Value.Z.Should().BeApproximately(target.Z, 3.0);
+    }
+
+    [Fact]
+    public void Multi_map_two_maps_bind_by_order_across_spots()
+    {
+        var (coord, pos, _) = BuildInv(multiMap: true);
+        (double X, double Z) a = (300, 300);
+        (double X, double Z) b = (-150, 480);
+
+        void S(double x, double z, DateTimeOffset at) => Spot(coord, pos, x, z, at,
+            (int)Math.Round(D(x, z, a.X, a.Z)),    // k0 → slot 0
+            (int)Math.Round(D(x, z, b.X, b.Z)));   // k1 → slot 1
+
+        S(0, 0, T0);
+        S(900, 0, T0.AddMinutes(2));
+        S(0, 900, T0.AddMinutes(4));
+
+        var surveys = coord.Snapshot().Surveys;
+        surveys.Should().HaveCount(2);
+        surveys[0].SolvedWorld!.Value.X.Should().BeApproximately(a.X, 3.0);
+        surveys[0].SolvedWorld!.Value.Z.Should().BeApproximately(a.Z, 3.0);
+        surveys[1].SolvedWorld!.Value.X.Should().BeApproximately(b.X, 3.0);
+        surveys[1].SolvedWorld!.Value.Z.Should().BeApproximately(b.Z, 3.0);
+    }
+
+    [Fact]
+    public void Measure_then_dig_the_cluster_collects_in_order()
+    {
+        // The real multi-map workflow: triangulate the whole stack across all
+        // spots first, *then* walk and dig — completion is post-measurement.
+        var (coord, pos, inv) = BuildInv(multiMap: true);
+        inv.Add(1, KurSimple);                                  // register (no slot)
+        inv.Add(2, KurBasic);
+        (double X, double Z) a = (300, 300);
+        (double X, double Z) c = (-150, 480);
+
+        void S(double x, double z, DateTimeOffset at) => Spot(coord, pos, x, z, at,
+            (int)Math.Round(D(x, z, a.X, a.Z)), (int)Math.Round(D(x, z, c.X, c.Z)));
+
+        S(0, 0, T0);
+        S(900, 0, T0.AddMinutes(2));
+        S(0, 900, T0.AddMinutes(4));
+
+        inv.Delete(1, T0.AddMinutes(6).UtcDateTime);            // dig both
+        inv.Delete(2, T0.AddMinutes(6).AddSeconds(8).UtcDateTime);
+
+        var snap = coord.Snapshot();
+        snap.MapsDug.Should().Be(2);
+        snap.Surveys.Should().OnlyContain(s => s.Collected);
+        snap.Surveys.Should().HaveCount(2);                     // solved before retirement
+        snap.Surveys.Select(s => s.SolvedWorld).Should().OnlyContain(w => w != null);
+    }
+
+    [Fact]
+    public void Spot_count_shortfall_raises_cross_spot_divergence()
+    {
+        var (coord, pos, _) = BuildInv(multiMap: true);
+
+        Spot(coord, pos, 0, 0, T0, 500, 600);                 // spot 1: 2 reads
+        Spot(coord, pos, 900, 0, T0.AddMinutes(2), 480);      // spot 2: 1 read (short!)
+        Spot(coord, pos, 0, 900, T0.AddMinutes(4), 450, 470); // spot 3 (open)
+
+        var snap = coord.Snapshot();
+        snap.Guidance.Should().Contain("Spot #2");
+        snap.ReadsPerLocation.Should().Equal(2, 1, 2);
+    }
+
+    [Fact]
+    public void Final_open_short_batch_does_not_false_positive()
+    {
+        var (coord, pos, _) = BuildInv(multiMap: true);
+
+        Spot(coord, pos, 0, 0, T0, 500, 600);              // spot 1: 2 reads
+        Spot(coord, pos, 900, 0, T0.AddMinutes(2), 480);   // spot 2 still open: 1 read so far
+
+        var g = coord.Snapshot().Guidance ?? string.Empty;
+        g.Should().NotContain("Spot #");                   // the open batch legitimately trails
+    }
+
+    [Fact]
+    public void ReadsPerLocation_projection_matches_bindings()
+    {
+        var (coord, pos, _) = BuildInv(multiMap: true);
+
+        Spot(coord, pos, 0, 0, T0, 500, 600);
+        Spot(coord, pos, 900, 0, T0.AddMinutes(2), 480, 470);
+
+        coord.Snapshot().ReadsPerLocation.Should().Equal(2, 2);
+    }
+
+    // ---- Risk-1 same-spot clustering -------------------------------------
+
+    [Fact]
+    public void Slow_same_spot_batch_does_not_split_or_desync()
+    {
+        var (coord, pos, _) = Build();
+
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0);
+        coord.OnUse(T0);
+        coord.OnDistance(900, T0.AddSeconds(2)); // commits the only location
+
+        // 45 s later, still standing on the same spot (>30 s time gate).
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0.AddSeconds(45));
+        coord.OnUse(T0.AddSeconds(45));
+        coord.OnDistance(905, T0.AddSeconds(47));
+
+        coord.Snapshot().LocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Genuine_move_within_time_gate_splits()
+    {
+        var (coord, pos, _) = Build();
+
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, T0);
+        coord.OnUse(T0);
+        coord.OnDistance(900, T0.AddSeconds(2));
+
+        pos.Push(500, 0, 0, PlayerPositionSource.Spawn, T0.AddSeconds(45));
+        coord.OnUse(T0.AddSeconds(45));
+        coord.OnDistance(700, T0.AddSeconds(47));
+
+        coord.Snapshot().LocationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Same_spot_merge_uses_frozen_anchor_not_drifting_fix()
+    {
+        var (coord, _, pins) = Build();
+        var now = DateTimeOffset.UtcNow;
+
+        pins.Add(0, 0, "p");
+        coord.OnUse(now);
+        coord.OnDistance(100, now.AddSeconds(2));          // anchor frozen at (0,0)
+
+        pins.Add(10, 0, "p");                               // 10 m ≤ 12 → merge
+        coord.OnUse(now.AddSeconds(45));
+        coord.OnDistance(100, now.AddSeconds(47));
+
+        pins.Add(19, 0, "p");                               // 19 m from frozen (0,0) → split
+        coord.OnUse(now.AddSeconds(90));
+        coord.OnDistance(100, now.AddSeconds(92));
+
+        coord.Snapshot().LocationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void No_position_falls_back_to_time_gate()
+    {
+        var (coord, _, _) = Build();             // no feeder fix ever pushed
+
+        coord.OnUse(T0);
+        coord.OnDistance(100, T0.AddSeconds(2)); // fix-less row committed
+
+        coord.OnUse(T0.AddSeconds(45));          // gap > 30 s, no fix to compare
+        coord.OnDistance(100, T0.AddSeconds(47));
+
+        coord.Snapshot().LocationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Self_named_pin_outranks_a_generic_pin_in_feeder_confidence()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var selfPins = new FakePlayerPinTracker();
+        var charPin = new CharacterPinAnchor(selfPins, new FakeActiveCharacterService());
+        var selfCoord = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), new MotherlodeFlowController(new SessionState()),
+            new FakePlayerPositionTracker(), selfPins, characterPin: charPin);
+        selfPins.Add(0, 0, CharacterPinAnchor.SelfPinSentinel);
+        selfCoord.OnUse(now);
+        selfCoord.OnDistance(100, now.AddSeconds(2));
+
+        var (genCoord, _, genPins) = Build();
+        genPins.Add(0, 0, "somewhere");
+        genCoord.OnUse(now);
+        genCoord.OnDistance(100, now.AddSeconds(2));
+
+        var self = selfCoord.Snapshot().Locations.Single().Confidence;
+        var generic = genCoord.Snapshot().Locations.Single().Confidence;
+        self.Should().BeGreaterThan(generic);
+        self.Should().BeApproximately(0.85, 1e-9);   // NamedMapPin
+        generic.Should().BeApproximately(0.6, 1e-9); // MapPin
+    }
+
+    // ---- area scoping (GameState PlayerAreaTracker) ----------------------
+
+    private static (MotherlodeMeasurementCoordinator coord, FakePlayerPositionTracker pos,
+        FakeInventoryService inv, PlayerAreaTracker area) BuildAreaInv()
+    {
+        var pos = new FakePlayerPositionTracker();
+        var pins = new FakePlayerPinTracker();
+        var inv = new FakeInventoryService();
+        var area = new PlayerAreaTracker(new AreaTransitionParser());
+        var flow = new MotherlodeFlowController(new SessionState());
+        var coord = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), flow, pos, pins, inv, RefData(),
+            new LegolasSettings(), null, area);
+        return (coord, pos, inv, area);
+    }
+
+    [Fact]
+    public void Area_change_clears_measurement_but_keeps_the_dug_count()
+    {
+        var (coord, pos, inv, area) = BuildAreaInv();
+        area.Observe("LOADING LEVEL AreaKurMountains", T0.UtcDateTime);
+        inv.Add(1, KurSimple);
+
+        Spot(coord, pos, 0, 0, T0, 500, 600);                  // measurement in area A
+        inv.Delete(1, T0.AddSeconds(30).UtcDateTime);          // a dig → MapsDug = 1
+        coord.Snapshot().MapsDug.Should().Be(1);
+        coord.Snapshot().LocationCount.Should().BeGreaterThan(0);
+
+        area.Observe("LOADING LEVEL AreaEltibule", T0.AddMinutes(5).UtcDateTime);
+        Spot(coord, pos, 10, 10, T0.AddMinutes(6), 700);       // first use in the new area
+
+        var snap = coord.Snapshot();
+        snap.MapsDug.Should().Be(1);                           // cumulative stat kept
+        snap.LocationCount.Should().Be(1);                     // old area-local fixes cleared
+        snap.Surveys.Should().ContainSingle();                 // old slots cleared
+    }
+
+    [Fact]
+    public void Same_area_re_observed_does_not_reset()
+    {
+        var (coord, pos, _, area) = BuildAreaInv();
+        area.Observe("LOADING LEVEL AreaKurMountains", T0.UtcDateTime);
+
+        Spot(coord, pos, 0, 0, T0, 500);
+        area.Observe("LOADING LEVEL AreaKurMountains", T0.AddMinutes(1).UtcDateTime); // same area
+        Spot(coord, pos, 800, 0, T0.AddMinutes(2), 520);
+
+        coord.Snapshot().LocationCount.Should().Be(2);         // not reset
     }
 }

--- a/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
+++ b/tests/Legolas.Tests/Settings/LegolasSettingsMigrationTests.cs
@@ -214,4 +214,19 @@ public class LegolasSettingsMigrationTests
         c.ResidualPixels.Should().BeApproximately(1.75, 1e-9);
         c.SchemaVersion.Should().Be(1);
     }
+
+    [Fact]
+    public void MotherlodeMultiMapMode_defaults_true_and_round_trips()
+    {
+        // Additive (#488): a v4 blob without the key loads the true default,
+        // so no SchemaVersion bump / Migrate branch is needed.
+        var legacy = JsonSerializer.Deserialize(
+            "{ \"schemaVersion\": 4 }", LegolasSettingsJsonContext.Default.LegolasSettings)!;
+        legacy.MotherlodeMultiMapMode.Should().BeTrue();
+
+        var settings = new LegolasSettings { MotherlodeMultiMapMode = false };
+        var written = JsonSerializer.Serialize(settings, LegolasSettingsJsonContext.Default.LegolasSettings);
+        var reloaded = JsonSerializer.Deserialize(written, LegolasSettingsJsonContext.Default.LegolasSettings)!;
+        reloaded.MotherlodeMultiMapMode.Should().BeFalse();
+    }
 }

--- a/tests/Legolas.Tests/ViewModels/InventoryOverlayViewModelMotherlodeTests.cs
+++ b/tests/Legolas.Tests/ViewModels/InventoryOverlayViewModelMotherlodeTests.cs
@@ -1,0 +1,128 @@
+using System.Collections;
+using FluentAssertions;
+using Legolas.Domain;
+using Legolas.Flow;
+using Legolas.Services;
+using Legolas.ViewModels;
+using Mithril.GameState.Movement;
+
+namespace Legolas.Tests.ViewModels;
+
+/// <summary>
+/// #488 (locked model): in Motherlode mode the inventory overlay surfaces the
+/// <b>create-on-use</b> working slots as a read-order list (use-line name +
+/// 1-based ordinal), sourced from the coordinator via
+/// <see cref="MotherlodeViewModel"/> and kept separate from Survey state. A
+/// dug map (motherlode-map <c>Deleted</c>) retires its slot and the list
+/// recompacts. Holding stock creates nothing. (No Application dispatcher in a
+/// unit test ⇒ the VM rebuilds synchronously.)
+/// </summary>
+public class InventoryOverlayViewModelMotherlodeTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private const string KurSimpleIN = "MiningSurveyKurMountains1X";
+    private const string KurBasicIN = "MiningSurveyKurMountains2X";
+    private const string KurSimple = "Kur Mountains Simple Metal Motherlode Map";
+    private const string KurBasic = "Kur Mountains Basic Metal Motherlode Map";
+
+    private static (InventoryOverlayViewModel overlay, SessionState session,
+        MotherlodeMeasurementCoordinator coord, FakePlayerPositionTracker pos,
+        FakeInventoryService inv) Build()
+    {
+        var session = new SessionState();
+        var pos = new FakePlayerPositionTracker();
+        var pins = new FakePlayerPinTracker();
+        var inv = new FakeInventoryService();
+        var refData = new FakeMotherlodeRefData(
+            (KurSimpleIN, KurSimple), (KurBasicIN, KurBasic));
+        var flow = new MotherlodeFlowController(new SessionState());
+        var coord = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), flow, pos, pins, inv, refData,
+            new LegolasSettings());                       // multi-map default
+        var optimizer = new AdaptiveRouteOptimizer(
+            new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var mlVm = new MotherlodeViewModel(coord, optimizer, flow, pins);
+        var overlay = new InventoryOverlayViewModel(new InventoryGridSettings(), session, mlVm);
+        return (overlay, session, coord, pos, inv);
+    }
+
+    /// <summary>One read = a named use + its distance (create-on-use).</summary>
+    private static void Read(MotherlodeMeasurementCoordinator coord, FakePlayerPositionTracker pos,
+        string mapName, int dist, DateTimeOffset at)
+    {
+        pos.Push(0, 0, 0, PlayerPositionSource.Spawn, at);
+        coord.OnUse(at, mapName);
+        coord.OnDistance(dist, at.AddSeconds(1));
+    }
+
+    private static List<SurveyItemViewModel> Items(InventoryOverlayViewModel o) =>
+        ((IEnumerable)o.ActiveSlots).Cast<SurveyItemViewModel>().ToList();
+
+    [Fact]
+    public void Holding_stock_shows_nothing_in_motherlode_mode()
+    {
+        var (overlay, session, _, _, inv) = Build();
+        session.Mode = SessionMode.Motherlode;
+        for (var i = 1; i <= 50; i++) inv.Add(i, KurSimpleIN);   // carried, unused
+
+        Items(overlay).Should().BeEmpty();                       // create-on-use
+    }
+
+    [Fact]
+    public void Survey_mode_yields_the_survey_collection_not_motherlode()
+    {
+        var (overlay, session, coord, pos, _) = Build();
+        Read(coord, pos, KurSimple, 500, T0);                    // a tracked slot exists
+
+        session.Mode.Should().Be(SessionMode.Survey);
+        Items(overlay).Should().BeEmpty();                       // _session.Surveys is empty
+    }
+
+    [Fact]
+    public void Motherlode_mode_lists_created_slots_in_read_order()
+    {
+        var (overlay, session, coord, pos, _) = Build();
+        session.Mode = SessionMode.Motherlode;
+
+        Read(coord, pos, KurSimple, 500, T0);                    // slot 0
+        Read(coord, pos, KurBasic, 600, T0.AddSeconds(3));       // slot 1 (same spot)
+
+        var items = Items(overlay);
+        items.Should().HaveCount(2);
+        items[0].Name.Should().Be(KurSimple);
+        items[0].GridIndex.Should().Be(0);                       // 1-based via the XAML converter
+        items[1].Name.Should().Be(KurBasic);
+        items[1].GridIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void Dug_map_drops_out_and_the_list_recompacts()
+    {
+        var (overlay, session, coord, pos, inv) = Build();
+        session.Mode = SessionMode.Motherlode;
+        inv.Add(1, KurSimpleIN);                                 // register (no slot)
+        inv.Add(2, KurBasicIN);
+        Read(coord, pos, KurSimple, 500, T0);                    // slot 0
+        Read(coord, pos, KurBasic, 600, T0.AddSeconds(3));       // slot 1
+        Items(overlay).Should().HaveCount(2);
+
+        inv.Delete(1, T0.AddSeconds(10).UtcDateTime);            // a dig → retire next-uncollected (slot 0)
+
+        var items = Items(overlay);
+        items.Should().ContainSingle().Which.Name.Should().Be(KurBasic);
+        items[0].GridIndex.Should().Be(0);                       // ordinal recompacts
+    }
+
+    [Fact]
+    public void Switching_back_to_survey_restores_the_survey_source()
+    {
+        var (overlay, session, coord, pos, _) = Build();
+        session.Mode = SessionMode.Motherlode;
+        Read(coord, pos, KurSimple, 500, T0);
+        Items(overlay).Should().ContainSingle();
+
+        session.Mode = SessionMode.Survey;
+        Items(overlay).Should().BeEmpty();                       // back to the (empty) survey view
+    }
+}

--- a/tests/Legolas.Tests/ViewModels/MotherlodeViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/MotherlodeViewModelTests.cs
@@ -86,9 +86,20 @@ public class MotherlodeViewModelTests
     }
 
     [Fact]
-    public void Collecting_the_only_treasure_reaches_Done()
+    public void Digging_the_only_treasure_reaches_Done()
     {
-        var (vm, coord, pos, _) = Build();
+        var pos = new FakePlayerPositionTracker();
+        var pins = new FakePlayerPinTracker();
+        var inv = new FakeInventoryService();
+        var refData = new FakeMotherlodeRefData(
+            ("MiningSurveyKurMountains1X", "Kur Mountains Simple Metal Motherlode Map"));
+        var flow = new MotherlodeFlowController(new SessionState());
+        var coord = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), flow, pos, pins, inv, refData, new LegolasSettings());
+        var optimizer = new AdaptiveRouteOptimizer(
+            new HeldKarpOptimizer(), new NearestNeighbourTwoOptOptimizer());
+        var vm = new MotherlodeViewModel(coord, optimizer, flow, pins, new FakeAreaCalibrationService());
+        inv.Add(1, "MiningSurveyKurMountains1X");          // register (create-on-use ⇒ no slot)
         (double X, double Z) target = (420, -260);
 
         Measure(coord, pos, 0, 0, target, T0);
@@ -96,10 +107,11 @@ public class MotherlodeViewModelTests
         Measure(coord, pos, 0, -800, target, T0.AddMinutes(4));
         vm.Stage.Should().Be(MotherlodeStage.Walk);
 
-        coord.OnItemCollected("Iron Metal Slab");
+        inv.Delete(1, T0.AddMinutes(6).UtcDateTime);       // the dig
 
         vm.Stage.Should().Be(MotherlodeStage.Done);
-        vm.Slots.Should().ContainSingle().Which.Collected.Should().BeTrue();
+        vm.Slots.Should().BeEmpty();                       // active-only: the retired slot drops out
+        vm.MapsDug.Should().Be(1);
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

Reworks Motherlode to the **empirically-locked model** derived from live `Player.log` forensics, fixing the scaling/correctness problems the rebased #488 inventory-identity approach had, and adds a multi-level "undo last reading" affordance.

**Empirical basis** (decoded from a real farming session — belongs in the wiki Player-Log-Signals page, see Follow-ups):
- One map = one treasure. The use line `ProcessDoDelayLoop(…"Using <Type> Motherlode Map"…)` carries only the map *type* name + icon — **no per-map identity**; a same-type stack is byte-identical.
- Batch-reading a stack of same-type maps across spots is the **primary** workflow (the original "stand, read many, move, repeat").
- The "dig" is a motherlode-map `ProcessDeleteItem`; it **spawns a mining node** — loot is decoupled (arrives later via generic mining, no log link). So *items-found is a documented data ceiling*; the session summary is **maps-dug + time** only.
- `LocalPlayer` position is sparse (≈7 `ProcessNewPosition` in 34 MB); the `@me`/character-named pin (#497) is the high-accuracy per-read fix.

## Changes

**Locked model (`a0f63cf`)**
- **Create-on-use**: working slots are born from *readings*, never from holding inventory — carrying 100+/500+ maps now costs nothing (the reported pathology). Dropped `_slotByInstance` / `_inventorySeen` / `OnInventory.Added` slot-creation / `MotherlodeSurvey.InstanceId`.
- **Completion = motherlode-map `Deleted`** (the dig): increments a session dug count, retires the next uncollected slot (order-based). Dropped the "Metal Slab added" `OnItemCollected` coupling (Survey keeps it).
- **Working-set divergence** (cross-spot read-count), not inventory-held count. `MotherlodeStatus`: `ExpectedMapCount` → `MapsDug`.
- Use-line map *type* name re-captured as a display label (binding stays order-based). **Multi-map toggle kept, default on**; serial = the degenerate n=1 case (one decision seam in `SelectSlot`).
- **Area scoping**: consumes the shared GameState `PlayerAreaTracker`; a confirmed area change clears the area-local-frame measurement but **keeps** the cumulative dug count (not frame-bound). Null area = unknown → no reset (self-heals).
- VM/overlay project the **active working set only** (retired slots drop out, ordinals recompact) → O(active) per event regardless of session volume.
- Reconciles cleanly with the upstream **#497/#498 `NamedMapPin`** self-pin work (adopted main's `ICharacterPinAnchor` mechanism; discarded my ad-hoc `@me`-label check) and the **#512/#514/#516** rebase.

**Multi-level undo (`f23249f`)** — "oops, I accidentally checked a map"
- LIFO `ReadUndo` stack; `UndoLastReading()` restores the prior distance, drops a slot/row the bad read created, **rewinds the open spot's per-spot ordinal so the next real read re-takes that slot** (re-aligns the order-bound multi-map contract — the load-bearing bit), re-solves, recomputes divergence. Cleared with the measurement (Reset / area change).
- `MotherlodeStatus.CanUndo` → VM `UndoLastReadingCommand`/`CanUndo` → **"Oops — undo last check"** button beside Reset on the Measuring/Locating wizard steps.

## Testing

- Pristine full-solution suite (owner-run, pre-shell, current head): **3360 passed**.
- Legolas suite on a real (non-`--no-build`) build: **450/450**, incl. new create-on-use, completion-by-delete, working-set divergence, area-scoping, and undo (LIFO + ordinal-rewind realignment + clear-on-reset/area) tests.
- Smoke-tested in the running shell: create-on-use confirmed good; calibration-validation gating confirmed correct (not a regression).

## Follow-ups (filed, out of scope here)

- **#519** — Survey-parity session lifecycle (StartedAt anchor, run-out Done via configurable settle delay, report + auto-reset reusing `AutoResetWhenAllCollected`/`ShowReportOnDone`). The "time" half of the summary lands there.
- **#506 / #505** — guided next-best-spot + tolerance-ring overlay; inventory-overlay guidance polish.
- **Wiki:** the decoded Motherlode `Player.log` grammar above is canonical-in-wiki (Player-Log-Signals); needs adding to that page (separate repo, not pushable from this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
