### PR TITLE
fix(logging): chain-serialize RunAsync restarts (#547)

### DIFF
--- a/src/Mithril.Shared/Logging/PlayerLogActorRouter.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogActorRouter.cs
@@ -62,7 +62,12 @@ public sealed class PlayerLogActorRouter :
     private readonly PipeRegistry<SystemSignalLogLine> _system = new();
 
     private CancellationTokenSource? _runCts;
-    private Task? _runTask;
+    // Chain of consecutive RunAsync invocations. A new run is queued via
+    // ContinueWith so it can only start after the prior task has fully
+    // unwound its `await foreach` over the upstream feed — closing the
+    // restart race (#547) where a fast unsub→sub previously spawned a
+    // second RunAsync concurrently with the still-draining first.
+    private Task _runChain = Task.CompletedTask;
     private long _discardCount;
     private long _anomalyCount;
     private long _samplesEmitted;
@@ -155,17 +160,50 @@ public sealed class PlayerLogActorRouter :
 
     private void EnsureRunning()
     {
-        if (_runTask is { IsCompleted: false }) return;
-        _runCts = new CancellationTokenSource();
-        _runTask = Task.Run(() => RunAsync(_runCts.Token));
+        // A healthy uncancelled run already in progress? Keep it.
+        if (_runCts is { IsCancellationRequested: false } && !_runChain.IsCompleted) return;
+
+        // Otherwise queue a new RunAsync at the tail of the chain. Using
+        // ContinueWith guarantees the prior task has fully drained its
+        // `await foreach` over upstream before the new one subscribes —
+        // upstream sees at most one active subscription at any moment.
+        // ConfigureAwait/ExecuteSynchronously isn't used so the continuation
+        // runs on the thread pool rather than whatever happened to complete
+        // the previous task.
+        var cts = new CancellationTokenSource();
+        _runCts = cts;
+        _runChain = _runChain.ContinueWith(
+            _ => RunChainLinkAsync(cts),
+            CancellationToken.None,
+            TaskContinuationOptions.None,
+            TaskScheduler.Default).Unwrap();
+    }
+
+    private async Task RunChainLinkAsync(CancellationTokenSource cts)
+    {
+        try
+        {
+            // A StopRunning landing between queueing and this point makes
+            // the queued link a no-op — don't subscribe to upstream just to
+            // see "already canceled" on the first iteration.
+            bool shouldRun;
+            lock (_gate) shouldRun = !NoSubscribers() && !cts.IsCancellationRequested;
+            if (!shouldRun) return;
+            await RunAsync(cts.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            cts.Dispose();
+        }
     }
 
     private void StopRunning()
     {
+        // Signal cancellation; the chain links observe it and unwind. The
+        // CTS itself is disposed by the link's finally — we DON'T null it
+        // out here, because EnsureRunning needs to read IsCancellationRequested
+        // to decide whether to queue a successor.
         try { _runCts?.Cancel(); } catch { }
-        _runCts?.Dispose();
-        _runCts = null;
-        _runTask = null;
         _localPlayer.ClearReplay();
         _combat.ClearReplay();
         _system.ClearReplay();

--- a/src/Mithril.Shared/Logging/PlayerLogStream.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogStream.cs
@@ -29,7 +29,12 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
     // session, bounded in practice by one game session's log volume.
     private List<RawLogLine>? _sessionReplay;
     private CancellationTokenSource? _runCts;
-    private Task? _runTask;
+    // Chain of consecutive RunAsync invocations. See #547 — a fast
+    // unsub→sub previously spawned a second RunAsync while the first was
+    // still mid-poll, briefly putting two file readers into the publish
+    // path. ContinueWith guarantees the next run only starts after the
+    // prior unwinds. The chain replaces the nullable _runTask field.
+    private Task _runChain = Task.CompletedTask;
     private string? _activePath;
 
     public PlayerLogStream(
@@ -107,20 +112,48 @@ public sealed class PlayerLogStream : IPlayerLogStream, IDisposable
 
     private void EnsureRunning()
     {
-        if (_runTask is { IsCompleted: false }) return;
+        // Healthy uncancelled run already in progress? Keep it.
+        if (_runCts is { IsCancellationRequested: false } && !_runChain.IsCompleted) return;
+
         var path = _config.PlayerLogPath;
         if (string.IsNullOrEmpty(path)) return;
         _activePath = path;
-        _runCts = new CancellationTokenSource();
-        _runTask = Task.Run(() => RunAsync(path, _runCts.Token));
+
+        // Queue a new RunAsync at the tail of the chain via ContinueWith so
+        // it only starts after the prior task has fully drained its poll
+        // loop — at most one file reader is active at any moment (#547).
+        var cts = new CancellationTokenSource();
+        _runCts = cts;
+        _runChain = _runChain.ContinueWith(
+            _ => RunChainLinkAsync(path, cts),
+            CancellationToken.None,
+            TaskContinuationOptions.None,
+            TaskScheduler.Default).Unwrap();
+    }
+
+    private async Task RunChainLinkAsync(string path, CancellationTokenSource cts)
+    {
+        try
+        {
+            // A StopRunning landing between queueing and this point makes
+            // the queued link a no-op.
+            bool shouldRun;
+            lock (_gate) shouldRun = _subs.Count > 0 && !cts.IsCancellationRequested;
+            if (!shouldRun) return;
+            await RunAsync(path, cts.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            cts.Dispose();
+        }
     }
 
     private void StopRunning()
     {
+        // Signal cancellation; the chain link observes it and unwinds. We
+        // DON'T null _runCts here, because EnsureRunning reads
+        // IsCancellationRequested to decide whether to queue a successor.
         try { _runCts?.Cancel(); } catch { }
-        _runCts?.Dispose();
-        _runCts = null;
-        _runTask = null;
         _activePath = null;
         _sessionReplay = null;
     }

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogActorRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogActorRouterTests.cs
@@ -172,6 +172,99 @@ public sealed class PlayerLogActorRouterTests
         return result;
     }
 
+    [Fact]
+    public async Task Fast_unsub_then_resub_does_not_double_route_lines_to_new_subscriber()
+    {
+        // #547 race: PlayerLogActorRouter.StopRunning previously nulled _runTask
+        // synchronously while the prior RunAsync's `await foreach` was still
+        // unwinding. A fast unsubscribe → subscribe → push then spawned a
+        // SECOND RunAsync alongside the still-draining first; both routed the
+        // same upstream emission to the new subscriber's pipe channel.
+        //
+        // We expose the window deterministically with a per-subscriber upstream
+        // whose enumerator only completes once externally released — the
+        // router's old RunAsync remains alive and subscribed to upstream
+        // through the moment the new subscriber attaches.
+        var upstream = new BlockingPerSubscriberStream();
+        using var router = new PlayerLogActorRouter(upstream);
+
+        // First subscriber: receives line 1 then closes.
+        var firstCollected = await CollectOneThenCloseAsync(router.SubscribeAsync, async () =>
+        {
+            await WaitUntilAsync(() => upstream.SubscriberCount == 1, TimeSpan.FromSeconds(5));
+            upstream.Push("[20:01:17] LocalPlayer: ProcessAddItem(A(1), -1, False)");
+        });
+        firstCollected.Should().HaveCount(1);
+        firstCollected[0].Data.Should().StartWith("ProcessAddItem(A");
+
+        // At this moment: the first consumer has exited (StopRunning fired
+        // synchronously inside its finally{}), but the prior RunAsync may
+        // still be inside upstream's await foreach because the upstream
+        // enumerator hasn't been released yet — exactly the race window.
+
+        // Second subscriber attaches. With the bug, EnsureRunning saw
+        // _runTask is null (StopRunning had nulled it) and spawned a SECOND
+        // RunAsync alongside the still-draining first; upstream then had
+        // TWO subscribers and any push routed twice to the new pipe channel.
+        //
+        // With the chain-serialize fix, EnsureRunning queues the new run via
+        // ContinueWith — it only subscribes to upstream after the prior run
+        // unwinds. So while upstream is held open, only the PRIOR RunAsync
+        // is subscribed; the new pipe channel receives exactly one
+        // emission per push (routed by the prior RunAsync, which is still
+        // alive and observing PipeRegistry).
+        //
+        // CollectAsync runs synchronously up to the first await in its body
+        // — past `router.SubscribeAsync.GetAsyncEnumerator().MoveNextAsync()`,
+        // which has already done lock + AddSubscriber + EnsureRunning by the
+        // time `lateTask` is assigned, so the new pipe subscriber is in
+        // place. We still wait briefly for upstream to reach two subscribers
+        // — on UNFIXED code this succeeds (proves the race is observably
+        // open) and a subsequent push routes twice; on FIXED code this
+        // times out (only one subscriber ever; the chain serializes
+        // restarts), the catch swallows the timeout, and the subsequent
+        // push routes only once via the still-alive prior RunAsync. Either
+        // branch leads to the same assertion: exactly one emission.
+        var lateTask = CollectAsync(router.SubscribeAsync, expected: 5, timeBudget: TimeSpan.FromSeconds(2));
+        try { await WaitUntilAsync(() => upstream.SubscriberCount >= 2, TimeSpan.FromSeconds(1)); }
+        catch (TimeoutException) { /* fix path — count stays at 1; proceed */ }
+
+        upstream.Push("[20:01:18] LocalPlayer: ProcessAddItem(B(2), -1, False)");
+        var collected = await lateTask;
+
+        // Release the held-open upstream subscriptions so they unwind cleanly
+        // for the test's disposal.
+        upstream.Release();
+
+        // Exactly-once: the new subscriber observes line B once, not twice.
+        // Before the fix: 2 items (both RunAsync instances routed the line).
+        // After the fix:  1 item (only one RunAsync subscribed at a time).
+        collected.Should().HaveCount(1,
+            because: $"observed Data values: [{string.Join(", ", collected.Select(x => $"\"{x.Data[..Math.Min(30, x.Data.Length)]}\""))}]");
+        collected[0].Data.Should().StartWith("ProcessAddItem(B");
+    }
+
+    /// <summary>
+    /// Subscribe once, run <paramref name="trigger"/> while subscribed, collect
+    /// exactly one item, then exit the iteration (triggering the router's
+    /// no-subscribers StopRunning path).
+    /// </summary>
+    private static async Task<List<LocalPlayerLogLine>> CollectOneThenCloseAsync(
+        Func<CancellationToken, IAsyncEnumerable<LocalPlayerLogLine>> subscribe,
+        Func<Task> trigger)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = new List<LocalPlayerLogLine>();
+        var triggerTask = Task.Run(trigger);
+        await foreach (var item in subscribe(cts.Token))
+        {
+            result.Add(item);
+            if (result.Count >= 1) break;
+        }
+        await triggerTask;
+        return result;
+    }
+
     private sealed class ScriptedPlayerLogStream : IPlayerLogStream
     {
         private readonly Channel<RawLogLine> _ch = Channel.CreateUnbounded<RawLogLine>();
@@ -193,6 +286,67 @@ public sealed class PlayerLogActorRouterTests
             {
                 while (_ch.Reader.TryRead(out var line))
                     yield return line;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Per-subscriber upstream that mirrors <see cref="PlayerLogStream"/>'s
+    /// real fan-out shape (each subscriber gets its own channel — needed to
+    /// reproduce #547; a shared-channel test stream hides the bug because
+    /// only one router instance ever reads the line). Subscriber enumerators
+    /// stay alive after cancellation until <see cref="Release"/> is called,
+    /// so a test can deterministically hold open the prior RunAsync's
+    /// `await foreach` while a new subscriber attaches.
+    /// </summary>
+    private sealed class BlockingPerSubscriberStream : IPlayerLogStream
+    {
+        private readonly object _gate = new();
+        private readonly List<Channel<RawLogLine>> _subs = new();
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private long _seq;
+
+        public int SubscriberCount { get { lock (_gate) return _subs.Count; } }
+
+        public void Push(string line)
+        {
+            Channel<RawLogLine>[] snapshot;
+            lock (_gate) snapshot = _subs.ToArray();
+            var seq = Interlocked.Increment(ref _seq);
+            var raw = new RawLogLine(
+                Timestamp: new DateTimeOffset(2026, 5, 19, 20, 0, 0, TimeSpan.Zero),
+                Line: line, Sequence: seq, ReadMonotonicTicks: 0);
+            foreach (var ch in snapshot) ch.Writer.TryWrite(raw);
+        }
+
+        public void Release() => _release.TrySetResult();
+
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync([EnumeratorCancellation] CancellationToken ct)
+        {
+            var ch = Channel.CreateUnbounded<RawLogLine>();
+            lock (_gate) _subs.Add(ch);
+            try
+            {
+                // Pump lines as they arrive. We deliberately do NOT pass `ct`
+                // to WaitToReadAsync so a cancellation does not immediately
+                // exit the iteration — the enumerator only completes once
+                // `Release()` fires (or the channel is closed). This matches
+                // the spirit of an upstream whose `await foreach` is "still
+                // in flight" while the router's StopRunning has already
+                // returned.
+                while (!_release.Task.IsCompleted)
+                {
+                    var any = await Task.WhenAny(
+                        ch.Reader.WaitToReadAsync().AsTask(),
+                        _release.Task);
+                    if (any == _release.Task) break;
+                    while (ch.Reader.TryRead(out var line)) yield return line;
+                }
+            }
+            finally
+            {
+                lock (_gate) _subs.Remove(ch);
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #547. Same fix shape applied to two structurally identical sites: `PlayerLogActorRouter.StopRunning` (new in #546) and `PlayerLogStream.StopRunning` (preexisting). Both previously nulled `_runTask` synchronously while the prior `RunAsync` was still draining → a fast unsubscribe → subscribe spawned a second `RunAsync` concurrently with the first → both routed the same upstream emission, producing duplicates on the new subscriber's pipe channel.

## Fix

Chain-serialize restarts. The nullable `_runTask` becomes `Task _runChain = Task.CompletedTask`; `EnsureRunning` queues a new `RunAsync` via `ContinueWith` onto the chain tail so the next run can only start after the prior unwinds. `StopRunning` signals cancellation but no longer nulls or disposes `_runCts` — `EnsureRunning` reads `_runCts.IsCancellationRequested` to decide whether to queue a successor; each chain link disposes its own CTS in `finally`.

**Invariant after fix:** at most one `RunAsync` subscribed to upstream (`IPlayerLogStream` / file tail) at any moment.

## Regression test

`PlayerLogActorRouterTests.Fast_unsub_then_resub_does_not_double_route_lines_to_new_subscriber`. Uses a new `BlockingPerSubscriberStream` that:

- Mirrors `PlayerLogStream`'s per-subscriber-channel fan-out — a shared-channel test stream **hides** the bug because only one router instance ever reads each line.
- Holds the prior `RunAsync`'s upstream subscription open via an external `Release` gate, so the race window is observable without timing flakiness.

The test asserts `collected.HaveCount(1)` for a single push after fast unsub→sub. Verified by reverting the fix locally — test fails with `collected.Count == 2` (both copies of the same line). Test passes after the fix.

## Why no dedicated PlayerLogStream race test

The PlayerLogStream code shape is identical to the router's (verified by side-by-side review of the diff); same fix, same invariant. A file-tail-driven race reproducer would be brittle: the window depends on the `Task.Delay(pollInterval)` interruption timing, and reproducing reliably would need either refactoring the poll loop or accepting a flaky stress test. The existing `LateSubscriber_ReceivesEveryReplayedLine_*` test still passes and continues to cover general correctness. Happy to add a per-subscriber harness test if you'd prefer a parallel guard for PlayerLogStream specifically.

## Test plan

- [x] `dotnet build Mithril.slnx` — green (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — 20/20 projects pass, 3489 tests (up from 3488 by the one added regression test)
- [x] New test fails reliably without the fix; passes with it
- [x] Existing PlayerLogStream + Router tests untouched, all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)