### PR TITLE
docs(logging): #550 final sweep — Tier-3 doc + retirement verification

### DIFF
--- a/docs/cross-source-correlation.md
+++ b/docs/cross-source-correlation.md
@@ -158,33 +158,55 @@ template for "fails cleanly on inversion."
 
 ## Tier 3 — live read-order tiebreak
 
-> ⚠️ **Blocked on L1's `IsReplay` flag** ([#511](https://github.com/moumantai-gg/mithril/issues/511)
-> deliverable 3, not yet built). This section is a forward-reference
-> contract; the mechanism becomes usable when L1 ships.
-
 **Recognition.** Tiers 1 and 2 don't apply — no shared key, no causal
 request/response — but you only need to tiebreak the order of two events
 *within a shared game-second*. Both streams are tailed live by the same
 Mithril process, so the order they were read off disk is a real signal.
 
-**Contract sketch.** L0 mints a high-resolution monotonic
+**Contract.** L0 mints a high-resolution monotonic
 [`ReadMonotonicTicks`](../src/Mithril.Shared/Logging/LogEvent.cs) field on
-every emitted line (from `TimeProvider.GetTimestamp()` at tail time). When
-L1's forthcoming `IsReplay == false` is set on a line — i.e. the line came
-from live tailing, not the session-replay backlog — `ReadMonotonicTicks` is
-a usable cross-source tiebreaker within a shared game-second. When
-`IsReplay == true` (replay), read-order is meaningless: PG slurped the
-backlog file in bulk and no live tailing happened, so the tiebreaker
-collapses to nonsense and the consumer must fall back to per-source
-`Sequence` + game-second + Tier 1/2 keyed correlation.
+every emitted line (from `TimeProvider.GetTimestamp()` at tail time). L1
+ships the
+[`LogEnvelope<T>.IsReplay`](../src/Mithril.Shared/Logging/LogEnvelope.cs)
+bit alongside every delivered payload (PR [#554](https://github.com/moumantai-gg/mithril/pull/554)),
+so a Tier-3 consumer can gate the tiebreak on a per-envelope basis:
+`ReadMonotonicTicks` is a usable cross-source tiebreaker within a shared
+game-second **only when** `IsReplay == false` (the envelope came from live
+tailing, not the session-replay backlog). When `IsReplay == true`,
+read-order is meaningless — PG slurped the backlog file in bulk and no
+live tailing happened, so the tiebreaker collapses to nonsense and the
+consumer must fall back to per-source `Sequence` + game-second + Tier 1/2
+keyed correlation.
 
 **Failure mode.** Read-order is also unreliable when live tailing falls
 behind (the [#507](https://github.com/moumantai-gg/mithril/issues/507)
-condition). That state is **alarmed and observable**, not silent — when L1
-lands, Tier-3 consumers should refuse to tiebreak while #507's lag signal
-is set, rather than producing a confidently-wrong ordering.
+condition). That state is **alarmed and observable**, not silent —
+Tier-3 consumers should refuse to tiebreak while #507's lag signal is
+set, rather than producing a confidently-wrong ordering.
 
-**In-repo reference.** None yet; pending L1.
+**In-repo reference.** No consumer currently sits in Tier 3. The four
+producers that the [#556](https://github.com/moumantai-gg/mithril/issues/556)
+multi-pipe split initially flagged as Tier-3 candidates ended up solved
+differently:
+
+- **Pin / Weather / Position** — migrated to the unified
+  `IClassifiedPlayerLogLine` pipe (#556 phases 1–3 / PRs
+  [#567](https://github.com/moumantai-gg/mithril/pull/567) /
+  [#568](https://github.com/moumantai-gg/mithril/pull/568) /
+  [#569](https://github.com/moumantai-gg/mithril/pull/569)). That is a
+  *same-source cross-pipe* mechanism — every consumer reads a single
+  classified Player.log stream that preserves in-source order across
+  pipes — which is a structurally different problem than Tier 3's
+  *cross-source same-game-second tiebreak*.
+- **Inventory** — solved as two parallel L1 subscriptions (Player.log
+  `ProcessAddItem` and chat `[Status] added`) feeding the existing
+  `PendingCorrelator<TKey,TReq>`. That's Tier 1, keyed by `InternalName`
+  — see PR [#566](https://github.com/moumantai-gg/mithril/pull/566) and
+  the `InventoryService` row in the mapping table.
+
+Tier 3 remains available for a future cross-source consumer that genuinely
+needs to tiebreak two unrelated events within a shared game-second; no
+such consumer exists in-repo today.
 
 ## Tier 4 — order-insensitive consumer (the irreducible case)
 
@@ -221,13 +243,14 @@ If one ever does, this section gets the first reference.
 | `InventoryService` (`ProcessAddItem` ↔ chat `[Status] added`) | 1 | Keyed by `InternalName`, 5 s TTL |
 | `Legolas.Services.LogIngestionService` (chat `added` ↔ chat `collected!`) | 1 | Keyed by item name, 5 s TTL; credit-0 + warn on unmatched takes; Trace on TTL eviction (post-#541) |
 | `Legolas.Services.MotherlodeMeasurementCoordinator` (Player.log `ProcessDoDelayLoop` ↔ chat `[Status] The treasure is N meters`) | 2 | Currently cross-source; k-th-to-slot-k binding; label-agnostic temporal pairing. Same-source migration to Player.log `ProcessScreenText(ImportantInfo, …)` is feasible but deferred to #511 deliverable 6 |
-| *(future Tier-3 consumer)* | 3 | Awaits L1 (#511 deliverable 3) |
+| *(no in-repo consumer)* | 3 | Tier-3 mechanism is available (L1 ships `LogEnvelope<T>.IsReplay`, PR #554) but unused — the four #556 candidates resolved via the unified pipe (Pin/Weather/Position) or Tier 1 (Inventory). Slot reserved for a future cross-source same-game-second tiebreak need. |
 
 ## Open questions / future work
 
-- **L1 / `IsReplay`** lands (#511 deliverable 3) → Tier-3 implementation
-  becomes possible; the first Tier-3 consumer reference moves into the
-  mapping table above.
+- **First Tier-3 consumer**, if one ever surfaces (cross-source pair, no
+  shared key, no causal request/response, same-game-second tiebreak
+  required), gets the first in-repo reference in §Tier 3 — the mechanism
+  is available now that L1 ships `LogEnvelope<T>.IsReplay` (PR #554).
 - **First Tier-4 consumer**, if one ever surfaces, gets the first reference
   in §Tier 4.
 - **PG's ADD-before-COLLECT emission order** across the survey vocabulary is


### PR DESCRIPTION
## Summary

Closing housekeeping for #550 (the L1 subscription driver rollout umbrella). All migration PRs have landed on main: L1 driver (#554), archetype-A initial batch (#555), 8 archetype-B migrations (#557–#564), Inventory cross-source (#566), and the multi-pipe Classifier+Splitter split (#567–#569 closing #556).

This PR is doc-update + retirement accounting:

- **Tier-3 doc promoted** — `docs/cross-source-correlation.md` no longer carries the ⚠️ "blocked on L1's `IsReplay` flag" callout. L1 ships `LogEnvelope<T>.IsReplay` (PR #554), so Tier 3 is mechanism-available; the new copy documents that no in-repo consumer uses it today and accounts for where the four #556 candidates landed (Pin/Weather/Position → unified-pipe, Inventory → Tier 1).
- **Retirement scoreboards** below verify the 11 containment sites and 5 dispatcher helpers that #550 capabilities C + E identified as retirable.

Closes #550.

## Containment retirement scoreboard

The L1 driver owns containment for every subscription via the unified `ThrottledWarn` + per-subscription fault state machine. Per-service `ThrottledWarn` instances that previously wrapped log-handler `try/catch` should be gone.

| Site | Status |
|---|---|
| `src/Arwen.Module/State/FavorIngestionService.cs` | ✅ gone — doc-comment at line 54 records the retirement |
| `src/Pippin.Module/State/GourmandIngestionService.cs` | ✅ gone — doc-comment at line 49 records the retirement |
| `src/Samwise.Module/State/GardenIngestionService.cs` | ✅ gone — doc-comment at line 51 records the retirement; line 148 references the retired bucket name in a code comment |
| `src/Smaug.Module/State/VendorIngestionService.cs` | ✅ gone — doc-comment at line 48 records the retirement |
| `src/Saruman.Module/Services/SarumanDiscoveryIngestionService.cs` | ✅ gone — doc-comment at line 38/42 records the retirement |
| `src/Saruman.Module/Services/SarumanChatIngestionService.cs` | ✅ gone — doc-comment at line 36 records the retirement |
| `src/Legolas.Module/Services/LogIngestionService.cs` | ⚠️ **still present** — line 28/48 hold a `ThrottledWarn` field and ctor init for the **chat-log** path. This is the chat ingestion service (different from `PlayerLogIngestionService`); its L1 migration is tracked by #531 (still open) per the brief's "or this file may be removed entirely per #531" allowance. The remaining `_warn.Warn(...)` call at line 237 is the credit-0 unmatched-take warn (a Tier-1 PendingCorrelator concern documented in `cross-source-correlation.md`), not the per-line catch — but the catch on line 68 is also still present. **Deferred to #531, not a #550 regression.** |
| `src/Legolas.Module/Services/PlayerLogIngestionService.cs` | ✅ gone — the per-line catch is gone (doc-comment at line 62–67 records the retirement). The two remaining `_diag?.Warn(...)` calls at lines 418/464 are high-water persistence I/O failure warns (load/save of `LegolasIngestionState`), a different concern. |
| `src/Mithril.GameState/Sessions/GameSessionService.cs` | ✅ gone — doc-comment at line 39 records the retirement |
| `src/Mithril.GameState/Skills/PlayerSkillStateService.cs` | ✅ gone — doc-comment at line 36/40 records the retirement |
| `src/Mithril.GameState/Recipes/PlayerRecipeStateService.cs` | ✅ gone — doc-comment at line 37/41 records the retirement |

**Net result.** 10 of 11 sites confirmed gone. One — Legolas's **chat-log** ingestion service — is intentionally deferred to #531, which is the open issue covering the chat-pipeline rework. No silent retention.

### Sites that SHOULD remain (confirmed present)

| Site | Reason | Verified |
|---|---|---|
| `src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs:86` | int.Parse overflow guard per #525 (per-row numeric parse, not L1 containment) | ✅ present |
| `src/Mithril.GameState/Recipes/Parsing/RecipeLogParser.cs:74` | Same per-row numeric guard per #525 | ✅ present |
| `src/Mithril.Shared/Logging/PlayerLogClassifier.cs:78` | L0.5 anomaly counter — retained in the classifier after #567's split | ✅ present |
| `src/Mithril.Shared/Logging/PlayerLogPipeSplitter.cs:65` | L0.5 splitter fault counter — added during #567's Classifier+Splitter refactor (new home for the pre-split anomaly path) | ✅ present (added in #567, not in original #550 inventory) |
| `src/Mithril.Shared/Logging/LogStreamDriver.cs:268` | The unified L1 driver containment instance itself | ✅ present |

Verified by `grep "new ThrottledWarn(" src/` returning exactly these 5 + the 1 deferred chat-log site.

## Dispatcher helper retirement scoreboard

#550 capability E: every consumer that mutates `ObservableCollection` from a log handler should rely on `DeliveryContext.Marshaled(dispatcher)` from the L1 driver, retiring the hand-rolled `Application.Current?.Dispatcher` + `CheckAccess` + `InvokeAsync` helper pattern.

| Site | Status |
|---|---|
| `src/Arwen.Module/State/FavorIngestionService.cs` | ✅ helper gone — line 101 still references `Application.Current?.Dispatcher` but only to resolve the dispatcher **once** at subscription setup so it can be passed to `DeliveryContext.Marshaled(dispatcher)`. The per-call hand-rolled `CheckAccess`/`InvokeAsync` helper is gone. Doc-comment at line 48 records the retirement. |
| `src/Pippin.Module/State/GourmandIngestionService.cs` | ✅ helper gone — only remaining mention is the doc-comment at line 40 recording the retirement. No `Application.Current?.Dispatcher` code remains. |
| `src/Legolas.Module/Services/LogIngestionService.cs` | ⚠️ **`PostToUi` still present at line 137** — chat-log ingestion path, deferred to #531 (same reason as the containment site above). Not a #550 regression. |
| `src/Legolas.Module/Services/PlayerLogIngestionService.cs` | ✅ helper gone — line 159 resolves dispatcher once for `Marshaled(...)` construction. Doc-comment at line 69–76 records the retirement. No `PostToUi`/`CheckAccess`/`InvokeAsync` remain. |
| `src/Samwise.Module/State/GardenIngestionService.cs` | ✅ L1-path helper gone — line 152 resolves dispatcher once for `Marshaled(...)`. Doc-comment at line 24–28 records the retirement. The file retains `DispatchHydrate` (line 238) and `DispatchInventory` (line 252) — both explicitly documented as **non-L1 paths** (one-shot hydration + IInventoryService event feed, neither owned by L1) and intentionally retained. |

**Net result.** 4 of 5 L1-path helpers confirmed gone. One — Legolas's chat-log `PostToUi` — deferred to #531.

### Dispatcher patterns that should remain (confirmed)

- **Gandalf timer dispatch helpers** (`TimerExpirationScheduler.Dispatch`, `TimerAlarmService.Dispatch`, `ShiftAlarmService.Dispatch`, `DashboardAggregator.Dispatch`, `TimerSourceBinder.Dispatch`) — timer-side, not log-stream. Untouched.
- **VM-side dispatch** (`SarumanViewModel.Dispatch`, `Palantir.WorldStateViewModel.DefaultDispatch`, `Palantir.LiveInventoryViewModel.DefaultDispatch`, etc.) — view-model concern, not the L1 ingestion path. Untouched.
- **Sharing-target dispatch helpers** (`CraftListImportTarget.Dispatch`, `SavedLevelingPlanImportTarget.Dispatch`, `ArwenModule.UiDispatch`) — import-target concern, not log subscription. Untouched.
- **Samwise's `DispatchHydrate` and `DispatchInventory`** — explicitly documented as non-L1 (see above).

## Tier-3 doc promotion

See `docs/cross-source-correlation.md` lines 159–214 in this PR's diff. Specifically:

- Removed the ⚠️ "Blocked on L1's `IsReplay` flag" callout (lines 161–163 in the prior version).
- Renamed "Contract sketch" → "Contract"; updated the body to link `LogEnvelope<T>.IsReplay` from PR #554 and explain the per-envelope gate.
- Removed the "when L1 lands" hedge from the #507 failure-mode paragraph (it has landed).
- Added an in-repo reference paragraph documenting that no consumer currently uses Tier 3, with the explicit #556 accounting (Pin/Weather/Position via unified pipe; Inventory via Tier 1).
- Updated the consumer-to-tier mapping table: the `(future Tier-3 consumer)` row became `(no in-repo consumer)` with a note that the mechanism is available but unused.
- Reworded the "Open questions / future work" bullet to reflect that L1/`IsReplay` shipped.

## Test verification

Both pre-existing cross-thread `ObservableCollection` regression tests build and pass:

- `Mithril.Shared.Tests.Logging.LogStreamDriverTests.DeliveryContext_Marshaled_StructurallyPreventsCrossThreadObservableCollectionMutation` — added in PR #554.
- `Smaug.Tests.VendorIngestionServiceL1Tests.L1_Marshaled_StructurallyGuardsCalibrationViewModelRefreshPath` — added in PR #558, exercises real `CalibrationViewModel.Refresh()` path with STA dispatcher.

Full `dotnet test Mithril.slnx`: **3867 passed / 0 failed / 0 skipped** across 21 test projects (Mithril.Shared.Tests 1244, Silmarillion.Tests 556, Legolas.Tests 465, Gandalf.Tests 306, Mithril.GameState.Tests 296, Samwise.Tests 114, Mithril.Reference.Tests 105, Celebrimbor.Tests 87, Arwen.Tests 85, Elrond.Tests 53, Pippin.Tests 46, Mithril.LogSanitizer.Tests 34, Smaug.Tests 33, Bilbo.Tests 31, Saruman.Tests 31, Palantir.Tests 29, Mithril.Planning.Tests 23, Mithril.Leveling.Tests 12, RefreshAndValidate.Tests 5, Mithril.Shell.Tests 2).

## Concerns / surprises

- **Legolas chat-log `LogIngestionService.cs` was NOT migrated.** Both the per-service `ThrottledWarn` (containment) and the `PostToUi` helper (dispatcher) remain. This file consumes `IChatLogStream`, not `IPlayerLogStream` — the L1 driver currently surfaces `LogEnvelope<T>` only for player-log subscriptions, and `IChatLogStream` is live-only by design (per the [Player-Log-Signals wiki](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#replay-semantics)). The chat-pipeline rework is the open umbrella #511, with Legolas's specific requirements captured in **#531** (open). The brief's "or this file may be removed entirely per #531" allowance accepts this disposition. Filing this as ⚠️ rather than ✅ because the brief listed the site under the gone-from-main scoreboard; the deferral is intentional but worth surfacing.

- No other surprises. Every other retirement landed; every "should remain" site is confirmed present; no design ambiguity surfaced during the Tier-3 doc rewrite.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — 3867 passed, 0 failed
- [x] `DeliveryContext_Marshaled_StructurallyPreventsCrossThreadObservableCollectionMutation` — passes
- [x] `L1_Marshaled_StructurallyGuardsCalibrationViewModelRefreshPath` — passes
- [x] Visually re-read `docs/cross-source-correlation.md` Tier-3 section + mapping table for internal consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
