### PR TITLE
feat(saruman): L1 migration — SarumanDiscoveryIngestionService with high-water dedup (#550 PR 3 archetype-B)

### DIFF
--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -231,7 +231,7 @@
       ]
     },
     "saruman.WordOfPowerDiscoveredParser.DiscoveryRx": {
-      "pattern": "LocalPlayer:\\s*ProcessBook\\(\"You discovered a word of power!\",\\s*\"You've discovered a word of power: <sel>(?<code>[A-Z]+)</sel>.*?<b><size=125%>Word of Power: (?<effect>[^<]+)</size></b>\\\\n(?<desc>.+?)\\\\n\\\\n<i>",
+      "pattern": "ProcessBook\\(\"You discovered a word of power!\",\\s*\"You've discovered a word of power: <sel>(?<code>[A-Z]+)</sel>.*?<b><size=125%>Word of Power: (?<effect>[^<]+)</size></b>\\\\n(?<desc>.+?)\\\\n\\\\n<i>",
       "source": "player",
       "module": "saruman",
       "csharp": { "type": "Saruman.Parsing.WordOfPowerDiscoveredParser", "method": "DiscoveryRx" },

--- a/src/Saruman.Module/Parsing/WordOfPowerDiscoveredParser.cs
+++ b/src/Saruman.Module/Parsing/WordOfPowerDiscoveredParser.cs
@@ -4,13 +4,27 @@ using Saruman.Domain;
 
 namespace Saruman.Parsing;
 
+/// <summary>
+/// Parses Project Gorgon's "you discovered a word of power" <c>ProcessBook</c>
+/// line into a typed <see cref="WordOfPowerDiscovered"/> event.
+///
+/// <para>Post-#550 L1 migration: consumes the envelope-stripped
+/// <see cref="LocalPlayerLogLine.Data"/> payload — L0.5 (#532) has already
+/// classified the line as <c>LocalPlayer:</c>-actored and eaten the envelope,
+/// so the regex no longer re-anchors on it. A cheap substring pre-check
+/// short-circuits the (overwhelmingly common) unrelated line before any
+/// regex runs.</para>
+/// </summary>
 public sealed partial class WordOfPowerDiscoveredParser : ILogParser
 {
     // The second ProcessBook argument contains the discovery narrative. Newlines
     // inside the string are stored as literal two-char \n escapes (backslash + n),
     // not real newlines, so `\\n` in the pattern matches the file bytes.
+    //
+    // Post-L1: no `LocalPlayer:` anchor — the envelope is eaten upstream by
+    // L0.5 and never re-matched downstream (#550 PR #555 review).
     [GeneratedRegex(
-        """LocalPlayer:\s*ProcessBook\("You discovered a word of power!",\s*"You've discovered a word of power: <sel>(?<code>[A-Z]+)</sel>.*?<b><size=125%>Word of Power: (?<effect>[^<]+)</size></b>\\n(?<desc>.+?)\\n\\n<i>""",
+        """ProcessBook\("You discovered a word of power!",\s*"You've discovered a word of power: <sel>(?<code>[A-Z]+)</sel>.*?<b><size=125%>Word of Power: (?<effect>[^<]+)</size></b>\\n(?<desc>.+?)\\n\\n<i>""",
         RegexOptions.CultureInvariant)]
     private static partial Regex DiscoveryRx();
 

--- a/src/Saruman.Module/Services/SarumanCodebookService.cs
+++ b/src/Saruman.Module/Services/SarumanCodebookService.cs
@@ -1,4 +1,5 @@
 using Mithril.Shared.Character;
+using Mithril.Shared.Logging;
 using Saruman.Domain;
 using Saruman.Settings;
 
@@ -52,7 +53,15 @@ public sealed class SarumanCodebookService
     /// <see cref="KnownWord.DiscoveryCount"/>; re-discovery of a spent word flips it
     /// back to <see cref="WordOfPowerState.Known"/>. No-op when no character is active.
     /// </summary>
-    public void RecordDiscovery(WordOfPowerDiscovered evt)
+    /// <param name="sequence">
+    /// Optional <c>LocalPlayerLogLine.Sequence</c> of the originating log envelope.
+    /// When supplied, the active character's
+    /// <see cref="SarumanState.DiscoveryHighWaterSequence"/> is advanced to
+    /// <c>max(prior, sequence)</c> as part of the same persist. The discovery
+    /// ingestion service supplies this; tests / chat-driven callers may pass
+    /// null and the high-water is left untouched.
+    /// </param>
+    public void RecordDiscovery(WordOfPowerDiscovered evt, long? sequence = null)
     {
         var state = _view.Current;
         if (state is null) return;
@@ -79,9 +88,33 @@ public sealed class SarumanCodebookService
                     FirstDiscoveredAt = evt.Timestamp,
                 };
             }
+            if (sequence is long s && (state.DiscoveryHighWaterSequence is not long prior || s > prior))
+            {
+                state.DiscoveryHighWaterSequence = s;
+            }
             Persist();
         }
         CodebookChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Read the persisted high-water Player.log sequence for the active
+    /// character — what the L1 driver should pass as
+    /// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> on the
+    /// discovery subscription so replayed envelopes whose sequence is
+    /// <c>&lt;= HighWater</c> are dropped before the handler runs and the
+    /// monotonic <see cref="KnownWord.DiscoveryCount"/> doesn't re-inflate
+    /// across a Mithril restart. Returns null when no character is active
+    /// or the character has never recorded a discovery.
+    /// </summary>
+    public long? DiscoveryHighWaterSequence
+    {
+        get
+        {
+            var state = _view.Current;
+            if (state is null) return null;
+            lock (_lock) return state.DiscoveryHighWaterSequence;
+        }
     }
 
     public bool MarkSpent(string code, DateTime spokenAt)

--- a/src/Saruman.Module/Services/SarumanDiscoveryIngestionService.cs
+++ b/src/Saruman.Module/Services/SarumanDiscoveryIngestionService.cs
@@ -1,46 +1,124 @@
+using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Microsoft.Extensions.Hosting;
 using Saruman.Domain;
 using Saruman.Parsing;
+using Saruman.Settings;
 
 namespace Saruman.Services;
 
+/// <summary>
+/// Post-#550 PR 3 L1 migration. Subscribes to the L1 driver's LocalPlayer
+/// pipe (the typed L0.5 actor-classified surface) with archetype-B options
+/// per #549's disposition row for this consumer:
+///
+/// <list type="bullet">
+///   <item><c>ReplayMode.SinceSubscribe</c> — lazy module; only live
+///   discoveries matter for codebook authority. The driver drops replay-phase
+///   envelopes structurally so a gate-open after the first discovery doesn't
+///   re-inflate <see cref="KnownWord.DiscoveryCount"/> by walking the backlog
+///   again.</item>
+///   <item><c>DeliveryContext.Inline</c> — the VM self-dispatches on
+///   <c>CodebookChanged</c>; no need for the driver to marshal onto a UI
+///   dispatcher.</item>
+///   <item><c>SkipProcessedHighWater</c> — per-code dedup is impossible
+///   because <c>DiscoveryCount</c> is monotonic, so we persist the highest
+///   <see cref="LocalPlayerLogLine.Sequence"/> we've ever applied (in
+///   <see cref="SarumanState.DiscoveryHighWaterSequence"/>, per-character)
+///   and reuse it on the next subscription. Restart-safe defence-in-depth
+///   even with <c>SinceSubscribe</c>: future replay-window variants of
+///   <c>SinceSubscribe</c> (see <see cref="ReplayMode.SinceSubscribe"/>
+///   docs) would still be filtered correctly without a code change here.</item>
+/// </list>
+///
+/// <para><b>Containment retired.</b> The driver wraps every handler
+/// invocation in try/catch + rate-limited Warn (#550 capability C), so the
+/// per-service <c>ThrottledWarn</c> ctor + try/catch this file used to hold
+/// are gone. Failures surface on <c>IDiagnosticsSink</c> under the
+/// <c>Saruman.Ingestion</c> category via the driver's
+/// <see cref="LogSubscriptionOptions.DiagnosticCategory"/> override (same
+/// category the pre-L1 hand-rolled <c>ThrottledWarn</c> used, so log
+/// consumers see no category churn).</para>
+///
+/// <para><b>Character switching.</b> The <see cref="SarumanCodebookService"/>
+/// reads / writes through <see cref="PerCharacterView{T}"/>, so a switch
+/// silently swaps both the codebook and its high-water atomically. The
+/// driver subscription is created once at gate-open and stays bound to the
+/// current Mithril process — character-switch correctness lives at the
+/// codebook layer (mutations no-op when no character is active), not the
+/// subscription layer.</para>
+/// </summary>
 public sealed class SarumanDiscoveryIngestionService : BackgroundService
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ILogStreamDriver _driver;
     private readonly WordOfPowerDiscoveredParser _parser;
     private readonly SarumanCodebookService _codebook;
     private readonly ModuleGate _gate;
-    private readonly ThrottledWarn _warn;
+    private readonly IDiagnosticsSink? _diag;
+    private ILogSubscription? _subscription;
 
     public SarumanDiscoveryIngestionService(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         WordOfPowerDiscoveredParser parser,
         SarumanCodebookService codebook,
         ModuleGates gates,
         IDiagnosticsSink? diag = null)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
         _codebook = codebook;
         _gate = gates.For("saruman");
-        _warn = new ThrottledWarn(diag, "Saruman.Ingestion");
+        _diag = diag;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await _gate.WaitAsync(stoppingToken).ConfigureAwait(false);
 
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
+        // Persisted per-character high-water sequence — replay envelopes
+        // (and any live envelope at or below this seq, e.g. a restart-window
+        // duplicate) are dropped by the driver before reaching the handler.
+        // Null is the documented "no filter" signal (see
+        // LogSubscriptionOptions.SkipProcessedHighWater).
+        var highWater = _codebook.DiscoveryHighWaterSequence;
+
+        _diag?.Info(
+            "Saruman.Ingestion",
+            $"Subscribing to L1 driver (LocalPlayer pipe) for word-of-power discoveries (highWater={highWater?.ToString() ?? "none"}).");
+
+        _subscription = _driver.Subscribe<LocalPlayerLogLine>(
+            envelope =>
             {
-                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is WordOfPowerDiscovered d)
-                    _codebook.RecordDiscovery(d);
-            }
-            catch (Exception ex) { _warn.Warn($"Ingestion error: {ex.Message}"); }
+                var payload = envelope.Payload;
+                if (_parser.TryParse(payload.Data, payload.Timestamp.UtcDateTime) is WordOfPowerDiscovered d)
+                {
+                    _codebook.RecordDiscovery(d, payload.Sequence);
+                }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.SinceSubscribe,
+                DeliveryContext = DeliveryContext.Inline,
+                SkipProcessedHighWater = highWater,
+                DiagnosticCategory = "Saruman.Ingestion",
+            });
+
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
         }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
     }
 }

--- a/src/Saruman.Module/Settings/SarumanState.cs
+++ b/src/Saruman.Module/Settings/SarumanState.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Mithril.Shared.Character;
+using Mithril.Shared.Logging;
 using Saruman.Domain;
 
 namespace Saruman.Settings;
@@ -14,6 +15,35 @@ public sealed class SarumanState : IVersionedState<SarumanState>
 
     /// <summary>Known words keyed by uppercase code.</summary>
     public Dictionary<string, KnownWord> Codebook { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Highest <c>LocalPlayerLogLine.Sequence</c> already applied to
+    /// <see cref="Codebook"/> via <c>RecordDiscovery</c>. Persisted so that on
+    /// a Mithril restart the L1 driver can replay the LocalPlayer pipe with
+    /// <c>SkipProcessedHighWater = DiscoveryHighWaterSequence</c> and the
+    /// monotonic <see cref="KnownWord.DiscoveryCount"/> bumps don't re-inflate.
+    /// Null until the first discovery has been recorded — the driver treats a
+    /// null/missing high-water as "no filter" (capability F of #550).
+    ///
+    /// <para>This is per-character because <see cref="Codebook"/> is
+    /// per-character (the canonical owner of the active-character split is
+    /// <see cref="PerCharacterView{T}"/>). A character switch swaps both the
+    /// codebook and its high-water atomically; no cross-character leakage.</para>
+    ///
+    /// <para>Defence-in-depth alongside <c>ReplayMode.SinceSubscribe</c>:
+    /// SinceSubscribe drops every replay envelope structurally (and is
+    /// today's primary defense), but persisting the high-water keeps the
+    /// filter useful if SinceSubscribe's behaviour later changes to a
+    /// replay-window variant (see <see cref="ReplayMode.SinceSubscribe"/>
+    /// docs) without a code change here.</para>
+    ///
+    /// <para>Field is added without a SchemaVersion bump because the default
+    /// (<c>null</c>) reads correctly out of legacy <c>SchemaVersion = 1</c>
+    /// files — System.Text.Json source-generated deserialisation leaves
+    /// missing fields at their default value. <see cref="Migrate"/> stays an
+    /// identity passthrough.</para>
+    /// </summary>
+    public long? DiscoveryHighWaterSequence { get; set; }
 }
 
 [JsonSourceGenerationOptions(

--- a/tests/Saruman.Tests/Parsing/WordOfPowerDiscoveredParserTests.cs
+++ b/tests/Saruman.Tests/Parsing/WordOfPowerDiscoveredParserTests.cs
@@ -9,35 +9,36 @@ public sealed class WordOfPowerDiscoveredParserTests
 {
     private readonly WordOfPowerDiscoveredParser _parser = new();
 
-    // Five concrete lines captured from Player.log on 2026-04-22.
+    // Five concrete lines captured from Player.log on 2026-04-22 — envelope-stripped
+    // (the L0.5 router eats the `[ts] LocalPlayer:` prefix before the parser sees it).
     public static TheoryData<string, string, string, string> DiscoveryCases() => new()
     {
         {
-            "[02:02:56] LocalPlayer: ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>ZOCKZECH</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Anemia</size></b>\\nSpeaking this word weakens your body so that all attacks cost +5 Power. Lasts 5 minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
+            "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>ZOCKZECH</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Anemia</size></b>\\nSpeaking this word weakens your body so that all attacks cost +5 Power. Lasts 5 minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
             "ZOCKZECH",
             "Anemia",
             "Speaking this word weakens your body so that all attacks cost +5 Power. Lasts 5 minutes."
         },
         {
-            "[02:02:57] LocalPlayer: ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>WHUBGLUX</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Fear of Water</size></b>\\nSpeaking this word causes you to hyperventilate underwater so that your breath depletes at five times its normal rate. Lasts 5 minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
+            "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>WHUBGLUX</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Fear of Water</size></b>\\nSpeaking this word causes you to hyperventilate underwater so that your breath depletes at five times its normal rate. Lasts 5 minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
             "WHUBGLUX",
             "Fear of Water",
             "Speaking this word causes you to hyperventilate underwater so that your breath depletes at five times its normal rate. Lasts 5 minutes."
         },
         {
-            "[02:02:58] LocalPlayer: ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>FEAVEG</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Fast Swimmer</size></b>\\nSpeaking this word makes you swim much faster for five minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
+            "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>FEAVEG</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Fast Swimmer</size></b>\\nSpeaking this word makes you swim much faster for five minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
             "FEAVEG",
             "Fast Swimmer",
             "Speaking this word makes you swim much faster for five minutes."
         },
         {
-            "[02:02:58] LocalPlayer: ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>HOIMWOB</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Increased Inventory</size></b>\\nSpeaking this word increases your inventory size by 10 for an hour.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
+            "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>HOIMWOB</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Increased Inventory</size></b>\\nSpeaking this word increases your inventory size by 10 for an hour.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
             "HOIMWOB",
             "Increased Inventory",
             "Speaking this word increases your inventory size by 10 for an hour."
         },
         {
-            "[02:02:59] LocalPlayer: ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>TECKPLUE</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Cure Bovinity</size></b>\\nSpeaking this word causes you to stop being a cow if you are one.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
+            "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>TECKPLUE</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Cure Bovinity</size></b>\\nSpeaking this word causes you to stop being a cow if you are one.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")",
             "TECKPLUE",
             "Cure Bovinity",
             "Speaking this word causes you to stop being a cow if you are one."
@@ -60,14 +61,16 @@ public sealed class WordOfPowerDiscoveredParserTests
     [Fact]
     public void Returns_null_for_unrelated_process_book()
     {
-        var line = "[10:00:00] LocalPlayer: ProcessBook(\"Skill Info\", \"Foods Consumed:\\n\\nApple: 1\", \"\", \"\", \"\", False, False, False, False, False, \"SkillReport\")";
+        // Envelope-stripped (post-L0.5).
+        var line = "ProcessBook(\"Skill Info\", \"Foods Consumed:\\n\\nApple: 1\", \"\", \"\", \"\", False, False, False, False, False, \"SkillReport\")";
         _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
     }
 
     [Fact]
     public void Returns_null_for_unrelated_line()
     {
-        _parser.TryParse("LocalPlayer: ProcessAddItem(Apple(1234), -1, True)", DateTime.UtcNow).Should().BeNull();
+        // Envelope-stripped (post-L0.5).
+        _parser.TryParse("ProcessAddItem(Apple(1234), -1, True)", DateTime.UtcNow).Should().BeNull();
     }
 
     [Fact]

--- a/tests/Saruman.Tests/Services/SarumanDiscoveryIngestionServiceTests.cs
+++ b/tests/Saruman.Tests/Services/SarumanDiscoveryIngestionServiceTests.cs
@@ -1,0 +1,348 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Character;
+using Mithril.Shared.Logging;
+using Mithril.Shared.Modules;
+using Saruman.Domain;
+using Saruman.Parsing;
+using Saruman.Services;
+using Saruman.Settings;
+using Xunit;
+
+namespace Saruman.Tests.Services;
+
+/// <summary>
+/// L1-migration tests for <see cref="SarumanDiscoveryIngestionService"/>
+/// (#550 PR 3 archetype-B). The service subscribes to the L1 driver's
+/// <see cref="LocalPlayerLogLine"/> pipe with <see cref="ReplayMode.SinceSubscribe"/>
+/// + <see cref="DeliveryContext.Inline"/> + a persisted high-water
+/// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/>; the test
+/// driver below captures the handler so the test can synthesise envelopes
+/// directly. Mirrors the <c>SarumanChatIngestionServiceTests</c> stub
+/// pattern (#557 / PR #556 review).
+///
+/// <para>Two shapes covered:</para>
+/// <list type="bullet">
+///   <item><b>Subscription-options shape</b> — assert the four #549
+///   disposition knobs (ReplayMode, DeliveryContext, DiagnosticCategory,
+///   SkipProcessedHighWater) land verbatim at the L1 driver. SinceSubscribe
+///   semantics + the high-water gate live INSIDE the driver — that's
+///   tested in <c>LogStreamDriverTests</c>. These consumer-side tests
+///   assert the CONFIG the consumer hands to the driver, not the driver's
+///   runtime filtering.</item>
+///   <item><b>Byte-equivalence under restart</b> — feed N envelopes via the
+///   captured handler, snapshot state, dispose; instantiate a fresh service
+///   with the same on-disk state, confirm it passes the persisted
+///   high-water to the driver as <c>SkipProcessedHighWater</c>. The
+///   per-character state file is what makes the gate survive restart, and
+///   that's what this test pins.</item>
+/// </list>
+///
+/// <para>First archetype-B consumer to land high-water persistence — the
+/// shape here is the template for the parallel Pippin / Samwise / Legolas
+/// migrations.</para>
+/// </summary>
+[Trait("Category", "FileIO")]
+[Collection("FileIO")]
+public sealed class SarumanDiscoveryIngestionServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FakeActiveCharacterService _active;
+
+    public SarumanDiscoveryIngestionServiceTests()
+    {
+        _root = Mithril.TestSupport.TestPaths.CreateTempDir("saruman-discovery-l1");
+        _active = new FakeActiveCharacterService();
+        _active.SetActiveCharacter("Arthur", "Kwatoxi");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private const string DiscoveryLineZockzech =
+        "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>ZOCKZECH</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Anemia</size></b>\\nSpeaking this word weakens your body so that all attacks cost +5 Power. Lasts 5 minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")";
+
+    private const string DiscoveryLineFeaveg =
+        "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>FEAVEG</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Fast Swimmer</size></b>\\nSpeaking this word makes you swim much faster for five minutes.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")";
+
+    private const string DiscoveryLineTeckplue =
+        "ProcessBook(\"You discovered a word of power!\", \"You've discovered a word of power: <sel>TECKPLUE</sel>Speak it out loud for this effect:\\n\\n<b><size=125%>Word of Power: Cure Bovinity</size></b>\\nSpeaking this word causes you to stop being a cow if you are one.\\n\\n<i><size=75%>Words of Power can only be spoken once, then they lose their power. Write this Word down, so you can use it later.\\n\\nYou can only benefit from the effects of two Words of Power simultaneously.</size></i>\", \"\", \"\", \"\", True, False, False, False, False, \"\")";
+
+    [Fact]
+    public async Task ConfiguresSubscriptionWithExpectedOptions()
+    {
+        // Asserts the four #549-disposition knobs land verbatim at the
+        // L1 driver: SinceSubscribe + Inline + persisted high-water (null
+        // on first cold start, when no discovery has yet been recorded)
+        // + DiagnosticCategory "Saruman.Ingestion".
+        var (codebook, view, _) = NewCodebookEmpty();
+        var driver = new FakeLogStreamDriver();
+        var (svc, exec) = await StartServiceAsync(driver, codebook);
+
+        var opts = driver.LastOptions!;
+        opts.ReplayMode.Should().Be(ReplayMode.SinceSubscribe,
+            because: "lazy module — only live discoveries matter; FromSessionStart would re-inflate DiscoveryCount every gate-open (#549 row)");
+        opts.DeliveryContext.Should().Be(DeliveryContext.Inline,
+            because: "VM self-dispatches on CodebookChanged; no need for driver-side dispatcher hop");
+        opts.DiagnosticCategory.Should().Be("Saruman.Ingestion",
+            because: "preserves the pre-L1 ThrottledWarn category so log consumers see no churn");
+        opts.SkipProcessedHighWater.Should().BeNull(
+            because: "no discovery has been recorded yet — null is the documented \"no filter\" signal");
+
+        await StopAsync(svc, exec);
+        view.Dispose();
+    }
+
+    [Fact]
+    public async Task Live_discovery_advances_codebook_and_highwater()
+    {
+        var (codebook, view, _) = NewCodebookEmpty();
+        var driver = new FakeLogStreamDriver();
+        var (svc, exec) = await StartServiceAsync(driver, codebook);
+
+        await driver.Deliver(MakeEnvelope(DiscoveryLineZockzech, sequence: 4242));
+
+        codebook.IsTracked("ZOCKZECH").Should().BeTrue();
+        codebook.TryGet("ZOCKZECH")!.DiscoveryCount.Should().Be(1);
+        codebook.DiscoveryHighWaterSequence.Should().Be(4242,
+            because: "the ingestion service must advance the persisted high-water to the envelope's Sequence");
+
+        await StopAsync(svc, exec);
+        view.Dispose();
+    }
+
+    [Fact]
+    public async Task Highwater_is_max_of_seen_sequences_not_last_seen()
+    {
+        var (codebook, view, _) = NewCodebookEmpty();
+        var driver = new FakeLogStreamDriver();
+        var (svc, exec) = await StartServiceAsync(driver, codebook);
+
+        // Out-of-order sequences (the production driver never delivers
+        // these out of order, but the max-clamp invariant lives in the
+        // codebook layer — defend it explicitly).
+        await driver.Deliver(MakeEnvelope(DiscoveryLineFeaveg, sequence: 9000));
+        await driver.Deliver(MakeEnvelope(DiscoveryLineTeckplue, sequence: 1500));
+
+        codebook.DiscoveryHighWaterSequence.Should().Be(9000,
+            because: "max-clamp invariant: a smaller sequence must not regress the high-water");
+
+        await StopAsync(svc, exec);
+        view.Dispose();
+    }
+
+    /// <summary>
+    /// Byte-equivalence regression: feed N envelopes, snapshot the codebook
+    /// + persisted high-water, dispose; on a fresh service the second
+    /// subscription must pass the persisted high-water back to the driver
+    /// as <c>SkipProcessedHighWater</c>. The driver's gate then drops every
+    /// already-seen envelope before the handler runs — preventing
+    /// <see cref="KnownWord.DiscoveryCount"/> re-inflation, preserving the
+    /// <see cref="WordOfPowerState.Spent"/> flag, never resurrecting an
+    /// entry. The handler-side correctness (high-water as the gate) is
+    /// exercised in <c>LogStreamDriverTests</c>; this test pins the
+    /// CONSUMER-side wiring that makes the gate survive a Mithril restart.
+    /// </summary>
+    [Fact]
+    public async Task Restart_persists_highwater_and_passes_it_back_to_driver()
+    {
+        var store = NewStore();
+
+        // === Pass 1: cold start ===
+        long? firstPassHighWater;
+        Dictionary<string, KnownWord> firstPass;
+        {
+            var view = new PerCharacterView<SarumanState>(_active, store);
+            var codebook = new SarumanCodebookService(view);
+            var driver = new FakeLogStreamDriver();
+            var (svc, exec) = await StartServiceAsync(driver, codebook);
+
+            driver.LastOptions!.SkipProcessedHighWater.Should().BeNull(
+                because: "first cold start — no persisted high-water yet");
+
+            await driver.Deliver(MakeEnvelope(DiscoveryLineZockzech, sequence: 100));
+            await driver.Deliver(MakeEnvelope(DiscoveryLineFeaveg, sequence: 200));
+            await driver.Deliver(MakeEnvelope(DiscoveryLineTeckplue, sequence: 300));
+
+            // Spend one — the subtlest re-inflation risk is that a bare
+            // DiscoveryCount++ on replay also clears Spent → Known, which
+            // would silently destroy the user's "this word's been used"
+            // record across a restart.
+            codebook.MarkSpent("FEAVEG", DateTime.UtcNow).Should().BeTrue();
+
+            firstPassHighWater = codebook.DiscoveryHighWaterSequence;
+            firstPass = SnapshotCodebook(codebook);
+
+            await StopAsync(svc, exec);
+            view.Dispose();
+        }
+
+        firstPassHighWater.Should().Be(300);
+        firstPass.Should().HaveCount(3);
+        firstPass["FEAVEG"].State.Should().Be(WordOfPowerState.Spent);
+
+        // === Pass 2: simulated Mithril restart — same on-disk state ===
+        {
+            var view = new PerCharacterView<SarumanState>(_active, store);
+            var codebook = new SarumanCodebookService(view);
+
+            codebook.DiscoveryHighWaterSequence.Should().Be(300,
+                because: "the persisted high-water survives a Mithril restart and is what feeds the driver's SkipProcessedHighWater");
+            // The codebook contents themselves must round-trip the Spent flag.
+            codebook.TryGet("FEAVEG")!.State.Should().Be(WordOfPowerState.Spent);
+
+            var driver = new FakeLogStreamDriver();
+            var (svc, exec) = await StartServiceAsync(driver, codebook);
+
+            driver.LastOptions!.SkipProcessedHighWater.Should().Be(300,
+                because: "on restart, the ingestion service reads the persisted high-water and hands it to the L1 driver as SkipProcessedHighWater — the driver's gate then drops every replayed/redelivered envelope with seq <= 300 before our handler runs, preventing DiscoveryCount re-inflation");
+
+            // A NEW envelope at seq 400 > the high-water DOES get
+            // processed — proving the filter isn't over-aggressive
+            // (a follow-up live discovery after a restart still works).
+            await driver.Deliver(MakeEnvelope(DiscoveryLineZockzech, sequence: 400));
+            codebook.TryGet("ZOCKZECH")!.DiscoveryCount.Should().Be(2,
+                because: "a new envelope above the high-water IS processed; the persistence is a filter not a kill-switch");
+            codebook.DiscoveryHighWaterSequence.Should().Be(400);
+
+            await StopAsync(svc, exec);
+            view.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Restart_with_no_recorded_discovery_passes_null_highwater()
+    {
+        var store = NewStore();
+        var view = new PerCharacterView<SarumanState>(_active, store);
+        var codebook = new SarumanCodebookService(view);
+        var driver = new FakeLogStreamDriver();
+        var (svc, exec) = await StartServiceAsync(driver, codebook);
+
+        driver.LastOptions!.SkipProcessedHighWater.Should().BeNull(
+            because: "DiscoveryHighWaterSequence is null until the first discovery is recorded; the ingestion service must propagate null rather than coerce to 0 (which would still filter seq=0)");
+
+        await StopAsync(svc, exec);
+        view.Dispose();
+    }
+
+    // === Helpers ===
+
+    private (SarumanCodebookService codebook, PerCharacterView<SarumanState> view, PerCharacterStore<SarumanState> store) NewCodebookEmpty()
+    {
+        var store = NewStore();
+        var view = new PerCharacterView<SarumanState>(_active, store);
+        return (new SarumanCodebookService(view), view, store);
+    }
+
+    private PerCharacterStore<SarumanState> NewStore() =>
+        new(_root, "saruman.json", SarumanJsonContext.Default.SarumanState);
+
+    private async Task<(SarumanDiscoveryIngestionService svc, Task exec)> StartServiceAsync(
+        FakeLogStreamDriver driver, SarumanCodebookService codebook)
+    {
+        var gates = new ModuleGates();
+        var svc = new SarumanDiscoveryIngestionService(
+            driver, new WordOfPowerDiscoveredParser(), codebook, gates);
+        var exec = svc.StartAsync(CancellationToken.None);
+        gates.For("saruman").Open();
+        await WaitUntilAsync(() => driver.HasSubscription);
+        return (svc, exec);
+    }
+
+    private static async Task StopAsync(SarumanDiscoveryIngestionService svc, Task exec)
+    {
+        await svc.StopAsync(CancellationToken.None);
+        await exec;
+    }
+
+    private static LogEnvelope<LocalPlayerLogLine> MakeEnvelope(string data, long sequence) =>
+        new(new LocalPlayerLogLine(
+                Timestamp: DateTimeOffset.UtcNow,
+                Data: data,
+                Sequence: sequence,
+                ReadMonotonicTicks: 0),
+            IsReplay: false);
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan? timeout = null)
+    {
+        var budget = timeout ?? TimeSpan.FromSeconds(5);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (sw.Elapsed > budget) throw new TimeoutException("WaitUntilAsync gave up");
+            await Task.Delay(10);
+        }
+    }
+
+    private static Dictionary<string, KnownWord> SnapshotCodebook(SarumanCodebookService codebook)
+    {
+        var dict = new Dictionary<string, KnownWord>(StringComparer.Ordinal);
+        foreach (var w in codebook.Words)
+        {
+            dict[w.Code] = new KnownWord
+            {
+                Code = w.Code,
+                EffectName = w.EffectName,
+                Description = w.Description,
+                FirstDiscoveredAt = w.FirstDiscoveredAt,
+                DiscoveryCount = w.DiscoveryCount,
+                State = w.State,
+                SpentAt = w.SpentAt,
+            };
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// Minimal in-process <see cref="ILogStreamDriver"/> that captures the
+    /// subscription callback so the test can synthesise envelopes directly.
+    /// Mirrors the stub in <c>SarumanChatIngestionServiceTests</c> (which
+    /// itself follows the <c>LogStreamDriverTests</c> shape) — scoped to
+    /// one subscription because Saruman/Discovery only subscribes once.
+    ///
+    /// <para>Intentionally does NOT replicate the driver's
+    /// <see cref="LogSubscriptionOptions.SkipProcessedHighWater"/> gate;
+    /// the driver's filter behaviour is exercised in
+    /// <c>LogStreamDriverTests</c>. These consumer-side tests assert the
+    /// CONFIG the consumer hands to the driver, not the driver's runtime
+    /// filtering.</para>
+    /// </summary>
+    private sealed class FakeLogStreamDriver : ILogStreamDriver
+    {
+        private Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>? _handler;
+
+        public LogSubscriptionOptions? LastOptions { get; private set; }
+        public bool HasSubscription => _handler is not null;
+
+        public ILogSubscription Subscribe<T>(
+            Func<LogEnvelope<T>, ValueTask> handler,
+            LogSubscriptionOptions? options = null) where T : class
+        {
+            if (typeof(T) != typeof(LocalPlayerLogLine))
+                throw new InvalidOperationException(
+                    $"SarumanDiscoveryIngestionService must subscribe with T=LocalPlayerLogLine, got {typeof(T).Name}");
+            LastOptions = options ?? LogSubscriptionOptions.Default;
+            _handler = (Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>)(object)handler;
+            return new FakeSub(() => _handler = null);
+        }
+
+        public ValueTask Deliver(LogEnvelope<LocalPlayerLogLine> envelope)
+        {
+            var h = _handler ?? throw new InvalidOperationException("No active subscription");
+            return h(envelope);
+        }
+
+        private sealed class FakeSub : ILogSubscription
+        {
+            private readonly Action _onDispose;
+            public FakeSub(Action onDispose) { _onDispose = onDispose; }
+            public string Id => "fake#discovery";
+            public LogSubscriptionDiagnostics Diagnostics => new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+            public event EventHandler? StateChanged { add { } remove { } }
+            public void Dispose() => _onDispose();
+        }
+    }
+}


### PR DESCRIPTION
## Why this PR

Migrates `SarumanDiscoveryIngestionService` from its hand-rolled
`IPlayerLogStream.SubscribeAsync` await-loop onto the L1 driver shipped in
#554 (PR 1) and consumed by the archetype-A producers in #555 (PR 2).
This is PR 3 of #550 for the archetype-B Saruman/Discovery row of the
[#549 disposition table](https://github.com/moumantai-gg/mithril/issues/549) —
sibling to the parallel Pippin / Samwise / Legolas archetype-B subagents.

**First archetype-B consumer to land high-water persistence — the shape
here is the template the next three (Pippin / Samwise / Legolas Player.log
+ Chat) will copy.**

## Disposition row consumed (#549)

| Knob | Value | Why |
|---|---|---|
| Stream | `IPlayerLogStream` (LocalPlayer pipe via L1) | The discovery `ProcessBook` line is a LocalPlayer-actored Player.log line. |
| `ReplayMode` | `SinceSubscribe` | Lazy module — only live discoveries matter for codebook authority. `FromSessionStart` would re-inflate `DiscoveryCount++` every gate-open (every Saruman tab click) by walking the full Player.log backlog. The driver gate at `LogStreamDriver.cs:308-313` (added in the PR #554 review fix `07c494b`) drops every replay envelope structurally. |
| `DeliveryContext` | `Inline` | VM self-dispatches on `CodebookChanged`; no driver-side dispatcher hop needed. |
| Idempotence | `SkipProcessedHighWater(Sequence)` | Per-code dedup is impossible because `DiscoveryCount` is monotonic. Persist the highest `LocalPlayerLogLine.Sequence` ever applied (in `SarumanState.DiscoveryHighWaterSequence`, per-character) and feed it back to the driver on each subscription. Defence-in-depth alongside `SinceSubscribe`: future replay-window variants of `SinceSubscribe` (see `ReplayMode` docs) would still be filtered correctly without a code change. |
| Containment to retire | `ThrottledWarn` ctor + try/catch at `:29` and `:38-43` | Gone — the L1 driver wraps every handler invocation in try/catch + rate-limited Warn (#550 capability C) under the same `Saruman.Ingestion` diagnostic bucket the pre-L1 throttle used. |

## High-water persistence shape (template for the next three PRs)

- **New optional `long? DiscoveryHighWaterSequence` field on `SarumanState`** (per-character). Null by default. No `SchemaVersion` bump because the default reads correctly out of legacy `v=1` files — `System.Text.Json` source-gen leaves missing fields at default; `Migrate` stays an identity passthrough.
- **`RecordDiscovery(evt, sequence)` advances the high-water atomically** with the codebook mutation, max-clamp on write so out-of-order delivery doesn't regress. The new `sequence` param is optional so the chat-driven `MarkSpent` path (which doesn't carry a Player.log sequence) doesn't need to thread one through.
- **`DiscoveryHighWaterSequence` getter on `SarumanCodebookService`** reads the active character's high-water; `ExecuteAsync` passes it to the driver as `SkipProcessedHighWater`. Per-character correctness is inherited from `PerCharacterView<SarumanState>` — a character switch swaps both the codebook and its high-water atomically; no cross-character leakage.

## Parser anchor dropped (PR #555 review followup)

`WordOfPowerDiscoveredParser.DiscoveryRx` no longer carries a `LocalPlayer:\s*` anchor — L0.5 has already eaten the actor envelope by the time the parser sees the `LocalPlayerLogLine.Data` payload. Mirrors the six parsers retired in PR #555's review fix. `log-patterns.json` catalog updated in lockstep — `LogPatternCatalogParityTests` passes.

The OTHER Saruman parser (`WordOfPowerChatParser`) is live-only and untouched (the chat sibling PR #557 didn't need the anchor change).

## Tests

New `tests/Saruman.Tests/Services/SarumanDiscoveryIngestionServiceTests.cs` uses a minimal in-process `FakeLogStreamDriver` (same shape as the stub in `SarumanChatIngestionServiceTests` from #557 / `LogStreamDriverTests`). Covers:

1. **`ConfiguresSubscriptionWithExpectedOptions`** — the four #549 disposition knobs land verbatim at the L1 driver.
2. **`Live_discovery_advances_codebook_and_highwater`** — the high-water is bumped to the envelope's `Sequence` after `RecordDiscovery`.
3. **`Highwater_is_max_of_seen_sequences_not_last_seen`** — max-clamp invariant defends against out-of-order delivery.
4. **`Restart_persists_highwater_and_passes_it_back_to_driver`** — byte-equivalence under restart: persisted high-water round-trips through `PerCharacterStore` and feeds back to the driver as `SkipProcessedHighWater`, with a follow-up new envelope above the high-water proving the filter isn't a kill-switch.
5. **`Restart_with_no_recorded_discovery_passes_null_highwater`** — null high-water propagates as null rather than coercing to `0` (which would still filter `seq=0`).

`WordOfPowerDiscoveredParserTests` updated to feed envelope-stripped payloads (matching what L0.5 hands to the parser post-migration).

The driver's runtime high-water gate behaviour is exercised in `LogStreamDriverTests` (PR #554) and intentionally NOT replicated by the test fake — these consumer-side tests assert the CONFIG the consumer hands to the driver, not the driver's filter mechanics.

## Verification

- `dotnet build Mithril.slnx` — clean, 0 warnings.
- `dotnet test Mithril.slnx --no-build` — **3525 passed, 0 failed, 0 skipped** (+5 over the post-#558 baseline of 3520; my 5 new tests).
- Saruman.Tests: 31 / 31 pass (26 baseline + 5 new).
- `LogPatternCatalogParityTests` passes (parity between the regex catalog and the `[GeneratedRegex]` attribute).

## Test plan

- [x] Build clean
- [x] All tests pass
- [x] Parity tests pass after `log-patterns.json` edit
- [x] No `LocalPlayer:` anchor remaining in `WordOfPowerDiscoveredParser`
- [x] `SarumanDiscoveryIngestionService` no longer references `IPlayerLogStream` or `ThrottledWarn`
- [x] High-water round-trip exercised end-to-end (pass 1 records, pass 2 reads + passes to driver)
- [ ] Manual: confirm the codebook tab still populates from a real Player.log on a Mithril cold-start (defer to merge-time spot-check — the unit test stack pins the wiring shape, the open question is whether the L0.5 → L1 → consumer pipeline still hydrates the codebook on a real session; same risk surface as the post-merge re-verify for #555).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
