### PR TITLE
docs(charters): GameState owns the emulated game; modules project subsets

### DIFF
--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -39,7 +39,51 @@ A **Does NOT own** entry is one of two kinds, and the distinction matters:
 
 ## Cross-cutting ownership (confirmed)
 
-Applies to *every* module; owner-confirmed 2026-05-16:
+**GameState owns the emulated game world; modules project subsets for UX. ✅
+owner-confirmed 2026-05-21.** This is the strategic principle the tactical
+rules below follow from. [#511](https://github.com/moumantai-gg/mithril/issues/511)'s
+layered log pipeline (L0 → L0.5 → L1 → L2) exists to rebuild the emulated
+game — the player, the NPCs, the world — from `Player.log`. The GameState
+services that have emerged organically through the project's arc —
+[`IPlayerPositionTracker`](../src/Mithril.GameState/Movement/IPlayerPositionTracker.cs)
+([#454](https://github.com/moumantai-gg/mithril/pull/454)),
+[`IPlayerSkillState`](../src/Mithril.GameState/Skills/IPlayerSkillState.cs)
+([#462](https://github.com/moumantai-gg/mithril/issues/462)/[#465](https://github.com/moumantai-gg/mithril/pull/465)),
+[`IPlayerPinTracker`](../src/Mithril.GameState/Pins/IPlayerPinTracker.cs)
+([#468](https://github.com/moumantai-gg/mithril/issues/468)),
+[`IInventoryService`](../src/Mithril.GameState/Inventory/IInventoryService.cs),
+[`IPlayerWeatherTracker`](../src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs),
+[`IPlayerCelestialState`](../src/Mithril.GameState/Celestial/IPlayerCelestialState.cs)
+([#490](https://github.com/moumantai-gg/mithril/pull/490)),
+[`IPlayerRecipeState`](../src/Mithril.GameState/Recipes/IPlayerRecipeState.cs)
+([#475](https://github.com/moumantai-gg/mithril/pull/475)),
+[`IGameSessionService`](../src/Mithril.GameState/Sessions/IGameSessionService.cs),
+[`IQuestService`](../src/Mithril.GameState/Quests/IQuestService.cs),
+[`PlayerAreaTracker`](../src/Mithril.GameState/Areas/PlayerAreaTracker.cs),
+and [`INpcStateTracker`](https://github.com/moumantai-gg/mithril/issues/552)
+(#552, in flight) — are **not** parallel abstractions of their domains;
+they **are** the one canonical model of the emulated game. Modules
+**project subsets** of that emulated game with module-specific UX
+(Samwise → garden subset; Smaug → vendor-economics subset; Arwen → NPC-
+favor subset; Gandalf → timer/cooldown subset; Legolas → surveying
+subset; etc.). A module is a *surface* over GameState, never a parallel
+emulation.
+
+The two tactical rules below — *modules consume the service surface
+(not raw logs)* (added 2026-05-21 via
+[#578](https://github.com/moumantai-gg/mithril/pull/578)) and *services
+translate logs into a developer-facing domain model with three
+channels: query, react, bind* (added 2026-05-21 via
+[#584](https://github.com/moumantai-gg/mithril/pull/584)) — are
+**derivations** of this strategic principle, not separate commitments.
+The underlying direction has been in place since #511 shipped the
+layered pipeline; this paragraph articulates it explicitly so future
+module/service design questions can be answered from the principle
+directly without re-deriving.
+
+Applies to *every* module; owner-confirmed 2026-05-16 (section
+structure + bullets 1-2), 2026-05-21 (consumption-side rule, three-
+channel rule, and this strategic principle):
 
 - **Recipe / crafting → Elrond or Celebrimbor.** Anything recipe- or crafting-related
   — items as crafting ingredients, crafting *use* of an item, craft planning, leveling
@@ -577,6 +621,31 @@ libraries; the charter follows the code:
 
 ## History
 
+- **2026-05-21** — **Strategic principle made explicit: GameState owns the emulated
+  game; modules project subsets for UX (✅ owner-confirmed 2026-05-21).** The two
+  tactical rules previously landed today ([#578](https://github.com/moumantai-gg/mithril/pull/578)
+  consumption-side, [#584](https://github.com/moumantai-gg/mithril/pull/584) three-channel
+  service-design) are **derivations** of this principle, not separate commitments.
+  The underlying direction has been in place since [#511](https://github.com/moumantai-gg/mithril/issues/511)
+  shipped the layered log pipeline (L0/L0.5/L1/L2): #511's mission is rebuilding the
+  emulated game from logs, and the GameState services that emerged through the project's
+  arc (`IPlayerPositionTracker` #454, `IPlayerSkillState` #462/#465, `IPlayerPinTracker`
+  #468, `IInventoryService`, `IPlayerWeatherTracker`, `IPlayerCelestialState` #490,
+  `IPlayerRecipeState` #475, `IGameSessionService`, `IQuestService`, `PlayerAreaTracker`,
+  and `INpcStateTracker` #552 in flight) are the canonical model of that emulated game.
+  Articulating the principle explicitly clarifies that modules are *projections* of
+  subsets for UX — they consume the canonical model, they don't parallel-emulate it.
+  Future design questions ("does this thing belong in GameState or in a module?") have a
+  direct answer from the principle rather than re-derivation. Surfaced during the
+  discussion thread arising from the L2 spec review chain
+  ([#574](https://github.com/moumantai-gg/mithril/issues/574)) and the audit umbrella
+  ([#579](https://github.com/moumantai-gg/mithril/issues/579)) — specifically the
+  realisation that the audit's "Class A migration" classification was too coarse for
+  consumers using cross-cutting verbs as *temporal anchors for correlation* (Arwen
+  gift attribution, Gandalf bracket discrimination) versus consumers *rebuilding
+  cross-cutting state* (Samwise garden inventory map, Smaug CivicPride). Both share
+  the symptom (a module parsing a cross-cutting verb) but the right disposition
+  differs — the strategic principle disambiguates them.
 - **2026-05-21** — **GameState service-design rule added: three channels (query, react,
   bind) over a developer-facing domain model (✅ owner-confirmed 2026-05-21).** Companion
   rule to the consumption-side bullet landed earlier the same day in


### PR DESCRIPTION
## Summary

Makes the strategic principle behind [#578](https://github.com/moumantai-gg/mithril/pull/578)
and [#584](https://github.com/moumantai-gg/mithril/pull/584) explicit:

> **GameState owns the emulated game world; modules project subsets for UX.**

Both prior PRs landed *tactical rules* — consumption-side (modules use
service APIs, not raw logs) and service-design (three channels: query,
react, bind). This PR articulates the strategic principle they're
derivations of, which has been the project's direction since
[#511](https://github.com/moumantai-gg/mithril/issues/511) shipped the
layered log pipeline.

Not a new commitment. A clarification of the commitment that's been
in place all along.

## The arc this PR articulates

[#511](https://github.com/moumantai-gg/mithril/issues/511)'s mission was
rebuilding the emulated game world from `Player.log` via the layered
pipeline (L0 → L0.5 → L1 → L2). The GameState services that have emerged
organically through the project's arc — each lift recorded by its own
PR — are the canonical model of that emulated game:

- [`IPlayerPositionTracker`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Movement/IPlayerPositionTracker.cs) (#454)
- [`IPlayerSkillState`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Skills/IPlayerSkillState.cs) (#462 / #465)
- [`IPlayerPinTracker`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Pins/IPlayerPinTracker.cs) (#468)
- [`IInventoryService`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Inventory/IInventoryService.cs)
- [`IPlayerWeatherTracker`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Weather/IPlayerWeatherTracker.cs)
- [`IPlayerCelestialState`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Celestial/IPlayerCelestialState.cs) (#490)
- [`IPlayerRecipeState`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Recipes/IPlayerRecipeState.cs) (#475)
- [`IGameSessionService`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Sessions/IGameSessionService.cs)
- [`IQuestService`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Quests/IQuestService.cs)
- [`PlayerAreaTracker`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Areas/PlayerAreaTracker.cs)
- [`INpcStateTracker`](https://github.com/moumantai-gg/mithril/issues/552) (#552, in flight)

Modules are **projections** over subsets — Samwise / Smaug / Arwen /
Gandalf / Legolas each surface a slice of the emulated game with
module-specific UX, calibration, or advice. A module is a *surface*,
never a parallel emulation.

## Why now

The framing was implicit in the rules that landed today but not stated
directly. Surfaced during the audit umbrella ([#579](https://github.com/moumantai-gg/mithril/issues/579))
discussion when re-examining whether the *temporal anchor* uses of
cross-cutting verbs (Arwen's gift attribution at
[`CalibrationService.cs:180-220`](https://github.com/moumantai-gg/mithril/blob/main/src/Arwen.Module/Domain/CalibrationService.cs#L180-L220),
Gandalf's bracket discrimination at
[`LootBracketTracker.cs:208`](https://github.com/moumantai-gg/mithril/blob/main/src/Gandalf.Module/Services/LootBracketTracker.cs#L208))
are the same anti-pattern as *state-rebuild* uses (Samwise's
`_itemIdToCrop` map, Smaug's CivicPride re-detection).

Symptomatically they look identical — a module parsing a cross-cutting
verb. But under the principle made explicit here, they're structurally
different cases:

- **State-rebuild**: module is parallel-emulating part of the game.
  Anti-pattern. Migrate to the GameState service.
- **Temporal anchor**: module is using a verb-firing as a clock tick
  for correlation logic that itself is part of the emulated game (gift
  attribution, interaction-type discrimination). The right disposition
  isn't "migrate to subscribe" — it's "GameState should detect the
  signature and emit the typed domain event; the module subscribes to
  *that*." Deferred to a Tier-2 signature initiative under #552's
  follow-up.

The strategic principle disambiguates the two cases without re-deriving
each time.

## What this changes / doesn't change

**Changes:**

- Adds the principle paragraph at the top of `Cross-cutting ownership
  (confirmed)` in `docs/module-charters.md`.
- Adds a History entry pointing at #511 as the strategic origin and at
  #574 / #579 as the surfacing context.
- Frames the existing #578 / #584 bullets as *derivations* of the
  principle rather than separate commitments.

**Does not change:**

- The existing #578 (consumption-side) and #584 (three-channel) bullets'
  body content. They land as-is, with the framing above them showing
  what they derive from.
- The existing 2026-05-16 cross-cutting bullets (recipe ownership; data
  vs. surface). Unchanged.
- Per-module charters below. The principle explains *why* the existing
  charters are shaped the way they are; it doesn't rewrite them.

## Charter rewording — deferred

The principle implies some module charter wordings could be sharpened
(e.g., "Arwen owns per-NPC favor state" → "Arwen owns the **exposure**
of NPC favor + the gift-rate calibration; the favor state and gift-
detection live in GameState"). Deferred to a separate per-module pass
once the implementation arc (Tier-2 signature work atop #552) lands.

## Test plan

- [x] No code changes; doc-only diff.
- [x] `dotnet build Mithril.slnx` passes unchanged.
- [x] Diff reviewed: new strategic paragraph sits at the top of the
  `Cross-cutting ownership (confirmed)` section, ahead of the existing
  bullets; History entry sits at the top of the History section per
  existing convention.

## Follow-ups (not in this PR)

- Tier-2 signature detection initiative under
  [#552](https://github.com/moumantai-gg/mithril/issues/552) — synthesize
  `GiftGiven`, `InteractionResolved`, `VendorSale`, etc. domain events
  from observed verb sequences. To be filed as an umbrella + sub-issues.
- Disposition update for [#582](https://github.com/moumantai-gg/mithril/issues/582)
  (Arwen ItemDeleted) and [#586](https://github.com/moumantai-gg/mithril/issues/586)
  (Gandalf LootBracketTracker): close as "deferred to Tier-2 work" or
  re-spec as consumers of the synthesized events. Audit umbrella
  ([#579](https://github.com/moumantai-gg/mithril/issues/579)) gets the
  corresponding update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
