### PR TITLE
test(logging): pin cross-source UTC↔local timestamp contract (closes #535)

### DIFF
--- a/tests/Mithril.Shared.Tests/Logging/ChatLogClockTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/ChatLogClockTests.cs
@@ -129,7 +129,7 @@ public sealed class ChatLogClockTests
     // fixture encodes the gap so the refactor tracked in #538 can flip
     // Skip to null and gain a green regression test in the same commit.
 
-    [Fact(Skip = "Tracking gap #538: ChatLogClock uses TimeZoneInfo.Local instead of the originating banner's Timezone Offset, so cross-machine chat-log replay produces a wrong-by-the-offset UTC. Flip Skip to null once #538 lands.")]
+    [Fact(Skip = "Tracking gap #538 — ChatLogClock uses TimeZoneInfo.Local; flip Skip when #538 lands. See doc comment above for the full reason.")]
     public void Pair3_WithReplayMachineTimeZone_GapWitness()
     {
         // Simulate the user replaying the alt machine's chat log (whose
@@ -160,10 +160,10 @@ public sealed class ChatLogClockTests
 
     private static TimeZoneInfo FixedOffsetZone(TimeSpan offset)
     {
-        // Per-call unique id so two callers with the same offset don't
-        // collide on the global TimeZoneInfo registry under parallel
-        // xunit execution.
-        var id = $"FixedOffsetTestZone_{offset.Ticks}_{Guid.NewGuid():N}";
+        // CreateCustomTimeZone doesn't register in any global table —
+        // each call returns a fresh instance — so the id only needs to
+        // be human-readable, not globally unique.
+        var id = $"FixedOffsetTestZone_{offset.Ticks}";
         return TimeZoneInfo.CreateCustomTimeZone(id, offset, id, id);
     }
 }

--- a/tests/Mithril.Shared.Tests/Logging/ChatLogClockTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/ChatLogClockTests.cs
@@ -1,0 +1,169 @@
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Logging;
+
+/// <summary>
+/// Fixture for the chat-side half of the cross-source UTC↔local
+/// timestamp contract — see wiki Player-Log-Signals #cross-source-timestamp-contract
+/// and issue #535. The corpus is three live-captured login-banner pairs
+/// from 2026-05-19 (one same-day UTC+1, one cross-local-midnight UTC+1,
+/// one opposite-sign UTC-7); the Player-side half lives in
+/// <see cref="PlayerLogClockTests"/>.
+///
+/// <para>The contract this fixture pins:</para>
+/// <list type="bullet">
+///   <item>With the originating banner's <c>Timezone Offset</c> injected
+///   as a fixed-offset <see cref="TimeZoneInfo"/>, <see cref="ChatLogClock"/>
+///   round-trips the local-stamped chat line to a UTC instant that
+///   exactly equals the corresponding Player.log <c>Time UTC=…</c> value.
+///   This is the cross-source contract: the same physical event,
+///   reconstructed identically from either log.</item>
+///   <item>Pair 2 specifically witnesses that a chat-file rotation
+///   across the local midnight (file rolls from <c>Chat-26-05-19.log</c>
+///   to <c>Chat-26-05-20.log</c>) does not affect the round-trip — the
+///   clock reads the in-line date prefix, not the filename, so the UTC
+///   reconstruction lands on May 19 (the actual UTC day) regardless.</item>
+///   <item>Pair 3 with <see cref="TimeZoneInfo.Local"/>-flavoured
+///   injection (rather than the originating banner's offset) is the
+///   <b>gap-witness</b>: <see cref="ChatLogClock"/> today folds via
+///   <see cref="TimeZoneInfo.Local"/>, which is wrong for replay of
+///   another machine's chat logs. The skip-tagged fact below converts
+///   that silent mis-conversion risk into an explicit, future-flippable
+///   regression target.</item>
+/// </list>
+/// </summary>
+public sealed class ChatLogClockTests
+{
+    // ── Live capture corpus ────────────────────────────────────────
+    // 2026-05-19 chat banners, hand-copied from real ChatLogs/*.log files.
+    // Each pair below has a matching Player.log banner — see
+    // PlayerLogClockTests for the Player-side half.
+
+    // Pair 1 — same-day, UTC+1 (file Chat-26-05-19.log, character Emraell).
+    private const string Pair1ChatBanner =
+        "26-05-19 21:01:14\t**************************************** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00.";
+    private static readonly DateTime Pair1ExpectedUtc =
+        new(2026, 5, 19, 20, 1, 14, DateTimeKind.Utc);
+    private static readonly TimeSpan Pair1OriginOffset = TimeSpan.FromHours(1);
+
+    // Pair 2 — cross-local-midnight, UTC+1 (file rotates to
+    // Chat-26-05-20.log mid-session, character Emraell). The local
+    // clock has rolled past midnight (00:08:03 on May 20) but the
+    // matching Player.log banner is still 23:08:03 UTC on May 19 — so
+    // the chat clock's job is to fold the local-date forward + offset
+    // back to recover the UTC May 19 instant.
+    private const string Pair2ChatBanner =
+        "26-05-20 00:08:03\t**************************************** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00.";
+    private static readonly DateTime Pair2ExpectedUtc =
+        new(2026, 5, 19, 23, 8, 3, DateTimeKind.Utc);
+    private static readonly TimeSpan Pair2OriginOffset = TimeSpan.FromHours(1);
+
+    // Pair 3 — opposite-sign offset, UTC-7 (alt machine, file
+    // Chat-26-05-19.log, character Praxi, Windows user mikew). Same
+    // physical login as the Player.log Time UTC=05/19/2026 16:36:04
+    // line; the chat side's local stamp is 09:36:04 because the alt
+    // machine is 7h behind UTC.
+    private const string Pair3ChatBanner =
+        "26-05-19 09:36:04\t**************************************** Logged In As Praxi. Server Laeth. Timezone Offset -07:00:00.";
+    private static readonly DateTime Pair3ExpectedUtc =
+        new(2026, 5, 19, 16, 36, 4, DateTimeKind.Utc);
+    private static readonly TimeSpan Pair3OriginOffset = TimeSpan.FromHours(-7);
+
+    // ── Round-trip: chat banner ⇒ ChatLogClock ⇒ UTC ───────────────
+    // With the originating banner's offset injected explicitly (NOT
+    // TimeZoneInfo.Local — that would be wrong for replay of another
+    // machine's logs, which is exactly the gap pair 3 witnesses below),
+    // every pair round-trips to the matching Player.log UTC.
+
+    [Theory]
+    [InlineData(nameof(Pair1ChatBanner))]
+    [InlineData(nameof(Pair2ChatBanner))]
+    [InlineData(nameof(Pair3ChatBanner))]
+    public void StampForLine_WithOriginatingOffsetInjected_RoundTripsToPlayerLogUtc(string pairName)
+    {
+        var (line, expectedUtc, originOffset) = LookupPair(pairName);
+        var fixedOriginTz = FixedOffsetZone(originOffset);
+        var clock = new ChatLogClock(TimeProvider.System, fixedOriginTz);
+
+        var stamp = clock.StampForLine(line);
+
+        stamp.UtcDateTime.Should().Be(expectedUtc);
+        // Belt-and-braces: the emitted offset is the offset we injected
+        // (the per-instant offset of the fixed-offset zone), so two
+        // consumers comparing on Offset see consistent values across the
+        // pair. Mixed-offset emission from one source would break a
+        // future offset-comparing consumer.
+        stamp.Offset.Should().Be(originOffset);
+    }
+
+    // ── Pair 2 specifically: local-midnight chat-file rotation ─────
+
+    [Fact]
+    public void Pair2_LocalMidnightRotation_DoesNotBreakRoundTrip()
+    {
+        // The chat clock reads the in-line `yy-MM-dd` date, not the
+        // filename. So even though the chat line came from
+        // Chat-26-05-20.log (post-rotation, local-day May 20), the UTC
+        // reconstruction lands on May 19 — which is the correct day in
+        // UTC terms and matches the Player.log Time UTC= for the same
+        // physical login moment.
+        var clock = new ChatLogClock(TimeProvider.System, FixedOffsetZone(Pair2OriginOffset));
+
+        var stamp = clock.StampForLine(Pair2ChatBanner);
+
+        stamp.UtcDateTime.Date.Should().Be(new DateTime(2026, 5, 19));
+        stamp.UtcDateTime.Should().Be(Pair2ExpectedUtc);
+        // Sanity: the local component is indeed the May 20 line — we
+        // are exercising the rotation case, not a coincidence where the
+        // local and UTC days happen to match.
+        stamp.DateTime.Date.Should().Be(new DateTime(2026, 5, 20));
+    }
+
+    // ── Pair 3 gap-witness (skipped) ───────────────────────────────
+    // Today ChatLogClock folds via TimeZoneInfo.Local rather than the
+    // originating banner's Timezone Offset. That is correct for the
+    // common case (Mithril reading the host machine's own chat logs)
+    // and wrong for replay of another machine's chat logs. This
+    // fixture encodes the gap so the refactor tracked in #538 can flip
+    // Skip to null and gain a green regression test in the same commit.
+
+    [Fact(Skip = "Tracking gap #538: ChatLogClock uses TimeZoneInfo.Local instead of the originating banner's Timezone Offset, so cross-machine chat-log replay produces a wrong-by-the-offset UTC. Flip Skip to null once #538 lands.")]
+    public void Pair3_WithReplayMachineTimeZone_GapWitness()
+    {
+        // Simulate the user replaying the alt machine's chat log (whose
+        // offset is UTC-7) on Arthur's machine (UTC+1). ChatLogClock
+        // today reads TimeZoneInfo.Local — so the alt machine's
+        // local-stamped `26-05-19 09:36:04` gets folded as if it were
+        // 09:36:04 UTC+1 ⇒ 08:36:04 UTC, off by 8 hours from the true
+        // 16:36:04 UTC instant. The assertion below is what we WANT to
+        // hold; it will hold the moment ChatLogClock consumes the
+        // banner's offset instead.
+        var replayMachineTz = FixedOffsetZone(TimeSpan.FromHours(1));
+        var clock = new ChatLogClock(TimeProvider.System, replayMachineTz);
+
+        var stamp = clock.StampForLine(Pair3ChatBanner);
+
+        stamp.UtcDateTime.Should().Be(Pair3ExpectedUtc);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private static (string Line, DateTime ExpectedUtc, TimeSpan OriginOffset) LookupPair(string pairName) => pairName switch
+    {
+        nameof(Pair1ChatBanner) => (Pair1ChatBanner, Pair1ExpectedUtc, Pair1OriginOffset),
+        nameof(Pair2ChatBanner) => (Pair2ChatBanner, Pair2ExpectedUtc, Pair2OriginOffset),
+        nameof(Pair3ChatBanner) => (Pair3ChatBanner, Pair3ExpectedUtc, Pair3OriginOffset),
+        _ => throw new ArgumentOutOfRangeException(nameof(pairName), pairName, "unknown pair"),
+    };
+
+    private static TimeZoneInfo FixedOffsetZone(TimeSpan offset)
+    {
+        // Per-call unique id so two callers with the same offset don't
+        // collide on the global TimeZoneInfo registry under parallel
+        // xunit execution.
+        var id = $"FixedOffsetTestZone_{offset.Ticks}_{Guid.NewGuid():N}";
+        return TimeZoneInfo.CreateCustomTimeZone(id, offset, id, id);
+    }
+}

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogClockTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogClockTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Logging;
+
+/// <summary>
+/// Fixture for the Player-side half of the cross-source UTC↔local
+/// timestamp contract — see wiki Player-Log-Signals #cross-source-timestamp-contract
+/// and issue #535. The corpus is three live-captured login-banner pairs
+/// from 2026-05-19 (one same-day UTC+1, one cross-local-midnight UTC+1,
+/// one opposite-sign UTC-7); the chat-side half lives in
+/// <see cref="ChatLogClockTests"/>.
+///
+/// <para>The contract this fixture pins:</para>
+/// <list type="bullet">
+///   <item><see cref="PlayerLogClock"/> emits a <see cref="DateTimeOffset"/>
+///   whose <see cref="DateTimeOffset.UtcDateTime"/> exactly equals the
+///   <c>Time UTC=…</c> value in the banner.</item>
+///   <item>The emitted offset is <see cref="TimeSpan.Zero"/> — Player.log
+///   is always UTC, and that is the load-bearing assumption every
+///   downstream consumer relies on.</item>
+///   <item>The <c>[HH:MM:SS]</c> bracket value matches <c>Time UTC=…</c>'s
+///   time-of-day byte-for-byte. This is the property the session-anchor
+///   path silently relies on; asserting it directly converts a future
+///   log-format change into a test failure rather than a runtime drift.</item>
+/// </list>
+/// </summary>
+public sealed class PlayerLogClockTests
+{
+    // ── Live capture corpus ────────────────────────────────────────
+    // 2026-05-19 login banners, hand-copied from real Player.log files.
+    // Each pair below also has a matching chat banner — see
+    // ChatLogClockTests for the chat-side half.
+
+    // Pair 1 — same-day, UTC+1 (Arthur's machine, character Emraell).
+    private const string Pair1PlayerBanner =
+        "[20:01:14] Logged in as character Emraell. Time UTC=05/19/2026 20:01:14. Timezone Offset 01:00:00";
+    private static readonly DateTime Pair1ExpectedUtc =
+        new(2026, 5, 19, 20, 1, 14, DateTimeKind.Utc);
+
+    // Pair 2 — cross-local-midnight, UTC+1 (Arthur's machine, character
+    // Emraell). Local clock is past midnight (00:08:03 on May 20) but the
+    // UTC banner is still on May 19; this is the case that exercises
+    // chat-file rotation on the chat side, and on the Player side
+    // exercises "UTC date != local date at this moment."
+    private const string Pair2PlayerBanner =
+        "[23:08:03] Logged in as character Emraell. Time UTC=05/19/2026 23:08:03. Timezone Offset 01:00:00";
+    private static readonly DateTime Pair2ExpectedUtc =
+        new(2026, 5, 19, 23, 8, 3, DateTimeKind.Utc);
+
+    // Pair 3 — opposite-sign offset, UTC-7 (alt machine, character Praxi,
+    // Windows user mikew). The minus-sign capture rules out a
+    // "+offset only" coincidence; if a refactor added an unsigned-offset
+    // parse error this is the test that would catch it.
+    private const string Pair3PlayerBanner =
+        "[16:36:04] Logged in as character Praxi. Time UTC=05/19/2026 16:36:04. Timezone Offset -07:00:00";
+    private static readonly DateTime Pair3ExpectedUtc =
+        new(2026, 5, 19, 16, 36, 4, DateTimeKind.Utc);
+
+    // ── Round-trip: banner ⇒ PlayerLogClock ⇒ UTC ──────────────────
+
+    [Theory]
+    [InlineData(nameof(Pair1PlayerBanner))]
+    [InlineData(nameof(Pair2PlayerBanner))]
+    [InlineData(nameof(Pair3PlayerBanner))]
+    public void StampForLine_WithSessionAnchorPrimedFromBanner_ProducesBannerUtc(string pairName)
+    {
+        var (line, expectedUtc) = LookupPair(pairName);
+        var anchor = new FakeSessionAnchor(expectedUtc);
+        var clock = new PlayerLogClock(TimeProvider.System, anchor);
+        // EnsureAnchored reads the anchor and pins _currentUtcDate; the
+        // mtime accessor is dead in this path (the anchor pre-empts it)
+        // so it's deliberately set to a value that would be wrong if the
+        // anchor weren't honoured.
+        clock.EnsureAnchored(new[] { line }, () => new DateTime(2099, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var stamp = clock.StampForLine(line);
+
+        stamp.UtcDateTime.Should().Be(expectedUtc);
+    }
+
+    [Theory]
+    [InlineData(nameof(Pair1PlayerBanner))]
+    [InlineData(nameof(Pair2PlayerBanner))]
+    [InlineData(nameof(Pair3PlayerBanner))]
+    public void StampForLine_EmittedOffsetIsZero(string pairName)
+    {
+        var (line, expectedUtc) = LookupPair(pairName);
+        var anchor = new FakeSessionAnchor(expectedUtc);
+        var clock = new PlayerLogClock(TimeProvider.System, anchor);
+        clock.EnsureAnchored(new[] { line }, () => expectedUtc);
+
+        var stamp = clock.StampForLine(line);
+
+        stamp.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    // ── Fixture self-check: bracket prefix == Time UTC= time-of-day ─
+
+    [Theory]
+    [InlineData(nameof(Pair1PlayerBanner))]
+    [InlineData(nameof(Pair2PlayerBanner))]
+    [InlineData(nameof(Pair3PlayerBanner))]
+    public void BannerBracketPrefix_MatchesTimeUtcTimeOfDay_ByteForByte(string pairName)
+    {
+        // The PlayerLogClock contract — and every downstream consumer
+        // that treats `[HH:MM:SS]` as UTC — relies on the bracket prefix
+        // being the time-of-day component of the banner's `Time UTC=`
+        // value, character-for-character. If the PG client ever changed
+        // the prefix to local-time, this assertion fires before any
+        // round-trip test would notice.
+        var (line, _) = LookupPair(pairName);
+        var bracket = line.Substring(1, 8);  // "[HH:MM:SS] …" → "HH:MM:SS"
+
+        var timeUtcMarker = line.IndexOf("Time UTC=", StringComparison.Ordinal);
+        timeUtcMarker.Should().BeGreaterThan(0,
+            "the banner format used to encode the UTC instant inline");
+        // "Time UTC=MM/DD/YYYY HH:MM:SS." — skip "Time UTC=" (9) + "MM/DD/YYYY " (11) → +20
+        var fromTimeUtc = line.Substring(timeUtcMarker + 20, 8);
+
+        fromTimeUtc.Should().Be(bracket);
+    }
+
+    private static (string Line, DateTime ExpectedUtc) LookupPair(string pairName) => pairName switch
+    {
+        nameof(Pair1PlayerBanner) => (Pair1PlayerBanner, Pair1ExpectedUtc),
+        nameof(Pair2PlayerBanner) => (Pair2PlayerBanner, Pair2ExpectedUtc),
+        nameof(Pair3PlayerBanner) => (Pair3PlayerBanner, Pair3ExpectedUtc),
+        _ => throw new ArgumentOutOfRangeException(nameof(pairName), pairName, "unknown pair"),
+    };
+
+    private sealed class FakeSessionAnchor : ISessionAnchor
+    {
+        public FakeSessionAnchor(DateTime loggedInUtc) { LoggedInUtc = loggedInUtc; }
+        public DateTime? LoggedInUtc { get; }
+        public event EventHandler? AnchorChanged { add { } remove { } }
+    }
+}


### PR DESCRIPTION
## Summary

- New `tests/Mithril.Shared.Tests/Logging/PlayerLogClockTests.cs` + `ChatLogClockTests.cs` — 13 passing facts + 1 intentional `[Skip]`, no production code change. Closes #535.
- Three live-captured 2026-05-19 banner pairs (same-day UTC+1, cross-local-midnight UTC+1, opposite-sign UTC-7 from an alt machine) lock the L0 contract documented in [Player-Log-Signals#cross-source-timestamp-contract](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#cross-source-timestamp-contract).
- The pair-3 gap-witness is `[Fact(Skip = "Tracking gap #538: …")]` — converts the silent cross-machine-replay mis-conversion into a future-flippable regression target. The fix is tracked in #538.

## Test plan

- [x] All three pairs round-trip green through `PlayerLogClock` with the session anchor primed from `Time UTC=…`.
- [x] All three pairs round-trip green through `ChatLogClock` with the originating banner's offset injected as a fixed-offset `TimeZoneInfo`.
- [x] Pair 2 specifically round-trips green across the local-midnight chat-file rotation (in-line `yy-MM-dd` prefix, not filename, governs the reconstruction).
- [x] Pair 3 with replay-machine `TimeZoneInfo.Local` is skipped pending #538, with the skip reason naming the gap and the issue.
- [x] No regression on incidental coverage — `PlayerLogTailReaderTests` (21) + `GameClockTests` (30) all still green.
- [x] Fixture self-check: the `[HH:MM:SS]` bracket prefix matches `Time UTC=…`'s time-of-day byte-for-byte across all three pairs.

## Related

- Closes #535 — the spec issue for this fixture.
- Spawns #538 — the ChatLogClock banner-offset fix that the pair-3 skip witnesses.
- Wiki: [Player-Log-Signals#cross-source-timestamp-contract](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#cross-source-timestamp-contract).
- #183 — original UTC↔local bug whose root cause this contract addresses.
- #511 / #532 — L0 / L0.5 pipeline work this contract is a precondition for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
