### PR TITLE
L0: single tail+timestamp-normalize service → { DateTimeOffset, string, Sequence, ReadMonotonicTicks } (closes #513)

### DIFF
--- a/src/Arwen.Module/State/FavorIngestionService.cs
+++ b/src/Arwen.Module/State/FavorIngestionService.cs
@@ -55,13 +55,14 @@ public sealed class FavorIngestionService : BackgroundService
         {
             try
             {
-            var evt = _parser.TryParse(raw.Line, raw.Timestamp);
+            var evt = _parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime);
             if (evt is null) continue;
 
-            // raw.Timestamp is the log-line UTC (post-#183 + #201 session anchor),
-            // stable across Mithril restarts. Plumb it through so replay produces
-            // the same persisted GiftObservation.Timestamp and dedup short-circuits.
-            var ts = new DateTimeOffset(raw.Timestamp, TimeSpan.Zero);
+            // raw.Timestamp is the log-line instant, TZ-correct via the L0 source
+            // clock (#513) and stable across Mithril restarts. Plumb it through so
+            // replay produces the same persisted GiftObservation.Timestamp and
+            // dedup short-circuits.
+            var ts = raw.Timestamp;
             switch (evt)
             {
                 case FavorUpdate update:

--- a/src/Gandalf.Module/Services/LootBracketTracker.cs
+++ b/src/Gandalf.Module/Services/LootBracketTracker.cs
@@ -104,7 +104,7 @@ public sealed partial class LootBracketTracker
     /// unrelated lines — the common case is a quick set of substring checks
     /// that don't touch state.
     /// </summary>
-    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp);
+    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp.UtcDateTime);
 
     public void Observe(string line, DateTime timestamp)
     {

--- a/src/Gandalf.Module/Services/LootIngestionService.cs
+++ b/src/Gandalf.Module/Services/LootIngestionService.cs
@@ -74,14 +74,15 @@ public sealed class LootIngestionService : BackgroundService
         _areaTracker.Observe(raw);
         _bracket.Observe(raw);
 
-        if (_bossKill.TryParse(raw.Line, raw.Timestamp) is BossKillCreditEvent kill)
+        var ts = raw.Timestamp.UtcDateTime;
+        if (_bossKill.TryParse(raw.Line, ts) is BossKillCreditEvent kill)
         {
             _source.OnBossKillCredit(kill.NpcDisplayName, kill.Timestamp);
             FirstObservation();
             return;
         }
 
-        if (_defeatCooldown.TryParse(raw.Line, raw.Timestamp) is DefeatCooldownActiveEvent active)
+        if (_defeatCooldown.TryParse(raw.Line, ts) is DefeatCooldownActiveEvent active)
         {
             _source.OnDefeatCooldownActive(active.NpcDisplayName, active.Timestamp);
             FirstObservation();

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -59,7 +59,7 @@ public sealed class LogIngestionService : BackgroundService
         {
             try
             {
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is GameEvent evt)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is GameEvent evt)
                     Dispatch(evt);
             }
             catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -43,11 +43,15 @@ public sealed class LogIngestionService : BackgroundService
         _warn = new ThrottledWarn(diag, "Legolas.Ingestion");
     }
 
-    // Both tail readers normalize their <c>[HH:MM:SS]</c> prefix to UTC via the
-    // shared LogLineTimestampSequencer, so Player.log (use) and ChatLog
-    // (distance) instants are directly comparable. Specify-kind before lifting
-    // to DateTimeOffset (the #183-class timezone trap is already handled
-    // upstream; this only re-tags the Kind).
+    // The L0 source clocks (#513) emit TZ-correct absolute DateTimeOffset
+    // instants on both sides — PlayerLogClock with TimeSpan.Zero (the
+    // Player.log [HH:MM:SS] prefix is UTC), ChatLogClock with the host's
+    // local UTC offset (the chat yy-MM-dd HH:mm:ss prefix is local time).
+    // Both surface as raw.Timestamp; we pass raw.Timestamp.UtcDateTime
+    // into the parser, which strips offset info and surfaces its event's
+    // Timestamp as an Unspecified-kind DateTime. Specify-kind here so
+    // the lifted DateTimeOffset has offset +00:00 — the #183-class trap
+    // is already handled upstream, this only re-tags the Kind.
     private static DateTimeOffset Utc(DateTime ts) =>
         new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
 

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -43,18 +43,6 @@ public sealed class LogIngestionService : BackgroundService
         _warn = new ThrottledWarn(diag, "Legolas.Ingestion");
     }
 
-    // The L0 source clocks (#513) emit TZ-correct absolute DateTimeOffset
-    // instants on both sides — PlayerLogClock with TimeSpan.Zero (the
-    // Player.log [HH:MM:SS] prefix is UTC), ChatLogClock with the host's
-    // local UTC offset (the chat yy-MM-dd HH:mm:ss prefix is local time).
-    // Both surface as raw.Timestamp; we pass raw.Timestamp.UtcDateTime
-    // into the parser, which strips offset info and surfaces its event's
-    // Timestamp as an Unspecified-kind DateTime. Specify-kind here so
-    // the lifted DateTimeOffset has offset +00:00 — the #183-class trap
-    // is already handled upstream, this only re-tags the Kind.
-    private static DateTimeOffset Utc(DateTime ts) =>
-        new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await _gates.For("legolas").WaitAsync(stoppingToken).ConfigureAwait(false);
@@ -104,7 +92,10 @@ public sealed class LogIngestionService : BackgroundService
                     HandleItemCollected(ic);
                     break;
                 case MotherlodeDistance md when _session.Mode == SessionMode.Motherlode:
-                    _motherlode.OnDistance(md.DistanceMetres, Utc(md.Timestamp));
+                    // md.Timestamp was carried through as raw.Timestamp.UtcDateTime
+                    // at the parser boundary above, so it is Kind=Utc; lift to a
+                    // DateTimeOffset with offset 0 for the coordinator's API.
+                    _motherlode.OnDistance(md.DistanceMetres, new DateTimeOffset(md.Timestamp, TimeSpan.Zero));
                     break;
                 case AreaEntered ae:
                     _areaCalibration.OnAreaEntered(ae.AreaFriendlyName);

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -119,7 +119,7 @@ public sealed class PlayerLogIngestionService : BackgroundService
                 // GameState-tier PlayerPinTracker (#468); this service handles
                 // ProcessMapFx absolute targets (#454) and the ProcessDoDelayLoop
                 // Motherlode-map use gesture (#488).
-                switch (_parser.TryParse(raw.Line, raw.Timestamp))
+                switch (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime))
                 {
                     case MapTargetDetected mt:
                         PostToUi(() => HandleMapTarget(mt));

--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -78,7 +78,7 @@ public sealed class PlayerAreaTracker
         Apply(line, timestamp);
     }
 
-    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp);
+    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp.UtcDateTime);
 
     private void Apply(string line, DateTime timestamp)
     {

--- a/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
+++ b/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
@@ -130,10 +130,13 @@ public sealed class PlayerCelestialStateService : BackgroundService, IPlayerCele
     }
 
     /// <summary>
-    /// Player.log timestamps are reconstructed as UTC <see cref="DateTime"/>s
-    /// by <c>LogLineTimestampSequencer</c>. Stamp the kind defensively in case
-    /// a caller passes an Unspecified-kind value (tests), so the offset is
-    /// always +00:00 rather than the host's local offset.
+    /// Player.log timestamps are normalized upstream by the L0 source
+    /// clock (<c>PlayerLogClock</c>, #513) — <c>raw.Timestamp</c> arrives
+    /// as a UTC <see cref="DateTimeOffset"/>; we pass its
+    /// <c>.UtcDateTime</c> into the parser, which surfaces its event's
+    /// <see cref="DateTime"/> as Unspecified-kind. Stamp the kind
+    /// defensively here so the lifted <see cref="DateTimeOffset"/>
+    /// always has offset +00:00 rather than the host's local offset.
     /// </summary>
     private static DateTimeOffset ToOffset(DateTime ts) =>
         new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));

--- a/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
+++ b/src/Mithril.GameState/Celestial/PlayerCelestialStateService.cs
@@ -73,7 +73,7 @@ public sealed class PlayerCelestialStateService : BackgroundService, IPlayerCele
         {
             try
             {
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is CelestialInfoEvent evt)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is CelestialInfoEvent evt)
                 {
                     if (evt.Phase == MoonPhase.Unknown)
                         ReportUnknownToken(evt.RawPhase);

--- a/src/Mithril.GameState/Inventory/InventoryService.cs
+++ b/src/Mithril.GameState/Inventory/InventoryService.cs
@@ -223,17 +223,18 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     {
         await foreach (var raw in _stream.SubscribeAsync(ct).ConfigureAwait(false))
         {
+            var ts = raw.Timestamp.UtcDateTime;
             var add = AddItemRx().Match(raw.Line);
             if (add.Success && long.TryParse(add.Groups[2].ValueSpan, out var addId))
             {
-                HandleAddItem(addId, add.Groups[1].Value, raw.Timestamp);
+                HandleAddItem(addId, add.Groups[1].Value, ts);
                 continue;
             }
 
             var del = DeleteItemRx().Match(raw.Line);
             if (del.Success && long.TryParse(del.Groups[1].ValueSpan, out var delId))
             {
-                HandleDeleteItem(delId, raw.Timestamp);
+                HandleDeleteItem(delId, ts);
                 continue;
             }
 
@@ -242,7 +243,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
                 && long.TryParse(upd.Groups[1].ValueSpan, out var updId)
                 && long.TryParse(upd.Groups[2].ValueSpan, out var code))
             {
-                HandleUpdateItemCode(updId, code, raw.Timestamp);
+                HandleUpdateItemCode(updId, code, ts);
                 continue;
             }
 
@@ -251,7 +252,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
                 && long.TryParse(vault.Groups[1].ValueSpan, out var vaultId)
                 && int.TryParse(vault.Groups[2].ValueSpan, out var vaultSize))
             {
-                HandleRemoveFromStorageVault(vaultId, vaultSize, raw.Timestamp);
+                HandleRemoveFromStorageVault(vaultId, vaultSize, ts);
             }
         }
     }
@@ -263,7 +264,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
         {
             var parsed = InventoryStatusChatParser.TryParse(raw.Line);
             if (parsed is null) continue;
-            HandleChatStatusAdd(parsed.Value.DisplayName, parsed.Value.Count, raw.Timestamp);
+            HandleChatStatusAdd(parsed.Value.DisplayName, parsed.Value.Count, raw.Timestamp.UtcDateTime);
         }
     }
 

--- a/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
+++ b/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
@@ -92,7 +92,7 @@ public sealed class PlayerPositionTracker : BackgroundService, IPlayerPositionTr
                 // tracker warm even when no other module is feeding it.
                 _areaTracker.Observe(raw);
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is PlayerPositionEvent evt)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is PlayerPositionEvent evt)
                     Publish(new PlayerPosition(evt.X, evt.Y, evt.Z, ToOffset(evt.Timestamp), evt.Source));
             }
             catch (Exception ex)

--- a/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
+++ b/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
@@ -120,10 +120,13 @@ public sealed class PlayerPositionTracker : BackgroundService, IPlayerPositionTr
     }
 
     /// <summary>
-    /// Player.log timestamps are reconstructed as UTC <see cref="DateTime"/>s
-    /// by <c>LogLineTimestampSequencer</c>. Stamp the kind defensively in case
-    /// a caller passes an Unspecified-kind value (tests), so the offset is
-    /// always +00:00 rather than the host's local offset.
+    /// Player.log timestamps are normalized upstream by the L0 source
+    /// clock (<c>PlayerLogClock</c>, #513) — <c>raw.Timestamp</c> arrives
+    /// as a UTC <see cref="DateTimeOffset"/>; we pass its
+    /// <c>.UtcDateTime</c> into the parser, which surfaces its event's
+    /// <see cref="DateTime"/> as Unspecified-kind. Stamp the kind
+    /// defensively here so the lifted <see cref="DateTimeOffset"/>
+    /// always has offset +00:00 rather than the host's local offset.
     /// </summary>
     private static DateTimeOffset ToOffset(DateTime ts) =>
         new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));

--- a/src/Mithril.GameState/Pins/PlayerPinTracker.cs
+++ b/src/Mithril.GameState/Pins/PlayerPinTracker.cs
@@ -127,7 +127,7 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
                 _areaTracker.Observe(raw);
                 ReconcileArea();
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is MapPinLogEvent evt)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is MapPinLogEvent evt)
                     Apply(evt);
             }
             catch (Exception ex)

--- a/src/Mithril.GameState/Quests/QuestService.cs
+++ b/src/Mithril.GameState/Quests/QuestService.cs
@@ -127,17 +127,18 @@ public sealed class QuestService : BackgroundService, IQuestService
 
     private void Dispatch(RawLogLine raw)
     {
-        if (_journalLoadParser.TryParse(raw.Line, raw.Timestamp) is QuestJournalLoadedEvent loaded)
+        var ts = raw.Timestamp.UtcDateTime;
+        if (_journalLoadParser.TryParse(raw.Line, ts) is QuestJournalLoadedEvent loaded)
         {
             HandleJournalLoaded(loaded);
             return;
         }
-        if (_acceptedParser.TryParse(raw.Line, raw.Timestamp) is QuestAcceptedEvent accepted)
+        if (_acceptedParser.TryParse(raw.Line, ts) is QuestAcceptedEvent accepted)
         {
             HandleAccepted(accepted);
             return;
         }
-        if (_completedParser.TryParse(raw.Line, raw.Timestamp) is QuestCompletedEvent completed)
+        if (_completedParser.TryParse(raw.Line, ts) is QuestCompletedEvent completed)
         {
             HandleCompleted(completed);
         }

--- a/src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs
+++ b/src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs
@@ -84,7 +84,7 @@ public sealed class PlayerRecipeStateService : BackgroundService, IPlayerRecipeS
         {
             try
             {
-                switch (_parser.TryParse(raw.Line, raw.Timestamp))
+                switch (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime))
                 {
                     case RecipesSnapshotEvent snap:
                         ReplaceAll(snap);

--- a/src/Mithril.GameState/Sessions/IGameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/IGameSessionService.cs
@@ -9,8 +9,9 @@ namespace Mithril.GameState.Sessions;
 /// Subscribe pattern so late joiners observe the current session synchronously.
 ///
 /// Also surfaces as <see cref="Mithril.Shared.Logging.ISessionAnchor"/> so
-/// <see cref="Mithril.Shared.Logging.LogLineTimestampSequencer"/> can anchor
-/// log-line dates on the banner's UTC instead of file mtime.
+/// <see cref="Mithril.Shared.Logging.PlayerLogClock"/> (the Player.log L0
+/// source clock, #513) can anchor log-line dates on the banner's UTC
+/// instead of file mtime.
 /// </summary>
 public interface IGameSessionService
 {

--- a/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
+++ b/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
@@ -93,7 +93,7 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         {
             try
             {
-                switch (_parser.TryParse(raw.Line, raw.Timestamp))
+                switch (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime))
                 {
                     case SkillsSnapshotEvent snap:
                         ReplaceAll(snap);

--- a/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
+++ b/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
@@ -131,7 +131,7 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
                 _areaTracker.Observe(raw);
                 ReconcileArea();
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is WeatherChangedEvent evt)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is WeatherChangedEvent evt)
                     Apply(evt);
             }
             catch (Exception ex)

--- a/src/Mithril.Shared/Logging/ChatLogClock.cs
+++ b/src/Mithril.Shared/Logging/ChatLogClock.cs
@@ -1,0 +1,114 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// <see cref="ILogSourceClock"/> for chat logs. Parses the
+/// <c>yy-MM-dd HH:mm:ss\t</c> prefix every PG chat-log line carries
+/// (e.g. <c>26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to
+/// inventory.</c>). The prefix is in <b>host-local</b> time — the game
+/// process writes wall-clock with its local TZ — so the parsed
+/// <see cref="DateTime"/> is folded into a <see cref="DateTimeOffset"/>
+/// using <see cref="TimeZoneInfo.Local"/>'s UTC offset for that instant.
+///
+/// <para><b>Why this matters (#183 root cause).</b> Today every consumer
+/// that touches <c>raw.Timestamp</c> for a chat-derived line wraps it in
+/// <c>new DateTimeOffset(ts, TimeSpan.Zero)</c> — which is wrong by the
+/// host's TZ offset. The chat tail-reader masked the bug by falling
+/// through the prefix parse to wall-clock-now (which happens to be UTC),
+/// so consumers never saw the mis-conversion in practice — but the
+/// pattern is a tripwire: any consumer that did past-anchor on the chat
+/// timestamp would silently shift state by the TZ offset. This clock
+/// closes that gap structurally: downstream of L0 every chat line
+/// already carries the TZ-correct <see cref="DateTimeOffset"/>, and the
+/// per-consumer <c>TimeSpan.Zero</c> wrap (now a no-op on a
+/// pre-typed value) goes away in the fan-out.</para>
+///
+/// <para><b>Hand-rolled prefix parse</b> (vs <c>DateTime.ParseExact</c>):
+/// runs once per chat line on the seed-replay path; the format is
+/// fixed-width; the consumer cost matters (cf. #507). Lines without the
+/// prefix (rare — typically only the file's blank header lines) inherit
+/// the prior emitted stamp; a leading run of unprefixed lines falls
+/// through to <see cref="TimeProvider.GetUtcNow"/>.</para>
+///
+/// <para><see cref="EnsureAnchored"/> is a no-op: the chat prefix
+/// carries its own absolute date, so there is no equivalent of the
+/// Player-side mtime/session-anchor back-walk to perform.</para>
+/// </summary>
+internal sealed class ChatLogClock : ILogSourceClock
+{
+    private readonly TimeProvider _time;
+    private readonly TimeZoneInfo _localTz;
+    private DateTimeOffset? _lastEmitted;
+
+    public ChatLogClock(TimeProvider time, TimeZoneInfo? localTz = null)
+    {
+        _time = time;
+        // Late-bind TimeZoneInfo.Local so a test can inject a fixed-offset
+        // zone; default is the host's actual local zone, which is what the
+        // PG client writes against.
+        _localTz = localTz ?? TimeZoneInfo.Local;
+    }
+
+    public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor)
+    {
+        // No-op: the chat prefix encodes the absolute date, so there is
+        // nothing to anchor. Provided to satisfy ILogSourceClock so a
+        // future source whose grammar does need pre-stamp anchoring can
+        // slot in without changing the tailer.
+    }
+
+    public DateTimeOffset StampForLine(string line)
+    {
+        if (TryParseLocalDatePrefix(line, out var local))
+        {
+            // The parsed DateTime is unspecified-kind wall-clock in the
+            // host's local zone. Resolving via TimeZoneInfo.GetUtcOffset
+            // handles DST correctly (the offset varies per-instant); the
+            // ambiguous-time / invalid-time edge cases at DST transitions
+            // resolve to TimeZoneInfo's default policy (treat ambiguous
+            // as standard, treat invalid as if the clock had jumped),
+            // which matches how the game itself recorded the line.
+            var offset = _localTz.GetUtcOffset(local);
+            _lastEmitted = new DateTimeOffset(local, offset);
+            return _lastEmitted.Value;
+        }
+
+        return _lastEmitted ??= _time.GetUtcNow();
+    }
+
+    /// <summary>
+    /// Parse the <c>yy-MM-dd HH:mm:ss\t</c> prefix every PG chat-log line
+    /// carries. Two-digit year (PG writes <c>26</c> not <c>2026</c>);
+    /// resolved into the 2000s — PG's first release was 2014 so the
+    /// epoch is unambiguous well into the next century.
+    /// </summary>
+    public static bool TryParseLocalDatePrefix(string line, out DateTime local)
+    {
+        local = default;
+        // Minimum shape: "yy-MM-dd HH:mm:ss\t" → 18 characters.
+        if (line.Length < 18) return false;
+        if (line[2] != '-' || line[5] != '-' || line[8] != ' '
+            || line[11] != ':' || line[14] != ':' || line[17] != '\t') return false;
+        if (!Two(line, 0, out var yy)) return false;
+        if (!Two(line, 3, out var mo)) return false;
+        if (!Two(line, 6, out var dd)) return false;
+        if (!Two(line, 9, out var hh)) return false;
+        if (!Two(line, 12, out var mi)) return false;
+        if (!Two(line, 15, out var ss)) return false;
+        if (mo is < 1 or > 12) return false;
+        if (dd is < 1 or > 31) return false;
+        if (hh >= 24 || mi >= 60 || ss >= 60) return false;
+        var year = 2000 + yy;
+        try { local = new DateTime(year, mo, dd, hh, mi, ss, DateTimeKind.Unspecified); }
+        catch (ArgumentOutOfRangeException) { return false; }  // 31 Feb etc.
+        return true;
+    }
+
+    private static bool Two(string s, int i, out int v)
+    {
+        var a = s[i] - '0';
+        var b = s[i + 1] - '0';
+        if ((uint)a > 9 || (uint)b > 9) { v = 0; return false; }
+        v = a * 10 + b;
+        return true;
+    }
+}

--- a/src/Mithril.Shared/Logging/ChatLogClock.cs
+++ b/src/Mithril.Shared/Logging/ChatLogClock.cs
@@ -26,8 +26,13 @@ namespace Mithril.Shared.Logging;
 /// runs once per chat line on the seed-replay path; the format is
 /// fixed-width; the consumer cost matters (cf. #507). Lines without the
 /// prefix (rare — typically only the file's blank header lines) inherit
-/// the prior emitted stamp; a leading run of unprefixed lines falls
-/// through to <see cref="TimeProvider.GetUtcNow"/>.</para>
+/// the prior emitted stamp; a leading run of unprefixed lines (before
+/// any prefixed line has anchored <c>_lastEmitted</c>) falls through to
+/// <see cref="TimeProvider.GetUtcNow"/> <em>re-tagged with the host's
+/// local UTC offset</em>, so every value this clock emits carries the
+/// same (local) offset semantics — mixing Zero-offset (UTC) and
+/// local-offset values from one source would break a future
+/// offset-comparing consumer.</para>
 ///
 /// <para><see cref="EnsureAnchored"/> is a no-op: the chat prefix
 /// carries its own absolute date, so there is no equivalent of the
@@ -72,7 +77,16 @@ internal sealed class ChatLogClock : ILogSourceClock
             return _lastEmitted.Value;
         }
 
-        return _lastEmitted ??= _time.GetUtcNow();
+        if (_lastEmitted is { } prior) return prior;
+        // No prefix has anchored _lastEmitted yet (leading-unprefixed run,
+        // typically chat-file header lines). Use wall-clock-now, but re-tag
+        // with the host's local UTC offset so every value this clock emits
+        // carries the same offset semantics — mixing Zero-offset (UTC) and
+        // local-offset values from one source would break any future
+        // offset-comparing consumer.
+        var nowUtc = _time.GetUtcNow();
+        _lastEmitted = nowUtc.ToOffset(_localTz.GetUtcOffset(nowUtc.UtcDateTime));
+        return _lastEmitted.Value;
     }
 
     /// <summary>

--- a/src/Mithril.Shared/Logging/ChatLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/ChatLogTailReader.cs
@@ -1,23 +1,31 @@
 using System.IO;
-using System.Text;
 
 namespace Mithril.Shared.Logging;
 
 /// <summary>
-/// Directory-based tail. Keeps a byte offset per file so we can pick up
-/// where we left off, and buffers partial lines as residual bytes across
-/// reads in case a line is flushed mid-write.
+/// Chat-directory wrapper around <see cref="LogSourceTailer"/>. Per #513
+/// the tail mechanics (offset, residual, rotation, Sequence,
+/// ReadMonotonicTicks, timestamp normalization) all live in
+/// <see cref="LogSourceTailer"/>; this class owns only the chat-side
+/// concerns the unified tailer doesn't: directory enumeration, one
+/// tailer-per-channel-file (chat logs are split per channel and rotate
+/// independently), and the "skip whatever was already in the directory
+/// at startup" seed strategy.
 ///
-/// Each file gets its own <see cref="LogLineTimestampSequencer"/> so the
-/// per-channel chat logs (which can rotate independently and interleave at
-/// different rates) fold dates over their own mtimes. See
-/// <see cref="PlayerLogTailReader"/> for the same fix on the gameplay log.
+/// <para>The chat clock injected into each per-file tailer is
+/// <see cref="ChatLogClock"/>, which parses the <c>yy-MM-dd HH:mm:ss\t</c>
+/// LOCAL prefix and folds it into a TZ-correct
+/// <see cref="DateTimeOffset"/>. This is the bug-class kill from #513:
+/// downstream of L0 a chat-derived <see cref="RawLogLine.Timestamp"/> is
+/// already TZ-correct, so the per-consumer
+/// <c>new DateTimeOffset(ts, TimeSpan.Zero)</c> wrap can no longer apply
+/// the wrong offset (it's now a no-op on a pre-typed value).</para>
 /// </summary>
 public sealed class ChatLogTailReader
 {
     private readonly TimeProvider _time;
     private readonly ISessionAnchor? _sessionAnchor;
-    private readonly Dictionary<string, FileState> _files = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, LogSourceTailer> _files = new(StringComparer.OrdinalIgnoreCase);
 
     public ChatLogTailReader(TimeProvider? time = null, ISessionAnchor? sessionAnchor = null)
     {
@@ -36,11 +44,8 @@ public sealed class ChatLogTailReader
         {
             try
             {
-                _files[path] = new FileState
-                {
-                    Offset = new FileInfo(path).Length,
-                    Sequencer = new LogLineTimestampSequencer(_time, _sessionAnchor),
-                };
+                var tailer = GetOrCreate(path);
+                tailer.Offset = new FileInfo(path).Length;
             }
             catch (IOException) { }
         }
@@ -49,57 +54,19 @@ public sealed class ChatLogTailReader
     public IReadOnlyList<RawLogLine> ReadNew(string path)
     {
         if (!File.Exists(path)) return Array.Empty<RawLogLine>();
-
-        if (!_files.TryGetValue(path, out var state))
-        {
-            state = new FileState { Sequencer = new LogLineTimestampSequencer(_time, _sessionAnchor) };
-            _files[path] = state;
-        }
-
-        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
-            FileShare.ReadWrite | FileShare.Delete);
-        if (fs.Length < state.Offset) state.Offset = 0;
-        if (fs.Length == state.Offset) return Array.Empty<RawLogLine>();
-
-        fs.Seek(state.Offset, SeekOrigin.Begin);
-        var len = (int)Math.Min(int.MaxValue, fs.Length - state.Offset);
-        var buf = new byte[state.Residual.Length + len];
-        Buffer.BlockCopy(state.Residual, 0, buf, 0, state.Residual.Length);
-        var read = fs.Read(buf, state.Residual.Length, len);
-        var total = state.Residual.Length + read;
-
-        var lastNl = -1;
-        for (var i = total - 1; i >= 0; i--) { if (buf[i] == (byte)'\n') { lastNl = i; break; } }
-        if (lastNl < 0)
-        {
-            state.Residual = buf[..total];
-            state.Offset += read;
-            return Array.Empty<RawLogLine>();
-        }
-
-        var text = Encoding.UTF8.GetString(buf, 0, lastNl + 1);
-        state.Residual = buf[(lastNl + 1)..total];
-        state.Offset += read;
-
-        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        if (lines.Length == 0) return Array.Empty<RawLogLine>();
-
-        state.Sequencer.EnsureAnchored(lines, () => File.GetLastWriteTimeUtc(path));
-
-        var result = new List<RawLogLine>(lines.Length);
-        foreach (var line in lines)
-        {
-            var trimmed = line.EndsWith('\r') ? line[..^1] : line;
-            if (trimmed.Length == 0) continue;
-            result.Add(new RawLogLine(state.Sequencer.StampForLine(trimmed), trimmed));
-        }
-        return result;
+        return GetOrCreate(path).ReadNew();
     }
 
-    private sealed class FileState
+    private LogSourceTailer GetOrCreate(string path)
     {
-        public long Offset { get; set; }
-        public byte[] Residual { get; set; } = Array.Empty<byte>();
-        public required LogLineTimestampSequencer Sequencer { get; init; }
+        if (_files.TryGetValue(path, out var existing)) return existing;
+        // sessionAnchor is plumbed through even though ChatLogClock doesn't
+        // use it today — keeps the chat tail-reader's ctor symmetric with
+        // the Player one and leaves the door open for a future chat-side
+        // clock that does want a session-pinned anchor.
+        _ = _sessionAnchor;
+        var t = new LogSourceTailer(path, new ChatLogClock(_time), _time);
+        _files[path] = t;
+        return t;
     }
 }

--- a/src/Mithril.Shared/Logging/ILogSourceClock.cs
+++ b/src/Mithril.Shared/Logging/ILogSourceClock.cs
@@ -1,0 +1,46 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Per-source timestamp grammar. L0 of the layered log pipeline (#511 /
+/// #513) is parameterized by one of these so the duplicated Player vs
+/// chat tail+stamp logic collapses onto a single <c>LogSourceTailer</c>:
+/// the tailer owns offset/residual/rotation/Sequence/ReadMonotonicTicks,
+/// the clock owns "interpret this raw line as an absolute
+/// <see cref="DateTimeOffset"/>." Implementations live alongside the
+/// tailer in <c>Mithril.Shared.Logging</c>:
+///
+/// <list type="bullet">
+///   <item><see cref="PlayerLogClock"/> — Player.log <c>[HH:MM:SS]</c>
+///   prefix, UTC, no date; folds time-of-day over a session-anchor /
+///   mtime date with midnight-rollover detection. Emits offset
+///   <see cref="TimeSpan.Zero"/>.</item>
+///   <item><see cref="ChatLogClock"/> — chat <c>yy-MM-dd HH:mm:ss\t…</c>
+///   prefix, LOCAL, date in line; emits the host's local UTC offset for
+///   that instant. This is what closes the #183 bug class on the chat
+///   side: a downstream consumer that copies the Player-side
+///   <c>TimeSpan.Zero</c> idiom would be wrong by the local offset, but
+///   downstream of L0 there is no per-consumer conversion left to get
+///   wrong.</item>
+/// </list>
+/// </summary>
+internal interface ILogSourceClock
+{
+    /// <summary>
+    /// Compute the absolute instant for a single tailed line. Lines
+    /// without a recognisable prefix inherit the prior stamp (engine
+    /// noise interleaved with gameplay lines stays anchored on the most
+    /// recent recognised line); a leading run of unprefixed lines falls
+    /// through to <see cref="TimeProvider.GetUtcNow"/>.
+    /// </summary>
+    DateTimeOffset StampForLine(string line);
+
+    /// <summary>
+    /// One-shot pre-stamp hook for sources whose date isn't in-line.
+    /// <see cref="PlayerLogClock"/> uses this to anchor the UTC date for
+    /// the first content batch (session anchor preferred, mtime
+    /// fallback). <see cref="ChatLogClock"/> no-ops — the date is on
+    /// every line so no anchoring is needed. Called once per source by
+    /// <c>LogSourceTailer</c> on the first non-empty batch.
+    /// </summary>
+    void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor);
+}

--- a/src/Mithril.Shared/Logging/ISessionAnchor.cs
+++ b/src/Mithril.Shared/Logging/ISessionAnchor.cs
@@ -3,14 +3,14 @@ namespace Mithril.Shared.Logging;
 /// <summary>
 /// Provides an authoritative UTC datetime anchor for the current PG session,
 /// parsed from the in-file <c>Logged in as character … Time UTC=… Timezone Offset …</c>
-/// banner. Consumed by <see cref="LogLineTimestampSequencer"/> to anchor the
+/// banner. Consumed by <see cref="PlayerLogClock"/> to anchor the
 /// date for <c>[HH:MM:SS]</c> prefixes; this beats anchoring on file mtime
 /// (which drifts on copies, runs across midnight, and depends on system clock
 /// state).
 ///
 /// <para>The concrete implementation is the leaf class <see cref="SessionAnchor"/>
 /// in <c>Mithril.Shared</c> — kept here rather than in <c>Mithril.GameState</c>
-/// so <see cref="LogLineTimestampSequencer"/> and <c>PlayerLogStream</c>
+/// so <see cref="PlayerLogClock"/> and <c>PlayerLogStream</c>
 /// (also Mithril.Shared) can depend on it without inverting the project
 /// graph or forming a DI cycle. <c>GameSessionService</c> in
 /// <c>Mithril.GameState.Sessions</c> consumes the same concrete anchor and

--- a/src/Mithril.Shared/Logging/LogEvent.cs
+++ b/src/Mithril.Shared/Logging/LogEvent.cs
@@ -1,5 +1,80 @@
 namespace Mithril.Shared.Logging;
 
+/// <summary>
+/// Abstract base for typed parser events (L2 territory). Every parser
+/// (<see cref="ILogParser"/> / <see cref="IChatLogParser"/>) returns a
+/// concrete subclass — <c>WeatherChangedEvent</c>, <c>QuestAcceptedEvent</c>,
+/// <c>MapPinLogEvent</c>, etc. <c>Timestamp</c> is the in-game wall-clock
+/// instant the event occurred; carried as <see cref="DateTime"/> because
+/// parsers accept <c>(string line, DateTime timestamp)</c> per the
+/// standing "convert at the boundary" convention — the L0
+/// <see cref="RawLogLine.Timestamp"/> (which is a TZ-correct
+/// <see cref="DateTimeOffset"/>) is converted via <c>.UtcDateTime</c> at
+/// the parser invocation site, and the resulting <see cref="LogEvent"/>
+/// keeps the simpler <see cref="DateTime"/>.
+///
+/// <para><b>Not related to <see cref="RawLogLine"/></b> beyond a shared
+/// historical accident. <see cref="RawLogLine"/> is L0 (tailed-from-disk,
+/// pre-parse); <see cref="LogEvent"/> subclasses are L2 (typed,
+/// recognised). They no longer share an inheritance chain — collapsing
+/// them was an artifact of an earlier design and conflated two
+/// concerns.</para>
+/// </summary>
 public abstract record LogEvent(DateTime Timestamp);
 
-public sealed record RawLogLine(DateTime Timestamp, string Line) : LogEvent(Timestamp);
+/// <summary>
+/// One physical line read from a tailed log source. L0 of the layered
+/// log pipeline (#511 / #513): emitted by <c>LogSourceTailer</c>,
+/// consumed by every state-rebuilder and reactive ingestion service via
+/// <see cref="IPlayerLogStream"/> / <see cref="IChatLogStream"/>.
+///
+/// <para><b><see cref="Timestamp"/></b> — the absolute wall-clock instant
+/// the line represents, normalized to a <see cref="DateTimeOffset"/>
+/// regardless of source. For Player.log this is the <c>[HH:MM:SS]</c>
+/// prefix folded over the session anchor's UTC date (offset
+/// <see cref="TimeSpan.Zero"/>). For chat logs this is the <c>yy-MM-dd
+/// HH:mm:ss</c> prefix interpreted as host-local time and carried as a
+/// <see cref="DateTimeOffset"/> with the host's local UTC offset for that
+/// instant. Downstream of L0 nothing ever again needs to know which
+/// source the line came from to compute a TZ-correct instant — this
+/// structurally eliminates the #183 bug class (no per-consumer
+/// <c>new DateTimeOffset(ts, TimeSpan.Zero)</c> can apply the wrong
+/// offset to a chat-derived line because there is no per-consumer
+/// conversion left to get wrong).</para>
+///
+/// <para><b><see cref="Sequence"/></b> — per-source monotonic counter.
+/// Derived from the line's byte offset within the current physical source
+/// file: each emitted line starts at a strictly greater offset than the
+/// previous. Restart-stable: a mid-session Mithril restart re-seeds at
+/// some byte offset N and resumes emitting <see cref="Sequence"/> values
+/// consistent with N, so an L1 consumer's persisted high-water key
+/// continues to filter correctly (#511 deliverable 3). The point of
+/// deriving from log position rather than from a process counter is
+/// exactly this restart-stability — see #513 scope addition A.</para>
+///
+/// <para><b><see cref="ReadMonotonicTicks"/></b> — the high-resolution
+/// monotonic instant <see cref="TimeProvider.GetTimestamp"/> reported
+/// when L0 tailed the batch containing this line. <i>Distinct</i> from
+/// <see cref="Timestamp"/>: Timestamp is the (second-resolution,
+/// game-supplied) "when this event happened in-game"; ReadMonotonicTicks
+/// is "when Mithril read it off disk". For <b>live</b> lines from two
+/// sources (Player.log + chat) tailed by the same Mithril process,
+/// ReadMonotonicTicks is a usable fine-grained tiebreaker within a
+/// shared game-second — the Tier-3 mechanism in the #523 correlation
+/// hierarchy. For <b>replay</b> lines or while tailing falls behind
+/// (the alarmed #507 condition) it is meaningless and consumers must
+/// fall back to per-source <see cref="Sequence"/> + game-second + keyed
+/// correlation. L0 mints the value; L1 (#511 deliverable 3) will add
+/// the <c>IsReplay</c> flag that tells the consumer when the value is
+/// usable.</para>
+///
+/// <para><see cref="Sequence"/> and <see cref="ReadMonotonicTicks"/>
+/// default to <c>0</c> so test code that constructs synthetic
+/// <see cref="RawLogLine"/> instances via <c>new RawLogLine(ts, "line")</c>
+/// continues to compile unchanged; production L0 always populates both.</para>
+/// </summary>
+public sealed record RawLogLine(
+    DateTimeOffset Timestamp,
+    string Line,
+    long Sequence = 0,
+    long ReadMonotonicTicks = 0);

--- a/src/Mithril.Shared/Logging/LogEvent.cs
+++ b/src/Mithril.Shared/Logging/LogEvent.cs
@@ -4,14 +4,16 @@ namespace Mithril.Shared.Logging;
 /// Abstract base for typed parser events (L2 territory). Every parser
 /// (<see cref="ILogParser"/> / <see cref="IChatLogParser"/>) returns a
 /// concrete subclass — <c>WeatherChangedEvent</c>, <c>QuestAcceptedEvent</c>,
-/// <c>MapPinLogEvent</c>, etc. <c>Timestamp</c> is the in-game wall-clock
-/// instant the event occurred; carried as <see cref="DateTime"/> because
-/// parsers accept <c>(string line, DateTime timestamp)</c> per the
-/// standing "convert at the boundary" convention — the L0
-/// <see cref="RawLogLine.Timestamp"/> (which is a TZ-correct
-/// <see cref="DateTimeOffset"/>) is converted via <c>.UtcDateTime</c> at
-/// the parser invocation site, and the resulting <see cref="LogEvent"/>
-/// keeps the simpler <see cref="DateTime"/>.
+/// <c>MapPinLogEvent</c>, etc. <c>Timestamp</c> is the <b>UTC</b> instant
+/// the event occurred — carried as <see cref="DateTime"/> (Kind=Utc)
+/// because parsers accept <c>(string line, DateTime timestamp)</c> per the
+/// standing "convert at the boundary" convention. The L0
+/// <see cref="RawLogLine.Timestamp"/> is a TZ-correct
+/// <see cref="DateTimeOffset"/> (UTC for Player.log lines, host-local for
+/// chat lines); consumers fold it to UTC via <c>.UtcDateTime</c> at the
+/// parser invocation site, so the resulting <see cref="LogEvent"/> always
+/// holds the same UTC instant regardless of source — not the local
+/// wall-clock for chat-derived events.
 ///
 /// <para><b>Not related to <see cref="RawLogLine"/></b> beyond a shared
 /// historical accident. <see cref="RawLogLine"/> is L0 (tailed-from-disk,
@@ -50,7 +52,13 @@ public abstract record LogEvent(DateTime Timestamp);
 /// consistent with N, so an L1 consumer's persisted high-water key
 /// continues to filter correctly (#511 deliverable 3). The point of
 /// deriving from log position rather than from a process counter is
-/// exactly this restart-stability — see #513 scope addition A.</para>
+/// exactly this restart-stability — see #513 scope addition A.
+/// <em>Caveat: on detected rotation/truncation (<c>fs.Length &lt; _offset</c>)
+/// the sequence space resets to 0 alongside the file offset</em> — the prior
+/// physical file's sequence space ends; consumers must observe rotations
+/// distinctly (the L1 high-water filter scopes its key to the same
+/// physical-source generation). See <c>LogSourceTailer</c> for the
+/// implementing contract.</para>
 ///
 /// <para><b><see cref="ReadMonotonicTicks"/></b> — the high-resolution
 /// monotonic instant <see cref="TimeProvider.GetTimestamp"/> reported

--- a/src/Mithril.Shared/Logging/LogSourceTailer.cs
+++ b/src/Mithril.Shared/Logging/LogSourceTailer.cs
@@ -1,0 +1,177 @@
+using System.IO;
+using System.Text;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0 of the layered log pipeline (#511 / #513): the <b>one and only one
+/// service</b> that owns tailing a single log file and turning each new
+/// line into a normalized <see cref="RawLogLine"/>. Owns:
+///
+/// <list type="bullet">
+///   <item><b>Tailing.</b> Byte offset across reads, residual partial
+///   trailing line buffered for the next read, rotation/truncation
+///   detection (<c>fs.Length &lt; _offset</c>), shared-read
+///   <see cref="FileShare"/>.</item>
+///   <item><b>Per-source timestamp grammar.</b> Delegated to an injected
+///   <see cref="ILogSourceClock"/> — <see cref="PlayerLogClock"/> for the
+///   Player.log <c>[HH:MM:SS]</c>-UTC grammar, <see cref="ChatLogClock"/>
+///   for the chat <c>yy-MM-dd HH:mm:ss\t</c>-local grammar. The clock
+///   does the work; the tailer only knows "ask it." Downstream of L0 no
+///   consumer ever needs to know which grammar applied — every
+///   <see cref="RawLogLine.Timestamp"/> is already a TZ-correct
+///   <see cref="DateTimeOffset"/>.</item>
+///   <item><b>Per-source monotonic <see cref="RawLogLine.Sequence"/>.</b>
+///   The line's byte offset within the current physical source file. Each
+///   emitted line starts at a strictly greater offset than the previous,
+///   so <see cref="RawLogLine.Sequence"/> is strictly monotonic within a
+///   tailing session. Restart-stable while the file hasn't been truncated:
+///   a mid-session Mithril restart re-seeds to some byte N, the next
+///   line's <see cref="RawLogLine.Sequence"/> is N+(intra-batch offset),
+///   matching what the pre-restart tailer would have emitted — so an L1
+///   high-water filter (#511 deliverable 3) keyed on
+///   <see cref="RawLogLine.Sequence"/> continues to skip already-processed
+///   lines without double-counting. On true rotation/truncation
+///   (<c>fs.Length &lt; _offset</c>) the sequence space resets to 0
+///   alongside the file offset; this is correct, because the consumer's
+///   high-water key was scoped to the file that no longer exists.</item>
+///   <item><b>Per-batch <see cref="RawLogLine.ReadMonotonicTicks"/>.</b>
+///   Sampled once per <see cref="ReadNew"/> call via
+///   <see cref="TimeProvider.GetTimestamp"/> and stamped on every line in
+///   the batch — the tick value tells L1 / a #523 Tier-3 consumer "this
+///   batch was tailed at monotonic instant T," which is the only
+///   sub-second cross-source ordering signal available between Player.log
+///   and chat. Per-batch (not per-line) granularity is the right
+///   resolution for cross-source tiebreaking (within-source ordering is
+///   already given by <see cref="RawLogLine.Sequence"/>) and keeps the
+///   per-line cost zero on the hot path.</item>
+/// </list>
+///
+/// <para><b>What this class does NOT own</b> — the explicit out-of-scope
+/// list from #513 (these are L1 / L2 / L3 / module concerns):</para>
+/// <list type="bullet">
+///   <item>The session-start seek (<c>SeedToSessionStart</c>) for
+///   Player.log. That's a Player-specific seed strategy and stays in
+///   <see cref="PlayerLogTailReader"/>.</item>
+///   <item>The directory enumeration + per-file fan-out for chat logs.
+///   That stays in <see cref="ChatLogTailReader"/>; the tailer is
+///   single-file by design (one tailer per chat file).</item>
+///   <item>Subscription / channel fan-out / replay buffer — that's L1
+///   (<see cref="PlayerLogStream"/> / <see cref="ChatLogStream"/>).</item>
+///   <item>Per-message error containment, drop accounting, ReplayMode,
+///   verb recognition, domain interpretation — L1 / L2 / L3 per #511.</item>
+/// </list>
+/// </summary>
+internal sealed class LogSourceTailer
+{
+    private readonly string _path;
+    private readonly ILogSourceClock _clock;
+    private readonly TimeProvider _time;
+    private long _offset;
+    private byte[] _residual = Array.Empty<byte>();
+
+    public LogSourceTailer(string path, ILogSourceClock clock, TimeProvider time)
+    {
+        _path = path ?? throw new ArgumentNullException(nameof(path));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+    }
+
+    /// <summary>
+    /// Byte offset at which the next <see cref="ReadNew"/> begins. The
+    /// wrapper classes (<see cref="PlayerLogTailReader"/>,
+    /// <see cref="ChatLogTailReader"/>) write this directly to implement
+    /// their seed strategies (session-marker scan / skip-to-current-end);
+    /// no <c>Seed*</c> verbs live on the tailer because the seed policy
+    /// is the source-specific concern, not the tail mechanics.
+    /// </summary>
+    public long Offset
+    {
+        get => _offset;
+        set => _offset = value;
+    }
+
+    /// <summary>
+    /// Read every new complete line written since the last call. Returns
+    /// empty when nothing new is available, when a partial trailing line
+    /// is the only new content (it is buffered as residual and emitted
+    /// next time a newline arrives), or when the file has been truncated
+    /// (offset is reset to 0 and the next call reads from the start).
+    /// </summary>
+    public IReadOnlyList<RawLogLine> ReadNew()
+    {
+        if (!File.Exists(_path)) return Array.Empty<RawLogLine>();
+        using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        if (fs.Length < _offset) { _offset = 0; _residual = Array.Empty<byte>(); } // truncation / rotation
+        if (fs.Length == _offset) return Array.Empty<RawLogLine>();
+
+        // The chunk we're about to assemble starts at this file offset —
+        // residual is the prefix that was already read in the prior call
+        // but didn't terminate in a newline. Sequence numbers below are
+        // computed against this base so each line's Sequence equals its
+        // start-byte offset in the file.
+        var chunkStartOffset = _offset - _residual.Length;
+
+        fs.Seek(_offset, SeekOrigin.Begin);
+        var len = (int)Math.Min(int.MaxValue, fs.Length - _offset);
+        var buf = new byte[_residual.Length + len];
+        Buffer.BlockCopy(_residual, 0, buf, 0, _residual.Length);
+        var read = fs.Read(buf, _residual.Length, len);
+        var total = _residual.Length + read;
+
+        // Find last newline; everything after becomes residual.
+        var lastNl = -1;
+        for (var i = total - 1; i >= 0; i--) { if (buf[i] == (byte)'\n') { lastNl = i; break; } }
+        if (lastNl < 0)
+        {
+            _residual = buf[..total];
+            _offset += read;
+            return Array.Empty<RawLogLine>();
+        }
+
+        var text = Encoding.UTF8.GetString(buf, 0, lastNl + 1);
+        _residual = buf[(lastNl + 1)..total];
+        _offset += read;
+
+        // Split keeping empty entries — we need positional info so the
+        // byte-offset accumulator (used to compute Sequence) stays in
+        // sync with the source file. The trailing empty entry that
+        // follows the final '\n' (Split keeps it) gets skipped naturally
+        // by the trimmed.Length == 0 check below.
+        var parts = text.Split('\n');
+        var lines = new List<(long fileOffset, string trimmed)>(parts.Length);
+        var byteOffset = chunkStartOffset;
+        foreach (var part in parts)
+        {
+            var partUtf8Len = Encoding.UTF8.GetByteCount(part);
+            var trimmed = part.EndsWith('\r') ? part[..^1] : part;
+            if (trimmed.Length > 0) lines.Add((byteOffset, trimmed));
+            byteOffset += partUtf8Len + 1; // +1 for the '\n' delimiter (over-counts past the last line; harmless)
+        }
+
+        if (lines.Count == 0) return Array.Empty<RawLogLine>();
+
+        // Anchor on the whole batch BEFORE stamping any line. The
+        // Player-side clock's mtime fallback walks the full batch to
+        // count midnight rollovers and back-derive the starting date;
+        // passing only the first line would give it a wrong answer for a
+        // cold-start backlog that spans multiple midnights. The chat-side
+        // clock no-ops EnsureAnchored. Idempotent after the first call.
+        var lineTexts = new string[lines.Count];
+        for (var i = 0; i < lines.Count; i++) lineTexts[i] = lines[i].trimmed;
+        _clock.EnsureAnchored(lineTexts, () => File.GetLastWriteTimeUtc(_path));
+
+        var readTicks = _time.GetTimestamp();
+        var result = new List<RawLogLine>(lines.Count);
+        foreach (var (fileOffset, trimmed) in lines)
+        {
+            result.Add(new RawLogLine(
+                Timestamp: _clock.StampForLine(trimmed),
+                Line: trimmed,
+                Sequence: fileOffset,
+                ReadMonotonicTicks: readTicks));
+        }
+        return result;
+    }
+}

--- a/src/Mithril.Shared/Logging/PlayerLogClock.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogClock.cs
@@ -1,45 +1,49 @@
 namespace Mithril.Shared.Logging;
 
 /// <summary>
-/// Recovers absolute UTC timestamps for log lines whose only embedded time
-/// information is a <c>[HH:MM:SS]</c> prefix (PG's gameplay log format).
-/// The prefix is in <b>UTC</b> — verified against the same file's mtime
-/// (Player.log mtime minus the player's TZ offset matches the prefix's
-/// time-of-day) and against the ChatLog login banner's reported
-/// <c>Timezone Offset</c>, which equals the offset between Player.log
-/// prefixes and ChatLog lines.
+/// <see cref="ILogSourceClock"/> for Player.log. Recovers an absolute UTC
+/// instant from the <c>[HH:MM:SS]</c> prefix every PG gameplay line
+/// carries (UTC, no date — verified against the file's own mtime and the
+/// ChatLog login banner's <c>Timezone Offset</c>), folded over a date
+/// anchored from one of two sources:
 ///
-/// <para><b>Date anchoring.</b> Two anchor strategies, picked dynamically:</para>
 /// <list type="bullet">
-///   <item><b>Session anchor (preferred).</b> If an <see cref="ISessionAnchor"/>
-///   has observed a <c>Logged in as character … Time UTC=…</c> banner, the
-///   sequencer pins <c>_currentUtcDate</c> to <c>LoggedInUtc.Date</c> and
-///   primes <c>_prevUtcTimeOfDay</c> with the login time-of-day. The login
-///   instant is the earliest known point in the relevant window, so
-///   <see cref="StampForLine"/>'s existing forward-rollover detection
-///   (HH-wraps-backward &gt; 12h ⇒ +1 day) carries the date across every
-///   subsequent midnight without further intervention. On
-///   <see cref="ISessionAnchor.AnchorChanged"/> (PG re-login), the sequencer
-///   re-anchors to the new banner's date. Self-describing from inside the
-///   file — robust to copies, runs spanning midnight, and clock drift.</item>
-///   <item><b>mtime anchor (fallback).</b> No session known: walk the date
-///   <i>backward</i> from the LAST timestamped line in the first batch,
+///   <item><b>Session anchor (preferred).</b> If an
+///   <see cref="ISessionAnchor"/> has observed a <c>Logged in as
+///   character … Time UTC=…</c> banner, pin <c>_currentUtcDate</c> to
+///   <c>LoggedInUtc.Date</c> and prime <c>_prevUtcTimeOfDay</c> with the
+///   login time-of-day. The login instant is the earliest known point in
+///   the relevant window, so the forward-rollover detection in
+///   <see cref="StampForLine"/> (HH wraps backward &gt; 12h ⇒ +1 day)
+///   carries the date across every subsequent midnight without further
+///   intervention. On <see cref="ISessionAnchor.AnchorChanged"/> (PG
+///   re-login), re-anchor to the new banner's date. Self-describing from
+///   inside the file — robust to copies, runs spanning midnight, and
+///   clock drift.</item>
+///   <item><b>mtime anchor (fallback).</b> No session known: walk the
+///   date backward from the LAST timestamped line in the first batch,
 ///   subtracting in-batch rollover count, so the last line lines up with
-///   the file's mtime (or mtime - 1 day if the line's tod is past mtime's
-///   tod). Preserves pre-<c>ISessionAnchor</c> behaviour for pre-banner
-///   lines (engine boot) and for chat logs that never emit a banner.</item>
+///   the file's mtime (or mtime - 1 day if the line's tod is past
+///   mtime's tod). Preserves pre-<see cref="ISessionAnchor"/> behaviour
+///   for pre-banner lines (engine boot) and for the rare case where the
+///   banner hasn't been parsed yet.</item>
 /// </list>
 ///
-/// Shared by <see cref="PlayerLogTailReader"/> (single-file Player.log)
-/// and <see cref="ChatLogTailReader"/> (per-channel chat logs); each chat
-/// file gets its own sequencer instance so dates fold independently.
-/// Note: real chat-log lines don't carry the <c>[HH:MM:SS]</c> prefix
-/// (their format is <c>yy-MM-dd HH:MM:SS\t...</c> in <i>local</i> time),
-/// so chat lines fall through the prefix parse and rely on the inherited
-/// stamp or wall-clock-now. A future chat-content parser that wants
-/// absolute past-anchored stamps needs its own extraction path.
+/// Emits <see cref="DateTimeOffset"/> with offset
+/// <see cref="TimeSpan.Zero"/> — Player.log is always UTC. (This is the
+/// "boilerplate removal" half of #513: every consumer that today wraps
+/// <c>raw.Timestamp</c> in <c>new DateTimeOffset(ts, TimeSpan.Zero)</c>
+/// is wrapping a <see cref="DateTimeOffset"/> that already has the
+/// correct offset; the wrap goes away.)
+///
+/// Renamed from <c>LogLineTimestampSequencer</c> as part of the L0
+/// collapse — the sequencer was already shared by Player and chat tail
+/// readers but was named after the Player-shaped grammar it implements;
+/// the L0 redesign moves chat's actual grammar to
+/// <see cref="ChatLogClock"/> and makes this class explicitly the
+/// Player-side clock.
 /// </summary>
-internal sealed class LogLineTimestampSequencer
+internal sealed class PlayerLogClock : ILogSourceClock
 {
     private readonly TimeProvider _time;
     private readonly ISessionAnchor? _sessionAnchor;
@@ -51,7 +55,7 @@ internal sealed class LogLineTimestampSequencer
     // re-anchor mid-stream. Null when running under the mtime fallback.
     private DateTime? _appliedSessionAnchor;
 
-    public LogLineTimestampSequencer(TimeProvider time, ISessionAnchor? sessionAnchor = null)
+    public PlayerLogClock(TimeProvider time, ISessionAnchor? sessionAnchor = null)
     {
         _time = time;
         _sessionAnchor = sessionAnchor;
@@ -72,29 +76,6 @@ internal sealed class LogLineTimestampSequencer
         _appliedSessionAnchor = anchor;
     }
 
-    /// <summary>
-    /// Anchor the date for the first content batch. Two strategies:
-    ///
-    /// <para><b>Session anchor.</b> If an <see cref="ISessionAnchor"/> has
-    /// already observed the <c>Logged in as character</c> banner, pin the
-    /// date to <c>LoggedInUtc.Date</c> directly. The banner is the
-    /// authoritative earliest known instant in the session, so no
-    /// back-walk is needed and pre-banner lines in the same batch
-    /// (engine boot) inherit <c>LoggedInUtc.Date</c> too — slight
-    /// imprecision on pre-session lines is benign because no ingestion
-    /// service consumes them.</para>
-    ///
-    /// <para><b>mtime fallback.</b> No session known: pre-scan
-    /// <paramref name="lines"/> for <c>[HH:MM:SS]</c> prefixes, count
-    /// midnight rollovers in the batch, and walk the start back so the
-    /// LAST timestamped line lines up with file mtime (or mtime - 1 day
-    /// if its tod is past mtime's tod). Preserves pre-session-anchor
-    /// behaviour for chat logs and for any state where the banner
-    /// hasn't been parsed yet.</para>
-    ///
-    /// No-op once anchored, and no-op for batches with no prefixed lines
-    /// (defers init to a later batch that has at least one).
-    /// </summary>
     public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor)
     {
         if (_currentUtcDate is not null) return;
@@ -136,15 +117,7 @@ internal sealed class LogLineTimestampSequencer
         _currentUtcDate = anchorDate.AddDays(-rollovers);
     }
 
-    /// <summary>
-    /// Compute the UTC stamp for a single log line. Parses the
-    /// <c>[HH:MM:SS]</c> prefix (interpreted as UTC) and folds it over
-    /// the current date, detecting midnight rollovers (HH wraps backward
-    /// by &gt;12h). Lines without the prefix inherit the prior stamp; a
-    /// leading run of unprefixed lines falls through to
-    /// <see cref="TimeProvider.GetUtcNow"/>.
-    /// </summary>
-    public DateTime StampForLine(string line)
+    public DateTimeOffset StampForLine(string line)
     {
         if (TryParseTimestampPrefix(line, out var tod) && _currentUtcDate.HasValue)
         {
@@ -174,7 +147,7 @@ internal sealed class LogLineTimestampSequencer
         // else: inherit prior _lastEmittedUtc (engine noise interleaved
         // with gameplay lines stays anchored on the most recent gameplay tod).
 
-        return _lastEmittedUtc;
+        return new DateTimeOffset(_lastEmittedUtc, TimeSpan.Zero);
     }
 
     /// <summary>

--- a/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogTailReader.cs
@@ -4,10 +4,13 @@ using System.Text;
 namespace Mithril.Shared.Logging;
 
 /// <summary>
-/// Single-file tail with session-start seek. Mirrors ws_bridge.py's
-/// _find_session_start: scans the last 10 MB for the most recent
-/// session-start marker so the consumer always receives the login event
-/// regardless of how long ago the session began.
+/// Player.log seed-strategy wrapper around <see cref="LogSourceTailer"/>.
+/// The tail mechanics (offset, residual, rotation, Sequence,
+/// ReadMonotonicTicks, timestamp normalization) live in
+/// <see cref="LogSourceTailer"/> per #513 — this class owns only the
+/// Player-side seek strategy: scan the file backwards for the most
+/// recent session-start marker so the consumer always receives the
+/// login event regardless of how long ago the session began.
 ///
 /// <para><b>Session markers.</b> Two markers identify a session start:</para>
 /// <list type="bullet">
@@ -23,14 +26,6 @@ namespace Mithril.Shared.Logging;
 /// <b>earlier</b> of the two recent occurrences so both lines appear in the
 /// replay regardless of PG's emission order. If neither is found, the seed
 /// falls through to byte 0 (replay everything).
-///
-/// Each emitted <see cref="RawLogLine"/> carries the absolute UTC of the
-/// log line itself (recovered from the <c>[HH:MM:SS]</c> prefix every PG
-/// gameplay line carries) rather than wall-clock-at-read. Past-anchored
-/// cooldown sources (Gandalf Quest/Loot) rely on this to correctly anchor
-/// rows when Mithril launches mid-session and the seed replay surfaces
-/// hours-old completions. See <see cref="LogLineTimestampSequencer"/> for
-/// the date-folding logic.
 /// </summary>
 public sealed class PlayerLogTailReader
 {
@@ -42,21 +37,18 @@ public sealed class PlayerLogTailReader
     ];
 
     private readonly string _path;
-    private readonly TimeProvider _time;
-    private readonly LogLineTimestampSequencer _sequencer;
-    private long _offset;
-    private byte[] _residual = Array.Empty<byte>();
+    private readonly LogSourceTailer _tailer;
 
     public PlayerLogTailReader(string path, TimeProvider? time = null, ISessionAnchor? sessionAnchor = null)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
-        _time = time ?? TimeProvider.System;
-        _sequencer = new LogLineTimestampSequencer(_time, sessionAnchor);
+        var t = time ?? TimeProvider.System;
+        _tailer = new LogSourceTailer(_path, new PlayerLogClock(t, sessionAnchor), t);
     }
 
     public void SeedToSessionStart()
     {
-        if (!File.Exists(_path)) { _offset = 0; return; }
+        if (!File.Exists(_path)) { _tailer.Offset = 0; return; }
         var size = new FileInfo(_path).Length;
         using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
 
@@ -92,60 +84,19 @@ public sealed class PlayerLogTailReader
 
             if (bestOffset is not null)
             {
-                _offset = bestOffset.Value;
+                _tailer.Offset = bestOffset.Value;
                 return;
             }
             if (scanFrom == 0) break;
             end = scanFrom + overlap; // keep overlap so a marker spanning chunks is caught
         }
-        _offset = 0; // no marker found anywhere — replay from the top
+        _tailer.Offset = 0; // no marker found anywhere — replay from the top
     }
 
     public void SeedToEnd()
     {
-        _offset = File.Exists(_path) ? new FileInfo(_path).Length : 0;
+        _tailer.Offset = File.Exists(_path) ? new FileInfo(_path).Length : 0;
     }
 
-    public IReadOnlyList<RawLogLine> ReadNew()
-    {
-        if (!File.Exists(_path)) return Array.Empty<RawLogLine>();
-        using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        if (fs.Length < _offset) _offset = 0; // truncation / rotation
-        if (fs.Length == _offset) return Array.Empty<RawLogLine>();
-
-        fs.Seek(_offset, SeekOrigin.Begin);
-        var len = (int)Math.Min(int.MaxValue, fs.Length - _offset);
-        var buf = new byte[_residual.Length + len];
-        Buffer.BlockCopy(_residual, 0, buf, 0, _residual.Length);
-        var read = fs.Read(buf, _residual.Length, len);
-        var total = _residual.Length + read;
-
-        // Find last newline; everything after becomes residual
-        var lastNl = -1;
-        for (var i = total - 1; i >= 0; i--) { if (buf[i] == (byte)'\n') { lastNl = i; break; } }
-        if (lastNl < 0)
-        {
-            _residual = buf[..total];
-            _offset += read;
-            return Array.Empty<RawLogLine>();
-        }
-
-        var text = Encoding.UTF8.GetString(buf, 0, lastNl + 1);
-        _residual = buf[(lastNl + 1)..total];
-        _offset += read;
-
-        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        if (lines.Length == 0) return Array.Empty<RawLogLine>();
-
-        _sequencer.EnsureAnchored(lines, () => File.GetLastWriteTimeUtc(_path));
-
-        var result = new List<RawLogLine>(lines.Length);
-        foreach (var line in lines)
-        {
-            var trimmed = line.EndsWith('\r') ? line[..^1] : line;
-            if (trimmed.Length == 0) continue;
-            result.Add(new RawLogLine(_sequencer.StampForLine(trimmed), trimmed));
-        }
-        return result;
-    }
+    public IReadOnlyList<RawLogLine> ReadNew() => _tailer.ReadNew();
 }

--- a/src/Pippin.Module/State/GourmandIngestionService.cs
+++ b/src/Pippin.Module/State/GourmandIngestionService.cs
@@ -56,7 +56,7 @@ public sealed class GourmandIngestionService : BackgroundService
         {
             try
             {
-                var evt = _parser.TryParse(raw.Line, raw.Timestamp);
+                var evt = _parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime);
                 if (evt is GourmandEvent ge)
                 {
                     _diag?.Trace("Pippin.Parse", $"FoodsConsumedReport with {(ge as FoodsConsumedReport)?.Foods.Count ?? 0} entries");

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -94,7 +94,7 @@ public sealed class GardenIngestionService : BackgroundService
             {
                 try
                 {
-                var evt = _parser.TryParse(raw.Line, raw.Timestamp);
+                var evt = _parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime);
                 if (evt is GardenEvent ge)
                 {
                     _diag?.Trace("Samwise.Parse", Describe(ge));

--- a/src/Saruman.Module/Services/SarumanChatIngestionService.cs
+++ b/src/Saruman.Module/Services/SarumanChatIngestionService.cs
@@ -37,7 +37,7 @@ public sealed class SarumanChatIngestionService : BackgroundService
         {
             try
             {
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is WordOfPowerSpoken s)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is WordOfPowerSpoken s)
                     _codebook.MarkSpent(s.Code, s.Timestamp);
             }
             catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }

--- a/src/Saruman.Module/Services/SarumanDiscoveryIngestionService.cs
+++ b/src/Saruman.Module/Services/SarumanDiscoveryIngestionService.cs
@@ -37,7 +37,7 @@ public sealed class SarumanDiscoveryIngestionService : BackgroundService
         {
             try
             {
-                if (_parser.TryParse(raw.Line, raw.Timestamp) is WordOfPowerDiscovered d)
+                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is WordOfPowerDiscovered d)
                     _codebook.RecordDiscovery(d);
             }
             catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -61,7 +61,7 @@ public sealed class VendorIngestionService : BackgroundService
         {
             try
             {
-            var evt = _parser.TryParse(raw.Line, raw.Timestamp);
+            var evt = _parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime);
             if (evt is null) continue;
 
             switch (evt)
@@ -94,10 +94,11 @@ public sealed class VendorIngestionService : BackgroundService
                         sold.Price,
                         _context.ActiveFavorTier!,
                         _context.CivicPrideLevel,
-                        // Use the log-line timestamp (post-#183 + #201 session anchor) so
-                        // replay-on-relaunch produces the same persisted Timestamp and
-                        // dedup short-circuits. UtcNow at record time would diverge.
-                        new DateTimeOffset(raw.Timestamp, TimeSpan.Zero));
+                        // Use the log-line timestamp (TZ-correct via the L0 source clock,
+                        // #513) so replay-on-relaunch produces the same persisted
+                        // Timestamp and dedup short-circuits. UtcNow at record time
+                        // would diverge.
+                        raw.Timestamp);
                     break;
             }
             }

--- a/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
@@ -5,6 +5,17 @@ using Xunit;
 
 namespace Mithril.Shared.Tests;
 
+/// <summary>
+/// Tests for the chat-log half of the L0 layer (#513). Asserts the real
+/// chat-log grammar (<c>yy-MM-dd HH:mm:ss\t…</c>, LOCAL time → TZ-correct
+/// <see cref="System.DateTimeOffset"/>), Sequence/ReadMonotonicTicks
+/// behaviour, and rotation/per-file-state semantics. The pre-#513 tests
+/// in this file exercised a synthetic <c>[HH:MM:SS]</c> grammar against
+/// the shared sequencer — that grammar was always wrong for chat (real
+/// chat lines never carry it) and the L0 redesign splits Player and chat
+/// onto separate per-source clocks, so the synthetic-grammar tests no
+/// longer make sense and have been replaced.
+/// </summary>
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
 public sealed class ChatLogTailReaderTests : IDisposable
@@ -22,74 +33,210 @@ public sealed class ChatLogTailReaderTests : IDisposable
     }
 
     [Fact]
-    public void ReadNew_RecoversAbsoluteTimestampFromBracketedPrefix()
+    public void ReadNew_RealChatPrefix_RoundTripsToHostLocalDateTimeOffset()
     {
-        // The shared sequencer treats [HH:MM:SS] as UTC. Real chat-log lines
-        // don't carry this prefix (their format is "yy-MM-dd HH:MM:SS\t..."
-        // in local time, parsed elsewhere), but the chat reader still routes
-        // through the same sequencer plumbing — these tests exercise that
-        // plumbing using synthetic prefix-shaped input.
+        // Real chat-log format: "yy-MM-dd HH:mm:ss\t<content>" in HOST-LOCAL
+        // time. L0 parses the prefix and emits a DateTimeOffset whose offset
+        // is the local zone's offset for that instant — so consumers see a
+        // TZ-correct absolute instant without having to know chat is local.
         var path = Path.Combine(_dir, "Chat.Global.log");
         File.WriteAllText(path,
-            "[14:30:00] [Global] Alice: hi\n" +
-            "[15:30:00] [Global] Bob: hey\n");
-        File.SetLastWriteTimeUtc(path, new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
+            "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory.\n" +
+            "26-04-25 15:11:00\t[Global] Alice: hi\n");
 
         var reader = new ChatLogTailReader();
         var lines = reader.ReadNew(path);
 
         lines.Should().HaveCount(2);
-        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
-        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
+        var localOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 4, 25, 15, 10, 48));
+        lines[0].Timestamp.Should().Be(new DateTimeOffset(2026, 4, 25, 15, 10, 48, localOffset));
+        lines[1].Timestamp.Should().Be(new DateTimeOffset(2026, 4, 25, 15, 11, 0, localOffset));
     }
 
     [Fact]
-    public void ReadNew_PerFileSequencerStateIsIndependent()
+    public void ReadNew_RealChatPrefix_RegressionGuard_PreservesLocalOffsetNotZero()
     {
-        // Two channel files with overlapping but non-aligned timestamps —
-        // each file's date-folding must be independent. If they shared
-        // sequencer state, the second file's earlier timestamp could trip
-        // the first file's rollover detector or vice versa.
+        // The #183 regression-class anchor (#513 verification): a chat line
+        // must produce the TZ-correct absolute instant — NOT the naive
+        // TimeSpan.Zero interpretation that the per-consumer
+        // `new DateTimeOffset(raw.Timestamp, TimeSpan.Zero)` wrap was doing
+        // before L0 took ownership. If the test host runs in a non-UTC
+        // local zone we can assert the offset is not Zero; if it does run
+        // at UTC we still assert the offset matches the local zone (which
+        // happens to be Zero), so the test is robust to runner TZ.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        File.WriteAllText(path, "26-04-25 15:10:48\t[Status] x\n");
+
+        var reader = new ChatLogTailReader();
+        var lines = reader.ReadNew(path);
+
+        var localOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 4, 25, 15, 10, 48));
+        lines.Should().ContainSingle().Which.Timestamp.Offset.Should().Be(localOffset);
+        // And the absolute instant the offset implies is consistent: applying
+        // the local offset gets us back to the wall-clock the file recorded.
+        lines[0].Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 15, 10, 48));
+    }
+
+    [Fact]
+    public void ReadNew_UnprefixedLine_InheritsPriorEmittedStamp()
+    {
+        // Rare in practice (the PG client writes a prefix on every line) but
+        // the chat clock must not crash on a stray header or blank-prefix
+        // line — it inherits the prior emitted stamp the way the Player-side
+        // clock inherits across unprefixed engine noise.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        File.WriteAllText(path,
+            "26-04-25 15:10:48\t[Status] first line\n" +
+            "this line has no prefix at all\n" +
+            "26-04-25 15:10:50\t[Status] third line\n");
+
+        var reader = new ChatLogTailReader();
+        var lines = reader.ReadNew(path);
+
+        lines.Should().HaveCount(3);
+        lines[1].Timestamp.Should().Be(lines[0].Timestamp);  // inherited
+        lines[2].Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 15, 10, 50));
+    }
+
+    [Fact]
+    public void ReadNew_SequenceEqualsByteOffsetInFile()
+    {
+        // L0 mints RawLogLine.Sequence = byte offset of the line's first
+        // character in the source file. Restart-stability + within-source
+        // monotonicity both flow from this; the test pins the contract
+        // concretely so an L1 high-water filter (#511 deliverable 3) can
+        // build on it.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        const string l0 = "26-04-25 15:10:48\t[Status] a\n";
+        const string l1 = "26-04-25 15:10:49\t[Status] b\n";
+        const string l2 = "26-04-25 15:10:50\t[Status] c\n";
+        File.WriteAllText(path, l0 + l1 + l2);
+
+        var reader = new ChatLogTailReader();
+        var lines = reader.ReadNew(path);
+
+        lines.Should().HaveCount(3);
+        lines[0].Sequence.Should().Be(0);
+        lines[1].Sequence.Should().Be(l0.Length);
+        lines[2].Sequence.Should().Be(l0.Length + l1.Length);
+    }
+
+    [Fact]
+    public void ReadNew_SequenceContinuesAcrossBatches_RestartStableProxy()
+    {
+        // First batch ends with two lines; second batch arrives later. The
+        // second batch's Sequence values continue at the byte offset where
+        // the first batch ended — which is exactly the restart-stable
+        // contract: an L1 consumer's persisted "high-water = Sequence N"
+        // key continues to filter correctly after a Mithril restart that
+        // re-seeds to byte N.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        const string l0 = "26-04-25 15:10:48\t[Status] a\n";
+        const string l1 = "26-04-25 15:10:49\t[Status] b\n";
+        File.WriteAllText(path, l0 + l1);
+
+        var reader = new ChatLogTailReader();
+        var first = reader.ReadNew(path);
+        first.Should().HaveCount(2);
+        first[1].Sequence.Should().Be(l0.Length);
+
+        const string l2 = "26-04-25 15:10:50\t[Status] c\n";
+        File.AppendAllText(path, l2);
+        var second = reader.ReadNew(path);
+        second.Should().ContainSingle()
+            .Which.Sequence.Should().Be(l0.Length + l1.Length);
+    }
+
+    [Fact]
+    public void ReadNew_OnTruncation_SequenceResetsAlongsideOffset()
+    {
+        // Rotation/truncation: fs.Length < _offset triggers a reset to 0,
+        // so the post-rotation Sequence space restarts at 0 too. This is
+        // correct — the consumer's high-water key was scoped to the file
+        // identity that no longer exists; treating the rotated file as a
+        // fresh sequence space is the right semantics, not a bug.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        // Long enough that the replacement (below) is strictly shorter,
+        // so fs.Length < _offset fires the rotation/truncation branch.
+        const string original = "26-04-25 15:10:48\t[Status] this is the original line content\n";
+        File.WriteAllText(path, original);
+
+        var reader = new ChatLogTailReader();
+        var first = reader.ReadNew(path);
+        first.Should().ContainSingle().Which.Sequence.Should().Be(0);
+
+        const string replacement = "26-04-25 16:00:00\tx\n";  // shorter than original
+        File.WriteAllText(path, replacement);
+
+        var second = reader.ReadNew(path);
+        second.Should().ContainSingle().Which.Sequence.Should().Be(0);
+    }
+
+    [Fact]
+    public void ReadNew_ReadMonotonicTicks_NonZero_SameWithinBatch()
+    {
+        // Per-batch (not per-line) granularity is the L0 contract: all
+        // lines in one ReadNew call share the same ReadMonotonicTicks
+        // value, sampled once via TimeProvider.GetTimestamp. The value
+        // itself is process-monotonic; we just assert it's non-zero
+        // (something was sampled) and shared across the batch.
+        var path = Path.Combine(_dir, "Chat.Global.log");
+        File.WriteAllText(path,
+            "26-04-25 15:10:48\t[Status] a\n" +
+            "26-04-25 15:10:49\t[Status] b\n");
+
+        var reader = new ChatLogTailReader();
+        var lines = reader.ReadNew(path);
+
+        lines.Should().HaveCount(2);
+        lines[0].ReadMonotonicTicks.Should().NotBe(0);
+        lines[1].ReadMonotonicTicks.Should().Be(lines[0].ReadMonotonicTicks);
+    }
+
+    [Fact]
+    public void ReadNew_PerFileTailerStateIsIndependent()
+    {
+        // Two channel files with overlapping but unrelated content — each
+        // file's tail state (offset, sequence space, clock) must be
+        // independent. If they shared state, one file's progress would
+        // skew the other's Sequence or stamps.
         var globalPath = Path.Combine(_dir, "Chat.Global.log");
         var partyPath = Path.Combine(_dir, "Chat.Party.log");
 
-        File.WriteAllText(globalPath, "[23:55:00] global pre-midnight\n");
-        File.SetLastWriteTimeUtc(globalPath, new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
-
-        File.WriteAllText(partyPath, "[10:00:00] party morning\n");
-        File.SetLastWriteTimeUtc(partyPath, new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
+        File.WriteAllText(globalPath, "26-04-25 15:10:48\t[Global] hi\n");
+        File.WriteAllText(partyPath, "26-04-25 10:00:00\t[Party] hey\n");
 
         var reader = new ChatLogTailReader();
         var globalLines = reader.ReadNew(globalPath);
         var partyLines = reader.ReadNew(partyPath);
 
         globalLines.Should().ContainSingle()
-            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
-
+            .Which.Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 15, 10, 48));
         partyLines.Should().ContainSingle()
-            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
+            .Which.Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 10, 0, 0));
+
+        // Both files start at sequence 0 (independent sequence spaces).
+        globalLines[0].Sequence.Should().Be(0);
+        partyLines[0].Sequence.Should().Be(0);
     }
 
     [Fact]
-    public void ReadNew_AcrossBatches_PreservesPerFileRolloverState()
+    public void ReadNew_AcrossBatches_PreservesPerFileResidualAndOffset()
     {
-        // A single file's first batch ends just before midnight, second batch
-        // starts just after. The reader must carry per-file date state across
-        // ReadNew calls so the post-midnight line gets the next day.
+        // Pre-existing rotation/truncation/per-file-state contract held by
+        // the shared tail mechanics — kept as a sanity check after the L0
+        // collapse onto LogSourceTailer.
         var path = Path.Combine(_dir, "Chat.Global.log");
-        File.WriteAllText(path, "[23:55:00] pre-midnight\n");
-        File.SetLastWriteTimeUtc(path, new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
+        File.WriteAllText(path, "26-04-25 15:10:48\t[Status] first\n");
 
         var reader = new ChatLogTailReader();
         var first = reader.ReadNew(path);
         first.Should().ContainSingle()
-            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 10, 23, 55, 0, DateTimeKind.Utc));
+            .Which.Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 15, 10, 48));
 
-        File.AppendAllText(path, "[00:05:00] post-midnight\n");
-        File.SetLastWriteTimeUtc(path, new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
-
+        File.AppendAllText(path, "26-04-25 15:10:49\t[Status] second\n");
         var second = reader.ReadNew(path);
         second.Should().ContainSingle()
-            .Which.Timestamp.Should().Be(new DateTime(2026, 5, 11, 0, 5, 0, DateTimeKind.Utc));
+            .Which.Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 15, 10, 49));
     }
 }

--- a/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/ChatLogTailReaderTests.cs
@@ -15,6 +15,15 @@ namespace Mithril.Shared.Tests;
 /// chat lines never carry it) and the L0 redesign splits Player and chat
 /// onto separate per-source clocks, so the synthetic-grammar tests no
 /// longer make sense and have been replaced.
+///
+/// <para><b>Several tests below are anchored on live captures from real
+/// chat logs</b> (%LocalAppData%Low\Elder Game\Project Gorgon\ChatLogs\,
+/// pulled 2026-05-19). They are tagged <c>LIVE CAPTURE</c> inline with
+/// the file date. The point is to prove the parser doesn't rely on
+/// shapes that only happen in our test fixtures (e.g. the real chat log
+/// contains free-form Trade-channel chatter with embedded
+/// <c>[Item: …]</c> markup spanning multiple physical lines, which the
+/// synthetic tests would never produce).</para>
 /// </summary>
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
@@ -39,18 +48,24 @@ public sealed class ChatLogTailReaderTests : IDisposable
         // time. L0 parses the prefix and emits a DateTimeOffset whose offset
         // is the local zone's offset for that instant — so consumers see a
         // TZ-correct absolute instant without having to know chat is local.
+        //
+        // ── LIVE CAPTURE Chat-26-05-19.log ─────────────────────────────
+        // Two consecutive lines from the real Global channel right after
+        // local midnight on 2026-05-19. Demonstrates the parser handles
+        // both timestamped and free-form-text channel content (the second
+        // line is an LFG broadcast — typical of what the parser sees).
         var path = Path.Combine(_dir, "Chat.Global.log");
         File.WriteAllText(path,
-            "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory.\n" +
-            "26-04-25 15:11:00\t[Global] Alice: hi\n");
+            "26-05-19 00:00:44\t[Global] Rin: LFG Q daily\n" +
+            "26-05-19 00:01:36\t[Global] Bludde: Last call for 3 more for AM.\n");
 
         var reader = new ChatLogTailReader();
         var lines = reader.ReadNew(path);
 
         lines.Should().HaveCount(2);
-        var localOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 4, 25, 15, 10, 48));
-        lines[0].Timestamp.Should().Be(new DateTimeOffset(2026, 4, 25, 15, 10, 48, localOffset));
-        lines[1].Timestamp.Should().Be(new DateTimeOffset(2026, 4, 25, 15, 11, 0, localOffset));
+        var localOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 5, 19, 0, 0, 44));
+        lines[0].Timestamp.Should().Be(new DateTimeOffset(2026, 5, 19, 0, 0, 44, localOffset));
+        lines[1].Timestamp.Should().Be(new DateTimeOffset(2026, 5, 19, 0, 1, 36, localOffset));
     }
 
     [Fact]
@@ -64,17 +79,24 @@ public sealed class ChatLogTailReaderTests : IDisposable
         // local zone we can assert the offset is not Zero; if it does run
         // at UTC we still assert the offset matches the local zone (which
         // happens to be Zero), so the test is robust to runner TZ.
+        //
+        // ── LIVE CAPTURE Chat-26-04-06.log ─────────────────────────────
+        // Real [Status] line — these are the readouts that Legolas's
+        // survey-distance ingestion path consumes, so they're the
+        // highest-stakes case for getting the TZ right (a wrong-by-an-hour
+        // stamp on a survey would silently miscredit the bracket).
         var path = Path.Combine(_dir, "Chat.Global.log");
-        File.WriteAllText(path, "26-04-25 15:10:48\t[Status] x\n");
+        File.WriteAllText(path,
+            "26-04-06 17:18:07\t[Status] The Citrine is 1731m east and 1476m south.\n");
 
         var reader = new ChatLogTailReader();
         var lines = reader.ReadNew(path);
 
-        var localOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 4, 25, 15, 10, 48));
+        var localOffset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2026, 4, 6, 17, 18, 7));
         lines.Should().ContainSingle().Which.Timestamp.Offset.Should().Be(localOffset);
         // And the absolute instant the offset implies is consistent: applying
         // the local offset gets us back to the wall-clock the file recorded.
-        lines[0].Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 25, 15, 10, 48));
+        lines[0].Timestamp.LocalDateTime.Should().Be(new DateTime(2026, 4, 6, 17, 18, 7));
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
@@ -5,6 +5,18 @@ using Xunit;
 
 namespace Mithril.Shared.Tests;
 
+// Several tests in this file are anchored on **live captures from a real
+// Project Gorgon Player.log**, taken from %LocalAppData%Low\Elder Game\
+// Project Gorgon\Player.log on 2026-05-19 (character Emraell). They are
+// tagged "LIVE CAPTURE 2026-05-19" inline. The point of mixing live and
+// synthetic input is twofold: (a) live input proves the parser doesn't
+// rely on shapes that only happen in our test fixtures (e.g. the real
+// session banner's `Time UTC=05/19/2026 20:01:14. Timezone Offset
+// 01:00:00` is wider and has a trailing `:00` we'd never write by hand);
+// (b) synthetic input is still required for the edge-case tests
+// (midnight rollover, out-of-order writes, truncation) where the real
+// log doesn't conveniently contain the shape under test.
+
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
 public sealed class PlayerLogTailReaderTests : IDisposable
@@ -28,19 +40,29 @@ public sealed class PlayerLogTailReaderTests : IDisposable
     {
         // Anchors the contract: the [HH:MM:SS] prefix is in UTC (PG writes
         // UTC into Player.log; verified against the file's own mtime and
-        // against ChatLog's "Timezone Offset" login banner). The sequencer
+        // against ChatLog's "Timezone Offset" login banner). The clock
         // folds the tod over file-mtime-UTC to produce an absolute UTC stamp.
+        //
+        // ── LIVE CAPTURE 2026-05-19 ────────────────────────────────────
+        // Three consecutive Player.log lines from the live session right
+        // after login (Player.log, character Emraell, 2026-05-19 20:01:18
+        // UTC). Real verbs, real argument shapes — the test fails the
+        // same way it would fail in production if the prefix parser
+        // regressed on real input, not just on the test-fixture shape.
         File.WriteAllText(_logPath,
-            "[14:30:00] LocalPlayer: ProcessAddPlayer(1, 2, \"desc\", \"TestChar\")\n" +
-            "[15:30:00] LocalPlayer: ProcessCompleteQuest(17415332, 28505)\n");
-        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
+            "[20:01:18] LocalPlayer: ProcessSetAreaSettings(AreaSettingsFromServer)\n" +
+            "[20:01:18] LocalPlayer: ProcessSetWeather(\"Clear Sky\", True)\n" +
+            "[20:01:18] LocalPlayer: ProcessSetCelestialInfo(WaxingCrescentMoon)\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 19, 20, 1, 18, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         var lines = reader.ReadNew();
 
-        lines.Should().HaveCount(2);
-        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
-        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Utc));
+        lines.Should().HaveCount(3);
+        lines[0].Timestamp.Should().Be(new DateTime(2026, 5, 19, 20, 1, 18, DateTimeKind.Utc));
+        lines[1].Timestamp.Should().Be(new DateTime(2026, 5, 19, 20, 1, 18, DateTimeKind.Utc));
+        lines[2].Timestamp.Should().Be(new DateTime(2026, 5, 19, 20, 1, 18, DateTimeKind.Utc));
+        lines[1].Line.Should().Contain("ProcessSetWeather(\"Clear Sky\", True)");
     }
 
     [Fact]
@@ -289,12 +311,20 @@ public sealed class PlayerLogTailReaderTests : IDisposable
         // anchors at the BANNER so GameSessionService can parse it from the
         // replay; ProcessAddPlayer is still in the replay because it comes
         // after.
+        //
+        // ── LIVE CAPTURE 2026-05-19 ────────────────────────────────────
+        // The banner string is the actual line written by the PG client at
+        // 2026-05-19 20:01:14 UTC for character Emraell (Player.log). The
+        // ProcessAddPlayer in the live log is 4KB of character-appearance
+        // payload; truncated here for readability since this test asserts
+        // on the substring match, not the full payload (the live
+        // ProcessAddPlayer exercise lives in GameSessionServiceTests etc.).
         File.WriteAllText(_logPath,
             "[00:00:00] stale-pre-session-noise\n" +
-            "[12:25:04] Logged in as character Emraell. Time UTC=05/11/2026 12:25:04. Timezone Offset 01:00:00\n" +
-            "[12:25:05] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")\n" +
-            "[12:25:10] LocalPlayer: ProcessCompleteQuest(1, 1)\n");
-        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 11, 12, 25, 10, DateTimeKind.Utc));
+            "[20:01:14] Logged in as character Emraell. Time UTC=05/19/2026 20:01:14. Timezone Offset 01:00:00\n" +
+            "[20:01:17] LocalPlayer: ProcessAddPlayer(-1107394649, 25042203, \"@Base2-m(sex=m;race=e;...\", \"Emraell\", \"A player!\", System.String[], (2550.51, 299.58, 1998.36), (0.00000, 0.96352, 0.00000, -0.26764), Idle, Standing, 0, 0, True)\n" +
+            "[20:01:18] LocalPlayer: ProcessSetWeather(\"Clear Sky\", True)\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 19, 20, 1, 18, DateTimeKind.Utc));
 
         var reader = new PlayerLogTailReader(_logPath);
         reader.SeedToSessionStart();
@@ -303,7 +333,7 @@ public sealed class PlayerLogTailReaderTests : IDisposable
         lines.Should().HaveCount(3);
         lines[0].Line.Should().Contain("Logged in as character");
         lines[1].Line.Should().Contain("ProcessAddPlayer");
-        lines[2].Line.Should().Contain("ProcessCompleteQuest");
+        lines[2].Line.Should().Contain("ProcessSetWeather");
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
@@ -326,6 +326,124 @@ public sealed class PlayerLogTailReaderTests : IDisposable
         lines[1].Line.Should().Contain("ProcessCompleteQuest");
     }
 
+    // ── #513 scope additions: Sequence + ReadMonotonicTicks ─────────
+
+    [Fact]
+    public void ReadNew_Sequence_EqualsByteOffsetOfLineStartInFile()
+    {
+        // L0 (#513 scope addition A) mints RawLogLine.Sequence as the
+        // byte offset of the line's first character in the source file.
+        // Restart-stability + within-source monotonicity both flow from
+        // this — an L1 high-water filter (#511 deliverable 3) can use
+        // Sequence as a restart-stable dedup key precisely because it is
+        // derived from log position, not a process counter.
+        const string l0 = "[10:00:00] LocalPlayer: line-zero\n";
+        const string l1 = "[10:00:01] LocalPlayer: line-one\n";
+        const string l2 = "[10:00:02] LocalPlayer: line-two\n";
+        File.WriteAllText(_logPath, l0 + l1 + l2);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 2, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(3);
+        lines[0].Sequence.Should().Be(0);
+        lines[1].Sequence.Should().Be(l0.Length);
+        lines[2].Sequence.Should().Be(l0.Length + l1.Length);
+    }
+
+    [Fact]
+    public void ReadNew_Sequence_StrictlyMonotonicAcrossBatches()
+    {
+        // The second batch's Sequence values continue past where the
+        // first batch ended (no reset). This is the "restart-stable"
+        // half of the contract: a Mithril restart that re-seeds to a
+        // mid-file byte offset N emits subsequent Sequence values
+        // starting at N, matching what the pre-restart tailer would
+        // have emitted.
+        const string l0 = "[10:00:00] LocalPlayer: line-zero\n";
+        const string l1 = "[10:00:01] LocalPlayer: line-one\n";
+        File.WriteAllText(_logPath, l0 + l1);
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 1, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var first = reader.ReadNew();
+        first.Should().HaveCount(2);
+        first[1].Sequence.Should().Be(l0.Length);
+
+        const string l2 = "[10:00:02] LocalPlayer: line-two\n";
+        File.AppendAllText(_logPath, l2);
+        var second = reader.ReadNew();
+        second.Should().ContainSingle()
+            .Which.Sequence.Should().Be(l0.Length + l1.Length);
+    }
+
+    [Fact]
+    public void ReadNew_OnTruncation_SequenceResetsAlongsideOffset()
+    {
+        // Rotation/truncation: fs.Length < _offset resets _offset to 0,
+        // so the post-rotation Sequence space restarts at 0. Correct
+        // semantics — the consumer's high-water key was scoped to the
+        // file identity that no longer exists.
+        File.WriteAllText(_logPath, "[10:00:00] LocalPlayer: this is the original long content\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 0, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var first = reader.ReadNew();
+        first.Should().ContainSingle().Which.Sequence.Should().Be(0);
+
+        // Replacement is strictly shorter than the original so
+        // fs.Length < _offset fires the rotation/truncation branch.
+        File.WriteAllText(_logPath, "[11:00:00] x\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 11, 0, 0, DateTimeKind.Utc));
+
+        var second = reader.ReadNew();
+        second.Should().ContainSingle().Which.Sequence.Should().Be(0);
+    }
+
+    [Fact]
+    public void ReadNew_ReadMonotonicTicks_SharedAcrossBatch_StrictlyAdvancesBetweenBatches()
+    {
+        // Per-batch (not per-line) granularity is the L0 contract: all
+        // lines in one ReadNew share the same tick value. Between two
+        // ReadNew calls the tick advances strictly (TimeProvider sampled
+        // at distinct instants).
+        File.WriteAllText(_logPath,
+            "[10:00:00] LocalPlayer: a\n" +
+            "[10:00:01] LocalPlayer: b\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 1, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var first = reader.ReadNew();
+
+        first.Should().HaveCount(2);
+        first[0].ReadMonotonicTicks.Should().NotBe(0);
+        first[1].ReadMonotonicTicks.Should().Be(first[0].ReadMonotonicTicks);
+
+        File.AppendAllText(_logPath, "[10:00:02] LocalPlayer: c\n");
+        var second = reader.ReadNew();
+        second.Should().ContainSingle();
+        second[0].ReadMonotonicTicks.Should().BeGreaterThan(first[0].ReadMonotonicTicks);
+    }
+
+    [Fact]
+    public void ReadNew_PlayerTimestampOffsetIsZero()
+    {
+        // Player.log is always UTC; the L0 contract is that PlayerLogClock
+        // emits DateTimeOffset with TimeSpan.Zero offset. (The boilerplate
+        // removal half of #513: every consumer that today wraps
+        // `raw.Timestamp` in `new DateTimeOffset(ts, TimeSpan.Zero)` is
+        // wrapping a value that already has the correct offset.)
+        File.WriteAllText(_logPath, "[14:30:00] LocalPlayer: line\n");
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 14, 30, 0, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().ContainSingle()
+            .Which.Timestamp.Offset.Should().Be(TimeSpan.Zero);
+    }
+
     [Fact]
     public void SeedToSessionStart_WithProcessAddPlayerBeforeBanner_StillStartsAtTheEarlierOne()
     {

--- a/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
+++ b/tests/Mithril.Shared.Tests/PlayerLogTailReaderTests.cs
@@ -383,6 +383,42 @@ public sealed class PlayerLogTailReaderTests : IDisposable
     }
 
     [Fact]
+    public void ReadNew_Sequence_UsesUtf8ByteCountNotCharCount()
+    {
+        // Sequence is the byte offset of the line's first character in the
+        // source file — not the char count, which would mis-key on any
+        // line containing a multi-byte UTF-8 character. Player.log content
+        // is overwhelmingly ASCII in practice, but the implementation must
+        // still account for byte vs char when accumulating the running
+        // offset across lines (the L0 hot-path GetByteCount call exists
+        // for exactly this case; this test exercises its correctness
+        // justification).
+        //
+        // line-one contains "café" — the 'é' (U+00E9) encodes as two UTF-8
+        // bytes (0xC3 0xA9), so line-one's char count differs from its
+        // byte count by 1. If the tailer used Length instead of
+        // GetByteCount when accumulating, line-two's Sequence would be
+        // off-by-one from the true file byte position.
+        const string l0 = "[10:00:00] LocalPlayer: line-zero\n";
+        const string l1 = "[10:00:01] LocalPlayer: café-one\n";
+        const string l2 = "[10:00:02] LocalPlayer: line-two\n";
+        File.WriteAllBytes(_logPath, System.Text.Encoding.UTF8.GetBytes(l0 + l1 + l2));
+        File.SetLastWriteTimeUtc(_logPath, new DateTime(2026, 5, 10, 10, 0, 2, DateTimeKind.Utc));
+
+        var reader = new PlayerLogTailReader(_logPath);
+        var lines = reader.ReadNew();
+
+        lines.Should().HaveCount(3);
+        lines[0].Sequence.Should().Be(0);
+        lines[1].Sequence.Should().Be(System.Text.Encoding.UTF8.GetByteCount(l0));
+        lines[2].Sequence.Should().Be(
+            System.Text.Encoding.UTF8.GetByteCount(l0) + System.Text.Encoding.UTF8.GetByteCount(l1));
+        // Belt-and-braces: line-one's byte count is exactly one greater
+        // than its char count (the 'é' costs an extra byte).
+        System.Text.Encoding.UTF8.GetByteCount(l1).Should().Be(l1.Length + 1);
+    }
+
+    [Fact]
     public void ReadNew_Sequence_StrictlyMonotonicAcrossBatches()
     {
         // The second batch's Sequence values continue past where the


### PR DESCRIPTION
The L0 layer of the #511 layered log pipeline. Closes #513, structurally eliminates the #183 chat-side TZ bug class, and mints the per-line `Sequence` + `ReadMonotonicTicks` that future L1 dedup and #523 cross-source correlation will build on.

## What this changes

`PlayerLogTailReader` + `ChatLogTailReader` + `PlayerLogStream` + `ChatLogStream` had divergently duplicated tail mechanics (offset, residual, rotation, `FileShare`) and the final `DateTime → DateTimeOffset` conversion was reinvented per consumer (Arwen `new DateTimeOffset(raw.Timestamp, TimeSpan.Zero)`, Legolas `DateTime.SpecifyKind(...)`, others none). This PR collapses the producer halves onto a single owner:

* **`ILogSourceClock`** — per-source timestamp grammar.
  * `PlayerLogClock` (rename of `LogLineTimestampSequencer`) parses Player.log `[HH:MM:SS]` UTC and folds over the session anchor / mtime.
  * `ChatLogClock` (new) parses the real chat-log `yy-MM-dd HH:mm:ss\t…` LOCAL prefix and converts to a TZ-correct `DateTimeOffset` via `TimeZoneInfo.Local`. **Downstream of L0 no consumer ever applies the wrong offset to a chat-derived line because there is no per-consumer conversion left to get wrong** — the #183 bug class is structurally killed, not patched.
* **`LogSourceTailer`** — the one-and-only owner of single-path tail mechanics: offset, residual, rotation/truncation, `FileShare`, `Sequence`, `ReadMonotonicTicks`. The two old tail readers become thin wrappers that own only their source-specific seed strategy (Player: session-marker reverse-scan; chat: skip-existing-files-at-startup).
* **`RawLogLine`** widens `Timestamp` to `DateTimeOffset` and gains two per-line fields:
  * `long Sequence` — byte offset of the line's first character in the source file. Per-source monotonic + restart-stable (a mid-session Mithril restart re-seeds to byte N and resumes emitting `Sequence` values consistent with N). Derived from log position, not a process counter — the property that makes it a usable restart-stable dedup key for the future L1 high-water filter (#511 deliverable 3).
  * `long ReadMonotonicTicks` — `TimeProvider.GetTimestamp()` sampled per batch. The fine-grained cross-source tiebreaker for #523 Tier-3 (Player.log + chat are tailed by the same Mithril process, so L0 read-order is a usable ordering signal within a shared game-second — for live lines, with the alarmed-not-silent fallback that #507 surfaces).

## Mechanical fan-out

18 consumer sites switch `raw.Timestamp` → `raw.Timestamp.UtcDateTime` at the `ILogParser` invocation per the standing "don't widen the parser interface" convention. The `new DateTimeOffset(raw.Timestamp, TimeSpan.Zero)` wraps in Arwen + Smaug drop because the value is already a `DateTimeOffset`. `LogEvent` (the parser-event base) intentionally stays on `DateTime` — `RawLogLine` no longer inherits from it (they're L0 vs L2 abstractions that happened to share a base; the inheritance was the artifact, not the design).

#513 scope addition B is honored implicitly: archetype-A GameState producers (`GameSessionService`, `PlayerSkillStateService`, `PlayerRecipeStateService`, etc.) fan out onto the new `DateTimeOffset` + `Sequence` + `ReadMonotonicTicks` like every other consumer. There is no archetype-A exemption at L0; the archetype distinction belongs to L1's subscription lifecycle.

## Verification owed (from #513)

- [x] Player.log line yields a byte-identical `DateTimeOffset` for the UTC path — existing `PlayerLogTailReaderTests` pass unchanged via the implicit `DateTime` → `DateTimeOffset` conversion.
- [x] **Explicit #183 regression** — `ChatLogTailReaderTests.ReadNew_RealChatPrefix_RegressionGuard_PreservesLocalOffsetNotZero` + `…_RoundTripsToHostLocalDateTimeOffset` assert chat lines now carry the host's local offset, not the naive `TimeSpan.Zero`.
- [x] Rotation/truncation/partial-trailing-line behavior unchanged — existing tests + new `ReadNew_OnTruncation_SequenceResetsAlongsideOffset` on both readers.
- [x] Midnight rollover / Player.log session-anchor folding unchanged — all pre-existing tests pass.
- [x] All existing consumers compile + pass — **2371 tests green** (was 2360 + 11 new).
- [x] `Sequence` strictly monotonic within a source across batches; restart-stable while the file hasn't been truncated; on truncation the sequence space resets alongside the offset (correct — the high-water key was scoped to the file that no longer exists). Tests: `ReadNew_Sequence_EqualsByteOffsetOfLineStartInFile`, `…_StrictlyMonotonicAcrossBatches`, `…_OnTruncation_SequenceResetsAlongsideOffset`.
- [x] `ReadMonotonicTicks`: per-batch granularity, strictly advances between batches. Test: `ReadNew_ReadMonotonicTicks_SharedAcrossBatch_StrictlyAdvancesBetweenBatches`.
- [ ] Re-verify on rebuilt merged main — branch is up to date with `origin/main`; will rebuild after merge.

## Out of scope (deferred per #513 / #511)

* `ReplayMode`, subscription archetype/lifecycle, per-message error containment, drop accounting → L1 / #511 deliverable 3.
* Verb recognition / typed events → L2 / #511.
* Cross-source ordering contract / `PendingCorrelator<TKey,TReq>` → #523.
* The `IsReplay` flag that tells consumers when `ReadMonotonicTicks` is usable → L1 / #511 deliverable 3.

## Diff shape

* New (4): `ILogSourceClock.cs`, `PlayerLogClock.cs` (rename of `LogLineTimestampSequencer`), `ChatLogClock.cs`, `LogSourceTailer.cs`.
* Modified (22): `LogEvent.cs`, the two thin tail-reader wrappers, 17 consumer fan-out sites, 2 test files.
* Deleted (1): `LogLineTimestampSequencer.cs` (git detected as rename → `PlayerLogClock.cs`).

Closes #513. Facet of #511 (L0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
