### PR TITLE
refactor(smaug): consume CivicPride from IPlayerSkillState (#580)

### DIFF
--- a/src/Mithril.GameState/AssemblyInfo.cs
+++ b/src/Mithril.GameState/AssemblyInfo.cs
@@ -1,3 +1,9 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Mithril.GameState.Tests")]
+// #580 — Smaug consumes IPlayerSkillState in tests of its VendorIngestionService
+// CivicPride migration; the internal PlayerSkillSnapshot ctor is the simplest
+// way for a consumer test to mint a curated snapshot without spinning up a
+// real PlayerSkillStateService + log stream. Same trust boundary as
+// Mithril.GameState.Tests.
+[assembly: InternalsVisibleTo("Smaug.Tests")]

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -171,17 +171,6 @@
         { "name": "npcKey", "group": 2, "type": "string" }
       ]
     },
-    "smaug.VendorLogParser.CivicPrideRx": {
-      "pattern": "\\{type=CivicPride,raw=(\\d+),bonus=(\\d+),",
-      "source": "player",
-      "module": "smaug",
-      "csharp": { "type": "Smaug.Parsing.VendorLogParser", "method": "CivicPrideRx" },
-      "eventType": "smaug.CivicPrideUpdated",
-      "fields": [
-        { "name": "raw", "group": 1, "type": "int" },
-        { "name": "bonus", "group": 2, "type": "int" }
-      ]
-    },
     "pippin.GourmandLogParser.ProcessBookFoodsRx": {
       "pattern": "ProcessBook\\(\"Skill Info\",\\s*\"(Foods Consumed:\\\\n\\\\n(?:[^\"\\\\]|\\\\.)*)\".*\"SkillReport\"",
       "source": "player",

--- a/src/Smaug.Module/Parsing/VendorEvents.cs
+++ b/src/Smaug.Module/Parsing/VendorEvents.cs
@@ -39,15 +39,3 @@ public sealed record NpcInteractionStarted(
     int EntityId,
     string NpcKey) : VendorEvent(Timestamp);
 
-/// <summary>
-/// Civic Pride skill snapshot from <c>ProcessLoadSkills</c> (session start) or
-/// <c>ProcessUpdateSkill</c> (on level up). Effective level is <c>Raw + Bonus</c>.
-/// </summary>
-public sealed record CivicPrideUpdated(
-    DateTime Timestamp,
-    int Raw,
-    int Bonus) : VendorEvent(Timestamp)
-{
-    public int EffectiveLevel => Raw + Bonus;
-}
-

--- a/src/Smaug.Module/Parsing/VendorLogParser.cs
+++ b/src/Smaug.Module/Parsing/VendorLogParser.cs
@@ -9,9 +9,17 @@ namespace Smaug.Parsing;
 ///   ProcessVendorAddItem(price, ItemName(instanceId), bool)
 ///   ProcessVendorUpdateAvailableGold(gold, reset, cap)
 ///   ProcessStartInteraction(entityId, uid, favor, bool, "NPC_Key")
-///   {type=CivicPride,raw=N,bonus=M,...} — appears inside ProcessLoadSkills / ProcessUpdateSkill
-/// Active-character tracking lives in <c>ActiveCharacterLogSynchronizer</c> — this
-/// parser does not handle <c>ProcessAddPlayer</c>.
+///
+/// <para>Civic Pride is intentionally <b>not</b> parsed here — it lives in the
+/// shared <see cref="Mithril.GameState.Skills.IPlayerSkillState"/> service
+/// (which already tails <c>ProcessLoadSkills</c> / <c>ProcessUpdateSkill</c>),
+/// and <c>VendorIngestionService</c> consumes the projected
+/// <c>PlayerSkillSnapshot</c> directly. Per <see href="https://github.com/moumantai-gg/mithril/issues/580">#580</see>
+/// (Class A finding #2 from the post-#578 cross-cutting consumer audit) modules
+/// don't re-parse skill verbs.</para>
+///
+/// <para>Active-character tracking lives in <c>ActiveCharacterLogSynchronizer</c> —
+/// this parser does not handle <c>ProcessAddPlayer</c>.</para>
 /// </summary>
 public sealed partial class VendorLogParser
 {
@@ -30,10 +38,6 @@ public sealed partial class VendorLogParser
     [GeneratedRegex(@"ProcessStartInteraction\((\d+),\s*\d+,\s*[\d.-]+,\s*\w+,\s*""(NPC_\w+)""\)",
         RegexOptions.CultureInvariant)]
     private static partial Regex StartInteractionRx();
-
-    [GeneratedRegex(@"\{type=CivicPride,raw=(\d+),bonus=(\d+),",
-        RegexOptions.CultureInvariant)]
-    private static partial Regex CivicPrideRx();
 
     public VendorEvent? TryParse(string line, DateTime timestamp)
     {
@@ -75,15 +79,6 @@ public sealed partial class VendorLogParser
             var m = StartInteractionRx().Match(line);
             if (m.Success && int.TryParse(m.Groups[1].ValueSpan, out var entityId))
                 return new NpcInteractionStarted(timestamp, entityId, m.Groups[2].Value);
-        }
-
-        if (line.Contains("type=CivicPride", StringComparison.Ordinal))
-        {
-            var m = CivicPrideRx().Match(line);
-            if (m.Success
-                && int.TryParse(m.Groups[1].ValueSpan, out var raw)
-                && int.TryParse(m.Groups[2].ValueSpan, out var bonus))
-                return new CivicPrideUpdated(timestamp, raw, bonus);
         }
 
         return null;

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -210,6 +210,19 @@ public sealed class VendorIngestionService : BackgroundService
     /// path or a prior live snapshot already set. The shared skill snapshot is
     /// authoritative when the key is present; absent is "not yet observed",
     /// not "the skill is unlearned".</para>
+    ///
+    /// <para><b>Threading.</b> Per the <see cref="IPlayerSkillState.Subscribe"/>
+    /// contract this runs <b>synchronously under the tracker's lock</b> — on
+    /// the caller's thread for the initial replay and on the L1 ingestion
+    /// thread for live dispatch — <b>not</b> on the WPF dispatcher. Safe today
+    /// because <c>_context.CivicPrideLevel</c> is a plain field write on a POCO
+    /// and the downstream WPF binding path
+    /// (<c>PriceCalibrationService.DataChanged</c> → <c>CalibrationViewModel</c>)
+    /// already hops to the dispatcher via the L1 subscription's
+    /// <see cref="DeliveryContext.Marshaled"/>. <b>Future trap:</b> if
+    /// <see cref="VendorSellContext"/> grows <c>INotifyPropertyChanged</c>
+    /// properties bound directly to the UI, this handler must marshal to the
+    /// UI thread before mutating them.</para>
     /// </summary>
     private void OnSkillSnapshot(PlayerSkillSnapshot snapshot)
     {
@@ -229,6 +242,16 @@ public sealed class VendorIngestionService : BackgroundService
     /// before Smaug's ingestion loop was running, pull Civic Pride from the character export.
     /// When the active character changes, overwrites unconditionally; on first prime, only fills in
     /// a zero level so a live log-parsed value is not clobbered by a stale export.
+    ///
+    /// <para><b>Ordering — live wins over export.</b> <see cref="ExecuteAsync"/>
+    /// calls this <em>before</em> subscribing to <see cref="IPlayerSkillState"/>,
+    /// so the export-derived value is in place first and the subsequent
+    /// synchronous replay of <see cref="OnSkillSnapshot"/> overwrites it with
+    /// the live tracker snapshot. This is deliberate: the character export is a
+    /// stale on-disk file (last <c>/dumpchar</c>), while <c>IPlayerSkillState</c>
+    /// reflects the current session — flipping the order would let a stale export
+    /// clobber correct live data. The post-prime <c>ActiveCharacterChanged</c>
+    /// overwrite path is the one exception (a deliberate character switch).</para>
     /// </summary>
     private void PrimeCivicPrideFromActiveCharacter(bool overwrite = false)
     {

--- a/src/Smaug.Module/State/VendorIngestionService.cs
+++ b/src/Smaug.Module/State/VendorIngestionService.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Mithril.GameState.Skills;
 using Mithril.Shared.Character;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
@@ -16,11 +17,23 @@ namespace Smaug.State;
 ///
 /// <para><b>L1 migration shape (#550 PR 3, archetype-B).</b> Subscribes to
 /// <see cref="LocalPlayerLogLine"/> with
-/// <see cref="ReplayMode.FromSessionStart"/> — Civic-Pride (from
-/// <c>ProcessLoadSkills</c>) plus <c>NpcInteractionStarted</c> /
+/// <see cref="ReplayMode.FromSessionStart"/> — <c>NpcInteractionStarted</c> /
 /// <c>VendorScreenOpened</c> context lines must arrive before any
 /// <c>VendorItemSold</c> for that sell to be attributable; <c>LiveOnly</c>
 /// would silently skip sells that landed in the replay window.</para>
+///
+/// <para><b>Civic Pride via shared skill state (#580).</b> Smaug no longer
+/// re-parses <c>ProcessLoadSkills</c> / <c>ProcessUpdateSkill</c> for the
+/// CivicPride skill — it consumes the shared
+/// <see cref="IPlayerSkillState"/> service (#462 / PR #465) and reads the
+/// effective level (<c>Level + BonusLevels</c>) off the replayed snapshot.
+/// The subscription is taken before the L1 vendor subscription, and
+/// <see cref="IPlayerSkillState.Subscribe"/> delivers the current snapshot
+/// synchronously under its lock, so a CivicPride level known to the tracker
+/// at subscribe time is set on <see cref="_context"/> before any vendor
+/// envelope is dispatched. Per Class A finding #2 from the consumer audit
+/// (#579) and the consumption-side rule documented in
+/// <c>docs/module-charters.md</c> post-PR #578.</para>
 ///
 /// <para><b>Latent-bug fix.</b> Per <see href="https://github.com/moumantai-gg/mithril/issues/549">#549</see>
 /// the pre-L1 ingestion path mutates the UI-bound
@@ -39,8 +52,8 @@ namespace Smaug.State;
 /// already owns per-key dedup at the sink (HashSet keyed
 /// <c>SessionId|NpcKey|InternalName|PricePaid|Timestamp:O</c>); an L1
 /// high-water <c>Sequence</c> filter would be redundant. The context
-/// mutations (<c>CivicPrideUpdated</c>, <c>VendorScreenOpened</c>,
-/// <c>NpcInteractionStarted</c>) are last-write-wins and structurally
+/// mutations (<c>VendorScreenOpened</c>, <c>NpcInteractionStarted</c>,
+/// CivicPride snapshot replay) are last-write-wins and structurally
 /// idempotent under replay.</para>
 ///
 /// <para><b>Containment.</b> The L1 driver wraps every handler invocation in
@@ -57,9 +70,11 @@ public sealed class VendorIngestionService : BackgroundService
     private readonly PriceCalibrationService _calibration;
     private readonly VendorSellContext _context;
     private readonly IActiveCharacterService _activeCharacter;
+    private readonly IPlayerSkillState _skillState;
     private readonly IDiagnosticsSink? _diag;
     private readonly ModuleGate _gate;
     private ILogSubscription? _subscription;
+    private IDisposable? _skillSubscription;
 
     public VendorIngestionService(
         ILogStreamDriver driver,
@@ -67,6 +82,7 @@ public sealed class VendorIngestionService : BackgroundService
         PriceCalibrationService calibration,
         VendorSellContext context,
         IActiveCharacterService activeCharacter,
+        IPlayerSkillState skillState,
         ModuleGates gates,
         IDiagnosticsSink? diag = null)
     {
@@ -75,6 +91,7 @@ public sealed class VendorIngestionService : BackgroundService
         _calibration = calibration;
         _context = context;
         _activeCharacter = activeCharacter;
+        _skillState = skillState;
         _diag = diag;
         _gate = gates.For("smaug");
     }
@@ -93,6 +110,13 @@ public sealed class VendorIngestionService : BackgroundService
             _activeCharacter.ActiveCharacterChanged -= OnActiveCharacterChanged;
             _activeCharacter.CharacterExportsChanged -= OnActiveCharacterChanged;
         });
+
+        // Subscribe to shared skill state (#580). Subscribe is atomic
+        // replay + live under the tracker's lock, so the current snapshot
+        // — including any CivicPride observed pre-gate — is delivered
+        // synchronously before this call returns, and before any vendor
+        // envelope reaches the L1 handler below.
+        _skillSubscription = _skillState.Subscribe(OnSkillSnapshot);
 
         // Latent-bug fix per #549 + #550 capability E. The Smaug gate only
         // opens after the user has clicked the Smaug tab, so Application.Current
@@ -114,12 +138,6 @@ public sealed class VendorIngestionService : BackgroundService
 
                 switch (evt)
                 {
-                    case CivicPrideUpdated cp:
-                        _context.CivicPrideLevel = cp.EffectiveLevel;
-                        _diag?.Trace("Smaug.Parse",
-                            $"CivicPride level={cp.EffectiveLevel} (raw={cp.Raw}+bonus={cp.Bonus})");
-                        break;
-
                     case NpcInteractionStarted started:
                         _context.RememberEntity(started.EntityId, started.NpcKey);
                         break;
@@ -165,6 +183,8 @@ public sealed class VendorIngestionService : BackgroundService
         {
             _subscription?.Dispose();
             _subscription = null;
+            _skillSubscription?.Dispose();
+            _skillSubscription = null;
         }
     }
 
@@ -172,7 +192,33 @@ public sealed class VendorIngestionService : BackgroundService
     {
         _subscription?.Dispose();
         _subscription = null;
+        _skillSubscription?.Dispose();
+        _skillSubscription = null;
         base.Dispose();
+    }
+
+    /// <summary>
+    /// Whole-snapshot handler — invoked synchronously by
+    /// <see cref="IPlayerSkillState.Subscribe"/> with the current snapshot
+    /// on attach (replay) and on every subsequent
+    /// <c>ProcessLoadSkills</c> / <c>ProcessUpdateSkill</c>.
+    ///
+    /// <para>If the snapshot does not carry <c>CivicPride</c> (cold session
+    /// before the first <c>ProcessLoadSkills</c> of the session, or a
+    /// partial-snapshot warm-up window), <b>do not</b> reset
+    /// <c>_context.CivicPrideLevel</c> — preserve whatever the prime-from-export
+    /// path or a prior live snapshot already set. The shared skill snapshot is
+    /// authoritative when the key is present; absent is "not yet observed",
+    /// not "the skill is unlearned".</para>
+    /// </summary>
+    private void OnSkillSnapshot(PlayerSkillSnapshot snapshot)
+    {
+        if (!snapshot.Skills.TryGetValue("CivicPride", out var cp)) return;
+        var effective = cp.Level + cp.BonusLevels;
+        if (_context.CivicPrideLevel == effective) return;
+        _context.CivicPrideLevel = effective;
+        _diag?.Trace("Smaug.Skills",
+            $"CivicPride level={effective} (raw={cp.Level}+bonus={cp.BonusLevels}) from IPlayerSkillState");
     }
 
     private void OnActiveCharacterChanged(object? sender, EventArgs e) =>

--- a/tests/Smaug.Tests/Smaug.Tests.csproj
+++ b/tests/Smaug.Tests/Smaug.Tests.csproj
@@ -14,5 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Smaug.Module\Smaug.Module.csproj" />
     <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.GameState\Mithril.GameState.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Smaug.Tests/VendorIngestionServiceL1Tests.cs
+++ b/tests/Smaug.Tests/VendorIngestionServiceL1Tests.cs
@@ -178,9 +178,6 @@ public sealed class VendorIngestionServiceL1Tests
 
                     switch (evt)
                     {
-                        case CivicPrideUpdated cp:
-                            context.CivicPrideLevel = cp.EffectiveLevel;
-                            break;
                         case NpcInteractionStarted started:
                             context.RememberEntity(started.EntityId, started.NpcKey);
                             break;
@@ -284,9 +281,6 @@ public sealed class VendorIngestionServiceL1Tests
 
                     switch (evt)
                     {
-                        case CivicPrideUpdated cp:
-                            context.CivicPrideLevel = cp.EffectiveLevel;
-                            break;
                         case NpcInteractionStarted started:
                             context.RememberEntity(started.EntityId, started.NpcKey);
                             break;

--- a/tests/Smaug.Tests/VendorIngestionServiceSkillStateTests.cs
+++ b/tests/Smaug.Tests/VendorIngestionServiceSkillStateTests.cs
@@ -1,0 +1,568 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.GameState.Sessions;
+using Mithril.GameState.Skills;
+using Mithril.Reference.Models.Items;
+using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Character;
+using Mithril.Shared.Logging;
+using Mithril.Shared.Modules;
+using Mithril.Shared.Reference;
+using Mithril.Shared.Storage;
+using Smaug.Domain;
+using Smaug.Parsing;
+using Smaug.State;
+using Xunit;
+
+namespace Smaug.Tests;
+
+/// <summary>
+/// #580 — verifies <see cref="VendorIngestionService"/> sources its
+/// CivicPride effective level from the shared
+/// <see cref="IPlayerSkillState"/> rather than from re-parsing
+/// <c>ProcessLoadSkills</c> / <c>ProcessUpdateSkill</c>. Class A migration
+/// from the post-#578 consumer audit (#579).
+///
+/// <para>Covers the four spec test points:</para>
+/// <list type="number">
+///   <item>Snapshot carrying <c>CivicPride</c> with <c>Level + BonusLevels</c>
+///   is folded into <see cref="VendorSellContext.CivicPrideLevel"/>.</item>
+///   <item>Snapshot missing the <c>CivicPride</c> key does <b>not</b> reset
+///   the previously-set level — absent ≠ unlearned, it's "not yet observed."
+///   Load-bearing for the (future) granular-changes channel and for any
+///   warm-up window where a snapshot arrives partial.</item>
+///   <item>Replay-then-live ordering: a level set during snapshot replay is
+///   visible to the first vendor envelope. Concretely, a sell observed
+///   via the vendor pipe immediately after gate open + replayed snapshot
+///   records with the replayed <c>CivicPrideLevel</c>.</item>
+///   <item>The CivicPride-less <see cref="VendorLogParser"/> still delivers
+///   the surviving event surface end-to-end (covered by
+///   <see cref="VendorIngestionServiceL1Tests"/> — this file does not
+///   re-cover the byte-equivalence / Marshaled paths).</item>
+/// </list>
+/// </summary>
+public sealed class VendorIngestionServiceSkillStateTests
+{
+    private const string StartInteractionLine =
+        "[22:27:38] LocalPlayer: ProcessStartInteraction(14564, 0, 3926, True, \"NPC_Therese\")";
+    private const string ScreenLine =
+        "[22:27:38] LocalPlayer: ProcessVendorScreen(14564, Neutral, 3926, 1776704476729, 4000, \"\", VendorInfo[], VendorInfo[], VendorInfo[], VendorPurchaseCap[], [-1201,-1601,], System.String[], -1601)";
+    private const string AddItemLine =
+        "[22:27:48] LocalPlayer: ProcessVendorAddItem(130, BottleOfWater(78177652), False)";
+
+    // ============================================================
+    // Test 1 — snapshot with CivicPride → context updated to raw+bonus.
+    // ============================================================
+
+    [Fact]
+    public async Task SnapshotWithCivicPride_SetsEffectiveLevel()
+    {
+        await using var harness = await TestHarness.StartAsync();
+
+        harness.SkillState.Push(SnapshotWithCivicPride(level: 15, bonus: 5));
+
+        harness.Context.CivicPrideLevel.Should().Be(20,
+            because: "OnSkillSnapshot must fold Level + BonusLevels into VendorSellContext.CivicPrideLevel");
+    }
+
+    // ============================================================
+    // Test 2 — snapshot missing CivicPride does NOT reset prior value.
+    // ============================================================
+
+    [Fact]
+    public async Task SnapshotWithoutCivicPride_PreservesPriorLevel()
+    {
+        await using var harness = await TestHarness.StartAsync();
+
+        // First snapshot establishes the level.
+        harness.SkillState.Push(SnapshotWithCivicPride(level: 12, bonus: 3));
+        harness.Context.CivicPrideLevel.Should().Be(15);
+
+        // Second snapshot — same author (skill tracker), but without the
+        // CivicPride key (e.g. a deliberately-partial state during the
+        // ProcessUpdateSkill warm-up window before the first
+        // ProcessLoadSkills, or a future granular-changes channel that
+        // omits unchanged skills). The level must stay put.
+        harness.SkillState.Push(SnapshotWithoutCivicPride());
+
+        harness.Context.CivicPrideLevel.Should().Be(15,
+            because: "absence of the CivicPride key in a snapshot means 'not yet observed', not 'skill is unlearned' — the prior value is preserved");
+    }
+
+    // ============================================================
+    // Test 3 — replay-then-live ordering: the replayed snapshot is
+    // applied before the first vendor envelope reaches the handler.
+    // ============================================================
+
+    [Fact]
+    public async Task ReplayedSnapshot_IsVisibleToFirstVendorSale()
+    {
+        // Seed the fake skill state BEFORE the service subscribes; that's
+        // what IPlayerSkillState.Subscribe's atomic replay+attach
+        // contract is designed to make visible to a late subscriber.
+        var initial = SnapshotWithCivicPride(level: 27, bonus: 8); // effective = 35
+
+        await using var harness = await TestHarness.StartAsync(initialSkillSnapshot: initial);
+
+        // The service was started AFTER seeding; its Subscribe call should
+        // have replayed the snapshot synchronously, populating
+        // VendorSellContext.CivicPrideLevel before any vendor envelope is
+        // dispatched.
+        harness.Context.CivicPrideLevel.Should().Be(35);
+
+        // Now feed the full vendor lead-up + sale; the recorded
+        // observation must carry the replayed CivicPride level.
+        harness.Driver.PushLive(MakeLocal(StartInteractionLine));
+        harness.Driver.PushLive(MakeLocal(ScreenLine));
+        harness.Driver.PushLive(MakeLocal(AddItemLine));
+
+        await harness.Driver.DrainAsync();
+
+        harness.Calibration.Data.Observations.Should().HaveCount(1);
+        var obs = harness.Calibration.Data.Observations[0];
+        obs.CivicPrideLevel.Should().Be(35,
+            because: "the replayed CivicPride value must be picked up before the first vendor sale records — that is the IPlayerSkillState.Subscribe contract");
+        obs.NpcKey.Should().Be("NPC_Therese");
+        obs.PricePaid.Should().Be(130);
+    }
+
+    // ============================================================
+    // Test 4 — live snapshot AFTER subscribe still updates the context.
+    // ============================================================
+
+    [Fact]
+    public async Task LiveSnapshotAfterSubscribe_UpdatesContext()
+    {
+        await using var harness = await TestHarness.StartAsync();
+
+        harness.SkillState.Push(SnapshotWithCivicPride(level: 5, bonus: 0));
+        harness.Context.CivicPrideLevel.Should().Be(5);
+
+        // Simulate a ProcessUpdateSkill landing later in the session.
+        harness.SkillState.Push(SnapshotWithCivicPride(level: 6, bonus: 0));
+        harness.Context.CivicPrideLevel.Should().Be(6,
+            because: "subsequent snapshots delivered live by the tracker must continue to update the context");
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private static PlayerSkillSnapshot SnapshotWithCivicPride(int level, int bonus)
+    {
+        var skills = new Dictionary<string, SkillProgressSnapshot>(StringComparer.Ordinal)
+        {
+            ["CivicPride"] = new SkillProgressSnapshot(
+                Level: level,
+                BonusLevels: bonus,
+                XpTowardNextLevel: 0,
+                XpNeededForNextLevel: 0,
+                MaxLevel: 50),
+        };
+        return new PlayerSkillSnapshot(skills, DateTime.UtcNow, SkillStateSource.LiveLog);
+    }
+
+    private static PlayerSkillSnapshot SnapshotWithoutCivicPride()
+    {
+        // A snapshot carrying some other skill but not CivicPride.
+        var skills = new Dictionary<string, SkillProgressSnapshot>(StringComparer.Ordinal)
+        {
+            ["Toolcrafting"] = new SkillProgressSnapshot(
+                Level: 15, BonusLevels: 0,
+                XpTowardNextLevel: 0, XpNeededForNextLevel: 0, MaxLevel: 50),
+        };
+        return new PlayerSkillSnapshot(skills, DateTime.UtcNow, SkillStateSource.LiveLog);
+    }
+
+    private static LocalPlayerLogLine MakeLocal(string fullLine, long sequence = 0)
+    {
+        // Same envelope-stripping the L0.5 pipeline does, mirrored from
+        // VendorIngestionServiceL1Tests.MakeLocal.
+        const string actorToken = "LocalPlayer: ";
+        var idx = 0;
+        if (fullLine.Length > 11
+            && fullLine[0] == '['
+            && fullLine[3] == ':'
+            && fullLine[6] == ':'
+            && fullLine[9] == ']')
+        {
+            idx = 11;
+        }
+        if (idx + actorToken.Length <= fullLine.Length
+            && fullLine.IndexOf(actorToken, idx, StringComparison.Ordinal) == idx)
+        {
+            idx += actorToken.Length;
+        }
+        var data = idx == 0 ? fullLine : fullLine.Substring(idx);
+        return new LocalPlayerLogLine(
+            new DateTimeOffset(2026, 5, 19, 22, 27, 48, TimeSpan.Zero),
+            data,
+            Sequence: sequence,
+            ReadMonotonicTicks: 0);
+    }
+
+    // ============================================================
+    // Test harness — minimal scaffold to start VendorIngestionService
+    // against a fake IPlayerSkillState + an in-memory L1 driver.
+    // ============================================================
+
+    private sealed class TestHarness : IAsyncDisposable
+    {
+        public VendorIngestionService Service { get; }
+        public TestDriver Driver { get; }
+        public FakeSkillState SkillState { get; }
+        public VendorSellContext Context { get; }
+        public PriceCalibrationService Calibration { get; }
+        private readonly string _tempDir;
+        private readonly CancellationTokenSource _cts = new();
+
+        private TestHarness(
+            VendorIngestionService service,
+            TestDriver driver,
+            FakeSkillState skillState,
+            VendorSellContext context,
+            PriceCalibrationService calibration,
+            string tempDir)
+        {
+            Service = service;
+            Driver = driver;
+            SkillState = skillState;
+            Context = context;
+            Calibration = calibration;
+            _tempDir = tempDir;
+        }
+
+        public static async Task<TestHarness> StartAsync(
+            PlayerSkillSnapshot? initialSkillSnapshot = null)
+        {
+            var tempDir = Mithril.TestSupport.TestPaths.CreateTempDir("smaug_580_test");
+            var refData = new FakeRefData();
+            var session = new FakeSession("char|2026-05-19T20:00:00Z");
+            var calibration = new PriceCalibrationService(refData, tempDir, session: session);
+            var parser = new VendorLogParser();
+            var context = new VendorSellContext();
+            var activeChar = new TestActiveCharacterService();
+            var gates = new ModuleGates();
+            var driver = new TestDriver();
+            var skillState = new FakeSkillState(initialSkillSnapshot ?? PlayerSkillSnapshot.Empty);
+
+            var service = new VendorIngestionService(
+                driver, parser, calibration, context, activeChar, skillState, gates);
+
+            // Open the gate so ExecuteAsync drops into subscribing immediately.
+            gates.For("smaug").Open();
+
+            // Kick the service via the hosted-service contract. StartAsync
+            // returns once the executor has begun (does not wait for the
+            // infinite-delay loop to complete).
+            await service.StartAsync(CancellationToken.None);
+
+            // Give the service a moment to land on its Subscribe calls.
+            await WaitUntilAsync(() => skillState.HandlerAttached, TimeSpan.FromSeconds(2));
+
+            return new TestHarness(service, driver, skillState, context, calibration, tempDir);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try { _cts.Cancel(); } catch { }
+            try { await Service.StopAsync(CancellationToken.None).ConfigureAwait(false); } catch { }
+            try { Service.Dispose(); } catch { }
+            try { _cts.Dispose(); } catch { }
+            try { System.IO.Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            while (!predicate())
+            {
+                if (sw.Elapsed > timeout) throw new TimeoutException("WaitUntilAsync gave up");
+                await Task.Delay(10);
+            }
+        }
+    }
+
+    // ============================================================
+    // Test stubs
+    // ============================================================
+
+    /// <summary>
+    /// In-memory <see cref="IPlayerSkillState"/> that captures the
+    /// subscribed handler and lets the test drive snapshots through it.
+    /// Mirrors the production tracker's atomic replay+attach contract on
+    /// the snapshot channel (Subscribe delivers Current synchronously
+    /// before returning).
+    /// </summary>
+    private sealed class FakeSkillState : IPlayerSkillState
+    {
+        private readonly object _lock = new();
+        private readonly List<Action<PlayerSkillSnapshot>> _handlers = new();
+        private PlayerSkillSnapshot _current;
+
+        public FakeSkillState(PlayerSkillSnapshot initial) { _current = initial; }
+
+        public PlayerSkillSnapshot Current
+        {
+            get { lock (_lock) return _current; }
+        }
+
+        public bool HandlerAttached
+        {
+            get { lock (_lock) return _handlers.Count > 0; }
+        }
+
+        public IDisposable Subscribe(Action<PlayerSkillSnapshot> handler)
+        {
+            lock (_lock)
+            {
+                handler(_current); // atomic replay under the lock
+                _handlers.Add(handler);
+                return new Unsub(this, handler);
+            }
+        }
+
+        public IDisposable SubscribeChanges(Action<SkillChange> handler)
+        {
+            // Not exercised by this consumer (Smaug uses the snapshot
+            // channel). Return a no-op disposable.
+            return new NoopDisposable();
+        }
+
+        /// <summary>
+        /// Test-side push: updates <see cref="Current"/> and fires every
+        /// subscribed handler synchronously under the lock, mirroring the
+        /// production service's live-dispatch shape.
+        /// </summary>
+        public void Push(PlayerSkillSnapshot snapshot)
+        {
+            lock (_lock)
+            {
+                _current = snapshot;
+                foreach (var h in _handlers) h(snapshot);
+            }
+        }
+
+        private sealed class Unsub : IDisposable
+        {
+            private FakeSkillState? _owner;
+            private readonly Action<PlayerSkillSnapshot> _h;
+            public Unsub(FakeSkillState o, Action<PlayerSkillSnapshot> h) { _owner = o; _h = h; }
+            public void Dispose()
+            {
+                var o = Interlocked.Exchange(ref _owner, null);
+                if (o is null) return;
+                lock (o._lock) { o._handlers.Remove(_h); }
+            }
+        }
+
+        private sealed class NoopDisposable : IDisposable { public void Dispose() { } }
+    }
+
+    /// <summary>
+    /// In-memory L1 driver shaped after the production driver — only the
+    /// pieces VendorIngestionService exercises. Same Channel-backed live
+    /// queue pattern as VendorIngestionServiceL1Tests.TestDriver, kept
+    /// minimal here.
+    /// </summary>
+    private sealed class TestDriver : ILogStreamDriver
+    {
+        private readonly Channel<LocalPlayerLogLine> _live = Channel.CreateUnbounded<LocalPlayerLogLine>();
+        private long _pending;
+        private TaskCompletionSource _drained = NewDrainedTcs();
+
+        public void PushLive(LocalPlayerLogLine line)
+        {
+            Interlocked.Increment(ref _pending);
+            Interlocked.Exchange(ref _drained, NewDrainTcs());
+            _live.Writer.TryWrite(line);
+        }
+
+        public Task DrainAsync(TimeSpan? timeout = null) =>
+            _drained.Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(5));
+
+        public ILogSubscription Subscribe<T>(
+            Func<LogEnvelope<T>, ValueTask> handler,
+            LogSubscriptionOptions? options = null) where T : class
+        {
+            if (typeof(T) != typeof(LocalPlayerLogLine))
+                throw new ArgumentException(
+                    "TestDriver only supports LocalPlayerLogLine subscriptions.",
+                    nameof(T));
+
+            var typedHandler = (Func<LogEnvelope<LocalPlayerLogLine>, ValueTask>)(object)handler;
+            var sub = new Sub(this, typedHandler);
+            sub.Start();
+            return sub;
+        }
+
+        private async IAsyncEnumerable<LogEnvelope<LocalPlayerLogLine>> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            await foreach (var line in _live.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+                yield return new LogEnvelope<LocalPlayerLogLine>(line, IsReplay: false);
+        }
+
+        private void RecordDelivered()
+        {
+            if (Interlocked.Decrement(ref _pending) == 0)
+                _drained.TrySetResult();
+        }
+
+        private static TaskCompletionSource NewDrainTcs() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static TaskCompletionSource NewDrainedTcs()
+        {
+            var tcs = NewDrainTcs();
+            tcs.TrySetResult();
+            return tcs;
+        }
+
+        private sealed class Sub : ILogSubscription
+        {
+            private readonly TestDriver _driver;
+            private readonly Func<LogEnvelope<LocalPlayerLogLine>, ValueTask> _handler;
+            private readonly CancellationTokenSource _cts = new();
+            private Task? _pumpTask;
+            private int _disposed;
+
+            public Sub(TestDriver d, Func<LogEnvelope<LocalPlayerLogLine>, ValueTask> h)
+            {
+                _driver = d;
+                _handler = h;
+            }
+
+            public string Id { get; } = $"test#{Guid.NewGuid():N}";
+            public LogSubscriptionDiagnostics Diagnostics =>
+                new(0, 0, 0, 0, 0, LogSubscriptionState.Healthy);
+            public event EventHandler? StateChanged { add { } remove { } }
+
+            public void Start() => _pumpTask = Task.Run(PumpAsync);
+
+            private async Task PumpAsync()
+            {
+                var ct = _cts.Token;
+                try
+                {
+                    await foreach (var env in _driver.SubscribeAsync(ct).ConfigureAwait(false))
+                    {
+                        if (ct.IsCancellationRequested) break;
+                        try { await _handler(env).ConfigureAwait(false); }
+                        catch { /* mirror driver containment */ }
+                        finally { _driver.RecordDelivered(); }
+                    }
+                }
+                catch (OperationCanceledException) { /* expected on dispose */ }
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+                try { _cts.Cancel(); } catch { }
+                try { _pumpTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+                try { _cts.Dispose(); } catch { }
+            }
+        }
+    }
+
+    private sealed class FakeSession : IGameSessionService
+    {
+        public GameSession? Current { get; private set; }
+        public event EventHandler<GameSession>? SessionStarted;
+        public FakeSession(string sessionId)
+        {
+            Current = new GameSession(sessionId, "char",
+                new DateTime(2026, 5, 19, 20, 0, 0, DateTimeKind.Utc), TimeSpan.Zero);
+        }
+        public IDisposable Subscribe(Action<GameSession> handler)
+        {
+            if (Current is not null) handler(Current);
+            return new Sub();
+        }
+        private sealed class Sub : IDisposable { public void Dispose() { } }
+        private void RaiseUnused() => SessionStarted?.Invoke(this, Current!);
+    }
+
+    private sealed class FakeRefData : IReferenceDataService
+    {
+        public IReadOnlyList<string> Keys { get; } = ["items"];
+        public IReadOnlyDictionary<long, Item> Items { get; }
+        public IReadOnlyDictionary<string, Item> ItemsByInternalName { get; }
+        public ItemKeywordIndex KeywordIndex => new(new Dictionary<long, Item>());
+        public IReadOnlyDictionary<string, Recipe> Recipes { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, Recipe> RecipesByInternalName { get; } = new Dictionary<string, Recipe>();
+        public IReadOnlyDictionary<string, SkillEntry> Skills { get; } = new Dictionary<string, SkillEntry>();
+        public IReadOnlyDictionary<string, XpTableEntry> XpTables { get; } = new Dictionary<string, XpTableEntry>();
+        public IReadOnlyDictionary<string, NpcEntry> Npcs { get; }
+        public IReadOnlyDictionary<string, AreaEntry> Areas { get; } = new Dictionary<string, AreaEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<ItemSource>> ItemSources { get; } = new Dictionary<string, IReadOnlyList<ItemSource>>();
+        public IReadOnlyDictionary<string, AttributeEntry> Attributes { get; } = new Dictionary<string, AttributeEntry>();
+        public IReadOnlyDictionary<string, PowerEntry> Powers { get; } = new Dictionary<string, PowerEntry>();
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Profiles { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> Quests { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
+        public IReadOnlyDictionary<string, Mithril.Reference.Models.Quests.Quest> QuestsByInternalName { get; } = new Dictionary<string, Mithril.Reference.Models.Quests.Quest>();
+        public IReadOnlyDictionary<string, string> Strings { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        public FakeRefData()
+        {
+            var water = new Item
+            {
+                Id = 1,
+                Name = "Bottle of Water",
+                InternalName = "BottleOfWater",
+                MaxStackSize = 10,
+                IconId = 0,
+                Keywords = [new ItemKeyword("Drink", 0)],
+                Value = 11m,
+            };
+            Items = new Dictionary<long, Item> { [1] = water };
+            ItemsByInternalName = new Dictionary<string, Item>(StringComparer.Ordinal)
+            {
+                ["BottleOfWater"] = water,
+            };
+            Npcs = new Dictionary<string, NpcEntry>(StringComparer.Ordinal)
+            {
+                ["NPC_Therese"] = new NpcEntry(
+                    Key: "NPC_Therese",
+                    Name: "Therese",
+                    Area: "",
+                    Preferences: Array.Empty<NpcPreference>(),
+                    ItemGiftTiers: Array.Empty<string>(),
+                    Services: Array.Empty<NpcService>()),
+            };
+        }
+
+        public ReferenceFileSnapshot GetSnapshot(string key) =>
+            new("items", ReferenceFileSource.Bundled, "test", null, 1);
+        public Task RefreshAsync(string key, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void BeginBackgroundRefresh() { }
+        public event EventHandler<string>? FileUpdated { add { } remove { } }
+    }
+
+    private sealed class TestActiveCharacterService : IActiveCharacterService
+    {
+        public IReadOnlyList<CharacterSnapshot> Characters { get; set; } = [];
+        public IReadOnlyList<ReportFileInfo> StorageReports { get; set; } = [];
+        public string? ActiveCharacterName { get; private set; }
+        public string? ActiveServer { get; private set; }
+        public CharacterSnapshot? ActiveCharacter { get; set; }
+        public ReportFileInfo? ActiveStorageReport { get; set; }
+        public StorageReport? ActiveStorageContents { get; set; }
+        public void SetActiveCharacter(string name, string server)
+        {
+            ActiveCharacterName = name;
+            ActiveServer = server;
+            ActiveCharacterChanged?.Invoke(this, EventArgs.Empty);
+        }
+        public void Refresh() { }
+        public event EventHandler? ActiveCharacterChanged;
+#pragma warning disable CS0067
+        public event EventHandler? CharacterExportsChanged;
+        public event EventHandler? StorageReportsChanged;
+#pragma warning restore CS0067
+        public void Dispose() { }
+    }
+}

--- a/tests/Smaug.Tests/VendorLogParserTests.cs
+++ b/tests/Smaug.Tests/VendorLogParserTests.cs
@@ -61,17 +61,14 @@ public sealed class VendorLogParserTests
     }
 
     [Fact]
-    public void ParsesCivicPrideFromLoadSkills()
+    public void DoesNotParseCivicPrideFromLoadSkills_PostMigration()
     {
-        // Embedded within the giant ProcessLoadSkills line; only the substring matters.
+        // Per #580 — CivicPride is consumed off IPlayerSkillState, not
+        // re-parsed here. A ProcessLoadSkills line that embeds the CivicPride
+        // skill record must return null from this parser; the integration
+        // test below covers the IPlayerSkillState consumption path.
         var line = "ProcessLoadSkills(... {type=CivicPride,raw=1,bonus=1,xp=45,tnl=60,max=50}, ...)";
-        var evt = _parser.TryParse(line, DateTime.UtcNow);
-
-        evt.Should().BeOfType<CivicPrideUpdated>();
-        var cp = (CivicPrideUpdated)evt!;
-        cp.Raw.Should().Be(1);
-        cp.Bonus.Should().Be(1);
-        cp.EffectiveLevel.Should().Be(2);
+        _parser.TryParse(line, DateTime.UtcNow).Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #580.

## Summary

Class A migration from the post-#578 cross-cutting consumer audit (#579). Smaug no longer re-parses `{type=CivicPride,raw=N,bonus=M,...}` out of `ProcessLoadSkills` / `ProcessUpdateSkill` envelopes — it consumes the effective CivicPride level (`Level + BonusLevels`) directly off the shared `IPlayerSkillState` service (PR #465 / issue #462).

Per [`docs/module-charters.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/module-charters.md#cross-cutting-ownership-confirmed) post-#578: modules consume GameState `Subscribe(...)` surfaces for cross-cutting state, not raw logs.

## What changed

**Production (`src/Smaug.Module`)**
- `VendorLogParser` — drop `CivicPrideRx` and the `type=CivicPride` substring branch; parser now handles only the four vendor verbs (`ProcessVendorAddItem`, `ProcessVendorScreen`, `ProcessVendorUpdateAvailableGold`, `ProcessStartInteraction`).
- `VendorEvents` — drop the `CivicPrideUpdated` record.
- `VendorIngestionService` — inject `IPlayerSkillState`; subscribe via `Subscribe(OnSkillSnapshot)` immediately after gate-open, before the L1 vendor subscription. `IPlayerSkillState.Subscribe` delivers the current snapshot synchronously under its lock, so any CivicPride observed pre-gate populates `_context.CivicPrideLevel` before any vendor envelope is dispatched. Subscription token disposed alongside the L1 subscription.

**Consumption rules**
- `OnSkillSnapshot` reads `Level + BonusLevels` — same effective value `VendorCapResolver.CivicPrideMultiplierFor` and `PriceCalibration` bucketing currently consume; only the **source** of the value changes.
- A snapshot that does **not** carry the `CivicPride` key (cold session pre-`ProcessLoadSkills`, or a future granular channel that omits unchanged skills) does **not** reset `_context.CivicPrideLevel` — absent ≠ unlearned. The prime-from-export fallback path is preserved.

**Catalog**
- Drop the now-orphaned `smaug.VendorLogParser.CivicPrideRx` entry from `src/Mithril.Shared/Reference/log-patterns.json` (the catalog-parity test was the canary that flagged it on the first run).

**Tests**
- New `VendorIngestionServiceSkillStateTests` covers the four spec points: snapshot with CivicPride sets effective level, snapshot without CivicPride preserves prior value, replay-then-live ordering is visible to the first vendor sale, live snapshot updates the context.
- `VendorLogParserTests.ParsesCivicPrideFromLoadSkills` → `DoesNotParseCivicPrideFromLoadSkills_PostMigration` — asserts the parser now returns `null` for that substring.
- `VendorIngestionServiceL1Tests` switch handlers updated to drop the `CivicPrideUpdated` arm; byte-equivalence + Marshaled regressions remain unchanged.
- `Mithril.GameState` opens internals to `Smaug.Tests` so the test can mint a curated `PlayerSkillSnapshot` (same trust boundary as `Mithril.GameState.Tests`).
- `Smaug.Tests` now references `Mithril.GameState` (was indirect via `Smaug.Module`).

## Verification

`dotnet build Mithril.slnx`:

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

`dotnet test Mithril.slnx --no-build` (21 test projects, all green):

```
Passed!  - Failed:     0, Passed:    37, Skipped:     0, Total:    37, Duration: 602 ms - Smaug.Tests.dll
Passed!  - Failed:     0, Passed:   288, Skipped:     0, Total:   288, Duration: 641 ms - Mithril.GameState.Tests.dll
Passed!  - Failed:     0, Passed:  1246, Skipped:     0, Total:  1246, Duration: 22 s - Mithril.Shared.Tests.dll
[...]
```

All 21 projects pass; Smaug 37/37 (4 new), Mithril.GameState 288/288, Mithril.Shared 1246/1246 (log-pattern-catalog-parity passes after the JSON entry removal).

## Verification owed (from the spec)

- [x] `grep -E "CivicPride|CivicPrideUpdated|CivicPrideRx" src/Smaug.Module/Parsing/` returns nothing — confirmed.
- [x] `IPlayerSkillState` is registered globally by `AddMithrilGameState()` (`GameStateServiceCollectionExtensions.cs:60-67`) — no Smaug-side DI wiring needed beyond the constructor inject.
- [x] `VendorCapResolver.CivicPrideMultiplierFor` is unchanged — only the source of the level changes; the multiplier table is byte-identical.

## Test plan

- [x] Unit: snapshot with `CivicPride{Level=15, BonusLevels=5}` → `_context.CivicPrideLevel == 20`.
- [x] Unit: missing `CivicPride` entry → `_context.CivicPrideLevel` stays at its prior value.
- [x] Integration: replay-then-live — value set during snapshot replay is visible to the first vendor sale.
- [x] Existing `VendorIngestionService` tests pass without `CivicPrideUpdated` in the parser output.
- [x] `dotnet build` clean; `dotnet test` full pass.

— drafted by Claude (Opus 4.7), posted by @arthur-conde
