### PR TITLE
feat(inventory): L1 migration — InventoryService (cross-source) (#565)

### DIFF
--- a/src/Mithril.GameState/Inventory/InventoryService.cs
+++ b/src/Mithril.GameState/Inventory/InventoryService.cs
@@ -11,12 +11,25 @@ using Microsoft.Extensions.Hosting;
 namespace Mithril.GameState.Inventory;
 
 /// <summary>
-/// Eagerly subscribes to <see cref="IPlayerLogStream"/> at shell startup and
-/// maintains the canonical <c>instanceId → (InternalName, StackSize)</c> map.
-/// The stream's session-replay buffer guarantees that the initial flush of
-/// <c>ProcessAddItem</c> events is observed here regardless of subscriber
-/// ordering; modules that need inventory lookups should depend on
-/// <see cref="IInventoryService"/> rather than re-parsing the log.
+/// Eagerly subscribes to the L1 driver's LocalPlayer + chat pipes at shell
+/// startup and maintains the canonical <c>instanceId → (InternalName, StackSize)</c>
+/// map. The driver's per-pipe session-replay buffer guarantees that the
+/// initial flush of <c>ProcessAddItem</c> events is observed here regardless
+/// of subscriber ordering; modules that need inventory lookups should depend
+/// on <see cref="IInventoryService"/> rather than re-parsing the log.
+///
+/// <para><b>L1 migration (#565).</b> Player.log consumption moved from
+/// <see cref="IPlayerLogStream"/> to
+/// <see cref="ILogStreamDriver.Subscribe{T}"/> over
+/// <see cref="LocalPlayerLogLine"/>; chat moved from
+/// <see cref="IChatLogStream"/> to <see cref="RawLogLine"/>. The Tier-1
+/// <see cref="PendingCorrelator{TKey,TReq}"/> stays — chat + Player.log are
+/// two physically separate sources with no shared total order, so the
+/// 5-second TTL correlator is the right ordering primitive (not the L1
+/// multi-pipe shape used by Position / Pin / Weather in #556). What L1
+/// adds: per-message handler containment, drop accounting, and the fault
+/// state machine that surfaces a degraded subscription on
+/// <see cref="Mithril.Shared.Modules.IAttentionAggregator"/>.</para>
 ///
 /// Subscribers attach via <see cref="Subscribe"/>, which atomically replays
 /// the current live-map contents before going live. This closes the late-join
@@ -33,9 +46,10 @@ namespace Mithril.GameState.Inventory;
 ///   splits, merges, plant-consumption, and similar in-place mutations.</item>
 ///   <item><c>ProcessRemoveFromStorageVault(_, _, Id, N)</c> carries the literal
 ///   stack size for vault-to-bag transfers. Authoritative when present.</item>
-///   <item>Chat <c>[Status] X [xN] added to inventory.</c> via
-///   <see cref="IChatLogStream"/> carries the count for fresh additions —
-///   correlated to <c>ProcessAddItem</c> by InternalName + arrival window.</item>
+///   <item>Chat <c>[Status] X [xN] added to inventory.</c> via the L1
+///   <c>Subscribe&lt;RawLogLine&gt;</c> chat pipe carries the count for fresh
+///   additions — correlated to <c>ProcessAddItem</c> by InternalName +
+///   arrival window.</item>
 /// </list>
 /// Stack size for entries marked <c>Deleted</c> is retained so late lookups
 /// (Arwen's gift-attribution path) can see the pre-removal size.
@@ -62,20 +76,23 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     // Chat-side correlation has a small staleness window; entries older than this are dropped.
     private static readonly TimeSpan PendingChatTtl = TimeSpan.FromSeconds(5);
 
-    private readonly IPlayerLogStream _stream;
-    private readonly IChatLogStream? _chatStream;
+    private readonly ILogStreamDriver _driver;
     private readonly IReferenceDataService? _refData;
     private readonly IDiagnosticsSink? _diag;
     private readonly GameConfig? _gameConfig;
     private readonly TimeProvider _time;
     private FileSystemWatcher? _seedWatcher;
     private Timer? _seedDebounce;
+    private ILogSubscription? _playerSubscription;
+    private ILogSubscription? _chatSubscription;
 
     // _subLock guards _map and _handlers. _pendingChat / _pendingAdd are
     // PendingCorrelator instances that are independently thread-safe via their own
-    // internal _gate; they don't require _subLock for correctness, but both
-    // ingestion loops take _subLock around correlator calls anyway so the
-    // drain-then-mutate-_map sequence stays atomic within a handler.
+    // internal _gate; they don't require _subLock for correctness, but both L1
+    // subscription handlers (OnLocalPlayer, OnChat) take _subLock around correlator
+    // calls anyway so the drain-then-mutate-_map sequence stays atomic within a
+    // handler. The two subscriptions have independent pump threads, so _subLock is
+    // load-bearing for cross-pipe serialization too.
     private readonly object _subLock = new();
     private readonly Dictionary<long, MapEntry> _map = new();
     private readonly List<Action<InventoryEvent>> _handlers = new();
@@ -134,16 +151,14 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     private readonly record struct LiveEntrySnapshot(long Id, int Size, bool Confirmed);
 
     public InventoryService(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         IDiagnosticsSink? diag = null,
-        IChatLogStream? chatStream = null,
         IReferenceDataService? refData = null,
         GameConfig? gameConfig = null,
         TimeProvider? time = null)
     {
-        _stream = stream;
+        _driver = driver;
         _diag = diag;
-        _chatStream = chatStream;
         _refData = refData;
         _gameConfig = gameConfig;
         _time = time ?? TimeProvider.System;
@@ -210,77 +225,85 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
 
         try
         {
-            _diag?.Info("Inventory", "Subscribing to Player.log for inventory events");
-            var playerTask = ConsumePlayerLogAsync(stoppingToken);
+            _diag?.Info("GameState.Inventory", "Subscribing to L1 driver (LocalPlayer + chat pipes) for inventory events");
+            _playerSubscription = _driver.Subscribe<LocalPlayerLogLine>(
+                OnLocalPlayer,
+                new LogSubscriptionOptions
+                {
+                    ReplayMode = ReplayMode.FromSessionStart,
+                    DeliveryContext = DeliveryContext.Inline,
+                    DiagnosticCategory = "GameState.Inventory",
+                });
+            // Chat carries no backlog by construction — L1 coerces any
+            // non-LiveOnly request to LiveOnly. Asking for it explicitly so
+            // the intent reads at the call site.
+            _chatSubscription = _driver.Subscribe<RawLogLine>(
+                OnChat,
+                new LogSubscriptionOptions
+                {
+                    ReplayMode = ReplayMode.LiveOnly,
+                    DeliveryContext = DeliveryContext.Inline,
+                    DiagnosticCategory = "GameState.Inventory",
+                });
 
-            if (_chatStream is not null)
-            {
-                _diag?.Info("Inventory", "Subscribing to ChatLogs for [Status] correlation");
-                var chatTask = ConsumeChatLogAsync(stoppingToken);
-                await Task.WhenAll(playerTask, chatTask).ConfigureAwait(false);
-            }
-            else
-            {
-                // No chat stream registered (test path); player log alone still tracks
-                // sizes via UpdateItemCode and RemoveFromStorageVault — just no
-                // chat-correlated AddItem sizing.
-                await playerTask.ConfigureAwait(false);
-            }
+            try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* expected on host stop */ }
         }
         finally
         {
+            _playerSubscription?.Dispose();
+            _playerSubscription = null;
+            _chatSubscription?.Dispose();
+            _chatSubscription = null;
             _seedDebounce?.Dispose();
             _seedWatcher?.Dispose();
         }
     }
 
-    private async Task ConsumePlayerLogAsync(CancellationToken ct)
+    private ValueTask OnLocalPlayer(LogEnvelope<LocalPlayerLogLine> envelope)
     {
-        await foreach (var raw in _stream.SubscribeAsync(ct).ConfigureAwait(false))
+        var data = envelope.Payload.Data;
+        var ts = envelope.Payload.Timestamp.UtcDateTime;
+
+        var add = AddItemRx().Match(data);
+        if (add.Success && long.TryParse(add.Groups[2].ValueSpan, out var addId))
         {
-            var ts = raw.Timestamp.UtcDateTime;
-            var add = AddItemRx().Match(raw.Line);
-            if (add.Success && long.TryParse(add.Groups[2].ValueSpan, out var addId))
-            {
-                HandleAddItem(addId, add.Groups[1].Value, ts);
-                continue;
-            }
-
-            var del = DeleteItemRx().Match(raw.Line);
-            if (del.Success && long.TryParse(del.Groups[1].ValueSpan, out var delId))
-            {
-                HandleDeleteItem(delId, ts);
-                continue;
-            }
-
-            var upd = UpdateItemCodeRx().Match(raw.Line);
-            if (upd.Success
-                && long.TryParse(upd.Groups[1].ValueSpan, out var updId)
-                && long.TryParse(upd.Groups[2].ValueSpan, out var code))
-            {
-                HandleUpdateItemCode(updId, code, ts);
-                continue;
-            }
-
-            var vault = RemoveFromStorageVaultRx().Match(raw.Line);
-            if (vault.Success
-                && long.TryParse(vault.Groups[1].ValueSpan, out var vaultId)
-                && int.TryParse(vault.Groups[2].ValueSpan, out var vaultSize))
-            {
-                HandleRemoveFromStorageVault(vaultId, vaultSize, ts);
-            }
+            HandleAddItem(addId, add.Groups[1].Value, ts);
+            return ValueTask.CompletedTask;
         }
+
+        var del = DeleteItemRx().Match(data);
+        if (del.Success && long.TryParse(del.Groups[1].ValueSpan, out var delId))
+        {
+            HandleDeleteItem(delId, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var upd = UpdateItemCodeRx().Match(data);
+        if (upd.Success
+            && long.TryParse(upd.Groups[1].ValueSpan, out var updId)
+            && long.TryParse(upd.Groups[2].ValueSpan, out var code))
+        {
+            HandleUpdateItemCode(updId, code, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var vault = RemoveFromStorageVaultRx().Match(data);
+        if (vault.Success
+            && long.TryParse(vault.Groups[1].ValueSpan, out var vaultId)
+            && int.TryParse(vault.Groups[2].ValueSpan, out var vaultSize))
+        {
+            HandleRemoveFromStorageVault(vaultId, vaultSize, ts);
+        }
+        return ValueTask.CompletedTask;
     }
 
-    private async Task ConsumeChatLogAsync(CancellationToken ct)
+    private ValueTask OnChat(LogEnvelope<RawLogLine> envelope)
     {
-        if (_chatStream is null) return;
-        await foreach (var raw in _chatStream.SubscribeAsync(ct).ConfigureAwait(false))
-        {
-            var parsed = InventoryStatusChatParser.TryParse(raw.Line);
-            if (parsed is null) continue;
-            HandleChatStatusAdd(parsed.Value.DisplayName, parsed.Value.Count, raw.Timestamp.UtcDateTime);
-        }
+        var parsed = InventoryStatusChatParser.TryParse(envelope.Payload.Line);
+        if (parsed is not null)
+            HandleChatStatusAdd(parsed.Value.DisplayName, parsed.Value.Count, envelope.Payload.Timestamp.UtcDateTime);
+        return ValueTask.CompletedTask;
     }
 
     private void HandleAddItem(long instanceId, string internalName, DateTime timestamp)
@@ -297,7 +320,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             if (_map.TryGetValue(instanceId, out var existing) && !existing.Deleted)
             {
                 _map[instanceId] = existing with { Timestamp = timestamp };
-                _diag?.Trace("Inventory",
+                _diag?.Trace("GameState.Inventory",
                     $"Add-reemit id={instanceId} name={existing.InternalName} size={existing.StackSize} confirmed={existing.SizeConfirmed}");
                 return;
             }
@@ -346,7 +369,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
                 : seeded ? " (export-seeded)"
                 : confirmed ? " (chat)"
                 : " (unconfirmed)";
-            _diag?.Trace("Inventory", $"Add    id={instanceId} name={internalName} size={size}{sourceTag} (total={_map.Count})");
+            _diag?.Trace("GameState.Inventory", $"Add    id={instanceId} name={internalName} size={size}{sourceTag} (total={_map.Count})");
             Fire(new InventoryEvent(InventoryEventKind.Added, instanceId, internalName, timestamp, size, confirmed));
         }
     }
@@ -376,7 +399,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             DrainPendingStale();
             if (!_map.TryGetValue(instanceId, out var entry))
             {
-                _diag?.Trace("Inventory", $"Delete id={instanceId} — not in map, ignored");
+                _diag?.Trace("GameState.Inventory", $"Delete id={instanceId} — not in map, ignored");
                 return;
             }
             if (entry.Deleted)
@@ -389,7 +412,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             // gift-attribution path) can still resolve an id whose delete line
             // they've already read past.
             _map[instanceId] = entry with { Deleted = true, Timestamp = timestamp };
-            _diag?.Trace("Inventory", $"Delete id={instanceId} name={entry.InternalName} size={entry.StackSize} (retained)");
+            _diag?.Trace("GameState.Inventory", $"Delete id={instanceId} name={entry.InternalName} size={entry.StackSize} (retained)");
             Fire(new InventoryEvent(InventoryEventKind.Deleted, instanceId, entry.InternalName, timestamp, entry.StackSize, entry.SizeConfirmed));
         }
     }
@@ -407,7 +430,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             {
                 // Update for an InstanceId we've never seen — game can emit these for
                 // entries that pre-date the session log. Skip; we'd have no InternalName.
-                _diag?.Trace("Inventory", $"UpdateCode id={instanceId} size={newSize} — not in map, ignored");
+                _diag?.Trace("GameState.Inventory", $"UpdateCode id={instanceId} size={newSize} — not in map, ignored");
                 return;
             }
             // UpdateCode is authoritative for the post-event size, so confirmation
@@ -417,7 +440,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             // both size and confirmation status match what's already there.
             if (entry.StackSize == newSize && entry.SizeConfirmed) return;
             _map[instanceId] = entry with { StackSize = newSize, Timestamp = timestamp, SizeConfirmed = true };
-            _diag?.Trace("Inventory", $"UpdateCode id={instanceId} name={entry.InternalName} size={newSize}");
+            _diag?.Trace("GameState.Inventory", $"UpdateCode id={instanceId} name={entry.InternalName} size={newSize}");
             Fire(new InventoryEvent(InventoryEventKind.StackChanged, instanceId, entry.InternalName, timestamp, newSize, SizeConfirmed: true));
         }
     }
@@ -436,7 +459,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             if (entry.StackSize == stackSize && entry.SizeConfirmed) return;
 
             _map[instanceId] = entry with { StackSize = stackSize, Timestamp = timestamp, SizeConfirmed = true };
-            _diag?.Trace("Inventory", $"RemoveFromVault id={instanceId} name={entry.InternalName} size={stackSize}");
+            _diag?.Trace("GameState.Inventory", $"RemoveFromVault id={instanceId} name={entry.InternalName} size={stackSize}");
             Fire(new InventoryEvent(InventoryEventKind.StackChanged, instanceId, entry.InternalName, timestamp, stackSize, SizeConfirmed: true));
         }
     }
@@ -451,7 +474,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             // reference data — likely a name-mapping miss (renamed item, localization
             // variant, or new item not in the bundled fallback). Logging here is the
             // bread-crumb that lets us spot the gap when an AddItem stays unconfirmed.
-            _diag?.Trace("Inventory", $"Chat status: '{displayName}' (x{count}) — no InternalName match in reference data");
+            _diag?.Trace("GameState.Inventory", $"Chat status: '{displayName}' (x{count}) — no InternalName match in reference data");
             return;
         }
 
@@ -465,7 +488,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
                     && (entry.StackSize != count || !entry.SizeConfirmed))
                 {
                     _map[instanceId] = entry with { StackSize = count, Timestamp = timestamp, SizeConfirmed = true };
-                    _diag?.Trace("Inventory", $"Chat → Add id={instanceId} name={internalName} size={count}");
+                    _diag?.Trace("GameState.Inventory", $"Chat → Add id={instanceId} name={internalName} size={count}");
                     Fire(new InventoryEvent(InventoryEventKind.StackChanged, instanceId, internalName, timestamp, count, SizeConfirmed: true));
                 }
                 return;
@@ -520,14 +543,14 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             newest = StorageReportLoader.ScanForReports(dir).FirstOrDefault();
             if (newest is null)
             {
-                _diag?.Trace("Inventory", $"Seed: no exports found in {dir}");
+                _diag?.Trace("GameState.Inventory", $"Seed: no exports found in {dir}");
                 return;
             }
             report = StorageReportLoader.Load(newest.FilePath);
         }
         catch (Exception ex)
         {
-            _diag?.Warn("Inventory", $"Seed: failed to load export: {ex.Message}");
+            _diag?.Warn("GameState.Inventory", $"Seed: failed to load export: {ex.Message}");
             return;
         }
 
@@ -556,7 +579,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             {
                 if (count == 1) _seededStackSizes[name] = sizes[name];
             }
-            _diag?.Trace("Inventory", $"Seeded {_seededStackSizes.Count} stack sizes from {Path.GetFileName(newest.FilePath)}");
+            _diag?.Trace("GameState.Inventory", $"Seeded {_seededStackSizes.Count} stack sizes from {Path.GetFileName(newest.FilePath)}");
 
             // Non-stackable confirm pass: any un-confirmed live entry whose item has
             // MaxStackSize == 1 is trivially size = 1. The export trigger is just a
@@ -572,12 +595,12 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
                 if (itemEntry.MaxStackSize != 1) continue;
 
                 _map[id] = entry with { StackSize = 1, Timestamp = nowNs, SizeConfirmed = true };
-                _diag?.Trace("Inventory", $"Non-stack confirm id={id} name={entry.InternalName} size=1");
+                _diag?.Trace("GameState.Inventory", $"Non-stack confirm id={id} name={entry.InternalName} size=1");
                 Fire(new InventoryEvent(InventoryEventKind.StackChanged, id, entry.InternalName, nowNs, 1, SizeConfirmed: true));
                 nonStackConfirmed++;
             }
             if (nonStackConfirmed > 0)
-                _diag?.Info("Inventory", $"Confirmed {nonStackConfirmed} non-stackable live entries from reference data");
+                _diag?.Info("GameState.Inventory", $"Confirmed {nonStackConfirmed} non-stackable live entries from reference data");
 
             // Reconcile already-tracked instances against the fresh export. Tally
             // un-deleted live entries by InternalName; mark any name that appears
@@ -616,13 +639,13 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
 
                 var entry = _map[live.Id];
                 _map[live.Id] = entry with { StackSize = exportSize, Timestamp = now, SizeConfirmed = true };
-                _diag?.Trace("Inventory",
+                _diag?.Trace("GameState.Inventory",
                     $"Export reconcile id={live.Id} name={name} size {live.Size} → {exportSize}{(live.Confirmed ? "" : " (confirming)")}");
                 Fire(new InventoryEvent(InventoryEventKind.StackChanged, live.Id, name, now, exportSize, SizeConfirmed: true));
                 reconciled++;
             }
             if (reconciled > 0)
-                _diag?.Info("Inventory", $"Export reconciled {reconciled} live entries against {Path.GetFileName(newest.FilePath)}");
+                _diag?.Info("GameState.Inventory", $"Export reconciled {reconciled} live entries against {Path.GetFileName(newest.FilePath)}");
         }
     }
 
@@ -646,7 +669,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
         }
         catch (Exception ex)
         {
-            _diag?.Warn("Inventory", $"Seed: watcher setup failed: {ex.Message}");
+            _diag?.Warn("GameState.Inventory", $"Seed: watcher setup failed: {ex.Message}");
         }
     }
 
@@ -658,7 +681,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
             new Timer(_ =>
             {
                 try { LoadExportSeeds(); }
-                catch (Exception ex) { _diag?.Warn("Inventory", $"Seed: refresh failed: {ex.Message}"); }
+                catch (Exception ex) { _diag?.Warn("GameState.Inventory", $"Seed: refresh failed: {ex.Message}"); }
             }, null, TimeSpan.FromMilliseconds(500), Timeout.InfiniteTimeSpan));
         prev?.Dispose();
     }
@@ -699,7 +722,7 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     private void Invoke(Action<InventoryEvent> handler, InventoryEvent evt)
     {
         try { handler(evt); }
-        catch (Exception ex) { _diag?.Warn("Inventory", $"Subscriber threw: {ex.Message}"); }
+        catch (Exception ex) { _diag?.Warn("GameState.Inventory", $"Subscriber threw: {ex.Message}"); }
     }
 
     /// <summary>

--- a/tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs
+++ b/tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs
@@ -1,8 +1,8 @@
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
-using System.Threading.Channels;
 using FluentAssertions;
 using Mithril.GameState.Inventory;
+using Mithril.GameState.Tests.TestSupport;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Xunit;
@@ -26,7 +26,7 @@ public sealed class InventoryServiceStackSizeTests
         // distinguish "we know it's a single item" from "we replayed an AddItem
         // for a carryover stack of 10 and have no idea what size to trust."
         var stream = new ScriptedPlayerStream("[00:00:01] LocalPlayer: ProcessAddItem(BirdEgg(100), -1, True)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         svc.TryGetStackSize(100, out _).Should().BeFalse(
@@ -43,7 +43,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 70848, True)",
             "[00:00:03] LocalPlayer: ProcessUpdateItemCode(100, 136384, True)",
             "[00:00:04] LocalPlayer: ProcessUpdateItemCode(100, 201920, True)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         svc.TryGetStackSize(100, out var size).Should().BeTrue();
@@ -55,7 +55,7 @@ public sealed class InventoryServiceStackSizeTests
     {
         var stream = new ScriptedPlayerStream(
             "[00:00:01] LocalPlayer: ProcessUpdateItemCode(999, 136384, True)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         svc.TryGetStackSize(999, out _).Should().BeFalse();
@@ -74,7 +74,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 201920, True)", // grow to 4
             "[00:00:03] LocalPlayer: ProcessUpdateItemCode(100, 136384, False)", // split: now 3
             "[00:00:03] LocalPlayer: ProcessAddItem(Guava(101), -1, True)"); // split-off
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         svc.TryGetStackSize(100, out var origSize).Should().BeTrue();
@@ -94,7 +94,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:01] LocalPlayer: ProcessAddItem(GiantSkull(100), -1, True)",
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 3211264, True)", // size 50
             "[00:00:03] LocalPlayer: ProcessDeleteItem(100)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         // Entry retained with name AND size after delete.
@@ -113,7 +113,7 @@ public sealed class InventoryServiceStackSizeTests
         var stream = new ScriptedPlayerStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Guava(100), 116, True)",
             "[00:00:01] LocalPlayer: ProcessRemoveFromStorageVault(-131, -1, 100, 46)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         svc.TryGetStackSize(100, out var size).Should().BeTrue();
@@ -130,7 +130,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:01] LocalPlayer: ProcessAddItem(Guava(100), -1, True)",
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 2757824, True)", // size 43 from bag merge
             "[00:00:02] LocalPlayer: ProcessRemoveFromStorageVault(4368409, -1, 999, 42)"); // vault id we don't know
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunAsync(svc, stream);
 
         svc.TryGetStackSize(100, out var size).Should().BeTrue();
@@ -143,18 +143,17 @@ public sealed class InventoryServiceStackSizeTests
     {
         // Chat status arrives before its ProcessAddItem within the correlation window.
         var ts = new DateTime(2026, 4, 25, 14, 10, 48, DateTimeKind.Utc);
-        var playerStream = new ScriptedPlayerStream();
-        var chatStream = new ScriptedPlayerStream();
+        var stream = new ScriptedPlayerStream();
         var refData = new FakeRefData(("Phlogiston1", "Shoddy Phlogiston"));
-        var svc = new InventoryService(playerStream, diag: null, chatStream: chatStream, refData: refData);
+        var svc = new InventoryService(stream.Driver, diag: null, refData: refData);
         var run = svc.StartAsync(CancellationToken.None);
 
         // Chat first.
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory."));
-        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory."));
+        await stream.WaitForChatDrainAsync(TimeSpan.FromSeconds(2));
         // Then AddItem.
-        playerStream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
 
         svc.TryGetStackSize(100, out var size).Should().BeTrue();
         size.Should().Be(5);
@@ -169,20 +168,19 @@ public sealed class InventoryServiceStackSizeTests
         // Reverse arrival order: AddItem fires first (defaults size to 1), chat lands
         // moments later and back-fills the size.
         var ts = new DateTime(2026, 4, 25, 14, 10, 48, DateTimeKind.Utc);
-        var playerStream = new ScriptedPlayerStream();
-        var chatStream = new ScriptedPlayerStream();
+        var stream = new ScriptedPlayerStream();
         var refData = new FakeRefData(("Phlogiston1", "Shoddy Phlogiston"));
-        var svc = new InventoryService(playerStream, diag: null, chatStream: chatStream, refData: refData);
+        var svc = new InventoryService(stream.Driver, diag: null, refData: refData);
         var run = svc.StartAsync(CancellationToken.None);
 
-        playerStream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
         // Without chat yet, the default-1 size is unconfirmed.
         svc.TryGetStackSize(100, out _).Should().BeFalse(
             because: "AddItem-default-1 is unconfirmed until chat or a code-update lands");
 
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory."));
-        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory."));
+        await stream.WaitForChatDrainAsync(TimeSpan.FromSeconds(2));
 
         svc.TryGetStackSize(100, out var postChatSize).Should().BeTrue();
         postChatSize.Should().Be(5);
@@ -200,7 +198,7 @@ public sealed class InventoryServiceStackSizeTests
         // lands this session — even one that would set size 1 again — the
         // entry flips to confirmed and the size is trustworthy.
         var stream = new ScriptedPlayerStream();
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var run = svc.StartAsync(CancellationToken.None);
 
         stream.Push(new RawLogLine(DateTime.UtcNow, "[00:00:01] LocalPlayer: ProcessAddItem(Guava(100), -1, True)"));
@@ -227,7 +225,7 @@ public sealed class InventoryServiceStackSizeTests
         // so subscribers see the transition.
         using var fixture = new InventoryServiceTests.SeedFixture();
         var stream = new ScriptedPlayerStream();
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
         var run = svc.StartAsync(CancellationToken.None);
@@ -265,18 +263,17 @@ public sealed class InventoryServiceStackSizeTests
         // event-driven views (Palantir) need the StackChanged signal — TryGetStackSize
         // alone wouldn't trigger a re-render.
         var ts = new DateTime(2026, 4, 25, 14, 10, 48, DateTimeKind.Utc);
-        var playerStream = new ScriptedPlayerStream();
-        var chatStream = new ScriptedPlayerStream();
+        var stream = new ScriptedPlayerStream();
         var refData = new FakeRefData(("Phlogiston1", "Shoddy Phlogiston"));
-        var svc = new InventoryService(playerStream, diag: null, chatStream: chatStream, refData: refData);
+        var svc = new InventoryService(stream.Driver, diag: null, refData: refData);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
         var run = svc.StartAsync(CancellationToken.None);
 
-        playerStream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory."));
-        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Shoddy Phlogiston x5 added to inventory."));
+        await stream.WaitForChatDrainAsync(TimeSpan.FromSeconds(2));
 
         // Subscribe-on-startup wins: first the Added (size 1), then the StackChanged (size 5).
         events.Should().HaveCount(2);
@@ -295,17 +292,16 @@ public sealed class InventoryServiceStackSizeTests
     public async Task NonStatusChatLines_AreIgnored()
     {
         var ts = new DateTime(2026, 4, 25, 14, 10, 48, DateTimeKind.Utc);
-        var playerStream = new ScriptedPlayerStream();
-        var chatStream = new ScriptedPlayerStream();
+        var stream = new ScriptedPlayerStream();
         var refData = new FakeRefData(("Phlogiston1", "Shoddy Phlogiston"));
-        var svc = new InventoryService(playerStream, diag: null, chatStream: chatStream, refData: refData);
+        var svc = new InventoryService(stream.Driver, diag: null, refData: refData);
         var run = svc.StartAsync(CancellationToken.None);
 
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Trade] Joltknocker: wtb 1 phoenix egg 25k"));
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Guild status changed."));
-        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
-        playerStream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:48\t[Trade] Joltknocker: wtb 1 phoenix egg 25k"));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Guild status changed."));
+        await stream.WaitForChatDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(Phlogiston1(100), -1, True)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
 
         // No correlation found → unconfirmed default 1, reported as unknown.
         svc.TryGetStackSize(100, out _).Should().BeFalse();
@@ -328,7 +324,7 @@ public sealed class InventoryServiceStackSizeTests
             "[01:06:03] LocalPlayer: ProcessAddItem(HumanSkull(108233134), -1, False)",
             "[01:48:58] LocalPlayer: ProcessAddItem(HumanSkull(108233134), -1, False)",
             "[01:52:45] LocalPlayer: ProcessDeleteItem(108233134)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
         await RunAsync(svc, stream);
@@ -344,35 +340,34 @@ public sealed class InventoryServiceStackSizeTests
         // A re-emit must not dequeue from _pendingChat — chat correlation must remain
         // available for the next genuine new-stack AddItem of the same InternalName.
         var ts = new DateTime(2026, 4, 25, 14, 10, 48, DateTimeKind.Utc);
-        var playerStream = new ScriptedPlayerStream();
-        var chatStream = new ScriptedPlayerStream();
+        var stream = new ScriptedPlayerStream();
         var refData = new FakeRefData(("HumanSkull", "Human Skull"));
-        var svc = new InventoryService(playerStream, diag: null, chatStream: chatStream, refData: refData);
+        var svc = new InventoryService(stream.Driver, diag: null, refData: refData);
         var run = svc.StartAsync(CancellationToken.None);
 
         // Chat-first establishes id=100 at confirmed size 2 via the pending-chat path,
         // which leaves _pendingAdd empty (avoids the "chat back-fills the still-queued
         // original AddItem" interaction unrelated to this test).
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Human Skull x2 added to inventory."));
-        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
-        playerStream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:48\t[Status] Human Skull x2 added to inventory."));
+        await stream.WaitForChatDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:48] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
         svc.TryGetStackSize(100, out var seedSize).Should().BeTrue();
         seedSize.Should().Be(2);
 
         // Queue a chat count of 7 for the *next* HumanSkull pickup.
-        chatStream.Push(new RawLogLine(ts, "26-04-25 15:10:49\t[Status] Human Skull x7 added to inventory."));
-        await chatStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.PushChat(new RawLogLine(ts, "26-04-25 15:10:49\t[Status] Human Skull x7 added to inventory."));
+        await stream.WaitForChatDrainAsync(TimeSpan.FromSeconds(2));
 
         // Re-emit pulse for id=100 — must NOT dequeue the queued 7 from _pendingChat.
-        playerStream.Push(new RawLogLine(ts, "[14:10:50] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:50] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
         svc.TryGetStackSize(100, out var afterReemit).Should().BeTrue();
         afterReemit.Should().Be(2);
 
         // Genuinely new AddItem (different id) — should consume the queued 7.
-        playerStream.Push(new RawLogLine(ts, "[14:10:51] LocalPlayer: ProcessAddItem(HumanSkull(200), -1, True)"));
-        await playerStream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+        stream.Push(new RawLogLine(ts, "[14:10:51] LocalPlayer: ProcessAddItem(HumanSkull(200), -1, True)"));
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
 
         svc.TryGetStackSize(200, out var newSize).Should().BeTrue();
         newSize.Should().Be(7);
@@ -391,7 +386,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 201920, True)", // size 4
             "[00:00:03] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)",
             "[00:00:04] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, False)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
         await RunAsync(svc, stream);
@@ -413,7 +408,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:01] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)",
             "[00:00:02] LocalPlayer: ProcessDeleteItem(100)",
             "[00:00:03] LocalPlayer: ProcessAddItem(HumanSkull(100), -1, True)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
         await RunAsync(svc, stream);
@@ -434,7 +429,7 @@ public sealed class InventoryServiceStackSizeTests
             "[00:00:02] LocalPlayer: ProcessAddItem(HumanSkull(108363377), -1, False)",
             "[00:00:03] LocalPlayer: ProcessAddItem(HumanSkull(108363377), -1, False)",
             "[00:00:04] LocalPlayer: ProcessDeleteItem(108363377)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
         await RunAsync(svc, stream);
@@ -454,57 +449,43 @@ public sealed class InventoryServiceStackSizeTests
     }
 
     /// <summary>
-    /// Reusable scripted stream that satisfies both <see cref="IPlayerLogStream"/> and
-    /// <see cref="IChatLogStream"/> (same shape — both yield <see cref="RawLogLine"/>).
+    /// Driver-backed test stream supporting both the LocalPlayer pipe (via
+    /// <see cref="TestLogEnvelopeFactory.FromRawLine(RawLogLine)"/> envelope
+    /// stripping) and the chat <see cref="RawLogLine"/> pipe — InventoryService
+    /// is the only producer that consumes both. Push helpers separate the two
+    /// pipes so test bodies stay explicit about which source they're driving.
     /// </summary>
-    private sealed class ScriptedPlayerStream : IPlayerLogStream, IChatLogStream
+    internal sealed class ScriptedPlayerStream : IDisposable
     {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
-        private long _pending;
-        private TaskCompletionSource _drained = NewDrainTcs();
+        public TestLogStreamDriver Driver { get; } = new();
 
-        public ScriptedPlayerStream() { _drained.TrySetResult(); }
+        public ScriptedPlayerStream() { }
 
         public ScriptedPlayerStream(params string[] lines)
             : this(lines.Select(l => new RawLogLine(DateTime.UtcNow, l)).ToArray()) { }
 
         public ScriptedPlayerStream(RawLogLine[] lines)
         {
-            if (lines.Length == 0)
-            {
-                _drained.TrySetResult();
-                return;
-            }
-            Interlocked.Add(ref _pending, lines.Length);
-            foreach (var line in lines) _channel.Writer.TryWrite(line);
+            foreach (var line in lines)
+                Driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(line));
         }
 
-        public void Push(RawLogLine line)
-        {
-            Interlocked.Increment(ref _pending);
-            Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(line);
-        }
+        /// <summary>Push a Player.log line as a LIVE envelope on the LocalPlayer pipe.</summary>
+        public void Push(RawLogLine line) =>
+            Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(line));
 
-        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
-        public Task WaitForDrainAsync(TimeSpan timeout) => _drained.Task.WaitAsync(timeout);
+        /// <summary>Push a chat line as a LIVE envelope on the chat (RawLogLine) pipe.</summary>
+        public void PushChat(RawLogLine line) => Driver.PushLive(line);
 
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
-            {
-                while (_channel.Reader.TryRead(out var line))
-                {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0)
-                        _drained.TrySetResult();
-                }
-            }
-        }
+        public Task WaitForDrainAsync(CancellationToken ct) =>
+            Driver.DrainLocalPlayerAsync().WaitAsync(ct);
+        public Task WaitForDrainAsync(TimeSpan timeout) =>
+            Driver.DrainLocalPlayerAsync(timeout);
 
-        private static TaskCompletionSource NewDrainTcs() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task WaitForChatDrainAsync(TimeSpan timeout) =>
+            Driver.DrainChatAsync(timeout);
+
+        public void Dispose() => Driver.Dispose();
     }
 
     /// <summary>

--- a/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
@@ -1,9 +1,9 @@
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using System.IO;
-using System.Threading.Channels;
 using FluentAssertions;
 using Mithril.GameState.Inventory;
+using Mithril.GameState.Tests.TestSupport;
 using Mithril.Shared.Game;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
@@ -19,7 +19,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessAddItem(AppleJuice(99), -1, False)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunUntilDrainedAsync(svc, stream);
 
         svc.TryResolve(42, out var a).Should().BeTrue();
@@ -39,7 +39,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessDeleteItem(42)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunUntilDrainedAsync(svc, stream);
 
         svc.TryResolve(42, out var name).Should().BeTrue();
@@ -52,7 +52,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessDeleteItem(42)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
 
@@ -72,7 +72,7 @@ public sealed class InventoryServiceTests
     {
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessDeleteItem(999)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var deleted = new List<InventoryEvent>();
         using var sub = svc.Subscribe(e => { if (e.Kind == InventoryEventKind.Deleted) deleted.Add(e); });
 
@@ -92,7 +92,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessAddItem(BarleySeeds(7), -1, True)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunUntilDrainedAsync(svc, stream);
 
         var replayed = new List<InventoryEvent>();
@@ -116,7 +116,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessDeleteItem(42)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunUntilDrainedAsync(svc, stream);
 
         var replayed = new List<InventoryEvent>();
@@ -139,7 +139,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             new RawLogLine(ts1, "[10:00:00] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)"),
             new RawLogLine(ts2, "[10:00:01] LocalPlayer: ProcessAddItem(BarleySeeds(7), -1, True)"));
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunUntilDrainedAsync(svc, stream);
 
         var replayed = new List<InventoryEvent>();
@@ -154,7 +154,7 @@ public sealed class InventoryServiceTests
     public async Task DisposeSubscription_StopsFurtherEvents()
     {
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -184,7 +184,7 @@ public sealed class InventoryServiceTests
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Guava(100), -1, True)",
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 201920, True)"); // size 4
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         await RunUntilDrainedAsync(svc, stream);
 
         var replayed = new List<InventoryEvent>();
@@ -200,7 +200,7 @@ public sealed class InventoryServiceTests
     public async Task UpdateItemCode_FiresStackChangedEventWithNewSize()
     {
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -233,7 +233,7 @@ public sealed class InventoryServiceTests
         // numeric size matches. So set up a confirmed entry first, then
         // verify a literal repeat is suppressed.
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -265,7 +265,7 @@ public sealed class InventoryServiceTests
         // so subscribers know the size is now trustworthy — even when the decoded
         // size happens to be 1.
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -293,7 +293,7 @@ public sealed class InventoryServiceTests
     public async Task RemoveFromStorageVault_FiresStackChangedWithLiteralSize()
     {
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -322,7 +322,7 @@ public sealed class InventoryServiceTests
             "[00:00:01] LocalPlayer: ProcessAddItem(GiantSkull(100), -1, True)",
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 3211264, True)", // size 50
             "[00:00:03] LocalPlayer: ProcessDeleteItem(100)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
         var events = new List<InventoryEvent>();
         using var sub = svc.Subscribe(events.Add);
 
@@ -342,7 +342,7 @@ public sealed class InventoryServiceTests
         // DrainPendingStale at entry, so the next unrelated event evicts it.
         var time = new ManualTimeProvider(new DateTime(2026, 4, 25, 14, 0, 0, DateTimeKind.Utc));
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, time: time);
+        var svc = new InventoryService(stream.Driver, time: time);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         // 1) Drive an AddItem with no chat correlation → enqueues _pendingAdd["Moonstone"].
@@ -386,7 +386,7 @@ public sealed class InventoryServiceTests
 }
 """);
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -424,7 +424,7 @@ public sealed class InventoryServiceTests
 }
 """);
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -465,7 +465,7 @@ public sealed class InventoryServiceTests
 }
 """);
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -489,7 +489,7 @@ public sealed class InventoryServiceTests
         // export's authoritative size and fire StackChanged so subscribers see it.
         using var fixture = new SeedFixture();
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -538,7 +538,7 @@ public sealed class InventoryServiceTests
         // and just refresh _seededStackSizes for future AddItems.
         using var fixture = new SeedFixture();
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -594,7 +594,7 @@ public sealed class InventoryServiceTests
 }
 """);
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new InventoryService(stream, refData: fixture.RefData, gameConfig: fixture.GameConfig);
+        var svc = new InventoryService(stream.Driver, refData: fixture.RefData, gameConfig: fixture.GameConfig);
         var runTask = svc.StartAsync(CancellationToken.None);
 
         var events = new List<InventoryEvent>();
@@ -620,7 +620,7 @@ public sealed class InventoryServiceTests
     {
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)");
-        var svc = new InventoryService(stream);
+        var svc = new InventoryService(stream.Driver);
 
         var goodEvents = new List<InventoryEvent>();
         using var bad = svc.Subscribe(_ => throw new InvalidOperationException("boom"));
@@ -726,53 +726,39 @@ public sealed class InventoryServiceTests
         public void Advance(TimeSpan delta) => _now = _now.Add(delta);
     }
 
-    private sealed class ScriptedStream : IPlayerLogStream
+    /// <summary>
+    /// Driver-backed test stream. Wraps <see cref="TestLogStreamDriver"/> and
+    /// pre-strips Player.log shapes onto the LocalPlayer pipe via
+    /// <see cref="TestLogEnvelopeFactory.FromRawLine(RawLogLine)"/> — matches
+    /// the L0.5 router's envelope-strip behaviour so InventoryService's
+    /// LocalPlayer subscription sees the same shape as in production. Ctor
+    /// pushes lines as <em>replay</em> (so they're available before the
+    /// subscription starts); <see cref="Push"/> pushes <em>live</em>.
+    /// </summary>
+    internal sealed class ScriptedStream : IDisposable
     {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
-        private long _pending;
-        private TaskCompletionSource _drained = NewDrainTcs();
+        public TestLogStreamDriver Driver { get; } = new();
 
-        public ScriptedStream(params string[] lines) : this(lines.Select(l => new RawLogLine(DateTime.UtcNow, l)).ToArray()) { }
+        public ScriptedStream(params string[] lines)
+            : this(lines.Select(l => new RawLogLine(DateTime.UtcNow, l)).ToArray()) { }
 
         public ScriptedStream(params RawLogLine[] lines)
         {
-            if (lines.Length == 0)
-            {
-                // No initial lines — leave _drained signalled so callers can use Push.
-                _drained.TrySetResult();
-                return;
-            }
-            Interlocked.Add(ref _pending, lines.Length);
-            foreach (var line in lines) _channel.Writer.TryWrite(line);
+            foreach (var line in lines)
+                Driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(line));
         }
 
-        public void Push(string line)
-        {
-            // Reset drain latch for the next batch so callers can wait on the
-            // newly pushed line(s) without a stale completion firing.
-            Interlocked.Increment(ref _pending);
-            Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(DateTime.UtcNow, line));
-        }
+        public void Push(string line) =>
+            Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(new RawLogLine(DateTime.UtcNow, line)));
 
-        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
-        public Task WaitForDrainAsync(TimeSpan timeout) => _drained.Task.WaitAsync(timeout);
+        public void Push(RawLogLine line) =>
+            Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(line));
 
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
-            {
-                while (_channel.Reader.TryRead(out var line))
-                {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0)
-                        _drained.TrySetResult();
-                }
-            }
-        }
+        public Task WaitForDrainAsync(CancellationToken ct) =>
+            Driver.DrainLocalPlayerAsync().WaitAsync(ct);
+        public Task WaitForDrainAsync(TimeSpan timeout) =>
+            Driver.DrainLocalPlayerAsync(timeout);
 
-        private static TaskCompletionSource NewDrainTcs() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public void Dispose() => Driver.Dispose();
     }
 }

--- a/tests/Samwise.Tests/StackChangedResilienceTest.cs
+++ b/tests/Samwise.Tests/StackChangedResilienceTest.cs
@@ -53,14 +53,14 @@ public class StackChangedResilienceTest
         });
 
         // 1) ProcessAddItem — fires Added, creates the entry.
-        stream.Push(new RawLogLine(new DateTime(2026, 4, 15, 20, 48, 30, DateTimeKind.Utc),
-            "[20:48:30] LocalPlayer: ProcessAddItem(BarleySeeds(86940428), -1, False)"));
+        stream.Push("[20:48:30] LocalPlayer: ProcessAddItem(BarleySeeds(86940428), -1, False)",
+            new DateTime(2026, 4, 15, 20, 48, 30, DateTimeKind.Utc));
         await stream.WaitForDrainAsync(cts.Token);
 
         // 2) ProcessUpdateItemCode — fires StackChanged on the existing entry.
         //    Pre-fix this triggered InvalidOperationException in OnInventoryEvent.
-        stream.Push(new RawLogLine(new DateTime(2026, 4, 15, 20, 50, 22, DateTimeKind.Utc),
-            "[20:50:22] LocalPlayer: ProcessUpdateItemCode(86940428, 796683, True)"));
+        stream.Push("[20:50:22] LocalPlayer: ProcessUpdateItemCode(86940428, 796683, True)",
+            new DateTime(2026, 4, 15, 20, 50, 22, DateTimeKind.Utc));
         await stream.WaitForDrainAsync(cts.Token);
 
         observed.Should().BeNull(
@@ -73,35 +73,98 @@ public class StackChangedResilienceTest
         _ = runTask;
     }
 
-    private sealed class ScriptedStream : IPlayerLogStream
+    /// <summary>
+    /// Minimal <see cref="ILogStreamDriver"/> fake for Samwise tests after the
+    /// L1 migration (#565): only the <see cref="LocalPlayerLogLine"/> pipe is
+    /// exercised here (no chat). Strips the standard
+    /// <c>[HH:MM:SS] LocalPlayer: </c> envelope from pushed Player.log shapes
+    /// so the test reads like the pre-L1 raw-line stream did.
+    /// </summary>
+    private sealed class ScriptedStream : ILogStreamDriver
     {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private const int TsPrefixLen = 11;             // length of "[HH:MM:SS] "
+        private const string ActorToken = "LocalPlayer: ";
+
+        private readonly Channel<LocalPlayerLogLine> _channel =
+            Channel.CreateUnbounded<LocalPlayerLogLine>();
         private long _pending;
         private TaskCompletionSource _drained = NewDrainTcs();
 
-        public void Push(RawLogLine line)
+        public ILogSubscription Subscribe<T>(
+            Func<LogEnvelope<T>, ValueTask> handler,
+            LogSubscriptionOptions? options = null) where T : class
+        {
+            if (typeof(T) == typeof(LocalPlayerLogLine))
+            {
+                var typed = (Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>)(object)handler;
+                var cts = new CancellationTokenSource();
+                _ = Task.Run(() => PumpAsync(typed, cts.Token));
+                // Fire-and-forget cancel on dispose. Any in-flight handler invocation
+                // unwinds on its own thread; tests don't need to wait for it.
+                return new Sub(() => { try { cts.Cancel(); } catch { } });
+            }
+            // Chat / other pipes: accept-and-ignore so InventoryService's second
+            // Subscribe<RawLogLine> call doesn't blow up. Samwise tests don't
+            // exercise the chat path.
+            return new Sub(() => { });
+        }
+
+        public void Push(string line, DateTime? timestamp = null)
         {
             Interlocked.Increment(ref _pending);
             Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(line);
+            _channel.Writer.TryWrite(new LocalPlayerLogLine(
+                new DateTimeOffset(timestamp ?? DateTime.UtcNow, TimeSpan.Zero),
+                StripEnvelope(line), 0, 0));
         }
 
         public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
 
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        private async Task PumpAsync(
+            Func<LogEnvelope<LocalPlayerLogLine>, ValueTask> handler, CancellationToken ct)
         {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            try
             {
-                while (_channel.Reader.TryRead(out var line))
+                while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
                 {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0) _drained.TrySetResult();
+                    while (_channel.Reader.TryRead(out var line))
+                    {
+                        try { await handler(new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: false)).ConfigureAwait(false); }
+                        catch { /* mirror driver containment */ }
+                        finally
+                        {
+                            if (Interlocked.Decrement(ref _pending) == 0) _drained.TrySetResult();
+                        }
+                    }
                 }
             }
+            catch (OperationCanceledException) { /* expected on dispose */ }
+        }
+
+        private static string StripEnvelope(string line)
+        {
+            var idx = 0;
+            if (line.Length > TsPrefixLen
+                && line[0] == '[' && line[3] == ':' && line[6] == ':' && line[9] == ']')
+                idx = TsPrefixLen;
+            if (idx + ActorToken.Length <= line.Length
+                && line.IndexOf(ActorToken, idx, StringComparison.Ordinal) == idx)
+                idx += ActorToken.Length;
+            return idx == 0 ? line : line.Substring(idx);
         }
 
         private static TaskCompletionSource NewDrainTcs() =>
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private sealed class Sub : ILogSubscription
+        {
+            private readonly Action _onDispose;
+            public Sub(Action onDispose) { _onDispose = onDispose; }
+            public string Id => "samwise#scripted";
+            public LogSubscriptionDiagnostics Diagnostics =>
+                new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+            public event EventHandler? StateChanged { add { } remove { } }
+            public void Dispose() => _onDispose();
+        }
     }
 }

--- a/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
+++ b/tests/Samwise.Tests/TwoBarleyRegressionTest.cs
@@ -122,7 +122,7 @@ public class TwoBarleyRegressionTest
         ac.SetActiveCharacter("Hits", "");
         var sm = new GardenStateMachine(cfg, referenceData: new BarleyOnlyReferenceData(), activeChar: ac);
 
-        // Drive the real InventoryService against a scripted log stream.
+        // Drive the real InventoryService against a scripted L1 driver.
         var stream = new ScriptedStream();
         var inv = new InventoryService(stream);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -131,8 +131,8 @@ public class TwoBarleyRegressionTest
         // Push the seed AddItem BEFORE Samwise subscribes — simulating the gate
         // race where InventoryService is up but GardenIngestionService is still
         // doing LoadAllAsync.
-        stream.Push(new RawLogLine(new DateTime(2026, 4, 15, 20, 48, 30, DateTimeKind.Utc),
-            "[20:48:30] LocalPlayer: ProcessAddItem(BarleySeeds(86940428), -1, False)"));
+        stream.Push("[20:48:30] LocalPlayer: ProcessAddItem(BarleySeeds(86940428), -1, False)",
+            new DateTime(2026, 4, 15, 20, 48, 30, DateTimeKind.Utc));
         await stream.WaitForDrainAsync(cts.Token);
 
         // Now subscribe — replay must deliver the seed AddItem retroactively.
@@ -162,36 +162,98 @@ public class TwoBarleyRegressionTest
         _ = runTask;
     }
 
-    private sealed class ScriptedStream : IPlayerLogStream
+    /// <summary>
+    /// Minimal <see cref="ILogStreamDriver"/> fake for Samwise tests after the
+    /// L1 migration (#565): only the <see cref="LocalPlayerLogLine"/> pipe is
+    /// exercised here (no chat). Strips the standard
+    /// <c>[HH:MM:SS] LocalPlayer: </c> envelope from pushed Player.log shapes
+    /// so the test reads like the pre-L1 raw-line stream did.
+    /// </summary>
+    private sealed class ScriptedStream : ILogStreamDriver
     {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
+        private const int TsPrefixLen = 11;             // length of "[HH:MM:SS] "
+        private const string ActorToken = "LocalPlayer: ";
+
+        private readonly Channel<LocalPlayerLogLine> _channel =
+            Channel.CreateUnbounded<LocalPlayerLogLine>();
         private long _pending;
         private TaskCompletionSource _drained = NewDrainTcs();
 
-        public void Push(RawLogLine line)
+        public ILogSubscription Subscribe<T>(
+            Func<LogEnvelope<T>, ValueTask> handler,
+            LogSubscriptionOptions? options = null) where T : class
+        {
+            if (typeof(T) == typeof(LocalPlayerLogLine))
+            {
+                var typed = (Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>)(object)handler;
+                var cts = new CancellationTokenSource();
+                _ = Task.Run(() => PumpAsync(typed, cts.Token));
+                // Fire-and-forget cancel on dispose. Any in-flight handler invocation
+                // unwinds on its own thread; tests don't need to wait for it.
+                return new Sub(() => { try { cts.Cancel(); } catch { } });
+            }
+            // Chat / other pipes: accept-and-ignore so InventoryService's second
+            // Subscribe<RawLogLine> call doesn't blow up.
+            return new Sub(() => { });
+        }
+
+        public void Push(string line, DateTime? timestamp = null)
         {
             Interlocked.Increment(ref _pending);
             Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(line);
+            _channel.Writer.TryWrite(new LocalPlayerLogLine(
+                new DateTimeOffset(timestamp ?? DateTime.UtcNow, TimeSpan.Zero),
+                StripEnvelope(line), 0, 0));
         }
 
         public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
 
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        private async Task PumpAsync(
+            Func<LogEnvelope<LocalPlayerLogLine>, ValueTask> handler, CancellationToken ct)
         {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            try
             {
-                while (_channel.Reader.TryRead(out var line))
+                while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
                 {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0) _drained.TrySetResult();
+                    while (_channel.Reader.TryRead(out var line))
+                    {
+                        try { await handler(new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: false)).ConfigureAwait(false); }
+                        catch { /* mirror driver containment */ }
+                        finally
+                        {
+                            if (Interlocked.Decrement(ref _pending) == 0) _drained.TrySetResult();
+                        }
+                    }
                 }
             }
+            catch (OperationCanceledException) { /* expected on dispose */ }
+        }
+
+        private static string StripEnvelope(string line)
+        {
+            var idx = 0;
+            if (line.Length > TsPrefixLen
+                && line[0] == '[' && line[3] == ':' && line[6] == ':' && line[9] == ']')
+                idx = TsPrefixLen;
+            if (idx + ActorToken.Length <= line.Length
+                && line.IndexOf(ActorToken, idx, StringComparison.Ordinal) == idx)
+                idx += ActorToken.Length;
+            return idx == 0 ? line : line.Substring(idx);
         }
 
         private static TaskCompletionSource NewDrainTcs() =>
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private sealed class Sub : ILogSubscription
+        {
+            private readonly Action _onDispose;
+            public Sub(Action onDispose) { _onDispose = onDispose; }
+            public string Id => "samwise#scripted";
+            public LogSubscriptionDiagnostics Diagnostics =>
+                new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+            public event EventHandler? StateChanged { add { } remove { } }
+            public void Dispose() => _onDispose();
+        }
     }
 
     private sealed class BarleyOnlyReferenceData : IReferenceDataService


### PR DESCRIPTION
## Summary

- Closes #565. Migrates `InventoryService` from `IPlayerLogStream` + `IChatLogStream` directly to the L1 `ILogStreamDriver`: `Subscribe<LocalPlayerLogLine>` for Player.log verbs, `Subscribe<RawLogLine>` for chat `[Status]` lines.
- The Tier-1 `PendingCorrelator<string,_>` stays as-is. Chat + Player.log have no shared total order (separate files, separate timestamp domains), so the 5-second TTL correlator is the right ordering primitive — not the L1 multi-pipe shape that #556 still has to design for Position / Pin / Weather. What L1 buys this consumer is **containment + drop accounting + fault-SM**, not ordering.
- DI is unchanged. `AddSingleton<InventoryService>()` resolves the new ctor signature against the already-registered driver.

## What changed

**`src/Mithril.GameState/Inventory/InventoryService.cs`**
- Ctor drops `IPlayerLogStream` + `IChatLogStream`; takes `ILogStreamDriver`.
- `ExecuteAsync` issues two independent `Subscribe<T>` calls with `DiagnosticCategory = "GameState.Inventory"`, then `await Task.Delay(Timeout.Infinite, stoppingToken)` per the archetype-A template (mirrors `PlayerSkillStateService`).
- `OnLocalPlayer` matches the four regexes against `envelope.Payload.Data` (envelope already eaten by L0.5).
- `OnChat` keeps `InventoryStatusChatParser` semantics unchanged.
- Diag-bucket renamed `"Inventory"` → `"GameState.Inventory"` to match the L1 category convention.

**Tests**
- `tests/Mithril.GameState.Tests/InventoryServiceTests.cs` and `tests/Mithril.GameState.Tests/Inventory/InventoryServiceStackSizeTests.cs`: swap the bespoke `ScriptedStream` / `ScriptedPlayerStream` (which implemented `IPlayerLogStream`) for `TestLogStreamDriver` + `TestLogEnvelopeFactory.FromRawLine(…)` — the same helpers the other archetype-A migrations standardised on. The dual-pipe chat tests use a single driver with `PushChat` + `WaitForChatDrainAsync`.
- `tests/Samwise.Tests/StackChangedResilienceTest.cs` and `tests/Samwise.Tests/TwoBarleyRegressionTest.cs`: inline a minimal LocalPlayer-only `ILogStreamDriver` fake — these live outside `Mithril.GameState.Tests` so can't reach the shared `TestLogStreamDriver` directly, and they only exercise Player.log (no chat).

## What's explicitly NOT in this change

- **No new L1 primitive.** Inventory doesn't need cross-pipe ordering — that's #556's problem to solve for Position / Pin / Weather.
- **No `IsReplay` plumbing.** Inventory's handlers are state-machine-identical for replay vs. live; carryover stacks are reconciled via the export-seed pass, not via replay branching.
- **No `DeliveryContext.Marshaled`.** Headless service.
- **No changes to `PendingCorrelator`, `LoadExportSeeds`, the downstream `Subscribe(Action<InventoryEvent>)` contract, or `MapEntry` / `SizeConfirmed` semantics.**

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings.
- [x] `dotnet test Mithril.slnx` — full suite green. Key projects:
  - Mithril.GameState.Tests: 290 pass (incl. all Inventory tests)
  - Samwise.Tests: 114 pass (incl. the two e2e tests that drive `InventoryService` end-to-end)
  - Arwen.Tests: 85 pass (consumer of `IInventoryService.TryResolve` for gift attribution)
  - Palantir.Tests: 29 pass (consumer of `InventoryEvent` for the live inventory view)
  - Legolas.Tests: 465 pass
  - All other projects pass.
- [x] Byte-equivalence is implicit: the existing test corpus drives the same Player.log + chat shapes and asserts the same `InventoryEvent` stream and `_map` state. No behavioural changes were made — only the upstream subscription mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
