### PR TITLE
feat(saruman): L1 migration — SarumanChatIngestionService (#550 PR 3 archetype-B)

### DIFF
--- a/src/Saruman.Module/Services/SarumanChatIngestionService.cs
+++ b/src/Saruman.Module/Services/SarumanChatIngestionService.cs
@@ -7,40 +7,95 @@ using Saruman.Parsing;
 
 namespace Saruman.Services;
 
+/// <summary>
+/// Migrated to the L1 driver (#550 PR 3, archetype-B). Subscribes to the
+/// <see cref="IChatLogStream"/> path via
+/// <see cref="ILogStreamDriver.Subscribe{T}"/> as a typed
+/// <see cref="LogEnvelope{T}"/> stream of <see cref="RawLogLine"/>, applies
+/// the chat parser, and marks the matched code <see cref="WordOfPowerState.Spent"/>
+/// on the codebook.
+///
+/// <para><b>Replay policy.</b> <see cref="ReplayMode.LiveOnly"/> — chat is
+/// structurally live-only by construction (<c>ChatLogStream.cs</c> seeds the
+/// per-day directory to current-end before the first emission, see #549
+/// Divergence 1). The L1 driver also coerces any non-<c>LiveOnly</c> chat
+/// subscription to <c>LiveOnly</c> with a one-time Info diagnostic;
+/// passing <c>LiveOnly</c> here makes the intent explicit at the call site
+/// rather than relying on the coercion.</para>
+///
+/// <para><b>Delivery context.</b> <see cref="DeliveryContext.Inline"/> — the
+/// handler only flips <c>SarumanCodebookService.MarkSpent</c> state and
+/// raises <c>CodebookChanged</c>; the VM owns its own dispatcher hop
+/// (<c>SarumanViewModel.Dispatch(Refresh)</c>) on the changed event, so the
+/// ingestion path does not touch bound collections.</para>
+///
+/// <para><b>Idempotence.</b> None needed (#549 audit row). <c>MarkSpent</c>
+/// is a state-flip that no-ops if already <see cref="WordOfPowerState.Spent"/>,
+/// and the chat stream never replays anyway.</para>
+///
+/// <para><b>Containment retired.</b> The pre-L1 <c>ThrottledWarn</c> + per-
+/// line try/catch are gone — the L1 driver wraps every handler invocation
+/// in try/catch + rate-limited Warn under the
+/// <see cref="LogSubscriptionOptions.DiagnosticCategory"/> bucket
+/// ("Saruman.Ingestion"), retiring the bespoke instance per #550 capability C.</para>
+/// </summary>
 public sealed class SarumanChatIngestionService : BackgroundService
 {
-    private readonly IChatLogStream _stream;
+    private const string DiagCategory = "Saruman.Ingestion";
+
+    private readonly ILogStreamDriver _driver;
     private readonly WordOfPowerChatParser _parser;
     private readonly SarumanCodebookService _codebook;
     private readonly ModuleGate _gate;
-    private readonly ThrottledWarn _warn;
+    private ILogSubscription? _subscription;
 
     public SarumanChatIngestionService(
-        IChatLogStream stream,
+        ILogStreamDriver driver,
         WordOfPowerChatParser parser,
         SarumanCodebookService codebook,
-        ModuleGates gates,
-        IDiagnosticsSink? diag = null)
+        ModuleGates gates)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
         _codebook = codebook;
         _gate = gates.For("saruman");
-        _warn = new ThrottledWarn(diag, "Saruman.Ingestion");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await _gate.WaitAsync(stoppingToken).ConfigureAwait(false);
 
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
+        _subscription = _driver.Subscribe<RawLogLine>(
+            envelope =>
             {
-                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is WordOfPowerSpoken s)
+                if (_parser.TryParse(envelope.Payload.Line, envelope.Payload.Timestamp.UtcDateTime) is WordOfPowerSpoken s)
                     _codebook.MarkSpent(s.Code, s.Timestamp);
-            }
-            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                // Explicit LiveOnly — chat is structurally live-only, but
+                // expressing intent at the call site is the #549 disposition.
+                // The driver auto-coerces non-LiveOnly to LiveOnly with one
+                // Info diag; passing LiveOnly here avoids that diagnostic.
+                ReplayMode = ReplayMode.LiveOnly,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
         }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
     }
 }

--- a/tests/Saruman.Tests/Services/SarumanChatIngestionServiceTests.cs
+++ b/tests/Saruman.Tests/Services/SarumanChatIngestionServiceTests.cs
@@ -1,0 +1,217 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Character;
+using Mithril.Shared.Logging;
+using Mithril.Shared.Modules;
+using Saruman.Domain;
+using Saruman.Parsing;
+using Saruman.Services;
+using Saruman.Settings;
+using Xunit;
+
+namespace Saruman.Tests.Services;
+
+/// <summary>
+/// Regression tests for the L1 migration of <see cref="SarumanChatIngestionService"/>
+/// (#550 PR 3 archetype-B). The service subscribes to the L1 driver's
+/// <see cref="RawLogLine"/> chat path with <see cref="ReplayMode.LiveOnly"/>
+/// + <see cref="DeliveryContext.Inline"/>; the test driver below feeds
+/// envelopes directly to the captured handler so we exercise the
+/// service's wiring without spinning up the real L1 driver or
+/// <c>ChatLogStream</c>.
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class SarumanChatIngestionServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FakeActiveCharacterService _active;
+
+    public SarumanChatIngestionServiceTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("saruman-chat-l1");
+        _active = new FakeActiveCharacterService();
+        _active.SetActiveCharacter("Arthur", "Kwatoxi");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private (SarumanCodebookService codebook, WordOfPowerChatParser parser) NewCodebookWithFeavegKnown()
+    {
+        var store = new PerCharacterStore<SarumanState>(_root, "saruman.json",
+            SarumanJsonContext.Default.SarumanState);
+        var view = new PerCharacterView<SarumanState>(_active, store);
+        var codebook = new SarumanCodebookService(view);
+        codebook.RecordDiscovery(new WordOfPowerDiscovered(
+            DateTime.UtcNow, "FEAVEG", "Fast Swimmer", "swim faster"));
+        var parser = new WordOfPowerChatParser(codebook);
+        return (codebook, parser);
+    }
+
+    private static RawLogLine ChatLine(string body, DateTimeOffset? at = null, long seq = 1) =>
+        new(
+            Timestamp: at ?? new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero),
+            Line: $"26-05-20 12:00:00\t[Global] Wizard: {body}",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    [Fact]
+    public async Task LiveChat_MarksTrackedWordSpent()
+    {
+        var (codebook, parser) = NewCodebookWithFeavegKnown();
+        var gates = new ModuleGates();
+        var driver = new FakeLogStreamDriver();
+
+        var svc = new SarumanChatIngestionService(driver, parser, codebook, gates);
+        var exec = svc.StartAsync(CancellationToken.None);
+        gates.For("saruman").Open();
+
+        await WaitUntilAsync(() => driver.HasSubscription);
+        driver.LastOptions!.ReplayMode.Should().Be(ReplayMode.LiveOnly,
+            because: "chat consumer must pass LiveOnly explicitly (#549 disposition)");
+        driver.LastOptions.DeliveryContext.Should().Be(DeliveryContext.Inline);
+        driver.LastOptions.DiagnosticCategory.Should().Be("Saruman.Ingestion");
+
+        await driver.Deliver(new LogEnvelope<RawLogLine>(ChatLine("FEAVEG go go go!"), IsReplay: false));
+
+        codebook.TryGet("FEAVEG")!.State.Should().Be(WordOfPowerState.Spent);
+        codebook.TryGet("FEAVEG")!.SpentAt.Should().NotBeNull();
+
+        await svc.StopAsync(CancellationToken.None);
+        await exec;
+    }
+
+    [Fact]
+    public async Task UnknownCode_DoesNotMutateState()
+    {
+        var (codebook, parser) = NewCodebookWithFeavegKnown();
+        var gates = new ModuleGates();
+        var driver = new FakeLogStreamDriver();
+
+        var svc = new SarumanChatIngestionService(driver, parser, codebook, gates);
+        var exec = svc.StartAsync(CancellationToken.None);
+        gates.For("saruman").Open();
+        await WaitUntilAsync(() => driver.HasSubscription);
+
+        // Uppercase token, but not tracked.
+        await driver.Deliver(new LogEnvelope<RawLogLine>(ChatLine("HOWLER nope nope"), IsReplay: false));
+
+        codebook.TryGet("FEAVEG")!.State.Should().Be(WordOfPowerState.Known,
+            because: "the parser only fires on tracked codes");
+        codebook.TryGet("HOWLER").Should().BeNull();
+
+        await svc.StopAsync(CancellationToken.None);
+        await exec;
+    }
+
+    [Fact]
+    public async Task ConfiguresSubscriptionWithExpectedOptions()
+    {
+        // Lightweight option-shape assertion: the four #549-disposition
+        // knobs (ReplayMode, DeliveryContext, DiagnosticCategory, no
+        // SkipProcessedHighWater) must land verbatim at the L1 driver.
+        var (codebook, parser) = NewCodebookWithFeavegKnown();
+        var gates = new ModuleGates();
+        var driver = new FakeLogStreamDriver();
+
+        var svc = new SarumanChatIngestionService(driver, parser, codebook, gates);
+        var exec = svc.StartAsync(CancellationToken.None);
+        gates.For("saruman").Open();
+        await WaitUntilAsync(() => driver.HasSubscription);
+
+        var opts = driver.LastOptions!;
+        opts.ReplayMode.Should().Be(ReplayMode.LiveOnly);
+        opts.DeliveryContext.Should().Be(DeliveryContext.Inline);
+        opts.DiagnosticCategory.Should().Be("Saruman.Ingestion");
+        opts.SkipProcessedHighWater.Should().BeNull(
+            because: "MarkSpent is idempotent; no high-water filter needed (#549 row)");
+
+        await svc.StopAsync(CancellationToken.None);
+        await exec;
+    }
+
+    [Fact]
+    public async Task HandlerExceptionDoesNotKillSubscription()
+    {
+        // Containment is now owned by the L1 driver — but we can still
+        // verify the consumer's handler-level shape: a parse failure on
+        // one line must not prevent the next valid line from being applied.
+        // (The L1 driver wraps the handler in try/catch + rate-limited
+        // Warn; this test only requires the handler itself doesn't
+        // catastrophically tear down.)
+        var (codebook, parser) = NewCodebookWithFeavegKnown();
+        var gates = new ModuleGates();
+        var driver = new FakeLogStreamDriver();
+
+        var svc = new SarumanChatIngestionService(driver, parser, codebook, gates);
+        var exec = svc.StartAsync(CancellationToken.None);
+        gates.For("saruman").Open();
+        await WaitUntilAsync(() => driver.HasSubscription);
+
+        // Empty line is benign — parser returns null without throwing.
+        await driver.Deliver(new LogEnvelope<RawLogLine>(
+            new RawLogLine(DateTimeOffset.UtcNow, "", Sequence: 1, ReadMonotonicTicks: 0), IsReplay: false));
+        await driver.Deliver(new LogEnvelope<RawLogLine>(ChatLine("FEAVEG"), IsReplay: false));
+
+        codebook.TryGet("FEAVEG")!.State.Should().Be(WordOfPowerState.Spent);
+
+        await svc.StopAsync(CancellationToken.None);
+        await exec;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan? timeout = null)
+    {
+        var budget = timeout ?? TimeSpan.FromSeconds(5);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (sw.Elapsed > budget) throw new TimeoutException("WaitUntilAsync gave up");
+            await Task.Delay(10);
+        }
+    }
+
+    /// <summary>
+    /// Minimal in-process <see cref="ILogStreamDriver"/> that captures the
+    /// subscription callback so the test can synthesise envelopes directly.
+    /// Mirrors the test-stub shape used in <c>LogStreamDriverTests</c> but
+    /// scoped to one subscription — Saruman/Chat only subscribes once.
+    /// </summary>
+    private sealed class FakeLogStreamDriver : ILogStreamDriver
+    {
+        private Func<LogEnvelope<RawLogLine>, ValueTask>? _handler;
+
+        public LogSubscriptionOptions? LastOptions { get; private set; }
+        public bool HasSubscription => _handler is not null;
+
+        public ILogSubscription Subscribe<T>(
+            Func<LogEnvelope<T>, ValueTask> handler,
+            LogSubscriptionOptions? options = null) where T : class
+        {
+            if (typeof(T) != typeof(RawLogLine))
+                throw new InvalidOperationException(
+                    $"SarumanChatIngestionService must subscribe with T=RawLogLine, got {typeof(T).Name}");
+            LastOptions = options ?? LogSubscriptionOptions.Default;
+            _handler = (Func<LogEnvelope<RawLogLine>, ValueTask>)(object)handler;
+            return new FakeSub(() => _handler = null);
+        }
+
+        public ValueTask Deliver(LogEnvelope<RawLogLine> envelope)
+        {
+            var h = _handler ?? throw new InvalidOperationException("No active subscription");
+            return h(envelope);
+        }
+
+        private sealed class FakeSub : ILogSubscription
+        {
+            private readonly Action _onDispose;
+            public FakeSub(Action onDispose) { _onDispose = onDispose; }
+            public string Id => "fake#1";
+            public LogSubscriptionDiagnostics Diagnostics => new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+            public event EventHandler? StateChanged { add { } remove { } }
+            public void Dispose() => _onDispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Migrates `SarumanChatIngestionService` onto the L1 driver per [#549's audit row](https://github.com/moumantai-gg/mithril/issues/549) (archetype-B PR 3 of #550).

- **Stream:** `IChatLogStream` (chat path — `RawLogLine` envelopes through L1).
- **ReplayMode:** `LiveOnly`. Chat is structurally live-only by construction (#549 Divergence 1 — `ReplayMode` is semantically moot on chat; the L1 driver coerces non-`LiveOnly` to `LiveOnly` with one Info diag). Passing `LiveOnly` here makes intent explicit at the call site and skips the coercion diagnostic.
- **DeliveryContext:** `Inline`. Handler only flips `SarumanCodebookService.MarkSpent` state; `SarumanViewModel` owns its own `Dispatch(Refresh)` on `CodebookChanged` (out of scope for this PR).
- **Idempotence policy:** none. `MarkSpent` is a state-flip that no-ops if already `Spent`, and chat never replays anyway.
- **DiagnosticCategory:** `"Saruman.Ingestion"` — preserves the bucket the retired `ThrottledWarn` used.

### Containment retired

- `ThrottledWarn _warn` field + ctor init at `SarumanChatIngestionService.cs:29`
- Try/catch wrapper around the per-line parse + `MarkSpent` apply

The L1 driver now owns containment (try/catch + rate-limited Warn) per #550 capability C.

### LiveOnly coercion note

The L1 driver auto-coerces any non-`LiveOnly` chat subscription to `LiveOnly` with a one-time Info diagnostic (`LogStreamDriver.cs:117-123`). This PR passes `LiveOnly` explicitly so the diagnostic doesn't fire, and the call site reads as the disposition row prescribes (intent on paper, not implicit through coercion).

### Out of scope

- `SarumanDiscoveryIngestionService` — handled by a separate archetype-B subagent.
- `SarumanViewModel`'s `Dispatch(Refresh)` helper — out of scope for L1 (VM-owned).
- Chat parser regex / `log-patterns.json` parity — no parser changes here.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — all 3,816 tests pass.
- [x] New `tests/Saruman.Tests/Services/SarumanChatIngestionServiceTests.cs` covers:
  - Live chat line marks a tracked word `Spent` (with `Inline` delivery).
  - Unknown uppercase tokens don't leak into the codebook.
  - Subscription options match the #549 row (`LiveOnly` + `Inline` + `"Saruman.Ingestion"`, no `SkipProcessedHighWater`).
  - Benign per-line failure doesn't break the next valid line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
