### PR TITLE
fix(logging): contain per-message ingestion errors in 5 more consumers (#512)

### DIFF
--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Legolas.Domain;
@@ -22,6 +23,7 @@ public sealed class LogIngestionService : BackgroundService
     private readonly SessionState _session;
     private readonly MotherlodeMeasurementCoordinator _motherlode;
     private readonly IAreaCalibrationService _areaCalibration;
+    private readonly ThrottledWarn _warn;
 
     public LogIngestionService(
         IChatLogStream stream,
@@ -29,7 +31,8 @@ public sealed class LogIngestionService : BackgroundService
         ModuleGates gates,
         SessionState session,
         MotherlodeMeasurementCoordinator motherlode,
-        IAreaCalibrationService areaCalibration)
+        IAreaCalibrationService areaCalibration,
+        IDiagnosticsSink? diag = null)
     {
         _stream = stream;
         _parser = parser;
@@ -37,6 +40,7 @@ public sealed class LogIngestionService : BackgroundService
         _session = session;
         _motherlode = motherlode;
         _areaCalibration = areaCalibration;
+        _warn = new ThrottledWarn(diag, "Legolas.Ingestion");
     }
 
     // Both tail readers normalize their <c>[HH:MM:SS]</c> prefix to UTC via the
@@ -53,8 +57,12 @@ public sealed class LogIngestionService : BackgroundService
 
         await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
-            if (_parser.TryParse(raw.Line, raw.Timestamp) is GameEvent evt)
-                Dispatch(evt);
+            try
+            {
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is GameEvent evt)
+                    Dispatch(evt);
+            }
+            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
         }
     }
 

--- a/src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs
+++ b/src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs
@@ -34,6 +34,7 @@ public sealed class PlayerRecipeStateService : BackgroundService, IPlayerRecipeS
     private readonly IPlayerLogStream _stream;
     private readonly RecipeLogParser _parser;
     private readonly IDiagnosticsSink? _diag;
+    private readonly ThrottledWarn _warn;
 
     private readonly object _lock = new();
     private readonly List<Action<PlayerRecipeSnapshot>> _handlers = new();
@@ -48,6 +49,7 @@ public sealed class PlayerRecipeStateService : BackgroundService, IPlayerRecipeS
         _stream = stream;
         _parser = parser;
         _diag = diag;
+        _warn = new ThrottledWarn(diag, "GameState.Recipes");
     }
 
     public PlayerRecipeSnapshot Current => _current;
@@ -80,15 +82,19 @@ public sealed class PlayerRecipeStateService : BackgroundService, IPlayerRecipeS
         _diag?.Info("GameState.Recipes", "Subscribing to Player.log for recipe-state events");
         await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
-            switch (_parser.TryParse(raw.Line, raw.Timestamp))
+            try
             {
-                case RecipesSnapshotEvent snap:
-                    ReplaceAll(snap);
-                    break;
-                case RecipeUpdateEvent upd:
-                    Upsert(upd);
-                    break;
+                switch (_parser.TryParse(raw.Line, raw.Timestamp))
+                {
+                    case RecipesSnapshotEvent snap:
+                        ReplaceAll(snap);
+                        break;
+                    case RecipeUpdateEvent upd:
+                        Upsert(upd);
+                        break;
+                }
             }
+            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
         }
     }
 

--- a/src/Mithril.GameState/Sessions/GameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/GameSessionService.cs
@@ -32,6 +32,7 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
     private readonly IPlayerLogStream _stream;
     private readonly SessionAnchor? _anchor;
     private readonly IDiagnosticsSink? _diag;
+    private readonly ThrottledWarn _warn;
 
     private readonly object _lock = new();
     private readonly List<Action<GameSession>> _handlers = [];
@@ -45,6 +46,7 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
         _stream = stream;
         _anchor = anchor;
         _diag = diag;
+        _warn = new ThrottledWarn(diag, "Session");
     }
 
     public GameSession? Current
@@ -73,8 +75,12 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
         _diag?.Info("Session", "Subscribing to Player.log for login banner");
         await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
-            if (!LoginBannerParser.TryParse(raw.Line, out var session)) continue;
-            Publish(session);
+            try
+            {
+                if (!LoginBannerParser.TryParse(raw.Line, out var session)) continue;
+                Publish(session);
+            }
+            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
         }
     }
 

--- a/src/Pippin.Module/State/GourmandIngestionService.cs
+++ b/src/Pippin.Module/State/GourmandIngestionService.cs
@@ -18,6 +18,7 @@ public sealed class GourmandIngestionService : BackgroundService
     private readonly PerCharacterView<GourmandState> _view;
     private readonly IDiagnosticsSink? _diag;
     private readonly ModuleGate _gate;
+    private readonly ThrottledWarn _warn;
 
     public GourmandIngestionService(
         IPlayerLogStream stream,
@@ -35,6 +36,7 @@ public sealed class GourmandIngestionService : BackgroundService
         _view = view;
         _diag = diag;
         _gate = gates.For("pippin");
+        _warn = new ThrottledWarn(diag, "Pippin.Ingestion");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -52,12 +54,16 @@ public sealed class GourmandIngestionService : BackgroundService
 
         await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
-            var evt = _parser.TryParse(raw.Line, raw.Timestamp);
-            if (evt is GourmandEvent ge)
+            try
             {
-                _diag?.Trace("Pippin.Parse", $"FoodsConsumedReport with {(ge as FoodsConsumedReport)?.Foods.Count ?? 0} entries");
-                Dispatch(() => _state.Apply(ge));
+                var evt = _parser.TryParse(raw.Line, raw.Timestamp);
+                if (evt is GourmandEvent ge)
+                {
+                    _diag?.Trace("Pippin.Parse", $"FoodsConsumedReport with {(ge as FoodsConsumedReport)?.Foods.Count ?? 0} entries");
+                    Dispatch(() => _state.Apply(ge));
+                }
             }
+            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
         }
     }
 

--- a/src/Saruman.Module/Services/SarumanChatIngestionService.cs
+++ b/src/Saruman.Module/Services/SarumanChatIngestionService.cs
@@ -1,3 +1,4 @@
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Microsoft.Extensions.Hosting;
@@ -12,17 +13,20 @@ public sealed class SarumanChatIngestionService : BackgroundService
     private readonly WordOfPowerChatParser _parser;
     private readonly SarumanCodebookService _codebook;
     private readonly ModuleGate _gate;
+    private readonly ThrottledWarn _warn;
 
     public SarumanChatIngestionService(
         IChatLogStream stream,
         WordOfPowerChatParser parser,
         SarumanCodebookService codebook,
-        ModuleGates gates)
+        ModuleGates gates,
+        IDiagnosticsSink? diag = null)
     {
         _stream = stream;
         _parser = parser;
         _codebook = codebook;
         _gate = gates.For("saruman");
+        _warn = new ThrottledWarn(diag, "Saruman.Ingestion");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -31,8 +35,12 @@ public sealed class SarumanChatIngestionService : BackgroundService
 
         await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
-            if (_parser.TryParse(raw.Line, raw.Timestamp) is WordOfPowerSpoken s)
-                _codebook.MarkSpent(s.Code, s.Timestamp);
+            try
+            {
+                if (_parser.TryParse(raw.Line, raw.Timestamp) is WordOfPowerSpoken s)
+                    _codebook.MarkSpent(s.Code, s.Timestamp);
+            }
+            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
         }
     }
 }


### PR DESCRIPTION
Reopens and closes the under-counted tail of #512.

## Why this reopens #512

#515 fixed the per-message-containment defect in 5 log-stream consumers and explicitly listed siblings as "already guarded" — but its audit only inspected those 5 files. The **same-class defect** survived in the *adjacent* consumers it never opened. The #512 invariant ("one bad line must never silently kill a consumer for the session") is therefore not actually established repo-wide.

## Consumers fixed (the missed tail)

| Consumer | Why it was missed |
|---|---|
| `Mithril.GameState/Recipes/PlayerRecipeStateService.cs` | Sibling of the fixed `PlayerSkillStateService`; not inspected. Compounded by unguarded `int.Parse` in `RecipeLogParser`. |
| `Saruman.Module/Services/SarumanChatIngestionService.cs` | Sibling of the fixed `SarumanDiscoveryIngestionService`; had no `IDiagnosticsSink`. |
| `Legolas.Module/Services/LogIngestionService.cs` | The chat-log survey path — distinct from `PlayerLogIngestionService`, which #515 correctly listed as already guarded. Had no `IDiagnosticsSink`. |
| `Pippin.Module/State/GourmandIngestionService.cs` | Sink already injected; containment simply absent. |
| `Mithril.GameState/Sessions/GameSessionService.cs` | A throw out of `LoginBannerParser`/`Publish` (incl. the unguarded `SessionStarted.Invoke`) permanently stops session detection. |

## Approach

Identical `ThrottledWarn` catch+continue mechanism #515 introduced — no new pattern, no happy-path behaviour change. Saruman/Legolas gained the optional `IDiagnosticsSink? diag = null` ctor param per the standing instrumentation convention. Categories follow the `<Module>.Ingestion` / `GameState.<Area>` convention.

The L1 structural fix that makes this class impossible to reintroduce remains #511 (shared log-consumer driver); this is the stopgap that makes the remaining consumers fail-soft until then.

## Verification

- `dotnet build Mithril.slnx` clean — 0 warnings (warnings-as-errors), 0 errors.
- Suites green: Mithril.GameState (275), Pippin (42), Legolas (423), Saruman (22), Mithril.Shared (1146) — 1908 tests, 0 failures.
- Per-consumer fault injection deferred on the same precedent as #515: the catch+continue wrapping is mechanically identical to the five proven #515 sites, and `ThrottledWarn` itself is already unit-tested (window/rollup/null-sink).

Closes #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
