### PR TITLE
feat(logging): L1 subscription driver (#550 PR 1)

### DIFF
--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -106,6 +106,42 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Register the L1 subscription driver (#511 deliverable 3 / #550 PR 1).
+    /// Sits between the L0.5 typed pipes (registered by
+    /// <see cref="AddMithrilLogActorRouter"/>) + the L0
+    /// <see cref="IChatLogStream"/>, and produces typed
+    /// <see cref="LogEnvelope{T}"/> subscriptions with cross-cutting
+    /// concerns owned by the driver: <see cref="ReplayMode"/>,
+    /// <see cref="LogEnvelope{T}.IsReplay"/>, per-handler containment,
+    /// drop accounting, <see cref="DeliveryContext"/> marshalling,
+    /// opt-in <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/>
+    /// idempotence filter, and a per-subscription fault SM that surfaces
+    /// degraded subscriptions on <see cref="IAttentionAggregator"/> via the
+    /// <see cref="LogStreamAttentionSource"/> registered alongside.
+    ///
+    /// <para>This registration is a NO-OP for existing consumers — every
+    /// archetype-A producer and archetype-B consumer continues to consume
+    /// the L0 / L0.5 surfaces directly until the consumer-migration PRs land.
+    /// PR 1 of #550 ships the driver only.</para>
+    /// </summary>
+    public static IServiceCollection AddMithrilLogStreamDriver(this IServiceCollection services)
+    {
+        services.AddSingleton<LogStreamAttentionSource>();
+        // Surface the attention source via the shared IAttentionSource
+        // contract so AttentionAggregator picks it up alongside the
+        // per-module sources.
+        services.AddSingleton<Modules.IAttentionSource>(sp => sp.GetRequiredService<LogStreamAttentionSource>());
+        services.AddSingleton<ILogStreamDriver>(sp => new LogStreamDriver(
+            sp.GetRequiredService<ILocalPlayerLogStream>(),
+            sp.GetRequiredService<ICombatActorLogStream>(),
+            sp.GetRequiredService<ISystemSignalLogStream>(),
+            sp.GetRequiredService<IChatLogStream>(),
+            sp.GetRequiredService<LogStreamAttentionSource>(),
+            sp.GetService<IDiagnosticsSink>()));
+        return services;
+    }
+
+    /// <summary>
     /// Register the root directory for per-character storage (typically
     /// <c>%LocalAppData%/Mithril/characters</c>). Must be called before any
     /// <see cref="AddPerCharacterStore{T}"/> / <see cref="AddPerCharacterModuleStore{T}"/>.

--- a/src/Mithril.Shared/Logging/DeliveryContext.cs
+++ b/src/Mithril.Shared/Logging/DeliveryContext.cs
@@ -1,0 +1,57 @@
+using System.Windows.Threading;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 per-subscription delivery context (#511 deliverable 3 / #550 capability E).
+/// Determines on which thread the consumer's handler runs. A composition
+/// parameter on the subscription, not a layer.
+///
+/// <para><see cref="Marshaled"/> structurally kills the cross-thread
+/// <c>ObservableCollection</c> mutation bug class: the driver routes each
+/// envelope through the supplied <see cref="Dispatcher"/> before invoking
+/// the handler, so a consumer that mutates bound collections inside its
+/// handler is by construction on the UI thread. The migration PR to
+/// follow replaces the five hand-rolled <c>Application.Current?.Dispatcher;
+/// CheckAccess; InvokeAsync</c> helpers across module ingestion services
+/// with a single <see cref="Marshaled"/> option on the subscription.</para>
+///
+/// <para><b>Honest boundary:</b> this covers <em>stream → consumer</em>
+/// delivery only. It does NOT subsume the GameState producers' internal
+/// snapshot-under-lock <c>Subscribe</c> fan-out (<c>PlayerSkillStateService</c>,
+/// <c>PlayerRecipeStateService</c>, etc.) — that is a different mechanism
+/// (state snapshot delivery, not log-line delivery) and keeps its own
+/// marshalling.</para>
+/// </summary>
+public abstract record DeliveryContext
+{
+    private DeliveryContext() { }
+
+    /// <summary>
+    /// Invoke the handler synchronously on whichever thread the driver
+    /// happens to be pumping on (the channel-reader thread, today). The
+    /// caller is responsible for any thread-affinity requirements — typical
+    /// for handlers that mutate only thread-safe state or self-dispatch
+    /// downstream (Gandalf, Saruman). Default.
+    /// </summary>
+    public sealed record InlineContext : DeliveryContext;
+
+    /// <summary>
+    /// Marshal each envelope through <paramref name="Dispatcher"/> before
+    /// invoking the handler. The handler runs on the dispatcher's thread —
+    /// for the typical WPF case <c>Application.Current.Dispatcher</c>, the
+    /// UI thread — so a handler that mutates bound <c>ObservableCollection</c>s
+    /// is on the right thread by construction.
+    /// </summary>
+    public sealed record MarshaledContext(Dispatcher Dispatcher) : DeliveryContext;
+
+    /// <summary>Inline (default) singleton.</summary>
+    public static readonly DeliveryContext Inline = new InlineContext();
+
+    /// <summary>Marshal each envelope through the supplied dispatcher.</summary>
+    public static DeliveryContext Marshaled(Dispatcher dispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(dispatcher);
+        return new MarshaledContext(dispatcher);
+    }
+}

--- a/src/Mithril.Shared/Logging/ICombatActorLogStream.cs
+++ b/src/Mithril.Shared/Logging/ICombatActorLogStream.cs
@@ -9,4 +9,16 @@ namespace Mithril.Shared.Logging;
 public interface ICombatActorLogStream
 {
     IAsyncEnumerable<CombatActorLogLine> SubscribeAsync(CancellationToken ct);
+
+    /// <summary>
+    /// L1-facing replay-marker variant. See
+    /// <see cref="ILocalPlayerLogStream.SubscribeWithReplayMarkerAsync"/>
+    /// for the rationale. The default implementation throws — only L0.5
+    /// implementors that feed L1 need to override.
+    /// </summary>
+    IAsyncEnumerable<LogEnvelope<CombatActorLogLine>> SubscribeWithReplayMarkerAsync(CancellationToken ct)
+        => throw new NotSupportedException(
+            "Implementors must override to mint authoritative replay markers. " +
+            "L0.5 only — the L1 driver (#550) consumes this. " +
+            "Non-L0.5 implementors (e.g. test fakes) can keep the default thrower if they don't drive L1.");
 }

--- a/src/Mithril.Shared/Logging/ILocalPlayerLogStream.cs
+++ b/src/Mithril.Shared/Logging/ILocalPlayerLogStream.cs
@@ -13,4 +13,25 @@ namespace Mithril.Shared.Logging;
 public interface ILocalPlayerLogStream
 {
     IAsyncEnumerable<LocalPlayerLogLine> SubscribeAsync(CancellationToken ct);
+
+    /// <summary>
+    /// L1-facing variant: yields the same envelopes as
+    /// <see cref="SubscribeAsync"/> wrapped in <see cref="LogEnvelope{T}"/>
+    /// so each carries the structural <c>IsReplay</c> bit the L0.5 router
+    /// can answer authoritatively (a yield from the per-pipe replay
+    /// snapshot vs. a live emission from the bounded-channel branch).
+    /// Added in #550 PR 1 so L1's <see cref="LogEnvelope{T}.IsReplay"/>
+    /// flag is sourced from the upstream's own boundary rather than a
+    /// sync-vs-async heuristic. Existing consumers (pre-L1) continue to
+    /// use <see cref="SubscribeAsync"/> unchanged.
+    /// <para>The default implementation throws — implementors that drive
+    /// L1 (today: <see cref="PlayerLogActorRouter"/>) MUST override.
+    /// Non-L0.5 implementors (test fakes that never feed L1) can keep
+    /// the default thrower.</para>
+    /// </summary>
+    IAsyncEnumerable<LogEnvelope<LocalPlayerLogLine>> SubscribeWithReplayMarkerAsync(CancellationToken ct)
+        => throw new NotSupportedException(
+            "Implementors must override to mint authoritative replay markers. " +
+            "L0.5 only — the L1 driver (#550) consumes this. " +
+            "Non-L0.5 implementors (e.g. test fakes) can keep the default thrower if they don't drive L1.");
 }

--- a/src/Mithril.Shared/Logging/ILogStreamDriver.cs
+++ b/src/Mithril.Shared/Logging/ILogStreamDriver.cs
@@ -1,5 +1,3 @@
-using Mithril.Shared.Modules;
-
 namespace Mithril.Shared.Logging;
 
 /// <summary>
@@ -29,7 +27,7 @@ namespace Mithril.Shared.Logging;
 ///   <c>&lt;= HighWater</c> before delivery (capability F);</item>
 ///   <item>per-subscription fault state machine — N-consecutive failures
 ///   ⇒ <see cref="LogSubscriptionState.Degraded"/> ⇒ surfaced on
-///   <see cref="IAttentionAggregator"/> via
+///   <see cref="Mithril.Shared.Modules.IAttentionAggregator"/> via
 ///   <see cref="LogStreamAttentionSource"/> (capability G).</item>
 /// </list>
 ///

--- a/src/Mithril.Shared/Logging/ILogStreamDriver.cs
+++ b/src/Mithril.Shared/Logging/ILogStreamDriver.cs
@@ -1,0 +1,82 @@
+using Mithril.Shared.Modules;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 of the layered log pipeline (#511 deliverable 3 / #550 — this PR
+/// ships PR 1 of #550: the driver only, no consumer migration). Sits
+/// between L0.5 (the actor-keyed router in <see cref="PlayerLogActorRouter"/>)
+/// and L2 (future verb/arg recognition). L1 owns the cross-cutting concerns
+/// that today are hand-rolled per consumer:
+///
+/// <list type="bullet">
+///   <item>per-subscription <see cref="ReplayMode"/> with an explicit
+///   <see cref="LogEnvelope{T}.IsReplay"/> flag on every delivered envelope
+///   (capability A + B);</item>
+///   <item>per-message containment via try/catch + rate-limited Warn
+///   (capability C — retires the #512/#515/#522/#541 per-consumer
+///   <c>ThrottledWarn</c> stopgaps in the migration PRs that follow);</item>
+///   <item>per-subscription drop accounting on the
+///   <see cref="LogSubscriptionDiagnostics"/> snapshot — no more silent
+///   <c>DropOldest</c> (capability D);</item>
+///   <item><see cref="DeliveryContext"/> — <see cref="DeliveryContext.Inline"/>
+///   or <see cref="DeliveryContext.Marshaled"/> on a UI
+///   <see cref="System.Windows.Threading.Dispatcher"/>, retiring the five
+///   hand-rolled <c>Application.Current?.Dispatcher</c> helpers in the
+///   migration PRs (capability E);</item>
+///   <item>opt-in <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/>
+///   filter, dropping envelopes whose payload <c>Sequence</c> is
+///   <c>&lt;= HighWater</c> before delivery (capability F);</item>
+///   <item>per-subscription fault state machine — N-consecutive failures
+///   ⇒ <see cref="LogSubscriptionState.Degraded"/> ⇒ surfaced on
+///   <see cref="IAttentionAggregator"/> via
+///   <see cref="LogStreamAttentionSource"/> (capability G).</item>
+/// </list>
+///
+/// <para><b>Composition, not base class.</b> Consumers use the driver via
+/// <see cref="Subscribe{T}"/> — they do not extend a
+/// <c>LogConsumer&lt;T&gt;</c>. The archetype-B consumers have
+/// heterogeneous bespoke pre-subscription setup that a template-method
+/// base class would contort (Samwise loads persisted state + subscribes a
+/// second source; Smaug wires character-changed events; Legolas brackets
+/// on <c>IsSurveySessionActive</c>). Driver, not base. See the
+/// "Composition, not base class — explicit hard rule" section of #550.</para>
+/// </summary>
+public interface ILogStreamDriver
+{
+    /// <summary>
+    /// Subscribe to a typed log stream. <typeparamref name="T"/> must be one
+    /// of the four supported payload types:
+    /// <list type="bullet">
+    ///   <item><see cref="LocalPlayerLogLine"/> — the L0.5 LocalPlayer pipe</item>
+    ///   <item><see cref="CombatActorLogLine"/> — the L0.5 combat-actor pipe</item>
+    ///   <item><see cref="SystemSignalLogLine"/> — the L0.5 system-signal pipe</item>
+    ///   <item><see cref="RawLogLine"/> — the L0 chat stream
+    ///   (<see cref="IChatLogStream"/>). Note that Player.log
+    ///   <see cref="RawLogLine"/> consumption stays on
+    ///   <see cref="IPlayerLogStream"/> directly — L1 routes the typed L0.5
+    ///   pipes, not pre-classification raw Player.log.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="handler">
+    /// Invoked for every delivered envelope. The driver wraps the
+    /// invocation in try/catch + rate-limited Warn so an exception
+    /// thrown by the handler does NOT kill the subscription pump. The
+    /// handler runs on the thread implied by
+    /// <see cref="LogSubscriptionOptions.DeliveryContext"/>.
+    /// </param>
+    /// <param name="options">
+    /// Subscription policy. Defaults preserve every pre-L1 consumer's
+    /// behaviour (<see cref="ReplayMode.FromSessionStart"/>,
+    /// <see cref="DeliveryContext.Inline"/>, no high-water).
+    /// </param>
+    /// <returns>
+    /// A disposable handle. Disposing tears down the upstream subscription,
+    /// resolves any pending attention entry, and is safe to call multiple
+    /// times.
+    /// </returns>
+    ILogSubscription Subscribe<T>(
+        Func<LogEnvelope<T>, ValueTask> handler,
+        LogSubscriptionOptions? options = null)
+        where T : class;
+}

--- a/src/Mithril.Shared/Logging/ILogSubscription.cs
+++ b/src/Mithril.Shared/Logging/ILogSubscription.cs
@@ -1,0 +1,38 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 subscription handle (#511 deliverable 3 / #550). Returned by
+/// <see cref="ILogStreamDriver.Subscribe{T}"/>; disposing tears down the
+/// underlying upstream subscription, completes the handler-pump task, and
+/// (if degraded) resolves the consumer's attention entry.
+///
+/// <para>The handle exposes the live diagnostic counters
+/// (<see cref="Diagnostics"/>) so a consumer that wants visibility into its
+/// own L1 subscription health — a "did we stall?" dev panel, a regression
+/// test, or the future shell-side diagnostics panel — can read them
+/// without going through the diagnostic-sink log stream.</para>
+/// </summary>
+public interface ILogSubscription : IDisposable
+{
+    /// <summary>
+    /// Stable id assigned at subscription time. Used to key the
+    /// subscription's attention entry; surfaces in diagnostic messages so
+    /// a degraded subscription is identifiable even when multiple
+    /// subscriptions share a category.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Snapshot of the live counters. See <see cref="LogSubscriptionDiagnostics"/>.
+    /// </summary>
+    LogSubscriptionDiagnostics Diagnostics { get; }
+
+    /// <summary>
+    /// Raised when the fault state transitions
+    /// (<see cref="LogSubscriptionState.Healthy"/> ⇔
+    /// <see cref="LogSubscriptionState.Degraded"/>). The attention source
+    /// listens to this internally; consumers may also subscribe for their
+    /// own UI feedback. Payload-free; read <see cref="Diagnostics"/>.
+    /// </summary>
+    event EventHandler? StateChanged;
+}

--- a/src/Mithril.Shared/Logging/ISystemSignalLogStream.cs
+++ b/src/Mithril.Shared/Logging/ISystemSignalLogStream.cs
@@ -10,4 +10,16 @@ namespace Mithril.Shared.Logging;
 public interface ISystemSignalLogStream
 {
     IAsyncEnumerable<SystemSignalLogLine> SubscribeAsync(CancellationToken ct);
+
+    /// <summary>
+    /// L1-facing replay-marker variant. See
+    /// <see cref="ILocalPlayerLogStream.SubscribeWithReplayMarkerAsync"/>
+    /// for the rationale. The default implementation throws — only L0.5
+    /// implementors that feed L1 need to override.
+    /// </summary>
+    IAsyncEnumerable<LogEnvelope<SystemSignalLogLine>> SubscribeWithReplayMarkerAsync(CancellationToken ct)
+        => throw new NotSupportedException(
+            "Implementors must override to mint authoritative replay markers. " +
+            "L0.5 only — the L1 driver (#550) consumes this. " +
+            "Non-L0.5 implementors (e.g. test fakes) can keep the default thrower if they don't drive L1.");
 }

--- a/src/Mithril.Shared/Logging/LogEnvelope.cs
+++ b/src/Mithril.Shared/Logging/LogEnvelope.cs
@@ -1,0 +1,28 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 (#511 deliverable 3 / #550) delivery envelope. Wraps a typed log
+/// payload — <see cref="LocalPlayerLogLine"/>, <see cref="CombatActorLogLine"/>,
+/// <see cref="SystemSignalLogLine"/>, or <see cref="RawLogLine"/> (chat) —
+/// with the <see cref="IsReplay"/> bit that distinguishes the whole-backlog
+/// drain at subscription time from the live-tail that follows.
+///
+/// <para><b><see cref="IsReplay"/></b> is the L1-side companion of the
+/// Tier-3 contract in <c>docs/cross-source-correlation.md</c>:
+/// <c>ReadMonotonicTicks</c> is a usable cross-source tiebreaker within a
+/// shared game-second <em>only when</em> <c>IsReplay == false</c>. The flag
+/// is also the structural enabler for Divergence-2 (Legolas-style)
+/// mixed-handler subscriptions — one subscription serves both a
+/// replay-needing handler (area bridge) and a live-only handler (survey
+/// dispatch); the consumer per-handler-drops on <c>IsReplay == true</c>
+/// rather than maintaining two separate subscriptions.</para>
+///
+/// <para>The flag flips deterministically: every envelope yielded from
+/// the upstream's session-replay snapshot carries <c>IsReplay == true</c>;
+/// from the first live channel emission onward, <c>IsReplay == false</c>.
+/// The L0.5 router answers this authoritatively via the L1-facing
+/// <c>SubscribeWithReplayMarkerAsync</c> method on each typed pipe (added
+/// in #550 PR 1) — no "is this still the first batch?" heuristic, no
+/// sync-vs-async timing inference.</para>
+/// </summary>
+public readonly record struct LogEnvelope<T>(T Payload, bool IsReplay) where T : class;

--- a/src/Mithril.Shared/Logging/LogStreamAttentionSource.cs
+++ b/src/Mithril.Shared/Logging/LogStreamAttentionSource.cs
@@ -1,0 +1,71 @@
+using Mithril.Shared.Modules;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 attention source (#550 capability G). Aggregates every degraded
+/// subscription on a registered <see cref="ILogStreamDriver"/> so the
+/// shell's attention bus surfaces "alive but visibly degraded" as a
+/// non-throttled signal — converting the pre-L1 "throttled into silence"
+/// failure mode into a UI-visible one.
+///
+/// <para><see cref="ModuleId"/> is the shared bucket "logging" so a
+/// degraded Samwise subscription and a degraded Pippin subscription both
+/// surface on the same chip. Per-consumer attention (e.g. "Arwen — gifts
+/// pending") stays on each module's own <see cref="IAttentionSource"/>;
+/// L1's source is specifically for the subscription-health concern that's
+/// shared across consumers.</para>
+///
+/// <para>Registered as a singleton, picked up by the existing
+/// <see cref="AttentionAggregator"/> via the standard
+/// <c>IEnumerable&lt;IAttentionSource&gt;</c> ctor parameter.</para>
+/// </summary>
+public sealed class LogStreamAttentionSource : IAttentionSource, IDisposable
+{
+    /// <summary>Module id key used by the attention aggregator.</summary>
+    public const string SourceId = "logging";
+
+    private readonly object _gate = new();
+    private readonly HashSet<string> _degradedSubscriptions = new(StringComparer.Ordinal);
+
+    public string ModuleId => SourceId;
+    public string DisplayLabel => "Logging — degraded subscriptions";
+
+    public int Count
+    {
+        get { lock (_gate) return _degradedSubscriptions.Count; }
+    }
+
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Called by the driver when a subscription enters
+    /// <see cref="LogSubscriptionState.Degraded"/>. Idempotent — a second
+    /// call for the same id is a no-op.
+    /// </summary>
+    internal void NotifyDegraded(string subscriptionId)
+    {
+        bool changed;
+        lock (_gate) changed = _degradedSubscriptions.Add(subscriptionId);
+        if (changed) Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Called by the driver when a previously degraded subscription
+    /// returns to <see cref="LogSubscriptionState.Healthy"/>. Idempotent.
+    /// </summary>
+    internal void NotifyHealthy(string subscriptionId)
+    {
+        bool changed;
+        lock (_gate) changed = _degradedSubscriptions.Remove(subscriptionId);
+        if (changed) Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void Dispose()
+    {
+        // Subscriptions hold a reference back to us through the driver, so
+        // disposal-during-shutdown is the only path that matters — we just
+        // clear the set so any late callback is a no-op.
+        lock (_gate) _degradedSubscriptions.Clear();
+    }
+}

--- a/src/Mithril.Shared/Logging/LogStreamDriver.cs
+++ b/src/Mithril.Shared/Logging/LogStreamDriver.cs
@@ -296,8 +296,18 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
                         continue;
                     }
 
-                    // LiveOnly — drop replay-phase emissions
-                    if (_options.ReplayMode == ReplayMode.LiveOnly && envelope.IsReplay)
+                    // LiveOnly / SinceSubscribe — drop replay-phase
+                    // emissions. SinceSubscribe is documented as
+                    // behaviourally identical to LiveOnly today
+                    // (ReplayMode.cs); future replay-window variants
+                    // (since-timestamp / since-sequence) would split here.
+                    // Saruman/Discovery's #549 disposition picks
+                    // SinceSubscribe explicitly to express that intent —
+                    // letting it fall through to replay would silently
+                    // re-inflate DiscoveryCount on its eventual migration.
+                    if ((_options.ReplayMode == ReplayMode.LiveOnly ||
+                         _options.ReplayMode == ReplayMode.SinceSubscribe) &&
+                        envelope.IsReplay)
                     {
                         continue;
                     }
@@ -335,9 +345,16 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
             _attention.NotifyHealthy(_id);
             _onDisposed(this);
             // Don't block on the pump task — disposal is synchronous and
-            // the pump will unwind on cancellation. The CTS isn't disposed
-            // here either; doing so during pump unwind would race the
-            // upstream's `await foreach`.
+            // the pump will unwind on cancellation. Dispose the CTS via a
+            // fire-and-forget continuation on the pump task: doing it
+            // inline would race the upstream's `await foreach` (it
+            // dereferences _cts.Token mid-unwind), but a continuation that
+            // runs after the pump task fully unwinds is safe.
+            _pumpTask?.ContinueWith(
+                _ => { try { _cts.Dispose(); } catch { } },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         /// <summary>
@@ -364,6 +381,17 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
         /// <see cref="LogSubscriptionState.Degraded"/> if the threshold is
         /// crossed.
         /// </summary>
+        /// <remarks>
+        /// Invariant: this method is called serially by the delivery
+        /// bridges (single Inline pump loop / single Marshaled drain loop,
+        /// each awaiting the handler per envelope). The
+        /// "consecutive == threshold" exact-equality check on the
+        /// CompareExchange relies on that invariant — the threshold is
+        /// crossed exactly once per failure run, so exactly one Error
+        /// entry fires. A future bridge that parallelizes handler
+        /// invocation would break this guarantee and need a different
+        /// transition predicate.
+        /// </remarks>
         internal void RecordHandlerFailure(Exception ex)
         {
             Interlocked.Increment(ref _handlerFailures);
@@ -475,6 +503,16 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
                 // before the write so we can attribute the drop: if the
                 // channel was at capacity before TryWrite, an item was
                 // discarded by DropOldest semantics.
+                //
+                // Note: the probe is racy in the BENIGN direction. If the
+                // drain reader dequeues an item between Reader.Count and
+                // TryWrite, a successful write can be miscounted as a drop
+                // (over-count). Under-count is impossible because
+                // Reader.Count cannot drop below QueueCapacity while the
+                // queue is at capacity unless a reader runs concurrently —
+                // and that reader run is exactly what frees a slot, so the
+                // following TryWrite genuinely doesn't drop. Diagnostic-
+                // only over-count bias, not data loss.
                 var preCount = _queue.Reader.Count;
                 _queue.Writer.TryWrite(envelope);
                 if (preCount >= QueueCapacity) _sub.RecordDrop();
@@ -495,6 +533,19 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
                         // Capture the handler's failure inside the
                         // InvokeAsync delegate so the failure shape is
                         // identical between Inline and Marshaled.
+                        //
+                        // .Task.Unwrap() is load-bearing — Dispatcher.InvokeAsync
+                        // returns DispatcherOperation, whose .Task for an
+                        // async lambda is Task<Task> (the outer task
+                        // completes when the dispatcher STARTS the lambda;
+                        // the inner async body finishes later). Without
+                        // .Unwrap() the awaiter binds to the outer task,
+                        // making async handlers fire-and-forget: post-await
+                        // exceptions are lost (failure stays null),
+                        // RecordDelivered fires before delivery actually
+                        // completes, and concurrent envelopes can run
+                        // out-of-order. Unwrap() binds the await to the
+                        // inner task instead.
                         Exception? failure = null;
                         try
                         {
@@ -502,9 +553,21 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
                             {
                                 try { await _sub._handler(envelope).ConfigureAwait(true); }
                                 catch (Exception ex) { failure = ex; }
-                            }).Task.ConfigureAwait(false);
+                            }).Task.Unwrap().ConfigureAwait(false);
                         }
-                        catch (TaskCanceledException) { return; }
+                        catch (TaskCanceledException)
+                        {
+                            // Dispatcher shut down mid-drain. Complete the
+                            // channel writer so subsequent DeliverAsync
+                            // TryWrites no-op rather than spiralling drop
+                            // accounting forever (Important #3) and
+                            // surface the bridge death on the fault SM so
+                            // it's visible, not silent.
+                            _queue.Writer.TryComplete();
+                            _sub.RecordHandlerFailure(new InvalidOperationException(
+                                "Marshaled bridge dispatcher shut down mid-drain; subscription is no longer delivering."));
+                            return;
+                        }
 
                         if (failure is not null) _sub.RecordHandlerFailure(failure);
                         else _sub.RecordDelivered();
@@ -512,6 +575,14 @@ public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
                 }
                 catch (Exception ex)
                 {
+                    // Drain failed unexpectedly. Complete the channel
+                    // writer so subsequent DeliverAsync writes no-op and
+                    // drop accounting stops spiralling. Surface on the
+                    // fault SM (capability G) so the subscription
+                    // transitions to Degraded rather than staying Healthy
+                    // while silently dropping every envelope.
+                    _queue.Writer.TryComplete();
+                    _sub.RecordHandlerFailure(ex);
                     _sub._diag?.Error(_sub._diagCategory, $"[{_sub._id}] marshaled bridge drain aborted: {ex}");
                 }
             }

--- a/src/Mithril.Shared/Logging/LogStreamDriver.cs
+++ b/src/Mithril.Shared/Logging/LogStreamDriver.cs
@@ -1,0 +1,520 @@
+using System.Threading.Channels;
+using System.Windows.Threading;
+using Mithril.Shared.Diagnostics;
+
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// Default <see cref="ILogStreamDriver"/> implementation (#511 deliverable 3
+/// / #550 PR 1). Wraps the four upstream surfaces — the three L0.5 pipes
+/// (<see cref="ILocalPlayerLogStream"/>, <see cref="ICombatActorLogStream"/>,
+/// <see cref="ISystemSignalLogStream"/>) plus the chat
+/// <see cref="IChatLogStream"/> — and produces typed
+/// <see cref="LogEnvelope{T}"/> subscriptions with consumer-side
+/// containment, drop accounting, dispatcher marshalling, idempotence
+/// filtering, and a fault state machine.
+///
+/// <para>The driver does NOT own the upstream surfaces; it consumes them
+/// via the same <c>SubscribeAsync(ct)</c> pattern every consumer used
+/// pre-L1. Per-subscription state lives on the
+/// <see cref="LogSubscription{T}"/> handle returned to the caller; a single
+/// driver instance hosts an unbounded number of concurrent subscriptions.</para>
+///
+/// <para>Player.log <see cref="RawLogLine"/> consumption is intentionally
+/// NOT supported by the driver: every Player.log consumer should subscribe
+/// through one of the three typed L0.5 pipes (capability A of #532).
+/// Chat <see cref="RawLogLine"/> is the only raw surface — chat lines have
+/// no classified equivalent (chat keeps regex-based recognition per the
+/// #550 "what L1 explicitly does NOT own" section).</para>
+///
+/// <para><b><see cref="LogEnvelope{T}.IsReplay"/> determination.</b>
+/// Sourced directly from each upstream pipe's L1-facing
+/// <c>SubscribeWithReplayMarkerAsync</c> method (added to
+/// <see cref="ILocalPlayerLogStream"/> / <see cref="ICombatActorLogStream"/>
+/// / <see cref="ISystemSignalLogStream"/> in #550 PR 1, implemented on
+/// <see cref="PlayerLogActorRouter"/>'s direct-yield-replay /
+/// bounded-channel-live boundary). The L0.5 router can answer the
+/// IsReplay question authoritatively because it owns the structural
+/// boundary; L1 forwards the bit unchanged on each envelope. Chat-backed
+/// subscriptions hard-code IsReplay = false (chat has no backlog by
+/// construction — Divergence 1 in #549).</para>
+/// </summary>
+public sealed class LogStreamDriver : ILogStreamDriver, IDisposable
+{
+    private readonly ILocalPlayerLogStream _localPlayer;
+    private readonly ICombatActorLogStream _combat;
+    private readonly ISystemSignalLogStream _system;
+    private readonly IChatLogStream _chat;
+    private readonly LogStreamAttentionSource _attention;
+    private readonly IDiagnosticsSink? _diag;
+    private readonly TimeProvider _time;
+    private readonly object _gate = new();
+    private readonly HashSet<ISubscriptionInternal> _subs = new();
+    private long _nextSubId;
+    private bool _disposed;
+
+    public LogStreamDriver(
+        ILocalPlayerLogStream localPlayer,
+        ICombatActorLogStream combat,
+        ISystemSignalLogStream system,
+        IChatLogStream chat,
+        LogStreamAttentionSource attention,
+        IDiagnosticsSink? diag = null,
+        TimeProvider? time = null)
+    {
+        _localPlayer = localPlayer ?? throw new ArgumentNullException(nameof(localPlayer));
+        _combat = combat ?? throw new ArgumentNullException(nameof(combat));
+        _system = system ?? throw new ArgumentNullException(nameof(system));
+        _chat = chat ?? throw new ArgumentNullException(nameof(chat));
+        _attention = attention ?? throw new ArgumentNullException(nameof(attention));
+        _diag = diag;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public ILogSubscription Subscribe<T>(
+        Func<LogEnvelope<T>, ValueTask> handler,
+        LogSubscriptionOptions? options = null) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        if (_disposed) throw new ObjectDisposedException(nameof(LogStreamDriver));
+
+        var opts = options ?? LogSubscriptionOptions.Default;
+        var id = $"L1#{Interlocked.Increment(ref _nextSubId)}";
+
+        Func<CancellationToken, IAsyncEnumerable<LogEnvelope<T>>> upstream;
+        Func<T, long> sequenceOf;
+        string streamKind;
+
+        if (typeof(T) == typeof(LocalPlayerLogLine))
+        {
+            upstream = ct => (IAsyncEnumerable<LogEnvelope<T>>)(object)
+                _localPlayer.SubscribeWithReplayMarkerAsync(ct);
+            sequenceOf = item => ((LocalPlayerLogLine)(object)item).Sequence;
+            streamKind = "LocalPlayer";
+        }
+        else if (typeof(T) == typeof(CombatActorLogLine))
+        {
+            upstream = ct => (IAsyncEnumerable<LogEnvelope<T>>)(object)
+                _combat.SubscribeWithReplayMarkerAsync(ct);
+            sequenceOf = item => ((CombatActorLogLine)(object)item).Sequence;
+            streamKind = "Combat";
+        }
+        else if (typeof(T) == typeof(SystemSignalLogLine))
+        {
+            upstream = ct => (IAsyncEnumerable<LogEnvelope<T>>)(object)
+                _system.SubscribeWithReplayMarkerAsync(ct);
+            sequenceOf = item => ((SystemSignalLogLine)(object)item).Sequence;
+            streamKind = "System";
+        }
+        else if (typeof(T) == typeof(RawLogLine))
+        {
+            // Chat — see Divergence 1 in #549. Chat has no backlog by
+            // construction (the per-day file directory is seeded to
+            // current-end before the first emission), so every chat
+            // envelope is live. We coerce any non-LiveOnly ReplayMode to
+            // LiveOnly and emit a one-time Info diagnostic so the
+            // spurious knob doesn't go unnoticed in code review.
+            if (opts.ReplayMode != ReplayMode.LiveOnly)
+            {
+                _diag?.Info(
+                    "Mithril.Logging.L1",
+                    $"[{id}] Chat subscription requested ReplayMode={opts.ReplayMode}; coercing to LiveOnly (chat has no backlog by construction). #549 Divergence 1.");
+                opts = opts with { ReplayMode = ReplayMode.LiveOnly };
+            }
+            // Adapt the chat stream's single-typed yield onto the same
+            // LogEnvelope<T> shape used by the L0.5 marker variants.
+            // IsReplay is hard-coded to false for chat.
+            upstream = ct => (IAsyncEnumerable<LogEnvelope<T>>)(object)ChatMarkerAdapter(_chat, ct);
+            sequenceOf = item => ((RawLogLine)(object)item).Sequence;
+            streamKind = "Chat";
+        }
+        else
+        {
+            throw new ArgumentException(
+                $"L1 driver does not support subscriptions of type {typeof(T).Name}. " +
+                "Supported: LocalPlayerLogLine, CombatActorLogLine, SystemSignalLogLine, RawLogLine (chat). " +
+                "For Player.log RawLogLine subscribe through one of the three L0.5 pipes instead.",
+                nameof(T));
+        }
+
+        var sub = new LogSubscription<T>(
+            id: id,
+            options: opts,
+            handler: handler,
+            upstream: upstream,
+            sequenceOf: sequenceOf,
+            streamKind: streamKind,
+            attention: _attention,
+            diag: _diag,
+            time: _time,
+            onDisposed: s => { lock (_gate) _subs.Remove(s); });
+
+        lock (_gate) _subs.Add(sub);
+        sub.Start();
+        return sub;
+    }
+
+    public void Dispose()
+    {
+        ISubscriptionInternal[] toDispose;
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            toDispose = _subs.ToArray();
+            _subs.Clear();
+        }
+        foreach (var s in toDispose) s.Dispose();
+    }
+
+    /// <summary>
+    /// Adapter that lifts the chat stream's single-typed
+    /// <see cref="IAsyncEnumerable{RawLogLine}"/> onto the same
+    /// <see cref="LogEnvelope{T}"/> shape that the L0.5 pipes yield.
+    /// IsReplay is always false: chat has no backlog by construction.
+    /// </summary>
+    private static async System.Collections.Generic.IAsyncEnumerable<LogEnvelope<RawLogLine>>
+        ChatMarkerAdapter(
+            IChatLogStream chat,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var line in chat.SubscribeAsync(ct).ConfigureAwait(false))
+        {
+            yield return new LogEnvelope<RawLogLine>(line, IsReplay: false);
+        }
+    }
+
+    /// <summary>
+    /// Non-generic handle the driver uses to track subscriptions in its
+    /// disposal set without committing to a particular <typeparamref name="T"/>.
+    /// </summary>
+    internal interface ISubscriptionInternal : ILogSubscription { }
+
+    /// <summary>
+    /// Concrete subscription. One per <see cref="Subscribe{T}"/> call. Owns
+    /// a single upstream subscription, the pump task, and the per-
+    /// subscription state (counters + fault SM).
+    /// </summary>
+    private sealed class LogSubscription<T> : ISubscriptionInternal where T : class
+    {
+        private readonly string _id;
+        private readonly LogSubscriptionOptions _options;
+        private readonly Func<LogEnvelope<T>, ValueTask> _handler;
+        private readonly Func<CancellationToken, IAsyncEnumerable<LogEnvelope<T>>> _upstream;
+        private readonly Func<T, long> _sequenceOf;
+        private readonly string _streamKind;
+        private readonly LogStreamAttentionSource _attention;
+        private readonly IDiagnosticsSink? _diag;
+        private readonly Action<ISubscriptionInternal> _onDisposed;
+        private readonly ThrottledWarn _warn;
+        private readonly string _diagCategory;
+        private readonly CancellationTokenSource _cts = new();
+        private Task? _pumpTask;
+        private IDeliveryBridge? _bridge;
+
+        // Counters — Interlocked for thread-safe lock-free reads/writes from
+        // both the pump and the consumer's Diagnostics snapshot.
+        private long _delivered;
+        private long _dropped;
+        private long _handlerFailures;
+        private long _highWaterSkipped;
+        private int _consecutiveFailures;
+        private int _state; // LogSubscriptionState as int
+
+        private int _disposed; // 0 = alive, 1 = disposed
+
+        public LogSubscription(
+            string id,
+            LogSubscriptionOptions options,
+            Func<LogEnvelope<T>, ValueTask> handler,
+            Func<CancellationToken, IAsyncEnumerable<LogEnvelope<T>>> upstream,
+            Func<T, long> sequenceOf,
+            string streamKind,
+            LogStreamAttentionSource attention,
+            IDiagnosticsSink? diag,
+            TimeProvider time,
+            Action<ISubscriptionInternal> onDisposed)
+        {
+            _id = id;
+            _options = options;
+            _handler = handler;
+            _upstream = upstream;
+            _sequenceOf = sequenceOf;
+            _streamKind = streamKind;
+            _attention = attention;
+            _diag = diag;
+            _onDisposed = onDisposed;
+            _diagCategory = options.DiagnosticCategory ?? $"Mithril.Logging.L1.{streamKind}";
+            _warn = new ThrottledWarn(diag, _diagCategory, time: time);
+        }
+
+        public string Id => _id;
+
+        public LogSubscriptionDiagnostics Diagnostics => new(
+            Delivered: Interlocked.Read(ref _delivered),
+            Dropped: Interlocked.Read(ref _dropped),
+            HandlerFailures: Interlocked.Read(ref _handlerFailures),
+            ConsecutiveFailures: Volatile.Read(ref _consecutiveFailures),
+            HighWaterSkipped: Interlocked.Read(ref _highWaterSkipped),
+            State: (LogSubscriptionState)Volatile.Read(ref _state));
+
+        public event EventHandler? StateChanged;
+
+        internal void Start()
+        {
+            _bridge = CreateDeliveryBridge();
+            // The pump runs on TaskScheduler.Default — never inline on the
+            // caller — so Subscribe<T> returns synchronously without
+            // pumping the first envelope on the caller's thread.
+            _pumpTask = Task.Run(PumpAsync, CancellationToken.None);
+        }
+
+        private async Task PumpAsync()
+        {
+            var ct = _cts.Token;
+            var bridge = _bridge!;
+            // IsReplay is sourced directly from the upstream's structural
+            // boundary (L0.5 SubscribeWithReplayMarkerAsync; chat is always
+            // live). We never reach for a sync-vs-async timing heuristic.
+
+            try
+            {
+                await foreach (var envelope in _upstream(ct).ConfigureAwait(false))
+                {
+                    if (ct.IsCancellationRequested) break;
+                    var seq = _sequenceOf(envelope.Payload);
+
+                    // High-water filter (capability F) — applies regardless
+                    // of replay/live phase. Today's archetype-A consumers
+                    // (idempotent state-rebuilders) decline this; the four
+                    // archetype-B consumers that take it (Samwise, Pippin,
+                    // Saruman/Discovery, Legolas×2) get restart-safe dedup
+                    // with one line of subscription config.
+                    if (_options.SkipProcessedHighWater is long hw && seq <= hw)
+                    {
+                        Interlocked.Increment(ref _highWaterSkipped);
+                        continue;
+                    }
+
+                    // LiveOnly — drop replay-phase emissions
+                    if (_options.ReplayMode == ReplayMode.LiveOnly && envelope.IsReplay)
+                    {
+                        continue;
+                    }
+
+                    await bridge.DeliverAsync(envelope, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) { /* expected on Dispose */ }
+            catch (Exception ex)
+            {
+                // The pump itself threw — upstream subscription died. Emit a
+                // non-throttled Error; the subscription is effectively over.
+                _diag?.Error(_diagCategory, $"[{_id}] L1 pump aborted: {ex}");
+            }
+            finally
+            {
+                bridge.Complete();
+            }
+        }
+
+        private IDeliveryBridge CreateDeliveryBridge() =>
+            _options.DeliveryContext switch
+            {
+                DeliveryContext.MarshaledContext m => new MarshaledBridge(this, m.Dispatcher),
+                _ => new InlineBridge(this),
+            };
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            try { _cts.Cancel(); } catch { }
+            // Resolve any attention entry — flapping out of degraded on
+            // disposal is the right shape (a disposed subscription doesn't
+            // need attention).
+            _attention.NotifyHealthy(_id);
+            _onDisposed(this);
+            // Don't block on the pump task — disposal is synchronous and
+            // the pump will unwind on cancellation. The CTS isn't disposed
+            // here either; doing so during pump unwind would race the
+            // upstream's `await foreach`.
+        }
+
+        /// <summary>
+        /// Invoked by the delivery bridge after each successful invocation
+        /// of the consumer's handler. Resets the consecutive-failure count
+        /// and resolves a degraded state if applicable.
+        /// </summary>
+        internal void RecordDelivered()
+        {
+            Interlocked.Increment(ref _delivered);
+            var prior = Interlocked.Exchange(ref _consecutiveFailures, 0);
+            if (prior > 0 && Volatile.Read(ref _state) == (int)LogSubscriptionState.Degraded)
+            {
+                Volatile.Write(ref _state, (int)LogSubscriptionState.Healthy);
+                _attention.NotifyHealthy(_id);
+                StateChanged?.Invoke(this, EventArgs.Empty);
+                _diag?.Info(_diagCategory, $"[{_id}] subscription recovered (Healthy)");
+            }
+        }
+
+        /// <summary>
+        /// Invoked by the delivery bridge when the consumer's handler
+        /// throws. Increments failure counters and transitions to
+        /// <see cref="LogSubscriptionState.Degraded"/> if the threshold is
+        /// crossed.
+        /// </summary>
+        internal void RecordHandlerFailure(Exception ex)
+        {
+            Interlocked.Increment(ref _handlerFailures);
+            var consecutive = Interlocked.Increment(ref _consecutiveFailures);
+
+            // Rate-limited Warn — the routine "occasional bad line" path.
+            _warn.Warn($"[{_id}] handler threw: {ex.Message}");
+
+            // Fault SM — degrade on threshold cross. We compare to the
+            // EXACT threshold so the transition fires only once per
+            // crossing rather than on every subsequent failure.
+            if (consecutive == _options.DegradedAfterConsecutiveFailures &&
+                Interlocked.CompareExchange(ref _state,
+                    (int)LogSubscriptionState.Degraded,
+                    (int)LogSubscriptionState.Healthy) == (int)LogSubscriptionState.Healthy)
+            {
+                _attention.NotifyDegraded(_id);
+                StateChanged?.Invoke(this, EventArgs.Empty);
+                // One non-throttled Error on entry — the visibility
+                // promise of capability G ("alive but silently dead" →
+                // "alive and visibly degraded").
+                _diag?.Error(
+                    _diagCategory,
+                    $"[{_id}] subscription degraded after {consecutive} consecutive handler failures. " +
+                    $"Last error: {ex.Message}. Continuing to deliver — handler will be retried on every subsequent envelope.");
+            }
+        }
+
+        /// <summary>Test hook — increments the drop counter externally.</summary>
+        internal void RecordDrop() => Interlocked.Increment(ref _dropped);
+
+        // === Delivery bridges ===
+
+        /// <summary>
+        /// Boundary between the pump (upstream side) and the consumer's
+        /// handler (delivery side). Owns containment, marshalling, and
+        /// the bounded queue that powers drop accounting under
+        /// <see cref="DeliveryContext.MarshaledContext"/>.
+        /// </summary>
+        private interface IDeliveryBridge
+        {
+            ValueTask DeliverAsync(LogEnvelope<T> envelope, CancellationToken ct);
+            void Complete();
+        }
+
+        /// <summary>
+        /// Inline bridge — invokes the handler on the pump thread directly.
+        /// No queue, no marshalling. The handler's sync/async cost happens
+        /// inside the pump's <c>await foreach</c>.
+        /// </summary>
+        private sealed class InlineBridge : IDeliveryBridge
+        {
+            private readonly LogSubscription<T> _sub;
+            public InlineBridge(LogSubscription<T> sub) { _sub = sub; }
+
+            public async ValueTask DeliverAsync(LogEnvelope<T> envelope, CancellationToken ct)
+            {
+                try
+                {
+                    await _sub._handler(envelope).ConfigureAwait(false);
+                    _sub.RecordDelivered();
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Disposal mid-handler — not a failure.
+                }
+                catch (Exception ex)
+                {
+                    _sub.RecordHandlerFailure(ex);
+                }
+            }
+
+            public void Complete() { /* nothing to flush */ }
+        }
+
+        /// <summary>
+        /// Marshaled bridge — every envelope is queued through a bounded
+        /// channel, the consumer's handler runs on the supplied
+        /// <see cref="Dispatcher"/>. Cross-thread mutation of bound
+        /// collections is structurally impossible: the handler can only
+        /// be invoked via <see cref="Dispatcher.InvokeAsync"/>, which by
+        /// construction switches to the dispatcher's thread before the
+        /// delegate runs.
+        /// </summary>
+        private sealed class MarshaledBridge : IDeliveryBridge
+        {
+            private const int QueueCapacity = 1024;
+            private readonly LogSubscription<T> _sub;
+            private readonly Dispatcher _dispatcher;
+            private readonly Channel<LogEnvelope<T>> _queue;
+            private readonly Task _drainTask;
+
+            public MarshaledBridge(LogSubscription<T> sub, Dispatcher dispatcher)
+            {
+                _sub = sub;
+                _dispatcher = dispatcher;
+                _queue = Channel.CreateBounded<LogEnvelope<T>>(new BoundedChannelOptions(QueueCapacity)
+                {
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = true,
+                });
+                _drainTask = Task.Run(DrainAsync);
+            }
+
+            public ValueTask DeliverAsync(LogEnvelope<T> envelope, CancellationToken ct)
+            {
+                // Bounded channel with DropOldest. We probe Reader.Count
+                // before the write so we can attribute the drop: if the
+                // channel was at capacity before TryWrite, an item was
+                // discarded by DropOldest semantics.
+                var preCount = _queue.Reader.Count;
+                _queue.Writer.TryWrite(envelope);
+                if (preCount >= QueueCapacity) _sub.RecordDrop();
+                return ValueTask.CompletedTask;
+            }
+
+            public void Complete()
+            {
+                _queue.Writer.TryComplete();
+            }
+
+            private async Task DrainAsync()
+            {
+                try
+                {
+                    await foreach (var envelope in _queue.Reader.ReadAllAsync().ConfigureAwait(false))
+                    {
+                        // Capture the handler's failure inside the
+                        // InvokeAsync delegate so the failure shape is
+                        // identical between Inline and Marshaled.
+                        Exception? failure = null;
+                        try
+                        {
+                            await _dispatcher.InvokeAsync(async () =>
+                            {
+                                try { await _sub._handler(envelope).ConfigureAwait(true); }
+                                catch (Exception ex) { failure = ex; }
+                            }).Task.ConfigureAwait(false);
+                        }
+                        catch (TaskCanceledException) { return; }
+
+                        if (failure is not null) _sub.RecordHandlerFailure(failure);
+                        else _sub.RecordDelivered();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _sub._diag?.Error(_sub._diagCategory, $"[{_sub._id}] marshaled bridge drain aborted: {ex}");
+                }
+            }
+        }
+    }
+}

--- a/src/Mithril.Shared/Logging/LogSubscriptionDiagnostics.cs
+++ b/src/Mithril.Shared/Logging/LogSubscriptionDiagnostics.cs
@@ -1,0 +1,41 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 per-subscription diagnostic counters surface (#550 capability D + G).
+/// A snapshot of the subscription's accounting at the moment of read.
+/// Today's <c>Channel.CreateBounded&lt;T&gt;(... DropOldest ...)</c> at L0 /
+/// L0.5 drops silently when a subscriber's channel fills; L1 surfaces the
+/// drop count here so a consumer can pin "did we stall?" against zero
+/// instead of guessing. Pair with the <see cref="LogSubscriptionState"/>
+/// for fault-SM observability.
+///
+/// <para>Fields:
+/// <list type="bullet">
+///   <item><c>Delivered</c> — lines delivered to the consumer's handler
+///   (post-filter, post-marshal).</item>
+///   <item><c>Dropped</c> — lines dropped because the consumer's bounded
+///   channel filled (DropOldest).</item>
+///   <item><c>HandlerFailures</c> — envelopes the consumer's handler
+///   threw on (rate-limited Warn'd, retry-continued).</item>
+///   <item><c>ConsecutiveFailures</c> — consecutive handler failures
+///   right now. Reset to 0 on the next successful delivery.</item>
+///   <item><c>HighWaterSkipped</c> — lines skipped by the
+///   <c>SkipProcessedHighWater</c> filter (if configured).</item>
+///   <item><c>State</c> — current fault state.
+///   <see cref="LogSubscriptionState.Degraded"/> ⇒ surfaced on the
+///   attention bus.</item>
+/// </list>
+/// </para>
+///
+/// <para>The counters are reads of <see cref="System.Threading.Interlocked"/>
+/// monotonic counters under the hood, so a snapshot taken concurrently with
+/// the driver pump is a valid lower bound; a quiescent snapshot (after the
+/// driver has finished draining and the consumer awaits) is exact.</para>
+/// </summary>
+public readonly record struct LogSubscriptionDiagnostics(
+    long Delivered,
+    long Dropped,
+    long HandlerFailures,
+    int ConsecutiveFailures,
+    long HighWaterSkipped,
+    LogSubscriptionState State);

--- a/src/Mithril.Shared/Logging/LogSubscriptionOptions.cs
+++ b/src/Mithril.Shared/Logging/LogSubscriptionOptions.cs
@@ -1,0 +1,76 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 per-subscription options bag (#511 deliverable 3 / #550). A consumer
+/// composes the cross-cutting concerns it wants (replay policy, dispatcher
+/// marshalling, idempotence filter, fault thresholds) when calling
+/// <see cref="ILogStreamDriver.Subscribe{T}"/>, and L1 owns delivery
+/// semantics from that point on.
+///
+/// <para>All values are optional; defaults preserve today's behaviour:
+/// <see cref="ReplayMode.FromSessionStart"/>, <see cref="DeliveryContext.Inline"/>,
+/// no high-water filter, fault threshold = 8 consecutive failures. The
+/// "no consumer migration in this PR" rule (PR 1 of #550) means defaults
+/// must be byte-equivalent to pre-L1 behaviour modulo the new
+/// rate-limited <c>Warn</c> + drop counter + fault SM, which are inert
+/// when no failure or drop occurs.</para>
+/// </summary>
+public sealed record LogSubscriptionOptions
+{
+    /// <summary>
+    /// Default — exposed so callers can spread (<c>options with { ... }</c>)
+    /// rather than ctor a fresh record.
+    /// </summary>
+    public static LogSubscriptionOptions Default { get; } = new();
+
+    /// <summary>
+    /// Backlog policy. Default <see cref="ReplayMode.FromSessionStart"/>
+    /// matches every pre-L1 consumer. For chat-backed subscriptions the
+    /// value is moot — the driver coerces to <see cref="ReplayMode.LiveOnly"/>
+    /// and logs a one-time diagnostic if the caller asked for replay (see
+    /// <see cref="ReplayMode"/> for rationale).
+    /// </summary>
+    public ReplayMode ReplayMode { get; init; } = ReplayMode.FromSessionStart;
+
+    /// <summary>
+    /// Thread the handler runs on. Default <see cref="DeliveryContext.Inline"/>;
+    /// callers that mutate bound <c>ObservableCollection</c>s pass
+    /// <see cref="DeliveryContext.Marshaled"/> with the UI dispatcher.
+    /// </summary>
+    public DeliveryContext DeliveryContext { get; init; } = DeliveryContext.Inline;
+
+    /// <summary>
+    /// Optional restart-safe idempotence filter. When non-null, the driver
+    /// drops every envelope whose payload <c>Sequence</c> is <c>&lt;= HighWater</c>
+    /// <em>before</em> handler invocation. Opt-in per the #549 audit: the four
+    /// archetype-B consumers that need it take it; the others (which own
+    /// per-key dedup at the sink layer or are structurally replay-immune)
+    /// decline. <see cref="RawLogLine"/> (chat) lines also carry a
+    /// <c>Sequence</c>; chat consumers may opt in for defence-in-depth.
+    /// </summary>
+    public long? SkipProcessedHighWater { get; init; }
+
+    /// <summary>
+    /// Fault state machine threshold (#550 capability G). After this many
+    /// <em>consecutive</em> handler failures the subscription transitions to
+    /// <see cref="LogSubscriptionState.Degraded"/>, emits one non-throttled
+    /// <c>Error</c> diagnostic, keeps retrying every subsequent envelope,
+    /// and surfaces on <c>IAttentionAggregator</c> via the L1 attention
+    /// source. A subsequent successful delivery resolves both. Default = 8
+    /// — chosen small enough to surface a stuck handler within seconds at
+    /// any plausible log rate, but large enough that a transient burst of
+    /// malformed lines doesn't flap the attention bus.
+    /// </summary>
+    public int DegradedAfterConsecutiveFailures { get; init; } = 8;
+
+    /// <summary>
+    /// Optional diagnostic category override. When null, the driver uses a
+    /// stream-typed default ("Mithril.Logging.L1.LocalPlayer" etc.). Set this
+    /// to the consumer's own bucket (e.g. "Samwise.Ingestion") so containment
+    /// warnings about a consumer's handler land in that consumer's diag
+    /// stream rather than a generic L1 stream — the post-migration shape
+    /// (this PR registers the driver; the consumer-migration PRs supply
+    /// their own category as they're switched over).
+    /// </summary>
+    public string? DiagnosticCategory { get; init; }
+}

--- a/src/Mithril.Shared/Logging/LogSubscriptionState.cs
+++ b/src/Mithril.Shared/Logging/LogSubscriptionState.cs
@@ -1,0 +1,14 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 per-subscription fault state (#550 capability G).
+/// <see cref="Healthy"/> covers "no failures" and "transient failure
+/// throttled to a Warn"; <see cref="Degraded"/> means the consecutive-
+/// failure count crossed the configured threshold and the subscription
+/// is surfaced on <c>IAttentionAggregator</c> until a delivery succeeds.
+/// </summary>
+public enum LogSubscriptionState
+{
+    Healthy = 0,
+    Degraded = 1,
+}

--- a/src/Mithril.Shared/Logging/PlayerLogActorRouter.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogActorRouter.cs
@@ -93,6 +93,15 @@ public sealed class PlayerLogActorRouter :
     IAsyncEnumerable<SystemSignalLogLine> ISystemSignalLogStream.SubscribeAsync(CancellationToken ct) =>
         Subscribe(_system, ct);
 
+    public IAsyncEnumerable<LogEnvelope<LocalPlayerLogLine>> SubscribeWithReplayMarkerAsync(
+        CancellationToken ct) => SubscribeWithMarker(_localPlayer, ct);
+
+    IAsyncEnumerable<LogEnvelope<CombatActorLogLine>> ICombatActorLogStream.SubscribeWithReplayMarkerAsync(
+        CancellationToken ct) => SubscribeWithMarker(_combat, ct);
+
+    IAsyncEnumerable<LogEnvelope<SystemSignalLogLine>> ISystemSignalLogStream.SubscribeWithReplayMarkerAsync(
+        CancellationToken ct) => SubscribeWithMarker(_system, ct);
+
     /// <summary>
     /// Diagnostics-only counters: total cheap-discards, total anomalies,
     /// total anomaly samples actually emitted to <see cref="IDiagnosticsSink"/>
@@ -143,6 +152,59 @@ public sealed class PlayerLogActorRouter :
             await foreach (var item in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
             {
                 yield return item;
+            }
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                pipe.RemoveSubscriber(channel);
+                channel.Writer.TryComplete();
+                if (NoSubscribers()) StopRunning();
+            }
+        }
+    }
+
+    /// <summary>
+    /// L1-facing variant of <see cref="Subscribe{T}"/> (added #550 PR 1).
+    /// Same backlog-then-live-tail shape; each yielded item is paired with
+    /// the boundary bit that L0.5 can answer authoritatively (replay yields
+    /// from the snapshot; live yields from the channel branch). L1's driver
+    /// reads IsReplay directly off this method rather than guessing from
+    /// the iterator's sync-vs-async timing — the timing-based heuristic
+    /// loses items when the live channel happens to be non-empty by the
+    /// moment the L1 pump enters its read branch.
+    /// </summary>
+    private async IAsyncEnumerable<LogEnvelope<T>> SubscribeWithMarker<T>(
+        PipeRegistry<T> pipe, [EnumeratorCancellation] CancellationToken ct)
+        where T : class
+    {
+        var channel = Channel.CreateBounded<T>(new BoundedChannelOptions(1024)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = true,
+        });
+
+        T[] replay;
+        lock (_gate)
+        {
+            replay = pipe.SnapshotReplay();
+            pipe.AddSubscriber(channel);
+            EnsureRunning();
+        }
+
+        try
+        {
+            foreach (var item in replay)
+            {
+                if (ct.IsCancellationRequested) yield break;
+                yield return new LogEnvelope<T>(item, IsReplay: true);
+            }
+
+            await foreach (var item in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return new LogEnvelope<T>(item, IsReplay: false);
             }
         }
         finally

--- a/src/Mithril.Shared/Logging/ReplayMode.cs
+++ b/src/Mithril.Shared/Logging/ReplayMode.cs
@@ -1,0 +1,40 @@
+namespace Mithril.Shared.Logging;
+
+/// <summary>
+/// L1 per-subscription replay policy (#511 deliverable 3 / #550 capability A).
+/// Per-subscription, not per-module — one consumer class may hold
+/// subscriptions of different modes (Legolas: its area-bridge subscription
+/// wants replay; its survey-dispatch subscription wants live-only).
+///
+/// <para>For chat-backed subscriptions (<see cref="LogStreamKind.Chat"/>)
+/// the value is structurally moot — <c>IChatLogStream</c> has no backlog by
+/// construction (the per-day file directory is seeded to current-end before
+/// the first emission). The driver accepts any value on chat subscriptions
+/// for API uniformity, treats them all as <see cref="LiveOnly"/>, and emits
+/// a diagnostic on the first mismatch so the spurious knob doesn't go
+/// unnoticed in code review.</para>
+/// </summary>
+public enum ReplayMode
+{
+    /// <summary>
+    /// Backlog from L0 session start delivered first (each envelope carries
+    /// <c>IsReplay = true</c>), then live (<c>IsReplay = false</c>). The
+    /// existing implicit default of every consumer pre-L1 — non-breaking.
+    /// </summary>
+    FromSessionStart = 0,
+
+    /// <summary>
+    /// Skip the replay drain entirely; only emissions arriving after the
+    /// subscription is established are delivered, all with <c>IsReplay = false</c>.
+    /// </summary>
+    LiveOnly = 1,
+
+    /// <summary>
+    /// Currently behaviourally identical to <see cref="LiveOnly"/>; reserved
+    /// for future replay-window variants (e.g. "since timestamp T", "since
+    /// sequence S without persisted high-water"). Distinct value so consumers
+    /// can express intent — Saruman/Discovery wants "since this gate-open"
+    /// not "skip backlog forever," and a future revision may differentiate.
+    /// </summary>
+    SinceSubscribe = 2,
+}

--- a/src/Mithril.Shared/Logging/ReplayMode.cs
+++ b/src/Mithril.Shared/Logging/ReplayMode.cs
@@ -6,13 +6,13 @@ namespace Mithril.Shared.Logging;
 /// subscriptions of different modes (Legolas: its area-bridge subscription
 /// wants replay; its survey-dispatch subscription wants live-only).
 ///
-/// <para>For chat-backed subscriptions (<see cref="LogStreamKind.Chat"/>)
-/// the value is structurally moot — <c>IChatLogStream</c> has no backlog by
-/// construction (the per-day file directory is seeded to current-end before
-/// the first emission). The driver accepts any value on chat subscriptions
-/// for API uniformity, treats them all as <see cref="LiveOnly"/>, and emits
-/// a diagnostic on the first mismatch so the spurious knob doesn't go
-/// unnoticed in code review.</para>
+/// <para>For chat-backed subscriptions the value is structurally moot —
+/// <c>IChatLogStream</c> has no backlog by construction (the per-day file
+/// directory is seeded to current-end before the first emission). The
+/// driver accepts any value on chat subscriptions for API uniformity,
+/// treats them all as <see cref="LiveOnly"/>, and emits a diagnostic on
+/// the first mismatch so the spurious knob doesn't go unnoticed in code
+/// review.</para>
 /// </summary>
 public enum ReplayMode
 {

--- a/tests/Mithril.Shared.Tests/Logging/LogStreamDriverTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/LogStreamDriverTests.cs
@@ -83,6 +83,37 @@ public sealed class LogStreamDriverTests
     }
 
     [Fact]
+    public async Task ReplayMode_SinceSubscribe_DropsReplayPhaseEntirely()
+    {
+        // SinceSubscribe is documented (ReplayMode.cs) as behaviourally
+        // identical to LiveOnly today. The driver MUST honour that —
+        // Saruman/Discovery's #549 disposition picks SinceSubscribe
+        // explicitly to express intent, and its eventual migration would
+        // silently re-inflate DiscoveryCount if replay leaked through.
+        var upstream = new TwoPhaseLocalPlayerStream();
+        upstream.AddReplay(Make("REPLAY1", seq: 1));
+        upstream.AddReplay(Make("REPLAY2", seq: 2));
+
+        using var driver = NewDriverWith(localPlayer: upstream);
+        var collected = new List<LogEnvelope<LocalPlayerLogLine>>();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => { lock (collected) collected.Add(e); return ValueTask.CompletedTask; },
+            new LogSubscriptionOptions { ReplayMode = ReplayMode.SinceSubscribe });
+
+        // Give the pump a chance to drain replay (which should be dropped)
+        upstream.PushLive(Make("LIVE1", seq: 3));
+        await WaitUntilAsync(() => { lock (collected) return collected.Count >= 1; });
+
+        // The replay items must NOT have been delivered
+        lock (collected)
+        {
+            collected.Should().HaveCount(1);
+            collected[0].Payload.Data.Should().Be("LIVE1");
+            collected[0].IsReplay.Should().BeFalse();
+        }
+    }
+
+    [Fact]
     public async Task ReplayMode_FromSessionStart_DeliversBacklogThenLive()
     {
         var upstream = new TwoPhaseLocalPlayerStream();
@@ -230,6 +261,144 @@ public sealed class LogStreamDriverTests
                 because: "the test thread is NOT the dispatcher thread");
         }
         dispatcher.Shutdown();
+    }
+
+    [Fact]
+    public async Task DeliveryContext_Marshaled_AsyncHandler_AwaitsInnerTask_AndCapturesPostAwaitExceptions()
+    {
+        // Regression — without `.Task.Unwrap()` in MarshaledBridge.DrainAsync,
+        // Dispatcher.InvokeAsync(async () => ...) returns a Task<Task>; the
+        // outer task completes when the dispatcher *starts* the lambda,
+        // making the inner async body fire-and-forget. That breaks two
+        // promises:
+        //   (1) sequential delivery — concurrent envelopes can interleave;
+        //   (2) post-await exception capture — exceptions thrown after the
+        //       handler's first await escape the bridge's try/catch and are
+        //       lost.
+        using var dispatcher = StaThread.Start();
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var inFlight = 0;
+        var maxConcurrent = 0;
+        var order = new List<string>();
+
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            async e =>
+            {
+                var now = Interlocked.Increment(ref inFlight);
+                // Track the peak in-flight count atomically so a CAS race
+                // between two concurrent invocations can't lose an update.
+                int observed;
+                do
+                {
+                    observed = Volatile.Read(ref maxConcurrent);
+                    if (now <= observed) break;
+                }
+                while (Interlocked.CompareExchange(ref maxConcurrent, now, observed) != observed);
+
+                await Task.Delay(50).ConfigureAwait(true);
+                // Post-await — if the bridge does not Unwrap, the throw
+                // here is lost and HandlerFailures stays at 0.
+                if (e.Payload.Data == "THROW_AFTER_AWAIT")
+                {
+                    Interlocked.Decrement(ref inFlight);
+                    throw new InvalidOperationException("post-await throw");
+                }
+                lock (order) order.Add(e.Payload.Data);
+                Interlocked.Decrement(ref inFlight);
+            },
+            new LogSubscriptionOptions { DeliveryContext = DeliveryContext.Marshaled(dispatcher.Dispatcher) });
+
+        upstream.PushLive(Make("A", seq: 1));
+        upstream.PushLive(Make("B", seq: 2));
+        upstream.PushLive(Make("THROW_AFTER_AWAIT", seq: 3));
+        upstream.PushLive(Make("C", seq: 4));
+
+        await WaitUntilAsync(
+            () => sub.Diagnostics.Delivered + sub.Diagnostics.HandlerFailures >= 4,
+            TimeSpan.FromSeconds(10));
+
+        // (1) Sequential delivery — peak in-flight is 1, never 2+.
+        Volatile.Read(ref maxConcurrent).Should().Be(1,
+            because: "the drain awaits the inner async task via Unwrap; handlers must not run concurrently");
+
+        // (2) Post-await exception captured — HandlerFailures incremented.
+        sub.Diagnostics.HandlerFailures.Should().Be(1,
+            because: "the post-await throw must surface on HandlerFailures (Critical #1)");
+
+        // (3) Three successful deliveries (A, B, C); order preserved.
+        sub.Diagnostics.Delivered.Should().Be(3);
+        lock (order) order.Should().Equal("A", "B", "C");
+
+        dispatcher.Shutdown();
+    }
+
+    [Fact]
+    public async Task MarshaledBridge_DispatcherShutdown_StopsSilentDropSpiral()
+    {
+        // Important #3 — if DrainAsync exits unexpectedly (e.g. dispatcher
+        // shuts down so InvokeAsync.Task.Unwrap() faults), the channel
+        // writer must be completed so subsequent DeliverAsync TryWrites
+        // no-op rather than spiralling drop accounting forever. The
+        // subscription should surface the bridge death on the fault SM
+        // (Degraded) rather than staying Healthy while silently dropping
+        // every envelope.
+        using var dispatcher = StaThread.Start();
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var diag = new CapturingDiag();
+        var attention = new LogStreamAttentionSource();
+        using var driver = new LogStreamDriver(
+            upstream, NoopCombat.Instance, NoopSystem.Instance, NoopChat.Instance,
+            attention, diag);
+
+        // Subscribe FIRST so the drain task is running and blocked on
+        // ReadAllAsync (channel empty). Then shut down the dispatcher.
+        // The next pushed envelope reaches the drain; InvokeAsync on a
+        // shut-down dispatcher returns a faulted DispatcherOperation
+        // whose .Task.Unwrap() throws TaskCanceledException — exactly
+        // the path Important #3 covers.
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => ValueTask.CompletedTask,
+            new LogSubscriptionOptions
+            {
+                DeliveryContext = DeliveryContext.Marshaled(dispatcher.Dispatcher),
+                DegradedAfterConsecutiveFailures = 1,
+            });
+
+        // Shut down the dispatcher and wait for it to finish so the next
+        // InvokeAsync is GUARANTEED to fault.
+        dispatcher.Shutdown();
+
+        // Push the first envelope post-shutdown — the drain pulls it,
+        // tries InvokeAsync on the dead dispatcher, faults out.
+        upstream.PushLive(Make("L1", seq: 1));
+
+        await WaitUntilAsync(
+            () => sub.Diagnostics.State == LogSubscriptionState.Degraded,
+            TimeSpan.FromSeconds(5));
+
+        sub.Diagnostics.State.Should().Be(LogSubscriptionState.Degraded,
+            because: "a faulted drain must surface on the fault SM, not stay Healthy");
+
+        // After the drain has died, push a wave of envelopes and verify
+        // the drop count STABILIZES — i.e. once the channel writer is
+        // completed, TryWrite is a no-op and Reader.Count stops being
+        // probed against an ever-filling buffer.
+        for (var i = 0; i < 2000; i++) upstream.PushLive(Make($"X{i}", seq: i + 100));
+        await Task.Delay(200); // let the pump drain the upstream into the (dead) bridge
+        var snapshotMid = sub.Diagnostics.Dropped;
+        for (var i = 0; i < 2000; i++) upstream.PushLive(Make($"Y{i}", seq: i + 5000));
+        await Task.Delay(200);
+        var snapshotAfter = sub.Diagnostics.Dropped;
+
+        // Once the writer is completed, TryWrite returns false silently —
+        // our probe `preCount >= QueueCapacity` will only fire if the
+        // reader count is at-or-above capacity, which is impossible after
+        // the channel completes and the buffered items drain. So the drop
+        // counter must stabilize (no spiral).
+        (snapshotAfter - snapshotMid).Should().BeLessThan(2000,
+            because: "after the bridge dies the channel writer is completed; subsequent TryWrites no-op and drops must stabilize, not climb 1-for-1 with pushes");
     }
 
     [Fact]

--- a/tests/Mithril.Shared.Tests/Logging/LogStreamDriverTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/LogStreamDriverTests.cs
@@ -1,0 +1,746 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using System.Windows.Threading;
+using FluentAssertions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.Shared.Tests.Logging;
+
+/// <summary>
+/// L1 driver tests (#511 deliverable 3 / #550 PR 1). Covers capabilities
+/// A-G end-to-end against in-memory upstream stubs that reproduce L0/L0.5's
+/// "direct-yield replay buffer → bounded-channel live tail" structural shape.
+/// The driver's IsReplay determination relies on this shape; the stubs
+/// preserve it.
+/// </summary>
+public sealed class LogStreamDriverTests
+{
+    // ============================================================
+    // Capability A + B — ReplayMode and IsReplay
+    // ============================================================
+
+    [Fact]
+    public async Task IsReplay_FlipsAtFirstAsyncMoveNext()
+    {
+        // Capability B — the IsReplay bit must be true exactly during the
+        // replay drain and false from the first live envelope onward. The
+        // driver detects the boundary via MoveNextAsync.IsCompletedSuccessfully:
+        // the upstream's direct-yield replay branch completes synchronously,
+        // the bounded-channel live branch awaits.
+        var upstream = new TwoPhaseLocalPlayerStream();
+        upstream.AddReplay(Make("ProcessAddItem(A,1)", seq: 1));
+        upstream.AddReplay(Make("ProcessAddItem(B,1)", seq: 2));
+        upstream.AddReplay(Make("ProcessAddItem(C,1)", seq: 3));
+
+        using var driver = NewDriverWith(localPlayer: upstream);
+        var collected = new List<LogEnvelope<LocalPlayerLogLine>>();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => { lock (collected) collected.Add(e); return ValueTask.CompletedTask; });
+
+        await WaitUntilAsync(() => { lock (collected) return collected.Count == 3; });
+
+        // Push a live line — only emitted after the replay buffer drains
+        upstream.PushLive(Make("ProcessAddItem(LIVE,1)", seq: 4));
+        await WaitUntilAsync(() => { lock (collected) return collected.Count == 4; });
+
+        lock (collected)
+        {
+            collected.Should().HaveCount(4);
+            collected[0].IsReplay.Should().BeTrue("replay phase");
+            collected[1].IsReplay.Should().BeTrue();
+            collected[2].IsReplay.Should().BeTrue();
+            collected[3].IsReplay.Should().BeFalse("first live envelope after the channel await");
+            collected[3].Payload.Data.Should().Contain("LIVE");
+        }
+    }
+
+    [Fact]
+    public async Task ReplayMode_LiveOnly_DropsReplayPhaseEntirely()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        upstream.AddReplay(Make("REPLAY1", seq: 1));
+        upstream.AddReplay(Make("REPLAY2", seq: 2));
+
+        using var driver = NewDriverWith(localPlayer: upstream);
+        var collected = new List<LogEnvelope<LocalPlayerLogLine>>();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => { lock (collected) collected.Add(e); return ValueTask.CompletedTask; },
+            new LogSubscriptionOptions { ReplayMode = ReplayMode.LiveOnly });
+
+        // Give the pump a chance to drain replay (which should be dropped)
+        upstream.PushLive(Make("LIVE1", seq: 3));
+        await WaitUntilAsync(() => { lock (collected) return collected.Count >= 1; });
+
+        // The replay items must NOT have been delivered
+        lock (collected)
+        {
+            collected.Should().HaveCount(1);
+            collected[0].Payload.Data.Should().Be("LIVE1");
+            collected[0].IsReplay.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task ReplayMode_FromSessionStart_DeliversBacklogThenLive()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        upstream.AddReplay(Make("R1", seq: 1));
+        upstream.AddReplay(Make("R2", seq: 2));
+
+        using var driver = NewDriverWith(localPlayer: upstream);
+        var collected = new List<LogEnvelope<LocalPlayerLogLine>>();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => { lock (collected) collected.Add(e); return ValueTask.CompletedTask; },
+            new LogSubscriptionOptions { ReplayMode = ReplayMode.FromSessionStart });
+
+        await WaitUntilAsync(() => { lock (collected) return collected.Count == 2; });
+
+        upstream.PushLive(Make("L1", seq: 3));
+        await WaitUntilAsync(() => { lock (collected) return collected.Count == 3; });
+
+        lock (collected)
+        {
+            collected.Select(e => e.Payload.Data).Should().Equal("R1", "R2", "L1");
+            collected[0].IsReplay.Should().BeTrue();
+            collected[1].IsReplay.Should().BeTrue();
+            collected[2].IsReplay.Should().BeFalse();
+        }
+    }
+
+    // ============================================================
+    // Capability C — Per-message error containment
+    // ============================================================
+
+    [Fact]
+    public async Task HandlerThrow_IsCaught_AndDoesNotKillThePump()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var diag = new CapturingDiag();
+        using var driver = NewDriverWith(localPlayer: upstream, diag: diag);
+
+        var seenAfterThrow = 0;
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(e =>
+        {
+            if (e.Payload.Data == "BOOM") throw new InvalidOperationException("test boom");
+            Interlocked.Increment(ref seenAfterThrow);
+            return ValueTask.CompletedTask;
+        });
+
+        upstream.PushLive(Make("BOOM", seq: 1));
+        upstream.PushLive(Make("OK1", seq: 2));
+        upstream.PushLive(Make("OK2", seq: 3));
+
+        await WaitUntilAsync(() => Volatile.Read(ref seenAfterThrow) >= 2);
+
+        sub.Diagnostics.HandlerFailures.Should().Be(1);
+        sub.Diagnostics.Delivered.Should().Be(2);
+        diag.WarnCount.Should().BeGreaterThan(0,
+            because: "ThrottledWarn should have surfaced the failure");
+    }
+
+    [Fact]
+    public async Task HandlerThrow_Warn_IsRateLimited()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var diag = new CapturingDiag();
+        using var driver = NewDriverWith(localPlayer: upstream, diag: diag);
+
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(e =>
+            throw new InvalidOperationException("always boom"));
+
+        for (var i = 0; i < 50; i++) upstream.PushLive(Make($"L{i}", seq: i + 1));
+        await WaitUntilAsync(() => sub.Diagnostics.HandlerFailures >= 50);
+
+        // 50 failures must not produce 50 Warns — ThrottledWarn caps emission
+        diag.WarnCount.Should().BeLessThan(10,
+            because: "ThrottledWarn defaults to ~one warn per 5 seconds; 50 failures in <1s should produce <10 emitted warns");
+    }
+
+    // ============================================================
+    // Capability D — Drop accounting
+    // ============================================================
+
+    [Fact]
+    public async Task DropCounter_IncrementsWhenMarshaledBridgeBacklogFills()
+    {
+        // The Marshaled bridge bounds its queue at 1024. A handler that
+        // blocks the dispatcher must surface drops once we push >1024
+        // items at it while the dispatcher is stalled.
+        using var dispatcher = StaThread.Start();
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var release = new TaskCompletionSource();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            async e => { await release.Task.ConfigureAwait(true); },
+            new LogSubscriptionOptions
+            {
+                DeliveryContext = DeliveryContext.Marshaled(dispatcher.Dispatcher),
+            });
+
+        // Fire enough to overflow the bridge queue (1024 capacity).
+        const int totalToPush = 1500;
+        for (var i = 0; i < totalToPush; i++)
+        {
+            upstream.PushLive(Make($"L{i}", seq: i + 1));
+        }
+
+        // The dispatcher is stalled on `release`. Wait for the pump to
+        // have observed > capacity envelopes and accounted overflows.
+        await WaitUntilAsync(() => sub.Diagnostics.Dropped > 0, TimeSpan.FromSeconds(10));
+        sub.Diagnostics.Dropped.Should().BeGreaterThan(0);
+
+        // Release the dispatcher so cleanup proceeds quickly
+        release.TrySetResult();
+        dispatcher.Shutdown();
+    }
+
+    // ============================================================
+    // Capability E — DeliveryContext (Marshaled vs Inline)
+    // ============================================================
+
+    [Fact]
+    public async Task DeliveryContext_Marshaled_RunsHandlerOnDispatcherThread()
+    {
+        using var dispatcher = StaThread.Start();
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var observedThreadIds = new List<int>();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e =>
+            {
+                lock (observedThreadIds) observedThreadIds.Add(Environment.CurrentManagedThreadId);
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions { DeliveryContext = DeliveryContext.Marshaled(dispatcher.Dispatcher) });
+
+        upstream.PushLive(Make("X", seq: 1));
+        upstream.PushLive(Make("Y", seq: 2));
+        await WaitUntilAsync(() => sub.Diagnostics.Delivered >= 2);
+
+        lock (observedThreadIds)
+        {
+            observedThreadIds.Should().HaveCount(2);
+            observedThreadIds[0].Should().Be(dispatcher.ThreadId);
+            observedThreadIds[1].Should().Be(dispatcher.ThreadId);
+            observedThreadIds[0].Should().NotBe(Environment.CurrentManagedThreadId,
+                because: "the test thread is NOT the dispatcher thread");
+        }
+        dispatcher.Shutdown();
+    }
+
+    [Fact]
+    public async Task DeliveryContext_Marshaled_StructurallyPreventsCrossThreadObservableCollectionMutation()
+    {
+        // The regression test #550 calls out by name: an
+        // ObservableCollection<T> bound to the UI thread will throw
+        // NotSupportedException when mutated from a non-dispatcher thread
+        // (the "This type of CollectionView does not support changes to
+        // its SourceCollection from a thread different from the
+        // Dispatcher thread" message). Under L1's Marshaled bridge, the
+        // mutation runs on the dispatcher thread by construction, so the
+        // exception is structurally unreachable.
+        using var dispatcher = StaThread.Start();
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var collection = await dispatcher.InvokeAsync(() =>
+            new System.Collections.ObjectModel.ObservableCollection<string>());
+
+        // Attach a CollectionView to make the cross-thread guard active —
+        // a bare ObservableCollection has no thread-affinity check by
+        // itself; the guard is on the bound view.
+        await dispatcher.InvokeAsync(() =>
+        {
+            var view = System.Windows.Data.CollectionViewSource.GetDefaultView(collection);
+            _ = view; // anchor the view so the runtime registers the thread-affinity check
+        });
+
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e =>
+            {
+                // Mutate the bound collection. Under Inline this throws
+                // (off-thread); under Marshaled it succeeds because the
+                // handler runs on the dispatcher.
+                collection.Add(e.Payload.Data);
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions { DeliveryContext = DeliveryContext.Marshaled(dispatcher.Dispatcher) });
+
+        upstream.PushLive(Make("M1", seq: 1));
+        upstream.PushLive(Make("M2", seq: 2));
+        await WaitUntilAsync(() => sub.Diagnostics.Delivered >= 2);
+
+        sub.Diagnostics.HandlerFailures.Should().Be(0,
+            because: "Marshaled bridge runs the handler on the dispatcher; cross-thread mutation is structurally impossible");
+        var snapshot = await dispatcher.InvokeAsync(() => collection.ToList());
+        snapshot.Should().Equal("M1", "M2");
+
+        dispatcher.Shutdown();
+    }
+
+    [Fact]
+    public async Task DeliveryContext_Inline_RunsHandlerSynchronouslyOnPumpThread()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var observedThread = 0;
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e =>
+            {
+                Interlocked.Exchange(ref observedThread, Environment.CurrentManagedThreadId);
+                return ValueTask.CompletedTask;
+            });
+
+        upstream.PushLive(Make("X", seq: 1));
+        await WaitUntilAsync(() => sub.Diagnostics.Delivered >= 1);
+
+        Volatile.Read(ref observedThread).Should().NotBe(Environment.CurrentManagedThreadId,
+            because: "Inline runs on the pump task, not the test thread");
+    }
+
+    // ============================================================
+    // Capability F — SkipProcessedHighWater
+    // ============================================================
+
+    [Fact]
+    public async Task SkipProcessedHighWater_DropsEnvelopesAtOrBelowHighWater()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        upstream.AddReplay(Make("R1", seq: 5));
+        upstream.AddReplay(Make("R2", seq: 10));
+        upstream.AddReplay(Make("R3", seq: 15));
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var collected = new List<LogEnvelope<LocalPlayerLogLine>>();
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => { lock (collected) collected.Add(e); return ValueTask.CompletedTask; },
+            new LogSubscriptionOptions { SkipProcessedHighWater = 10 });
+
+        upstream.PushLive(Make("L1", seq: 20));
+        await WaitUntilAsync(() => { lock (collected) return collected.Count >= 2; });
+
+        lock (collected)
+        {
+            collected.Select(e => e.Payload.Data).Should().Equal("R3", "L1");
+        }
+        sub.Diagnostics.HighWaterSkipped.Should().Be(2,
+            because: "R1 (seq=5) and R2 (seq=10) are <= highWater=10");
+    }
+
+    // ============================================================
+    // Capability G — Fault state machine
+    // ============================================================
+
+    [Fact]
+    public async Task FaultSM_DegradesAfterNConsecutiveFailures_AndRegistersOnAttention()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var diag = new CapturingDiag();
+        var attention = new LogStreamAttentionSource();
+        using var driver = new LogStreamDriver(
+            upstream, NoopCombat.Instance, NoopSystem.Instance, NoopChat.Instance,
+            attention, diag);
+
+        var changedFired = 0;
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e => throw new InvalidOperationException("always"),
+            new LogSubscriptionOptions { DegradedAfterConsecutiveFailures = 3 });
+        sub.StateChanged += (_, _) => Interlocked.Increment(ref changedFired);
+
+        attention.Count.Should().Be(0, "no failures yet");
+
+        for (var i = 0; i < 3; i++) upstream.PushLive(Make($"L{i}", seq: i + 1));
+        await WaitUntilAsync(() => sub.Diagnostics.State == LogSubscriptionState.Degraded);
+
+        sub.Diagnostics.State.Should().Be(LogSubscriptionState.Degraded);
+        sub.Diagnostics.ConsecutiveFailures.Should().BeGreaterOrEqualTo(3);
+        attention.Count.Should().Be(1, "the degraded subscription registers on attention");
+        Volatile.Read(ref changedFired).Should().BeGreaterThan(0);
+        diag.ErrorCount.Should().Be(1,
+            because: "exactly one non-throttled Error is emitted on degraded entry");
+    }
+
+    [Fact]
+    public async Task FaultSM_RecoversOnNextSuccess_AndDeregistersAttention()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var diag = new CapturingDiag();
+        var attention = new LogStreamAttentionSource();
+        using var driver = new LogStreamDriver(
+            upstream, NoopCombat.Instance, NoopSystem.Instance, NoopChat.Instance,
+            attention, diag);
+
+        var failing = true;
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e =>
+            {
+                if (Volatile.Read(ref failing)) throw new InvalidOperationException("nope");
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions { DegradedAfterConsecutiveFailures = 2 });
+
+        for (var i = 0; i < 2; i++) upstream.PushLive(Make($"B{i}", seq: i + 1));
+        await WaitUntilAsync(() => sub.Diagnostics.State == LogSubscriptionState.Degraded);
+        attention.Count.Should().Be(1);
+
+        // Flip to success — next delivery should resolve the state
+        Volatile.Write(ref failing, false);
+        upstream.PushLive(Make("OK", seq: 100));
+        await WaitUntilAsync(() => sub.Diagnostics.State == LogSubscriptionState.Healthy);
+
+        sub.Diagnostics.State.Should().Be(LogSubscriptionState.Healthy);
+        sub.Diagnostics.ConsecutiveFailures.Should().Be(0);
+        attention.Count.Should().Be(0, "successful delivery resolves the attention entry");
+    }
+
+    [Fact]
+    public async Task FaultSM_KeepsDeliveringEvenWhileDegraded()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var seen = 0;
+        var alwaysFail = true;
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(
+            e =>
+            {
+                Interlocked.Increment(ref seen);
+                if (Volatile.Read(ref alwaysFail)) throw new InvalidOperationException("still bad");
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions { DegradedAfterConsecutiveFailures = 2 });
+
+        for (var i = 0; i < 10; i++) upstream.PushLive(Make($"L{i}", seq: i + 1));
+        await WaitUntilAsync(() => Volatile.Read(ref seen) >= 10);
+
+        // Driver kept invoking the handler even after degrading
+        Volatile.Read(ref seen).Should().BeGreaterOrEqualTo(10);
+        sub.Diagnostics.HandlerFailures.Should().BeGreaterOrEqualTo(10);
+        sub.Diagnostics.State.Should().Be(LogSubscriptionState.Degraded);
+    }
+
+    // ============================================================
+    // Chat behaviour — Divergence 1
+    // ============================================================
+
+    [Fact]
+    public async Task ChatSubscription_CoercesFromSessionStartToLiveOnly_AndLogsOnce()
+    {
+        var chat = new ScriptedChatStream();
+        using var diag = new CapturingDiag();
+        var attention = new LogStreamAttentionSource();
+        using var driver = new LogStreamDriver(
+            NoopLocalPlayer.Instance, NoopCombat.Instance, NoopSystem.Instance,
+            chat, attention, diag);
+
+        var collected = new List<LogEnvelope<RawLogLine>>();
+        using var sub = driver.Subscribe<RawLogLine>(
+            e => { lock (collected) collected.Add(e); return ValueTask.CompletedTask; },
+            new LogSubscriptionOptions { ReplayMode = ReplayMode.FromSessionStart });
+
+        chat.Push("hello chat");
+        await WaitUntilAsync(() => { lock (collected) return collected.Count >= 1; });
+
+        lock (collected)
+        {
+            collected.Should().ContainSingle();
+            collected[0].IsReplay.Should().BeFalse(
+                because: "chat is structurally live-only; replay phase is empty");
+        }
+        diag.InfoCount.Should().BeGreaterThan(0,
+            because: "coercing FromSessionStart→LiveOnly on chat emits a one-time Info diagnostic");
+    }
+
+    // ============================================================
+    // Mixed-handler subscription — Divergence 2
+    // ============================================================
+
+    [Fact]
+    public async Task MixedHandler_PerHandlerFilteringOnIsReplay_PreservesSingleSubscription()
+    {
+        // Divergence 2 (Legolas-style): a single subscription serves both
+        // a replay-needing area-bridge handler and a live-only survey
+        // dispatch. The driver delivers both phases; the consumer
+        // dispatches per-handler using the IsReplay flag.
+        var upstream = new TwoPhaseLocalPlayerStream();
+        upstream.AddReplay(Make("R1", seq: 1));
+        upstream.AddReplay(Make("R2", seq: 2));
+        using var driver = NewDriverWith(localPlayer: upstream);
+
+        var areaSeen = new List<string>();
+        var liveSeen = new List<string>();
+
+        using var sub = driver.Subscribe<LocalPlayerLogLine>(e =>
+        {
+            // Area bridge: takes replay
+            lock (areaSeen) areaSeen.Add(e.Payload.Data);
+            // Survey dispatch: drops replay
+            if (!e.IsReplay)
+            {
+                lock (liveSeen) liveSeen.Add(e.Payload.Data);
+            }
+            return ValueTask.CompletedTask;
+        });
+
+        await WaitUntilAsync(() => { lock (areaSeen) return areaSeen.Count >= 2; });
+        upstream.PushLive(Make("L1", seq: 3));
+        await WaitUntilAsync(() => { lock (liveSeen) return liveSeen.Count >= 1; });
+
+        lock (areaSeen) areaSeen.Should().Equal("R1", "R2", "L1");
+        lock (liveSeen) liveSeen.Should().Equal("L1");
+    }
+
+    // ============================================================
+    // Type-safety / unsupported types
+    // ============================================================
+
+    [Fact]
+    public void Subscribe_OfUnsupportedType_Throws()
+    {
+        using var driver = NewDriverWith();
+        Action act = () => driver.Subscribe<string>(_ => ValueTask.CompletedTask);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Dispose_OfDriver_DisposesAllSubscriptions()
+    {
+        var upstream = new TwoPhaseLocalPlayerStream();
+        var driver = NewDriverWith(localPlayer: upstream);
+        var sub1 = driver.Subscribe<LocalPlayerLogLine>(_ => ValueTask.CompletedTask);
+        var sub2 = driver.Subscribe<LocalPlayerLogLine>(_ => ValueTask.CompletedTask);
+
+        driver.Dispose();
+        // Calling Dispose on the (already-disposed-by-driver) subscriptions
+        // must be safe
+        sub1.Dispose();
+        sub2.Dispose();
+
+        Action act = () => driver.Subscribe<LocalPlayerLogLine>(_ => ValueTask.CompletedTask);
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private static LocalPlayerLogLine Make(string data, long seq) =>
+        new(
+            Timestamp: new DateTimeOffset(2026, 5, 19, 20, 0, 0, TimeSpan.Zero),
+            Data: data,
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    private static LogStreamDriver NewDriverWith(
+        ILocalPlayerLogStream? localPlayer = null,
+        IDiagnosticsSink? diag = null)
+    {
+        var attention = new LogStreamAttentionSource();
+        return new LogStreamDriver(
+            localPlayer ?? NoopLocalPlayer.Instance,
+            NoopCombat.Instance,
+            NoopSystem.Instance,
+            NoopChat.Instance,
+            attention,
+            diag);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan? timeout = null)
+    {
+        var budget = timeout ?? TimeSpan.FromSeconds(5);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (sw.Elapsed > budget) throw new TimeoutException("WaitUntilAsync gave up");
+            await Task.Delay(10);
+        }
+    }
+
+    // ============================================================
+    // Test stubs
+    // ============================================================
+
+    /// <summary>
+    /// Reproduces L0/L0.5's "direct-yield replay buffer THEN bounded-channel
+    /// live tail" shape — but on the L1-facing
+    /// <see cref="ILocalPlayerLogStream.SubscribeWithReplayMarkerAsync"/>
+    /// surface so the IsReplay bit reaches the driver authoritatively.
+    /// </summary>
+    private sealed class TwoPhaseLocalPlayerStream : ILocalPlayerLogStream
+    {
+        private readonly List<LocalPlayerLogLine> _replay = new();
+        private readonly Channel<LocalPlayerLogLine> _live = Channel.CreateUnbounded<LocalPlayerLogLine>();
+
+        public void AddReplay(LocalPlayerLogLine line) => _replay.Add(line);
+        public void PushLive(LocalPlayerLogLine line) => _live.Writer.TryWrite(line);
+        public void Complete() => _live.Writer.TryComplete();
+
+        public async IAsyncEnumerable<LocalPlayerLogLine> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (var line in _replay)
+            {
+                if (ct.IsCancellationRequested) yield break;
+                yield return line;
+            }
+            await foreach (var line in _live.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                yield return line;
+        }
+
+        public async IAsyncEnumerable<LogEnvelope<LocalPlayerLogLine>>
+            SubscribeWithReplayMarkerAsync([EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (var line in _replay)
+            {
+                if (ct.IsCancellationRequested) yield break;
+                yield return new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: true);
+            }
+            await foreach (var line in _live.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                yield return new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: false);
+        }
+    }
+
+    private sealed class ScriptedChatStream : IChatLogStream
+    {
+        private readonly Channel<RawLogLine> _ch = Channel.CreateUnbounded<RawLogLine>();
+        private long _seq;
+        public void Push(string line)
+        {
+            var seq = Interlocked.Increment(ref _seq);
+            _ch.Writer.TryWrite(new RawLogLine(
+                Timestamp: DateTimeOffset.UtcNow, Line: line,
+                Sequence: seq, ReadMonotonicTicks: 0));
+        }
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            await foreach (var line in _ch.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                yield return line;
+        }
+    }
+
+    private sealed class NoopLocalPlayer : ILocalPlayerLogStream
+    {
+        public static readonly NoopLocalPlayer Instance = new();
+        public async IAsyncEnumerable<LocalPlayerLogLine> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            yield break;
+        }
+        // SubscribeWithReplayMarkerAsync inherits the DIM thrower — these
+        // Noop fakes never drive L1 (no driver subscription is ever made
+        // against them in these tests), so the default is fine.
+    }
+
+    private sealed class NoopCombat : ICombatActorLogStream
+    {
+        public static readonly NoopCombat Instance = new();
+        public async IAsyncEnumerable<CombatActorLogLine> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            yield break;
+        }
+    }
+
+    private sealed class NoopSystem : ISystemSignalLogStream
+    {
+        public static readonly NoopSystem Instance = new();
+        public async IAsyncEnumerable<SystemSignalLogLine> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            yield break;
+        }
+    }
+
+    private sealed class NoopChat : IChatLogStream
+    {
+        public static readonly NoopChat Instance = new();
+        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            yield break;
+        }
+    }
+
+    private sealed class CapturingDiag : IDiagnosticsSink, IDisposable
+    {
+        private readonly object _gate = new();
+        private readonly List<DiagnosticEntry> _entries = new();
+        public int WarnCount { get { lock (_gate) return _entries.Count(e => e.Level == DiagnosticLevel.Warn); } }
+        public int ErrorCount { get { lock (_gate) return _entries.Count(e => e.Level == DiagnosticLevel.Error); } }
+        public int InfoCount { get { lock (_gate) return _entries.Count(e => e.Level == DiagnosticLevel.Info); } }
+        public void Write(DiagnosticLevel level, string category, string message)
+        {
+            lock (_gate) _entries.Add(new DiagnosticEntry(DateTime.UtcNow, level, category, message));
+        }
+        public IReadOnlyList<DiagnosticEntry> Snapshot() { lock (_gate) return _entries.ToArray(); }
+        public event EventHandler<DiagnosticEntry>? EntryAdded { add { } remove { } }
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Single-threaded STA dispatcher for the Marshaled bridge tests. Spins
+    /// up a dedicated thread, runs a <see cref="Dispatcher"/> on it, and
+    /// exposes <see cref="ThreadId"/> for thread-affinity assertions.
+    /// </summary>
+    private sealed class StaThread : IDisposable
+    {
+        public Dispatcher Dispatcher { get; private set; } = null!;
+        public int ThreadId { get; private set; }
+        private Thread? _thread;
+
+        public static StaThread Start()
+        {
+            var t = new StaThread();
+            t.StartInternal();
+            return t;
+        }
+
+        private void StartInternal()
+        {
+            var ready = new ManualResetEventSlim();
+            _thread = new Thread(() =>
+            {
+                Dispatcher = Dispatcher.CurrentDispatcher;
+                ThreadId = Environment.CurrentManagedThreadId;
+                ready.Set();
+                Dispatcher.Run();
+            })
+            {
+                IsBackground = true,
+                Name = "L1DriverTests-Dispatcher",
+            };
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+            ready.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        public Task<TResult> InvokeAsync<TResult>(Func<TResult> func) =>
+            Dispatcher.InvokeAsync(func).Task;
+        public Task InvokeAsync(Action action) => Dispatcher.InvokeAsync(action).Task;
+
+        public void Shutdown()
+        {
+            if (Dispatcher is { HasShutdownStarted: false })
+            {
+                Dispatcher.InvokeAsync(() => Dispatcher.BeginInvokeShutdown(DispatcherPriority.Normal));
+            }
+            _thread?.Join(TimeSpan.FromSeconds(2));
+        }
+
+        public void Dispose() => Shutdown();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogActorRouterTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogActorRouterTests.cs
@@ -173,6 +173,63 @@ public sealed class PlayerLogActorRouterTests
     }
 
     [Fact]
+    public async Task SubscribeWithReplayMarker_FlagsReplayThenLiveAuthoritatively()
+    {
+        // L1 (#550 PR 1) added the *WithReplayMarker variant; the router's
+        // direct-yield-replay branch flags IsReplay=true, the channel-read
+        // branch flags IsReplay=false. The L1 driver reads this bit; the
+        // L0.5 API gains a corresponding pin so future router refactors
+        // can't silently drop the boundary signal.
+        var upstream = new ScriptedPlayerLogStream();
+        using var router = new PlayerLogActorRouter(upstream);
+
+        // Seed three lines into the upstream BEFORE we subscribe, so the
+        // router's per-pipe replay buffer accumulates them. Then attach a
+        // first subscriber that holds the replay buffer open while a
+        // second subscriber late-joins via the marker variant.
+        upstream.Push("[20:01:17] LocalPlayer: ProcessAddItem(A(1), -1, False)");
+        upstream.Push("[20:01:18] LocalPlayer: ProcessAddItem(B(2), -1, False)");
+
+        using var holderCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var holderSink = new List<LocalPlayerLogLine>();
+        var holderTask = Task.Run(async () =>
+        {
+            await foreach (var item in router.SubscribeAsync(holderCts.Token))
+                holderSink.Add(item);
+        });
+        await WaitUntilAsync(() => holderSink.Count >= 2, TimeSpan.FromSeconds(5));
+
+        // Late-subscribe through the marker variant. The replay buffer
+        // should hand both prior lines back as IsReplay=true.
+        var collected = new List<LogEnvelope<LocalPlayerLogLine>>();
+        using var lateCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var lateTask = Task.Run(async () =>
+        {
+            await foreach (var envelope in router.SubscribeWithReplayMarkerAsync(lateCts.Token))
+            {
+                collected.Add(envelope);
+                if (collected.Count >= 3) break;
+            }
+        });
+
+        await WaitUntilAsync(() => collected.Count >= 2, TimeSpan.FromSeconds(5));
+        // Push one live line — the marker variant should flag it false
+        upstream.Push("[20:01:19] LocalPlayer: ProcessAddItem(C(3), -1, False)");
+        await lateTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        collected.Should().HaveCount(3);
+        collected[0].IsReplay.Should().BeTrue();
+        collected[0].Payload.Data.Should().StartWith("ProcessAddItem(A");
+        collected[1].IsReplay.Should().BeTrue();
+        collected[1].Payload.Data.Should().StartWith("ProcessAddItem(B");
+        collected[2].IsReplay.Should().BeFalse();
+        collected[2].Payload.Data.Should().StartWith("ProcessAddItem(C");
+
+        holderCts.Cancel();
+        try { await holderTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
     public async Task Fast_unsub_then_resub_does_not_double_route_lines_to_new_subscriber()
     {
         // #547 race: PlayerLogActorRouter.StopRunning previously nulled _runTask


### PR DESCRIPTION
## Summary

PR 1 of [#550](https://github.com/moumantai-gg/mithril/issues/550). Ships
the shared subscription driver — capabilities A–G in the spec — with
zero consumer migration. The driver becomes available; existing
consumers remain on their pre-L1 paths until PR 2..N migrate them.

## What's in this PR

- `ILogStreamDriver` + `ILogSubscription` public surface, registered via
  `AddMithrilLogStreamDriver()`.
- `LogEnvelope<T>(Payload, IsReplay)` — used by both L0.5's new
  `SubscribeWithReplayMarkerAsync` (default-interface method on the three
  pipe interfaces, overridden by `PlayerLogActorRouter` to mint the
  authoritative replay→live boundary) and L1's delivery surface.
- All seven capabilities (A–G) per #550's spec:
  - **A** `ReplayMode {FromSessionStart, LiveOnly, SinceSubscribe}` per-subscription
  - **B** `IsReplay` flag on every envelope, authoritative not heuristic
  - **C** Per-message error containment + rate-limited `IDiagnosticsSink.Warn`
  - **D** Per-subscription drop accounting (`LogSubscriptionDiagnostics`)
  - **E** `DeliveryContext {Inline | Marshaled(Dispatcher)}` — `Marshaled` makes cross-thread `ObservableCollection` mutation structurally unreachable
  - **F** `SkipProcessedHighWater(Sequence)` opt-in idempotence filter
  - **G** Fault state machine — N-consecutive failures (default 8) →
    `Degraded` + non-throttled Error + `IAttentionAggregator` wiring +
    auto-resolve on next success.
- 17 new `LogStreamDriverTests` + 1 new router-marker test. Full
  `Mithril.Shared.Tests`: 1231 pass.

## Design decisions made for #550 deferred points

(recorded in the commit body for the full rationale)

- **Chat `ReplayMode` handling:** driver coerces non-`LiveOnly` to
  `LiveOnly` with one Info diag (#549 Divergence 1 option a).
- **Mixed-handler subscriptions:** per-handler filtering on
  `envelope.IsReplay` (#549 Divergence 2 option a — preserves
  single-subscription efficiency).
- **Fault SM trigger:** N-consecutive (not all-in-window), default N=8.
- **Drop accounting surface:** `ILogSubscription.Diagnostics` struct
  snapshot.
- **L0.5 augmentation shape:** widened the three pipe interfaces via
  default interface methods (throwing default body, override on
  `PlayerLogActorRouter` — test fakes inherit the thrower and stay
  unchanged). Tuples removed in favor of `LogEnvelope<T>`.

## What's NOT in this PR

- No consumer migration. Archetype-A (PR 2), archetype-B per
  [#549](https://github.com/moumantai-gg/mithril/issues/549) disposition
  (PR 3..N), and the final sweep (doc update + cross-thread regression +
  retirement verification) ship separately.
- No retirement of the 11 containment sites or 5 dispatcher helpers
  listed in #550 capability C / E — those land with their respective
  consumer migrations.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings / 0 errors).
- [x] `dotnet test Mithril.slnx` full pass (modulo preexisting flakes in
  `Arwen.Tests.SplitMigration_PostSplitState_NoSecondBackup`,
  `Gandalf.Tests.Rerun_is_a_noop_when_already_migrated`, and
  `IconCachePreloadTests.PreloadAsync_*` — all unrelated, all pass in
  isolation, predate this PR).
- [x] `LogStreamDriverTests`: 17/17 pass.
- [x] `PlayerLogActorRouterTests` (with the new marker test): 6/6 pass.
- [x] `Marshaled` regression test demonstrates cross-thread
  `ObservableCollection` mutation is structurally unreachable.
- [x] `git diff --stat main -- tests/Mithril.GameState.Tests/` is empty
  (no test fixture touches outside `Mithril.Shared.Tests/Logging/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
