### PR TITLE
feat(pippin): L1 migration — GourmandIngestionService with high-water restart-stability (#550 PR 3 archetype-B)

### DIFF
--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -183,7 +183,7 @@
       ]
     },
     "pippin.GourmandLogParser.ProcessBookFoodsRx": {
-      "pattern": "LocalPlayer:\\s*ProcessBook\\(\"Skill Info\",\\s*\"(Foods Consumed:\\\\n\\\\n(?:[^\"\\\\]|\\\\.)*)\".*\"SkillReport\"",
+      "pattern": "ProcessBook\\(\"Skill Info\",\\s*\"(Foods Consumed:\\\\n\\\\n(?:[^\"\\\\]|\\\\.)*)\".*\"SkillReport\"",
       "source": "player",
       "module": "pippin",
       "csharp": { "type": "Pippin.Parsing.GourmandLogParser", "method": "ProcessBookFoodsRx" },

--- a/src/Pippin.Module/Domain/GourmandState.cs
+++ b/src/Pippin.Module/Domain/GourmandState.cs
@@ -59,6 +59,22 @@ public sealed class GourmandState : IVersionedState<GourmandState>
     public DateTimeOffset? LastReportTime { get; set; }
 
     /// <summary>
+    /// L1 (#550) restart-stability high-water. The driver-side
+    /// <see cref="Mithril.Shared.Logging.LogSubscriptionOptions.SkipProcessedHighWater"/>
+    /// filter drops every envelope whose <c>Sequence</c> is <c>&lt;=</c> this
+    /// value before handler invocation, so a cold-start that re-reads the
+    /// session's <c>Player.log</c> doesn't re-run the snapshot-overwrite
+    /// <c>HandleReport</c> apply path on a report Mithril already processed.
+    /// Pippin is the canonical demo of the high-water shape (#549): the apply
+    /// is in-session idempotent (Clear + repopulate) but every cold start
+    /// re-runs the full apply absent this gate; the filter introduces restart
+    /// stability where none existed pre-L1. <c>null</c> = no prior session
+    /// processed (first run / pre-#550 fresh state) — every envelope is
+    /// delivered.
+    /// </summary>
+    public long? LastProcessedSequence { get; set; }
+
+    /// <summary>
     /// Display-name-keyed entries inherited from a v1 file that the catalog hasn't yet
     /// resolved into <see cref="EatenFoodsByInternalName"/> + <see cref="UnknownByName"/>.
     /// Drained by <c>GourmandStateService.PromoteLegacyIfReady</c> once the catalog is

--- a/src/Pippin.Module/Parsing/GourmandLogParser.cs
+++ b/src/Pippin.Module/Parsing/GourmandLogParser.cs
@@ -7,7 +7,12 @@ public sealed partial class GourmandLogParser : ILogParser
 {
     // Match the ProcessBook line containing the Foods Consumed report.
     // The body uses literal \n escapes (not real newlines) in the log file.
-    [GeneratedRegex(@"LocalPlayer:\s*ProcessBook\(""Skill Info"",\s*""(Foods Consumed:\\n\\n(?:[^""\\]|\\.)*)"".*""SkillReport""")]
+    // L0.5 (#532) eats the [ts] + LocalPlayer: envelope before this parser
+    // sees the line — the anchor is dropped per the #550 PR #555 review
+    // ("downstream never re-matches the actor envelope"). The L1 driver
+    // surface this consumer migrated to delivers a LocalPlayerLogLine.Data
+    // string that starts at ProcessBook(...).
+    [GeneratedRegex(@"ProcessBook\(""Skill Info"",\s*""(Foods Consumed:\\n\\n(?:[^""\\]|\\.)*)"".*""SkillReport""")]
     private static partial Regex ProcessBookFoodsRx();
 
     // Match a single food entry line: "  FoodName (HAS TAG, HAS TAG): count"

--- a/src/Pippin.Module/State/GourmandIngestionService.cs
+++ b/src/Pippin.Module/State/GourmandIngestionService.cs
@@ -9,19 +9,65 @@ using Pippin.Parsing;
 
 namespace Pippin.State;
 
+/// <summary>
+/// Subscribes to the L1 (#550) driver's LocalPlayer pipe and feeds parsed
+/// <see cref="FoodsConsumedReport"/> events into <see cref="GourmandStateMachine"/>.
+///
+/// <para><b>L1 migration disposition (#549 row, #550 PR 3 archetype-B).</b>
+/// Pippin is the canonical demo of the
+/// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> idempotence
+/// pattern: <see cref="GourmandStateMachine.HandleReport"/> does
+/// <c>Clear()</c>+repopulate (in-session idempotent), but every cold start
+/// re-runs the full snapshot-overwrite apply against every replayed report.
+/// The high-water filter persisted in <see cref="GourmandState.LastProcessedSequence"/>
+/// drops envelopes whose <c>Sequence</c> the prior session already processed,
+/// stabilising the restart shape. Pre-L1 Pippin had no idempotence at all
+/// — the high-water introduces restart-stability where none existed, it does
+/// NOT fix a <c>UtcNow</c> double-count bug (the umbrella's G1 framing was
+/// factually wrong against live code; verified in #549 G1 correction).</para>
+///
+/// <para><b>Subscription shape.</b>
+/// <list type="bullet">
+///   <item><see cref="ReplayMode.FromSessionStart"/> — Pippin must catch the
+///   most-recent in-session <c>FoodsConsumedReport</c> after a Mithril restart
+///   to repopulate the in-memory state.</item>
+///   <item><see cref="DeliveryContext.Marshaled"/> on the UI dispatcher — the
+///   handler raises <see cref="GourmandStateMachine.StateChanged"/>, consumed
+///   by <c>GourmandViewModel</c>'s bound
+///   <c>ObservableCollection&lt;FoodItemViewModel&gt;</c>. The driver routes
+///   each envelope through <see cref="Dispatcher"/> before invoking the
+///   handler, retiring the per-service hand-rolled
+///   <c>Application.Current?.Dispatcher; CheckAccess; InvokeAsync</c> helper
+///   (#550 capability E).</item>
+///   <item><see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> seeded
+///   from <see cref="GourmandState.LastProcessedSequence"/> — restart-stable
+///   idempotence (#550 capability F). The high-water is advanced after each
+///   delivered envelope (whether it produced an event or not) and persisted
+///   alongside the rest of <see cref="GourmandState"/> via the existing
+///   <see cref="GourmandStateService"/> debounce-write path.</item>
+///   <item>Containment is owned by the driver: the per-service
+///   <c>ThrottledWarn</c> + try/catch retired (#550 capability C). Failures
+///   surface on <c>IDiagnosticsSink</c> under <c>Pippin.Ingestion</c> via the
+///   driver's <see cref="LogSubscriptionOptions.DiagnosticCategory"/>
+///   override; a stuck handler trips
+///   <see cref="LogSubscriptionState.Degraded"/> and surfaces on
+///   <c>IAttentionAggregator</c>.</item>
+/// </list>
+/// </para>
+/// </summary>
 public sealed class GourmandIngestionService : BackgroundService
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ILogStreamDriver _driver;
     private readonly GourmandLogParser _parser;
     private readonly GourmandStateMachine _state;
     private readonly GourmandStateService _stateService;
     private readonly PerCharacterView<GourmandState> _view;
     private readonly IDiagnosticsSink? _diag;
     private readonly ModuleGate _gate;
-    private readonly ThrottledWarn _warn;
+    private ILogSubscription? _subscription;
 
     public GourmandIngestionService(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         GourmandLogParser parser,
         GourmandStateMachine state,
         GourmandStateService stateService,
@@ -29,14 +75,13 @@ public sealed class GourmandIngestionService : BackgroundService
         ModuleGates gates,
         IDiagnosticsSink? diag = null)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
         _state = state;
         _stateService = stateService;
         _view = view;
         _diag = diag;
         _gate = gates.For("pippin");
-        _warn = new ThrottledWarn(diag, "Pippin.Ingestion");
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -50,21 +95,78 @@ public sealed class GourmandIngestionService : BackgroundService
         try { await _stateService.LoadAsync(stoppingToken).ConfigureAwait(false); }
         catch (Exception ex) { _diag?.Warn("Pippin", $"Failed to load state: {ex.Message}"); }
 
-        _diag?.Info("Pippin", "State hydrated — subscribing to Player.log");
+        _diag?.Info("Pippin", "State hydrated — subscribing to L1 driver (LocalPlayer pipe)");
 
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
+        // Seed the high-water from the freshly hydrated per-character state.
+        // null = no prior session processed (first run / pre-#550 fresh state).
+        // The driver drops every envelope whose Sequence is <= this value
+        // before handler invocation — restart-safe idempotence (#549 / #550
+        // capability F). Pippin is the canonical demo of the pattern.
+        var persistedHighWater = _view.Current?.LastProcessedSequence;
+
+        // L0.5 (#532) eats the [ts] + LocalPlayer: envelope; the parser now
+        // consumes LocalPlayerLogLine.Data directly (anchor dropped per the
+        // #550 PR #555 review).
+        _subscription = _driver.Subscribe<LocalPlayerLogLine>(
+            envelope =>
             {
-                var evt = _parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime);
+                var payload = envelope.Payload;
+                var evt = _parser.TryParse(payload.Data, payload.Timestamp.UtcDateTime);
                 if (evt is GourmandEvent ge)
                 {
-                    _diag?.Trace("Pippin.Parse", $"FoodsConsumedReport with {(ge as FoodsConsumedReport)?.Foods.Count ?? 0} entries");
-                    Dispatch(() => _state.Apply(ge));
+                    _diag?.Trace(
+                        "Pippin.Parse",
+                        $"FoodsConsumedReport with {(ge as FoodsConsumedReport)?.Foods.Count ?? 0} entries");
+                    _state.Apply(ge);
                 }
-            }
-            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
+                // Advance the high-water on every delivered envelope. The
+                // driver hands them up in monotonic Sequence order from the
+                // L0.5 pipe's replay snapshot then live tail, so this is the
+                // canonical "I have processed every envelope up to seq X"
+                // mark. The existing GourmandStateService.OnChanged →
+                // MarkDirty → debounce → _view.Save() path persists it (the
+                // state-machine StateChanged event already runs the debounce
+                // when an event was applied; on no-event lines we touch the
+                // view directly so the next StateChanged-driven flush
+                // captures the advance, and a one-shot flush on disposal
+                // catches the tail).
+                var current = _view.Current;
+                if (current is not null)
+                {
+                    current.LastProcessedSequence = payload.Sequence;
+                }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Marshaled(Application.Current.Dispatcher),
+                SkipProcessedHighWater = persistedHighWater,
+                DiagnosticCategory = "Pippin.Ingestion",
+            });
+
+        // Park until the host stops. The L1 subscription runs its own pump
+        // on a Task.Run; ExecuteAsync's job is to dispose it on shutdown.
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+            // Best-effort flush of the trailing high-water advance so a
+            // crash-after-no-event-applied run doesn't lose progress. The
+            // GourmandStateService debounce writes on StateChanged; a tail
+            // of replay-skip + no-events leaves the latest high-water
+            // un-flushed unless we nudge a save here.
+            try { _view.Save(); } catch { /* best-effort on host stop */ }
         }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
     }
 
     private async Task WaitForActiveCharacterAsync(CancellationToken ct)
@@ -88,11 +190,5 @@ public sealed class GourmandIngestionService : BackgroundService
         {
             _view.CurrentChanged -= Handler;
         }
-    }
-
-    private static void Dispatch(Action a)
-    {
-        var d = Application.Current?.Dispatcher;
-        if (d is null || d.CheckAccess()) a(); else d.InvokeAsync(a);
     }
 }

--- a/tests/Pippin.Tests/GourmandIngestionL1Tests.cs
+++ b/tests/Pippin.Tests/GourmandIngestionL1Tests.cs
@@ -1,0 +1,511 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Logging;
+using Mithril.Shared.Reference;
+using Pippin.Domain;
+using Pippin.Parsing;
+using Pippin.State;
+using Xunit;
+
+namespace Pippin.Tests;
+
+/// <summary>
+/// L1 migration (#550 PR 3 archetype-B) regression tests for the
+/// <see cref="GourmandIngestionService"/> shape. Three claims pinned:
+///
+/// <list type="bullet">
+///   <item><b>Replay-then-live byte equivalence.</b> Splitting the same
+///   <c>FoodsConsumedReport</c>-bearing line across the driver's
+///   <c>PushReplay</c> + <c>PushLive</c> boundary yields the same state as
+///   pushing it all-live. The flag in
+///   <see cref="LogEnvelope{T}.IsReplay"/> must not gate the handler.</item>
+///   <item><b>High-water restart stability.</b> A second subscription seeded
+///   with <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> set to
+///   the prior session's last-processed <c>Sequence</c> drops every
+///   re-emitted envelope before the handler runs — no further state change.
+///   This is the canonical Pippin idempotence pattern (#549).</item>
+///   <item><b>Parser anchor-drop.</b> The L0.5 <c>LocalPlayer:</c> actor
+///   token is stripped upstream; the parser must consume bare
+///   <c>ProcessBook(...)</c> shapes. Pinned by
+///   <see cref="GourmandLogParser_consumes_bare_ProcessBook_payload"/>.</item>
+/// </list>
+///
+/// <para><b>Scope note.</b> The full ingestion service requires
+/// <see cref="Mithril.Shared.Character.PerCharacterView{T}"/> +
+/// <see cref="Mithril.Shared.Modules.ModuleGates"/> + WPF dispatcher
+/// wiring. These tests drive the state-machine + parser layer using the
+/// same handler shape the service composes — the slice under test is the
+/// driver-bounded envelope-fan + the parser/state-machine pair, which is
+/// where the L1 migration's behavioural changes live. The dispatcher
+/// marshalling is the driver's invariant (tested in
+/// <c>Mithril.Shared.Tests</c>); we deliberately use
+/// <see cref="DeliveryContext.Inline"/> here so the test pump doesn't need
+/// a UI dispatcher.</para>
+/// </summary>
+public class GourmandIngestionL1Tests
+{
+    private const string ReportLine =
+        """[22:04:09] LocalPlayer: ProcessBook("Skill Info", "Foods Consumed:\n\n  Apple Juice: 8\n  Bacon (HAS MEAT): 2\n", "SkillReport", "", "", False, False, False, False, False, "")""";
+
+    // Same body, different displayed Foods Consumed list — used to assert
+    // state actually changes when the high-water filter ISN'T set.
+    private const string SecondReportLine =
+        """[22:05:10] LocalPlayer: ProcessBook("Skill Info", "Foods Consumed:\n\n  Apple Juice: 8\n  Bacon (HAS MEAT): 2\n  Grapes: 3\n", "SkillReport", "", "", False, False, False, False, False, "")""";
+
+    private static FoodCatalog NewCatalog()
+    {
+        var stub = new StubReferenceDataService(new Dictionary<long, Item>
+        {
+            [1] = new() { Id = 1, Name = "Apple Juice", InternalName = "FoodAppleJuice", MaxStackSize = 1, IconId = 0, Keywords = [], FoodDesc = "Level 0 Snack" },
+            [2] = new() { Id = 2, Name = "Bacon", InternalName = "FoodBacon", MaxStackSize = 1, IconId = 0, Keywords = [], FoodDesc = "Level 0 Snack" },
+            [3] = new() { Id = 3, Name = "Grapes", InternalName = "FoodGrapes", MaxStackSize = 1, IconId = 0, Keywords = [], FoodDesc = "Level 0 Snack" },
+        });
+        return new FoodCatalog(stub);
+    }
+
+    /// <summary>
+    /// The post-#550 PR #555 anchor-drop: <see cref="GourmandLogParser"/>
+    /// must match a payload that has already had the <c>[ts] LocalPlayer:</c>
+    /// envelope eaten by L0.5 — i.e. the bare <c>ProcessBook(...)</c> shape.
+    /// </summary>
+    [Fact]
+    public void GourmandLogParser_consumes_bare_ProcessBook_payload()
+    {
+        var parser = new GourmandLogParser();
+        // Strip the envelope manually to mimic L0.5's classification: the
+        // production LocalPlayerLogLine.Data is the bare verb-and-args
+        // string.
+        const string bareData =
+            """ProcessBook("Skill Info", "Foods Consumed:\n\n  Apple Juice: 8\n", "SkillReport", "", "", False, False, False, False, False, "")""";
+
+        var result = parser.TryParse(bareData, DateTime.UtcNow);
+
+        result.Should().BeOfType<FoodsConsumedReport>();
+        ((FoodsConsumedReport)result!).Foods.Single().Name.Should().Be("Apple Juice");
+    }
+
+    /// <summary>
+    /// Feed the same report once all-live and once split replay→live; assert
+    /// the resulting state-machine snapshot is identical. The handler must
+    /// NOT gate on <see cref="LogEnvelope{T}.IsReplay"/>.
+    /// </summary>
+    [Fact]
+    public async Task Replay_then_live_byte_equivalence()
+    {
+        // Pass 1 — single all-live emission.
+        Dictionary<string, int> pass1Eaten;
+        long pass1HighWater;
+        {
+            var catalog = NewCatalog();
+            var state = new GourmandStateMachine(catalog);
+            using var driver = new TestLogStreamDriver();
+            var (sub, highWater) = SubscribeWithHighWaterCapture(driver, state, null);
+
+            driver.PushLive(MakeLine(ReportLine, sequence: 100));
+            await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+            pass1Eaten = new(state.EatenFoodsByInternalName, StringComparer.Ordinal);
+            pass1HighWater = highWater();
+            sub.Dispose();
+        }
+
+        // Pass 2 — same line split across the replay→live boundary. The L1
+        // driver yields the replay snapshot first, then the live tail. The
+        // handler must apply both: the second snapshot replaces with
+        // identical content → state-machine ends in the same place as
+        // pass 1.
+        Dictionary<string, int> pass2Eaten;
+        long pass2HighWater;
+        {
+            var catalog = NewCatalog();
+            var state = new GourmandStateMachine(catalog);
+            using var driver = new TestLogStreamDriver();
+
+            driver.PushReplay(MakeLine(ReportLine, sequence: 100));
+            var (sub, highWater) = SubscribeWithHighWaterCapture(driver, state, null);
+            await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+            // Live re-emit of the same line at a higher sequence: snapshot
+            // overwrite is idempotent (Clear + repopulate).
+            driver.PushLive(MakeLine(ReportLine, sequence: 200));
+            await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+            pass2Eaten = new(state.EatenFoodsByInternalName, StringComparer.Ordinal);
+            pass2HighWater = highWater();
+            sub.Dispose();
+        }
+
+        pass2Eaten.Should().BeEquivalentTo(pass1Eaten);
+        // Both passes process at least the seq=100 envelope; pass 2 also
+        // processes seq=200. High-water should reflect the latest seen.
+        pass1HighWater.Should().Be(100);
+        pass2HighWater.Should().Be(200);
+    }
+
+    /// <summary>
+    /// Restart-stability: a second subscription seeded with
+    /// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> at the
+    /// prior session's last-processed sequence drops every replayed envelope
+    /// before the handler runs. State-machine sees no Apply, so the
+    /// downstream <see cref="GourmandStateMachine.StateChanged"/> count is
+    /// zero. This is the canonical Pippin idempotence pattern (#549).
+    /// </summary>
+    [Fact]
+    public async Task High_water_filter_skips_already_processed_envelopes()
+    {
+        // Session 1 — process both reports, track the high-water.
+        var catalog = NewCatalog();
+        var state = new GourmandStateMachine(catalog);
+        long session1HighWater;
+        {
+            using var driver = new TestLogStreamDriver();
+            var (sub, highWater) = SubscribeWithHighWaterCapture(driver, state, null);
+
+            driver.PushLive(MakeLine(ReportLine, sequence: 100));
+            driver.PushLive(MakeLine(SecondReportLine, sequence: 200));
+            await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+            session1HighWater = highWater();
+            sub.Dispose();
+        }
+
+        // Snapshot state after session 1 + how many times StateChanged
+        // fired in session 2 to assert the high-water gate actually fired
+        // (no Apply means no StateChanged).
+        var session1Snapshot = new Dictionary<string, int>(state.EatenFoodsByInternalName, StringComparer.Ordinal);
+        session1HighWater.Should().Be(200);
+
+        // Session 2 — fresh state machine, re-feed the same envelopes with
+        // the high-water seeded from session 1. The driver must drop them
+        // before handler invocation. The fresh state machine stays empty.
+        var freshState = new GourmandStateMachine(NewCatalog());
+        var freshChangedCount = 0;
+        freshState.StateChanged += (_, _) => freshChangedCount++;
+        {
+            using var driver = new TestLogStreamDriver();
+            var (sub, _) = SubscribeWithHighWaterCapture(driver, freshState, session1HighWater);
+
+            // Replay phase — these are exactly the envelopes session 1 saw.
+            driver.PushReplay(MakeLine(ReportLine, sequence: 100));
+            driver.PushReplay(MakeLine(SecondReportLine, sequence: 200));
+            await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+            sub.Dispose();
+        }
+
+        freshChangedCount.Should().Be(0, "every envelope was <= the high-water and skipped before the handler");
+        freshState.EatenFoodsByInternalName.Should().BeEmpty();
+
+        // And the original state's contents reflect session 1's two reports
+        // (last one wins per GourmandStateMachine snapshot-overwrite shape):
+        session1Snapshot.Should().ContainKey("FoodGrapes");
+        session1Snapshot["FoodAppleJuice"].Should().Be(8);
+    }
+
+    /// <summary>
+    /// A new envelope after the high-water STILL gets through — the filter
+    /// is a "skip <= HighWater" gate, not a global mute.
+    /// </summary>
+    [Fact]
+    public async Task High_water_does_not_block_post_high_water_envelopes()
+    {
+        var catalog = NewCatalog();
+        var state = new GourmandStateMachine(catalog);
+
+        using var driver = new TestLogStreamDriver();
+        var (sub, highWater) = SubscribeWithHighWaterCapture(driver, state, persistedHighWater: 100);
+
+        // Replay seq=50 (below high-water): skipped.
+        driver.PushReplay(MakeLine(ReportLine, sequence: 50));
+        // Replay seq=100 (== high-water): skipped (the filter is <=).
+        driver.PushReplay(MakeLine(ReportLine, sequence: 100));
+        // Live seq=200 (above high-water): delivered.
+        await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+        driver.PushLive(MakeLine(SecondReportLine, sequence: 200));
+        await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+        state.EatenFoodsByInternalName.Should().ContainKey("FoodGrapes");
+        highWater().Should().Be(200);
+        sub.Dispose();
+    }
+
+    // === helpers ===
+
+    /// <summary>
+    /// Mirrors <see cref="GourmandIngestionService"/>'s handler shape minus
+    /// the <c>PerCharacterView</c>/dispatcher plumbing: parse → Apply →
+    /// advance high-water. The returned <see cref="Func{Long}"/> exposes
+    /// the current high-water for assertions.
+    /// </summary>
+    private static (ILogSubscription Sub, Func<long> HighWater) SubscribeWithHighWaterCapture(
+        TestLogStreamDriver driver,
+        GourmandStateMachine state,
+        long? persistedHighWater)
+    {
+        var parser = new GourmandLogParser();
+        long highWater = persistedHighWater ?? 0;
+
+        var sub = driver.Subscribe<LocalPlayerLogLine>(
+            envelope =>
+            {
+                var payload = envelope.Payload;
+                var evt = parser.TryParse(payload.Data, payload.Timestamp.UtcDateTime);
+                if (evt is GourmandEvent ge) state.Apply(ge);
+                Interlocked.Exchange(ref highWater, payload.Sequence);
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                SkipProcessedHighWater = persistedHighWater,
+                DiagnosticCategory = "Pippin.Ingestion.Test",
+            });
+
+        return (sub, () => Interlocked.Read(ref highWater));
+    }
+
+    /// <summary>
+    /// Build a <see cref="LocalPlayerLogLine"/> directly from a full Player.log
+    /// shape, mimicking what L0.5 (#532) does on real input: peel the
+    /// <c>[ts] LocalPlayer:</c> envelope, leave the rest as <c>Data</c>.
+    /// </summary>
+    private static LocalPlayerLogLine MakeLine(string fullLine, long sequence)
+    {
+        const int tsPrefixLen = 11;            // "[HH:MM:SS] "
+        const string actorToken = "LocalPlayer: ";
+        var idx = 0;
+        if (fullLine.Length > tsPrefixLen
+            && fullLine[0] == '['
+            && fullLine[3] == ':'
+            && fullLine[6] == ':'
+            && fullLine[9] == ']')
+        {
+            idx = tsPrefixLen;
+        }
+        if (idx + actorToken.Length <= fullLine.Length
+            && fullLine.IndexOf(actorToken, idx, StringComparison.Ordinal) == idx)
+        {
+            idx += actorToken.Length;
+        }
+        var data = idx == 0 ? fullLine : fullLine.Substring(idx);
+        return new LocalPlayerLogLine(
+            Timestamp: new DateTimeOffset(2026, 5, 18, 22, 4, 9, TimeSpan.Zero),
+            Data: data,
+            Sequence: sequence,
+            ReadMonotonicTicks: 0);
+    }
+
+    /// <summary>Minimal stub so FoodCatalog can be constructed with controllable contents.</summary>
+    private sealed class StubReferenceDataService : IReferenceDataService
+    {
+        private readonly Dictionary<long, Item> _items;
+        public StubReferenceDataService(Dictionary<long, Item> items) { _items = items; }
+        public IReadOnlyList<string> Keys { get; } = [];
+        public IReadOnlyDictionary<long, Item> Items => _items;
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; } = new Dictionary<string, Item>();
+        public ItemKeywordIndex KeywordIndex => ItemKeywordIndex.Empty;
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; } = new Dictionary<string, NpcEntry>();
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> Quests { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> QuestsByInternalName { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+        public ReferenceFileSnapshot GetSnapshot(string key) => new(key, ReferenceFileSource.Bundled, "", null, 0);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+    }
+
+    /// <summary>
+    /// Test-only <see cref="ILogStreamDriver"/> — minimal copy of the pattern
+    /// used by archetype-A tests (<c>tests/Mithril.GameState.Tests/TestSupport/TestLogStreamDriver.cs</c>),
+    /// scoped to the <see cref="LocalPlayerLogLine"/> path Pippin needs. The
+    /// archetype-B sibling consumers (Samwise, Saruman/Discovery, Legolas)
+    /// converge on the same shape — once a third consumer needs it, this
+    /// should move to <c>Mithril.Shared.TestSupport</c> (call-site: #549
+    /// disposition table, four archetype-B consumers all want this).
+    /// </summary>
+    private sealed class TestLogStreamDriver : ILogStreamDriver, IDisposable
+    {
+        private readonly Pipe<LocalPlayerLogLine> _localPlayer = new();
+        private readonly List<IDisposable> _subscriptions = new();
+
+        public void PushReplay(LocalPlayerLogLine line) => _localPlayer.AddReplay(line);
+        public void PushLive(LocalPlayerLogLine line) => _localPlayer.PushLive(line);
+
+        public Task DrainLocalPlayerAsync(TimeSpan? timeout = null) =>
+            _localPlayer.DrainAsync(timeout ?? TimeSpan.FromSeconds(5));
+
+        public ILogSubscription Subscribe<T>(
+            Func<LogEnvelope<T>, ValueTask> handler,
+            LogSubscriptionOptions? options = null) where T : class
+        {
+            var opts = options ?? LogSubscriptionOptions.Default;
+            if (typeof(T) != typeof(LocalPlayerLogLine))
+                throw new ArgumentException("test driver only handles LocalPlayerLogLine", nameof(T));
+
+            var sub = new Subscription<LocalPlayerLogLine>(
+                _localPlayer,
+                (Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>)(object)handler,
+                line => line.Sequence,
+                opts);
+            sub.Start();
+            lock (_subscriptions) _subscriptions.Add(sub);
+            return sub;
+        }
+
+        public void Dispose()
+        {
+            IDisposable[] toDispose;
+            lock (_subscriptions) { toDispose = _subscriptions.ToArray(); _subscriptions.Clear(); }
+            foreach (var s in toDispose) s.Dispose();
+        }
+
+        internal sealed class Pipe<T> where T : class
+        {
+            private readonly List<T> _replay = new();
+            private readonly Channel<T> _live = Channel.CreateUnbounded<T>();
+            private long _pending;
+            private TaskCompletionSource _drained = NewDrainTcsResolved();
+            private readonly object _gate = new();
+            private bool _replaySnapshotted;
+
+            internal void AddReplay(T line)
+            {
+                lock (_gate)
+                {
+                    if (_replaySnapshotted)
+                        throw new InvalidOperationException(
+                            "AddReplay must be called before any Subscribe<T> consumes the pipe.");
+                    Interlocked.Increment(ref _pending);
+                    _replay.Add(line);
+                    Interlocked.Exchange(ref _drained, NewDrainTcs());
+                }
+            }
+
+            internal void PushLive(T line)
+            {
+                Interlocked.Increment(ref _pending);
+                Interlocked.Exchange(ref _drained, NewDrainTcs());
+                _live.Writer.TryWrite(line);
+            }
+
+            internal void RecordDelivered()
+            {
+                if (Interlocked.Decrement(ref _pending) == 0)
+                    _drained.TrySetResult();
+            }
+
+            internal Task DrainAsync(TimeSpan timeout) => _drained.Task.WaitAsync(timeout);
+
+            private static TaskCompletionSource NewDrainTcsResolved()
+            {
+                var tcs = NewDrainTcs();
+                tcs.TrySetResult();
+                return tcs;
+            }
+
+            private static TaskCompletionSource NewDrainTcs() =>
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal async IAsyncEnumerable<LogEnvelope<T>> SubscribeAsync(
+                [EnumeratorCancellation] CancellationToken ct)
+            {
+                T[] replaySnap;
+                lock (_gate) { replaySnap = _replay.ToArray(); _replaySnapshotted = true; }
+                foreach (var line in replaySnap)
+                {
+                    if (ct.IsCancellationRequested) yield break;
+                    yield return new LogEnvelope<T>(line, IsReplay: true);
+                }
+                await foreach (var line in _live.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                    yield return new LogEnvelope<T>(line, IsReplay: false);
+            }
+        }
+
+        private sealed class Subscription<T> : ILogSubscription, IDisposable where T : class
+        {
+            private readonly Pipe<T> _pipe;
+            private readonly Func<LogEnvelope<T>, ValueTask> _handler;
+            private readonly Func<T, long> _sequenceOf;
+            private readonly LogSubscriptionOptions _options;
+            private readonly CancellationTokenSource _cts = new();
+            private Task? _pumpTask;
+            private int _disposed;
+
+            public Subscription(
+                Pipe<T> pipe,
+                Func<LogEnvelope<T>, ValueTask> handler,
+                Func<T, long> sequenceOf,
+                LogSubscriptionOptions options)
+            {
+                _pipe = pipe;
+                _handler = handler;
+                _sequenceOf = sequenceOf;
+                _options = options;
+            }
+
+            public string Id { get; } = $"test#{Guid.NewGuid():N}";
+            public LogSubscriptionDiagnostics Diagnostics =>
+                new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+            public event EventHandler? StateChanged { add { } remove { } }
+
+            public void Start() => _pumpTask = Task.Run(PumpAsync);
+
+            private async Task PumpAsync()
+            {
+                var ct = _cts.Token;
+                try
+                {
+                    await foreach (var env in _pipe.SubscribeAsync(ct).ConfigureAwait(false))
+                    {
+                        if (ct.IsCancellationRequested) break;
+
+                        // High-water filter — drops envelopes whose Sequence
+                        // is <= the persisted high-water before handler
+                        // invocation. Mirrors the production driver.
+                        if (_options.SkipProcessedHighWater is long hw && _sequenceOf(env.Payload) <= hw)
+                        {
+                            _pipe.RecordDelivered();
+                            continue;
+                        }
+
+                        // Honor LiveOnly / SinceSubscribe: drop replay-phase.
+                        if ((_options.ReplayMode == ReplayMode.LiveOnly ||
+                             _options.ReplayMode == ReplayMode.SinceSubscribe) &&
+                            env.IsReplay)
+                        {
+                            _pipe.RecordDelivered();
+                            continue;
+                        }
+
+                        try { await _handler(env).ConfigureAwait(false); }
+                        catch { /* mirror driver containment */ }
+                        finally { _pipe.RecordDelivered(); }
+                    }
+                }
+                catch (OperationCanceledException) { /* expected on dispose */ }
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+                try { _cts.Cancel(); } catch { }
+                try { _pumpTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+                try { _cts.Dispose(); } catch { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Per #549's audit row for `GourmandIngestionService`, migrates Pippin onto the L1 driver shipped in #554. Pippin is the **canonical demo of the `SkipProcessedHighWater` idempotence pattern** (#549, #550 capability F).

- **Stream:** `IPlayerLogStream` → `ILogStreamDriver.Subscribe<LocalPlayerLogLine>`.
- **ReplayMode:** `FromSessionStart` — must catch the most-recent in-session `FoodsConsumedReport` after a Mithril restart.
- **DeliveryContext:** `Marshaled(Application.Current.Dispatcher)` — `_state.Apply` → `StateChanged` → `GourmandViewModel`'s bound `ObservableCollection<FoodItemViewModel>` runs on the UI thread by construction. Retires the hand-rolled `Dispatch()` helper.
- **SkipProcessedHighWater:** seeded from persisted `GourmandState.LastProcessedSequence`. `HandleReport` is `Clear()`+repopulate (in-session idempotent) but every cold start re-runs the full apply against every replayed report; the filter drops envelopes whose `Sequence` the prior session already processed.
- **DiagnosticCategory:** `Pippin.Ingestion`.

## #550 G1 correction

The #550 body says Pippin had a `UtcNow` double-count bug. **Factually wrong against live code** (verified in #549 G1 correction): the live ingestion service has zero idempotence today. The high-water introduces restart-stability where **none existed pre-L1** — it does NOT fix a bug. Pippin is still the right canonical demo of the pattern (cheap, ergonomic example) — only the framing changes.

## Retired (#550 capability C, E)

- `ThrottledWarn` field + ctor init at the old `:21,39`.
- Per-line `try/catch` wrapper at the old `:57-66`.
- `Dispatch()` helper at the old `:93-97` (`Application.Current?.Dispatcher; CheckAccess; InvokeAsync` pattern).

L1 owns containment + rate-limited Warn + dispatcher marshaling now.

## Parser anchor-drop (per #555 review)

- `GourmandLogParser.ProcessBookFoodsRx` no longer pins `LocalPlayer:` — L0.5 (#532) eats the actor envelope.
- `src/Mithril.Shared/Reference/log-patterns.json` updated in lockstep (parity test enforces character-for-character match).
- Existing parser tests still pass: regex is unanchored, full Player.log shapes contain `ProcessBook(…)` as a substring.

## Schema

`GourmandState.LastProcessedSequence` (`long?`) added. Forward-compatible with v2 — missing fields default to `null` (the correct "no prior session processed" semantics). No schema version bump needed.

## High-water persistence shape

Written directly on `_view.Current.LastProcessedSequence` after each delivered envelope (whether or not it produced a parsed event). The existing `GourmandStateService` `OnChanged → MarkDirty → debounce → _view.Save()` path persists it when an event was applied; a best-effort `_view.Save()` on host stop captures the tail. **Sibling consumers (Samwise, Saruman/Discovery, Legolas×2) may converge on this same shape** — persisted on the existing per-character state record, advanced per-envelope, no schema version bump.

## Tests (`tests/Pippin.Tests/GourmandIngestionL1Tests.cs`, 4 new)

- `GourmandLogParser_consumes_bare_ProcessBook_payload` — pins the anchor-drop.
- `Replay_then_live_byte_equivalence` — same `FoodsConsumedReport` split across the driver's `PushReplay → PushLive` boundary yields identical state.
- `High_water_filter_skips_already_processed_envelopes` — second subscription seeded with prior session's high-water drops every replayed envelope before the handler runs; fresh state machine stays empty, zero `StateChanged` events.
- `High_water_does_not_block_post_high_water_envelopes` — envelope above the high-water still gets through.

Local slim `TestLogStreamDriver` scoped to the `LocalPlayer` pipe. Three archetype-B sibling consumers need the same shape; once a third one converges, this should be promoted to `Mithril.Shared.TestSupport`. Lives in `Pippin.Tests` today so this PR doesn't add a cross-cutting infrastructure dependency siblings haven't asked for yet.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — 3522 passed, 0 failed.
- [x] `dotnet test tests/Pippin.Tests` — 46 passed (42 baseline + 4 new L1).
- [x] `LogPatternCatalogParityTests` — passes (json updated in lockstep).
- [ ] Manual: launch Mithril, eat a food, observe `Pippin.json` carries `lastProcessedSequence`; relaunch and confirm no double-process.

## References

- #549 row for `GourmandIngestionService` (canonical high-water demo).
- #550 capability E (Marshaled) + C (containment) + F (high-water).
- #554 (L1 driver) / #555 (anchor-drop precedent) / #557 (Saruman/Chat sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
