### PR TITLE
fix(logging): ChatLogClock reads Timezone Offset from chat banner (closes #538)

### DIFF
--- a/src/Mithril.Shared/Logging/ChatLogClock.cs
+++ b/src/Mithril.Shared/Logging/ChatLogClock.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
 namespace Mithril.Shared.Logging;
 
 /// <summary>
@@ -5,22 +8,43 @@ namespace Mithril.Shared.Logging;
 /// <c>yy-MM-dd HH:mm:ss\t</c> prefix every PG chat-log line carries
 /// (e.g. <c>26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to
 /// inventory.</c>). The prefix is in <b>host-local</b> time — the game
-/// process writes wall-clock with its local TZ — so the parsed
-/// <see cref="DateTime"/> is folded into a <see cref="DateTimeOffset"/>
-/// using <see cref="TimeZoneInfo.Local"/>'s UTC offset for that instant.
+/// process writes wall-clock with its local TZ. The clock folds the
+/// parsed <see cref="DateTime"/> into a <see cref="DateTimeOffset"/>
+/// using <b>the originating session's <c>Timezone Offset</c></b> when a
+/// chat-side login banner has been observed, falling back to the
+/// constructor-injected <see cref="TimeZoneInfo"/> (or
+/// <see cref="TimeZoneInfo.Local"/>) for the pre-banner run.
 ///
-/// <para><b>Why this matters (#183 root cause).</b> Today every consumer
-/// that touches <c>raw.Timestamp</c> for a chat-derived line wraps it in
-/// <c>new DateTimeOffset(ts, TimeSpan.Zero)</c> — which is wrong by the
-/// host's TZ offset. The chat tail-reader masked the bug by falling
-/// through the prefix parse to wall-clock-now (which happens to be UTC),
-/// so consumers never saw the mis-conversion in practice — but the
-/// pattern is a tripwire: any consumer that did past-anchor on the chat
-/// timestamp would silently shift state by the TZ offset. This clock
-/// closes that gap structurally: downstream of L0 every chat line
-/// already carries the TZ-correct <see cref="DateTimeOffset"/>, and the
-/// per-consumer <c>TimeSpan.Zero</c> wrap (now a no-op on a
-/// pre-typed value) goes away in the fan-out.</para>
+/// <para><b>Why this matters (#183 root cause, #538 close).</b> Today
+/// every consumer that touches <c>raw.Timestamp</c> for a chat-derived
+/// line wraps it in <c>new DateTimeOffset(ts, TimeSpan.Zero)</c> —
+/// which is wrong by the host's TZ offset. The chat tail-reader masked
+/// the bug by falling through the prefix parse to wall-clock-now (which
+/// happens to be UTC), so consumers never saw the mis-conversion in
+/// practice. The L0 redesign typed every chat line with the host's TZ
+/// at emission, which closed the *live-tail* half. #538 closes the
+/// *replay* half: a chat log written on a UTC-7 machine and replayed on
+/// a UTC+1 host would still be wrong by 8h with host-TZ-only folding.
+/// Reading the originating offset from the per-session
+/// <c>Logged In As … Timezone Offset HH:MM:SS.</c> banner removes the
+/// gap — downstream of L0 the timestamp is correct regardless of which
+/// machine wrote the log.</para>
+///
+/// <para><b>Deferred abstraction (no <c>IChatSessionAnchor</c>).</b>
+/// The Player-side <see cref="ISessionAnchor"/> exists specifically to
+/// break a DI cycle: <c>PlayerLogStream → anchor → GameSessionService →
+/// PlayerLogStream</c>. On the chat side there is no analogous cycle —
+/// <see cref="ChatLogClock"/> is consumed by chat-stream / tailer code
+/// and nothing in <c>Mithril.GameState</c> writes chat-session state
+/// back through them — so an interface + leaf-class pair would be pure
+/// ceremony. The banner parse lives in-clock as a private static. If a
+/// future need arises (a chat-session service in another assembly that
+/// also needs the offset; cross-consumer offset sharing), the
+/// extraction is mechanical: lift the private regex into a
+/// <c>ChatBannerParser</c>, lift <see cref="_bannerOffset"/> into an
+/// <c>IChatSessionAnchor</c> consumed alongside the existing TZ
+/// fallback, wire the chat parser/banner consumer to write to it. The
+/// emission semantics this class advertises don't change.</para>
 ///
 /// <para><b>Hand-rolled prefix parse</b> (vs <c>DateTime.ParseExact</c>):
 /// runs once per chat line on the seed-replay path; the format is
@@ -28,29 +52,38 @@ namespace Mithril.Shared.Logging;
 /// prefix (rare — typically only the file's blank header lines) inherit
 /// the prior emitted stamp; a leading run of unprefixed lines (before
 /// any prefixed line has anchored <c>_lastEmitted</c>) falls through to
-/// <see cref="TimeProvider.GetUtcNow"/> <em>re-tagged with the host's
-/// local UTC offset</em>, so every value this clock emits carries the
-/// same (local) offset semantics — mixing Zero-offset (UTC) and
-/// local-offset values from one source would break a future
-/// offset-comparing consumer.</para>
+/// <see cref="TimeProvider.GetUtcNow"/> <em>re-tagged with the current
+/// fallback offset</em>, so every value this clock emits carries the
+/// same offset semantics — mixing Zero-offset (UTC) and local-offset
+/// values from one source would break a future offset-comparing
+/// consumer.</para>
 ///
 /// <para><see cref="EnsureAnchored"/> is a no-op: the chat prefix
 /// carries its own absolute date, so there is no equivalent of the
 /// Player-side mtime/session-anchor back-walk to perform.</para>
 /// </summary>
-internal sealed class ChatLogClock : ILogSourceClock
+internal sealed partial class ChatLogClock : ILogSourceClock
 {
     private readonly TimeProvider _time;
-    private readonly TimeZoneInfo _localTz;
+    private readonly TimeZoneInfo _fallbackTz;
     private DateTimeOffset? _lastEmitted;
+    // Originating offset captured from the most recent
+    // `Logged In As … Timezone Offset HH:MM:SS.` chat banner. Null until
+    // the first banner is observed, after which it wins over
+    // _fallbackTz for every subsequent stamp. Re-anchored on every new
+    // banner (PG re-login during the same Mithril run).
+    private TimeSpan? _bannerOffset;
 
-    public ChatLogClock(TimeProvider time, TimeZoneInfo? localTz = null)
+    public ChatLogClock(TimeProvider time, TimeZoneInfo? fallbackTz = null)
     {
         _time = time;
         // Late-bind TimeZoneInfo.Local so a test can inject a fixed-offset
-        // zone; default is the host's actual local zone, which is what the
-        // PG client writes against.
-        _localTz = localTz ?? TimeZoneInfo.Local;
+        // zone; the default is the host's actual local zone, which is
+        // correct for the common live-tail case (the PG client wrote the
+        // log on this same machine, so its local zone matches the
+        // host's). The banner-derived offset, once seen, supersedes this
+        // for the cross-machine-replay case (see #538).
+        _fallbackTz = fallbackTz ?? TimeZoneInfo.Local;
     }
 
     public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor)
@@ -63,16 +96,27 @@ internal sealed class ChatLogClock : ILogSourceClock
 
     public DateTimeOffset StampForLine(string line)
     {
+        // Banner recognition runs on every line (cheap regex against a
+        // short string; the early-out on the prefix bound limits cost
+        // for the long lines too). Updating _bannerOffset before the
+        // fold ensures the banner *line itself* is also stamped with
+        // its own offset, not the previous fallback — which is what
+        // both Player and chat would observe if the offset changed mid-
+        // session.
+        if (TryParseBannerOffset(line, out var bannerOffset))
+            _bannerOffset = bannerOffset;
+
         if (TryParseLocalDatePrefix(line, out var local))
         {
-            // The parsed DateTime is unspecified-kind wall-clock in the
-            // host's local zone. Resolving via TimeZoneInfo.GetUtcOffset
-            // handles DST correctly (the offset varies per-instant); the
-            // ambiguous-time / invalid-time edge cases at DST transitions
-            // resolve to TimeZoneInfo's default policy (treat ambiguous
-            // as standard, treat invalid as if the clock had jumped),
-            // which matches how the game itself recorded the line.
-            var offset = _localTz.GetUtcOffset(local);
+            // Prefer the banner-derived offset (once seen) over the
+            // host-TZ fallback. The fallback-TZ path resolves via
+            // TimeZoneInfo.GetUtcOffset, which handles DST correctly
+            // (the offset varies per-instant); ambiguous-time / invalid-
+            // time edge cases at DST transitions resolve to TimeZoneInfo's
+            // default policy (treat ambiguous as standard, treat invalid
+            // as if the clock had jumped), which matches how the game
+            // itself recorded the line.
+            var offset = _bannerOffset ?? _fallbackTz.GetUtcOffset(local);
             _lastEmitted = new DateTimeOffset(local, offset);
             return _lastEmitted.Value;
         }
@@ -80,12 +124,13 @@ internal sealed class ChatLogClock : ILogSourceClock
         if (_lastEmitted is { } prior) return prior;
         // No prefix has anchored _lastEmitted yet (leading-unprefixed run,
         // typically chat-file header lines). Use wall-clock-now, but re-tag
-        // with the host's local UTC offset so every value this clock emits
+        // with the current fallback offset so every value this clock emits
         // carries the same offset semantics — mixing Zero-offset (UTC) and
         // local-offset values from one source would break any future
         // offset-comparing consumer.
         var nowUtc = _time.GetUtcNow();
-        _lastEmitted = nowUtc.ToOffset(_localTz.GetUtcOffset(nowUtc.UtcDateTime));
+        var fallbackOffset = _bannerOffset ?? _fallbackTz.GetUtcOffset(nowUtc.UtcDateTime);
+        _lastEmitted = nowUtc.ToOffset(fallbackOffset);
         return _lastEmitted.Value;
     }
 
@@ -124,5 +169,31 @@ internal sealed class ChatLogClock : ILogSourceClock
         if ((uint)a > 9 || (uint)b > 9) { v = 0; return false; }
         v = a * 10 + b;
         return true;
+    }
+
+    // Chat-side login banner: e.g.
+    // `26-05-19 21:01:14\t**************************************** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00.`
+    // Distinguished from the Player-side `Logged in as character …` by
+    // the capitalisation (`Logged In As`) and the absence of a `Time
+    // UTC=` field — the chat banner doesn't carry the UTC instant, only
+    // the offset. Offset is signed `HH:MM:SS` (PG omits the `+` for
+    // east-of-UTC), mirroring the LoginBannerParser shape.
+    [GeneratedRegex(
+        @"Logged In As [^.]+\. Server [^.]+\. Timezone Offset (?<off>-?\d{1,2}:\d{2}:\d{2})",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex ChatBannerOffsetRx();
+
+    private static bool TryParseBannerOffset(string line, out TimeSpan offset)
+    {
+        offset = default;
+        // Cheap negative-match short-circuit: the literal substring is
+        // present in every banner and absent from every non-banner chat
+        // line. Skips the regex entirely on the 99%+ common case.
+        if (line.IndexOf("Logged In As ", StringComparison.Ordinal) < 0) return false;
+
+        var m = ChatBannerOffsetRx().Match(line);
+        if (!m.Success) return false;
+
+        return TimeSpan.TryParse(m.Groups["off"].Value, CultureInfo.InvariantCulture, out offset);
     }
 }

--- a/tests/Mithril.Shared.Tests/Logging/ChatLogClockTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/ChatLogClockTests.cs
@@ -25,13 +25,20 @@ namespace Mithril.Shared.Tests.Logging;
 ///   to <c>Chat-26-05-20.log</c>) does not affect the round-trip — the
 ///   clock reads the in-line date prefix, not the filename, so the UTC
 ///   reconstruction lands on May 19 (the actual UTC day) regardless.</item>
-///   <item>Pair 3 with <see cref="TimeZoneInfo.Local"/>-flavoured
-///   injection (rather than the originating banner's offset) is the
-///   <b>gap-witness</b>: <see cref="ChatLogClock"/> today folds via
-///   <see cref="TimeZoneInfo.Local"/>, which is wrong for replay of
-///   another machine's chat logs. The skip-tagged fact below converts
-///   that silent mis-conversion risk into an explicit, future-flippable
-///   regression target.</item>
+///   <item>Pair 3 — alt machine's UTC-7 chat banner replayed on a
+///   UTC+1 host TZ — round-trips correctly because <see cref="ChatLogClock"/>
+///   reads the in-line <c>Logged In As … Timezone Offset HH:MM:SS.</c>
+///   banner and folds via the banner's offset rather than the host TZ.
+///   This was the #538 gap-witness; the fix lands with this fixture
+///   green.</item>
+///   <item>Pre-banner lines (the leading run before the
+///   <c>Logged In As …</c> banner has been observed) fall through to
+///   the injected/local TZ, preserving live-tail behaviour where the
+///   host machine wrote the log.</item>
+///   <item>A second <c>Logged In As</c> banner mid-stream (PG re-login)
+///   re-anchors the offset for subsequent lines, the same way
+///   <see cref="ISessionAnchor.AnchorChanged"/> re-anchors the Player
+///   clock.</item>
 /// </list>
 /// </summary>
 public sealed class ChatLogClockTests
@@ -121,31 +128,86 @@ public sealed class ChatLogClockTests
         stamp.DateTime.Date.Should().Be(new DateTime(2026, 5, 20));
     }
 
-    // ── Pair 3 gap-witness (skipped) ───────────────────────────────
-    // Today ChatLogClock folds via TimeZoneInfo.Local rather than the
-    // originating banner's Timezone Offset. That is correct for the
-    // common case (Mithril reading the host machine's own chat logs)
-    // and wrong for replay of another machine's chat logs. This
-    // fixture encodes the gap so the refactor tracked in #538 can flip
-    // Skip to null and gain a green regression test in the same commit.
+    // ── Pair 3 banner-wins-over-injected-TZ (was #538 gap-witness) ─
 
-    [Fact(Skip = "Tracking gap #538 — ChatLogClock uses TimeZoneInfo.Local; flip Skip when #538 lands. See doc comment above for the full reason.")]
-    public void Pair3_WithReplayMachineTimeZone_GapWitness()
+    [Fact]
+    public void Pair3_BannerOffsetWinsOverInjectedReplayMachineTimeZone()
     {
-        // Simulate the user replaying the alt machine's chat log (whose
-        // offset is UTC-7) on Arthur's machine (UTC+1). ChatLogClock
-        // today reads TimeZoneInfo.Local — so the alt machine's
-        // local-stamped `26-05-19 09:36:04` gets folded as if it were
-        // 09:36:04 UTC+1 ⇒ 08:36:04 UTC, off by 8 hours from the true
-        // 16:36:04 UTC instant. The assertion below is what we WANT to
-        // hold; it will hold the moment ChatLogClock consumes the
-        // banner's offset instead.
+        // The user replays the alt machine's chat log (whose banner records
+        // UTC-7) on Arthur's machine (UTC+1). The clock must reconstruct
+        // 16:36:04 UTC from the alt-machine local stamp `09:36:04` by
+        // reading the banner's `Timezone Offset -07:00:00.` — *not* by
+        // folding through the injected UTC+1 (which would land 8 hours off
+        // at 08:36:04 UTC). This is the #538 fix: in-clock banner parse
+        // wins over the constructor-injected fallback TZ.
         var replayMachineTz = FixedOffsetZone(TimeSpan.FromHours(1));
         var clock = new ChatLogClock(TimeProvider.System, replayMachineTz);
 
         var stamp = clock.StampForLine(Pair3ChatBanner);
 
         stamp.UtcDateTime.Should().Be(Pair3ExpectedUtc);
+        stamp.Offset.Should().Be(Pair3OriginOffset);
+    }
+
+    // ── Pre-banner fallback ─────────────────────────────────────────
+
+    [Fact]
+    public void StampForLine_BeforeBannerSeen_FoldsViaInjectedFallbackTimeZone()
+    {
+        // Lines that arrive before any `Logged In As …` banner (typical
+        // chat-file headers, plus the rare leading content line on a
+        // freshly-rotated file before login) preserve today's behaviour:
+        // fold via the injected (or `TimeZoneInfo.Local`) fallback. The
+        // banner-derived offset only kicks in once a banner has actually
+        // been observed; this keeps live-tail on the host machine
+        // bit-identical to pre-#538 behaviour.
+        var fallbackTz = FixedOffsetZone(TimeSpan.FromHours(5));
+        var clock = new ChatLogClock(TimeProvider.System, fallbackTz);
+        const string preBannerStatusLine =
+            "26-05-19 12:00:00\t[Status] Some pre-login status notification.";
+
+        var stamp = clock.StampForLine(preBannerStatusLine);
+
+        // 12:00:00 local in UTC+5 ⇒ 07:00:00 UTC.
+        stamp.UtcDateTime.Should().Be(new DateTime(2026, 5, 19, 7, 0, 0, DateTimeKind.Utc));
+        stamp.Offset.Should().Be(TimeSpan.FromHours(5));
+    }
+
+    // ── Mid-stream re-anchor on a second banner (PG re-login) ──────
+
+    [Fact]
+    public void StampForLine_SecondBannerMidStream_ReAnchorsOffsetForSubsequentLines()
+    {
+        // PG re-login during the same Mithril run: a second
+        // `Logged In As …` banner with a different `Timezone Offset`
+        // value must re-anchor the offset for subsequent chat lines,
+        // mirroring the Player-clock's response to
+        // ISessionAnchor.AnchorChanged. Without re-anchoring, the chat
+        // clock would silently keep using the first banner's offset and
+        // mis-convert every post-relogin line by the offset delta.
+        //
+        // Sequence: Pair-1 banner (UTC+1) ⇒ generic line under UTC+1 ⇒
+        // Pair-3 banner (UTC-7) ⇒ generic line under UTC-7. Asserting
+        // the *generic* lines (not the banners themselves) is what
+        // proves the offset state carried forward correctly.
+        var clock = new ChatLogClock(TimeProvider.System);
+        const string postPair1Line =
+            "26-05-19 21:05:00\t[Status] Generic line after Pair-1 banner.";
+        const string postPair3Line =
+            "26-05-19 10:00:00\t[Status] Generic line after Pair-3 banner.";
+
+        clock.StampForLine(Pair1ChatBanner);
+        var firstFollowup = clock.StampForLine(postPair1Line);
+        clock.StampForLine(Pair3ChatBanner);
+        var secondFollowup = clock.StampForLine(postPair3Line);
+
+        // 21:05:00 local in UTC+1 ⇒ 20:05:00 UTC (Pair-1 offset).
+        firstFollowup.UtcDateTime.Should().Be(new DateTime(2026, 5, 19, 20, 5, 0, DateTimeKind.Utc));
+        firstFollowup.Offset.Should().Be(Pair1OriginOffset);
+
+        // 10:00:00 local in UTC-7 ⇒ 17:00:00 UTC (Pair-3 offset).
+        secondFollowup.UtcDateTime.Should().Be(new DateTime(2026, 5, 19, 17, 0, 0, DateTimeKind.Utc));
+        secondFollowup.Offset.Should().Be(Pair3OriginOffset);
     }
 
     // ── Helpers ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `ChatLogClock` ([src/Mithril.Shared/Logging/ChatLogClock.cs](src/Mithril.Shared/Logging/ChatLogClock.cs)) now parses the chat-side `Logged In As <name>. Server <name>. Timezone Offset HH:MM:SS.` banner in-clock and uses the captured offset for every subsequent local→UTC fold. Re-anchors on every new banner (PG re-login).
- Pre-banner lines + leading-unprefixed run preserve the host-TZ behaviour exactly — live-tail on the writing machine is bit-identical to pre-#538.
- Closes the cross-machine-replay gap encoded as the skip-tagged regression target in #535: alt-machine UTC-7 chat log replayed on a UTC+1 host now reconstructs the true UTC instant from the banner's offset.

## Design choice (per #538)

In-clock parse, **no `IChatSessionAnchor`** parallel to `ISessionAnchor`. The Player-side interface exists specifically to break a DI cycle (`PlayerLogStream → anchor → GameSessionService → PlayerLogStream`); the chat side has no analogous cycle, so an interface + leaf-class pair would be pure ceremony. The deferred abstraction + its one-shot migration path is documented in `ChatLogClock`'s XML doc so the next reader knows the call was deliberate.

## Test plan

- [x] `Pair3_BannerOffsetWinsOverInjectedReplayMachineTimeZone` — was the skip-tagged #538 gap-witness; flipped `[Fact(Skip = …)]` → `[Fact]`, now green.
- [x] `StampForLine_BeforeBannerSeen_FoldsViaInjectedFallbackTimeZone` — new fact; pins the live-tail-on-writing-machine path (offset comes from the injected `TimeZoneInfo`, not from a banner that hasn't been seen yet).
- [x] `StampForLine_SecondBannerMidStream_ReAnchorsOffsetForSubsequentLines` — new fact; mirrors `ISessionAnchor.AnchorChanged` re-anchor semantics on the chat side.
- [x] Pairs 1/2/3 round-trip + Pair 2 local-midnight rotation still green — including the per-instant `Offset` assertion (banner offset matches the injected fallback in all three pairs, so the assertion holds without modification).
- [x] Full `Mithril.Shared.Tests` suite: 1195 passed.
- [x] `Mithril.GameState.Tests / InventoryServiceStackSizeTests` (only other test project that references chat-stream code): 18 passed.

## Related

- Closes #538 — the gap discussion + Option 2 (in-clock parse) decision.
- #535 — the fixture that encoded this as a skip-tagged regression target (closed via #539).
- Wiki: [Player-Log-Signals#cross-source-timestamp-contract](https://github.com/moumantai-gg/wiki/Player-Log-Signals#cross-source-timestamp-contract).
- #183 — original UTC↔local bug whose root cause this contract addresses.
- #511 — log-pipeline rework umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
