### PR TITLE
feat(logging): L0.5 actor-keyed envelope router → LocalPlayerLogLine (#532)

### DIFF
--- a/src/Mithril.GameState/Sessions/GameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/GameSessionService.cs
@@ -5,10 +5,13 @@ using Microsoft.Extensions.Hosting;
 namespace Mithril.GameState.Sessions;
 
 /// <summary>
-/// Hosted-service implementation of <see cref="IGameSessionService"/>. Tails
-/// <see cref="IPlayerLogStream"/>, parses the login banner via
-/// <see cref="LoginBannerParser"/>, and publishes session transitions to
-/// subscribers + the shared <see cref="SessionAnchor"/> consumer.
+/// Hosted-service implementation of <see cref="IGameSessionService"/>.
+/// Consumes the L0.5 (#532) <see cref="ISystemSignalLogStream"/> — filters
+/// for <see cref="SystemSignalKind.LoginBanner"/>, parses the banner body
+/// via <see cref="LoginBannerParser"/>, and publishes session transitions to
+/// subscribers + the shared <see cref="SessionAnchor"/> consumer. This is the
+/// L0.5 migration reference; pre-L0.5 the service consumed
+/// <see cref="IPlayerLogStream"/> and matched the banner shape itself.
 ///
 /// <para>The anchor is pushed-to, not implemented-by, to avoid a DI cycle:
 /// the streams that consume the anchor are in <c>Mithril.Shared</c>, and
@@ -29,7 +32,7 @@ namespace Mithril.GameState.Sessions;
 /// </summary>
 public sealed class GameSessionService : BackgroundService, IGameSessionService
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ISystemSignalLogStream _stream;
     private readonly SessionAnchor? _anchor;
     private readonly IDiagnosticsSink? _diag;
     private readonly ThrottledWarn _warn;
@@ -39,7 +42,7 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
     private GameSession? _current;
 
     public GameSessionService(
-        IPlayerLogStream stream,
+        ISystemSignalLogStream stream,
         SessionAnchor? anchor = null,
         IDiagnosticsSink? diag = null)
     {
@@ -72,12 +75,16 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _diag?.Info("Session", "Subscribing to Player.log for login banner");
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
+        _diag?.Info("Session", "Subscribing to L0.5 system-signal pipe for login banner");
+        await foreach (var signal in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
         {
+            // L0.5 already classified the line as a system signal — we only
+            // care about LoginBanner here. Other kinds (AreaLoading,
+            // PlayerAdded, SessionLifecycle) flow past without us.
+            if (signal.Kind != SystemSignalKind.LoginBanner) continue;
             try
             {
-                if (!LoginBannerParser.TryParse(raw.Line, out var session)) continue;
+                if (!LoginBannerParser.TryParse(signal.Data, out var session)) continue;
                 Publish(session);
             }
             catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -78,6 +78,34 @@ public static class ServiceCollectionExtensions
             .AddHostedService<ActiveCharacterLogSynchronizer>();
 
     /// <summary>
+    /// Register the L0.5 actor-keyed envelope router (#532). Consumes
+    /// <see cref="IPlayerLogStream"/>, classifies each line, and emits typed
+    /// records on three pipes: <see cref="ILocalPlayerLogStream"/>,
+    /// <see cref="ICombatActorLogStream"/>, <see cref="ISystemSignalLogStream"/>.
+    ///
+    /// <para><paramref name="captureRawAccessor"/> is a late-bound read of an
+    /// infra diagnostic setting (typically a <c>ShellSettings</c> property)
+    /// — when it returns <c>true</c> the router fills the <c>Raw</c> field on
+    /// emitted records with the exact source line; when <c>false</c> (the
+    /// default) <c>Raw</c> stays <c>null</c> and no per-line string
+    /// allocation occurs. Mirrors the perf-trace pattern: flip the setting
+    /// and subsequent emissions reflect the new state.</para>
+    /// </summary>
+    public static IServiceCollection AddMithrilLogActorRouter(
+        this IServiceCollection services,
+        Func<IServiceProvider, Func<bool>>? captureRawAccessor = null)
+    {
+        services.AddSingleton<PlayerLogActorRouter>(sp => new PlayerLogActorRouter(
+            sp.GetRequiredService<IPlayerLogStream>(),
+            sp.GetService<IDiagnosticsSink>(),
+            captureRawAccessor?.Invoke(sp)));
+        services.AddSingleton<ILocalPlayerLogStream>(sp => sp.GetRequiredService<PlayerLogActorRouter>());
+        services.AddSingleton<ICombatActorLogStream>(sp => sp.GetRequiredService<PlayerLogActorRouter>());
+        services.AddSingleton<ISystemSignalLogStream>(sp => sp.GetRequiredService<PlayerLogActorRouter>());
+        return services;
+    }
+
+    /// <summary>
     /// Register the root directory for per-character storage (typically
     /// <c>%LocalAppData%/Mithril/characters</c>). Must be called before any
     /// <see cref="AddPerCharacterStore{T}"/> / <see cref="AddPerCharacterModuleStore{T}"/>.

--- a/src/Mithril.Shared/Logging/CombatActorLogLine.cs
+++ b/src/Mithril.Shared/Logging/CombatActorLogLine.cs
@@ -1,0 +1,28 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532): a Player.log line classified as <c>[ts] entity_&lt;id&gt;: On*(…)</c>
+/// — a combat-actor event where a mob/entity registers being hit by the local
+/// player's ability. Corpus shape: <c>OnAttackHitMe(&lt;ability&gt;). Evaded = &lt;bool&gt;</c>,
+/// though the verb space is open-ended.
+///
+/// <para>The <c>entity_&lt;id&gt;:</c> envelope is eaten exactly the same way
+/// <see cref="LocalPlayerLogLine"/> eats <c>LocalPlayer:</c>; the parsed
+/// <see cref="EntityId"/> is surfaced separately so combat consumers don't
+/// re-parse it. <see cref="Data"/> is the bare <c>OnVerb(args)</c>.</para>
+///
+/// <para><b>Reserved pipe.</b> No consumer subscribes today. Per #532, the
+/// classifier still routes these lines distinctly (not to the cheap-discard
+/// bucket) so a future combat consumer slots in without moving the channel
+/// boundary. A token-prefix shortcut filing all <c>entity_</c> lines into
+/// discard would silently bleed this signal — see the
+/// <c>entity_&lt;id&gt;_skin</c> / <c>Not on nav mesh!</c> regression guards
+/// in the per-rule fixtures.</para>
+/// </summary>
+public sealed record CombatActorLogLine(
+    DateTimeOffset Timestamp,
+    long EntityId,
+    string Data,
+    long Sequence,
+    long ReadMonotonicTicks,
+    string? Raw = null);

--- a/src/Mithril.Shared/Logging/ICombatActorLogStream.cs
+++ b/src/Mithril.Shared/Logging/ICombatActorLogStream.cs
@@ -1,0 +1,12 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532) public surface for the combat-actor pipe — typed
+/// <see cref="CombatActorLogLine"/> emissions. Reserved per the design;
+/// no consumer subscribes today. Future combat consumers slot in here
+/// without moving the channel boundary.
+/// </summary>
+public interface ICombatActorLogStream
+{
+    IAsyncEnumerable<CombatActorLogLine> SubscribeAsync(CancellationToken ct);
+}

--- a/src/Mithril.Shared/Logging/ILocalPlayerLogStream.cs
+++ b/src/Mithril.Shared/Logging/ILocalPlayerLogStream.cs
@@ -1,0 +1,16 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532) public surface for the LocalPlayer pipe — typed
+/// <see cref="LocalPlayerLogLine"/> emissions classified from L0's
+/// <see cref="IPlayerLogStream"/> Player.log feed. All current GameState
+/// state-rebuilders and reactive module ingestion services that today
+/// consume <see cref="IPlayerLogStream"/> + match <c>LocalPlayer:</c>
+/// will migrate to this stream as part of #511 deliverable 5; until then
+/// L0.5 ships dark alongside the existing <see cref="IPlayerLogStream"/>
+/// surface.
+/// </summary>
+public interface ILocalPlayerLogStream
+{
+    IAsyncEnumerable<LocalPlayerLogLine> SubscribeAsync(CancellationToken ct);
+}

--- a/src/Mithril.Shared/Logging/ISystemSignalLogStream.cs
+++ b/src/Mithril.Shared/Logging/ISystemSignalLogStream.cs
@@ -1,0 +1,13 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532) public surface for the system-signal pipe — typed
+/// <see cref="SystemSignalLogLine"/> emissions covering the small fixed set
+/// of session-level non-actor lines (<see cref="SystemSignalKind"/>).
+/// <see cref="Mithril.Shared.Logging"/>'s <c>GameSessionService</c> consumes
+/// this stream as the L0.5 migration reference.
+/// </summary>
+public interface ISystemSignalLogStream
+{
+    IAsyncEnumerable<SystemSignalLogLine> SubscribeAsync(CancellationToken ct);
+}

--- a/src/Mithril.Shared/Logging/LocalPlayerLogLine.cs
+++ b/src/Mithril.Shared/Logging/LocalPlayerLogLine.cs
@@ -1,0 +1,28 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 of the layered log pipeline (#511 / #532): a Player.log line classified
+/// as <c>[ts] LocalPlayer: Process*(…)</c>, with the <c>LocalPlayer:</c> actor
+/// envelope already eaten. Downstream of L0.5, no consumer ever sees or
+/// re-matches the actor envelope — <see cref="Data"/> is the bare
+/// <c>Verb(args)</c> string ready for L2's verb-keyed dispatch.
+///
+/// <para><see cref="Timestamp"/>, <see cref="Sequence"/>, and
+/// <see cref="ReadMonotonicTicks"/> pass through verbatim from the originating
+/// <see cref="RawLogLine"/> — L0.5 owns classification + envelope-eating only,
+/// not re-timestamping.</para>
+///
+/// <para><b><see cref="Raw"/></b> is <c>null</c> unless the infra diagnostic
+/// setting (sampled at emit by the L0.5 router) is on, in which case it
+/// carries the exact source <see cref="RawLogLine.Line"/>. The L1 diagnostic
+/// mirror (#511 deliverable 3) reads <see cref="Raw"/> rather than maintaining
+/// a parallel raw-capture path. <c>null</c> by design rather than empty-string
+/// so the typical zero-allocation path is observable: an off-toggle costs no
+/// per-line string allocation.</para>
+/// </summary>
+public sealed record LocalPlayerLogLine(
+    DateTimeOffset Timestamp,
+    string Data,
+    long Sequence,
+    long ReadMonotonicTicks,
+    string? Raw = null);

--- a/src/Mithril.Shared/Logging/PlayerLogActorRouter.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogActorRouter.cs
@@ -1,0 +1,310 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Mithril.Shared.Diagnostics;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532) actor-keyed envelope router. Subscribes to L0's
+/// <see cref="IPlayerLogStream"/> Player.log feed, runs the line-local
+/// <see cref="PlayerLogClassifier"/>, eats the <c>Actor: </c> envelope, and
+/// fans out typed records to three public pipes:
+///
+/// <list type="bullet">
+///   <item><see cref="ILocalPlayerLogStream"/> — <c>[ts] LocalPlayer: Process*(…)</c></item>
+///   <item><see cref="ICombatActorLogStream"/> — <c>[ts] entity_&lt;id&gt;: On*(…)</c>
+///   (reserved; no consumer today)</item>
+///   <item><see cref="ISystemSignalLogStream"/> — the small fixed
+///   <see cref="SystemSignalKind"/> set</item>
+/// </list>
+///
+/// <para>~95% of the corpus (engine/asset noise, exception headers,
+/// indented stack frames, native-address frames, the <c>entity_*</c>
+/// non-actor shapes) is cheap-discarded. Genuinely unknown shapes are
+/// counted and rate-limit-sampled via <see cref="IDiagnosticsSink"/> as G7
+/// telemetry — they never assert-fail in production.</para>
+///
+/// <para><b>Lifecycle.</b> Mirrors <see cref="PlayerLogStream"/>:
+/// lazy-start on first subscribe across any of the three pipes; per-pipe
+/// session-replay buffer for late joiners; bounded per-subscriber channel
+/// for live delivery. The replay buffer holds <em>classified</em>
+/// records — a subscriber that attaches mid-session sees everything
+/// since L0's session start that survived classification, not the raw
+/// pre-classification feed.</para>
+///
+/// <para><b><see cref="LocalPlayerLogLine.Raw"/></b> is filled iff
+/// <see cref="_captureRaw"/> samples <c>true</c> at emit time — sampled
+/// per-line cheaply (no per-line settings store lookup). Flip the
+/// underlying setting and subsequent emissions reflect the new state;
+/// existing buffered records are unaffected.</para>
+///
+/// <para>G6 carries the constraint that classification + discard run on
+/// the L0/tailing side of the L1 channel. L1 doesn't exist yet (#511
+/// deliverable 3); for this L0.5 PR the router subscribes to L0 via
+/// <see cref="IPlayerLogStream"/> — so the ~95% discarded lines do cross
+/// L0's bounded channel before being discarded here. Strict G6 placement
+/// gets settled in the L1 PR when L0 / L1 actually separate.</para>
+/// </summary>
+public sealed class PlayerLogActorRouter :
+    ILocalPlayerLogStream,
+    ICombatActorLogStream,
+    ISystemSignalLogStream,
+    IDisposable
+{
+    private readonly IPlayerLogStream _upstream;
+    private readonly IDiagnosticsSink? _diag;
+    private readonly Func<bool> _captureRaw;
+    private readonly ThrottledWarn _anomalyWarn;
+
+    private readonly object _gate = new();
+    private readonly PipeRegistry<LocalPlayerLogLine> _localPlayer = new();
+    private readonly PipeRegistry<CombatActorLogLine> _combat = new();
+    private readonly PipeRegistry<SystemSignalLogLine> _system = new();
+
+    private CancellationTokenSource? _runCts;
+    private Task? _runTask;
+    private long _discardCount;
+    private long _anomalyCount;
+    private long _samplesEmitted;
+    private const int AnomalySampleLogBudget = 8;
+
+    public PlayerLogActorRouter(
+        IPlayerLogStream upstream,
+        IDiagnosticsSink? diag = null,
+        Func<bool>? captureRawAccessor = null)
+    {
+        _upstream = upstream ?? throw new ArgumentNullException(nameof(upstream));
+        _diag = diag;
+        _captureRaw = captureRawAccessor ?? (static () => false);
+        _anomalyWarn = new ThrottledWarn(diag, "PlayerLogL05");
+    }
+
+    public IAsyncEnumerable<LocalPlayerLogLine> SubscribeAsync(CancellationToken ct) =>
+        Subscribe(_localPlayer, ct);
+
+    IAsyncEnumerable<CombatActorLogLine> ICombatActorLogStream.SubscribeAsync(CancellationToken ct) =>
+        Subscribe(_combat, ct);
+
+    IAsyncEnumerable<SystemSignalLogLine> ISystemSignalLogStream.SubscribeAsync(CancellationToken ct) =>
+        Subscribe(_system, ct);
+
+    /// <summary>
+    /// Diagnostics-only counters: total cheap-discards, total anomalies,
+    /// total anomaly samples actually emitted to <see cref="IDiagnosticsSink"/>
+    /// (rate-limited).
+    /// </summary>
+    public RouterCounters Counters
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return new RouterCounters(_discardCount, _anomalyCount, _samplesEmitted);
+            }
+        }
+    }
+
+    public readonly record struct RouterCounters(long Discarded, long Anomaly, long AnomalySamplesEmitted);
+
+    private async IAsyncEnumerable<T> Subscribe<T>(PipeRegistry<T> pipe, [EnumeratorCancellation] CancellationToken ct)
+        where T : class
+    {
+        var channel = Channel.CreateBounded<T>(new BoundedChannelOptions(1024)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = true,
+        });
+
+        T[] replay;
+        lock (_gate)
+        {
+            replay = pipe.SnapshotReplay();
+            pipe.AddSubscriber(channel);
+            EnsureRunning();
+        }
+
+        try
+        {
+            // Drain replay buffer directly via yield (same bypass-the-bounded-
+            // channel pattern as PlayerLogStream) so a late joiner can't lose
+            // history to DropOldest when the buffer exceeds 1024 lines.
+            foreach (var item in replay)
+            {
+                if (ct.IsCancellationRequested) yield break;
+                yield return item;
+            }
+
+            await foreach (var item in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                pipe.RemoveSubscriber(channel);
+                channel.Writer.TryComplete();
+                if (NoSubscribers()) StopRunning();
+            }
+        }
+    }
+
+    private bool NoSubscribers() => _localPlayer.IsEmpty && _combat.IsEmpty && _system.IsEmpty;
+
+    private void EnsureRunning()
+    {
+        if (_runTask is { IsCompleted: false }) return;
+        _runCts = new CancellationTokenSource();
+        _runTask = Task.Run(() => RunAsync(_runCts.Token));
+    }
+
+    private void StopRunning()
+    {
+        try { _runCts?.Cancel(); } catch { }
+        _runCts?.Dispose();
+        _runCts = null;
+        _runTask = null;
+        _localPlayer.ClearReplay();
+        _combat.ClearReplay();
+        _system.ClearReplay();
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        _diag?.Info("PlayerLogL05", "Subscribing to L0 Player.log feed for classification");
+        try
+        {
+            await foreach (var raw in _upstream.SubscribeAsync(ct).ConfigureAwait(false))
+            {
+                try { Route(raw); }
+                catch (Exception ex)
+                {
+                    // Per-line containment — same #512 idiom every other consumer
+                    // adopted. A throw from Route should not kill the L0.5 loop.
+                    _anomalyWarn.Warn($"Route threw: {ex.Message}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on shutdown / StopRunning
+        }
+    }
+
+    private void Route(RawLogLine raw)
+    {
+        var line = raw.Line;
+        var result = PlayerLogClassifier.Classify(line);
+        var capture = _captureRaw();
+        var rawField = capture ? line : null;
+
+        switch (result.Kind)
+        {
+            case PlayerLogClassifier.LineKind.LocalPlayer:
+            {
+                var data = line.Substring(result.DataStart);
+                var item = new LocalPlayerLogLine(
+                    raw.Timestamp, data, raw.Sequence, raw.ReadMonotonicTicks, rawField);
+                PublishLocal(item);
+                break;
+            }
+            case PlayerLogClassifier.LineKind.CombatActor:
+            {
+                var data = line.Substring(result.DataStart);
+                var item = new CombatActorLogLine(
+                    raw.Timestamp, result.CombatEntityId, data, raw.Sequence, raw.ReadMonotonicTicks, rawField);
+                PublishCombat(item);
+                break;
+            }
+            case PlayerLogClassifier.LineKind.SystemSignal:
+            {
+                var data = line.Substring(result.DataStart);
+                var item = new SystemSignalLogLine(
+                    raw.Timestamp, result.SystemKind, data, raw.Sequence, raw.ReadMonotonicTicks, rawField);
+                PublishSystem(item);
+                break;
+            }
+            case PlayerLogClassifier.LineKind.Discard:
+                lock (_gate) { _discardCount++; }
+                break;
+            case PlayerLogClassifier.LineKind.Anomaly:
+                long sample;
+                lock (_gate)
+                {
+                    _anomalyCount++;
+                    sample = _samplesEmitted;
+                }
+                // Cap samples to a small fixed budget — a runaway anomaly
+                // pattern shouldn't dominate the diagnostic log even after
+                // ThrottledWarn rate-limiting; the budget plus throttle
+                // together give G7's "count + sample, never assert" shape.
+                if (sample < AnomalySampleLogBudget)
+                {
+                    var truncated = line.Length > 240 ? line.Substring(0, 240) + "…" : line;
+                    _anomalyWarn.Warn($"unclassified shape: \"{truncated}\"");
+                    lock (_gate) { _samplesEmitted++; }
+                }
+                break;
+        }
+    }
+
+    private void PublishLocal(LocalPlayerLogLine item)
+    {
+        Channel<LocalPlayerLogLine>[] snapshot;
+        lock (_gate) snapshot = _localPlayer.Append(item);
+        foreach (var ch in snapshot) ch.Writer.TryWrite(item);
+    }
+
+    private void PublishCombat(CombatActorLogLine item)
+    {
+        Channel<CombatActorLogLine>[] snapshot;
+        lock (_gate) snapshot = _combat.Append(item);
+        foreach (var ch in snapshot) ch.Writer.TryWrite(item);
+    }
+
+    private void PublishSystem(SystemSignalLogLine item)
+    {
+        Channel<SystemSignalLogLine>[] snapshot;
+        lock (_gate) snapshot = _system.Append(item);
+        foreach (var ch in snapshot) ch.Writer.TryWrite(item);
+    }
+
+    public void Dispose()
+    {
+        lock (_gate) { StopRunning(); }
+    }
+
+    /// <summary>
+    /// Per-pipe subscription + session-replay buffer. Mirrors the inner
+    /// structure of <see cref="PlayerLogStream"/> but generic over the
+    /// emitted record type. All access is gated by the outer router's
+    /// <c>_gate</c>; the registry does not lock internally.
+    /// </summary>
+    private sealed class PipeRegistry<T> where T : class
+    {
+        private readonly List<Channel<T>> _subs = new();
+        private List<T>? _replay;
+
+        public bool IsEmpty => _subs.Count == 0;
+
+        public T[] SnapshotReplay() => _replay is { Count: > 0 } r ? r.ToArray() : Array.Empty<T>();
+
+        public void AddSubscriber(Channel<T> ch)
+        {
+            _subs.Add(ch);
+            _replay ??= new List<T>();
+        }
+
+        public void RemoveSubscriber(Channel<T> ch) => _subs.Remove(ch);
+
+        public Channel<T>[] Append(T item)
+        {
+            _replay?.Add(item);
+            return _subs.ToArray();
+        }
+
+        public void ClearReplay() => _replay = null;
+    }
+}

--- a/src/Mithril.Shared/Logging/PlayerLogClassifier.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogClassifier.cs
@@ -1,0 +1,343 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532) line-local classifier. Hand-parsed, no regex, no per-line
+/// allocation — runs in the L0.5 router's hot path which sits on the same
+/// thread that ingested the line from disk (G6 pre-channel discard
+/// constraint). Same allocation-free contract as
+/// <see cref="PlayerLogClock.TryParseTimestampPrefix"/>.
+///
+/// <para><b>Grammar-keyed, not token-keyed.</b> Classification matches the
+/// full <c>[ts] actor: Verb(args)</c> shape, never the actor token in
+/// isolation. The <c>entity_</c> prefix spans three orthogonal buckets in
+/// the corpus (combat-actor / <c>_skin</c> teardown / nav-mesh diagnostic) —
+/// a token-prefix shortcut would silently bleed the combat pipe into
+/// discard. See the <c>prefix-collision-onattack</c> and
+/// <c>entity-skin-teardown</c> / <c>entity-navmesh-nots</c> regression
+/// fixtures.</para>
+/// </summary>
+internal static class PlayerLogClassifier
+{
+    /// <summary>
+    /// Classification verdict + the offset into the source line where the
+    /// post-envelope payload begins. Returned by value as a small struct so
+    /// the classifier remains allocation-free.
+    /// </summary>
+    public readonly record struct Result(
+        LineKind Kind,
+        int DataStart,
+        long CombatEntityId,
+        SystemSignalKind SystemKind);
+
+    /// <summary>
+    /// Classify <paramref name="line"/>. <see cref="Result.DataStart"/> is the
+    /// index of the first character of the payload (caller does
+    /// <c>line.Substring(DataStart)</c> only on the surviving ~5%) or <c>-1</c>
+    /// when the kind does not surface a typed payload (<see cref="LineKind.Discard"/>,
+    /// <see cref="LineKind.Anomaly"/>).
+    /// </summary>
+    public static Result Classify(string line)
+    {
+        // Defensive guard for the empty-line case the tailer trims out, but
+        // a fixture or synthetic input might still pass.
+        if (string.IsNullOrEmpty(line)) return new Result(LineKind.Discard, -1, 0, default);
+
+        // --- Cheap-discard rules that don't depend on a `[ts]` prefix ---
+        // Order matters only as a hot-path optimisation; the buckets are
+        // disjoint by design (verified by the per-rule fixtures).
+
+        // Blank / whitespace-only line.
+        if (IsAllWhitespace(line)) return new Result(LineKind.Discard, -1, 0, default);
+
+        // Any indented (leading-whitespace) line: stack frames in any
+        // namespace, header-continuation blocks (Direct3D: + indented
+        // Version: / Renderer: / Vendor: / VRAM: / Driver:). Catches both
+        // gaps with one rule; safe because no real signal line is indented.
+        if (line[0] == ' ' || line[0] == '\t') return new Result(LineKind.Discard, -1, 0, default);
+
+        // Native-address frames `0x[0-9a-fA-F]+ (`. Live data shows these
+        // sit before the first [ts] line (preamble territory, handled by
+        // #514's seed), so this rule is rarely if ever exercised by L0.5
+        // post-preamble — kept defensively for the straddle case.
+        if (line[0] == '0' && line.Length >= 4 && line[1] == 'x' && IsHexDigit(line[2]))
+        {
+            // walk forward looking for " ("
+            for (var i = 3; i < line.Length - 1 && i < 24; i++)
+            {
+                if (IsHexDigit(line[i])) continue;
+                if (line[i] == ' ' && line[i + 1] == '(') return new Result(LineKind.Discard, -1, 0, default);
+                break;
+            }
+        }
+
+        // Engine subsystem brackets `[Word…]` with NO timestamp prefix.
+        // The `[HH:MM:SS]` timestamp shape has digits at positions 1/2,
+        // colons at 3/6, etc., so this is unambiguous against a real
+        // timestamped line: a bracket whose interior starts with an
+        // ASCII letter is a subsystem tag (e.g. `[Physics::Module]`,
+        // `[D3D12 Device Filter]`, `[Subsystems]`, `[Vulkan::Renderer]`).
+        if (line[0] == '[' && line.Length >= 3 && IsAsciiLetter(line[1]))
+        {
+            return new Result(LineKind.Discard, -1, 0, default);
+        }
+
+        // EVENT(Ok): lifecycle phases — no [ts], system-signal pipe.
+        // Verify the EVENT( prefix and (Ok) parens, then look at the verb
+        // after the colon-space.
+        if (StartsWithLiteral(line, "EVENT(Ok): "))
+        {
+            const int dataStart = 11; // length of "EVENT(Ok): "
+            // The lifecycle phases we route: loginCharacter | playing | sessionUpdate.
+            // (The pre-login preamble's EVENT(Ok): connected sits outside the
+            // L0 replay window and is #514's seed-facility territory.)
+            if (StartsWithLiteral(line, "EVENT(Ok): loginCharacter")
+                || StartsWithLiteral(line, "EVENT(Ok): playing")
+                || StartsWithLiteral(line, "EVENT(Ok): sessionUpdate"))
+            {
+                return new Result(LineKind.SystemSignal, dataStart, 0, SystemSignalKind.SessionLifecycle);
+            }
+            // EVENT(Ok): connected and any other unknown phase falls to anomaly.
+            return new Result(LineKind.Anomaly, -1, 0, default);
+        }
+
+        // Standalone engine diagnostics that aren't bracketed but are still
+        // pure noise. Each kept as its own literal so a refactor that adds
+        // a sibling rule doesn't unintentionally absorb new shapes.
+        if (StartsWithLiteral(line, "ClearCursor(SelectionController)"))
+            return new Result(LineKind.Discard, -1, 0, default);
+
+        // Asset / loader noise. PG emits these with AND without a `[ts] `
+        // prefix in the same session — accept either by checking at offset 0
+        // and (when present) at offset 11.
+        if (IsAssetLoaderNoise(line, 0)) return new Result(LineKind.Discard, -1, 0, default);
+        if (PlayerLogClock.TryParseTimestampPrefix(line, out _)
+            && IsAssetLoaderNoise(line, 11))
+        {
+            return new Result(LineKind.Discard, -1, 0, default);
+        }
+
+        // `Direct3D:` is the header of a deterministic 6-line block; the five
+        // indented continuation lines are caught by the indented rule above,
+        // but the header itself is no-ts and not bracketed.
+        if (StartsWithLiteral(line, "Direct3D:")) return new Result(LineKind.Discard, -1, 0, default);
+
+        // entity_<id>_skin : destroying … — Unity renderer asset teardown
+        // (no-ts, prefix-collides with the `entity_<id>:` combat actor).
+        if (StartsWithLiteral(line, "entity_") && IsEntitySkinTeardown(line))
+            return new Result(LineKind.Discard, -1, 0, default);
+
+        // entity_<id>: Not on nav mesh! — Unity AI engine diagnostic (no-ts,
+        // also a prefix-collision shape).
+        if (StartsWithLiteral(line, "entity_") && IsEntityNavMeshNoTs(line))
+            return new Result(LineKind.Discard, -1, 0, default);
+
+        // Exception headers like `InvalidOperationException:`, `NullReferenceException:`,
+        // and the bespoke `The referenced script on this Behaviour …` (no-ts).
+        if (IsExceptionHeader(line)) return new Result(LineKind.Discard, -1, 0, default);
+
+        // --- Timestamped lines from here on ---
+        if (!PlayerLogClock.TryParseTimestampPrefix(line, out _))
+        {
+            // No timestamp + no discard rule matched → anomaly.
+            return new Result(LineKind.Anomaly, -1, 0, default);
+        }
+
+        // Post-prefix slice starts at index 11 (`[HH:MM:SS] `).
+        const int prefixLen = 11;
+        if (line.Length <= prefixLen) return new Result(LineKind.Anomaly, -1, 0, default);
+
+        // LOADING LEVEL <Area>
+        if (StartsAt(line, prefixLen, "LOADING LEVEL "))
+        {
+            return new Result(LineKind.SystemSignal, prefixLen, 0, SystemSignalKind.AreaLoading);
+        }
+
+        // Logged in as character <Name>. Time UTC=… Timezone Offset …
+        if (StartsAt(line, prefixLen, "Logged in as character "))
+        {
+            return new Result(LineKind.SystemSignal, prefixLen, 0, SystemSignalKind.LoginBanner);
+        }
+
+        // [ts] LocalPlayer: …
+        if (StartsAt(line, prefixLen, "LocalPlayer: "))
+        {
+            var dataStart = prefixLen + "LocalPlayer: ".Length;
+            // ProcessAddPlayer is system-signal (login completion), not
+            // LocalPlayer pipe — even though it shares the LocalPlayer:
+            // envelope. Routed before the generic Process* check.
+            if (StartsAt(line, dataStart, "ProcessAddPlayer("))
+            {
+                return new Result(LineKind.SystemSignal, dataStart, 0, SystemSignalKind.PlayerAdded);
+            }
+            // Generic LocalPlayer pipe: any Process<Verb>(…
+            if (StartsAt(line, dataStart, "Process"))
+            {
+                return new Result(LineKind.LocalPlayer, dataStart, 0, default);
+            }
+            // Unknown LocalPlayer: <verb-not-Process*> is anomaly — the
+            // corpus has no such shape; surfacing it lets G7 telemetry
+            // catch a PG patch that introduces a non-Process actor verb.
+            return new Result(LineKind.Anomaly, -1, 0, default);
+        }
+
+        // [ts] entity_<id>: …
+        if (StartsAt(line, prefixLen, "entity_"))
+        {
+            var idStart = prefixLen + "entity_".Length;
+            if (TryParseEntityIdAndColon(line, idStart, out var entityId, out var dataStart))
+            {
+                // The same `entity_<id>:` token can appear with a non-actor
+                // body when the line is a [ts]-prefixed Unity AI diagnostic
+                // (`entity_<id>: Not on nav mesh!`). Combat-actor lines
+                // start with `On<Verb>(` — anything else under the actor
+                // envelope falls to anomaly so PG verb-space drift surfaces.
+                if (StartsAt(line, dataStart, "On") && dataStart + 2 < line.Length
+                    && IsAsciiUpperLetter(line[dataStart + 2]))
+                {
+                    return new Result(LineKind.CombatActor, dataStart, entityId, default);
+                }
+                // [ts] entity_<id>: Not on nav mesh! — non-actor diagnostic.
+                if (StartsAt(line, dataStart, "Not on nav mesh"))
+                    return new Result(LineKind.Discard, -1, 0, default);
+                return new Result(LineKind.Anomaly, -1, 0, default);
+            }
+            // entity_<garbage>: didn't parse as an integer id — anomaly.
+            return new Result(LineKind.Anomaly, -1, 0, default);
+        }
+
+        // [ts] <something else>: catches any other actor token. Anomaly
+        // routing lets G7 telemetry catch new actor tokens introduced by PG.
+        return new Result(LineKind.Anomaly, -1, 0, default);
+    }
+
+    public enum LineKind
+    {
+        /// <summary><c>[ts] LocalPlayer: Process*(…)</c> — typed L0.5 pipe.</summary>
+        LocalPlayer,
+        /// <summary><c>[ts] entity_&lt;id&gt;: On*(…)</c> — reserved combat pipe.</summary>
+        CombatActor,
+        /// <summary>Small set of session-level non-actor signals (see <see cref="SystemSignalKind"/>).</summary>
+        SystemSignal,
+        /// <summary>Engine/asset/exception noise. ~95% of the corpus.</summary>
+        Discard,
+        /// <summary>Genuinely unknown shape. Counted + sampled via diagnostics; never asserts.</summary>
+        Anomaly,
+    }
+
+    // --- helpers ---
+
+    private static bool IsAllWhitespace(string s)
+    {
+        for (var i = 0; i < s.Length; i++)
+        {
+            var c = s[i];
+            if (c != ' ' && c != '\t' && c != '\r') return false;
+        }
+        return true;
+    }
+
+    private static bool IsAsciiDigit(char c) => (uint)(c - '0') <= 9;
+    private static bool IsHexDigit(char c) => IsAsciiDigit(c) || (uint)(c - 'a') <= 5 || (uint)(c - 'A') <= 5;
+    private static bool IsAsciiLetter(char c) => ((uint)(c - 'a') <= 25) || ((uint)(c - 'A') <= 25);
+    private static bool IsAsciiUpperLetter(char c) => (uint)(c - 'A') <= 25;
+
+    private static bool StartsWithLiteral(string line, string literal)
+    {
+        if (line.Length < literal.Length) return false;
+        for (var i = 0; i < literal.Length; i++)
+            if (line[i] != literal[i]) return false;
+        return true;
+    }
+
+    private static bool StartsAt(string line, int offset, string literal)
+    {
+        if (line.Length - offset < literal.Length) return false;
+        for (var i = 0; i < literal.Length; i++)
+            if (line[offset + i] != literal[i]) return false;
+        return true;
+    }
+
+    private static bool IsAssetLoaderNoise(string line, int offset)
+    {
+        // Centralised list so the no-ts and `[ts] `-prefixed callsites stay
+        // in sync. Each literal is a deterministic engine/asset-loader shape
+        // confirmed in the merged-corpus fixture.
+        return StartsAt(line, offset, "Download")
+            || StartsAt(line, offset, "LoadAssetAsync:")
+            || StartsAt(line, offset, "IsDoneLoading:")
+            || StartsAt(line, offset, "Ref-count")
+            || StartsAt(line, offset, "Completed ")
+            || StartsAt(line, offset, "Successfully ")
+            || StartsAt(line, offset, "Uploading ")
+            || StartsAt(line, offset, "UnloadTime:");
+    }
+
+    private static bool IsEntitySkinTeardown(string line)
+    {
+        // entity_<id>_skin : destroying ...
+        // Walk past the digits, expect "_skin : destroying".
+        var i = "entity_".Length;
+        if (i >= line.Length || !IsAsciiDigit(line[i])) return false;
+        while (i < line.Length && IsAsciiDigit(line[i])) i++;
+        return StartsAt(line, i, "_skin : destroying");
+    }
+
+    private static bool IsEntityNavMeshNoTs(string line)
+    {
+        // entity_<id>: Not on nav mesh!  (no [ts] prefix)
+        var i = "entity_".Length;
+        if (i >= line.Length || !IsAsciiDigit(line[i])) return false;
+        while (i < line.Length && IsAsciiDigit(line[i])) i++;
+        return StartsAt(line, i, ": Not on nav mesh");
+    }
+
+    private static bool IsExceptionHeader(string line)
+    {
+        // `<UppercaseName>Exception: ` or `<UppercaseName>Exception <...>`
+        // followed by indented stack frames (the indented rule above catches
+        // the frames; this rule catches the header).
+        // Also catch the specific `The referenced script on this Behaviour…`
+        // shape Unity emits for missing-script renderer warnings.
+        if (StartsWithLiteral(line, "The referenced script on this Behaviour")) return true;
+
+        // Look for "Exception" anywhere up to a ': ' or ' '. Bounded so the
+        // scan stays cheap (real exception names are < ~64 chars).
+        if (!IsAsciiUpperLetter(line[0])) return false;
+        var cap = Math.Min(line.Length, 80);
+        for (var i = 1; i < cap; i++)
+        {
+            var c = line[i];
+            if (IsAsciiLetter(c)) continue;
+            // First non-letter: must be `Exception` ending at position i,
+            // followed by `:` or end-of-relevant-prefix.
+            const string suffix = "Exception";
+            if (i < suffix.Length) return false;
+            if (!StartsAt(line, i - suffix.Length, suffix)) return false;
+            return c == ':' || c == ' ';
+        }
+        return false;
+    }
+
+    private static bool TryParseEntityIdAndColon(string line, int idStart, out long entityId, out int dataStart)
+    {
+        entityId = 0;
+        dataStart = -1;
+        var i = idStart;
+        if (i >= line.Length || !IsAsciiDigit(line[i])) return false;
+        long acc = 0;
+        while (i < line.Length && IsAsciiDigit(line[i]))
+        {
+            // Bound the accumulator to avoid pathological overflow on a
+            // malformed token; PG entity ids are < 2^31 in practice but
+            // long-typed defensively.
+            acc = acc * 10 + (line[i] - '0');
+            if (acc < 0) return false;
+            i++;
+        }
+        // Need ": " right after the digits to be a real actor envelope.
+        if (i + 1 >= line.Length || line[i] != ':' || line[i + 1] != ' ') return false;
+        entityId = acc;
+        dataStart = i + 2;
+        return true;
+    }
+}

--- a/src/Mithril.Shared/Logging/SystemSignalKind.cs
+++ b/src/Mithril.Shared/Logging/SystemSignalKind.cs
@@ -1,0 +1,40 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Discriminator for <see cref="SystemSignalLogLine"/>. Enumerates the small
+/// fixed set of non-actor Player.log lines that carry session-level state
+/// transitions — the lines that drive <see cref="ISessionAnchor"/> /
+/// <c>PlayerAreaTracker</c> / etc. — distinct from the high-volume
+/// actor-tier traffic (<see cref="LocalPlayerLogLine"/> /
+/// <see cref="CombatActorLogLine"/>) and from cheap-discard engine noise.
+/// </summary>
+public enum SystemSignalKind
+{
+    /// <summary>
+    /// <c>[ts] LOADING LEVEL &lt;Area&gt;</c>. Area-change marker.
+    /// </summary>
+    AreaLoading,
+
+    /// <summary>
+    /// <c>[ts] Logged in as character &lt;Name&gt;. Time UTC=… Timezone Offset …</c>.
+    /// The login banner — <see cref="ISessionAnchor"/> /
+    /// <see cref="PlayerLogClock"/>'s authoritative date source.
+    /// </summary>
+    LoginBanner,
+
+    /// <summary>
+    /// <c>[ts] LocalPlayer: ProcessAddPlayer(…)</c>. Distinguished from the
+    /// <see cref="LocalPlayerLogLine"/> pipe because PG also emits this for
+    /// the local player's own appearance at session start — i.e. it doubles
+    /// as a login-completion signal alongside <see cref="LoginBanner"/>.
+    /// </summary>
+    PlayerAdded,
+
+    /// <summary>
+    /// <c>EVENT(Ok): loginCharacter | playing | sessionUpdate</c> — in-window,
+    /// no-<c>[ts]</c> session-lifecycle phases. The pre-login preamble's
+    /// <c>EVENT(Ok): connected</c> is structurally outside the L0 replay
+    /// window and is handled by #514's seed facility, not here.
+    /// </summary>
+    SessionLifecycle,
+}

--- a/src/Mithril.Shared/Logging/SystemSignalLogLine.cs
+++ b/src/Mithril.Shared/Logging/SystemSignalLogLine.cs
@@ -1,0 +1,23 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L0.5 (#532): a Player.log line classified as a session-level system signal.
+/// The small fixed set is enumerated by <see cref="Kind"/>; <see cref="Data"/>
+/// is the post-prefix payload (e.g. for <see cref="SystemSignalKind.AreaLoading"/>
+/// the area name; for <see cref="SystemSignalKind.LoginBanner"/> the banner
+/// body sans the <c>[ts] </c> bracket). Verb-arg parsing is L2's job — L0.5
+/// only classifies and trims the envelope.
+///
+/// <para>Pass-through fields (<see cref="Timestamp"/> / <see cref="Sequence"/>
+/// / <see cref="ReadMonotonicTicks"/> / <see cref="Raw"/>) follow the same
+/// rules as <see cref="LocalPlayerLogLine"/>. <see cref="SystemSignalKind.SessionLifecycle"/>
+/// lines lack a <c>[ts]</c> prefix in the source file but inherit the most
+/// recently observed gameplay timestamp from <see cref="PlayerLogClock"/>.</para>
+/// </summary>
+public sealed record SystemSignalLogLine(
+    DateTimeOffset Timestamp,
+    SystemSignalKind Kind,
+    string Data,
+    long Sequence,
+    long ReadMonotonicTicks,
+    string? Raw = null);

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -53,6 +53,7 @@ public static class ShellComposition
             .AddMithrilDiagnostics(o.LogDir)
             .AddMithrilPerfTrace(o.PerfDir, sp => () => sp.GetRequiredService<ShellSettings>().VerboseFrameEvents)
             .AddMithrilGameServices()
+            .AddMithrilLogActorRouter(sp => () => sp.GetRequiredService<ShellSettings>().CaptureRawPlayerLogLines)
             .AddMithrilGameState()
             .AddMithrilPerCharacterStorage(o.CharactersRootDir)
             .AddMithrilReferenceData(o.ReferenceCacheDir)

--- a/src/Mithril.Shell/ShellSettings.cs
+++ b/src/Mithril.Shell/ShellSettings.cs
@@ -44,6 +44,17 @@ public sealed class ShellSettings : INotifyPropertyChanged, IActiveCharacterPers
     private bool _autoStartPerfTrace;
     public bool AutoStartPerfTrace { get => _autoStartPerfTrace; set => Set(ref _autoStartPerfTrace, value); }
 
+    /// <summary>When true, the L0.5 actor-router (#532 / <c>PlayerLogActorRouter</c>)
+    /// fills <see cref="Mithril.Shared.Logging.LocalPlayerLogLine.Raw"/> (and the
+    /// equivalent fields on the combat / system pipes) with the exact source
+    /// <see cref="Mithril.Shared.Logging.RawLogLine.Line"/>. <c>null</c> by
+    /// default — no per-line string allocation. Use when diagnosing an
+    /// L2 / L3 parse or interpretation failure where the original line is
+    /// useful at the failing datum. Flip takes effect forward (no restart).
+    /// Infra-level diagnostic; sibling to <see cref="VerboseFrameEvents"/>.</summary>
+    private bool _captureRawPlayerLogLines;
+    public bool CaptureRawPlayerLogLines { get => _captureRawPlayerLogLines; set => Set(ref _captureRawPlayerLogLines, value); }
+
     private string _uiFontFamily = "Segoe UI";
     public string UiFontFamily { get => _uiFontFamily; set => Set(ref _uiFontFamily, value); }
 

--- a/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
@@ -28,7 +28,7 @@ public sealed class GameSessionServiceTests
             GameSession? captured = null;
             svc.SessionStarted += (_, s) => captured = s;
 
-            stream.Push(BannerEmraell);
+            stream.PushBanner(BannerEmraell);
             await RunUntilDrainedAsync(svc, stream);
 
             svc.Current.Should().NotBeNull();
@@ -55,9 +55,9 @@ public sealed class GameSessionServiceTests
             svc.SessionStarted += (_, _) => startedCount++;
             anchor.AnchorChanged += (_, _) => anchorChangedCount++;
 
-            stream.Push(BannerEmraell);
-            stream.Push(BannerEmraell);
-            stream.Push(BannerEmraell);
+            stream.PushBanner(BannerEmraell);
+            stream.PushBanner(BannerEmraell);
+            stream.PushBanner(BannerEmraell);
             await RunUntilDrainedAsync(svc, stream);
 
             startedCount.Should().Be(1);
@@ -76,8 +76,8 @@ public sealed class GameSessionServiceTests
             var sessions = new List<GameSession>();
             svc.SessionStarted += (_, s) => sessions.Add(s);
 
-            stream.Push(BannerEmraell);
-            stream.Push(BannerSecond);
+            stream.PushBanner(BannerEmraell);
+            stream.PushBanner(BannerSecond);
             await RunUntilDrainedAsync(svc, stream);
 
             sessions.Should().HaveCount(2);
@@ -99,8 +99,8 @@ public sealed class GameSessionServiceTests
             var sessions = new List<GameSession>();
             svc.SessionStarted += (_, s) => sessions.Add(s);
 
-            stream.Push(BannerEmraell);
-            stream.Push(BannerOtherCharacter);
+            stream.PushBanner(BannerEmraell);
+            stream.PushBanner(BannerOtherCharacter);
             await RunUntilDrainedAsync(svc, stream);
 
             sessions.Should().HaveCount(2);
@@ -120,7 +120,7 @@ public sealed class GameSessionServiceTests
         var runTask = svc.StartAsync(cts.Token);
         try
         {
-            stream.Push(BannerEmraell);
+            stream.PushBanner(BannerEmraell);
             await stream.WaitForDrainAsync(cts.Token);
 
             var replayed = new List<GameSession>();
@@ -131,7 +131,7 @@ public sealed class GameSessionServiceTests
 
             // Live event still arrives without re-subscribing — the service is
             // still running and a second banner mints + delivers a new session.
-            stream.Push(BannerSecond);
+            stream.PushBanner(BannerSecond);
             await stream.WaitForDrainAsync(cts.Token);
 
             replayed.Should().HaveCount(2);
@@ -168,8 +168,11 @@ public sealed class GameSessionServiceTests
     }
 
     [Fact]
-    public async Task Non_banner_lines_do_not_affect_session()
+    public async Task Non_LoginBanner_system_signals_do_not_affect_session()
     {
+        // Post-L0.5: GameSessionService only sees system-signal-classified lines.
+        // Other Kinds (AreaLoading, PlayerAdded, SessionLifecycle) flow past
+        // without affecting session state.
         var stream = new ScriptedStream(Array.Empty<string>());
         var svc = new GameSessionService(stream);
         try
@@ -177,10 +180,11 @@ public sealed class GameSessionServiceTests
             var starts = 0;
             svc.SessionStarted += (_, _) => starts++;
 
-            stream.Push("[12:25:00] LocalPlayer: ProcessAddPlayer(1, 2, \"\", \"Emraell\")");
-            stream.Push("[12:25:01] Some unrelated engine log line.");
-            stream.Push(BannerEmraell);
-            stream.Push("[12:25:05] LocalPlayer: ProcessAddItem(Barley(1), 0, False)");
+            stream.Push(SystemSignalKind.AreaLoading, "LOADING LEVEL AreaSerbule");
+            stream.Push(SystemSignalKind.PlayerAdded, "ProcessAddPlayer(1, 2, \"\", \"Emraell\")");
+            stream.Push(SystemSignalKind.SessionLifecycle, "EVENT(Ok): playing");
+            stream.PushBanner(BannerEmraell);
+            stream.Push(SystemSignalKind.SessionLifecycle, "EVENT(Ok): sessionUpdate, playTime=60");
             await RunUntilDrainedAsync(svc, stream);
 
             starts.Should().Be(1);
@@ -206,34 +210,53 @@ public sealed class GameSessionServiceTests
         svc.Dispose();
     }
 
-    private sealed class ScriptedStream : IPlayerLogStream
+    /// <summary>
+    /// In-memory <see cref="ISystemSignalLogStream"/> that emits pre-classified
+    /// signals to the service under test — the same shape the L0.5 router
+    /// would produce in production. <see cref="PushBanner"/> takes a raw
+    /// <c>[ts] Logged in as character …</c> line, strips the <c>[ts] </c>
+    /// prefix, and emits with <see cref="SystemSignalKind.LoginBanner"/>;
+    /// <see cref="Push(SystemSignalKind, string)"/> emits an arbitrary
+    /// kind+data pair for the non-banner cases.
+    /// </summary>
+    private sealed class ScriptedStream : ISystemSignalLogStream
     {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private const int TsPrefixLen = 11; // length of "[HH:MM:SS] "
+        private readonly Channel<SystemSignalLogLine> _channel = Channel.CreateUnbounded<SystemSignalLogLine>();
         private long _pending;
         private TaskCompletionSource _drained = NewDrainTcs();
 
-        public ScriptedStream(params string[] lines)
+        public ScriptedStream(params string[] bannerLines)
         {
-            if (lines.Length == 0)
+            if (bannerLines.Length == 0)
             {
                 _drained.TrySetResult();
                 return;
             }
-            Interlocked.Add(ref _pending, lines.Length);
-            foreach (var line in lines) _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+            Interlocked.Add(ref _pending, bannerLines.Length);
+            foreach (var line in bannerLines)
+                _channel.Writer.TryWrite(MakeBanner(line));
         }
 
-        public void Push(string line)
+        public void PushBanner(string fullBannerLine)
         {
             Interlocked.Increment(ref _pending);
             Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
+            _channel.Writer.TryWrite(MakeBanner(fullBannerLine));
+        }
+
+        public void Push(SystemSignalKind kind, string data)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _channel.Writer.TryWrite(new SystemSignalLogLine(
+                DateTimeOffset.UtcNow, kind, data, Sequence: 0, ReadMonotonicTicks: 0));
         }
 
         public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
         public Task WaitForDrainAsync(TimeSpan timeout) => _drained.Task.WaitAsync(timeout);
 
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+        public async IAsyncEnumerable<SystemSignalLogLine> SubscribeAsync(
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
         {
             while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
@@ -245,6 +268,17 @@ public sealed class GameSessionServiceTests
                         _drained.TrySetResult();
                 }
             }
+        }
+
+        private static SystemSignalLogLine MakeBanner(string fullLine)
+        {
+            // Tolerate inputs without the [ts] prefix so tests can read either way.
+            var data = fullLine.Length > TsPrefixLen && fullLine[0] == '['
+                ? fullLine.Substring(TsPrefixLen)
+                : fullLine;
+            return new SystemSignalLogLine(
+                DateTimeOffset.UtcNow, SystemSignalKind.LoginBanner, data,
+                Sequence: 0, ReadMonotonicTicks: 0);
         }
 
         private static TaskCompletionSource NewDrainTcs() =>

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogActorRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogActorRouterTests.cs
@@ -1,0 +1,199 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Logging;
+
+/// <summary>
+/// L0.5 (#532) router end-to-end tests. Drives the classifier via the
+/// router with an in-memory <see cref="IPlayerLogStream"/> and asserts the
+/// fan-out + the <c>Raw</c> opt-in behaviour.
+/// </summary>
+public sealed class PlayerLogActorRouterTests
+{
+    [Fact]
+    public async Task Router_fans_out_to_three_typed_pipes()
+    {
+        var upstream = new ScriptedPlayerLogStream();
+        using var router = new PlayerLogActorRouter(upstream);
+
+        var localTask = CollectAsync(router.SubscribeAsync, 3);
+        var combatTask = CollectAsync(((ICombatActorLogStream)router).SubscribeAsync, 1);
+        var systemTask = CollectAsync(((ISystemSignalLogStream)router).SubscribeAsync, 2);
+
+        // Feed a mixed batch:
+        upstream.Push("[20:01:14] LOADING LEVEL AreaKurMountains");
+        upstream.Push("[20:01:14] Logged in as character TestChar. Time UTC=05/19/2026 20:01:14. Timezone Offset 01:00:00");
+        upstream.Push("[20:01:17] LocalPlayer: ProcessAddItem(GoblinCap(84741837), -1, False)");
+        upstream.Push("[20:01:18] LocalPlayer: ProcessSetAttributes(25042203, \"[]\", \"[]\")");
+        upstream.Push("[20:01:19] entity_25021745: OnAttackHitMe(Bear Bite (Pet)). Evaded = False");
+        upstream.Push("[20:01:20] LocalPlayer: ProcessRemoveEffects(25042203, [259278,])");
+        upstream.Push("UnloadTime: 4.729400 ms"); // discard
+        upstream.Push("entity_24902175_skin : destroying FluffySheep (Instance) #-153844"); // discard
+
+        var local = await localTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var combat = await combatTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var system = await systemTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        local.Should().HaveCount(3);
+        local[0].Data.Should().StartWith("ProcessAddItem(");
+        local[1].Data.Should().StartWith("ProcessSetAttributes(");
+        local[2].Data.Should().StartWith("ProcessRemoveEffects(");
+
+        combat.Should().HaveCount(1);
+        combat[0].EntityId.Should().Be(25021745L);
+        combat[0].Data.Should().StartWith("OnAttackHitMe(");
+
+        system.Should().HaveCount(2);
+        system.Should().ContainSingle(s => s.Kind == SystemSignalKind.AreaLoading);
+        system.Should().ContainSingle(s => s.Kind == SystemSignalKind.LoginBanner);
+
+        var counters = router.Counters;
+        counters.Discarded.Should().Be(2);
+        counters.Anomaly.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Raw_is_null_by_default_and_filled_when_accessor_returns_true()
+    {
+        // Two routers — one with the toggle off (default), one with it on —
+        // each fed an identical line; assert the toggle controls Raw.
+        var offUpstream = new ScriptedPlayerLogStream();
+        using var offRouter = new PlayerLogActorRouter(offUpstream, captureRawAccessor: () => false);
+        var offTask = CollectAsync(offRouter.SubscribeAsync, 1);
+        offUpstream.Push("[20:01:17] LocalPlayer: ProcessAddItem(GoblinCap(84741837), -1, False)");
+        var off = await offTask.WaitAsync(TimeSpan.FromSeconds(5));
+        off[0].Raw.Should().BeNull();
+
+        var onUpstream = new ScriptedPlayerLogStream();
+        using var onRouter = new PlayerLogActorRouter(onUpstream, captureRawAccessor: () => true);
+        var onTask = CollectAsync(onRouter.SubscribeAsync, 1);
+        var rawLine = "[20:01:17] LocalPlayer: ProcessAddItem(GoblinCap(84741837), -1, False)";
+        onUpstream.Push(rawLine);
+        var on = await onTask.WaitAsync(TimeSpan.FromSeconds(5));
+        on[0].Raw.Should().Be(rawLine);
+    }
+
+    [Fact]
+    public async Task Anomaly_lines_are_counted_without_being_emitted_on_any_pipe()
+    {
+        var upstream = new ScriptedPlayerLogStream();
+        using var router = new PlayerLogActorRouter(upstream);
+
+        // Late-subscribe so we have a chance to count anomalies without
+        // any pipe receiving them.
+        var localTask = CollectAsync(router.SubscribeAsync, 0, TimeSpan.FromMilliseconds(400));
+        var combatTask = CollectAsync(((ICombatActorLogStream)router).SubscribeAsync, 0, TimeSpan.FromMilliseconds(400));
+        var systemTask = CollectAsync(((ISystemSignalLogStream)router).SubscribeAsync, 0, TimeSpan.FromMilliseconds(400));
+
+        // Genuinely unknown shapes the classifier should escalate to anomaly:
+        upstream.Push("[20:01:17] !!! Initializing area! (502934): AreaKurMountains");
+        upstream.Push("[20:01:17] New Network State: PickingCharacter -> JoinedArea)");
+
+        var local = await localTask;
+        var combat = await combatTask;
+        var system = await systemTask;
+
+        local.Should().BeEmpty();
+        combat.Should().BeEmpty();
+        system.Should().BeEmpty();
+        router.Counters.Anomaly.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Late_subscriber_sees_replay_then_live()
+    {
+        // The replay buffer is alive only while at least one subscriber holds
+        // a pipe open — same shape as PlayerLogStream. To exercise the
+        // replay path the first subscriber stays attached while the late
+        // subscriber joins.
+        var upstream = new ScriptedPlayerLogStream();
+        using var router = new PlayerLogActorRouter(upstream);
+        using var firstCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // First subscriber: kept open for the duration of the test to keep the
+        // replay buffer populated. Collects without an item budget; we only
+        // care that it stays attached.
+        var firstSink = new List<LocalPlayerLogLine>();
+        var firstTask = Task.Run(async () =>
+        {
+            await foreach (var item in router.SubscribeAsync(firstCts.Token))
+                firstSink.Add(item);
+        });
+
+        upstream.Push("[20:01:17] LocalPlayer: ProcessAddItem(A(1), -1, False)");
+        // Wait for the first subscriber to actually observe the line so the
+        // replay buffer has had time to accumulate it.
+        await WaitUntilAsync(() => firstSink.Count >= 1, TimeSpan.FromSeconds(5));
+
+        // Subscribe AFTER the first line was emitted. The router's per-pipe
+        // replay buffer should deliver it to this new subscriber.
+        var lateTask = CollectAsync(router.SubscribeAsync, 2);
+        upstream.Push("[20:01:18] LocalPlayer: ProcessAddItem(B(2), -1, False)");
+
+        var collected = await lateTask.WaitAsync(TimeSpan.FromSeconds(5));
+        collected.Should().HaveCount(2);
+        collected[0].Data.Should().StartWith("ProcessAddItem(A");
+        collected[1].Data.Should().StartWith("ProcessAddItem(B");
+
+        firstCts.Cancel();
+        try { await firstTask; } catch (OperationCanceledException) { }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (sw.Elapsed > timeout) throw new TimeoutException("WaitUntilAsync gave up");
+            await Task.Delay(10);
+        }
+    }
+
+    private static async Task<List<T>> CollectAsync<T>(
+        Func<CancellationToken, IAsyncEnumerable<T>> subscribe,
+        int expected,
+        TimeSpan? timeBudget = null)
+    {
+        var budget = timeBudget ?? TimeSpan.FromSeconds(5);
+        using var cts = new CancellationTokenSource(budget);
+        var result = new List<T>();
+        try
+        {
+            await foreach (var item in subscribe(cts.Token).ConfigureAwait(false))
+            {
+                result.Add(item);
+                if (result.Count >= expected) break;
+            }
+        }
+        catch (OperationCanceledException) { /* expected when expected=0 */ }
+        return result;
+    }
+
+    private sealed class ScriptedPlayerLogStream : IPlayerLogStream
+    {
+        private readonly Channel<RawLogLine> _ch = Channel.CreateUnbounded<RawLogLine>();
+        private long _seq;
+
+        public void Push(string line)
+        {
+            var seq = Interlocked.Increment(ref _seq);
+            _ch.Writer.TryWrite(new RawLogLine(
+                Timestamp: new DateTimeOffset(2026, 5, 19, 20, 0, 0, TimeSpan.Zero),
+                Line: line,
+                Sequence: seq,
+                ReadMonotonicTicks: 0));
+        }
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync([EnumeratorCancellation] CancellationToken ct)
+        {
+            while (await _ch.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_ch.Reader.TryRead(out var line))
+                    yield return line;
+            }
+        }
+    }
+}

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogClassifierTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogClassifierTests.cs
@@ -1,0 +1,190 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Mithril.Shared.Tests.Logging;
+
+/// <summary>
+/// L0.5 (#532) classifier tests. Drives every line of every per-rule fixture
+/// + the merged-corpus through <see cref="PlayerLogClassifier"/> and asserts
+/// the expected kind/data. The per-rule fixtures are the literal regression
+/// guards from the #532 design — each is a small file dedicated to one
+/// rule, so test failures localize by filename.
+/// </summary>
+public sealed class PlayerLogClassifierTests
+{
+    private readonly ITestOutputHelper _output;
+    public PlayerLogClassifierTests(ITestOutputHelper output) { _output = output; }
+
+    private static string FixturePath(params string[] parts)
+    {
+        var p = new[] { AppContext.BaseDirectory, "Logging", "Fixtures" }
+            .Concat(parts).ToArray();
+        return Path.Combine(p);
+    }
+
+    private static IEnumerable<string> ReadFixtureLines(string relPath)
+    {
+        var full = FixturePath(relPath.Split('/'));
+        return File.ReadAllLines(full).Where(l => !string.IsNullOrWhiteSpace(l));
+    }
+
+    // --- Per-rule fixtures: every line classifies to one expected kind ---
+
+    [Fact]
+    public void LocalPlayer_pipe_routes_every_line_in_per_rule_fixture()
+    {
+        var lines = ReadFixtureLines("per-rule/localplayer-process.log").ToList();
+        lines.Should().NotBeEmpty();
+        foreach (var line in lines)
+        {
+            var r = PlayerLogClassifier.Classify(line);
+            r.Kind.Should().Be(PlayerLogClassifier.LineKind.LocalPlayer, because: $"line: {line[..Math.Min(80, line.Length)]}");
+            r.DataStart.Should().BeGreaterThan(0);
+            // The eaten envelope must be the full `[ts] LocalPlayer: ` prefix.
+            line[..r.DataStart].Should().EndWith("LocalPlayer: ");
+        }
+    }
+
+    [Fact]
+    public void Combat_actor_pipe_routes_every_line_in_per_rule_fixture()
+    {
+        var lines = ReadFixtureLines("per-rule/combat-actor-on.log").ToList();
+        lines.Should().NotBeEmpty();
+        foreach (var line in lines)
+        {
+            var r = PlayerLogClassifier.Classify(line);
+            r.Kind.Should().Be(PlayerLogClassifier.LineKind.CombatActor, because: $"line: {line[..Math.Min(80, line.Length)]}");
+            r.CombatEntityId.Should().BeGreaterThan(0);
+            // Data should start with "On" then an uppercase letter.
+            var data = line[r.DataStart..];
+            data.Should().StartWith("On");
+        }
+    }
+
+    [Fact]
+    public void Prefix_collision_OnAttack_routes_combat_line_to_combat_and_indented_frame_to_discard()
+    {
+        // The whole point of this fixture: one `entity_<id>: OnAttackHitMe(...)` line
+        // (combat) and one `  at Combatant.OnAttackHitMe (...)` stack frame
+        // (indented, must be cheap-discard). A token-prefix shortcut would
+        // misclassify either or both.
+        var lines = ReadFixtureLines("per-rule/prefix-collision-onattack.log").ToList();
+        lines.Should().HaveCountGreaterThanOrEqualTo(2);
+
+        var combat = PlayerLogClassifier.Classify(lines[0]);
+        combat.Kind.Should().Be(PlayerLogClassifier.LineKind.CombatActor);
+
+        var frame = PlayerLogClassifier.Classify(lines[1]);
+        frame.Kind.Should().Be(PlayerLogClassifier.LineKind.Discard);
+    }
+
+    [Theory]
+    [InlineData("per-rule/entity-skin-teardown.log")]
+    [InlineData("per-rule/entity-navmesh-nots.log")]
+    [InlineData("per-rule/exception-stackframe-xnamespace.log")]
+    [InlineData("per-rule/native-address-frames.log")]
+    [InlineData("per-rule/direct3d-continuation.log")]
+    [InlineData("per-rule/engine-subsystem-brackets.log")]
+    [InlineData("per-rule/asset-loader-noise.log")]
+    public void Cheap_discard_fixtures_route_every_line_to_discard(string fixture)
+    {
+        var lines = ReadFixtureLines(fixture).ToList();
+        lines.Should().NotBeEmpty();
+        foreach (var line in lines)
+        {
+            var r = PlayerLogClassifier.Classify(line);
+            r.Kind.Should().Be(PlayerLogClassifier.LineKind.Discard,
+                because: $"fixture {fixture} should cheap-discard: \"{line[..Math.Min(100, line.Length)]}\"");
+        }
+    }
+
+    [Fact]
+    public void System_signal_fixture_routes_every_line_to_system_signal_pipe()
+    {
+        var lines = ReadFixtureLines("per-rule/system-signals.log").ToList();
+        lines.Should().NotBeEmpty();
+        foreach (var line in lines)
+        {
+            var r = PlayerLogClassifier.Classify(line);
+            r.Kind.Should().Be(PlayerLogClassifier.LineKind.SystemSignal,
+                because: $"line: {line[..Math.Min(100, line.Length)]}");
+        }
+    }
+
+    [Fact]
+    public void System_signal_kinds_are_assigned_correctly()
+    {
+        // Spot-check that each SystemSignalKind is reachable from the fixture.
+        var lines = ReadFixtureLines("per-rule/system-signals.log").ToList();
+        var kinds = lines.Select(l => PlayerLogClassifier.Classify(l))
+            .Where(r => r.Kind == PlayerLogClassifier.LineKind.SystemSignal)
+            .Select(r => r.SystemKind)
+            .Distinct()
+            .ToHashSet();
+
+        kinds.Should().Contain(SystemSignalKind.AreaLoading);
+        kinds.Should().Contain(SystemSignalKind.LoginBanner);
+        kinds.Should().Contain(SystemSignalKind.PlayerAdded);
+        kinds.Should().Contain(SystemSignalKind.SessionLifecycle);
+    }
+
+    // --- Merged corpus: bucket distribution + anomaly cap ---
+
+    [Fact]
+    public void Merged_corpus_routes_within_documented_anomaly_budget()
+    {
+        var lines = File.ReadAllLines(FixturePath("merged-corpus.log"));
+        var buckets = new Dictionary<PlayerLogClassifier.LineKind, int>();
+        var anomalySamples = new List<string>();
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrEmpty(line)) continue;
+            var r = PlayerLogClassifier.Classify(line);
+            buckets[r.Kind] = buckets.GetValueOrDefault(r.Kind) + 1;
+            if (r.Kind == PlayerLogClassifier.LineKind.Anomaly && anomalySamples.Count < 30)
+                anomalySamples.Add(line[..Math.Min(120, line.Length)]);
+        }
+
+        // The whole corpus parsed without throwing. Bucket counts are
+        // diagnostic; only the anomaly cap is contractual.
+        var anomalyCount = buckets.GetValueOrDefault(PlayerLogClassifier.LineKind.Anomaly);
+        var nonEmpty = buckets.Values.Sum();
+
+        // Anomaly cap is *generous* in this initial PR per #532's "fixture grows,
+        // rules grow opportunistically" framing. Tighten in follow-up PRs as
+        // production telemetry surfaces new engine-noise shapes worth absorbing.
+        // The classifier's structural invariants are verified by the per-rule
+        // fixtures above; this assertion floors total drift on the current
+        // merged corpus (which is session-start-heavy, not combat-heavy —
+        // per-pipe density assertions belong on the per-rule fixtures).
+        // Current implementation: 35 anomalies on the n=1997-line corpus
+        // (1.8%). Budget is set well above current so opportunistic fixture
+        // additions don't break the test; consciously bump or tighten the
+        // rule set when a new capture pushes the number meaningfully higher.
+        const int AnomalyBudget = 100;
+        anomalyCount.Should().BeLessThanOrEqualTo(AnomalyBudget,
+            because: $"anomaly samples (first {anomalySamples.Count} of {anomalyCount}, {nonEmpty} non-empty lines total):\n  "
+                + string.Join("\n  ", anomalySamples));
+
+        // System signals must be present — the merged corpus includes the
+        // session-start preamble (LOADING LEVEL + login banner +
+        // ProcessAddPlayer + EVENT(Ok) lifecycle).
+        buckets.GetValueOrDefault(PlayerLogClassifier.LineKind.SystemSignal)
+            .Should().BeGreaterThan(0);
+
+        // Emit the distribution to the test output so it surfaces in CI
+        // and in `dotnet test -v normal` runs — useful when telemetry
+        // surfaces a new shape and we want to know the new baseline.
+        _output.WriteLine($"Merged corpus ({nonEmpty} non-empty lines):");
+        foreach (var k in Enum.GetValues<PlayerLogClassifier.LineKind>())
+        {
+            var c = buckets.GetValueOrDefault(k);
+            var pct = nonEmpty > 0 ? c * 100.0 / nonEmpty : 0;
+            _output.WriteLine($"  {k,-12} {c,5}  ({pct,5:N1}%)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements deliverable 2 of #511 — the L0.5 actor-keyed envelope router. Sits on top of L0's `IPlayerLogStream` (`RawLogLine`), classifies each line by the `<Actor>: ` envelope grammar, eats the envelope, and emits typed records on three pipes:

- **LocalPlayer** (`ILocalPlayerLogStream` → `LocalPlayerLogLine`) — `[ts] LocalPlayer: Process*(…)`
- **Combat-actor (reserved)** (`ICombatActorLogStream` → `CombatActorLogLine`) — `[ts] entity_<id>: On*(…)`, no current consumer
- **System-signal** (`ISystemSignalLogStream` → `SystemSignalLogLine` keyed by `SystemSignalKind`) — LOADING LEVEL / login banner / ProcessAddPlayer / `EVENT(Ok)` lifecycle

Engine/asset noise is cheap-discarded; genuinely unknown shapes route to a rate-limited anomaly bucket via `IDiagnosticsSink` (G7 — telemetry, never assert-fail).

## Merged-corpus distribution (1997 non-empty lines)

| Bucket | Count | % |
|---|---:|---:|
| Discard | 1957 | **98.0%** |
| Anomaly | 35 | 1.8% |
| SystemSignal | 4 | 0.2% |
| LocalPlayer | 1 | 0.1% |
| CombatActor | 0 | 0.0% |

Cheap-discard rate (98%) exceeds the design's ~95% target. The CombatActor count is 0 because `merged-corpus.log` is session-start-heavy, not combat-heavy — the per-rule `combat-actor-on.log` fixture (20 lines) covers that path. Anomaly budget is set to 100 (3× current) to allow opportunistic fixture growth without breaking the test; tighten or absorb shapes via follow-up PRs as G7 telemetry surfaces patterns.

## Verification owed — #532 checklist

- [x] `[ts] LocalPlayer: Process*(…)` → `LocalPlayerLogLine` (~5% of corpus). *Per-rule fixture: every line classifies as LocalPlayer.*
- [x] `[ts] entity_<id>: On*(…)` (combat) → reserved combat pipe — **NOT discarded, NOT anomaly**. *Per-rule fixture: 20/20 classify as CombatActor with parsed `EntityId`.*
- [x] **Same-token-but-non-actor regression guards** (`entity_<id>_skin`, no-ts `entity_<id>: Not on nav mesh!`, indented `^\s+at Combatant.OnAttackHitMe…`). *Per-rule fixtures + dedicated `Prefix_collision_OnAttack_routes_combat_line_to_combat_and_indented_frame_to_discard` test.*
- [x] **Indented no-ts lines in any namespace** → cheap-discard. *Single `^\s+\S` rule catches stack frames from any namespace + Direct3D continuation lines.*
- [x] **Header continuation blocks** — `Direct3D:` header + 5 indented lines. *Per-rule fixture: 6/6 classify as Discard.*
- [x] **Engine subsystem brackets are shape-keyed, not enumerated** — synthetic `[Vulkan::Renderer]` line routes to cheap-discard. *Per-rule fixture covers shape-keyed match.*
- [x] Engine/asset → cheap-discard. **98% on the merged corpus**, anomaly count ≤ 100 (current: 35).
- [x] System line → system-signal pipe (all four `SystemSignalKind`s reachable from `system-signals.log`).
- [x] Genuinely-unknown shape → anomaly (counted, sampled, never assert in production). *Rate-limited via `ThrottledWarn`; sample budget of 8 first occurrences then count-only.*
- [x] `Raw` is `null` with the diagnostic setting off; exact source `RawLogLine.Line` with it on. *`Raw_is_null_by_default_and_filled_when_accessor_returns_true` test.*
- [x] L2 only ever receives `LocalPlayerLogLine.Data`. *Envelope eaten in the router; downstream sees only the post-prefix payload.*
- [x] Re-verify on rebuilt merged main. *Rebased onto `392d401` (#518) then re-tested: 20/20 test projects pass.*
- [ ] **Native-address frames** — see open question below.

### Open: native-address-frame rule disposition

Per the [comment on #532](https://github.com/moumantai-gg/mithril/issues/532#issuecomment-4494111243) and [#511](https://github.com/moumantai-gg/mithril/issues/511#issuecomment-4494161577): all 101 native-address frames sit *before* the first `[HH:MM:SS]` line in 4/4 sampled logs (the three fixture sources + a fresh live capture), i.e. inside #514's preamble window. The rule is included in this PR (kept defensively for the straddle case) but is structurally unreachable in production until/unless a native crash dump straddles the boundary. The per-rule `native-address-frames.log` fixture still drives the rule in isolation. Leaving as-is here; happy to drop the rule + delete the per-rule fixture if you want to attribute it cleanly to #514's seed scope.

## Reference consumer migration

`GameSessionService` now subscribes to `ISystemSignalLogStream` (filters `Kind == LoginBanner`, parses via existing `LoginBannerParser` against `signal.Data`). Existing tests updated to feed pre-classified `SystemSignalLogLine` records through a new `ScriptedStream : ISystemSignalLogStream`. Other archetype-B consumers (Legolas / Arwen / Smaug / Samwise / Saruman) remain on `IPlayerLogStream` — their migration is L1-PR / #511 deliverable 5 territory.

## G6 placement note

The classifier currently runs **after** `PlayerLogStream`'s bounded channel rather than pre-channel — the router subscribes via `IPlayerLogStream` like any other consumer. Strict G6 (classify before transport, so the channel only carries the surviving ~2%) gets pinned when L0 and L1 actually separate in the L1 PR (#511 deliverable 3). Documented as a deliberate scope split in the `PlayerLogActorRouter` class XML doc.

## Open L1 design questions

Tracked in [the umbrella comment](https://github.com/moumantai-gg/mithril/issues/511#issuecomment-4494161577) (G4 fault state machine N/window + L2 unknown-verb sink semantics). Neither blocks merging this PR.

## Test plan

- [x] `dotnet build Mithril.slnx` — green (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — 20/20 test projects pass on rebased-onto-main
- [x] New tests cover: every per-rule fixture, prefix-collision regression, merged-corpus distribution, Raw opt-in (off → `null`, on → source line), late-subscriber sees replay then live, anomaly counted but not emitted on any pipe
- [x] Existing `GameSessionServiceTests` migrated to `ISystemSignalLogStream` feed — all 7 still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)