### PR TITLE
feat(gamestate): PlayerAreaTracker self-feed (#556 Phase 2)

### DIFF
--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -4,6 +4,7 @@ using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;
 using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
 
 namespace Mithril.GameState.Areas;
 
@@ -14,6 +15,18 @@ namespace Mithril.GameState.Areas;
 /// Gandalf (chest commits stamp <c>LearnedChest.Area</c>) and Legolas
 /// (per-area survey-projection calibration), among others.
 ///
+/// <para><b>Self-feeding via the L1 driver (#556 Phase 2).</b> When an
+/// <see cref="ILogStreamDriver"/> is supplied, the tracker is a
+/// <see cref="BackgroundService"/> that subscribes to L0.5's
+/// <see cref="ISystemSignalLogStream"/> typed pipe through the L1 driver,
+/// filtered for <see cref="SystemSignalKind.AreaLoading"/>. The shared
+/// state then updates without any other GameState producer feeding it via
+/// <see cref="Observe(RawLogLine)"/>. Both feed paths update the same
+/// state idempotently: the area key is string-compared, last-writer-wins,
+/// so a double-feed during the Phase 3 migration window is safe. The
+/// <see cref="Observe(RawLogLine)"/> overload retires in Phase 3's final
+/// PR (once Pin/Weather/Position move to the unified pipe).</para>
+///
 /// <para><b>Startup seeding.</b> <see cref="PlayerLogTailReader.SeedToSessionStart"/>
 /// rewinds the live replay window to the most recent <c>ProcessAddPlayer(</c>
 /// line, which lands ~9 s <em>after</em> the <c>LOADING LEVEL</c> line for the
@@ -23,35 +36,47 @@ namespace Mithril.GameState.Areas;
 /// before the live stream starts. Local change scope; no impact on other
 /// consumers tuned against <see cref="PlayerLogStream"/>'s seed.</para>
 ///
-/// <para><b>Threading.</b> <see cref="Observe"/> is called from the log
-/// ingestion background thread; <see cref="CurrentArea"/> is read from
+/// <para><b>Threading.</b> <see cref="Observe(string,DateTime)"/> is called
+/// from the log ingestion background thread; the L1 self-feed runs on the
+/// driver's pump thread; <see cref="CurrentArea"/> is read from
 /// chest-commit paths on whichever thread routes the bracket. A simple
 /// lock suffices — the contention is low (one area transition per
 /// minute-ish, vs. dozens of reads per chest interaction).</para>
 /// </summary>
-public sealed class PlayerAreaTracker
+public sealed class PlayerAreaTracker : BackgroundService
 {
     private readonly AreaTransitionParser _parser;
     private readonly IDiagnosticsSink? _diag;
     private readonly GameConfig? _config;
+    private readonly ILogStreamDriver? _driver;
     private readonly object _lock = new();
     private readonly object _seedLock = new();
     private bool _seedAttempted;
     private string? _currentArea;
+    private ILogSubscription? _subscription;
+
+    private const string DiagCategory = "GameState.Area";
 
     /// <param name="config">Optional. When supplied, the tracker owns its own
     /// one-shot pre-login-preamble seed (lazily, on the first
     /// <see cref="CurrentArea"/> read or <see cref="Observe(string,DateTime)"/>)
     /// — consumers no longer trigger <see cref="SeedFromLog"/>. Null in tests
     /// that drive state directly.</param>
+    /// <param name="driver">Optional L1 subscription driver. When supplied,
+    /// <see cref="ExecuteAsync"/> subscribes to the L0.5 system-signal pipe
+    /// and self-feeds <see cref="SystemSignalKind.AreaLoading"/> envelopes
+    /// (#556 Phase 2). Null in tests that drive state directly via
+    /// <see cref="Observe(string,DateTime)"/>.</param>
     public PlayerAreaTracker(
         AreaTransitionParser parser,
         IDiagnosticsSink? diag = null,
-        GameConfig? config = null)
+        GameConfig? config = null,
+        ILogStreamDriver? driver = null)
     {
         _parser = parser;
         _diag = diag;
         _config = config;
+        _driver = driver;
     }
 
     /// <summary>
@@ -79,6 +104,87 @@ public sealed class PlayerAreaTracker
     }
 
     public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp.UtcDateTime);
+
+    /// <summary>
+    /// Hosted-service entry point (#556 Phase 2). When an
+    /// <see cref="ILogStreamDriver"/> is configured, subscribes to L0.5's
+    /// system-signal pipe and folds every
+    /// <see cref="SystemSignalKind.AreaLoading"/> envelope into the shared
+    /// area state. When no driver is supplied (tests that drive state
+    /// directly), this method returns immediately — the
+    /// <see cref="Observe(string,DateTime)"/> path remains the source of
+    /// truth for those scenarios.
+    ///
+    /// <para>Per-envelope failures are contained by the L1 driver (the
+    /// <c>InlineBridge</c> per-handler try/catch + degraded-state SM); the
+    /// handler body itself is intentionally tiny and unlikely to throw —
+    /// <see cref="Apply"/> swallows non-matching lines via the parser's
+    /// substring fast-path.</para>
+    /// </summary>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (_driver is null)
+        {
+            // Test path / no L1 driver — nothing to subscribe to. Park so
+            // the host's StartAsync await unblocks cleanly; the host will
+            // cancel on shutdown and this method unwinds.
+            try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            return;
+        }
+
+        _diag?.Info(DiagCategory,
+            "Subscribing to L1 driver (SystemSignal pipe) for AreaLoading self-feed");
+
+        // Lazy-seed before the live stream starts so the reverse-scan
+        // catches a LOADING LEVEL line that sits upstream of the L1
+        // replay window. Mirrors the pre-#556 CurrentArea-read self-seed,
+        // just driven once at startup.
+        EnsureSeeded();
+
+        _subscription = _driver.Subscribe<SystemSignalLogLine>(
+            envelope =>
+            {
+                var s = envelope.Payload;
+                // The unified pipe (and the typed system pipe) carries the
+                // full SystemSignalKind set; ignore everything except
+                // AreaLoading. PG only emits one transition per actual
+                // portal, so this filter is cheap.
+                if (s.Kind == SystemSignalKind.AreaLoading)
+                {
+                    // SystemSignalLogLine.Data is the "LOADING LEVEL <area>"
+                    // tail (with the [ts] prefix eaten by L0.5). The
+                    // parser's substring guard handles unrelated content
+                    // as no-op, so feeding raw Data is safe.
+                    Apply(s.Data, s.Timestamp.UtcDateTime);
+                }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        // Park until host stop; the L1 subscription runs its own pump on
+        // a Task.Run, so ExecuteAsync's only job after Subscribe is to
+        // dispose the handle on shutdown.
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+        }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
+    }
 
     private void Apply(string line, DateTime timestamp)
     {

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -47,8 +47,15 @@ public static class GameStateServiceCollectionExtensions
         // Area tracking is shared live game-state (Gandalf chest-area
         // stamping, Legolas per-area survey calibration, …). One parser,
         // one tracker, registered once here — consumers inject the tracker.
+        // Self-feeding hosted service since #556 Phase 2 — subscribes to
+        // the L0.5 SystemSignal pipe through the L1 driver and folds
+        // AreaLoading envelopes into CurrentArea. Pin/Weather/Position
+        // still call Observe(raw) until Phase 3 retires that surface;
+        // the double-feed is idempotent under last-writer-wins.
         services.AddSingleton<AreaTransitionParser>();
-        services.AddSingleton<PlayerAreaTracker>();
+        services
+            .AddSingleton<PlayerAreaTracker>()
+            .AddHostedService(sp => sp.GetRequiredService<PlayerAreaTracker>());
 
         // Shared live skill state from Player.log (ProcessLoadSkills /
         // ProcessUpdateSkill) — no character re-export required. Single parser,

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
@@ -5,6 +5,7 @@ using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Areas;
@@ -236,5 +237,143 @@ public sealed class PlayerAreaTrackerTests : IDisposable
         // parser's "^" anchor. Use BOM-less UTF-8 to mirror live shape.
         File.WriteAllText(path, string.Join('\n', lines) + "\n", new UTF8Encoding(false));
         return path;
+    }
+
+    // ---- #556 Phase 2: L1 self-feed via SystemSignal pipe -----------------
+
+    private static SystemSignalLogLine MakeAreaLoading(string area, long seq) =>
+        new(
+            Timestamp: DateTimeOffset.UtcNow,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: $"LOADING LEVEL {area}",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    private static SystemSignalLogLine MakeSignal(SystemSignalKind kind, string data, long seq) =>
+        new(
+            Timestamp: DateTimeOffset.UtcNow,
+            Kind: kind,
+            Data: data,
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    [Fact]
+    public async Task L1_self_feed_updates_CurrentArea_from_AreaLoading_envelopes()
+    {
+        // Phase 2 — AreaTracker subscribes via the L1 driver to the typed
+        // SystemSignal pipe and folds AreaLoading envelopes into CurrentArea.
+        // No other producer needs to call Observe(raw) for this state to
+        // stay live.
+        using var driver = new Mithril.GameState.Tests.TestSupport.TestLogStreamDriver();
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", seq: 1));
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), driver: driver);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await tracker.StartAsync(cts.Token);
+        try
+        {
+            await driver.DrainSystemAsync();
+            tracker.CurrentArea.Should().Be("AreaSerbule");
+
+            driver.PushLive(MakeAreaLoading("AreaEltibule", seq: 2));
+            await driver.DrainSystemAsync();
+            tracker.CurrentArea.Should().Be("AreaEltibule");
+        }
+        finally
+        {
+            await tracker.StopAsync(CancellationToken.None);
+            tracker.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task L1_self_feed_ignores_non_AreaLoading_kinds()
+    {
+        // The handler filters for Kind == AreaLoading; other SystemSignal
+        // kinds (LoginBanner, PlayerAdded, SessionLifecycle) must not
+        // overwrite CurrentArea even when the typed pipe carries them.
+        using var driver = new Mithril.GameState.Tests.TestSupport.TestLogStreamDriver();
+        driver.PushReplay(MakeAreaLoading("AreaSerbule", seq: 1));
+        driver.PushReplay(MakeSignal(SystemSignalKind.LoginBanner,
+            "Logged in as character X. Time UTC=...", seq: 2));
+        driver.PushReplay(MakeSignal(SystemSignalKind.PlayerAdded,
+            "ProcessAddPlayer(...)", seq: 3));
+        driver.PushReplay(MakeSignal(SystemSignalKind.SessionLifecycle,
+            "loginCharacter", seq: 4));
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), driver: driver);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await tracker.StartAsync(cts.Token);
+        try
+        {
+            await driver.DrainSystemAsync();
+            tracker.CurrentArea.Should().Be("AreaSerbule");
+        }
+        finally
+        {
+            await tracker.StopAsync(CancellationToken.None);
+            tracker.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task L1_self_feed_and_Observe_double_feed_is_idempotent()
+    {
+        // Load-bearing Phase 2 safety: during the Phase 3 migration window
+        // both feed paths are live (L1 self-feed AND Pin/Weather/Position
+        // calling Observe(raw)). The double-feed must be idempotent under
+        // string-equality / last-writer-wins on the area key.
+        using var driver = new Mithril.GameState.Tests.TestSupport.TestLogStreamDriver();
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser(), driver: driver);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await tracker.StartAsync(cts.Token);
+        try
+        {
+            // Both paths see the same transition.
+            driver.PushLive(MakeAreaLoading("AreaSerbule", seq: 1));
+            await driver.DrainSystemAsync();
+            tracker.Observe(new RawLogLine(
+                Timestamp: DateTimeOffset.UtcNow,
+                Line: "[10:00:00] LOADING LEVEL AreaSerbule",
+                Sequence: 1,
+                ReadMonotonicTicks: 0));
+            tracker.CurrentArea.Should().Be("AreaSerbule");
+
+            // Race on the next transition: Observe lands first, then L1.
+            tracker.Observe(new RawLogLine(
+                Timestamp: DateTimeOffset.UtcNow,
+                Line: "[10:01:00] LOADING LEVEL AreaEltibule",
+                Sequence: 2,
+                ReadMonotonicTicks: 0));
+            tracker.CurrentArea.Should().Be("AreaEltibule");
+
+            driver.PushLive(MakeAreaLoading("AreaEltibule", seq: 2));
+            await driver.DrainSystemAsync();
+            // Same area key — last-writer-wins is a no-op.
+            tracker.CurrentArea.Should().Be("AreaEltibule");
+        }
+        finally
+        {
+            await tracker.StopAsync(CancellationToken.None);
+            tracker.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_with_null_driver_parks_cleanly()
+    {
+        // Test-path constructors omit the driver. ExecuteAsync must still
+        // start and stop cleanly without throwing.
+        var tracker = new PlayerAreaTracker(new AreaTransitionParser());
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        await tracker.StartAsync(cts.Token);
+        // Observe path still works while parked.
+        tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
+        tracker.CurrentArea.Should().Be("AreaSerbule");
+
+        await tracker.StopAsync(CancellationToken.None);
+        tracker.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the [#556 plan](https://github.com/moumantai-gg/mithril/issues/556#issuecomment-4500796409): `PlayerAreaTracker` becomes a `BackgroundService` that subscribes through the L1 driver to the L0.5 `SystemSignal` pipe (filtered for `Kind == AreaLoading`) and folds each envelope into the shared `CurrentArea` state.

The existing `Observe(RawLogLine)` and `Observe(string, DateTime)` surfaces stay intact — Pin/Weather/Position still call `Observe(raw)` until Phase 3 retires that path. Both feed paths update the same state idempotently (string-equality on the area key, last-writer-wins), so the double-feed window is safe by design. A dedicated regression test pins the idempotence.

- `ILogStreamDriver` is an OPTIONAL ctor param so the dozens of unit tests that construct the tracker directly with `new(parser)` are unaffected. `ExecuteAsync` no-ops cleanly when the driver is null (test path), parking on the stop token until shutdown.
- DI in `AddMithrilGameState` now registers the tracker as a hosted service so the host wires `StartAsync` at boot.
- Diagnostic category remains `GameState.Area`.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — all 4500+ tests pass
- [x] `L1_self_feed_updates_CurrentArea_from_AreaLoading_envelopes` — the happy path; replay + live envelopes both advance state
- [x] `L1_self_feed_ignores_non_AreaLoading_kinds` — verifies the handler's `Kind == AreaLoading` filter; LoginBanner/PlayerAdded/SessionLifecycle don't clobber state
- [x] `L1_self_feed_and_Observe_double_feed_is_idempotent` — the load-bearing Phase 2 safety property; both feeds converge on the same key
- [x] `ExecuteAsync_with_null_driver_parks_cleanly` — pins the test-path no-driver branch

Builds on #567 (Phase 1). Next: Phase 3 (Pin, Weather, Position → unified pipe, three PRs).

Refs #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
