### PR TITLE
feat(gamestate): Pin/Weather/Position → unified pipe (#556 Phase 3)

### DIFF
--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -103,8 +103,6 @@ public sealed class PlayerAreaTracker : BackgroundService
         Apply(line, timestamp);
     }
 
-    public void Observe(RawLogLine raw) => Observe(raw.Line, raw.Timestamp.UtcDateTime);
-
     /// <summary>
     /// Hosted-service entry point (#556 Phase 2). When an
     /// <see cref="ILogStreamDriver"/> is configured, subscribes to L0.5's

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -80,8 +80,10 @@ public static class GameStateServiceCollectionExtensions
 
         // Player position is shared live game-state (Palantir debug surface,
         // future overlay/positioning consumers). Self-feeding hosted service —
-        // also warms PlayerAreaTracker so the area is known without Legolas /
-        // Gandalf being active (idempotent when they are).
+        // since #556 Phase 3 subscribes via the L1 driver's unified
+        // classified pipe (LocalPlayer ProcessNewPosition + SystemSignal
+        // PlayerAdded). PlayerAreaTracker self-feeds independently
+        // (#556 Phase 2), so no warming dependency from here.
         services.AddSingleton<PlayerPositionParser>();
         services
             .AddSingleton<PlayerPositionTracker>()
@@ -93,7 +95,9 @@ public static class GameStateServiceCollectionExtensions
         // verb, so the service owns the full lifecycle (replay = idempotent
         // upsert, area change = swap) — Legolas's calibration consumes the
         // area-scoped set instead of hand-rolling a replay-arming gate.
-        // Self-feeding; also warms PlayerAreaTracker (idempotent).
+        // Subscribes via the L1 driver's unified classified pipe so the
+        // AreaLoading envelope always precedes the pin-burst for that area
+        // (#556 Phase 3).
         services.AddSingleton<MapPinParser>();
         services
             .AddSingleton<PlayerPinTracker>()

--- a/src/Mithril.GameState/Movement/PlayerPositionParser.cs
+++ b/src/Mithril.GameState/Movement/PlayerPositionParser.cs
@@ -89,6 +89,35 @@ public sealed partial class PlayerPositionParser : ILogParser
         return null;
     }
 
+    /// <summary>
+    /// Parses the spawn position from the L0.5-classified
+    /// <see cref="SystemSignalLogLine"/> payload data — i.e. the
+    /// <c>ProcessAddPlayer(…)</c> body with the <c>[ts] LocalPlayer: </c>
+    /// envelope already eaten by L0.5 (#532). Skips the actor-token gate
+    /// that <see cref="TryParse"/> uses, because L0.5's classifier
+    /// (PlayerLogLineClassifier) already routes only <c>LocalPlayer: ProcessAddPlayer</c>
+    /// to <see cref="SystemSignalKind.PlayerAdded"/> — the actor is
+    /// guaranteed upstream, so re-checking here would be a redundant gate.
+    ///
+    /// <para>Used by the post-#556 unified-pipe migration of
+    /// <see cref="PlayerPositionTracker"/>: when the tracker pattern-matches
+    /// <c>SystemSignalLogLine { Kind: PlayerAdded }</c>, it feeds the
+    /// envelope's <see cref="SystemSignalLogLine.Data"/> here to recover
+    /// the spawn seed. <see cref="TryParse"/> remains the entry point for
+    /// pre-L0.5 raw lines (full-line callers and the
+    /// <see cref="ILogParser"/> interface contract).</para>
+    /// </summary>
+    public PlayerPositionEvent? TryParseSpawnFromData(string data, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(data)) return null;
+        if (!data.Contains("ProcessAddPlayer", StringComparison.Ordinal)) return null;
+        if (AddPlayerPosRx().Match(data) is not { Success: true } m) return null;
+        if (!TryNum(m.Groups["x"].ValueSpan, out var x)) return null;
+        if (!TryNum(m.Groups["y"].ValueSpan, out var y)) return null;
+        if (!TryNum(m.Groups["z"].ValueSpan, out var z)) return null;
+        return new PlayerPositionEvent(timestamp, x, y, z, PlayerPositionSource.Spawn);
+    }
+
     private static bool TryNum(ReadOnlySpan<char> s, out double v) =>
         double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
 }

--- a/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
+++ b/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
@@ -1,4 +1,3 @@
-using Mithril.GameState.Areas;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Microsoft.Extensions.Hosting;
@@ -7,9 +6,11 @@ namespace Mithril.GameState.Movement;
 
 /// <summary>
 /// Hosted-service implementation of <see cref="IPlayerPositionTracker"/>.
-/// Tails <see cref="IPlayerLogStream"/>, parses <c>ProcessNewPosition</c> and
-/// the local player's <c>ProcessAddPlayer</c> via
-/// <see cref="PlayerPositionParser"/>, and holds the latest
+/// Subscribes to L1's unified classified pipe (#556 Phase 3), parses
+/// <c>ProcessNewPosition</c> on the <see cref="LocalPlayerLogLine"/>
+/// payload and the local player's <c>ProcessAddPlayer</c> on the
+/// <see cref="SystemSignalLogLine"/> { <see cref="SystemSignalKind.PlayerAdded"/> }
+/// payload via <see cref="PlayerPositionParser"/>, and holds the latest
 /// <see cref="PlayerPosition"/> (coords + the line's UTC instant + source).
 /// The <c>ProcessAddPlayer</c> spawn line is the live-replay seed point, so
 /// position is populated at session start rather than null until the first
@@ -19,44 +20,50 @@ namespace Mithril.GameState.Movement;
 /// <see cref="Sessions.GameSessionService"/> / <c>QuestService</c>: the
 /// position is shared live game-state and must be available to consumers
 /// (e.g. Palantir's debug surface) without depending on any other module
-/// being activated. Unlike the passive <see cref="PlayerAreaTracker"/>
-/// (which is fed by Legolas/Gandalf consumers), this owns its own
-/// subscription.</para>
+/// being activated.</para>
 ///
-/// <para><b>Also warms the shared area tracker.</b> The <c>LOADING LEVEL</c>
-/// area line lives in the same Player.log, so this loop also feeds the
-/// shared <see cref="PlayerAreaTracker"/> (and reverse-scan-seeds it at
-/// startup, since the live replay window opens <em>after</em> the current
-/// area's <c>LOADING LEVEL</c> line). Double-observing the tracker is
-/// idempotent — Legolas/Gandalf may also feed it when active; last-writer
-/// wins on the same key. This makes the area half of Palantir's
-/// map+position view populate standalone.</para>
+/// <para><b>Why the unified pipe and not the LocalPlayer typed pipe.</b>
+/// L0.5 routes <c>LocalPlayer: ProcessAddPlayer(…)</c> to the
+/// <see cref="ISystemSignalLogStream"/> { <see cref="SystemSignalKind.PlayerAdded"/> }
+/// pipe — distinct from the LocalPlayer typed pipe — even though the
+/// originating actor envelope says <c>LocalPlayer:</c>. Subscribing through
+/// the L0.5 unified pipe is the simplest way to see both verb classes in
+/// source-Sequence order through a single subscription, eliminating the
+/// cross-pipe two-pump race documented in #556.</para>
 ///
-/// <para><b>Threading.</b> Ingestion runs on the hosted-service loop thread;
-/// <see cref="Current"/> reads and subscriber dispatch happen under
-/// <c>_lock</c>. Subscribers doing non-trivial work should marshal off-thread
-/// immediately (the Palantir VM dispatches to the UI thread).</para>
+/// <para><b>No area-tracker dependency.</b> The
+/// <see cref="Areas.PlayerAreaTracker"/> self-feeds via L1 since Phase 2
+/// (#556 / PR #568); this tracker no longer warms it. Combat envelopes
+/// silently no-op on the unified pipe (no <c>switch</c> case matches them
+/// — by design; a future <c>default</c> warning would flood the diag log
+/// under heavy combat).</para>
+///
+/// <para><b>Threading.</b> The L1 driver's <c>InlineBridge</c> invokes the
+/// handler on its pump thread; <see cref="Current"/> reads and subscriber
+/// dispatch happen under <c>_lock</c>. Subscribers doing non-trivial work
+/// should marshal off-thread immediately (the Palantir VM dispatches to
+/// the UI thread).</para>
 /// </summary>
 public sealed class PlayerPositionTracker : BackgroundService, IPlayerPositionTracker
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ILogStreamDriver _driver;
     private readonly PlayerPositionParser _parser;
-    private readonly PlayerAreaTracker _areaTracker;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly object _lock = new();
     private readonly List<Action<PlayerPosition>> _handlers = [];
     private PlayerPosition? _current;
+    private ILogSubscription? _subscription;
+
+    private const string DiagCategory = "GameState.Position";
 
     public PlayerPositionTracker(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         PlayerPositionParser parser,
-        PlayerAreaTracker areaTracker,
         IDiagnosticsSink? diag = null)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
-        _areaTracker = areaTracker;
         _diag = diag;
     }
 
@@ -81,25 +88,76 @@ public sealed class PlayerPositionTracker : BackgroundService, IPlayerPositionTr
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Area is seeded by the shared PlayerAreaTracker itself (one-shot,
-        // owned — mithril#514); this service only feeds/reads it.
-        _diag?.Info("GameState.Position", "Subscribing to Player.log for ProcessNewPosition");
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
-            {
-                // Same line stream carries area transitions; keep the shared
-                // tracker warm even when no other module is feeding it.
-                _areaTracker.Observe(raw);
+        _diag?.Info(DiagCategory,
+            "Subscribing to L1 driver (unified classified pipe) for ProcessNewPosition + ProcessAddPlayer");
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is PlayerPositionEvent evt)
-                    Publish(new PlayerPosition(evt.X, evt.Y, evt.Z, ToOffset(evt.Timestamp), evt.Source));
-            }
-            catch (Exception ex)
+        _subscription = _driver.Subscribe<IClassifiedPlayerLogLine>(
+            envelope =>
             {
-                _diag?.Warn("GameState.Position", $"Ingestion error: {ex.Message}");
-            }
+                // Risk 4 (#556 brainstorm): L0.5 routes ProcessAddPlayer to
+                // SystemSignal { Kind: PlayerAdded } — NOT to the LocalPlayer
+                // pipe — even though the actor envelope says LocalPlayer.
+                // ProcessNewPosition lives on the LocalPlayer pipe. So the
+                // tracker must accept both payload classes off the unified
+                // pipe to recover the full pre-#556 behaviour.
+                switch (envelope.Payload)
+                {
+                    case LocalPlayerLogLine l:
+                        // Bare verb (envelope eaten) — the parser's
+                        // ProcessNewPosition regex doesn't anchor on the
+                        // actor token, so this works on Data directly.
+                        if (_parser.TryParse(l.Data, l.Timestamp.UtcDateTime)
+                            is PlayerPositionEvent posEvt)
+                        {
+                            Publish(new PlayerPosition(
+                                posEvt.X, posEvt.Y, posEvt.Z,
+                                ToOffset(posEvt.Timestamp), posEvt.Source));
+                        }
+                        break;
+
+                    case SystemSignalLogLine { Kind: SystemSignalKind.PlayerAdded } s:
+                        // Spawn seed. The parser's TryParseSpawnFromData
+                        // skips the actor-token gate (L0.5 already enforced
+                        // it before routing this envelope).
+                        if (_parser.TryParseSpawnFromData(s.Data, s.Timestamp.UtcDateTime)
+                            is PlayerPositionEvent spawnEvt)
+                        {
+                            Publish(new PlayerPosition(
+                                spawnEvt.X, spawnEvt.Y, spawnEvt.Z,
+                                ToOffset(spawnEvt.Timestamp), spawnEvt.Source));
+                        }
+                        break;
+
+                    // CombatActorLogLine / other SystemSignal kinds silently
+                    // no-op. The unified pipe carries everything in source
+                    // order; we only care about our two verbs. A default
+                    // warning here would flood the diag log under heavy
+                    // combat or session-banner traffic.
+                }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        // Park until host stop; the L1 subscription runs its own pump.
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
         }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
     }
 
     private void Publish(PlayerPosition position)

--- a/src/Mithril.GameState/Pins/PlayerPinTracker.cs
+++ b/src/Mithril.GameState/Pins/PlayerPinTracker.cs
@@ -1,4 +1,4 @@
-using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Microsoft.Extensions.Hosting;
@@ -6,10 +6,11 @@ using Microsoft.Extensions.Hosting;
 namespace Mithril.GameState.Pins;
 
 /// <summary>
-/// Hosted-service implementation of <see cref="IPlayerPinTracker"/>. Tails
-/// <see cref="IPlayerLogStream"/>, parses <c>ProcessMapPin{Add,Remove}</c> via
-/// <see cref="MapPinParser"/>, and folds the stream into the current area's
-/// pin set (#468).
+/// Hosted-service implementation of <see cref="IPlayerPinTracker"/>.
+/// Subscribes to L1's unified classified pipe (#556 Phase 3), parses
+/// <c>ProcessMapPin{Add,Remove}</c> on the <see cref="LocalPlayerLogLine"/>
+/// payload via <see cref="MapPinParser"/>, and folds the stream into the
+/// current area's pin set (#468).
 ///
 /// <para><b>Lifecycle the service owns</b> (so no consumer hand-rolls it):</para>
 /// <list type="bullet">
@@ -21,32 +22,34 @@ namespace Mithril.GameState.Pins;
 ///   <item><b>No edit/move verb.</b> A rename/move is <c>Remove</c>+<c>Add</c>;
 ///   it surfaces as a <see cref="PinSetChange.Removed"/> then
 ///   <see cref="PinSetChange.Added"/>, which is faithful to the log.</item>
-///   <item><b>Area transition = swap.</b> Pins are area-local; on any
-///   <c>PlayerAreaTracker.CurrentArea</c> change the set is dropped and a
-///   <see cref="PinSetChange.AreaChanged"/> (empty set) is raised. The
-///   subsequent replay burst repopulates it for the new area.</item>
+///   <item><b>Area transition = swap.</b> Pins are area-local; the tracker
+///   parses <see cref="SystemSignalKind.AreaLoading"/> envelopes off the
+///   unified pipe and clears the set on any change, raising a
+///   <see cref="PinSetChange.AreaChanged"/> (empty set). The subsequent
+///   replay burst repopulates it for the new area.</item>
 /// </list>
 ///
-/// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
-/// <see cref="Movement.PlayerPositionTracker"/> — shared live game-state must
-/// be available without any module being activated. It also calls
-/// <see cref="PlayerAreaTracker.Observe(RawLogLine)"/> to keep the shared area
-/// tracker warm (idempotent when the position tracker / Legolas also feed it).
-/// No area reverse-scan seed is needed: the pin replay burst lands inside the
-/// live window (after the login <c>ProcessAddPlayer</c> the window is seeded
-/// to), so the set self-populates.</para>
+/// <para><b>Why the unified pipe.</b> Pre-#556 this tracker read
+/// <c>PlayerAreaTracker.CurrentArea</c> for the area-reconcile and tailed
+/// the raw Player.log for pin events — a two-pump arrangement that risked
+/// reading a stale area at the moment a pin-burst arrived. Subscribing to
+/// the L0.5 unified classified pipe gives one ordered stream of
+/// <c>AreaLoading</c> and <c>LocalPlayer</c> envelopes through a single
+/// subscription, so the area reconcile always precedes the pins for that
+/// area. Combat envelopes silently no-op.</para>
 ///
-/// <para><b>Threading.</b> Ingestion runs on the hosted-service loop thread;
-/// <see cref="CurrentArea"/>/<see cref="CurrentAreaPins"/> reads, state
-/// mutation and subscriber dispatch are serialised under <c>_lock</c>; each
-/// notification carries an immutable snapshot, so handlers may hold it. They
-/// run on the ingestion thread — non-trivial / UI work must marshal off.</para>
+/// <para><b>Threading.</b> The L1 driver's <c>InlineBridge</c> invokes the
+/// handler on its pump thread; <see cref="CurrentArea"/>/<see cref="CurrentAreaPins"/>
+/// reads, state mutation, and subscriber dispatch are serialised under
+/// <c>_lock</c>; each notification carries an immutable snapshot, so
+/// handlers may hold it. They run on the L1 pump thread — non-trivial / UI
+/// work must marshal off.</para>
 /// </summary>
 public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ILogStreamDriver _driver;
     private readonly MapPinParser _parser;
-    private readonly PlayerAreaTracker _areaTracker;
+    private readonly AreaTransitionParser _areaParser;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly object _lock = new();
@@ -58,23 +61,29 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
     private readonly Dictionary<PinKey, MapPin> _pins = new();
     private string? _trackedArea;
     private bool _areaInitialised;
+    private ILogSubscription? _subscription;
 
-    /// <param name="stream">The shared Player.log line stream this service
-    /// tails (its live replay window already covers the login pin burst).</param>
+    private const string DiagCategory = "GameState.Pins";
+
+    /// <param name="driver">L1 driver — subscribed to via the
+    /// <see cref="IClassifiedPlayerLogLine"/> unified pipe.</param>
     /// <param name="parser">Stateless line→<see cref="MapPinLogEvent"/> parser.</param>
-    /// <param name="areaTracker">Shared area key source; also fed every line
-    /// here so it stays warm without another module being active.</param>
+    /// <param name="areaParser">Stateless parser used to extract the area
+    /// key from each <see cref="SystemSignalKind.AreaLoading"/> envelope
+    /// observed on the unified pipe. The tracker tracks its own area state
+    /// locally rather than reading from <c>PlayerAreaTracker</c>, so the
+    /// reconcile never depends on a separate pump's progress.</param>
     /// <param name="diag">Optional diagnostics sink (info on subscribe,
     /// warnings on ingestion / subscriber faults).</param>
     public PlayerPinTracker(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         MapPinParser parser,
-        PlayerAreaTracker areaTracker,
+        AreaTransitionParser areaParser,
         IDiagnosticsSink? diag = null)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
-        _areaTracker = areaTracker;
+        _areaParser = areaParser;
         _diag = diag;
     }
 
@@ -108,44 +117,81 @@ public sealed class PlayerPinTracker : BackgroundService, IPlayerPinTracker
     }
 
     /// <summary>
-    /// The hosted-service ingestion loop: for every Player.log line, warm the
-    /// shared area tracker, reconcile an area change, then fold a parsed
-    /// pin event into the set. Exits when <paramref name="stoppingToken"/> is
-    /// cancelled or the stream completes; per-line exceptions are logged and
-    /// swallowed so one bad line never stops ingestion.
+    /// The hosted-service entry point. Opens an L1 subscription to the
+    /// unified classified pipe and parks until host shutdown — the L1
+    /// subscription runs its own pump on a <see cref="Task.Run(Func{Task})"/>,
+    /// invoking the handler inline for each envelope in source order.
     /// </summary>
     /// <param name="stoppingToken">Host shutdown signal.</param>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _diag?.Info("GameState.Pins", "Subscribing to Player.log for ProcessMapPin*");
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
-            {
-                // Same line stream carries area transitions; keep the shared
-                // tracker warm even when no other feeder is active.
-                _areaTracker.Observe(raw);
-                ReconcileArea();
+        _diag?.Info(DiagCategory,
+            "Subscribing to L1 driver (unified classified pipe) for ProcessMapPin* + area reconcile");
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is MapPinLogEvent evt)
-                    Apply(evt);
-            }
-            catch (Exception ex)
+        _subscription = _driver.Subscribe<IClassifiedPlayerLogLine>(
+            envelope =>
             {
-                _diag?.Warn("GameState.Pins", $"Ingestion error: {ex.Message}");
-            }
+                // Both classes of envelopes arrive in source order on the
+                // unified pipe, so a LOADING LEVEL always lands before its
+                // following pin-replay burst — no cross-pump race.
+                switch (envelope.Payload)
+                {
+                    case SystemSignalLogLine { Kind: SystemSignalKind.AreaLoading } s:
+                        // The area parser handles the empty / ChooseCharacter
+                        // forms by returning AreaKey == null.
+                        if (_areaParser.TryParse(s.Data, s.Timestamp.UtcDateTime)
+                            is Areas.Parsing.AreaTransitionEvent areaEvt)
+                        {
+                            ReconcileArea(areaEvt.AreaKey);
+                        }
+                        break;
+
+                    case LocalPlayerLogLine l:
+                        if (_parser.TryParse(l.Data, l.Timestamp.UtcDateTime)
+                            is MapPinLogEvent pinEvt)
+                        {
+                            Apply(pinEvt);
+                        }
+                        break;
+
+                    // CombatActorLogLine / other SystemSignal kinds silently
+                    // no-op. Combat envelopes are rare on this consumer set;
+                    // a default warning would flood the diag log.
+                }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
         }
     }
 
-    /// <summary>
-    /// Drop the set whenever the shared area key changes (including the first
-    /// time it becomes known). The set is area-local; the new area's replay
-    /// burst — which follows the <c>LOADING LEVEL</c> line that moved the key
-    /// — repopulates it.
-    /// </summary>
-    private void ReconcileArea()
+    public override void Dispose()
     {
-        var area = _areaTracker.CurrentArea;
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
+    }
+
+    /// <summary>
+    /// Drop the set whenever the area key changes (including the first
+    /// time it becomes known). The set is area-local; the new area's replay
+    /// burst — which follows the <c>LOADING LEVEL</c> envelope that moved
+    /// the key — repopulates it. Called from the unified-pipe handler when a
+    /// new <see cref="SystemSignalKind.AreaLoading"/> envelope arrives.
+    /// </summary>
+    private void ReconcileArea(string? area)
+    {
         PinSetChanged? note = null;
         lock (_lock)
         {

--- a/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
+++ b/src/Mithril.GameState/Weather/PlayerWeatherTracker.cs
@@ -1,4 +1,4 @@
-using Mithril.GameState.Areas;
+using Mithril.GameState.Areas.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Microsoft.Extensions.Hosting;
@@ -6,55 +6,56 @@ using Microsoft.Extensions.Hosting;
 namespace Mithril.GameState.Weather;
 
 /// <summary>
-/// Hosted-service implementation of <see cref="IPlayerWeatherTracker"/>. Tails
-/// <see cref="IPlayerLogStream"/>, parses <c>ProcessSetWeather</c> via
-/// <see cref="WeatherLogParser"/>, and holds the current <b>map's</b>
-/// <see cref="WeatherState"/> (condition + opaque flag + the line's UTC
-/// instant).
+/// Hosted-service implementation of <see cref="IPlayerWeatherTracker"/>.
+/// Subscribes to L1's unified classified pipe (#556 Phase 3), parses
+/// <c>ProcessSetWeather</c> on the <see cref="LocalPlayerLogLine"/>
+/// payload via <see cref="WeatherLogParser"/>, and holds the current
+/// <b>map's</b> <see cref="WeatherState"/> (condition + opaque flag + the
+/// line's UTC instant).
 ///
 /// <para><b>Lifecycle the service owns</b> (so no consumer hand-rolls it) —
 /// the same area-scoped shape as <see cref="Pins.PlayerPinTracker"/> because
 /// weather is per-map (owner-confirmed):</para>
 /// <list type="bullet">
-///   <item><b>Map change = drop.</b> Weather belongs to the map; on any
-///   <c>PlayerAreaTracker.CurrentArea</c> change the value is cleared and a
-///   <see cref="WeatherChangeKind.AreaChanged"/> (<c>State == null</c>) is
-///   raised. <c>null</c> reads as "weather unknown for this map" — for the
-///   <c>Vampirism</c> consumer that is distinct from a known clear sky, so a
-///   stale foggy/sunny value never bleeds across a zone.</item>
+///   <item><b>Map change = drop.</b> Weather belongs to the map; the
+///   tracker parses <see cref="SystemSignalKind.AreaLoading"/> envelopes
+///   off the unified pipe and clears the value on any change, raising a
+///   <see cref="WeatherChangeKind.AreaChanged"/> (<c>State == null</c>).
+///   <c>null</c> reads as "weather unknown for this map" — for the
+///   <c>Vampirism</c> consumer that is distinct from a known clear sky, so
+///   a stale foggy/sunny value never bleeds across a zone.</item>
 ///   <item><b>Genuine change = update + notify.</b> A new condition/flag for
 ///   the current map updates <see cref="Current"/> and raises
 ///   <see cref="WeatherChangeKind.Changed"/>.</item>
 ///   <item><b>Idempotent re-emit.</b> If PG re-emits the current weather on
 ///   zone entry (replay — unverified but plausible), the repeat is a no-op and
-///   raises nothing, so consumers stay quiet through a backlog (the same
-///   idempotence stance as <c>PlayerPinTracker</c>'s replay burst).</item>
+///   raises nothing, so consumers stay quiet through a backlog.</item>
 /// </list>
 ///
-/// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
-/// <see cref="Pins.PlayerPinTracker"/> / <see cref="Movement.PlayerPositionTracker"/>:
-/// shared live game-state must be available to consumers (the future
-/// <c>Vampirism</c> sun-damage feature; Palantir's debug surface) without
-/// depending on any module being activated. It also calls
-/// <see cref="PlayerAreaTracker.Observe(RawLogLine)"/> to keep the shared area
-/// tracker warm (idempotent when the position/pin trackers also feed it). No
-/// reverse-scan seed is needed here: the shared <see cref="PlayerAreaTracker"/>
-/// singleton is already seeded at startup by the position tracker, and a
-/// per-map weather emit lands inside the live window after its
-/// <c>LOADING LEVEL</c> line.</para>
+/// <para><b>Why the unified pipe — the race fix.</b> Pre-#556 this tracker
+/// read <c>PlayerAreaTracker.CurrentArea</c> for the map reconcile and
+/// tailed the raw Player.log for weather events. A zone-change burst
+/// (<c>LOADING LEVEL Foo</c> immediately followed by
+/// <c>ProcessSetWeather Sunny</c>) could be processed by the two pumps
+/// out of order — Weather seeing the new weather before the area tracker
+/// had advanced — and the resulting reconcile would drop the just-set
+/// value as a "stale prior-area" emit. Subscribing to the L0.5 unified
+/// classified pipe puts both envelopes on one ordered stream through a
+/// single subscription, so the area reconcile always precedes the weather
+/// emit for that area. Combat envelopes silently no-op.</para>
 ///
-/// <para><b>Threading.</b> Ingestion runs on the hosted-service loop thread;
-/// <see cref="CurrentArea"/>/<see cref="Current"/> reads, state mutation and
-/// subscriber dispatch are serialised under <c>_lock</c>; each notification
-/// carries an immutable record, so handlers may hold it. They run on the
-/// ingestion thread — non-trivial / UI work must marshal off (mirrors
-/// PlayerPinTracker).</para>
+/// <para><b>Threading.</b> The L1 driver's <c>InlineBridge</c> invokes the
+/// handler on its pump thread; <see cref="CurrentArea"/>/<see cref="Current"/>
+/// reads, state mutation and subscriber dispatch are serialised under
+/// <c>_lock</c>; each notification carries an immutable record, so handlers
+/// may hold it. They run on the L1 pump thread — non-trivial / UI work
+/// must marshal off (mirrors PlayerPinTracker).</para>
 /// </summary>
 public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTracker
 {
-    private readonly IPlayerLogStream _stream;
+    private readonly ILogStreamDriver _driver;
     private readonly WeatherLogParser _parser;
-    private readonly PlayerAreaTracker _areaTracker;
+    private readonly AreaTransitionParser _areaParser;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly object _lock = new();
@@ -62,22 +63,30 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
     private WeatherState? _current;
     private string? _trackedArea;
     private bool _areaInitialised;
+    private ILogSubscription? _subscription;
 
-    /// <param name="stream">The shared Player.log line stream this service tails.</param>
+    private const string DiagCategory = "GameState.Weather";
+
+    /// <param name="driver">L1 driver — subscribed to via the
+    /// <see cref="IClassifiedPlayerLogLine"/> unified pipe.</param>
     /// <param name="parser">Stateless line→<see cref="WeatherChangedEvent"/> parser.</param>
-    /// <param name="areaTracker">Shared map key source; also fed every line
-    /// here so it stays warm without another module being active.</param>
+    /// <param name="areaParser">Stateless parser used to extract the area
+    /// key from each <see cref="SystemSignalKind.AreaLoading"/> envelope
+    /// observed on the unified pipe. The tracker tracks its own area state
+    /// locally rather than reading from <c>PlayerAreaTracker</c>, so the
+    /// reconcile never depends on a separate pump's progress — closing the
+    /// pre-#556 zone-change race.</param>
     /// <param name="diag">Optional diagnostics sink (info on subscribe,
     /// warnings on ingestion / subscriber faults).</param>
     public PlayerWeatherTracker(
-        IPlayerLogStream stream,
+        ILogStreamDriver driver,
         WeatherLogParser parser,
-        PlayerAreaTracker areaTracker,
+        AreaTransitionParser areaParser,
         IDiagnosticsSink? diag = null)
     {
-        _stream = stream;
+        _driver = driver;
         _parser = parser;
-        _areaTracker = areaTracker;
+        _areaParser = areaParser;
         _diag = diag;
     }
 
@@ -111,45 +120,75 @@ public sealed class PlayerWeatherTracker : BackgroundService, IPlayerWeatherTrac
     }
 
     /// <summary>
-    /// The hosted-service ingestion loop: for every Player.log line, warm the
-    /// shared area tracker, reconcile a map change, then fold a parsed weather
-    /// event into the current map's state. Exits when
-    /// <paramref name="stoppingToken"/> is cancelled or the stream completes;
-    /// per-line exceptions are logged and swallowed so one bad line never
-    /// stops ingestion.
+    /// The hosted-service entry point. Opens an L1 subscription to the
+    /// unified classified pipe and parks until host shutdown — the L1
+    /// subscription runs its own pump, invoking the handler inline for
+    /// each envelope in source order.
     /// </summary>
     /// <param name="stoppingToken">Host shutdown signal.</param>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _diag?.Info("GameState.Weather", "Subscribing to Player.log for ProcessSetWeather");
-        await foreach (var raw in _stream.SubscribeAsync(stoppingToken).ConfigureAwait(false))
-        {
-            try
-            {
-                // Same line stream carries map transitions; keep the shared
-                // tracker warm even when no other feeder is active.
-                _areaTracker.Observe(raw);
-                ReconcileArea();
+        _diag?.Info(DiagCategory,
+            "Subscribing to L1 driver (unified classified pipe) for ProcessSetWeather + area reconcile");
 
-                if (_parser.TryParse(raw.Line, raw.Timestamp.UtcDateTime) is WeatherChangedEvent evt)
-                    Apply(evt);
-            }
-            catch (Exception ex)
+        _subscription = _driver.Subscribe<IClassifiedPlayerLogLine>(
+            envelope =>
             {
-                _diag?.Warn("GameState.Weather", $"Ingestion error: {ex.Message}");
-            }
+                switch (envelope.Payload)
+                {
+                    case SystemSignalLogLine { Kind: SystemSignalKind.AreaLoading } s:
+                        if (_areaParser.TryParse(s.Data, s.Timestamp.UtcDateTime)
+                            is AreaTransitionEvent areaEvt)
+                        {
+                            ReconcileArea(areaEvt.AreaKey);
+                        }
+                        break;
+
+                    case LocalPlayerLogLine l:
+                        if (_parser.TryParse(l.Data, l.Timestamp.UtcDateTime)
+                            is WeatherChangedEvent weatherEvt)
+                        {
+                            Apply(weatherEvt);
+                        }
+                        break;
+
+                    // CombatActorLogLine / other SystemSignal kinds silently
+                    // no-op (combat envelopes on the unified pipe — by
+                    // design; a default warning would flood the diag log).
+                }
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
         }
     }
 
-    /// <summary>
-    /// Drop the weather whenever the shared map key changes (including the
-    /// first time it becomes known). Weather is per-map; the new map's
-    /// <c>ProcessSetWeather</c> — which follows the <c>LOADING LEVEL</c> line
-    /// that moved the key — repopulates it.
-    /// </summary>
-    private void ReconcileArea()
+    public override void Dispose()
     {
-        var area = _areaTracker.CurrentArea;
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
+    }
+
+    /// <summary>
+    /// Drop the weather whenever the map key changes (including the first
+    /// time it becomes known). Weather is per-map; the new map's
+    /// <c>ProcessSetWeather</c> — which follows the <c>LOADING LEVEL</c>
+    /// envelope on the same unified pipe — repopulates it.
+    /// </summary>
+    private void ReconcileArea(string? area)
+    {
         WeatherChanged? note = null;
         lock (_lock)
         {

--- a/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Areas/PlayerAreaTrackerTests.cs
@@ -330,22 +330,18 @@ public sealed class PlayerAreaTrackerTests : IDisposable
         await tracker.StartAsync(cts.Token);
         try
         {
-            // Both paths see the same transition.
+            // Both paths see the same transition. Observe(string, DateTime)
+            // is still alive — used by Legolas / Gandalf — so the
+            // double-feed regression remains relevant. (#556 Phase 3
+            // retired Observe(RawLogLine); Pin/Weather/Position now
+            // self-feed via the L1 unified pipe.)
             driver.PushLive(MakeAreaLoading("AreaSerbule", seq: 1));
             await driver.DrainSystemAsync();
-            tracker.Observe(new RawLogLine(
-                Timestamp: DateTimeOffset.UtcNow,
-                Line: "[10:00:00] LOADING LEVEL AreaSerbule",
-                Sequence: 1,
-                ReadMonotonicTicks: 0));
+            tracker.Observe("LOADING LEVEL AreaSerbule", DateTime.UtcNow);
             tracker.CurrentArea.Should().Be("AreaSerbule");
 
             // Race on the next transition: Observe lands first, then L1.
-            tracker.Observe(new RawLogLine(
-                Timestamp: DateTimeOffset.UtcNow,
-                Line: "[10:01:00] LOADING LEVEL AreaEltibule",
-                Sequence: 2,
-                ReadMonotonicTicks: 0));
+            tracker.Observe("LOADING LEVEL AreaEltibule", DateTime.UtcNow);
             tracker.CurrentArea.Should().Be("AreaEltibule");
 
             driver.PushLive(MakeAreaLoading("AreaEltibule", seq: 2));

--- a/tests/Mithril.GameState.Tests/Movement/PlayerPositionTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Movement/PlayerPositionTrackerTests.cs
@@ -1,45 +1,74 @@
-using System.Threading.Channels;
 using FluentAssertions;
-using Mithril.GameState.Areas;
-using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Movement;
-using Mithril.Shared.Game;
+using Mithril.GameState.Tests.TestSupport;
 using Mithril.Shared.Logging;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Movement;
 
+/// <summary>
+/// L0.5 #556 Phase 3 — PlayerPositionTracker now subscribes to the L1
+/// driver's unified classified pipe.
+/// <list type="bullet">
+///   <item><c>ProcessNewPosition</c> arrives as
+///   <see cref="LocalPlayerLogLine"/> (the LocalPlayer typed pipe).</item>
+///   <item><c>ProcessAddPlayer</c> arrives as
+///   <see cref="SystemSignalLogLine"/> { <see cref="SystemSignalKind.PlayerAdded"/> }
+///   — Risk-4 carve-out from #556 (L0.5 routes the local-player spawn line
+///   to the system-signal pipe because it's a session-lifecycle event,
+///   not a verb on the LocalPlayer pipe).</item>
+/// </list>
+/// Both reach the tracker on the same unified subscription in source-Sequence
+/// order; the tracker's <c>switch</c> dispatches them to the right parse path.
+/// </summary>
 public sealed class PlayerPositionTrackerTests
 {
-    private static readonly DateTime Stamp = new(2026, 5, 18, 10, 45, 47, DateTimeKind.Utc);
+    private static readonly DateTimeOffset Ts =
+        new(2026, 5, 18, 10, 45, 47, TimeSpan.Zero);
 
-    private const string PosLine =
-        "[10:45:47] LocalPlayer: ProcessNewPosition((834.09, 290.24, 3480.81), (0,0,0,1), Walk, OnLand, UseTeleportationCircle, Looping, 0, False, True, 1, 2)";
+    // Envelope-eaten payloads (what L0.5 produces in production — the
+    // [ts] LocalPlayer: prefix is stripped by the classifier).
+    private const string PosData =
+        "ProcessNewPosition((834.09, 290.24, 3480.81), (0,0,0,1), Walk, OnLand, UseTeleportationCircle, Looping, 0, False, True, 1, 2)";
+    private const string PosData2 =
+        "ProcessNewPosition((-790.06, 309.18, -3386.07), (0,0,0,1), Run, OnLand, Zone, Looping, 0, False, True, 1, 2)";
+    private const string SpawnData =
+        "ProcessAddPlayer(1, 2, \"@Base2-m(sex=m;Face=@eq(a=1))\", \"Emraell\", \"A player!\", System.String[], (1522.22, 112.27, 288.13), (0,0,0,1), Idle, Standing, 0, 0, True)";
 
-    private const string PosLine2 =
-        "[11:10:39] LocalPlayer: ProcessNewPosition((-790.06, 309.18, -3386.07), (0,0,0,1), Run, OnLand, Zone, Looping, 0, False, True, 1, 2)";
+    private static PlayerPositionTracker NewTracker(TestLogStreamDriver driver) =>
+        new(driver, new PlayerPositionParser());
 
-    private const string SpawnLine =
-        "[10:00:00] LocalPlayer: ProcessAddPlayer(1, 2, \"@Base2-m(sex=m;Face=@eq(a=1))\", \"Emraell\", \"A player!\", System.String[], (1522.22, 112.27, 288.13), (0,0,0,1), Idle, Standing, 0, 0, True)";
+    private static LocalPlayerLogLine LocalEnvelope(string data, long seq, DateTimeOffset? at = null) =>
+        new(
+            Timestamp: at ?? Ts,
+            Data: data,
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
 
-    private static PlayerPositionTracker NewTracker(ScriptedStream stream, PlayerAreaTracker? area = null) =>
-        new(stream, new PlayerPositionParser(), area ?? new PlayerAreaTracker(new AreaTransitionParser()));
+    private static SystemSignalLogLine SpawnEnvelope(string data, long seq, DateTimeOffset? at = null) =>
+        new(
+            Timestamp: at ?? Ts,
+            Kind: SystemSignalKind.PlayerAdded,
+            Data: data,
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
 
     [Fact]
     public async Task Position_line_populates_Current_with_coords_and_utc_instant()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(LocalEnvelope(PosData, seq: 1));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, PosLine);
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.Current.Should().NotBeNull();
             svc.Current!.X.Should().Be(834.09);
             svc.Current.Y.Should().Be(290.24);
             svc.Current.Z.Should().Be(3480.81);
-            svc.Current.MeasuredAt.Should().Be(new DateTimeOffset(Stamp));
             svc.Current.MeasuredAt.Offset.Should().Be(TimeSpan.Zero);
             svc.Current.Source.Should().Be(PlayerPositionSource.Movement);
         }
@@ -47,14 +76,19 @@ public sealed class PlayerPositionTrackerTests
     }
 
     [Fact]
-    public async Task Local_ProcessAddPlayer_spawn_line_populates_Current()
+    public async Task ProcessAddPlayer_spawn_envelope_populates_Current_as_Spawn_source()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        // Risk 4: ProcessAddPlayer is routed to SystemSignal { PlayerAdded }
+        // at L0.5, not the LocalPlayer pipe. The tracker MUST pattern-match
+        // that envelope kind to recover the spawn seed.
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(SpawnEnvelope(SpawnData, seq: 1));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, SpawnLine);
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.Current.Should().NotBeNull();
             svc.Current!.X.Should().Be(1522.22);
@@ -67,13 +101,16 @@ public sealed class PlayerPositionTrackerTests
     [Fact]
     public async Task Latest_position_wins()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(LocalEnvelope(PosData, seq: 1));
+        driver.PushReplay(LocalEnvelope(PosData2, seq: 2,
+            at: Ts.AddMinutes(25)));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, PosLine);
-            stream.Push(Stamp.AddMinutes(25), PosLine2);
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.Current!.X.Should().Be(-790.06);
             svc.Current.Z.Should().Be(-3386.07);
@@ -82,33 +119,39 @@ public sealed class PlayerPositionTrackerTests
     }
 
     [Fact]
-    public async Task Non_position_lines_do_not_affect_Current()
+    public async Task Spawn_then_movement_advances_via_both_payload_kinds()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        // Real session shape: spawn (SystemSignal PlayerAdded) followed by
+        // teleport / zone-change positions (LocalPlayer ProcessNewPosition).
+        // The tracker's switch handles both off the unified pipe.
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(SpawnEnvelope(SpawnData, seq: 1));
+        driver.PushReplay(LocalEnvelope(PosData, seq: 2));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, "[10:00:00] LocalPlayer: ProcessAddItem(Barley(1), 0, False)");
-            await RunUntilDrainedAsync(svc, stream);
-            svc.Current.Should().BeNull();
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+
+            svc.Current!.X.Should().Be(834.09);
+            svc.Current.Source.Should().Be(PlayerPositionSource.Movement);
         }
         finally { await StopAsync(svc); }
     }
 
     [Fact]
-    public async Task Also_feeds_shared_area_tracker_from_same_stream()
+    public async Task Non_position_LocalPlayer_lines_do_not_affect_Current()
     {
-        var stream = new ScriptedStream();
-        var area = new PlayerAreaTracker(new AreaTransitionParser());
-        var svc = NewTracker(stream, area);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(LocalEnvelope("ProcessAddItem(Barley(1), 0, False)", seq: 1));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, "[10:30:00] LOADING LEVEL AreaSerbule");
-            stream.Push(Stamp, PosLine);
-            await RunUntilDrainedAsync(svc, stream);
-
-            area.CurrentArea.Should().Be("AreaSerbule");
-            svc.Current.Should().NotBeNull();
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+            svc.Current.Should().BeNull();
         }
         finally { await StopAsync(svc); }
     }
@@ -116,62 +159,49 @@ public sealed class PlayerPositionTrackerTests
     [Fact]
     public async Task Subscribe_after_observed_replays_synchronously_then_delivers_live()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(LocalEnvelope(PosData, seq: 1));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, PosLine);
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             var seen = new List<PlayerPosition>();
             using var sub = svc.Subscribe(seen.Add);
             seen.Should().ContainSingle().Which.X.Should().Be(834.09);
 
-            stream.Push(Stamp.AddMinutes(25), PosLine2);
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(LocalEnvelope(PosData2, seq: 2,
+                at: Ts.AddMinutes(25)));
+            await driver.DrainClassifiedAsync();
 
             seen.Should().HaveCount(2);
             seen[1].X.Should().Be(-790.06);
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
     [Fact]
     public async Task Subscribe_with_no_position_does_not_invoke_handler()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        var svc = NewTracker(driver);
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            var runTask = svc.StartAsync(cts.Token);
+            await StartAsync(svc);
 
             var seen = 0;
             using var sub = svc.Subscribe(_ => seen++);
             seen.Should().Be(0);
-
-            await cts.CancelAsync();
-            _ = runTask;
         }
         finally { await StopAsync(svc); }
     }
 
-    private static async Task RunUntilDrainedAsync(PlayerPositionTracker svc, ScriptedStream stream)
+    private static async Task StartAsync(PlayerPositionTracker svc)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var runTask = svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
-        await cts.CancelAsync();
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-        _ = runTask;
+        await svc.StartAsync(cts.Token);
     }
 
     private static async Task StopAsync(PlayerPositionTracker svc)
@@ -179,40 +209,5 @@ public sealed class PlayerPositionTrackerTests
         try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
         catch { /* test cleanup */ }
         svc.Dispose();
-    }
-
-    private sealed class ScriptedStream : IPlayerLogStream
-    {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
-        private long _pending;
-        private TaskCompletionSource _drained = NewDrainTcs();
-
-        public ScriptedStream() => _drained.TrySetResult();
-
-        public void Push(DateTime ts, string line)
-        {
-            Interlocked.Increment(ref _pending);
-            Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(ts, line));
-        }
-
-        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
-
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
-            {
-                while (_channel.Reader.TryRead(out var line))
-                {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0)
-                        _drained.TrySetResult();
-                }
-            }
-        }
-
-        private static TaskCompletionSource NewDrainTcs() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Pins/PlayerPinTrackerTests.cs
@@ -1,37 +1,66 @@
-using System.Threading.Channels;
 using FluentAssertions;
-using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Pins;
+using Mithril.GameState.Tests.TestSupport;
 using Mithril.Shared.Logging;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Pins;
 
+/// <summary>
+/// L0.5 #556 Phase 3 — PlayerPinTracker now subscribes to the L1 driver's
+/// unified classified pipe instead of tailing the raw Player.log stream.
+/// Tests drive it via <see cref="TestLogStreamDriver"/> which pushes
+/// classified envelopes (LocalPlayer or SystemSignal) into the unified
+/// dispatch path that the splitter would have produced in production.
+/// </summary>
 public sealed class PlayerPinTrackerTests
 {
-    private static readonly DateTime Stamp = new(2026, 5, 18, 10, 10, 3, DateTimeKind.Utc);
+    private static readonly DateTimeOffset Ts =
+        new(2026, 5, 18, 10, 10, 3, TimeSpan.Zero);
 
-    private static PlayerPinTracker NewTracker(ScriptedStream stream, PlayerAreaTracker? area = null) =>
-        new(stream, new MapPinParser(),
-            area ?? new PlayerAreaTracker(new AreaTransitionParser()));
+    private static PlayerPinTracker NewTracker(TestLogStreamDriver driver) =>
+        new(driver, new MapPinParser(), new AreaTransitionParser());
 
-    private static string Area(string key) => $"[10:00:00] LOADING LEVEL {key}";
-    private static string Add(double x, double z, string label, int b = 0, int c = 0) =>
-        $"[10:10:03] LocalPlayer: ProcessMapPinAdd(1, {b}, {c}, ({x:0.00}, 0.00, {z:0.00}), \"{label}\")";
-    private static string Remove(double x, double z, string label) =>
-        $"[10:10:03] LocalPlayer: ProcessMapPinRemove(1, 0, 0, ({x:0.00}, 0.00, {z:0.00}), \"{label}\")";
+    /// <summary>
+    /// Builds a SystemSignal { AreaLoading } envelope carrying the
+    /// envelope-eaten <c>LOADING LEVEL …</c> payload (what the L0.5
+    /// splitter produces in production for the raw line
+    /// <c>[ts] LOADING LEVEL …</c>).
+    /// </summary>
+    private static SystemSignalLogLine AreaEnvelope(string areaKey, long seq) =>
+        new(
+            Timestamp: Ts,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: $"LOADING LEVEL {areaKey}",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    private static LocalPlayerLogLine PinAdd(double x, double z, string label, long seq, int b = 0, int c = 0) =>
+        new(
+            Timestamp: Ts,
+            Data: $"ProcessMapPinAdd(1, {b}, {c}, ({x:0.00}, 0.00, {z:0.00}), \"{label}\")",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    private static LocalPlayerLogLine PinRemove(double x, double z, string label, long seq) =>
+        new(
+            Timestamp: Ts,
+            Data: $"ProcessMapPinRemove(1, 0, 0, ({x:0.00}, 0.00, {z:0.00}), \"{label}\")",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
 
     [Fact]
     public async Task Add_populates_current_area_pins_with_decoded_appearance()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(1425.06, 2924.99, "South", seq: 2, b: 1, c: 1));
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Add(1425.06, 2924.99, "South", b: 1, c: 1));
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentArea.Should().Be("AreaSerbule");
             var pin = svc.CurrentAreaPins.Should().ContainSingle().Subject;
@@ -48,47 +77,44 @@ public sealed class PlayerPinTrackerTests
     [Fact]
     public async Task Replay_burst_is_idempotent_no_duplicates_no_extra_events()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(10, 20, "A", seq: 2));
+        driver.PushReplay(PinAdd(30, 40, "B", seq: 3));
+        // Login/area-entry re-emits the whole set verbatim.
+        driver.PushReplay(PinAdd(10, 20, "A", seq: 4));
+        driver.PushReplay(PinAdd(30, 40, "B", seq: 5));
+
+        var svc = NewTracker(driver);
         try
         {
             var seen = new List<PinSetChanged>();
             using var sub = svc.Subscribe(seen.Add);
 
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Add(10, 20, "A"));
-            stream.Push(Stamp, Add(30, 40, "B"));
-            await stream.WaitForDrainAsync(cts.Token);
-            // Login/area-entry re-emits the whole set verbatim.
-            stream.Push(Stamp, Add(10, 20, "A"));
-            stream.Push(Stamp, Add(30, 40, "B"));
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentAreaPins.Should().HaveCount(2);
+            // 1 Snapshot from Subscribe (above) + 2 Adds (idempotent re-adds
+            // produce no notification).
             seen.Count(n => n.Kind == PinSetChange.Added).Should().Be(2);
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
     [Fact]
     public async Task Remove_deletes_by_coordinate()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(10, 20, "A", seq: 2));
+        driver.PushReplay(PinRemove(10, 20, "A", seq: 3));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Add(10, 20, "A"));
-            stream.Push(Stamp, Remove(10, 20, "A"));
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentAreaPins.Should().BeEmpty();
         }
@@ -98,15 +124,17 @@ public sealed class PlayerPinTrackerTests
     [Fact]
     public async Task Rename_is_remove_then_add_at_same_coord()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(10, 20, "", seq: 2));
+        driver.PushReplay(PinRemove(10, 20, "", seq: 3));
+        driver.PushReplay(PinAdd(10, 20, "Calib 1", seq: 4));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Add(10, 20, ""));
-            stream.Push(Stamp, Remove(10, 20, ""));
-            stream.Push(Stamp, Add(10, 20, "Calib 1"));
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentAreaPins.Should().ContainSingle()
                 .Which.Label.Should().Be("Calib 1");
@@ -117,47 +145,41 @@ public sealed class PlayerPinTrackerTests
     [Fact]
     public async Task Area_change_swaps_the_set_and_raises_AreaChanged()
     {
-        var stream = new ScriptedStream();
-        var area = new PlayerAreaTracker(new AreaTransitionParser());
-        var svc = NewTracker(stream, area);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(10, 20, "A", seq: 2));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Add(10, 20, "A"));
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             var seen = new List<PinSetChanged>();
             using var sub = svc.Subscribe(seen.Add); // Snapshot replay first
-            stream.Push(Stamp, Area("AreaEltibule"));
-            await stream.WaitForDrainAsync(cts.Token);
+
+            driver.PushLive(AreaEnvelope("AreaEltibule", seq: 3));
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentArea.Should().Be("AreaEltibule");
             svc.CurrentAreaPins.Should().BeEmpty();
             seen.Should().Contain(n => n.Kind == PinSetChange.AreaChanged && n.Area == "AreaEltibule");
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
     [Fact]
     public async Task Subscribe_replays_snapshot_synchronously_then_delivers_live()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(10, 20, "A", seq: 2));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Add(10, 20, "A"));
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             var seen = new List<PinSetChanged>();
             using var sub = svc.Subscribe(seen.Add);
@@ -165,31 +187,56 @@ public sealed class PlayerPinTrackerTests
                 .Which.Should().Match<PinSetChanged>(n =>
                     n.Kind == PinSetChange.Snapshot && n.Pins.Count == 1);
 
-            stream.Push(Stamp, Add(30, 40, "B"));
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(PinAdd(30, 40, "B", seq: 3));
+            await driver.DrainClassifiedAsync();
 
             var added = seen.Last();
             added.Kind.Should().Be(PinSetChange.Added);
             added.Pin!.Label.Should().Be("B");
             added.ObservedAt.Offset.Should().Be(TimeSpan.Zero);
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
-    private static async Task RunUntilDrainedAsync(PlayerPinTracker svc, ScriptedStream stream)
+    [Fact]
+    public async Task Cross_pipe_ordering_AreaLoading_precedes_PinBurst_no_stale_drop()
+    {
+        // The unified-pipe race-fix property (#556 §1) — Pin tracker
+        // observes the LOADING LEVEL envelope BEFORE the pin replay burst
+        // for that area, so the ReconcileArea() drop fires first and the
+        // subsequent pins land in the *new* area's set rather than being
+        // wiped by a late-arriving area transition.
+        using var driver = new TestLogStreamDriver();
+        // Initial area + one pin.
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(PinAdd(100, 200, "OLD", seq: 2));
+
+        var svc = NewTracker(driver);
+        try
+        {
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+            svc.CurrentArea.Should().Be("AreaSerbule");
+            svc.CurrentAreaPins.Should().ContainSingle().Which.Label.Should().Be("OLD");
+
+            // Live zone change burst: LOADING LEVEL followed immediately
+            // by the new area's pin-add. On the unified pipe these arrive
+            // in source-Sequence order through the single subscription,
+            // so AreaLoading is observed first.
+            driver.PushLive(AreaEnvelope("AreaEltibule", seq: 3));
+            driver.PushLive(PinAdd(500, 600, "NEW", seq: 4));
+            await driver.DrainClassifiedAsync();
+
+            svc.CurrentArea.Should().Be("AreaEltibule");
+            svc.CurrentAreaPins.Should().ContainSingle().Which.Label.Should().Be("NEW");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    private static async Task StartAsync(PlayerPinTracker svc)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var runTask = svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
-        await cts.CancelAsync();
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-        _ = runTask;
+        await svc.StartAsync(cts.Token);
     }
 
     private static async Task StopAsync(PlayerPinTracker svc)
@@ -197,40 +244,5 @@ public sealed class PlayerPinTrackerTests
         try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
         catch { /* test cleanup */ }
         svc.Dispose();
-    }
-
-    private sealed class ScriptedStream : IPlayerLogStream
-    {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
-        private long _pending;
-        private TaskCompletionSource _drained = NewDrainTcs();
-
-        public ScriptedStream() => _drained.TrySetResult();
-
-        public void Push(DateTime ts, string line)
-        {
-            Interlocked.Increment(ref _pending);
-            Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(ts, line));
-        }
-
-        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
-
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
-            {
-                while (_channel.Reader.TryRead(out var line))
-                {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0)
-                        _drained.TrySetResult();
-                }
-            }
-        }
-
-        private static TaskCompletionSource NewDrainTcs() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/tests/Mithril.GameState.Tests/TestSupport/TestLogStreamDriver.cs
+++ b/tests/Mithril.GameState.Tests/TestSupport/TestLogStreamDriver.cs
@@ -31,15 +31,45 @@ public sealed class TestLogStreamDriver : ILogStreamDriver, IDisposable
     private readonly Pipe<LocalPlayerLogLine> _localPlayer = new();
     private readonly Pipe<CombatActorLogLine> _combat = new();
     private readonly Pipe<SystemSignalLogLine> _system = new();
+    private readonly Pipe<IClassifiedPlayerLogLine> _classified = new();
     private readonly Pipe<RawLogLine> _chat = new();
     private readonly List<IDisposable> _subscriptions = new();
 
-    public void PushReplay(LocalPlayerLogLine line) => _localPlayer.AddReplay(line);
-    public void PushLive(LocalPlayerLogLine line) => _localPlayer.PushLive(line);
-    public void PushReplay(SystemSignalLogLine line) => _system.AddReplay(line);
-    public void PushLive(SystemSignalLogLine line) => _system.PushLive(line);
-    public void PushReplay(CombatActorLogLine line) => _combat.AddReplay(line);
-    public void PushLive(CombatActorLogLine line) => _combat.PushLive(line);
+    // PushReplay / PushLive mirror to the unified pipe so a test pushing a
+    // typed envelope to the driver looks the same to a typed subscriber AND
+    // to a unified (IClassifiedPlayerLogLine) subscriber — matching the
+    // production splitter+classifier pair from #556. Tests pushing typed
+    // envelopes don't need a second "push to unified" call.
+    public void PushReplay(LocalPlayerLogLine line)
+    {
+        _localPlayer.AddReplay(line);
+        _classified.AddReplay(line);
+    }
+    public void PushLive(LocalPlayerLogLine line)
+    {
+        _localPlayer.PushLive(line);
+        _classified.PushLive(line);
+    }
+    public void PushReplay(SystemSignalLogLine line)
+    {
+        _system.AddReplay(line);
+        _classified.AddReplay(line);
+    }
+    public void PushLive(SystemSignalLogLine line)
+    {
+        _system.PushLive(line);
+        _classified.PushLive(line);
+    }
+    public void PushReplay(CombatActorLogLine line)
+    {
+        _combat.AddReplay(line);
+        _classified.AddReplay(line);
+    }
+    public void PushLive(CombatActorLogLine line)
+    {
+        _combat.PushLive(line);
+        _classified.PushLive(line);
+    }
     public void PushReplay(RawLogLine line) => _chat.AddReplay(line);
     public void PushLive(RawLogLine line) => _chat.PushLive(line);
 
@@ -49,6 +79,8 @@ public sealed class TestLogStreamDriver : ILogStreamDriver, IDisposable
         _system.DrainAsync(timeout ?? TimeSpan.FromSeconds(5));
     public Task DrainCombatAsync(TimeSpan? timeout = null) =>
         _combat.DrainAsync(timeout ?? TimeSpan.FromSeconds(5));
+    public Task DrainClassifiedAsync(TimeSpan? timeout = null) =>
+        _classified.DrainAsync(timeout ?? TimeSpan.FromSeconds(5));
     public Task DrainChatAsync(TimeSpan? timeout = null) =>
         _chat.DrainAsync(timeout ?? TimeSpan.FromSeconds(5));
 
@@ -82,6 +114,20 @@ public sealed class TestLogStreamDriver : ILogStreamDriver, IDisposable
             var sub = new Subscription<CombatActorLogLine>(
                 _combat,
                 (Func<LogEnvelope<CombatActorLogLine>, ValueTask>)(object)handler,
+                opts);
+            sub.Start();
+            lock (_subscriptions) _subscriptions.Add(sub);
+            return sub;
+        }
+        if (typeof(T) == typeof(IClassifiedPlayerLogLine))
+        {
+            // Unified pipe (#556). Same exact-equality dispatch as
+            // production LogStreamDriver — a concrete-type Subscribe (e.g.
+            // Subscribe<LocalPlayerLogLine>) still hits the typed-pipe
+            // branch above, not this one.
+            var sub = new Subscription<IClassifiedPlayerLogLine>(
+                _classified,
+                (Func<LogEnvelope<IClassifiedPlayerLogLine>, ValueTask>)(object)handler,
                 opts);
             sub.Start();
             lock (_subscriptions) _subscriptions.Add(sub);

--- a/tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs
+++ b/tests/Mithril.GameState.Tests/Weather/PlayerWeatherTrackerTests.cs
@@ -1,35 +1,55 @@
-using System.Threading.Channels;
 using FluentAssertions;
-using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
+using Mithril.GameState.Tests.TestSupport;
 using Mithril.GameState.Weather;
 using Mithril.Shared.Logging;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Weather;
 
+/// <summary>
+/// L0.5 #556 Phase 3 — PlayerWeatherTracker now subscribes to the L1
+/// driver's unified classified pipe; tests drive it via
+/// <see cref="TestLogStreamDriver"/>. The zone-change race that motivated
+/// #556 (Weather seeing a new condition before the area pump advanced)
+/// is structurally impossible with the single-subscription unified pipe;
+/// a dedicated test pins the race-elimination property.
+/// </summary>
 public sealed class PlayerWeatherTrackerTests
 {
-    private static readonly DateTime Stamp = new(2026, 5, 18, 19, 50, 42, DateTimeKind.Utc);
+    private static readonly DateTimeOffset Ts =
+        new(2026, 5, 18, 19, 50, 42, TimeSpan.Zero);
 
-    private static PlayerWeatherTracker NewTracker(ScriptedStream stream, PlayerAreaTracker? area = null) =>
-        new(stream, new WeatherLogParser(),
-            area ?? new PlayerAreaTracker(new AreaTransitionParser()));
+    private static PlayerWeatherTracker NewTracker(TestLogStreamDriver driver) =>
+        new(driver, new WeatherLogParser(), new AreaTransitionParser());
 
-    private static string Area(string key) => $"[10:00:00] LOADING LEVEL {key}";
-    private static string Set(string condition, bool flag = true) =>
-        $"[19:50:42] LocalPlayer: ProcessSetWeather(\"{condition}\", {(flag ? "True" : "False")})";
+    private static SystemSignalLogLine AreaEnvelope(string areaKey, long seq) =>
+        new(
+            Timestamp: Ts,
+            Kind: SystemSignalKind.AreaLoading,
+            Data: $"LOADING LEVEL {areaKey}",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
+
+    private static LocalPlayerLogLine WeatherEnvelope(string condition, bool flag, long seq) =>
+        new(
+            Timestamp: Ts,
+            Data: $"ProcessSetWeather(\"{condition}\", {(flag ? "True" : "False")})",
+            Sequence: seq,
+            ReadMonotonicTicks: 0);
 
     [Fact]
     public async Task First_weather_line_populates_Current_for_the_map()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 2));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Set("Foggy"));
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentArea.Should().Be("AreaSerbule");
             svc.Current.Should().NotBeNull();
@@ -43,14 +63,16 @@ public sealed class PlayerWeatherTrackerTests
     [Fact]
     public async Task Last_writer_wins_on_a_genuine_change()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 2));
+        driver.PushReplay(WeatherEnvelope("Clear", flag: false, seq: 3));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Set("Foggy"));
-            stream.Push(Stamp, Set("Clear", flag: false));
-            await RunUntilDrainedAsync(svc, stream);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             svc.Current!.Condition.Should().Be("Clear");
             svc.Current.Flag.Should().BeFalse();
@@ -61,24 +83,23 @@ public sealed class PlayerWeatherTrackerTests
     [Fact]
     public async Task Map_change_drops_weather_until_the_new_map_reports()
     {
-        var stream = new ScriptedStream();
-        var area = new PlayerAreaTracker(new AreaTransitionParser());
-        var svc = NewTracker(stream, area);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 2));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Set("Foggy"));
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
             svc.Current!.Condition.Should().Be("Foggy");
 
             var seen = new List<WeatherChanged>();
             using var sub = svc.Subscribe(seen.Add); // Snapshot replay first
 
             // Leave the foggy map: weather must not bleed into the next map.
-            stream.Push(Stamp, Area("AreaEltibule"));
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(AreaEnvelope("AreaEltibule", seq: 3));
+            await driver.DrainClassifiedAsync();
 
             svc.CurrentArea.Should().Be("AreaEltibule");
             svc.Current.Should().BeNull(); // unknown — NOT still Foggy
@@ -88,8 +109,8 @@ public sealed class PlayerWeatherTrackerTests
                 && n.State == null);
 
             // New map reports its own weather.
-            stream.Push(Stamp, Set("Clear", flag: false));
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(WeatherEnvelope("Clear", flag: false, seq: 4));
+            await driver.DrainClassifiedAsync();
 
             svc.Current!.Condition.Should().Be("Clear");
             seen.Last().Should().Match<WeatherChanged>(n =>
@@ -97,62 +118,50 @@ public sealed class PlayerWeatherTrackerTests
                 && n.Area == "AreaEltibule"
                 && n.State!.Condition == "Clear");
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
     [Fact]
     public async Task Replay_of_unchanged_weather_is_idempotent_no_extra_events()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 2));
+        // Zone re-emits the current weather verbatim.
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 3));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 4));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Set("Foggy"));
-            await stream.WaitForDrainAsync(cts.Token);
-
             var seen = new List<WeatherChanged>();
-            using var sub = svc.Subscribe(seen.Add); // Snapshot
-            seen.Should().ContainSingle()
-                .Which.Should().Match<WeatherChanged>(n =>
-                    n.Kind == WeatherChangeKind.Snapshot && n.State!.Condition == "Foggy");
+            using var sub = svc.Subscribe(seen.Add); // Snapshot first
 
-            // Zone re-emits the current weather verbatim.
-            stream.Push(Stamp, Set("Foggy"));
-            stream.Push(Stamp, Set("Foggy"));
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
-            seen.Should().ContainSingle(); // no further notifications
+            // 1 Snapshot (from Subscribe before Start) + 1 Changed (first
+            // Foggy line) + 0 from idempotent re-emits = 2 notifications.
+            // The Snapshot has State == null because Subscribe ran before
+            // the tracker had observed anything; the Changed brings it to
+            // Foggy and the re-emits are silent.
+            seen.Count(n => n.Kind == WeatherChangeKind.Changed).Should().Be(1);
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
     [Fact]
     public async Task Subscribe_replays_snapshot_synchronously_then_delivers_live()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 2));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
-            stream.Push(Stamp, Set("Foggy"));
-            await stream.WaitForDrainAsync(cts.Token);
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
 
             var seen = new List<WeatherChanged>();
             using var sub = svc.Subscribe(seen.Add);
@@ -160,63 +169,87 @@ public sealed class PlayerWeatherTrackerTests
                 .Which.Should().Match<WeatherChanged>(n =>
                     n.Kind == WeatherChangeKind.Snapshot && n.State!.Condition == "Foggy");
 
-            stream.Push(Stamp, Set("Rainy"));
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(WeatherEnvelope("Rainy", flag: true, seq: 3));
+            await driver.DrainClassifiedAsync();
 
             var last = seen.Last();
             last.Kind.Should().Be(WeatherChangeKind.Changed);
             last.State!.Condition.Should().Be("Rainy");
             last.ObservedAt.Offset.Should().Be(TimeSpan.Zero);
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
     [Fact]
     public async Task Disposed_subscription_stops_receiving_but_state_advances()
     {
-        var stream = new ScriptedStream();
-        var svc = NewTracker(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var runTask = svc.StartAsync(cts.Token);
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+
+        var svc = NewTracker(driver);
         try
         {
-            stream.Push(Stamp, Area("AreaSerbule"));
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+
             var seen = new List<WeatherChanged>();
             var sub = svc.Subscribe(seen.Add);
-            stream.Push(Stamp, Set("Foggy"));
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(WeatherEnvelope("Foggy", flag: true, seq: 2));
+            await driver.DrainClassifiedAsync();
             var countAtDispose = seen.Count;
             sub.Dispose();
 
-            stream.Push(Stamp, Set("Rainy"));
-            await stream.WaitForDrainAsync(cts.Token);
+            driver.PushLive(WeatherEnvelope("Rainy", flag: true, seq: 3));
+            await driver.DrainClassifiedAsync();
 
             seen.Should().HaveCount(countAtDispose); // no further delivery
             svc.Current!.Condition.Should().Be("Rainy"); // state still advances
         }
-        finally
-        {
-            await cts.CancelAsync();
-            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            _ = runTask;
-            svc.Dispose();
-        }
+        finally { await StopAsync(svc); }
     }
 
-    private static async Task RunUntilDrainedAsync(PlayerWeatherTracker svc, ScriptedStream stream)
+    [Fact]
+    public async Task Weather_survives_zone_change_burst_without_stale_state_drop()
+    {
+        // #556 race-elimination targeted test. Pre-#556 a zone-change burst
+        //   LOADING LEVEL AreaNewMap
+        //   ProcessSetWeather Sunny
+        // could be processed by two pumps in the wrong order — Weather
+        // would see Sunny first against the OLD area's tracked state,
+        // then the area pump would advance and Reconcile would DROP Sunny
+        // as if it had been a "stale prior-area" emission. On the unified
+        // pipe the two envelopes arrive on one subscription in source
+        // order, so the reconcile lands before the weather-set and Sunny
+        // is recorded under the new area.
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(AreaEnvelope("AreaSerbule", seq: 1));
+        driver.PushReplay(WeatherEnvelope("Foggy", flag: true, seq: 2));
+
+        var svc = NewTracker(driver);
+        try
+        {
+            await StartAsync(svc);
+            await driver.DrainClassifiedAsync();
+            svc.Current!.Condition.Should().Be("Foggy");
+
+            // The race-window burst:
+            driver.PushLive(AreaEnvelope("AreaEltibule", seq: 3));
+            driver.PushLive(WeatherEnvelope("Sunny", flag: true, seq: 4));
+            await driver.DrainClassifiedAsync();
+
+            svc.CurrentArea.Should().Be("AreaEltibule");
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Condition.Should().Be("Sunny",
+                because: "the unified pipe delivers LOADING LEVEL before ProcessSetWeather; " +
+                         "the reconcile clears Foggy first and Sunny lands in the new area");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    private static async Task StartAsync(PlayerWeatherTracker svc)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var runTask = svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
-        await cts.CancelAsync();
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-        _ = runTask;
+        await svc.StartAsync(cts.Token);
     }
 
     private static async Task StopAsync(PlayerWeatherTracker svc)
@@ -224,40 +257,5 @@ public sealed class PlayerWeatherTrackerTests
         try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
         catch { /* test cleanup */ }
         svc.Dispose();
-    }
-
-    private sealed class ScriptedStream : IPlayerLogStream
-    {
-        private readonly Channel<RawLogLine> _channel = Channel.CreateUnbounded<RawLogLine>();
-        private long _pending;
-        private TaskCompletionSource _drained = NewDrainTcs();
-
-        public ScriptedStream() => _drained.TrySetResult();
-
-        public void Push(DateTime ts, string line)
-        {
-            Interlocked.Increment(ref _pending);
-            Interlocked.Exchange(ref _drained, NewDrainTcs());
-            _channel.Writer.TryWrite(new RawLogLine(ts, line));
-        }
-
-        public Task WaitForDrainAsync(CancellationToken ct) => _drained.Task.WaitAsync(ct);
-
-        public async IAsyncEnumerable<RawLogLine> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _channel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
-            {
-                while (_channel.Reader.TryRead(out var line))
-                {
-                    yield return line;
-                    if (Interlocked.Decrement(ref _pending) == 0)
-                        _drained.TrySetResult();
-                }
-            }
-        }
-
-        private static TaskCompletionSource NewDrainTcs() =>
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }


### PR DESCRIPTION
## Summary

Final phase of the [#556 plan](https://github.com/moumantai-gg/mithril/issues/556#issuecomment-4500796409): migrate **PlayerPinTracker / PlayerWeatherTracker / PlayerPositionTracker** to the L0.5 unified classified pipe, and retire `PlayerAreaTracker.Observe(RawLogLine)`.

Each tracker now opens a single `Subscribe<IClassifiedPlayerLogLine>` subscription. The handler `switch`es on the runtime payload type — `SystemSignalLogLine { AreaLoading }` for the area reconcile (parsed locally via `AreaTransitionParser`, no cross-pump read of `PlayerAreaTracker.CurrentArea`), and the consumer's relevant verb on `LocalPlayerLogLine`. The two envelopes arrive on one ordered subscription, so the area reconcile always lands before the area-scoped verb for that area.

### Per-consumer changes
- **PlayerPinTracker** — drops `IPlayerLogStream` + `PlayerAreaTracker` deps; gains `ILogStreamDriver` + `AreaTransitionParser`. New cross-pipe-ordering test pins the "AreaLoading precedes pin-burst, no stale drop" invariant.
- **PlayerWeatherTracker** — same shape as Pin. Dedicated **race-elimination test** (`Weather_survives_zone_change_burst_without_stale_state_drop`) pins the documented two-pump race the unified pipe was designed to fix.
- **PlayerPositionTracker** — Risk-4 carve-out. `ProcessAddPlayer` is routed to `SystemSignalLogLine { Kind: PlayerAdded }` at L0.5 (not the LocalPlayer pipe), so the tracker pattern-matches BOTH `LocalPlayerLogLine` (`ProcessNewPosition`) and `SystemSignalLogLine { PlayerAdded }` (spawn seed). `PlayerPositionParser` gains `TryParseSpawnFromData(data, ts)` for the L0.5-envelope-eaten path — skips the `LocalPlayer:` actor gate (L0.5 enforces it upstream).
- **PlayerAreaTracker.Observe(RawLogLine)** — DELETED. No caller remains. `Observe(string, DateTime)` stays for Legolas + Gandalf.

### Test infrastructure
- `TestLogStreamDriver` — typed `PushReplay`/`PushLive` now mirror to a unified `Pipe<IClassifiedPlayerLogLine>` so a test pushing a typed envelope looks the same to a unified subscriber as to a typed subscriber. New `DrainClassifiedAsync()` + an `IClassifiedPlayerLogLine` dispatch branch using `typeof(T)` exact-equality, matching production `LogStreamDriver`.
- The three tracker test files are rewritten to drive the test driver. All behavioural assertions are preserved (byte-equivalence regression in spirit — the new fixtures express the same scenarios in the post-L0.5 envelope vocabulary).

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — all 4500+ tests pass
- [x] `PlayerPinTrackerTests.Cross_pipe_ordering_AreaLoading_precedes_PinBurst_no_stale_drop` — Pin's race-elimination
- [x] `PlayerWeatherTrackerTests.Weather_survives_zone_change_burst_without_stale_state_drop` — Weather's documented two-pump race fix
- [x] `PlayerPositionTrackerTests.ProcessAddPlayer_spawn_envelope_populates_Current_as_Spawn_source` — Risk-4 pin
- [x] `PlayerPositionTrackerTests.Spawn_then_movement_advances_via_both_payload_kinds` — switch over both payload classes off the unified pipe
- [x] All pre-existing per-tracker behavioural tests preserved (add/remove, last-writer-wins, area-scoped drop, replay idempotence, subscriber snapshot, dispose semantics)

Builds on #567 (Phase 1) + #568 (Phase 2). Closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
