### PR TITLE
docs(l05): clean up stale references after #556 merge

### DIFF
--- a/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
+++ b/src/Mithril.GameState/Areas/PlayerAreaTracker.cs
@@ -19,13 +19,14 @@ namespace Mithril.GameState.Areas;
 /// <see cref="ILogStreamDriver"/> is supplied, the tracker is a
 /// <see cref="BackgroundService"/> that subscribes to L0.5's
 /// <see cref="ISystemSignalLogStream"/> typed pipe through the L1 driver,
-/// filtered for <see cref="SystemSignalKind.AreaLoading"/>. The shared
-/// state then updates without any other GameState producer feeding it via
-/// <see cref="Observe(RawLogLine)"/>. Both feed paths update the same
-/// state idempotently: the area key is string-compared, last-writer-wins,
-/// so a double-feed during the Phase 3 migration window is safe. The
-/// <see cref="Observe(RawLogLine)"/> overload retires in Phase 3's final
-/// PR (once Pin/Weather/Position move to the unified pipe).</para>
+/// filtered for <see cref="SystemSignalKind.AreaLoading"/>. This is the
+/// canonical update path for shared area state in production.
+/// <see cref="Observe(string,DateTime)"/> remains for the two consumers
+/// (Legolas's <c>PlayerLogIngestionService</c> and Gandalf's
+/// <c>LootIngestionService</c>) that still feed already-classified data
+/// inline; both feed paths converge on the same string-equality,
+/// last-writer-wins state, so concurrent updates against the same area
+/// key are idempotent.</para>
 ///
 /// <para><b>Startup seeding.</b> <see cref="PlayerLogTailReader.SeedToSessionStart"/>
 /// rewinds the live replay window to the most recent <c>ProcessAddPlayer(</c>

--- a/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs
@@ -137,10 +137,12 @@ public static class ServiceCollectionExtensions
     /// degraded subscriptions on <see cref="IAttentionAggregator"/> via the
     /// <see cref="LogStreamAttentionSource"/> registered alongside.
     ///
-    /// <para>This registration is a NO-OP for existing consumers — every
-    /// archetype-A producer and archetype-B consumer continues to consume
-    /// the L0 / L0.5 surfaces directly until the consumer-migration PRs land.
-    /// PR 1 of #550 ships the driver only.</para>
+    /// <para>The producer + consumer fleets now route through this driver
+    /// (archetype-A migrations landed across #555 / #560–#564; archetype-A
+    /// shared GameState — Pin/Weather/Position — migrated to the unified
+    /// pipe in #556 Phase 3 / #569). Archetype-B consumers continue to
+    /// migrate per the #550 plan; un-migrated consumers still subscribe to
+    /// the L0 / L0.5 surfaces directly until their PR lands.</para>
     /// </summary>
     public static IServiceCollection AddMithrilLogStreamDriver(this IServiceCollection services)
     {

--- a/src/Mithril.Shared/Logging/ILogStreamDriver.cs
+++ b/src/Mithril.Shared/Logging/ILogStreamDriver.cs
@@ -45,15 +45,23 @@ public interface ILogStreamDriver
 {
     /// <summary>
     /// Subscribe to a typed log stream. <typeparamref name="T"/> must be one
-    /// of the four supported payload types:
+    /// of the five supported payload types:
     /// <list type="bullet">
     ///   <item><see cref="LocalPlayerLogLine"/> — the L0.5 LocalPlayer pipe</item>
     ///   <item><see cref="CombatActorLogLine"/> — the L0.5 combat-actor pipe</item>
     ///   <item><see cref="SystemSignalLogLine"/> — the L0.5 system-signal pipe</item>
+    ///   <item><see cref="IClassifiedPlayerLogLine"/> — the L0.5 unified
+    ///   classified pipe (#556). Dispatch is by <c>typeof(T)</c>
+    ///   exact-equality, so a <c>Subscribe&lt;LocalPlayerLogLine&gt;</c>
+    ///   continues to route to the typed pipe above, NOT here, even though
+    ///   <see cref="LocalPlayerLogLine"/> implements the interface. Used by
+    ///   cross-pipe-ordering-sensitive consumers (Pin/Weather/Position) that
+    ///   need source-Sequence ordering across LocalPlayer and SystemSignal
+    ///   envelopes on a single subscription.</item>
     ///   <item><see cref="RawLogLine"/> — the L0 chat stream
     ///   (<see cref="IChatLogStream"/>). Note that Player.log
     ///   <see cref="RawLogLine"/> consumption stays on
-    ///   <see cref="IPlayerLogStream"/> directly — L1 routes the typed L0.5
+    ///   <see cref="IPlayerLogStream"/> directly — L1 routes the L0.5
     ///   pipes, not pre-classification raw Player.log.</item>
     /// </list>
     /// </summary>


### PR DESCRIPTION
## Summary

Post-merge doc cleanup for the L0.5 #556 series (PRs #567 / #568 / #569). Three stale references surfaced in a retrospective code review; this PR fixes them. **No behavioural change** — comment and XML doc text only.

- **`PlayerAreaTracker`** — drops the two `<see cref="Observe(RawLogLine)"/>` references (the overload was deleted in Phase 3 / #569) and rewrites the "Phase 3 migration window is safe" paragraph to describe the post-migration steady state. The double-feed safety property is now stated for the surviving `Observe(string, DateTime)` callers (Legolas + Gandalf) rather than for the retired `Observe(RawLogLine)`.
- **`ILogStreamDriver.Subscribe<T>`** — the method-level XML listed "four supported payload types" but Phase 1 (#567) added a fifth (`IClassifiedPlayerLogLine`, the unified pipe). The type-level summary mentioned it, the method-level enumeration didn't. Fixed, plus a sentence describing the `typeof(T)` exact-equality dispatch (the Risk-3 invariant from the #556 brainstorm) and why cross-pipe-ordering-sensitive consumers subscribe here.
- **`AddMithrilLogStreamDriver`** — replaces the original-ship "NO-OP for existing consumers" remark (from #550 PR 1) with the current state. The producer fleet + archetype-A shared GameState consumers (Pin/Weather/Position via #569) now route through the driver; archetype-B consumers continue to migrate per the #550 plan.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test Mithril.slnx` — all 4500+ tests pass

Refs #556 (post-merge cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
