### PR TITLE
fix(gamestate): guard snapshot parsers against per-row int/long overflow (#525)

### DIFF
--- a/src/Mithril.GameState/Recipes/Parsing/RecipeLogParser.cs
+++ b/src/Mithril.GameState/Recipes/Parsing/RecipeLogParser.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 
 namespace Mithril.GameState.Recipes.Parsing;
@@ -59,6 +61,21 @@ public sealed partial class RecipeLogParser : ILogParser
 
     private static readonly char[] Comma = [','];
 
+    private readonly ThrottledWarn _warn;
+
+    /// <summary>
+    /// Constructs the parser. Pass an <see cref="IDiagnosticsSink"/> to surface
+    /// the rare malformed-row breadcrumb that <see cref="ParseRow"/> emits when
+    /// a numeric token fails <c>int.TryParse</c> (oversized id / count via
+    /// grammar drift — guards against issue #525). A <c>null</c> sink makes the
+    /// warn a no-op; the throttle window suppresses a per-line flood from a
+    /// pathologically corrupt payload.
+    /// </summary>
+    public RecipeLogParser(IDiagnosticsSink? diag = null)
+    {
+        _warn = new ThrottledWarn(diag, "GameState.Recipes");
+    }
+
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
         // Fast path: the vast majority of Player.log lines are neither verb.
@@ -85,9 +102,20 @@ public sealed partial class RecipeLogParser : ILogParser
             var recipes = new List<RecipeCompletionRecord>(ids.Length);
             for (int i = 0; i < ids.Length; i++)
             {
-                recipes.Add(new RecipeCompletionRecord(
-                    int.Parse(ids[i]), int.Parse(counts[i])));
+                // Per-row row-skip on overflow / non-numeric: parallel-array
+                // alignment is preserved when the bad (id, count) PAIR drops
+                // together. A 999-of-1000 partial snapshot is better than zero
+                // — the missing row recovers on the next ProcessLoadRecipes
+                // (zone / session transition). See #525.
+                if (TryParseRow(ids[i], counts[i], out var record))
+                    recipes.Add(record);
             }
+
+            // All rows were degenerate — fall through to the same "emit
+            // nothing" stance as line 83 (empty / mismatched payload). The
+            // already-published snapshot stands until the next transition.
+            if (recipes.Count == 0) return null;
+
             return new RecipesSnapshotEvent(timestamp, recipes);
         }
 
@@ -95,12 +123,28 @@ public sealed partial class RecipeLogParser : ILogParser
         {
             var m = UpdateRecipePayloadRx().Match(line);
             if (!m.Success) return null;
-            return new RecipeUpdateEvent(timestamp, new RecipeCompletionRecord(
-                int.Parse(m.Groups["id"].ValueSpan),
-                int.Parse(m.Groups["count"].ValueSpan)));
+
+            // Whole-event is one row; if either field overflows, drop the
+            // event entirely (with breadcrumb). Snapshot state stands.
+            if (!TryParseRow(m.Groups["id"].Value, m.Groups["count"].Value, out var record))
+                return null;
+            return new RecipeUpdateEvent(timestamp, record);
         }
 
         return null;
+    }
+
+    private bool TryParseRow(string idText, string countText, out RecipeCompletionRecord record)
+    {
+        if (int.TryParse(idText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id)
+            && int.TryParse(countText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
+        {
+            record = new RecipeCompletionRecord(id, count);
+            return true;
+        }
+        _warn.Warn($"Dropping recipe row with unparseable numeric token (id='{idText}', count='{countText}')");
+        record = default;
+        return false;
     }
 
     private static string[] Split(string list) =>

--- a/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 
 namespace Mithril.GameState.Skills.Parsing;
@@ -68,6 +70,21 @@ public sealed partial class SkillLogParser : ILogParser
         RegexOptions.CultureInvariant)]
     private static partial Regex SkillTupleRx();
 
+    private readonly ThrottledWarn _warn;
+
+    /// <summary>
+    /// Constructs the parser. Pass an <see cref="IDiagnosticsSink"/> to surface
+    /// the rare malformed-row breadcrumb that <see cref="TryToRecord"/> emits
+    /// when a numeric token fails <c>(int|long).TryParse</c> (oversized
+    /// raw/bonus/xp/tnl/max via grammar drift — guards against issue #525). A
+    /// <c>null</c> sink makes the warn a no-op; the throttle window suppresses
+    /// a per-line flood from a pathologically corrupt payload.
+    /// </summary>
+    public SkillLogParser(IDiagnosticsSink? diag = null)
+    {
+        _warn = new ThrottledWarn(diag, "GameState.Skills");
+    }
+
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
         // Fast path: the vast majority of Player.log lines are neither verb.
@@ -83,7 +100,12 @@ public sealed partial class SkillLogParser : ILogParser
             var skills = new List<SkillProgressRecord>();
             foreach (Match m in SkillTupleRx().Matches(line))
             {
-                skills.Add(ToRecord(m));
+                // Per-row row-skip on numeric overflow / non-integer: keep the
+                // surrounding ~124 well-formed skills rather than dropping the
+                // whole snapshot. The missing row recovers on the next
+                // ProcessLoadSkills (zone / session transition). See #525.
+                if (TryToRecord(m, out var record))
+                    skills.Add(record);
             }
 
             // A ProcessLoadSkills line with no parseable struct is degenerate
@@ -96,22 +118,49 @@ public sealed partial class SkillLogParser : ILogParser
         {
             var m = SkillTupleRx().Match(line);
             if (!m.Success) return null;
+            if (!TryToRecord(m, out var record)) return null;
 
             // arg3 = XP gained this tick. Defaults to 0 if the tail is absent
             // (grammar drift) — the struct is still authoritative for state.
+            // An oversized arg3 (would-be overflow) is also treated as 0 with
+            // a breadcrumb rather than killing the otherwise-valid update.
+            long gained = 0;
             var g = XpGainRx().Match(line);
-            long gained = g.Success ? long.Parse(g.Groups["gained"].ValueSpan) : 0;
-            return new SkillProgressUpdateEvent(timestamp, ToRecord(m), gained);
+            if (g.Success
+                && !long.TryParse(g.Groups["gained"].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out gained))
+            {
+                _warn.Warn($"ProcessUpdateSkill: unparseable XpGained '{g.Groups["gained"].Value}', defaulting to 0");
+                gained = 0;
+            }
+            return new SkillProgressUpdateEvent(timestamp, record, gained);
         }
 
         return null;
     }
 
-    private static SkillProgressRecord ToRecord(Match m) => new(
-        SkillKey: m.Groups["type"].Value,
-        Level: int.Parse(m.Groups["raw"].ValueSpan),
-        BonusLevels: int.Parse(m.Groups["bonus"].ValueSpan),
-        XpTowardNextLevel: long.Parse(m.Groups["xp"].ValueSpan),
-        XpNeededForNextLevel: long.Parse(m.Groups["tnl"].ValueSpan),
-        MaxLevel: int.Parse(m.Groups["max"].ValueSpan));
+    private bool TryToRecord(Match m, out SkillProgressRecord record)
+    {
+        if (int.TryParse(m.Groups["raw"].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var raw)
+            && int.TryParse(m.Groups["bonus"].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bonus)
+            && long.TryParse(m.Groups["xp"].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var xp)
+            && long.TryParse(m.Groups["tnl"].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tnl)
+            && int.TryParse(m.Groups["max"].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var max))
+        {
+            record = new SkillProgressRecord(
+                SkillKey: m.Groups["type"].Value,
+                Level: raw,
+                BonusLevels: bonus,
+                XpTowardNextLevel: xp,
+                XpNeededForNextLevel: tnl,
+                MaxLevel: max);
+            return true;
+        }
+        _warn.Warn(
+            $"Dropping skill row '{m.Groups["type"].Value}' with unparseable numeric field " +
+            $"(raw='{m.Groups["raw"].Value}', bonus='{m.Groups["bonus"].Value}', " +
+            $"xp='{m.Groups["xp"].Value}', tnl='{m.Groups["tnl"].Value}', " +
+            $"max='{m.Groups["max"].Value}')");
+        record = default!;
+        return false;
+    }
 }

--- a/tests/Mithril.GameState.Tests/Recipes/RecipeLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Recipes/RecipeLogParserTests.cs
@@ -90,4 +90,71 @@ public sealed class RecipeLogParserTests
     [InlineData("[10:10:03] LocalPlayer: ProcessSetStarredRecipes(System.Collections.Generic.HashSet`1[System.Int32])")]
     public void Unrelated_lines_return_null(string line)
         => _parser.TryParse(line, Ts).Should().BeNull();
+
+    // ----- #525: per-row int.TryParse guard (containment vs. snapshot loss) -----
+
+    [Fact]
+    public void ProcessLoadRecipes_skips_oversized_id_row_and_keeps_the_rest()
+    {
+        // The middle id overflows int (>= 2^31). Per #525 row-skip policy, the
+        // good rows still ship; only the bad PAIR (id+count) drops together so
+        // parallel-array alignment is preserved.
+        var line = "[10:10:03] LocalPlayer: ProcessLoadRecipes(" +
+                   "[1,99999999999999,3,], [7,42,9,])";
+        var snap = _parser.TryParse(line, Ts).Should().BeOfType<RecipesSnapshotEvent>().Subject;
+
+        snap.Recipes.Should().BeEquivalentTo(new[]
+        {
+            new RecipeCompletionRecord(1, 7),
+            new RecipeCompletionRecord(3, 9),
+        });
+    }
+
+    [Fact]
+    public void ProcessLoadRecipes_skips_oversized_count_row_and_keeps_the_rest()
+    {
+        // Symmetric: the count side overflows. The (id, count) pair drops.
+        var line = "[10:10:03] LocalPlayer: ProcessLoadRecipes(" +
+                   "[1,2,3,], [7,99999999999999,9,])";
+        var snap = _parser.TryParse(line, Ts).Should().BeOfType<RecipesSnapshotEvent>().Subject;
+
+        snap.Recipes.Select(r => r.RecipeId).Should().Equal(1, 3);
+    }
+
+    [Fact]
+    public void ProcessLoadRecipes_with_all_rows_degenerate_returns_null()
+    {
+        // No good rows survive — treat as the degenerate empty case (line 83):
+        // emit nothing, let prior snapshot stand until next transition.
+        var line = "LocalPlayer: ProcessLoadRecipes(" +
+                   "[99999999999999,88888888888888,], [0,0,])";
+        _parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void ProcessUpdateRecipe_with_oversized_id_returns_null()
+    {
+        // Single-record event: a malformed id is unrecoverable for THIS
+        // event. Drop it; snapshot state stands.
+        var line = "[10:22:39] LocalPlayer: ProcessUpdateRecipe(99999999999999, 1)";
+        _parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void ProcessUpdateRecipe_with_oversized_count_returns_null()
+    {
+        var line = "[10:22:39] LocalPlayer: ProcessUpdateRecipe(7026, 99999999999999)";
+        _parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void Oversized_token_does_not_throw_OverflowException()
+    {
+        // The whole point of #525: a single bad token must not poison the
+        // parser. (Containment in PlayerRecipeStateService catches throws too,
+        // but a throw would still discard the entire snapshot.)
+        var line = "LocalPlayer: ProcessLoadRecipes([1,99999999999999,3,], [7,42,9,])";
+        Action act = () => _parser.TryParse(line, Ts);
+        act.Should().NotThrow();
+    }
 }

--- a/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/SkillLogParserTests.cs
@@ -137,4 +137,68 @@ public sealed class SkillLogParserTests
         // snapshot that would wipe live state.
         _parser.TryParse("[08:22:21] LocalPlayer: ProcessLoadSkills()", Ts).Should().BeNull();
     }
+
+    // ----- #525: per-row (int|long).TryParse guard (containment vs. snapshot loss) -----
+
+    [Fact]
+    public void ProcessLoadSkills_skips_oversized_field_row_and_keeps_the_rest()
+    {
+        // The middle struct's `xp` would overflow long (>= 2^63). Per #525
+        // row-skip policy, the surrounding good rows still ship — only the
+        // unparseable per-skill row drops.
+        var line = "[08:22:21] LocalPlayer: ProcessLoadSkills(" +
+                   "{type=Toolcrafting,raw=15,bonus=0,xp=26,tnl=680,max=50}, " +
+                   "{type=Tanning,raw=50,bonus=3,xp=99999999999999999999,tnl=5280,max=50}, " +
+                   "{type=Werewolf,raw=56,bonus=4,xp=13091,tnl=188650,max=70})";
+        var snap = _parser.TryParse(line, Ts).Should().BeOfType<SkillsSnapshotEvent>().Subject;
+
+        snap.Skills.Select(s => s.SkillKey).Should().Equal("Toolcrafting", "Werewolf");
+    }
+
+    [Fact]
+    public void ProcessLoadSkills_with_all_rows_degenerate_returns_null()
+    {
+        // No struct survived row-parse — fall through to the same empty-payload
+        // stance as line 92 (emit nothing, snapshot stands).
+        var line = "LocalPlayer: ProcessLoadSkills(" +
+                   "{type=A,raw=99999999999,bonus=0,xp=0,tnl=0,max=0}, " +
+                   "{type=B,raw=0,bonus=0,xp=99999999999999999999,tnl=0,max=0})";
+        _parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void ProcessUpdateSkill_with_oversized_struct_field_returns_null()
+    {
+        // Single-record event: a malformed struct field is unrecoverable for
+        // THIS event. Drop it; snapshot state stands.
+        var line = "[10:49:51] LocalPlayer: ProcessUpdateSkill(" +
+                   "{type=NatureAppreciation,raw=99999999999,bonus=2,xp=315,tnl=1350,max=50}, True, 110, 0, 0)";
+        _parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void ProcessUpdateSkill_with_oversized_arg3_defaults_XpGained_to_zero()
+    {
+        // arg3 overflowing long must not kill the event — the struct is the
+        // authoritative state. Per #525, treat a malformed arg3 the same as
+        // arg3-absent: emit the update with XpGained=0.
+        var line = "[10:49:51] LocalPlayer: ProcessUpdateSkill(" +
+                   "{type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 99999999999999999999, 0, 0)";
+        var upd = _parser.TryParse(line, Ts).Should().BeOfType<SkillProgressUpdateEvent>().Subject;
+        upd.Skill.SkillKey.Should().Be("Sword");
+        upd.XpGained.Should().Be(0);
+    }
+
+    [Fact]
+    public void Oversized_token_does_not_throw_OverflowException()
+    {
+        // The whole point of #525: a single bad token must not poison the
+        // parser. (Containment in PlayerSkillStateService catches throws too,
+        // but a throw would still discard the entire snapshot.)
+        var line = "LocalPlayer: ProcessLoadSkills(" +
+                   "{type=A,raw=15,bonus=0,xp=99999999999999999999,tnl=680,max=50}, " +
+                   "{type=B,raw=50,bonus=3,xp=0,tnl=5280,max=50})";
+        Action act = () => _parser.TryParse(line, Ts);
+        act.Should().NotThrow();
+    }
 }


### PR DESCRIPTION
Closes #525.

## What

`RecipeLogParser` and `SkillLogParser` called `int.Parse` / `long.Parse` directly on regex-captured numeric tokens whose patterns (`[\d,]*` / `\d+`) place no upper bound on digit count. A single oversized token threw `OverflowException` mid-parse. Consumer containment (#515 / #522) stopped this from killing the stream, but the **whole snapshot was lost** for that ingestion event — for `ProcessLoadRecipes` / `ProcessLoadSkills` (full known-recipe / 125-skill dumps), one bad token wiped all rows until the next zone/session transition.

This is the parser-robustness counterpart to the #512 containment work: containment prevents *silent consumer death*; this PR prevents *silent snapshot loss*.

## Design call

Per the issue, **option A (row-skip + ThrottledWarn)**: parallel-array alignment is preserved when the bad `(id, count)` PAIR drops together. A 999-of-1000 partial snapshot is better than zero; the missing row recovers on the next snapshot emission. Mirrors `QuestJournalLoadParser.ParseIdList`'s silent-skip with an observability breadcrumb added.

Single-record updates (`ProcessUpdateRecipe` / `ProcessUpdateSkill`) can't partially recover — they drop the event entirely with a Warn; snapshot state stands. `SkillLogParser`'s `XpGain` extraction defaults to 0 on overflow, same as the arg3-absent fallback (the struct is still authoritative).

## How

- `RecipeLogParser` / `SkillLogParser` gain an optional `IDiagnosticsSink? diag = null` ctor param so DI threads `SerilogDiagnosticsSink` and existing test instantiations remain zero-arg.
- A `ThrottledWarn` (5s window, "GameState.Recipes" / "GameState.Skills" category) prevents a pathologically corrupt payload from flooding the sink — same pattern the consumer services already use.
- `TryParseRow` / `TryToRecord` helpers wrap the numeric extraction with `TryParse(NumberStyles.Integer, InvariantCulture)`; failures Warn and return `false` (caller skips the row).

## Tests

- `ProcessLoadRecipes_skips_oversized_id_row_and_keeps_the_rest`
- `ProcessLoadRecipes_skips_oversized_count_row_and_keeps_the_rest`
- `ProcessLoadRecipes_with_all_rows_degenerate_returns_null`
- `ProcessUpdateRecipe_with_oversized_id_returns_null`
- `ProcessUpdateRecipe_with_oversized_count_returns_null`
- `RecipeLogParser.Oversized_token_does_not_throw_OverflowException`
- `ProcessLoadSkills_skips_oversized_field_row_and_keeps_the_rest`
- `ProcessLoadSkills_with_all_rows_degenerate_returns_null`
- `ProcessUpdateSkill_with_oversized_struct_field_returns_null`
- `ProcessUpdateSkill_with_oversized_arg3_defaults_XpGained_to_zero`
- `SkillLogParser.Oversized_token_does_not_throw_OverflowException`

Existing parser tests (snapshot zip, log-order, XP-gained chat oracle, level-up tick, idempotent re-emit, mismatched-array, unrelated-line) all still pass — well-formed payloads parse byte-identically.

Full suite: `dotnet test Mithril.slnx` — all suites green (Mithril.GameState 286/286, plus Samwise/Legolas/Silmarillion/Mithril.Shared/etc.).

## Out of scope

- Containment — done (#515 / #522). Wrappers stay.
- Other parsers — chat parsers' grammar doesn't bind to numeric overflow; if a future `[GeneratedRegex]` audit finds similar unguarded conversions, file follow-ups.
- L2 recognizer migration (#511 deliverable 4) — this fix carries forward when the parsers move to the shared composable recognizers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
