### PR TITLE
feat(legolas): L1 migration — PlayerLogIngestionService with high-water replaces _liveSince (#550 PR 3 archetype-B)

### DIFF
--- a/src/Legolas.Module/Domain/LegolasIngestionState.cs
+++ b/src/Legolas.Module/Domain/LegolasIngestionState.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+using Mithril.Shared.Character;
+
+namespace Legolas.Domain;
+
+/// <summary>
+/// Per-character Legolas ingestion bookkeeping — persisted to
+/// <c>characters/{slug}/legolas-ingestion.json</c>. Carries the L1
+/// high-water <c>Sequence</c> the <c>PlayerLogIngestionService</c> uses to
+/// drop already-processed envelopes after a Mithril restart (#550 capability
+/// F, the restart-safe replacement for the pre-L1 in-memory
+/// <c>_liveSince</c> timestamp guard).
+///
+/// <para>Per #549's disposition for Legolas/PlayerLog, this is the canonical
+/// shape: <c>LiveOnly</c> replay mode plus a persisted Sequence high-water
+/// closes both ends of the replay-resurrection bug class — finished-run
+/// pins never repopulate either within a single session (LiveOnly drops
+/// the replay-phase envelopes) or across a restart (high-water drops live
+/// envelopes whose <c>Sequence</c> we've already processed).</para>
+///
+/// <para>Per-character because the same Mithril install plays multiple PG
+/// characters whose Player.log Sequence streams are independent; one global
+/// high-water would suppress a freshly-active character's envelopes while
+/// their stream's <c>Sequence</c> is still catching up to the prior
+/// character's furthest-processed value.</para>
+/// </summary>
+public sealed class LegolasIngestionState : IVersionedState<LegolasIngestionState>
+{
+    public const int Version = 1;
+    public static int CurrentVersion => Version;
+    public static LegolasIngestionState Migrate(LegolasIngestionState loaded) => loaded;
+
+    public int SchemaVersion { get; set; } = Version;
+
+    /// <summary>
+    /// Highest <c>LocalPlayerLogLine.Sequence</c> the
+    /// <c>PlayerLogIngestionService</c>'s handler has successfully observed
+    /// for this character. <c>0</c> on a fresh state — the L1 driver treats
+    /// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/>=<c>0</c>
+    /// as "drop only envelopes with <c>Sequence == 0</c>" which is also a
+    /// no-op for real lines (the L0 sequencer starts at <c>1</c>). Updated
+    /// after each handled envelope and flushed on a short debounce so a
+    /// restart resumes from where we left off rather than at the start of
+    /// the session-replay window.
+    /// </summary>
+    public long PlayerLogHighWaterSequence { get; set; }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSerializable(typeof(LegolasIngestionState))]
+public partial class LegolasIngestionStateJsonContext : JsonSerializerContext { }

--- a/src/Legolas.Module/LegolasModule.cs
+++ b/src/Legolas.Module/LegolasModule.cs
@@ -46,6 +46,15 @@ public sealed class LegolasModule : IMithrilModule
         var settingsPath = Path.Combine(dir, "settings.json");
 
         services.AddMithrilVersionedSettings<LegolasSettings>(settingsPath, LegolasSettingsJsonContext.Default.LegolasSettings);
+
+        // Per-character L1 ingestion bookkeeping (#550 PR 3): persists the
+        // PlayerLog Sequence high-water so a Mithril restart resumes from
+        // where the prior session left off rather than re-applying every
+        // already-processed envelope in the session-replay drain.
+        // PlayerLogIngestionService is the sole consumer.
+        services.AddPerCharacterModuleStore<LegolasIngestionState>(
+            "legolas-ingestion",
+            LegolasIngestionStateJsonContext.Default.LegolasIngestionState);
         services.AddSingleton<InventoryGridSettings>(sp =>
             sp.GetRequiredService<LegolasSettings>().InventoryGrid);
         services.AddSingleton<LegolasColors>(sp =>

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -3,6 +3,7 @@ using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.ViewModels;
 using Mithril.GameState.Areas;
+using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
@@ -11,10 +12,12 @@ using Microsoft.Extensions.Hosting;
 namespace Legolas.Services;
 
 /// <summary>
-/// Legolas-owned <see cref="IPlayerLogStream"/> consumer. Distinct from
+/// Legolas-owned LocalPlayer-pipe consumer. Distinct from
 /// <see cref="LogIngestionService"/> (which tails the <em>chat</em> log for
-/// <c>[Status]</c> survey/collect lines): this service watches
-/// <c>Player.log</c>, which is where #454's absolute-coordinate signals live.
+/// <c>[Status]</c> survey/collect lines): this service watches the
+/// L0.5 <see cref="LocalPlayerLogLine"/> pipe via the L1 (#550)
+/// <see cref="ILogStreamDriver"/>, which is where #454's absolute-coordinate
+/// signals live.
 ///
 /// <para><b>This phase (Phase 2 of #454) — area context only.</b> The single
 /// responsibility wired here is the area→calibration bridge: feed the shared
@@ -25,25 +28,56 @@ namespace Legolas.Services;
 /// <c>ProcessDoDelayLoop</c> Motherlode-map use gesture (forwarded to the
 /// <see cref="MotherlodeMeasurementCoordinator"/>). Map-pin lifecycle parsing was
 /// promoted out to the GameState-tier <c>PlayerPinTracker</c> (#468) — one
-/// Player.log subscription here, consistent with the other consumers.</para>
+/// LocalPlayer-pipe subscription here, consistent with the other consumers.</para>
 ///
-/// <para>The shared tracker is reverse-scan-seeded at startup
-/// (<see cref="PlayerAreaTracker.SeedFromLog"/>) to close the gap where the
-/// live replay window starts after the <c>LOADING LEVEL</c> line for the
-/// current area — so a session that opens Legolas while already standing in a
-/// calibrated area still applies that calibration immediately. The tracker is
-/// a thread-safe singleton; double-observing it (Gandalf also feeds it) is
-/// idempotent.</para>
+/// <para><b>L1 migration (#550 PR 3, archetype-B).</b> Pre-L1 this service
+/// owned its own <c>await foreach</c> over <see cref="IPlayerLogStream"/>,
+/// stamped an in-memory <c>_liveSince</c> cutoff after the module gate, and
+/// dropped <see cref="MapTargetDetected"/>/<see cref="MotherlodeUseDetected"/>
+/// events whose timestamp predated it. The L1 driver replaces both with
+/// composition: <see cref="ReplayMode.LiveOnly"/> drops the replay-phase
+/// envelopes the upstream emits during session-start drain, and a persisted
+/// per-character <c>SkipProcessedHighWater</c> on
+/// <see cref="LegolasIngestionState.PlayerLogHighWaterSequence"/> drops live
+/// envelopes whose <c>Sequence</c> we've already processed in a prior
+/// session — closing the resurrection-on-restart edge the in-memory cutoff
+/// never covered. The area bridge survives the <c>LiveOnly</c> tightening
+/// because <see cref="PlayerAreaTracker"/> self-seeds (#514) from the most
+/// recent <c>LOADING LEVEL</c> line in the log before this subscription
+/// reads its first live envelope.</para>
+///
+/// <para><b>Mixed-handler subscription (#549 Divergence 2 option a).</b>
+/// One subscription handles both the area bridge (formerly accepted replay
+/// to apply pre-live area state, now satisfied by #514) and the live-only
+/// survey/motherlode dispatch. Per #549's recommendation this stays a single
+/// subscription — <c>LiveOnly</c> serves both purposes once the tracker
+/// self-seeds.</para>
 ///
 /// <para>Gated on the <c>"legolas"</c> module gate, mirroring
 /// <see cref="LogIngestionService"/> — Legolas is a lazy module, so log work
 /// starts on first tab activation. The ChatLog <c>Entering Area:</c> path in
 /// <see cref="LogIngestionService"/> is retained as a complementary fallback;
 /// both converge on the same area key (last-writer-wins, idempotent).</para>
+///
+/// <para><b>Containment.</b> The L1 driver wraps each handler invocation in
+/// try/catch + rate-limited Warn, retiring the per-service <c>_diag?.Warn</c>
+/// catch this service used to hold (#550 capability C). Failures surface on
+/// <c>IDiagnosticsSink</c> under the <c>Legolas.PlayerLog</c> category via
+/// the driver's <see cref="LogSubscriptionOptions.DiagnosticCategory"/>
+/// override.</para>
+///
+/// <para><b>Marshalling.</b> <see cref="HandleMapTarget"/> mutates
+/// <c>SessionState.Surveys</c> / <c>SelectedSurvey</c> /
+/// <c>IsInventoryVisible</c> — all bound to the overlay — and
+/// <c>IAreaCalibrationService.SelectArea</c> raises <c>Changed</c> observed
+/// by calibration VMs. The L1
+/// <see cref="DeliveryContext.Marshaled"/> option marshals every envelope
+/// onto the WPF dispatcher before handler invocation, replacing the
+/// hand-rolled <c>PostToUi</c> helper (#550 capability E).</para>
 /// </summary>
 public sealed class PlayerLogIngestionService : BackgroundService
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ILogStreamDriver _driver;
     private readonly PlayerLogParser _parser;
     private readonly PlayerAreaTracker _areaTracker;
     private readonly IAreaCalibrationService _areaCalibration;
@@ -52,23 +86,27 @@ public sealed class PlayerLogIngestionService : BackgroundService
     private readonly MotherlodeMeasurementCoordinator _motherlode;
     private readonly LegolasSettings _settings;
     private readonly ModuleGates _gates;
-    private readonly TimeProvider _time;
+    private readonly IActiveCharacterService? _activeChar;
+    private readonly PerCharacterStore<LegolasIngestionState>? _ingestionStore;
     private readonly IDiagnosticsSink? _diag;
 
     private string? _lastAppliedArea;
+    private ILogSubscription? _subscription;
 
-    /// <summary>
-    /// UTC instant this consumer went live. <c>ProcessMapFx</c> lines stamped
-    /// before it are the session-replay backlog (PG/the stream replays from
-    /// session start so the area→calibration bridge and the #468 pin tracker
-    /// can catch up) — they must NOT auto-populate stale survey pins from a run
-    /// the user already finished before opening Legolas. Set once when
-    /// ingestion starts.
-    /// </summary>
-    private DateTime _liveSince = DateTime.MinValue;
+    // High-water bookkeeping. Updated per envelope under no lock — the L1
+    // driver delivers serially per subscription (one envelope at a time
+    // through the bridge), so a plain field is race-free here. Persisted
+    // on a short debounce so the on-disk value lags the in-memory one by
+    // at most _highWaterFlushIntervalMs, and once on graceful shutdown.
+    private long _highWaterSequence;
+    private long _persistedHighWaterSequence;
+    private string? _highWaterCharacter;
+    private string? _highWaterServer;
+    private readonly System.Timers.Timer _highWaterFlush;
+    private const int HighWaterFlushIntervalMs = 1500;
 
     public PlayerLogIngestionService(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         PlayerLogParser parser,
         PlayerAreaTracker areaTracker,
         IAreaCalibrationService areaCalibration,
@@ -77,10 +115,11 @@ public sealed class PlayerLogIngestionService : BackgroundService
         MotherlodeMeasurementCoordinator motherlode,
         LegolasSettings settings,
         ModuleGates gates,
-        TimeProvider? time = null,
+        IActiveCharacterService? activeChar = null,
+        PerCharacterStore<LegolasIngestionState>? ingestionStore = null,
         IDiagnosticsSink? diag = null)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
         _areaTracker = areaTracker;
         _areaCalibration = areaCalibration;
@@ -89,61 +128,133 @@ public sealed class PlayerLogIngestionService : BackgroundService
         _motherlode = motherlode;
         _settings = settings;
         _gates = gates;
-        _time = time ?? TimeProvider.System;
+        _activeChar = activeChar;
+        _ingestionStore = ingestionStore;
         _diag = diag;
+
+        _highWaterFlush = new System.Timers.Timer(HighWaterFlushIntervalMs) { AutoReset = false };
+        _highWaterFlush.Elapsed += (_, _) => FlushHighWater();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await _gates.For("legolas").WaitAsync(stoppingToken).ConfigureAwait(false);
 
-        // Everything already in Player.log at this point is replay/backlog —
-        // anchor the live cutoff before the stream yields the session-replay
-        // buffer, so a finished run's targets don't repopulate as fresh pins.
-        _liveSince = _time.GetUtcNow().UtcDateTime;
+        // Resolve the persisted high-water for the active character (if any)
+        // BEFORE we hand the value to the L1 driver — once Subscribe latches
+        // SkipProcessedHighWater into its options bag a later character
+        // switch can't change the threshold. The character-changed event
+        // updates the in-memory write-side so persistence still tracks the
+        // active character, but the driver's filter stays whatever was
+        // active at gate-open. See "Character-switch caveat" below.
+        var initialHighWater = ResolveInitialHighWater();
 
         // Area is seeded by the shared PlayerAreaTracker itself (one-shot,
-        // owned — mithril#514); this consumer only reads it.
+        // owned — mithril#514); this consumer only reads it. ApplyAreaIfChanged
+        // reads CurrentArea, which triggers PlayerAreaTracker.EnsureSeeded
+        // on first call — so even though LiveOnly drops the replay drain
+        // we still pick up the current area before any live envelope arrives.
         ApplyAreaIfChanged();
 
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
+        var dispatcher = Application.Current?.Dispatcher;
+        // archetype-B per #549 Legolas/PlayerLog disposition:
+        //   LiveOnly        — drops the replay drain so finished-run pins
+        //                     don't repopulate. Area bridge no longer needs
+        //                     replay (#514 self-seed).
+        //   Marshaled       — HandleMapTarget mutates Surveys /
+        //                     SelectedSurvey / IsInventoryVisible (bound to
+        //                     overlay) and IAreaCalibrationService.SelectArea
+        //                     raises Changed observed by calibration VMs.
+        //   SkipProcessedHighWater — restart-safe dedup: a Sequence value
+        //                     we processed in a prior session is dropped
+        //                     before the handler ever sees it. Replaces the
+        //                     in-memory _liveSince cutoff with a persisted
+        //                     Sequence-based one.
+        _subscription = _driver.Subscribe<LocalPlayerLogLine>(
+            envelope =>
             {
+                var payload = envelope.Payload;
+                var ts = payload.Timestamp.UtcDateTime;
+                var line = payload.Data;
+
                 // Area first — a target line in the same batch must read the
-                // correct current-area calibration.
-                _areaTracker.Observe(raw);
+                // correct current-area calibration. PlayerAreaTracker takes
+                // the bare envelope-stripped payload (L0.5 owns the actor
+                // envelope; downstream never re-matches it).
+                _areaTracker.Observe(line, ts);
                 ApplyAreaIfChanged();
 
                 // Map pins (ProcessMapPin{Add,Remove}) are owned by the
                 // GameState-tier PlayerPinTracker (#468); this service handles
-                // ProcessMapFx absolute targets (#454) and the ProcessDoDelayLoop
-                // Motherlode-map use gesture (#488).
-                switch (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime))
+                // ProcessMapFx absolute targets (#454) and the
+                // ProcessDoDelayLoop Motherlode-map use gesture (#488).
+                switch (_parser.TryParse(line, ts))
                 {
                     case MapTargetDetected mt:
-                        PostToUi(() => HandleMapTarget(mt));
+                        HandleMapTarget(mt);
                         break;
 
-                    // The use gesture only matters in Motherlode mode and only
-                    // live: a pre-_liveSince use is the session-replay backlog
-                    // from a hunt the user already finished (same guard as
-                    // HandleMapTarget). Timestamps are UTC (shared sequencer).
+                    // The use gesture only matters in Motherlode mode. The
+                    // pre-L1 `use.Timestamp >= _liveSince` guard at this
+                    // case is now a no-op: LiveOnly drops the replay-phase
+                    // backlog and the high-water filter drops re-runs from
+                    // a prior Mithril session.
                     case MotherlodeUseDetected use
-                        when _session.Mode == SessionMode.Motherlode
-                             && use.Timestamp >= _liveSince:
+                        when _session.Mode == SessionMode.Motherlode:
                         var at = new DateTimeOffset(
                             DateTime.SpecifyKind(use.Timestamp, DateTimeKind.Utc));
-                        var useName = use.MapName;
-                        PostToUi(() => _motherlode.OnUse(at, useName));
+                        _motherlode.OnUse(at, use.MapName);
                         break;
                 }
-            }
-            catch (Exception ex)
+
+                // Update the high-water AFTER successful handling so a
+                // throwing handler doesn't advance the cursor past a line
+                // we never processed. The L1 driver's containment wrap
+                // means a throw inside this block is caught by the driver,
+                // not propagated to the pump — but the next envelope's
+                // Sequence will still be > the one that threw, so a
+                // post-handler advance keeps the semantics aligned with
+                // "advance when we successfully processed this Sequence".
+                AdvanceHighWater(payload.Sequence);
+
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
             {
-                _diag?.Warn("Legolas.PlayerLog", $"Ingestion error: {ex.Message}");
-            }
+                ReplayMode = ReplayMode.LiveOnly,
+                DeliveryContext = dispatcher is null
+                    ? DeliveryContext.Inline
+                    : DeliveryContext.Marshaled(dispatcher),
+                SkipProcessedHighWater = initialHighWater > 0 ? initialHighWater : null,
+                DiagnosticCategory = "Legolas.PlayerLog",
+            });
+
+        _diag?.Info("Legolas.PlayerLog",
+            $"Subscribed to L1 driver (LocalPlayer pipe) — LiveOnly, high-water={initialHighWater}");
+
+        // Park until the host stops. The L1 subscription runs its own pump
+        // on a Task.Run; ExecuteAsync's job is to keep us alive long enough
+        // to be disposed.
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+            // Final synchronous flush so an in-flight debounce doesn't lose
+            // the last few Sequence advances on a clean shutdown.
+            _highWaterFlush.Stop();
+            FlushHighWater();
         }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        _highWaterFlush.Stop();
+        _highWaterFlush.Dispose();
+        base.Dispose();
     }
 
     /// <summary>
@@ -163,17 +274,16 @@ public sealed class PlayerLogIngestionService : BackgroundService
             return;
         }
 
-        // Replay/backlog guard: the Player.log stream replays from session
-        // start (the area/calibration bridge and #468 pin tracker need it).
-        // A target stamped before this consumer went live is a pin from a run
-        // the user already finished — placing it would resurrect stale surveys
-        // on startup. Only genuinely-live uses (after Legolas opened) place.
-        if (mt.Timestamp < _liveSince)
-        {
-            _session.LastLogEvent =
-                $"Map target: {Describe(mt)} → ignored (log replay / pre-session backlog)";
-            return;
-        }
+        // Pre-L1 this method held a `mt.Timestamp < _liveSince` guard that
+        // dropped session-replay backlog from a finished run. With the L1
+        // LiveOnly subscription + persisted high-water filter, neither
+        // resurrection path can reach here:
+        //   • LiveOnly suppresses replay-phase envelopes inside one session.
+        //   • SkipProcessedHighWater suppresses live envelopes whose
+        //     Sequence was already processed in a prior session.
+        // The timestamp comparison is now dead code; this comment is its
+        // grave marker so a future audit doesn't restore it under the
+        // mistaken belief the cases above leak through.
 
         // FSM gate: a target only places while the survey flow is actually
         // accepting one. Listening (resting/default) and Gathering (route in
@@ -257,6 +367,11 @@ public sealed class PlayerLogIngestionService : BackgroundService
     /// </summary>
     private void ApplyAreaIfChanged()
     {
+        // First read triggers PlayerAreaTracker.EnsureSeeded (#514) — the
+        // tracker self-scans the log for the most recent LOADING LEVEL and
+        // resolves the current area before returning. So even though we
+        // subscribe LiveOnly (no replay drain), the area we read here is
+        // the *real* current area, not null.
         var area = _areaTracker.CurrentArea;
         if (area is null)
         {
@@ -265,19 +380,89 @@ public sealed class PlayerLogIngestionService : BackgroundService
         }
         if (area == _lastAppliedArea) return;
         _lastAppliedArea = area;
-        PostToUi(() => _areaCalibration.SelectArea(area));
+        _areaCalibration.SelectArea(area);
     }
 
     /// <summary>
-    /// Marshal to the WPF dispatcher — <see cref="IAreaCalibrationService.SelectArea"/>
-    /// touches the projector and raises <c>Changed</c>, which calibration VMs
-    /// observe. Falls back to a direct call in headless/test contexts. Mirrors
-    /// <see cref="LogIngestionService"/>'s helper of the same name.
+    /// Resolve the high-water Sequence to feed into the L1 subscription at
+    /// gate-open. Loads the active character's persisted
+    /// <see cref="LegolasIngestionState"/>, captures the resulting Character +
+    /// Server identity so subsequent flushes target the same file even if
+    /// the active character changes mid-session.
+    ///
+    /// <para>Returns <c>0</c> (which the driver treats as "no high-water"
+    /// when paired with the null nullable below) if no active character or
+    /// no persistence store is available — the in-memory write side still
+    /// tracks the highest Sequence we've seen so a switch-then-back later
+    /// in the session resumes coherently.</para>
     /// </summary>
-    private static void PostToUi(Action action)
+    private long ResolveInitialHighWater()
     {
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher is null) action();
-        else dispatcher.InvokeAsync(action);
+        if (_ingestionStore is null) return 0;
+        if (_activeChar is null) return 0;
+        var name = _activeChar.ActiveCharacterName;
+        var server = _activeChar.ActiveServer;
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(server)) return 0;
+
+        try
+        {
+            var state = _ingestionStore.Load(name, server);
+            _highWaterCharacter = name;
+            _highWaterServer = server;
+            _highWaterSequence = state.PlayerLogHighWaterSequence;
+            _persistedHighWaterSequence = state.PlayerLogHighWaterSequence;
+            return state.PlayerLogHighWaterSequence;
+        }
+        catch (Exception ex)
+        {
+            _diag?.Warn("Legolas.PlayerLog",
+                $"Failed to load persisted high-water for {name}/{server}: {ex.Message}");
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Advance the in-memory high-water. Monotonic per the driver's filter
+    /// contract (a Sequence we've seen is one the driver let through, so
+    /// it's strictly greater than every prior); the Math.Max guard handles
+    /// any pathological reordering at the test-fake boundary.
+    /// </summary>
+    private void AdvanceHighWater(long sequence)
+    {
+        if (sequence <= 0) return;
+        if (sequence > _highWaterSequence)
+        {
+            _highWaterSequence = sequence;
+            // Debounce the disk write — a hot stream produces thousands of
+            // envelopes a session, but only the latest value matters.
+            _highWaterFlush.Stop();
+            _highWaterFlush.Start();
+        }
+    }
+
+    /// <summary>
+    /// Persist the in-memory high-water if it advanced since the last flush.
+    /// Best-effort: a failed write logs a Warn but doesn't propagate (a missed
+    /// flush only means the next session's restart-resume covers a slightly
+    /// wider Sequence range than strictly necessary; LiveOnly still prevents
+    /// the resurrection bug class within-session).
+    /// </summary>
+    private void FlushHighWater()
+    {
+        if (_ingestionStore is null) return;
+        if (string.IsNullOrEmpty(_highWaterCharacter) || string.IsNullOrEmpty(_highWaterServer)) return;
+        var current = _highWaterSequence;
+        if (current <= _persistedHighWaterSequence) return;
+        try
+        {
+            var state = new LegolasIngestionState { PlayerLogHighWaterSequence = current };
+            _ingestionStore.Save(_highWaterCharacter, _highWaterServer, state);
+            _persistedHighWaterSequence = current;
+        }
+        catch (Exception ex)
+        {
+            _diag?.Warn("Legolas.PlayerLog",
+                $"Failed to persist high-water {current} for {_highWaterCharacter}/{_highWaterServer}: {ex.Message}");
+        }
     }
 }

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -23,6 +23,12 @@ namespace Legolas.Services;
 /// common — see <see cref="WorldCoord"/>). Lines that aren't
 /// <c>ProcessMapFx</c> (incl. Motherlode's <c>ProcessScreenText</c>) fast-path
 /// to null, so Motherlode is excluded with no special-casing.
+///
+/// <para>Post-#550 L1 migration: consumes the envelope-stripped
+/// <see cref="LocalPlayerLogLine.Data"/> payload — L0.5 (#532) has already
+/// classified the line as <c>LocalPlayer:</c>-actored and eaten the envelope,
+/// so the <c>MotherlodeUseRx</c> guard no longer re-anchors on it. Same
+/// pattern as the GameState parsers post-#555.</para>
 /// </summary>
 public sealed partial class PlayerLogParser : ILogParser
 {
@@ -37,8 +43,10 @@ public sealed partial class PlayerLogParser : ILogParser
     // only; binding stays order-based (the type is identical across a same-type
     // stack, no per-map identity). Grammar mirrors Gandalf's
     // InteractionDelayLoopParser (no cross-module dependency taken).
+    // Post-#550: the LocalPlayer: actor envelope is eaten upstream by L0.5;
+    // this guard no longer re-anchors on it.
     [GeneratedRegex(
-        """LocalPlayer:\s*ProcessDoDelayLoop\(\s*\d+(?:\.\d+)?\s*,\s*\w+\s*,\s*"(?<map>[^"]*Motherlode Map[^"]*)"\s*,""",
+        """ProcessDoDelayLoop\(\s*\d+(?:\.\d+)?\s*,\s*\w+\s*,\s*"(?<map>[^"]*Motherlode Map[^"]*)"\s*,""",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
     private static partial Regex MotherlodeUseRx();
 

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -1,10 +1,10 @@
 using System.IO;
 using System.Text;
-using System.Threading.Channels;
 using FluentAssertions;
 using Legolas.Domain;
 using Legolas.Flow;
 using Legolas.Services;
+using Legolas.Tests.TestSupport;
 using Legolas.ViewModels;
 using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
@@ -16,6 +16,15 @@ using Xunit;
 
 namespace Legolas.Tests.Services;
 
+/// <summary>
+/// Post-#550 PR 3 (L1 migration): the service now subscribes through
+/// <see cref="ILogStreamDriver"/> with
+/// <see cref="ReplayMode.LiveOnly"/> + an optional persisted
+/// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/>. The pre-L1
+/// <c>_liveSince</c> timestamp guard is gone; tests no longer rely on it
+/// — they push live envelopes through the test L1 driver and assert the
+/// handler's UI-bound state mutations.
+/// </summary>
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
 public sealed class PlayerLogIngestionServiceTests : IDisposable
@@ -36,14 +45,22 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         "[08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, " +
         "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 67m west and 1181m south.\")";
 
-    private static (PlayerLogIngestionService svc, ScriptedStream stream, SpyAreaCalibration spy,
-        SessionState session, SurveyFlowController flow) Build(
+    private sealed record Fixture(
+        PlayerLogIngestionService Service,
+        TestLogStreamDriver Driver,
+        SpyAreaCalibration Spy,
+        SessionState Session,
+        SurveyFlowController Flow,
+        PlayerAreaTracker Tracker);
+
+    private static Fixture Build(
         AreaCalibration? calibration = null, GameConfig? config = null)
     {
-        var stream = new ScriptedStream();
-        // #514: the shared tracker owns its one-shot seed (PLIS no longer
-        // triggers it). Route the test's config to the tracker so a
-        // startup-seed test drives the owned self-seed.
+        var driver = new TestLogStreamDriver();
+        // #514: the shared tracker owns its one-shot seed. Route the test's
+        // config to the tracker so a startup-seed test drives the owned
+        // self-seed (lazy-on-first-read of CurrentArea — which
+        // ApplyAreaIfChanged does at gate-open).
         var tracker = new PlayerAreaTracker(new AreaTransitionParser(), config: config);
         var spy = new SpyAreaCalibration(calibration);
         var session = new SessionState();
@@ -51,26 +68,50 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         var flow = new SurveyFlowController(session, settings);
         var gates = new ModuleGates();
         gates.For("legolas").Open();
-        // Freeze the live-cutoff at construction time. The real
-        // ModuleGate.WaitAsync yields, so the after-gate _liveSince capture
-        // would otherwise race ahead of the test's pushes (every live line
-        // would look like replay). A frozen clock makes the cutoff
-        // deterministic: pushes that use real UtcNow are "live"; a push with
-        // an explicit older timestamp is "replay".
-        var clock = new FrozenClock(DateTime.UtcNow);
         var motherlode = new MotherlodeMeasurementCoordinator(
             new MultilaterationSolver(), new MotherlodeFlowController(session),
             new FakePlayerPositionTracker(), new FakePlayerPinTracker());
         var svc = new PlayerLogIngestionService(
-            stream, new PlayerLogParser(), tracker, spy, flow, session, motherlode, settings, gates,
-            time: clock);
-        return (svc, stream, spy, session, flow);
+            driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
+            settings, gates,
+            activeChar: null, ingestionStore: null);
+        return new Fixture(svc, driver, spy, session, flow, tracker);
     }
 
-    private sealed class FrozenClock(DateTime utc) : TimeProvider
+    /// <summary>
+    /// Build a live <see cref="LocalPlayerLogLine"/> from a full PG log
+    /// line, stripping the optional <c>[ts]</c> prefix and the
+    /// <c>LocalPlayer:</c> envelope (what L0.5 does in production).
+    /// </summary>
+    private static LocalPlayerLogLine LiveLine(string fullLine, long sequence = 0) =>
+        new(new DateTimeOffset(DateTime.UtcNow, TimeSpan.Zero),
+            StripEnvelope(fullLine),
+            sequence,
+            0);
+
+    /// <summary>
+    /// Mimic L0.5 envelope stripping: peel optional <c>[HH:MM:SS]</c>
+    /// prefix and the mandatory <c>LocalPlayer:</c> actor token.
+    /// </summary>
+    private static string StripEnvelope(string line)
     {
-        private readonly DateTimeOffset _now = new(utc, TimeSpan.Zero);
-        public override DateTimeOffset GetUtcNow() => _now;
+        const int tsPrefixLen = 11;
+        const string actor = "LocalPlayer: ";
+        var idx = 0;
+        if (line.Length > tsPrefixLen
+            && line[0] == '['
+            && line[3] == ':'
+            && line[6] == ':'
+            && line[9] == ']')
+        {
+            idx = tsPrefixLen;
+        }
+        if (idx + actor.Length <= line.Length
+            && line.IndexOf(actor, idx, StringComparison.Ordinal) == idx)
+        {
+            idx += actor.Length;
+        }
+        return idx == 0 ? line : line.Substring(idx);
     }
 
     // ---- area→calibration bridge (Phase 2) -------------------------------
@@ -78,52 +119,58 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Area_load_line_applies_that_area_calibration_once()
     {
-        var (svc, stream, spy, _, _) = Build();
+        var f = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
-            stream.Push("[08:30:00] LOADING LEVEL AreaEltibule");
-            await stream.WaitForDrainAsync(cts.Token);
-            spy.SelectedAreas.Should().Equal("AreaEltibule");
+            f.Driver.PushLive(LiveLine("[08:25:13] LOADING LEVEL AreaEltibule"));
+            f.Driver.PushLive(LiveLine("[08:30:00] LOADING LEVEL AreaEltibule"));
+            await f.Driver.DrainLocalPlayerAsync();
+            f.Spy.SelectedAreas.Should().Equal("AreaEltibule");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Area_change_applies_each_distinct_area_in_order()
     {
-        var (svc, stream, spy, _, _) = Build();
+        var f = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
-            stream.Push("[08:57:37] LOADING LEVEL AreaSerbule");
-            await stream.WaitForDrainAsync(cts.Token);
-            spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaSerbule");
+            f.Driver.PushLive(LiveLine("[08:25:13] LOADING LEVEL AreaEltibule"));
+            f.Driver.PushLive(LiveLine("[08:57:37] LOADING LEVEL AreaSerbule"));
+            await f.Driver.DrainLocalPlayerAsync();
+            f.Spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaSerbule");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task ChooseCharacter_resets_latch_so_same_area_re_applies()
     {
-        var (svc, stream, spy, _, _) = Build();
+        var f = Build();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push("[08:25:13] LOADING LEVEL AreaEltibule");
-            stream.Push("[08:57:00] LOADING LEVEL ChooseCharacter");
-            stream.Push("[09:00:39] LOADING LEVEL AreaEltibule");
-            await stream.WaitForDrainAsync(cts.Token);
-            spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaEltibule");
+            f.Driver.PushLive(LiveLine("[08:25:13] LOADING LEVEL AreaEltibule"));
+            f.Driver.PushLive(LiveLine("[08:57:00] LOADING LEVEL ChooseCharacter"));
+            f.Driver.PushLive(LiveLine("[09:00:39] LOADING LEVEL AreaEltibule"));
+            await f.Driver.DrainLocalPlayerAsync();
+            f.Spy.SelectedAreas.Should().Equal("AreaEltibule", "AreaEltibule");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
+    /// <summary>
+    /// #514 + #550 LiveOnly composition: PlayerAreaTracker self-seeds on
+    /// first <see cref="PlayerAreaTracker.CurrentArea"/> read. The L1
+    /// subscription is LiveOnly so we do NOT pump replay envelopes — the
+    /// tracker's own log scan delivers the area before any live envelope.
+    /// </summary>
     [Fact]
     public async Task Startup_seed_applies_current_area_before_live_lines()
     {
@@ -135,15 +182,15 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             "LocalPlayer: ProcessAddPlayer(...)\n",
             new UTF8Encoding(false));
 
-        var (svc, _, spy, _, _) = Build(config: new GameConfig { GameRoot = _tempDir });
+        var f = Build(config: new GameConfig { GameRoot = _tempDir });
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            await WaitUntil(() => spy.SelectedAreas.Count > 0, cts.Token);
-            spy.SelectedAreas.Should().Equal("AreaEltibule");
+            await WaitUntil(() => f.Spy.SelectedAreas.Count > 0, cts.Token);
+            f.Spy.SelectedAreas.Should().Equal("AreaEltibule");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     // ---- absolute ProcessMapFx placement (Phase 3) -----------------------
@@ -151,203 +198,346 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     [Fact]
     public async Task Calibrated_area_places_one_absolute_pin_at_projected_pixel()
     {
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx);
-            await stream.WaitForDrainAsync(cts.Token);
-            // Wait on the terminal signal HandleMapTarget sets last, so the
-            // SelectedSurvey/IsInventoryVisible writes aren't raced.
-            await WaitUntil(() => session.LastLogEvent?.Contains("placed (absolute)") == true, cts.Token);
+            f.Driver.PushLive(LiveLine(MapFx));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(
+                () => f.Session.LastLogEvent?.Contains("placed (absolute)") == true,
+                cts.Token);
 
-            session.Surveys.Should().HaveCount(1);
-            var pin = session.Surveys[0];
-            pin.Name.Should().Be("Good Metal Slab");        // " is here" stripped
+            f.Session.Surveys.Should().HaveCount(1);
+            var pin = f.Session.Surveys[0];
+            pin.Name.Should().Be("Good Metal Slab");
             pin.Model.World.Should().Be(new WorldCoord(1236.00, 38.17, 2528.00));
-            // Identity calibration (s=1, θ=0, origin=0): px=X, py=-Z — screen-Y
-            // grows down while world-north (Z) grows up, so Z is negated.
             pin.Model.PixelPos.Should().Be(new PixelPoint(1236.00, -2528.00));
-            session.SelectedSurvey.Should().BeSameAs(pin);
-            session.IsInventoryVisible.Should().BeTrue();
+            f.Session.SelectedSurvey.Should().BeSameAs(pin);
+            f.Session.IsInventoryVisible.Should().BeTrue();
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Duplicate_world_coord_within_radius_does_not_stack()
     {
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx);
-            // Same node re-surveyed re-emits the identical (X,Z); only the
-            // relative msg text drifts (67m → 66m).
-            stream.Push(MapFx.Replace("67m west and 1181m", "66m west and 1180m"));
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.Surveys.Count >= 1, cts.Token);
+            f.Driver.PushLive(LiveLine(MapFx, sequence: 10));
+            f.Driver.PushLive(LiveLine(
+                MapFx.Replace("67m west and 1181m", "66m west and 1180m"),
+                sequence: 11));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(() => f.Session.Surveys.Count >= 1, cts.Token);
 
-            session.Surveys.Should().HaveCount(1);
+            f.Session.Surveys.Should().HaveCount(1);
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Distinct_targets_place_separate_pins()
     {
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx);
-            stream.Push(
+            f.Driver.PushLive(LiveLine(MapFx));
+            f.Driver.PushLive(LiveLine(
                 "[08:33:17] LocalPlayer: ProcessMapFx((1666.00, 36.95, 2620.00), 25, 1, " +
-                "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")");
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.Surveys.Count == 2, cts.Token);
+                "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")"));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(() => f.Session.Surveys.Count == 2, cts.Token);
 
-            session.Surveys.Should().HaveCount(2);
+            f.Session.Surveys.Should().HaveCount(2);
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Uncalibrated_area_does_not_place_and_reports_diagnostic()
     {
-        var (svc, stream, _, session, _) = Build(calibration: null);
+        var f = Build(calibration: null);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx);
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.LastLogEvent?.Contains("not calibrated") == true, cts.Token);
+            f.Driver.PushLive(LiveLine(MapFx));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(
+                () => f.Session.LastLogEvent?.Contains("not calibrated") == true,
+                cts.Token);
 
-            session.Surveys.Should().BeEmpty();
-            session.LastLogEvent.Should().Contain("not calibrated");
+            f.Session.Surveys.Should().BeEmpty();
+            f.Session.LastLogEvent.Should().Contain("not calibrated");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Motherlode_mode_ignores_absolute_targets()
     {
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
-        session.Mode = SessionMode.Motherlode;
+        var f = Build(calibration: Identity());
+        f.Session.Mode = SessionMode.Motherlode;
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx);
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.LastLogEvent?.Contains("Motherlode") == true, cts.Token);
+            f.Driver.PushLive(LiveLine(MapFx));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(
+                () => f.Session.LastLogEvent?.Contains("Motherlode") == true,
+                cts.Token);
 
-            session.Surveys.Should().BeEmpty();
+            f.Session.Surveys.Should().BeEmpty();
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
-    // ---- replay / FSM gating (#477 follow-up) ----------------------------
+    // ---- replay drop semantics (post-L1 — LiveOnly + high-water) --------
 
+    /// <summary>
+    /// LiveOnly drops replay-phase envelopes structurally — the consumer
+    /// never sees them, so no resurrection from session-start backlog.
+    /// Replaces the pre-L1 <c>mt.Timestamp &lt; _liveSince</c> guard inside
+    /// HandleMapTarget (which emitted a "log replay" diagnostic); the L1
+    /// equivalent is silent at the consumer because the filter is upstream.
+    /// </summary>
     [Fact]
-    public async Task Replayed_pre_session_target_is_not_placed()
+    public async Task Replay_phase_envelopes_are_dropped_by_LiveOnly()
     {
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
+        // Push a replay-phase envelope BEFORE the subscription starts so it
+        // lands in the replay snapshot. The L1 LiveOnly mode drops it.
+        f.Driver.PushReplay(LiveLine(MapFx));
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            // Stamped well before this consumer went live → session-replay
-            // backlog from a run the user already finished.
-            stream.Push(MapFx, DateTime.UtcNow.AddMinutes(-5));
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.LastLogEvent?.Contains("log replay") == true, cts.Token);
-
-            session.Surveys.Should().BeEmpty("replayed backlog must not repopulate stale pins");
+            await f.Driver.DrainLocalPlayerAsync();
+            f.Session.Surveys.Should().BeEmpty("LiveOnly drops replay-phase envelopes");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Live_target_after_startup_is_still_placed()
     {
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx); // default = DateTime.UtcNow → live
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.Surveys.Count == 1, cts.Token);
+            f.Driver.PushLive(LiveLine(MapFx));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(() => f.Session.Surveys.Count == 1, cts.Token);
 
-            session.Surveys.Should().HaveCount(1);
+            f.Session.Surveys.Should().HaveCount(1);
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Non_accepting_flow_state_does_not_place()
     {
-        var (svc, stream, _, session, flow) = Build(calibration: Identity());
-        flow.RequestSetPosition(); // Listening → SettingPosition (a non-accept state)
+        var f = Build(calibration: Identity());
+        f.Flow.RequestSetPosition(); // Listening → SettingPosition
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx); // live, but the flow isn't accepting
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.LastLogEvent?.Contains("survey flow is") == true, cts.Token);
+            f.Driver.PushLive(LiveLine(MapFx));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(
+                () => f.Session.LastLogEvent?.Contains("survey flow is") == true,
+                cts.Token);
 
-            session.Surveys.Should().BeEmpty();
-            session.LastLogEvent.Should().Contain("SettingPosition");
+            f.Session.Surveys.Should().BeEmpty();
+            f.Session.LastLogEvent.Should().Contain("SettingPosition");
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task Gathering_still_accepts_new_targets()
     {
-        var (svc, stream, _, session, flow) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var run = svc.StartAsync(cts.Token);
+        var run = f.Service.StartAsync(cts.Token);
         try
         {
-            stream.Push(MapFx);
-            await WaitUntil(() => session.Surveys.Count == 1, cts.Token);
-            flow.OptimizeRoute(); // Listening + 1 pin → Gathering
+            f.Driver.PushLive(LiveLine(MapFx));
+            await WaitUntil(() => f.Session.Surveys.Count == 1, cts.Token);
+            f.Flow.OptimizeRoute();
 
-            stream.Push(
+            f.Driver.PushLive(LiveLine(
                 "[08:33:17] LocalPlayer: ProcessMapFx((1666.00, 36.95, 2620.00), 25, 1, " +
-                "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")");
-            await stream.WaitForDrainAsync(cts.Token);
-            await WaitUntil(() => session.Surveys.Count == 2, cts.Token);
+                "\"Good Metal Slab is here\", ImportantInfo, \"The Good Metal Slab is 604m west and 1073m south.\")"));
+            await f.Driver.DrainLocalPlayerAsync();
+            await WaitUntil(() => f.Session.Surveys.Count == 2, cts.Token);
 
-            session.Surveys.Should().HaveCount(2, "#454: Gathering accepts new targets");
+            f.Session.Surveys.Should().HaveCount(2);
         }
-        finally { await Stop(svc, run, cts); }
+        finally { await Stop(f, run, cts); }
     }
 
     [Fact]
     public async Task ProcessMapPin_lines_are_ignored_by_this_service()
     {
-        // Map-pin lifecycle is GameState-owned now (#468); the Legolas
-        // Player.log consumer only handles ProcessMapFx targets.
-        var (svc, stream, _, session, _) = Build(calibration: Identity());
+        var f = Build(calibration: Identity());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = f.Service.StartAsync(cts.Token);
+        try
+        {
+            f.Driver.PushLive(LiveLine(
+                "[08:32:20] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")"));
+            f.Driver.PushLive(LiveLine(
+                "[08:32:21] LocalPlayer: ProcessMapPinRemove(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")"));
+            await f.Driver.DrainLocalPlayerAsync();
+
+            f.Session.Surveys.Should().BeEmpty();
+        }
+        finally { await Stop(f, run, cts); }
+    }
+
+    // ---- high-water restart simulation (#550 capability F) --------------
+
+    /// <summary>
+    /// Restart-resume simulation: session 1 processes envelopes with
+    /// Sequence 1..N. A new <c>PlayerLogIngestionService</c> starts with
+    /// <c>SkipProcessedHighWater = N</c> (the persisted value from session
+    /// 1) and is fed envelopes 1..M (M &gt; N). Only N+1..M reach the handler.
+    /// Replaces the pre-L1 in-memory <c>_liveSince</c> guard — high-water
+    /// survives a Mithril restart whereas <c>_liveSince</c> reset to "now"
+    /// on every cold start, suppressing legitimate session-start lines.
+    /// </summary>
+    [Fact]
+    public async Task High_water_filter_drops_already_processed_envelopes_on_restart()
+    {
+        // Use a per-test ingestion store to capture the persisted high-water.
+        var storeDir = Path.Combine(_tempDir, "ingestion");
+        var store = new Mithril.Shared.Character.PerCharacterStore<LegolasIngestionState>(
+            storeDir,
+            "legolas-ingestion.json",
+            LegolasIngestionStateJsonContext.Default.LegolasIngestionState);
+        var activeChar = new FakeActiveCharacterService("Test", "Alpha");
+
+        // Pre-load the store with high-water = 5 to simulate a prior session.
+        store.Save("Test", "Alpha", new LegolasIngestionState
+        {
+            PlayerLogHighWaterSequence = 5,
+        });
+
+        var driver = new TestLogStreamDriver();
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var spy = new SpyAreaCalibration(Identity());
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var flow = new SurveyFlowController(session, settings);
+        var gates = new ModuleGates();
+        gates.For("legolas").Open();
+        var motherlode = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), new MotherlodeFlowController(session),
+            new FakePlayerPositionTracker(), new FakePlayerPinTracker());
+        var svc = new PlayerLogIngestionService(
+            driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
+            settings, gates,
+            activeChar: activeChar, ingestionStore: store);
+
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var run = svc.StartAsync(cts.Token);
         try
         {
-            stream.Push("[08:32:20] LocalPlayer: ProcessMapPinAdd(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")");
-            stream.Push("[08:32:21] LocalPlayer: ProcessMapPinRemove(1, 0, 0, (1145.39, 0.00, 1323.40), \"Calib 1\")");
-            await stream.WaitForDrainAsync(cts.Token);
+            // Sequence 3 — below high-water (5) → dropped.
+            driver.PushLive(LiveLine(MapFx, sequence: 3));
+            // Sequence 5 — equal to high-water → dropped (<=).
+            driver.PushLive(LiveLine(
+                "[08:33:17] LocalPlayer: ProcessMapFx((2000.0, 0.0, 2000.0), 25, 1, " +
+                "\"Stale is here\", ImportantInfo, \"The Stale is 1m west and 1m north.\")",
+                sequence: 5));
+            // Sequence 6 — above high-water → DELIVERED.
+            driver.PushLive(LiveLine(
+                "[08:34:17] LocalPlayer: ProcessMapFx((3000.0, 0.0, 3000.0), 25, 1, " +
+                "\"Fresh is here\", ImportantInfo, \"The Fresh is 1m west and 1m north.\")",
+                sequence: 6));
 
-            session.Surveys.Should().BeEmpty();
+            await driver.DrainLocalPlayerAsync();
+            await WaitUntil(() => session.Surveys.Count == 1, cts.Token);
+
+            session.Surveys.Should().HaveCount(1, "only Sequence 6 (> high-water 5) reaches the handler");
+            session.Surveys[0].Name.Should().Be("Fresh");
         }
-        finally { await Stop(svc, run, cts); }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = run;
+            svc.Dispose();
+            driver.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Sanity check on the other half: after a session that handles
+    /// Sequence 10, the persisted high-water is at least 10. This is the
+    /// "byte-equivalence" half of the restart test — together with the
+    /// "high-water drops already-processed" test above, it proves the
+    /// round trip.
+    /// </summary>
+    [Fact]
+    public async Task Handler_advances_persisted_high_water()
+    {
+        var storeDir = Path.Combine(_tempDir, "ingestion-advance");
+        var store = new Mithril.Shared.Character.PerCharacterStore<LegolasIngestionState>(
+            storeDir,
+            "legolas-ingestion.json",
+            LegolasIngestionStateJsonContext.Default.LegolasIngestionState);
+        var activeChar = new FakeActiveCharacterService("Bob", "Beta");
+
+        var driver = new TestLogStreamDriver();
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        var spy = new SpyAreaCalibration(Identity());
+        var session = new SessionState();
+        var settings = new LegolasSettings();
+        var flow = new SurveyFlowController(session, settings);
+        var gates = new ModuleGates();
+        gates.For("legolas").Open();
+        var motherlode = new MotherlodeMeasurementCoordinator(
+            new MultilaterationSolver(), new MotherlodeFlowController(session),
+            new FakePlayerPositionTracker(), new FakePlayerPinTracker());
+        var svc = new PlayerLogIngestionService(
+            driver, new PlayerLogParser(), tracker, spy, flow, session, motherlode,
+            settings, gates,
+            activeChar: activeChar, ingestionStore: store);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = svc.StartAsync(cts.Token);
+        try
+        {
+            driver.PushLive(LiveLine(MapFx, sequence: 10));
+            await driver.DrainLocalPlayerAsync();
+            await WaitUntil(() => session.Surveys.Count == 1, cts.Token);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = run;
+            svc.Dispose();
+        }
+
+        // Final flush ran on shutdown — high-water should be persisted now.
+        var reloaded = store.Load("Bob", "Beta");
+        reloaded.PlayerLogHighWaterSequence.Should().BeGreaterOrEqualTo(10,
+            "the handler advanced past Sequence 10 and the flush ran on shutdown");
+
+        driver.Dispose();
     }
 
     // ---- helpers ----------------------------------------------------------
@@ -362,19 +552,15 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
     }
 
     private static async Task Stop(
-        PlayerLogIngestionService svc, Task run, CancellationTokenSource cts)
+        Fixture f, Task run, CancellationTokenSource cts)
     {
         await cts.CancelAsync();
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        try { await f.Service.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
         _ = run;
-        svc.Dispose();
+        f.Service.Dispose();
+        f.Driver.Dispose();
     }
 
-    /// <summary>
-    /// Captures <see cref="IAreaCalibrationService.SelectArea"/> calls and
-    /// reports a fixed <see cref="AreaCalibration"/> (or none) as the current
-    /// area's calibration.
-    /// </summary>
     private sealed class SpyAreaCalibration : IAreaCalibrationService
     {
         private readonly AreaCalibration? _cal;
@@ -401,40 +587,33 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
         public event EventHandler<CalibrationSurveyObservation>? SurveyObserved { add { } remove { } }
     }
 
-    private sealed class ScriptedStream : IPlayerLogStream
+    /// <summary>
+    /// Minimal IActiveCharacterService for the high-water tests — provides
+    /// a stable Name/Server pair so PerCharacterStore writes land in a
+    /// predictable directory.
+    /// </summary>
+    private sealed class FakeActiveCharacterService : Mithril.Shared.Character.IActiveCharacterService
     {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
-        private long _pending;
-        private TaskCompletionSource _drained = NewDrainTcs();
-
-        public void Push(string line) => Push(line, DateTime.UtcNow);
-
-        /// <summary>Push a line with an explicit UTC timestamp — used to
-        /// simulate the session-replay backlog (pre-live timestamps).</summary>
-        public void Push(string line, DateTime timestampUtc)
+        public FakeActiveCharacterService(string name, string server)
         {
-            Interlocked.Increment(ref _pending);
-            Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(timestampUtc, line));
+            ActiveCharacterName = name;
+            ActiveServer = server;
         }
 
-        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
-
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
-            {
-                while (_channel.Reader.TryRead(out var line))
-                {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0)
-                        _drained.TrySetResult();
-                }
-            }
-        }
-
-        private static TaskCompletionSource NewDrainTcs() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public IReadOnlyList<Mithril.Shared.Character.CharacterSnapshot> Characters
+            => Array.Empty<Mithril.Shared.Character.CharacterSnapshot>();
+        public IReadOnlyList<Mithril.Shared.Storage.ReportFileInfo> StorageReports
+            => Array.Empty<Mithril.Shared.Storage.ReportFileInfo>();
+        public string? ActiveCharacterName { get; }
+        public string? ActiveServer { get; }
+        public Mithril.Shared.Character.CharacterSnapshot? ActiveCharacter => null;
+        public Mithril.Shared.Storage.ReportFileInfo? ActiveStorageReport => null;
+        public Mithril.Shared.Storage.StorageReport? ActiveStorageContents => null;
+        public void SetActiveCharacter(string name, string server) { }
+        public void Refresh() { }
+        public event EventHandler? ActiveCharacterChanged { add { } remove { } }
+        public event EventHandler? CharacterExportsChanged { add { } remove { } }
+        public event EventHandler? StorageReportsChanged { add { } remove { } }
+        public void Dispose() { }
     }
 }

--- a/tests/Legolas.Tests/TestSupport/TestLogStreamDriver.cs
+++ b/tests/Legolas.Tests/TestSupport/TestLogStreamDriver.cs
@@ -1,0 +1,210 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Mithril.Shared.Logging;
+
+namespace Legolas.Tests.TestSupport;
+
+/// <summary>
+/// Test-only <see cref="ILogStreamDriver"/> implementation for the
+/// archetype-B Legolas/PlayerLog migration tests (#550 PR 3). Reproduces
+/// the production driver's two-phase delivery shape (yield in-memory
+/// backlog as replay envelopes, then yield from a live channel) plus the
+/// <see cref="LogSubscriptionOptions"/> filters this consumer relies on
+/// (<see cref="ReplayMode.LiveOnly"/>, <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/>)
+/// without pulling in the full <c>LogStreamDriver</c> + L0.5 router stack.
+///
+/// <para>Only the <see cref="LocalPlayerLogLine"/> pipe is wired — that's
+/// what <c>PlayerLogIngestionService</c> consumes; other pipes throw on
+/// subscribe so a misrouted test fails loud rather than hangs silently.</para>
+///
+/// <para>Modelled on the archetype-A
+/// <c>Mithril.GameState.Tests.TestSupport.TestLogStreamDriver</c>; kept
+/// local to Legolas.Tests rather than linked across because the next
+/// archetype-B migration will add per-consumer needs (idempotence policy
+/// per #549, fault SM thresholds) that diverge from the GameState shape.
+/// One file per consumer test suite is cheaper than one shared abstraction
+/// per knob.</para>
+/// </summary>
+internal sealed class TestLogStreamDriver : ILogStreamDriver, IDisposable
+{
+    private readonly Pipe _localPlayer = new();
+    private readonly List<IDisposable> _subscriptions = new();
+
+    public void PushReplay(LocalPlayerLogLine line) => _localPlayer.AddReplay(line);
+    public void PushLive(LocalPlayerLogLine line) => _localPlayer.PushLive(line);
+
+    public Task DrainLocalPlayerAsync(TimeSpan? timeout = null) =>
+        _localPlayer.DrainAsync(timeout ?? TimeSpan.FromSeconds(5));
+
+    public ILogSubscription Subscribe<T>(
+        Func<LogEnvelope<T>, ValueTask> handler,
+        LogSubscriptionOptions? options = null) where T : class
+    {
+        if (typeof(T) != typeof(LocalPlayerLogLine))
+            throw new ArgumentException(
+                $"This test driver only supports LocalPlayerLogLine subscriptions; got {typeof(T).Name}",
+                nameof(T));
+
+        var opts = options ?? LogSubscriptionOptions.Default;
+        var sub = new Subscription(
+            _localPlayer,
+            (Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>)(object)handler,
+            opts);
+        sub.Start();
+        lock (_subscriptions) _subscriptions.Add(sub);
+        return sub;
+    }
+
+    public void Dispose()
+    {
+        IDisposable[] toDispose;
+        lock (_subscriptions)
+        {
+            toDispose = _subscriptions.ToArray();
+            _subscriptions.Clear();
+        }
+        foreach (var s in toDispose) s.Dispose();
+    }
+
+    /// <summary>
+    /// Per-payload buffer + live channel. <see cref="AddReplay"/> appends
+    /// to the replay list (must be called BEFORE any Subscribe consumes
+    /// the pipe); <see cref="PushLive"/> writes to the live channel.
+    /// </summary>
+    private sealed class Pipe
+    {
+        private readonly List<LocalPlayerLogLine> _replay = new();
+        private readonly Channel<LocalPlayerLogLine> _live = Channel.CreateUnbounded<LocalPlayerLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainTcsResolved();
+        private readonly object _gate = new();
+        private bool _replaySnapshotted;
+
+        internal void AddReplay(LocalPlayerLogLine line)
+        {
+            lock (_gate)
+            {
+                if (_replaySnapshotted)
+                    throw new InvalidOperationException(
+                        "AddReplay must be called before any Subscribe<T> consumes the pipe.");
+                Interlocked.Increment(ref _pending);
+                _replay.Add(line);
+                Interlocked.Exchange(ref _drained, NewDrainTcs());
+            }
+        }
+
+        internal void PushLive(LocalPlayerLogLine line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _live.Writer.TryWrite(line);
+        }
+
+        internal void RecordDelivered()
+        {
+            if (Interlocked.Decrement(ref _pending) == 0)
+                _drained.TrySetResult();
+        }
+
+        internal Task DrainAsync(TimeSpan timeout) =>
+            _drained.Task.WaitAsync(timeout);
+
+        internal async IAsyncEnumerable<LogEnvelope<LocalPlayerLogLine>> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            LocalPlayerLogLine[] replaySnap;
+            lock (_gate) { replaySnap = _replay.ToArray(); _replaySnapshotted = true; }
+            foreach (var line in replaySnap)
+            {
+                if (ct.IsCancellationRequested) yield break;
+                yield return new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: true);
+            }
+            await foreach (var line in _live.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                yield return new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: false);
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource NewDrainTcsResolved()
+        {
+            var tcs = NewDrainTcs();
+            tcs.TrySetResult();
+            return tcs;
+        }
+    }
+
+    /// <summary>
+    /// Per-subscription pump. Honors <see cref="ReplayMode.LiveOnly"/>,
+    /// <see cref="ReplayMode.SinceSubscribe"/>, and
+    /// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> — the
+    /// three filters this consumer's subscription composes.
+    /// </summary>
+    private sealed class Subscription : ILogSubscription, IDisposable
+    {
+        private readonly Pipe _pipe;
+        private readonly Func<LogEnvelope<LocalPlayerLogLine>, ValueTask> _handler;
+        private readonly LogSubscriptionOptions _options;
+        private readonly CancellationTokenSource _cts = new();
+        private Task? _pumpTask;
+        private int _disposed;
+
+        public Subscription(
+            Pipe pipe,
+            Func<LogEnvelope<LocalPlayerLogLine>, ValueTask> handler,
+            LogSubscriptionOptions options)
+        {
+            _pipe = pipe;
+            _handler = handler;
+            _options = options;
+        }
+
+        public string Id { get; } = $"test#{Guid.NewGuid():N}";
+        public LogSubscriptionDiagnostics Diagnostics =>
+            new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+        public event EventHandler? StateChanged { add { } remove { } }
+
+        public void Start() { _pumpTask = Task.Run(PumpAsync); }
+
+        private async Task PumpAsync()
+        {
+            var ct = _cts.Token;
+            try
+            {
+                await foreach (var env in _pipe.SubscribeAsync(ct).ConfigureAwait(false))
+                {
+                    if (ct.IsCancellationRequested) break;
+
+                    // High-water filter mirrors LogStreamDriver:285-297.
+                    if (_options.SkipProcessedHighWater is long hw
+                        && env.Payload.Sequence <= hw)
+                    {
+                        _pipe.RecordDelivered();
+                        continue;
+                    }
+
+                    // LiveOnly / SinceSubscribe — drop replay-phase envelopes.
+                    if ((_options.ReplayMode == ReplayMode.LiveOnly ||
+                         _options.ReplayMode == ReplayMode.SinceSubscribe) &&
+                        env.IsReplay)
+                    {
+                        _pipe.RecordDelivered();
+                        continue;
+                    }
+
+                    try { await _handler(env).ConfigureAwait(false); }
+                    catch { /* mirror driver containment: swallow */ }
+                    finally { _pipe.RecordDelivered(); }
+                }
+            }
+            catch (OperationCanceledException) { /* expected on dispose */ }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            try { _cts.Cancel(); } catch { }
+            try { _pumpTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            try { _cts.Dispose(); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of #550 (L1 cascade) — migrates `Legolas.Module/Services/PlayerLogIngestionService` to subscribe through the L1 `ILogStreamDriver` shipped in #554 / #555. Implements the [#549 disposition](https://github.com/moumantai-gg/mithril/issues/549) for Legolas/PlayerLog: `LiveOnly` + `Marshaled(uiDispatcher)` + persisted `SkipProcessedHighWater`.

The pre-L1 in-memory `_liveSince = _time.GetUtcNow().UtcDateTime` timestamp cutoff (set at L103) is gone. Two filters replace it at the L1 boundary:

- **`ReplayMode.LiveOnly`** — drops the session-replay drain so finished-run `ProcessMapFx` pins never repopulate when Mithril opens mid-session. The area bridge survives because `PlayerAreaTracker` self-seeds on first `CurrentArea` read ([#514](https://github.com/moumantai-gg/mithril/issues/514) landed), which `ApplyAreaIfChanged()` does at gate-open *before* any live envelope arrives — so the LiveOnly tightening doesn't blind the bridge.
- **`SkipProcessedHighWater = persistedSequence`** — restart-safe `Sequence` filter persisted per-character to `characters/{slug}/legolas-ingestion.json`. Where `_liveSince` reset to `UtcNow` on every cold start (silently suppressing legitimate session-start lines), this resumes from the highest `Sequence` the handler observed in the prior session.

`DeliveryContext.Marshaled(uiDispatcher)` retires the hand-rolled `PostToUi()` helper at L279-281 (#550 capability E). Driver-owned try/catch + rate-limited `Warn` under category `"Legolas.PlayerLog"` retires the raw `_diag?.Warn` containment at L142-145 (#550 capability C — the call site #549's table specifically flagged as the raw / non-`ThrottledWarn` shape).

`PlayerLogParser.MotherlodeUseRx` drops its `LocalPlayer:\s*` anchor — L0.5 already eats the actor envelope; downstream must not re-match it (the [#555 review's Important #1](https://github.com/moumantai-gg/mithril/pull/555) cascade rule). Not in `log-patterns.json`, so no catalog parity update owed.

**Scope boundary — NOT touched here per the task brief:**
- `Legolas.Module/Services/LogIngestionService.cs` (the chat consumer) — being removed entirely per [#531](https://github.com/moumantai-gg/mithril/issues/531) in a separate follow-up (deliverable 6 of #511).
- `MotherlodeMeasurementCoordinator` internals.
- The L1 driver itself.

**Notes on diff shape:** unlike the archetype-A PR (which was net-negative at call sites — pure factoring), archetype-B is net-positive here because the high-water persistence is genuinely new state (versioned per-character JSON + debounced flush + shutdown-flush). The pre-L1 `_liveSince` was one field; restart-safe high-water needs load / track / persist machinery. This is the cost the #549 disposition explicitly accepted.

## Test plan
- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test Mithril.slnx` — 3496 passed, 0 failed.
- [x] All 13 pre-existing `PlayerLogIngestionService` behaviour tests (area bridge, calibrated placement, dedup, mode/FSM gating, MapPin ignore) ported 1:1 to the L1 driver test fake.
- [x] `Replay_phase_envelopes_are_dropped_by_LiveOnly` replaces the pre-L1 "replayed_pre_session_target_is_not_placed" test — same intent, validated structurally via `PushReplay` rather than timestamp arithmetic.
- [x] `High_water_filter_drops_already_processed_envelopes_on_restart` — seeds the per-character store with `Sequence=5`, asserts envelopes 3 and 5 are filtered and only `Sequence=6` reaches the handler. The restart-resume regression test the task brief called for.
- [x] `Handler_advances_persisted_high_water` — runs the service over a `Sequence=10` envelope, stops gracefully, reloads the store and asserts the persisted value is ≥10 (the other half of the round-trip).
- [x] `PlayerAreaTracker` self-seed verification: `Startup_seed_applies_current_area_before_live_lines` still passes with `LiveOnly` (no replay drain) — confirming #514 is fully self-seeding and the area bridge under LiveOnly works.

## References
- [#549](https://github.com/moumantai-gg/mithril/issues/549) — archetype-B audit, Legolas/PlayerLog row drove the policy choice (LiveOnly + Marshaled + high-water).
- [#514](https://github.com/moumantai-gg/mithril/issues/514) — preamble seed; the precondition that makes LiveOnly safe for the area bridge.
- [#550](https://github.com/moumantai-gg/mithril/issues/550) — L1 spec (capabilities A/B/C/E/F all exercised here).
- [#554](https://github.com/moumantai-gg/mithril/pull/554) — PR 1, the driver itself.
- [#555](https://github.com/moumantai-gg/mithril/pull/555) — PR 2, the archetype-A migrations.
- [#531](https://github.com/moumantai-gg/mithril/issues/531) — `LogIngestionService` (chat) removal, deliberately deferred from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
