### PR TITLE
refactor(samwise): consume GardeningXp via IPlayerSkillState (#581)

### DIFF
--- a/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
+++ b/src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs
@@ -30,11 +30,11 @@ namespace Mithril.GameState.Skills.Parsing;
 /// short-circuits the (overwhelmingly common) unrelated line before any regex
 /// runs.</para>
 ///
-/// <para>This parser is independent of Samwise's
-/// <c>GardenLogParser.GardeningXpRx</c> (<c>ProcessUpdateSkill.*type=Gardening</c>):
-/// both can match the same Gardening update line; Samwise consumes it as a
-/// gardening heartbeat while this parser folds Gardening into the full skill
-/// state. There is no coupling or ordering dependency between them.</para>
+/// <para>Samwise consumes the Gardening update via
+/// <see cref="IPlayerSkillState.SubscribeChanges"/> (#581 — was a Samwise-side
+/// <c>ProcessUpdateSkill.*type=Gardening</c> regex pre-migration). This parser
+/// owns the single canonical match; the Samwise consumer filters the
+/// channel on <c>SkillKey == "Gardening"</c>.</para>
 ///
 /// <para>Catalogued in <c>log-patterns.json</c> as
 /// <c>shared.SkillLogParser.{LoadSkillsRx,UpdateSkillRx,SkillTupleRx}</c>

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -59,16 +59,6 @@
         { "name": "itemId", "group": 1, "type": "string" }
       ]
     },
-    "samwise.GardenLogParser.GardeningXpRx": {
-      "pattern": "ProcessUpdateSkill.*type=Gardening",
-      "source": "player",
-      "module": "samwise",
-      "csharp": { "type": "Samwise.Parsing.GardenLogParser", "method": "GardeningXpRx" },
-      "eventType": "samwise.GardeningXp",
-      "kind": "marker",
-      "notes": "IsMatch-only; produces a payload-less GardeningXp event.",
-      "fields": []
-    },
     "samwise.GardenLogParser.ScreenTextErrorRx": {
       "pattern": "ProcessScreenText.*ErrorMessage",
       "source": "player",
@@ -332,7 +322,7 @@
       "csharp": { "type": "Mithril.GameState.Skills.Parsing.SkillLogParser", "method": "UpdateSkillRx" },
       "eventType": "shared.SkillProgressUpdate",
       "kind": "marker",
-      "notes": "Guard for a single-skill delta. The leading struct is extracted by SkillTupleRx, the XP gained by XpGainRx. Independent of samwise.GardenLogParser.GardeningXpRx — both may match a Gardening update; no ordering dependency.",
+      "notes": "Guard for a single-skill delta. The leading struct is extracted by SkillTupleRx, the XP gained by XpGainRx. Samwise consumes the Gardening delta via IPlayerSkillState.SubscribeChanges (#581) rather than re-matching this line.",
       "fields": []
     },
     "shared.SkillLogParser.XpGainRx": {

--- a/src/Samwise.Module/Parsing/GardenLogParser.cs
+++ b/src/Samwise.Module/Parsing/GardenLogParser.cs
@@ -42,8 +42,10 @@ public sealed partial class GardenLogParser : ILogParser
     [GeneratedRegex(@"ProcessUpdateItemCode\((\d+)", RegexOptions.CultureInvariant)]
     private static partial Regex UpdateItemCodeRx();
 
-    [GeneratedRegex(@"ProcessUpdateSkill.*type=Gardening", RegexOptions.CultureInvariant)]
-    private static partial Regex GardeningXpRx();
+    // ProcessUpdateSkill(type=Gardening) is consumed via IPlayerSkillState.SubscribeChanges
+    // (Mithril.GameState) per #581 — no per-line regex here. The GardenStateMachine still
+    // applies a Samwise.Parsing.GardeningXp event; only its source changed from this parser
+    // to GardenIngestionService.OnSkillChange.
 
     [GeneratedRegex(@"ProcessScreenText.*ErrorMessage", RegexOptions.CultureInvariant)]
     private static partial Regex ScreenTextErrorRx();
@@ -79,8 +81,6 @@ public sealed partial class GardenLogParser : ILogParser
 
         m = UpdateItemCodeRx().Match(line);
         if (m.Success) return new UpdateItemCode(timestamp, m.Groups[1].Value);
-
-        if (GardeningXpRx().IsMatch(line)) return new GardeningXp(timestamp);
 
         m = PlantingCapRx().Match(line);
         if (m.Success) return new PlantingCapReached(timestamp, m.Groups[1].Value);

--- a/src/Samwise.Module/Samwise.Module.csproj
+++ b/src/Samwise.Module/Samwise.Module.csproj
@@ -17,6 +17,9 @@
     <ProjectReference Include="..\Mithril.Shared.Wpf\Mithril.Shared.Wpf.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Samwise.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="Config\crops.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using Mithril.Shared.Diagnostics;
 using Mithril.GameState.Inventory;
+using Mithril.GameState.Skills;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Modules;
 using Mithril.Shared.Settings;
@@ -12,10 +13,11 @@ using Samwise.Parsing;
 namespace Samwise.State;
 
 /// <summary>
-/// Bridges the L1 log driver and the <see cref="IInventoryService"/> event
-/// feed into the <see cref="GardenStateMachine"/>. Post-#550 PR 3, the
-/// Player.log path subscribes through <see cref="ILogStreamDriver"/> with
-/// the archetype-B disposition from <a href="https://github.com/moumantai-gg/mithril/issues/549">#549</a>:
+/// Bridges the L1 log driver, the <see cref="IInventoryService"/> event
+/// feed, and the <see cref="IPlayerSkillState"/> change channel into the
+/// <see cref="GardenStateMachine"/>. Post-#550 PR 3, the Player.log path
+/// subscribes through <see cref="ILogStreamDriver"/> with the archetype-B
+/// disposition from <a href="https://github.com/moumantai-gg/mithril/issues/549">#549</a>:
 ///
 /// <list type="bullet">
 ///   <item><c>ReplayMode = FromSessionStart</c> — Samwise needs the full
@@ -30,11 +32,13 @@ namespace Samwise.State;
 ///   textbook persisted-state-vs-replay collision: <see cref="GardenStateService.LoadAllAsync"/>
 ///   hydrates plot state from per-character <c>samwise.json</c>, then L1
 ///   replays the entire session. Without the filter, plant /
-///   <c>UpdateDescription</c> / <c>StartInteraction</c> / <c>GardeningXp</c>
-///   events would re-apply on top of already-persisted plots, advancing
-///   stages and burning slot caps. The <c>HandlePlant</c> plot-id
+///   <c>UpdateDescription</c> / <c>StartInteraction</c> events would
+///   re-apply on top of already-persisted plots, advancing stages and
+///   burning slot caps. The <c>HandlePlant</c> plot-id
 ///   <c>ContainsKey</c> guard is partial; the high-water makes restart
-///   semantics deterministic.</item>
+///   semantics deterministic. (Post-#581 the GardeningXp signal arrives
+///   via <see cref="IPlayerSkillState"/>, not L1; the high-water still
+///   covers the Player.log payloads Samwise still owns.)</item>
 /// </list>
 ///
 /// <para><b>Inventory stream stays as-is.</b> <see cref="IInventoryService"/>
@@ -54,11 +58,23 @@ namespace Samwise.State;
 /// rate-limited <c>Warn</c> + per-subscription fault state machine (#550
 /// capabilities C + G). The <c>InventoryService</c> path keeps its own
 /// in-process error surface (it never crossed L1).</para>
+///
+/// <para><b>Gardening XP via <see cref="IPlayerSkillState.SubscribeChanges"/>.</b>
+/// The harvest-confirmation signal (per
+/// <see cref="GardenStateMachine.Apply"/>'s <c>GardeningXp</c> arm) is
+/// sourced from the shared skill-state service rather than a Samwise-side
+/// regex (#581). Same self-marshal shape as the inventory channel —
+/// <see cref="IPlayerSkillState"/>'s callback fires on the tracker's
+/// ingestion thread under its lock, not the bound ObservableCollection's
+/// thread, so we hop via <see cref="DispatchInventory"/>.</para>
 /// </summary>
 public sealed class GardenIngestionService : BackgroundService
 {
+    private const string GardeningSkillKey = "Gardening";
+
     private readonly ILogStreamDriver _driver;
     private readonly IInventoryService _inventory;
+    private readonly IPlayerSkillState _skillState;
     private readonly GardenLogParser _parser;
     private readonly GardenStateMachine _state;
     private readonly GardenStateService _stateService;
@@ -71,6 +87,7 @@ public sealed class GardenIngestionService : BackgroundService
     public GardenIngestionService(
         ILogStreamDriver driver,
         IInventoryService inventory,
+        IPlayerSkillState skillState,
         GardenLogParser parser,
         GardenStateMachine state,
         GardenStateService stateService,
@@ -82,6 +99,7 @@ public sealed class GardenIngestionService : BackgroundService
     {
         _driver = driver;
         _inventory = inventory;
+        _skillState = skillState;
         _parser = parser;
         _state = state;
         _stateService = stateService;
@@ -138,6 +156,25 @@ public sealed class GardenIngestionService : BackgroundService
         // ObservableCollection stays single-threaded.
         var subscription = _inventory.Subscribe(OnInventoryEvent);
 
+        // Gardening XP arrival is the harvest-confirmation discriminator
+        // (GardenStateMachine.HandleGardeningXp commits the staged plot
+        // transition). Source: IPlayerSkillState's granular change channel,
+        // not a raw-log regex (#581 — consumption-side rule from #578).
+        //
+        // SubscribeChanges is event-shaped (no replay), so each Gardening
+        // delta arrives exactly once — matching the today-shape of one
+        // ProcessUpdateSkill line → one GardeningXp event. SnapshotReplace
+        // is deliberately ignored: today's regex only matched
+        // ProcessUpdateSkill, not the periodic ProcessLoadSkills re-sync,
+        // so a snapshot replay must not commit a harvest.
+        //
+        // The IPlayerSkillState callback fires on the tracker's ingestion
+        // thread under its internal lock — same shape as IInventoryService.
+        // Self-marshal via DispatchInventory for the same reason: the
+        // GardenStateMachine.Apply path raises PlotChanged → bound
+        // ObservableCollection which has UI-thread affinity.
+        var skillSubscription = _skillState.SubscribeChanges(OnSkillChange);
+
         // L1 driver subscription for the Player.log payloads Samwise still owns
         // (everything except AddItem/DeleteItem, which come via IInventoryService).
         //
@@ -188,6 +225,7 @@ public sealed class GardenIngestionService : BackgroundService
         {
             logSubscription.Dispose();
             subscription.Dispose();
+            skillSubscription.Dispose();
         }
     }
 
@@ -212,6 +250,59 @@ public sealed class GardenIngestionService : BackgroundService
         // pre-L1 ingestion did — this is NOT the L1 path, so L1's
         // Marshaled context doesn't cover it.
         DispatchInventory(() => _state.Apply(ge));
+    }
+
+    /// <summary>
+    /// Bridge from <see cref="IPlayerSkillState.SubscribeChanges"/> into the
+    /// state machine. Only Gardening Delta events matter — they are the
+    /// confirmation that closes a pending harvest interaction (#581).
+    ///
+    /// <para>SnapshotReplace is deliberately ignored: today's parser only
+    /// matched <c>ProcessUpdateSkill</c>, never the periodic
+    /// <c>ProcessLoadSkills</c> re-sync, so a snapshot reconcile must not
+    /// commit a harvest. Other skills are filtered out by the
+    /// <c>SkillKey == "Gardening"</c> check.</para>
+    ///
+    /// <para>The XP value on the <see cref="SkillChange"/> is discarded — the
+    /// state machine cares only that an update fired and at what timestamp,
+    /// mirroring the prior regex path's payload-less <see cref="GardeningXp"/>
+    /// event.</para>
+    /// </summary>
+    // internal for tests (Samwise.Tests has InternalsVisibleTo); production
+    // callers go through SubscribeChanges in ExecuteAsync above.
+    internal void OnSkillChange(SkillChange change)
+    {
+        var ge = TryProjectGardeningXp(change);
+        if (ge is null) return;
+
+        _diag?.Trace("Samwise.Parse", Describe(ge));
+        // The IPlayerSkillState callback fires on the L1 ingestion thread
+        // under the tracker's internal lock — not on the UI dispatcher.
+        // Self-marshal exactly like the inventory path so PlotChanged →
+        // bound ObservableCollection stays single-threaded.
+        DispatchInventory(() => _state.Apply(ge));
+    }
+
+    /// <summary>
+    /// Pure decision: does this <see cref="SkillChange"/> count as a
+    /// gardening-XP harvest-confirmation tick? Internal for direct unit
+    /// testing — the dispatch wrapper above adds only the diagnostics
+    /// + UI-thread hop on top of this filter.
+    ///
+    /// <list type="bullet">
+    ///   <item><see cref="SkillChangeKind.Delta"/> only — today's regex
+    ///   only matched <c>ProcessUpdateSkill</c>, not the periodic
+    ///   <c>ProcessLoadSkills</c> re-sync, so a snapshot reconcile must
+    ///   not commit a harvest.</item>
+    ///   <item><see cref="SkillChange.SkillKey"/> must equal
+    ///   <c>"Gardening"</c> — every other skill's delta is unrelated.</item>
+    /// </list>
+    /// </summary>
+    internal static GardeningXp? TryProjectGardeningXp(SkillChange change)
+    {
+        if (change.Kind != SkillChangeKind.Delta) return null;
+        if (!string.Equals(change.SkillKey, GardeningSkillKey, StringComparison.Ordinal)) return null;
+        return new GardeningXp(change.Timestamp);
     }
 
     private static string Describe(GardenEvent e) => e switch

--- a/src/Samwise.Module/State/GardenIngestionService.cs
+++ b/src/Samwise.Module/State/GardenIngestionService.cs
@@ -267,6 +267,19 @@ public sealed class GardenIngestionService : BackgroundService
     /// state machine cares only that an update fired and at what timestamp,
     /// mirroring the prior regex path's payload-less <see cref="GardeningXp"/>
     /// event.</para>
+    ///
+    /// <para><b>Cold-start inter-drain race (acknowledged bound; tracked in
+    /// <see href="https://github.com/moumantai-gg/mithril/issues/597">#597</see>):</b>
+    /// <see cref="IPlayerSkillState.SubscribeChanges"/> is no-replay — a late
+    /// subscriber sees only changes from the moment it attaches. The handler
+    /// here attaches after <c>_gate.WaitAsync</c> + <c>LoadAllAsync</c>, while
+    /// <c>PlayerSkillStateService</c> has no gate and can drain L1 envelopes
+    /// ahead of Samwise. Any Gardening <see cref="SkillChangeKind.Delta"/>
+    /// fired in that pre-attach window is lost. Bound: harvests completed in
+    /// that window stay <c>Ripe</c> with stale <c>_pendingHarvestPlotId</c>
+    /// until the next live interaction, where <c>MarkOldestRipeOfType</c>
+    /// recovers them. #597 closes this structurally via full-event-log replay
+    /// on <c>SubscribeChanges</c> (sister to <see href="https://github.com/moumantai-gg/mithril/issues/585">#585</see>).</para>
     /// </summary>
     // internal for tests (Samwise.Tests has InternalsVisibleTo); production
     // callers go through SubscribeChanges in ExecuteAsync above.

--- a/tests/Samwise.Tests/GardenLogParserTests.cs
+++ b/tests/Samwise.Tests/GardenLogParserTests.cs
@@ -82,10 +82,14 @@ public class GardenLogParserTests
     }
 
     [Fact]
-    public void Parses_GardeningXp()
+    public void Ignores_ProcessUpdateSkill_Gardening()
     {
+        // Post-#581 the GardeningXp signal is sourced from
+        // IPlayerSkillState.SubscribeChanges (Mithril.GameState), not from
+        // a Samwise-side regex. The parser must return null so the line
+        // isn't double-processed by the L1 driver subscription.
         var line = @"... ProcessUpdateSkill(name=Gardening, type=Gardening, xp=100)";
-        _p.TryParse(line, T).Should().BeOfType<GardeningXp>();
+        _p.TryParse(line, T).Should().BeNull();
     }
 
     [Fact]

--- a/tests/Samwise.Tests/GardeningXpSkillStateBridgeTests.cs
+++ b/tests/Samwise.Tests/GardeningXpSkillStateBridgeTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Mithril.GameState.Skills;
+using Samwise.Parsing;
+using Samwise.State;
+using Xunit;
+
+namespace Samwise.Tests;
+
+/// <summary>
+/// Regression tests for the <see cref="IPlayerSkillState.SubscribeChanges"/>
+/// → <see cref="GardenStateMachine"/> bridge introduced in
+/// <a href="https://github.com/moumantai-gg/mithril/issues/581">#581</a>
+/// (Class A migration from #579 — Samwise stops re-parsing
+/// <c>ProcessUpdateSkill.*type=Gardening</c> and consumes the canonical
+/// skill-state service instead).
+///
+/// <para>The bridge is exercised through
+/// <see cref="GardenIngestionService.TryProjectGardeningXp"/>, the pure
+/// decision helper. The dispatch wrapper above it adds only diagnostics
+/// and a UI-thread hop, so the filter contract is the load-bearing piece
+/// worth pinning here.</para>
+/// </summary>
+public class GardeningXpSkillStateBridgeTests
+{
+    private static readonly DateTime T = new(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc);
+
+    private static SkillProgressSnapshot AnySnapshot(int level = 50, long xp = 100) =>
+        new(Level: level, BonusLevels: 0, XpTowardNextLevel: xp, XpNeededForNextLevel: 1000, MaxLevel: 200);
+
+    [Fact]
+    public void Gardening_Delta_Projects_GardeningXp_With_Source_Timestamp()
+    {
+        var change = new SkillChange(
+            SkillKey: "Gardening",
+            Previous: AnySnapshot(level: 49),
+            Current: AnySnapshot(level: 50),
+            XpGained: 42,
+            Kind: SkillChangeKind.Delta,
+            Timestamp: T);
+
+        var projected = GardenIngestionService.TryProjectGardeningXp(change);
+
+        projected.Should().NotBeNull("a Gardening Delta is the harvest-confirmation signal");
+        projected!.Timestamp.Should().Be(T,
+            "the prior regex path produced GardeningXp(line.Timestamp); the bridge must preserve it");
+    }
+
+    [Fact]
+    public void Non_Gardening_Delta_Does_Not_Project()
+    {
+        // Every other skill's delta is unrelated to garden harvest commits.
+        var change = new SkillChange(
+            SkillKey: "Survey",
+            Previous: AnySnapshot(level: 49),
+            Current: AnySnapshot(level: 50),
+            XpGained: 42,
+            Kind: SkillChangeKind.Delta,
+            Timestamp: T);
+
+        GardenIngestionService.TryProjectGardeningXp(change).Should().BeNull();
+    }
+
+    [Fact]
+    public void Gardening_SnapshotReplace_Does_Not_Project()
+    {
+        // The pre-#581 regex only matched ProcessUpdateSkill, not the
+        // periodic ProcessLoadSkills re-sync. A snapshot reconcile must
+        // NOT commit a harvest — it would re-fire HandleGardeningXp on
+        // every zone change and burn pending-harvest discriminator state.
+        var change = new SkillChange(
+            SkillKey: "Gardening",
+            Previous: AnySnapshot(level: 49),
+            Current: AnySnapshot(level: 50),
+            XpGained: 0,
+            Kind: SkillChangeKind.SnapshotReplace,
+            Timestamp: T);
+
+        GardenIngestionService.TryProjectGardeningXp(change).Should().BeNull();
+    }
+
+    [Fact]
+    public void Other_Skill_SnapshotReplace_Does_Not_Project()
+    {
+        // Both gates fail; assert combined for completeness.
+        var change = new SkillChange(
+            SkillKey: "FireMagic",
+            Previous: null,
+            Current: AnySnapshot(),
+            XpGained: 0,
+            Kind: SkillChangeKind.SnapshotReplace,
+            Timestamp: T);
+
+        GardenIngestionService.TryProjectGardeningXp(change).Should().BeNull();
+    }
+
+    [Fact]
+    public void Gardening_Delta_Is_Case_Sensitive_On_SkillKey()
+    {
+        // SkillKey is the internal-name key (project-wide convention) —
+        // Ordinal compare. Mis-cased input should not project (the
+        // canonical IPlayerSkillState would never emit a mis-cased key,
+        // but we pin the strict-equality contract here so a future
+        // refactor doesn't silently loosen it).
+        var change = new SkillChange(
+            SkillKey: "gardening",
+            Previous: null,
+            Current: AnySnapshot(),
+            XpGained: 1,
+            Kind: SkillChangeKind.Delta,
+            Timestamp: T);
+
+        GardenIngestionService.TryProjectGardeningXp(change).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #581 (Class A migration #3 from the [post-#578 cross-cutting consumer audit (#579)](https://github.com/moumantai-gg/mithril/issues/579)).

Retires Samwise's regex-on-raw-log Gardening XP consumption (`GardenLogParser.GardeningXpRx` — `ProcessUpdateSkill.*type=Gardening`) and sources the harvest-confirmation tick from `IPlayerSkillState.SubscribeChanges` (PR #465) instead. Same shape as sibling #580 (Smaug CivicPride). Aligns Samwise with the consumption-side rule documented in [`docs/module-charters.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/module-charters.md#cross-cutting-ownership-confirmed) post-#578.

### What moved

- **`src/Samwise.Module/Parsing/GardenLogParser.cs`** — `GardeningXpRx` (regex + `IsMatch`-only branch) deleted. Comment-marker left so a future reader sees where the responsibility went.
- **`src/Samwise.Module/State/GardenIngestionService.cs`** — new `IPlayerSkillState` ctor dependency; new `_skillState.SubscribeChanges(OnSkillChange)` wired in `ExecuteAsync` after the inventory subscription and before the L1 driver subscription. `OnSkillChange` self-marshals via the same `DispatchInventory` UI-thread hop the inventory channel uses. Decision split into a pure `TryProjectGardeningXp(SkillChange)` for testability.
- **`src/Mithril.Shared/Reference/log-patterns.json`** — `samwise.GardenLogParser.GardeningXpRx` entry removed; `shared.SkillLogParser.UpdateSkillRx`'s `notes` updated.
- **`src/Mithril.GameState/Skills/Parsing/SkillLogParser.cs`** — comment updated to reflect that Samwise now consumes via the shared service.

### What stayed

- `GardeningXp` event in `GardenEvents.cs` — `GardenStateMachine` still dispatches on it.
- `HandleGardeningXp` body unchanged; pending-harvest discriminator state (`_pendingHarvestPlotId`, `_lastUpdateItemCropType`) unchanged.
- L1 subscription for everything except the now-retired skill regex (plant / `UpdateDescription` / `StartInteraction` / `UpdateItemCode` / `PlantingCap` / `ScreenTextError` still flow through the L1 path).

### Filter contract

`SkillKey == "Gardening"` (Ordinal) && `Kind == SkillChangeKind.Delta`. `SnapshotReplace` is deliberately ignored — today's regex only matched `ProcessUpdateSkill`, never the periodic `ProcessLoadSkills` re-sync, so a snapshot reconcile must not commit a harvest. The `XpGained` value is discarded; Samwise never cared how much, only that an update fired.

### Threading

`IPlayerSkillState` fires synchronously on the L1 ingestion thread under the tracker's internal lock — same shape as `IInventoryService.Subscribe`. We self-marshal via the existing `DispatchInventory` helper so `PlotChanged` → bound `ObservableCollection` stays single-threaded. The L1 `Marshaled` context does not cover this channel.

### Test plan

New `tests/Samwise.Tests/GardeningXpSkillStateBridgeTests.cs` covers the `TryProjectGardeningXp` pure decision against all 5 spec cases:

- Gardening Delta → projects `GardeningXp(Timestamp)` carrying the source timestamp
- Non-Gardening Delta (e.g. `"Survey"`) → drops
- Gardening SnapshotReplace → drops (no harvest commit on a snapshot re-sync)
- Other-skill SnapshotReplace → drops
- Mis-cased SkillKey (`"gardening"`) → drops (Ordinal-equal contract)

Existing tests preserved:

- `GardenStateMachineTests.Tier3_GardeningXp_With_Pending_Confirms` and `ScreenTextError_Cancels_PendingHarvest` — the state machine's `GardeningXp` Apply arm is unchanged.
- `GardenLogParserTests.Parses_GardeningXp` updated to `Ignores_ProcessUpdateSkill_Gardening` (the parser must now return null for these lines).

Catalog parity is preserved by `LogPatternCatalogParityTests`.

### Verification

```
$ dotnet build Mithril.slnx
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:00:14.87

$ dotnet test Mithril.slnx --no-build
Passed!  - Samwise.Tests:              465 / 465
Passed!  - Mithril.GameState.Tests:    288 / 288
Passed!  - Mithril.Shared.Tests:      1246 / 1246
...
All 20 test projects pass (3556+ tests, 0 failed, 0 skipped).
```

### Verification owed (from issue body) — confirmed

- `grep "ProcessUpdateSkill\|type=Gardening" src/Samwise.Module/Parsing/` returns only one comment line (the explanatory marker pointing to `IPlayerSkillState`). No live regex remains.
- `IPlayerSkillState` is registered in `GameStateServiceCollectionExtensions.AddMithrilGameState` (shell bootstrap, not Samwise DI).
- `GardenStateMachineTests` Tier-1/2/3 harvest flow regressions all pass.

### Out of scope (parallel work — do not touch in this PR)

- #580 Smaug CivicPride migration
- #585 `IInventoryService.Subscribe` rewrite
- #590 `IPlayerEffectsStateService`
- #587 deferred charter-wording edits
- L2 #574 anticipatory lifts

---
— drafted by Claude (Opus 4.7), posted by @arthur-conde
