### PR TITLE
docs(charters): modules consume GameState services, not raw logs

### DIFF
--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -71,6 +71,49 @@ Applies to *every* module; owner-confirmed 2026-05-16:
   *Recollection correction, verified:* the live-inventory sim is in **Mithril.GameState**,
   not Mithril.Shared; Mithril.Shared owns the static *export* only.
 
+- **Modules `Subscribe` to the GameState service surface; they do not subscribe to
+  raw logs for cross-cutting state. ✅ owner-confirmed 2026-05-21.** Each GameState
+  service ([`IInventoryService`](../src/Mithril.GameState/Inventory/IInventoryService.cs),
+  [`IPlayerPinTracker`](../src/Mithril.GameState/Pins/IPlayerPinTracker.cs),
+  [`IPlayerWeatherTracker`](../src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs),
+  [`IPlayerPositionTracker`](../src/Mithril.GameState/Movement/IPlayerPositionTracker.cs),
+  [`IPlayerSkillState`](../src/Mithril.GameState/Skills/IPlayerSkillState.cs), and the
+  shipped Recipe / Celestial / Area trackers) owns its L1 subscription internally and
+  exposes `Subscribe(Action<TEvent>)` with atomic replay-then-live. Modules consume the
+  service surface; they do **not** `Subscribe<LocalPlayerLogLine>` /
+  `IChatLogStream` / `IClassifiedPlayerLogLine` for any data domain that has a GameState
+  service. Direct log subscription is reserved for (a) the GameState services
+  themselves; (b) module-specific domains the module owns end-to-end (Samwise/Garden,
+  Pippin/Gourmand, Arwen/Favor business logic, Gandalf/Loot business logic, etc.).
+
+  *Why.* Real, hard-to-reproduce bugs from unclear ownership when multiple modules each
+  rebuilt their own view of the same underlying state from the raw log stream. Two
+  state machines on the same signal with subtly different framing produced symptoms
+  that didn't replay deterministically. Centralising the canonical view in a GameState
+  service — with the atomic replay-then-live `Subscribe` contract — retired that whole
+  bug class. The rule is the *consumption-side* complement of the data-owner-vs-surface
+  bullet above: that bullet says shared services *exist*; this one says modules
+  *consume them*, not the underlying log.
+
+  *Anti-pattern (flag immediately).* A module subscribing to `_driver.Subscribe<LocalPlayerLogLine>`
+  /`IPlayerLogStream` / `IChatLogStream` / `IClassifiedPlayerLogLine` and matching a
+  cross-cutting verb (`ProcessAddItem`, `ProcessDeleteItem`, `ProcessUpdateItemCode`,
+  `ProcessRemoveFromStorageVault`, `ProcessLoadSkills`, `ProcessUpdateSkill`,
+  `ProcessLoadRecipes`, `ProcessUpdateRecipe`, `ProcessSetWeather`, `ProcessMapPin*`,
+  `ProcessNewPosition`, area-transition verbs, celestial / moon-phase verbs), or
+  holding its own `[GeneratedRegex]` against one. The fix is "consume the corresponding
+  GameState service's `Subscribe(...)`," not "write your own state machine on the same
+  signal."
+
+  *Known anti-pattern instance — verification owed, audit + retire.*
+  [`Gandalf.Module/Services/LootBracketTracker.cs`](../src/Gandalf.Module/Services/LootBracketTracker.cs)'s
+  `AddItemRx` regex matches `ProcessAddItem(` on the raw envelope. The retiring fix is
+  to switch the bracket tracker to `IInventoryService.Subscribe`, filtering for
+  `InventoryEventKind.Added`. Surfaced during the mithril#574 L2 spec review chain;
+  the consumption-side fix is independent of L2 and can land sooner. A full repo audit
+  for additional instances is pending — file the audit as its own issue when prioritised
+  rather than appending to this charter.
+
 ---
 
 > **Coverage:** all 12 `*.Module` projects are charactered (owner-confirmed
@@ -453,6 +496,23 @@ libraries; the charter follows the code:
 
 ## History
 
+- **2026-05-21** — **Consumption-side rule added to cross-cutting ownership (✅ owner-confirmed
+  2026-05-21).** The existing "data + surface" bullet stated shared services exist
+  and are the single source of truth, with modules `Subscribe`/query them. The new
+  bullet closes the consumption-side gap: modules **never** subscribe to raw logs
+  (`IPlayerLogStream` / `IChatLogStream` / `IClassifiedPlayerLogLine`) for any
+  cross-cutting domain that has a GameState service. Direct log subscription is
+  reserved for the GameState services themselves and for module-specific domains.
+  Grounded in real, hard-to-reproduce bugs from earlier in the project's history
+  where multiple modules each rebuilt overlapping state from raw logs and produced
+  symptoms that didn't replay deterministically. Lists the five HEAD-existent
+  GameState services (`IInventoryService`, `IPlayerPinTracker`,
+  `IPlayerWeatherTracker`, `IPlayerPositionTracker`, `IPlayerSkillState`) plus
+  recipes/celestial/area trackers; names a verb list that signals the anti-pattern;
+  records `LootBracketTracker.AddItemRx` as a known instance to retire by switching
+  the tracker to `IInventoryService.Subscribe`. Surfaced during the mithril#574
+  L2 spec review chain. A full repo audit for additional anti-pattern instances is
+  pending and will be filed as its own issue.
 - **2026-05-19** — **Radagast charter sketch added (⚠️ Claude draft).** A proposed
   module for server-keyed environment state — moon phase, per-map weather,
   server-keyed gardening buff: sense → player-facing display → serverless


### PR DESCRIPTION
## Summary

Closes a consumption-side gap in `docs/module-charters.md`'s cross-cutting
ownership section.

The existing "data + surface" bullet states that shared services exist and
are the single source of truth, with modules `Subscribe`/query them. This
PR adds the consumption-side complement: **modules never subscribe to raw
logs for cross-cutting domains that have a GameState service.** Direct
log subscription is reserved for (a) the GameState services themselves
and (b) module-specific domains the module owns end-to-end.

Grounded in real, hard-to-reproduce bugs from earlier in the project's
history where multiple modules each rebuilt overlapping state from raw
logs and produced symptoms that didn't replay deterministically.
Centralising the canonical view in a GameState service — with the atomic
replay-then-live `Subscribe` contract — retired that whole bug class.

## What the new bullet covers

- Lists the five HEAD-existent GameState services with links
  (`IInventoryService`, `IPlayerPinTracker`, `IPlayerWeatherTracker`,
  `IPlayerPositionTracker`, `IPlayerSkillState`) plus the
  recipes / celestial / area trackers.
- Names the verb pattern that signals the anti-pattern
  (`ProcessAddItem`, `ProcessLoadSkills`, `ProcessSetWeather`,
  `ProcessMapPin*`, `ProcessNewPosition`, etc.) so future code review
  catches a regression cheaply.
- Records `LootBracketTracker.AddItemRx` as a known anti-pattern instance,
  with the retiring fix (`IInventoryService.Subscribe` consuming
  `InventoryEventKind.Added`). The L2 spec review chain (mithril#574)
  surfaced this; the consumption-side fix is independent of L2 and can
  land sooner.
- Flags that a full repo audit for additional anti-pattern instances is
  pending and will be filed as its own issue when prioritised.

## Why now

The mithril#574 L2 spec was about to ship a "dual-dispatch from
`LootIngestionService` + `LootBracketTracker.OnAddItem(AddItemEvent)`"
shape — module reaching into GameState's log layer. That direction
contradicted the architectural principle without anywhere in the repo
saying so durably. With the rule now in the charter, future spec /
implementation work has the principle to point at, and the L2 spec
resumes with the corrected framing.

## Test plan

- [x] No code changes; doc-only diff.
- [x] `dotnet build Mithril.slnx` should pass unchanged (verified locally before push).
- [x] Diff reviewed: new bullet sits inside the existing `Cross-cutting ownership (confirmed)` section between the existing two ✅ bullets and the `---` separator; History entry added at the top of the History section per existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
