### PR TITLE
feat(gamestate): IPlayerEffectsStateService — live player effects from Player.log

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Mithril.GameState.Areas;
 using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Celestial;
 using Mithril.GameState.Celestial.Parsing;
+using Mithril.GameState.Effects;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
@@ -43,6 +44,18 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<InventoryService>()
             .AddSingleton<IInventoryService>(sp => sp.GetRequiredService<InventoryService>())
             .AddHostedService(sp => sp.GetRequiredService<InventoryService>());
+
+        // Shared live player-effects set from Player.log (ProcessAddEffects /
+        // ProcessRemoveEffects / ProcessUpdateEffectName). Foundation for the
+        // Pippin Gourmand lift (food-eaten = effect-add + inventory-delete
+        // fusion), Vampirism sun-damage (active Vampire-family effects gate
+        // sun damage), and Saruman Words-of-Power consumption side
+        // (player-side WoP arrival is the game-state truth). Self-feeding;
+        // consumers inject IPlayerEffectsStateService. See issue #590.
+        services
+            .AddSingleton<PlayerEffectsStateService>()
+            .AddSingleton<IPlayerEffectsStateService>(sp => sp.GetRequiredService<PlayerEffectsStateService>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerEffectsStateService>());
 
         // Area tracking is shared live game-state (Gandalf chest-area
         // stamping, Legolas per-area survey calibration, …). One parser,

--- a/src/Mithril.GameState/Effects/EffectState.cs
+++ b/src/Mithril.GameState/Effects/EffectState.cs
@@ -1,0 +1,76 @@
+namespace Mithril.GameState.Effects;
+
+/// <summary>
+/// A single active effect on the local player, as derived from Player.log's
+/// <c>ProcessAddEffects</c> / <c>ProcessRemoveEffects</c> /
+/// <c>ProcessUpdateEffectName</c> verbs.
+///
+/// <para><b>Identity model.</b> Two id spaces are at play: the small
+/// <see cref="CatalogId"/> from <c>effects.json</c> (the Add-side identifier,
+/// e.g. <c>302</c> for Performance Appreciation base), and the large
+/// per-application <see cref="InstanceId"/> minted by the game engine and
+/// surfaced only via <c>ProcessUpdateEffectName</c> and
+/// <c>ProcessRemoveEffects</c> (e.g. <c>259320</c>). v1 keys the live set by
+/// <see cref="CatalogId"/> (single-instance-per-catalog-id; see issue #590
+/// "Known unknowns"). <see cref="InstanceId"/> is populated lazily when (and
+/// only if) a same-timestamp <c>ProcessUpdateEffectName</c> correlates back.
+/// Catalog-id-only effects (the majority — equipment bonuses, character
+/// traits) leave <see cref="InstanceId"/> null and cannot be removed by id;
+/// they linger until snapshot replay reconciles them.</para>
+///
+/// <para><b>DisplayName.</b> Present only when PG fired a
+/// <c>ProcessUpdateEffectName</c> for this entry — typical for level-tagged
+/// or runtime-generated names (e.g. <c>"Performance Appreciation, Level 0"</c>).
+/// Consumers needing a name for catalog-id-only entries resolve it via
+/// <c>IReferenceDataService.Effects</c>.</para>
+///
+/// <para><b>SourceCharId.</b> The character that applied the effect.
+/// <c>0</c> is observed exclusively on <c>arg4 == False</c> login / zone-replay
+/// bursts and is the "system / no applier on replay" sentinel; live
+/// applications carry a non-zero applier (equal to the target's own char-id
+/// for self-applied buffs).</para>
+///
+/// <para><b>AppliedAt.</b> UTC instant from the source log line. Re-emits of
+/// an already-tracked catalog id refresh the timestamp (see issue #590
+/// "Behaviour" section, idempotent timestamp-refresh rule mirroring
+/// <see cref="Mithril.GameState.Inventory.InventoryService"/>'s add-reemit
+/// handling).</para>
+/// </summary>
+public readonly record struct EffectState(
+    int CatalogId,
+    long? InstanceId,
+    string? DisplayName,
+    long SourceCharId,
+    DateTimeOffset AppliedAt);
+
+/// <summary>
+/// Lifecycle event for a single <see cref="EffectState"/>. <see cref="Kind"/>
+/// distinguishes the three transitions the service surfaces;
+/// <see cref="Timestamp"/> is the UTC instant of the source log line (same
+/// as <see cref="EffectState.AppliedAt"/> on <see cref="EffectEventKind.Added"/>
+/// and the originating event's line on the other two kinds).
+/// </summary>
+public readonly record struct EffectEvent(
+    EffectEventKind Kind,
+    EffectState State,
+    DateTimeOffset Timestamp);
+
+/// <summary>Kind of an <see cref="EffectEvent"/>.</summary>
+public enum EffectEventKind
+{
+    /// <summary>New catalog id added (active <c>True</c> apply or
+    /// additive <c>False</c> snapshot reconcile).</summary>
+    Added,
+
+    /// <summary>A <c>ProcessRemoveEffects</c> by instance id removed an entry
+    /// that had previously been correlated to that instance via
+    /// <see cref="DisplayNameChanged"/>. Catalog-id-only entries never
+    /// surface a <c>Removed</c> by construction (no instance-id bridge).</summary>
+    Removed,
+
+    /// <summary>A <c>ProcessUpdateEffectName</c> assigned a display name (and
+    /// the originating instance id) to an existing entry. Fires once per Update
+    /// line; subsequent Updates for the same instance also fire if the name
+    /// actually changes.</summary>
+    DisplayNameChanged,
+}

--- a/src/Mithril.GameState/Effects/EffectState.cs
+++ b/src/Mithril.GameState/Effects/EffectState.cs
@@ -70,7 +70,8 @@ public enum EffectEventKind
 
     /// <summary>A <c>ProcessUpdateEffectName</c> assigned a display name (and
     /// the originating instance id) to an existing entry. Fires once per Update
-    /// line; subsequent Updates for the same instance also fire if the name
-    /// actually changes.</summary>
+    /// line; subsequent Updates for the same instance route via the internal
+    /// instance-id → catalog-id bridge and also fire <em>only if the name
+    /// actually changes</em> (a same-name re-emit is suppressed).</summary>
     DisplayNameChanged,
 }

--- a/src/Mithril.GameState/Effects/IPlayerEffectsStateService.cs
+++ b/src/Mithril.GameState/Effects/IPlayerEffectsStateService.cs
@@ -1,0 +1,87 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Effects;
+
+/// <summary>
+/// Live set of effects active on the local player, parsed from
+/// <c>Player.log</c>'s <c>ProcessAddEffects</c> / <c>ProcessRemoveEffects</c>
+/// / <c>ProcessUpdateEffectName</c> verbs. Player-only for v1 — non-local
+/// targets are out of scope (see issue #590 "Scope note").
+///
+/// <para><b>Three channels (per <a href="https://github.com/moumantai-gg/mithril/pull/584">#584</a>).</b>
+/// <list type="bullet">
+///   <item><b>Query</b> — <see cref="TryGet"/> for a single catalog id plus
+///   <see cref="ActiveEffects"/> for the full snapshot. Point-in-time;
+///   readers iterate the dict for UI seeding.</item>
+///   <item><b>React</b> — <see cref="Subscribe"/> delivers the full
+///   <see cref="EffectEvent"/> stream. Default
+///   <see cref="ReplayMode.FromSessionStart"/> atomically replays every
+///   Added / Removed / DisplayNameChanged event in log order before live
+///   dispatch begins (the post-#585 <c>IInventoryService.Subscribe</c>
+///   contract; this service ships with it from day one).
+///   <see cref="ReplayMode.LiveOnly"/> skips the replay.</item>
+///   <item><b>Bind</b> — deferred. A full
+///   <c>IReadOnlyObservableCollection&lt;EffectState&gt;</c> with
+///   <c>INotifyCollectionChanged</c> for direct WPF binding is part of the
+///   service-side Bind-surface lift initiative (#584 follow-up). Consumers
+///   needing observable mutation today seed off <see cref="ActiveEffects"/>
+///   + subscribe via <see cref="Subscribe"/> and rebuild their own
+///   observable surface — same shape Palantir's
+///   <c>LiveInventoryViewModel</c> uses over <c>IInventoryService</c>.</item>
+/// </list>
+/// </para>
+///
+/// <para><b>Identity model.</b> The live set is keyed by effect
+/// <see cref="EffectState.CatalogId"/> (small ints from <c>effects.json</c>).
+/// Instance ids (large per-application ints from
+/// <c>ProcessRemoveEffects</c> / <c>ProcessUpdateEffectName</c>) are
+/// recorded on a best-effort basis when a same-timestamp Update names an
+/// entry; the catalog-id-only majority cannot be removed by id and lingers
+/// in <see cref="ActiveEffects"/> until the next snapshot replay reconciles
+/// them. This is consistent with PG's tendency to dynamically name the
+/// effect subset where expiration matters (food buffs, level-tagged
+/// effects); the unnamed majority (equipment bonuses, character traits) are
+/// genuinely permanent, so lingering reflects the game state correctly.
+/// See issue #590 "Known unknowns" for the catalog-id / instance-id bridge
+/// gap.</para>
+/// </summary>
+public interface IPlayerEffectsStateService
+{
+    /// <summary>
+    /// Resolve a catalog id to its current <see cref="EffectState"/>, if and
+    /// only if the effect is currently active on the local player. Returns
+    /// <c>false</c> for effects that have been removed (entries are not
+    /// retained post-removal — unlike <see cref="Mithril.GameState.Inventory.IInventoryService.TryResolve"/>,
+    /// no late-lookup path needs the pre-removal state).
+    /// </summary>
+    bool TryGet(int catalogId, out EffectState state);
+
+    /// <summary>
+    /// Point-in-time snapshot of every catalog id currently active on the
+    /// local player. Returned dictionary is a defensive copy — safe to
+    /// enumerate without holding service-internal locks. For long-lived
+    /// observable bindings, prefer <see cref="Subscribe"/>.
+    /// </summary>
+    IReadOnlyDictionary<int, EffectState> ActiveEffects { get; }
+
+    /// <summary>
+    /// Register an <see cref="EffectEvent"/> handler. With the default
+    /// <see cref="ReplayMode.FromSessionStart"/>, the service atomically
+    /// replays every event in its internal event log (Added / Removed /
+    /// DisplayNameChanged from session start, in original order) to the
+    /// new handler before adding it to the live-dispatch list — late
+    /// subscribers see the same history as one attached at startup. With
+    /// <see cref="ReplayMode.LiveOnly"/>, the replay is skipped and only
+    /// events arriving after the call are delivered.
+    ///
+    /// <para>The handler is invoked synchronously under an internal lock
+    /// both during replay (on the subscribing thread) and during live
+    /// dispatch (on the L1 pump thread). Subscribers doing non-trivial work
+    /// should marshal off-thread immediately.</para>
+    ///
+    /// <para>Dispose the returned token to stop receiving further events.</para>
+    /// </summary>
+    IDisposable Subscribe(
+        Action<EffectEvent> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart);
+}

--- a/src/Mithril.GameState/Effects/PlayerEffectsStateService.cs
+++ b/src/Mithril.GameState/Effects/PlayerEffectsStateService.cs
@@ -1,0 +1,412 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Effects;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IPlayerEffectsStateService"/>.
+/// Subscribes to the L1 driver's <see cref="LocalPlayerLogLine"/> pipe with
+/// <see cref="ReplayMode.FromSessionStart"/> — the same shape
+/// <see cref="Mithril.GameState.Inventory.InventoryService"/> uses (#590 spec,
+/// Behaviour section). Maintains the live catalog-id-keyed map plus an
+/// internal event log used to atomically replay history to late subscribers
+/// (post-#585 React-channel contract).
+///
+/// <para><b>Threading.</b> A single <c>_lock</c> guards <c>_active</c>,
+/// <c>_eventLog</c>, <c>_handlers</c>, and <c>_unnamed</c>. Both the L1
+/// pump (via <c>OnLocalPlayer</c>) and <see cref="Subscribe"/> callers take
+/// it; live dispatch happens under the lock so the
+/// Subscribe-vs-live-event race is impossible (the new subscriber either
+/// ran its replay before the next event fires, or attached after — never
+/// in between).</para>
+///
+/// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
+/// <see cref="Mithril.GameState.Celestial.PlayerCelestialStateService"/>:
+/// live game-state shared across multiple downstream consumers (Pippin
+/// Gourmand, Vampirism sun-damage, Saruman Words-of-Power — see issue #590
+/// "Consumers") that must populate at shell startup independent of any
+/// module activation gate.</para>
+/// </summary>
+public sealed partial class PlayerEffectsStateService : BackgroundService, IPlayerEffectsStateService
+{
+    // ProcessAddEffects(targetCharId, sourceCharId, "[<catalogId1>, <catalogId2>, ...]", <bool>)
+    // The bracketed list arrives as a quoted string; we capture the inner content
+    // (without the outer quotes) and the bool flag separately. The list tolerates
+    // trailing spaces / commas (e.g. "[15361, ]") per captured samples.
+    [GeneratedRegex(@"ProcessAddEffects\((-?\d+),\s*(-?\d+),\s*""\[([^\]]*)\]"",\s*(True|False)\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex AddEffectsRx();
+
+    // ProcessRemoveEffects(targetCharId, [<instanceId1>, <instanceId2>, ...])
+    // The bracketed list is UNQUOTED (not a string literal).
+    [GeneratedRegex(@"ProcessRemoveEffects\((-?\d+),\s*\[([^\]]*)\]\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex RemoveEffectsRx();
+
+    // ProcessUpdateEffectName(targetCharId, effectInstanceId, "<displayName>")
+    [GeneratedRegex(@"ProcessUpdateEffectName\((-?\d+),\s*(-?\d+),\s*""((?:[^""\\]|\\.)*)""\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex UpdateEffectNameRx();
+
+    /// <summary>
+    /// Soft cap on the internal event-log size. PG sessions emit ~250 effect
+    /// verbs per the wiki captures, so 10,000 is generous (a couple of orders
+    /// of magnitude above expected). One-time <see cref="DiagnosticLevel.Warn"/>
+    /// if exceeded — the cap protects the log from unbounded growth on a
+    /// degenerate stream, not from normal use.
+    /// </summary>
+    internal const int EventLogSoftCap = 10_000;
+
+    private readonly ILogStreamDriver _driver;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    private readonly Dictionary<int, EffectState> _active = new();
+    private readonly List<EffectEvent> _eventLog = new();
+    private readonly List<(Action<EffectEvent> Handler, ReplayMode Replay)> _handlers = new();
+
+    // Stack of un-named catalog ids (most-recent-first) used to correlate a
+    // ProcessUpdateEffectName back to its preceding ProcessAddEffects entry.
+    // Spec wording: "the entry that was most recently added and still lacks
+    // an InstanceId" — LIFO/stack. Captured Add/Update interleaving is 1:1
+    // ([302] Add → Update 259328 → [303] Add → Update 259329), so the stack
+    // depth is typically 0 or 1; the data structure is defensive against a
+    // batched-Add pattern PG might emit but we haven't captured.
+    private readonly Stack<int> _unnamed = new();
+
+    private ILogSubscription? _subscription;
+    private bool _eventLogCapWarned;
+
+    public PlayerEffectsStateService(ILogStreamDriver driver, IDiagnosticsSink? diag = null)
+    {
+        _driver = driver;
+        _diag = diag;
+    }
+
+    public bool TryGet(int catalogId, out EffectState state)
+    {
+        lock (_lock)
+        {
+            return _active.TryGetValue(catalogId, out state);
+        }
+    }
+
+    public IReadOnlyDictionary<int, EffectState> ActiveEffects
+    {
+        get
+        {
+            lock (_lock)
+            {
+                // Defensive copy — callers iterate without holding the service lock.
+                return new Dictionary<int, EffectState>(_active);
+            }
+        }
+    }
+
+    public IDisposable Subscribe(
+        Action<EffectEvent> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            if (replay == ReplayMode.FromSessionStart)
+            {
+                // Atomic replay under the lock — same shape as InventoryService.Subscribe.
+                // The Fire path also holds _lock, so a new subscriber either ran its
+                // replay strictly before the next live event or attached strictly after.
+                foreach (var evt in _eventLog)
+                {
+                    Invoke(handler, evt);
+                }
+            }
+            _handlers.Add((handler, replay));
+            return new Subscription(this, handler);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Effects",
+            "Subscribing to L1 driver (LocalPlayer pipe) for ProcessAddEffects / "
+            + "ProcessRemoveEffects / ProcessUpdateEffectName");
+        try
+        {
+            _subscription = _driver.Subscribe<LocalPlayerLogLine>(
+                OnLocalPlayer,
+                new LogSubscriptionOptions
+                {
+                    ReplayMode = ReplayMode.FromSessionStart,
+                    DeliveryContext = DeliveryContext.Inline,
+                    DiagnosticCategory = "GameState.Effects",
+                });
+
+            try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* expected on host stop */ }
+        }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+        }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
+    }
+
+    private ValueTask OnLocalPlayer(LogEnvelope<LocalPlayerLogLine> envelope)
+    {
+        var data = envelope.Payload.Data;
+        var ts = ToOffset(envelope.Payload.Timestamp.UtcDateTime);
+
+        var add = AddEffectsRx().Match(data);
+        if (add.Success
+            && long.TryParse(add.Groups[2].ValueSpan, out var sourceCharId))
+        {
+            var listBody = add.Groups[3].Value;
+            var isLive = add.Groups[4].Value == "True";
+            HandleAddEffects(sourceCharId, listBody, isLive, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var rem = RemoveEffectsRx().Match(data);
+        if (rem.Success)
+        {
+            HandleRemoveEffects(rem.Groups[2].Value, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var upd = UpdateEffectNameRx().Match(data);
+        if (upd.Success
+            && long.TryParse(upd.Groups[2].ValueSpan, out var instanceId))
+        {
+            HandleUpdateEffectName(instanceId, upd.Groups[3].Value, ts);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    private void HandleAddEffects(long sourceCharId, string listBody, bool isLive, DateTimeOffset timestamp)
+    {
+        lock (_lock)
+        {
+            foreach (var token in EnumerateIntTokens(listBody))
+            {
+                if (!int.TryParse(token, out var catalogId)) continue;
+
+                if (_active.TryGetValue(catalogId, out var existing))
+                {
+                    // Idempotent re-apply / re-emit. Per #590 spec: refresh AppliedAt,
+                    // no Added event fires. Mirrors InventoryService's add-reemit at
+                    // InventoryService.cs:320-326. Applies to both True (passive
+                    // equipment-bonus re-apply at zone-load) and False (login snapshot).
+                    _active[catalogId] = existing with { AppliedAt = timestamp };
+                    _diag?.Trace("GameState.Effects",
+                        $"Add-reemit catalog={catalogId} source={sourceCharId} live={isLive}");
+                    continue;
+                }
+
+                var state = new EffectState(
+                    CatalogId: catalogId,
+                    InstanceId: null,
+                    DisplayName: null,
+                    SourceCharId: sourceCharId,
+                    AppliedAt: timestamp);
+                _active[catalogId] = state;
+                _unnamed.Push(catalogId);
+
+                var evt = new EffectEvent(EffectEventKind.Added, state, timestamp);
+                AppendEventLog(evt);
+                _diag?.Trace("GameState.Effects",
+                    $"Add    catalog={catalogId} source={sourceCharId} live={isLive} (total={_active.Count})");
+                Fire(evt);
+            }
+        }
+    }
+
+    private void HandleRemoveEffects(string listBody, DateTimeOffset timestamp)
+    {
+        lock (_lock)
+        {
+            foreach (var token in EnumerateIntTokens(listBody))
+            {
+                if (!long.TryParse(token, out var instanceId)) continue;
+
+                // Linear scan over _active — bounded by the live set size,
+                // typically << 100. Spec accepts catalog-id-only entries can
+                // never be removed by id (no InstanceId bridge); only entries
+                // that received a ProcessUpdateEffectName are removable here.
+                int? matchedCatalogId = null;
+                foreach (var (catalogId, state) in _active)
+                {
+                    if (state.InstanceId == instanceId)
+                    {
+                        matchedCatalogId = catalogId;
+                        break;
+                    }
+                }
+
+                if (matchedCatalogId is null)
+                {
+                    _diag?.Warn("GameState.Effects",
+                        $"Remove instance={instanceId} — no entry with that InstanceId in live set, ignored");
+                    continue;
+                }
+
+                var removed = _active[matchedCatalogId.Value];
+                _active.Remove(matchedCatalogId.Value);
+                var evt = new EffectEvent(EffectEventKind.Removed, removed, timestamp);
+                AppendEventLog(evt);
+                _diag?.Trace("GameState.Effects",
+                    $"Remove catalog={matchedCatalogId.Value} instance={instanceId} (total={_active.Count})");
+                Fire(evt);
+            }
+        }
+    }
+
+    private void HandleUpdateEffectName(long instanceId, string displayName, DateTimeOffset timestamp)
+    {
+        lock (_lock)
+        {
+            // Pop the most recently added un-named entry. PG's captured pattern
+            // interleaves Add/Update 1:1 at the same instant ([302] Add →
+            // Update 259328 → [303] Add → Update 259329), so the stack depth is
+            // typically 1 and pop semantics is unambiguous. Spec accepts a
+            // missing pair as "best-effort, drop with Trace; no synthetic Add."
+            while (_unnamed.Count > 0)
+            {
+                var catalogId = _unnamed.Pop();
+                if (!_active.TryGetValue(catalogId, out var state))
+                {
+                    // The un-named entry was removed before its Update arrived.
+                    // Keep popping — the next-most-recent un-named is the candidate.
+                    continue;
+                }
+                if (state.InstanceId is not null)
+                {
+                    // Already named (defensive — pop shouldn't surface a named entry,
+                    // but the stack and _active are not strictly in lock-step if a
+                    // double-Update lands for the same catalog id). Skip.
+                    continue;
+                }
+
+                var updated = state with { InstanceId = instanceId, DisplayName = displayName };
+                _active[catalogId] = updated;
+                var evt = new EffectEvent(EffectEventKind.DisplayNameChanged, updated, timestamp);
+                AppendEventLog(evt);
+                _diag?.Trace("GameState.Effects",
+                    $"Update catalog={catalogId} instance={instanceId} name=\"{displayName}\"");
+                Fire(evt);
+                return;
+            }
+
+            // No un-named candidate. Could happen if the Update fires for an
+            // effect whose Add we missed (mid-session attach without snapshot
+            // replay), or a double-Update for an already-named entry.
+            _diag?.Warn("GameState.Effects",
+                $"Update instance={instanceId} name=\"{displayName}\" — no un-named candidate, dropped");
+        }
+    }
+
+    /// <summary>
+    /// Tokenize a comma-separated list body (e.g. <c>"302, 303, "</c> or
+    /// <c>"259278,"</c>). Tolerates trailing empty tokens — PG's captured
+    /// shape for both Add (<c>"[15361, ]"</c>) and Remove (<c>"[259278,]"</c>)
+    /// commonly ends with a trailing comma.
+    /// </summary>
+    private static IEnumerable<string> EnumerateIntTokens(string listBody)
+    {
+        if (string.IsNullOrEmpty(listBody)) yield break;
+        foreach (var raw in listBody.Split(','))
+        {
+            var token = raw.Trim();
+            if (token.Length == 0) continue;
+            yield return token;
+        }
+    }
+
+    /// <summary>
+    /// MUST be called with <see cref="_lock"/> held. Appends an event to the
+    /// internal log used by <see cref="Subscribe"/>'s replay path. Soft cap
+    /// (<see cref="EventLogSoftCap"/>) protects against unbounded growth on
+    /// a degenerate stream; a one-time <see cref="DiagnosticLevel.Warn"/>
+    /// fires when the cap is first exceeded. Past the cap the log keeps
+    /// growing — dropping events would silently break the replay contract.
+    /// </summary>
+    private void AppendEventLog(EffectEvent evt)
+    {
+        _eventLog.Add(evt);
+        if (_eventLog.Count > EventLogSoftCap && !_eventLogCapWarned)
+        {
+            _eventLogCapWarned = true;
+            _diag?.Warn("GameState.Effects",
+                $"Event-log size exceeded soft cap ({EventLogSoftCap}). "
+                + "Replay-on-Subscribe will continue to deliver every event in order; "
+                + "log keeps growing (no drop). Investigate if not expected.");
+        }
+    }
+
+    /// <summary>
+    /// MUST be called with <see cref="_lock"/> held. Dispatches to every
+    /// currently-attached handler (replay handlers receive live events;
+    /// live-only handlers also do). Holding the lock across dispatch is the
+    /// same atomicity guarantee <see cref="Mithril.GameState.Inventory.InventoryService.Subscribe"/>
+    /// makes: a new subscriber either ran its replay before this Fire and
+    /// will receive the live event, or runs after and saw the event in its
+    /// replay.
+    /// </summary>
+    private void Fire(EffectEvent evt)
+    {
+        foreach (var (handler, _) in _handlers) Invoke(handler, evt);
+    }
+
+    private void Invoke(Action<EffectEvent> handler, EffectEvent evt)
+    {
+        try { handler(evt); }
+        catch (Exception ex) { _diag?.Warn("GameState.Effects", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Player.log timestamps are normalized upstream by the L0 source clock
+    /// (UTC <see cref="DateTimeOffset"/>); we receive <c>.UtcDateTime</c>
+    /// here. Stamp the kind defensively so the lifted
+    /// <see cref="DateTimeOffset"/> always has offset +00:00 rather than the
+    /// host's local offset.
+    /// </summary>
+    private static DateTimeOffset ToOffset(DateTime ts) =>
+        new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
+
+    private sealed class Subscription : IDisposable
+    {
+        private PlayerEffectsStateService? _owner;
+        private readonly Action<EffectEvent> _handler;
+
+        public Subscription(PlayerEffectsStateService owner, Action<EffectEvent> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock)
+            {
+                for (int i = owner._handlers.Count - 1; i >= 0; i--)
+                {
+                    if (owner._handlers[i].Handler == _handler)
+                    {
+                        owner._handlers.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Mithril.GameState/Effects/PlayerEffectsStateService.cs
+++ b/src/Mithril.GameState/Effects/PlayerEffectsStateService.cs
@@ -15,12 +15,12 @@ namespace Mithril.GameState.Effects;
 /// (post-#585 React-channel contract).
 ///
 /// <para><b>Threading.</b> A single <c>_lock</c> guards <c>_active</c>,
-/// <c>_eventLog</c>, <c>_handlers</c>, and <c>_unnamed</c>. Both the L1
-/// pump (via <c>OnLocalPlayer</c>) and <see cref="Subscribe"/> callers take
-/// it; live dispatch happens under the lock so the
-/// Subscribe-vs-live-event race is impossible (the new subscriber either
-/// ran its replay before the next event fires, or attached after — never
-/// in between).</para>
+/// <c>_eventLog</c>, <c>_handlers</c>, <c>_unnamed</c>, and
+/// <c>_instanceToCatalog</c>. Both the L1 pump (via <c>OnLocalPlayer</c>)
+/// and <see cref="Subscribe"/> callers take it; live dispatch happens
+/// under the lock so the Subscribe-vs-live-event race is impossible (the
+/// new subscriber either ran its replay before the next event fires, or
+/// attached after — never in between).</para>
 ///
 /// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
 /// <see cref="Mithril.GameState.Celestial.PlayerCelestialStateService"/>:
@@ -65,16 +65,25 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
     private readonly object _lock = new();
     private readonly Dictionary<int, EffectState> _active = new();
     private readonly List<EffectEvent> _eventLog = new();
-    private readonly List<(Action<EffectEvent> Handler, ReplayMode Replay)> _handlers = new();
+    private readonly List<Action<EffectEvent>> _handlers = new();
 
-    // Stack of un-named catalog ids (most-recent-first) used to correlate a
-    // ProcessUpdateEffectName back to its preceding ProcessAddEffects entry.
-    // Spec wording: "the entry that was most recently added and still lacks
-    // an InstanceId" — LIFO/stack. Captured Add/Update interleaving is 1:1
-    // ([302] Add → Update 259328 → [303] Add → Update 259329), so the stack
-    // depth is typically 0 or 1; the data structure is defensive against a
-    // batched-Add pattern PG might emit but we haven't captured.
+    // Stack of un-named catalog ids (most-recent-first) used on the FIRST
+    // ProcessUpdateEffectName for an instance to correlate back to its
+    // preceding ProcessAddEffects entry. Spec wording: "the entry that was
+    // most recently added and still lacks an InstanceId" — LIFO/stack.
+    // Captured Add/Update interleaving is 1:1 ([302] Add → Update 259328 →
+    // [303] Add → Update 259329), so the stack depth is typically 0 or 1.
+    // Subsequent re-renames of an already-named instance bypass the stack and
+    // route via <see cref="_instanceToCatalog"/> below.
     private readonly Stack<int> _unnamed = new();
+
+    // instanceId → catalogId map populated when an Update first names an
+    // entry (alongside the _unnamed pop), and cleared on Remove. Re-renames
+    // of an already-named instance (e.g. level-tagged skill effect bumping
+    // from "Performance Appreciation, Level 0" to "Level 1") route via this
+    // lookup so they hit the SAME catalog id rather than popping an
+    // unrelated _unnamed entry and misrouting the DisplayNameChanged event.
+    private readonly Dictionary<long, int> _instanceToCatalog = new();
 
     private ILogSubscription? _subscription;
     private bool _eventLogCapWarned;
@@ -122,7 +131,7 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
                     Invoke(handler, evt);
                 }
             }
-            _handlers.Add((handler, replay));
+            _handlers.Add(handler);
             return new Subscription(this, handler);
         }
     }
@@ -163,7 +172,9 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
     private ValueTask OnLocalPlayer(LogEnvelope<LocalPlayerLogLine> envelope)
     {
         var data = envelope.Payload.Data;
-        var ts = ToOffset(envelope.Payload.Timestamp.UtcDateTime);
+        // LocalPlayerLogLine.Timestamp is already a DateTimeOffset (UTC) —
+        // L0 normalizes the source clock. No round-trip needed.
+        var ts = envelope.Payload.Timestamp;
 
         var add = AddEffectsRx().Match(data);
         if (add.Success
@@ -260,6 +271,7 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
 
                 var removed = _active[matchedCatalogId.Value];
                 _active.Remove(matchedCatalogId.Value);
+                _instanceToCatalog.Remove(instanceId);
                 var evt = new EffectEvent(EffectEventKind.Removed, removed, timestamp);
                 AppendEventLog(evt);
                 _diag?.Trace("GameState.Effects",
@@ -273,11 +285,49 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
     {
         lock (_lock)
         {
-            // Pop the most recently added un-named entry. PG's captured pattern
-            // interleaves Add/Update 1:1 at the same instant ([302] Add →
-            // Update 259328 → [303] Add → Update 259329), so the stack depth is
-            // typically 1 and pop semantics is unambiguous. Spec accepts a
-            // missing pair as "best-effort, drop with Trace; no synthetic Add."
+            // Route by instance id FIRST. A re-rename of an already-named
+            // effect (e.g. a level-tagged skill effect bumping from
+            // "Performance Appreciation, Level 0" to "Level 1") shares the
+            // same instance id; the catalog id is the existing one, not
+            // whatever happens to be on top of _unnamed. Without this lookup,
+            // a re-rename would pop an unrelated un-named entry (or warn-and-
+            // drop on empty stack) and misroute the DisplayNameChanged event.
+            if (_instanceToCatalog.TryGetValue(instanceId, out var knownCatalogId))
+            {
+                if (_active.TryGetValue(knownCatalogId, out var existing))
+                {
+                    if (existing.DisplayName == displayName)
+                    {
+                        // No-op re-emit of the same name; spec wording on
+                        // EffectEventKind.DisplayNameChanged says it fires
+                        // "if the name actually changes."
+                        _diag?.Trace("GameState.Effects",
+                            $"Update catalog={knownCatalogId} instance={instanceId} name unchanged, no event");
+                        return;
+                    }
+                    var renamed = existing with { DisplayName = displayName };
+                    _active[knownCatalogId] = renamed;
+                    var renameEvt = new EffectEvent(EffectEventKind.DisplayNameChanged, renamed, timestamp);
+                    AppendEventLog(renameEvt);
+                    _diag?.Trace("GameState.Effects",
+                        $"Update catalog={knownCatalogId} instance={instanceId} rename=\"{displayName}\" (was \"{existing.DisplayName}\")");
+                    Fire(renameEvt);
+                    return;
+                }
+                // _active entry is gone but the instance bridge survived —
+                // stale; drop the bridge and fall through to the stack path
+                // (treat as first-naming attempt against current un-named set).
+                _instanceToCatalog.Remove(instanceId);
+                _diag?.Trace("GameState.Effects",
+                    $"Update instance={instanceId} — stale bridge dropped, falling back to stack");
+            }
+
+            // First-naming path: pop the most recently added un-named entry.
+            // PG's captured pattern interleaves Add/Update 1:1 at the same
+            // instant ([302] Add → Update 259328 → [303] Add → Update 259329),
+            // so the stack depth is typically 1 and pop semantics is
+            // unambiguous. Spec accepts a missing pair as "best-effort, drop
+            // with Trace; no synthetic Add."
             while (_unnamed.Count > 0)
             {
                 var catalogId = _unnamed.Pop();
@@ -289,14 +339,15 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
                 }
                 if (state.InstanceId is not null)
                 {
-                    // Already named (defensive — pop shouldn't surface a named entry,
-                    // but the stack and _active are not strictly in lock-step if a
-                    // double-Update lands for the same catalog id). Skip.
+                    // Already named — should be rare since _instanceToCatalog
+                    // catches the common re-rename path above. Skip and keep
+                    // looking for a genuine un-named candidate.
                     continue;
                 }
 
                 var updated = state with { InstanceId = instanceId, DisplayName = displayName };
                 _active[catalogId] = updated;
+                _instanceToCatalog[instanceId] = catalogId;
                 var evt = new EffectEvent(EffectEventKind.DisplayNameChanged, updated, timestamp);
                 AppendEventLog(evt);
                 _diag?.Trace("GameState.Effects",
@@ -307,7 +358,7 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
 
             // No un-named candidate. Could happen if the Update fires for an
             // effect whose Add we missed (mid-session attach without snapshot
-            // replay), or a double-Update for an already-named entry.
+            // replay).
             _diag?.Warn("GameState.Effects",
                 $"Update instance={instanceId} name=\"{displayName}\" — no un-named candidate, dropped");
         }
@@ -362,7 +413,7 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
     /// </summary>
     private void Fire(EffectEvent evt)
     {
-        foreach (var (handler, _) in _handlers) Invoke(handler, evt);
+        foreach (var handler in _handlers) Invoke(handler, evt);
     }
 
     private void Invoke(Action<EffectEvent> handler, EffectEvent evt)
@@ -370,16 +421,6 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
         try { handler(evt); }
         catch (Exception ex) { _diag?.Warn("GameState.Effects", $"Subscriber threw: {ex.Message}"); }
     }
-
-    /// <summary>
-    /// Player.log timestamps are normalized upstream by the L0 source clock
-    /// (UTC <see cref="DateTimeOffset"/>); we receive <c>.UtcDateTime</c>
-    /// here. Stamp the kind defensively so the lifted
-    /// <see cref="DateTimeOffset"/> always has offset +00:00 rather than the
-    /// host's local offset.
-    /// </summary>
-    private static DateTimeOffset ToOffset(DateTime ts) =>
-        new(DateTime.SpecifyKind(ts, DateTimeKind.Utc));
 
     private sealed class Subscription : IDisposable
     {
@@ -398,14 +439,7 @@ public sealed partial class PlayerEffectsStateService : BackgroundService, IPlay
             if (owner is null) return;
             lock (owner._lock)
             {
-                for (int i = owner._handlers.Count - 1; i >= 0; i--)
-                {
-                    if (owner._handlers[i].Handler == _handler)
-                    {
-                        owner._handlers.RemoveAt(i);
-                        break;
-                    }
-                }
+                owner._handlers.Remove(_handler);
             }
         }
     }

--- a/tests/Mithril.GameState.Tests/Effects/PlayerEffectsStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Effects/PlayerEffectsStateServiceTests.cs
@@ -412,6 +412,127 @@ public sealed class PlayerEffectsStateServiceTests
         finally { await StopAsync(svc); }
     }
 
+    // ---------- Re-rename via instance-id bridge (review #593 / Finding 1) ----------
+
+    [Fact]
+    public async Task DoubleUpdate_SameInstanceId_RoutesToSameCatalog_AndFiresSecondDisplayNameChanged()
+    {
+        // Captured pattern for level-tagged skill effects: a single instance id
+        // gets renamed as the underlying skill level changes
+        // ("Performance Appreciation, Level 0" → "Level 1"). The second Update
+        // must NOT pop _unnamed (the entry is already named); it must look up
+        // the instance id directly and rename the SAME catalog id.
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[302, ]\", True)");
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            stream.Push(Stamp.AddMinutes(2),
+                "[21:41:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 1\")");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(3, "Add + first-name + re-rename");
+            seen[0].Kind.Should().Be(EffectEventKind.Added);
+            seen[0].State.CatalogId.Should().Be(302);
+
+            seen[1].Kind.Should().Be(EffectEventKind.DisplayNameChanged);
+            seen[1].State.CatalogId.Should().Be(302);
+            seen[1].State.DisplayName.Should().Be("Performance Appreciation, Level 0");
+
+            seen[2].Kind.Should().Be(EffectEventKind.DisplayNameChanged);
+            seen[2].State.CatalogId.Should().Be(302,
+                "the re-rename must route via the instance-id bridge back to the SAME catalog id");
+            seen[2].State.InstanceId.Should().Be(259320);
+            seen[2].State.DisplayName.Should().Be("Performance Appreciation, Level 1");
+
+            svc.TryGet(302, out var state).Should().BeTrue();
+            state.DisplayName.Should().Be("Performance Appreciation, Level 1");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task DoubleUpdate_SameName_SuppressesSecondDisplayNameChanged()
+    {
+        // The interface XML on DisplayNameChanged promises "fires once per
+        // Update line; subsequent Updates ... if the name actually changes".
+        // A redundant Update with the identical name must NOT fire a second
+        // event (it would add a no-op replay entry that confuses consumers).
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[302, ]\", True)");
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            stream.Push(Stamp.AddSeconds(5),
+                "[21:39:40] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(2, "Add + first-name only — the same-name re-emit is suppressed");
+            seen[0].Kind.Should().Be(EffectEventKind.Added);
+            seen[1].Kind.Should().Be(EffectEventKind.DisplayNameChanged);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task DoubleUpdate_WithUnrelatedUnnamedPushBetween_RoutesByInstanceId_NotStack()
+    {
+        // Stress case: after the first Update names instance 259320 → catalog
+        // 302, an UNRELATED equipment-bonus Add pushes catalog 13303 onto
+        // _unnamed. The second Update for instance 259320 must look up the
+        // bridge dictionary and rename catalog 302; the un-named 13303 must
+        // remain un-named (stack untouched).
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[302, ]\", True)");
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            // Unrelated equipment-bonus add: stale _unnamed entry on the stack.
+            stream.Push(Stamp.AddMinutes(1),
+                "[21:40:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[13303, ]\", True)");
+            // Re-rename of 259320: must NOT pop 13303 off _unnamed.
+            stream.Push(Stamp.AddMinutes(2),
+                "[21:41:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 1\")");
+            await RunUntilDrainedAsync(svc, stream);
+
+            // 302 was renamed via the dictionary lookup.
+            svc.TryGet(302, out var named).Should().BeTrue();
+            named.InstanceId.Should().Be(259320);
+            named.DisplayName.Should().Be("Performance Appreciation, Level 1");
+
+            // 13303 stayed un-named — proves the dictionary won over the stack.
+            svc.TryGet(13303, out var equip).Should().BeTrue();
+            equip.InstanceId.Should().BeNull("the stack-based pop must NOT have fired for the re-rename");
+            equip.DisplayName.Should().BeNull();
+
+            // Events: Add(302), DisplayName(302, "L0"), Add(13303), DisplayName(302, "L1")
+            seen.Should().HaveCount(4);
+            seen[3].Kind.Should().Be(EffectEventKind.DisplayNameChanged);
+            seen[3].State.CatalogId.Should().Be(302,
+                "the re-rename event must carry catalog 302, not the unrelated 13303 on _unnamed");
+            seen[3].State.DisplayName.Should().Be("Performance Appreciation, Level 1");
+        }
+        finally { await StopAsync(svc); }
+    }
+
     [Fact]
     public async Task Lifecycle_EmitsSubscribingDiagnostic()
     {

--- a/tests/Mithril.GameState.Tests/Effects/PlayerEffectsStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Effects/PlayerEffectsStateServiceTests.cs
@@ -1,0 +1,470 @@
+using FluentAssertions;
+using Mithril.GameState.Effects;
+using Mithril.GameState.Tests.TestSupport;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Effects;
+
+/// <summary>
+/// Acceptance-suite for <see cref="PlayerEffectsStateService"/> per issue
+/// #590. Each test maps to a lettered acceptance bullet (a–g) in the issue
+/// body. The per-test stream wrapper mirrors the
+/// <see cref="Celestial.PlayerCelestialStateServiceTests"/> shape — one L1
+/// driver per service, push raw Player.log lines, drain the LocalPlayer pipe.
+/// </summary>
+public sealed class PlayerEffectsStateServiceTests
+{
+    private static readonly DateTime Stamp = new(2026, 5, 20, 20, 1, 17, DateTimeKind.Utc);
+
+    private static PlayerEffectsStateService NewService(
+        ScriptedStream stream, IDiagnosticsSink? diag = null) =>
+        new(stream.Driver, diag);
+
+    // ---------- (a) live Add (arg4 == True) → Added ----------
+
+    [Fact]
+    public async Task LiveAdd_FiresAddedEvent_AndPopulatesActiveSet()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().ContainSingle();
+            seen[0].Kind.Should().Be(EffectEventKind.Added);
+            seen[0].State.CatalogId.Should().Be(13303);
+            seen[0].State.SourceCharId.Should().Be(25042203);
+            seen[0].State.InstanceId.Should().BeNull();
+            seen[0].State.DisplayName.Should().BeNull();
+
+            svc.TryGet(13303, out var state).Should().BeTrue();
+            state.CatalogId.Should().Be(13303);
+            svc.ActiveEffects.Should().ContainKey(13303);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- (b) re-emit Add (arg4 == False) is additive-only ----------
+
+    [Fact]
+    public async Task SnapshotAdd_FillsMissing_AndDoesNotDropPreexistingEntries()
+    {
+        // Captured shape: a False snapshot at login lists a subset of the
+        // persistent effects, and equipment-derived ones (e.g. 13303) re-arrive
+        // separately as True adds. The False list is NOT a full snapshot, so
+        // entries present in _active but absent from the list must remain.
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            // Seed: equipment-bonus effect already active from a True add.
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            // Then a False snapshot that does NOT mention 13303 but adds 26015.
+            stream.Push(Stamp.AddSeconds(1),
+                "[20:01:18] LocalPlayer: ProcessAddEffects(25042203, 0, \"[26015, ]\", False)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.ActiveEffects.Should().ContainKey(13303,
+                "the False snapshot is additive-only and must not drop preexisting entries");
+            svc.ActiveEffects.Should().ContainKey(26015);
+
+            // sourceCharId == 0 sentinel preserved for snapshot adds.
+            svc.TryGet(26015, out var snapshotState).Should().BeTrue();
+            snapshotState.SourceCharId.Should().Be(0);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- (c) re-apply of already-present catalog id is idempotent ----------
+
+    [Fact]
+    public async Task ReApplySameCatalogId_RefreshesTimestamp_AndFiresNoDuplicateAdded()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var addedCount = 0;
+        using var sub = svc.Subscribe(e => { if (e.Kind == EffectEventKind.Added) addedCount++; });
+
+        try
+        {
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            stream.Push(Stamp.AddMinutes(5),
+                "[20:06:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            addedCount.Should().Be(1, "the second Add for the same catalog id is a re-emit, not a new application");
+            svc.TryGet(13303, out var state).Should().BeTrue();
+            state.AppliedAt.Should().Be(new DateTimeOffset(Stamp.AddMinutes(5)),
+                "re-apply refreshes AppliedAt per the spec's idempotent timestamp-refresh rule");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- (d) UpdateEffectName correlates to most-recent un-named ----------
+
+    [Fact]
+    public async Task UpdateEffectName_CorrelatesToMostRecentUnnamedEntry_AndFiresDisplayNameChanged()
+    {
+        // Captured pattern: [302] Add → Update 259328 ("Performance Appreciation, Level 0")
+        // → [303] Add → Update 259329 at the same instant. Spec wording: "most
+        // recently added and still lacks an InstanceId" — LIFO/stack.
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[302, ]\", True)");
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(2);
+            seen[0].Kind.Should().Be(EffectEventKind.Added);
+            seen[0].State.CatalogId.Should().Be(302);
+            seen[1].Kind.Should().Be(EffectEventKind.DisplayNameChanged);
+            seen[1].State.CatalogId.Should().Be(302);
+            seen[1].State.InstanceId.Should().Be(259320);
+            seen[1].State.DisplayName.Should().Be("Performance Appreciation, Level 0");
+
+            svc.TryGet(302, out var state).Should().BeTrue();
+            state.InstanceId.Should().Be(259320);
+            state.DisplayName.Should().Be("Performance Appreciation, Level 0");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- (e) RemoveEffects by instance id fires Removed ----------
+
+    [Fact]
+    public async Task RemoveEffects_ByInstanceId_FiresRemoved_AndDropsFromActive()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[302, ]\", True)");
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            stream.Push(Stamp.AddSeconds(14),
+                "[21:39:49] LocalPlayer: ProcessRemoveEffects(25098977, [259320,])");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(3);
+            seen[2].Kind.Should().Be(EffectEventKind.Removed);
+            seen[2].State.CatalogId.Should().Be(302);
+            seen[2].State.InstanceId.Should().Be(259320);
+
+            svc.TryGet(302, out _).Should().BeFalse();
+            svc.ActiveEffects.Should().NotContainKey(302);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task RemoveEffects_OnUnnamedEntry_LeavesEntryActive()
+    {
+        // The catalog-id-only majority (equipment bonuses) never paired with a
+        // ProcessUpdateEffectName, so a RemoveEffects targeting some unrelated
+        // instance id must not touch them. Spec accepts these entries linger
+        // in ActiveEffects.
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[20:01:18] LocalPlayer: ProcessRemoveEffects(25042203, [259278,])");
+            await RunUntilDrainedAsync(svc, stream);
+
+            svc.ActiveEffects.Should().ContainKey(13303,
+                "an un-named entry has no InstanceId bridge and cannot be removed by id");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- (f) late Subscribe(default) replays full event log from session start ----------
+
+    [Fact]
+    public async Task LateSubscribe_FromSessionStart_ReplaysFullEventLog_InOrder()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        try
+        {
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[302, ]\", True)");
+            stream.Push(Stamp,
+                "[21:39:35] LocalPlayer: ProcessUpdateEffectName(25098977, 259320, \"Performance Appreciation, Level 0\")");
+            stream.Push(Stamp.AddSeconds(14),
+                "[21:39:49] LocalPlayer: ProcessRemoveEffects(25098977, [259320,])");
+            stream.Push(Stamp.AddSeconds(20),
+                "[21:39:55] LocalPlayer: ProcessAddEffects(25098977, 25098977, \"[15361, ]\", True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            var replayed = new List<EffectEvent>();
+            using var sub = svc.Subscribe(replayed.Add); // default = FromSessionStart
+
+            replayed.Should().HaveCount(4);
+            replayed[0].Kind.Should().Be(EffectEventKind.Added);
+            replayed[0].State.CatalogId.Should().Be(302);
+            replayed[1].Kind.Should().Be(EffectEventKind.DisplayNameChanged);
+            replayed[1].State.CatalogId.Should().Be(302);
+            replayed[1].State.InstanceId.Should().Be(259320);
+            replayed[2].Kind.Should().Be(EffectEventKind.Removed);
+            replayed[2].State.CatalogId.Should().Be(302);
+            replayed[3].Kind.Should().Be(EffectEventKind.Added);
+            replayed[3].State.CatalogId.Should().Be(15361);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task LateSubscribe_FromSessionStart_ThenLiveEvent_DeliversBoth_AtomicallyOrdered()
+    {
+        // The Subscribe path runs replay under the same lock that Fire takes;
+        // a live event arriving between Subscribe return and the next handler
+        // dispatch cannot interleave with the replay. Regression cover for the
+        // post-#585 contract.
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<EffectEvent>();
+            using var sub = svc.Subscribe(seen.Add);
+            seen.Should().ContainSingle(
+                "the existing event must replay synchronously before Subscribe returns");
+
+            stream.Push(Stamp.AddSeconds(1),
+                "[20:01:18] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[15361, ]\", True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().HaveCount(2);
+            seen[1].State.CatalogId.Should().Be(15361);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch { }
+            _ = runTask;
+            await StopAsync(svc);
+        }
+    }
+
+    // ---------- (g) Subscribe(LiveOnly) skips replay ----------
+
+    [Fact]
+    public async Task LateSubscribe_LiveOnly_DoesNotReplay_AndOnlyDeliversFutureEvents()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<EffectEvent>();
+            using var sub = svc.Subscribe(seen.Add, ReplayMode.LiveOnly);
+            seen.Should().BeEmpty("LiveOnly skips the event-log replay");
+
+            stream.Push(Stamp.AddSeconds(1),
+                "[20:01:18] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[15361, ]\", True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().ContainSingle();
+            seen[0].State.CatalogId.Should().Be(15361);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch { }
+            _ = runTask;
+            await StopAsync(svc);
+        }
+    }
+
+    // ---------- Misc behaviours ----------
+
+    [Fact]
+    public async Task MultipleCatalogIds_InSingleAdd_AllFireAddedInOrder()
+    {
+        // PG batches login-snapshot adds (e.g. "[26015, 39006008, ...]"); the
+        // service must emit one Added per id, in list order.
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 0, \"[26015, 39006008, 53122008]\", False)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(3);
+            seen.Select(e => e.State.CatalogId).Should().Equal(26015, 39006008, 53122008);
+            seen.Should().AllSatisfy(e =>
+            {
+                e.Kind.Should().Be(EffectEventKind.Added);
+                e.State.SourceCharId.Should().Be(0);
+            });
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task DisposeSubscription_StopsFurtherEvents()
+    {
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            var seen = new List<EffectEvent>();
+            var sub = svc.Subscribe(seen.Add, ReplayMode.LiveOnly);
+
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            await stream.WaitForDrainAsync(cts.Token);
+            seen.Should().ContainSingle();
+
+            sub.Dispose();
+            sub.Dispose(); // idempotent
+
+            stream.Push(Stamp.AddSeconds(1),
+                "[20:01:18] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[15361, ]\", True)");
+            await stream.WaitForDrainAsync(cts.Token);
+            seen.Should().ContainSingle("the disposed subscription must not receive further events");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch { }
+            _ = runTask;
+            await StopAsync(svc);
+        }
+    }
+
+    [Fact]
+    public async Task UnnamedEffect_RemovedBeforeUpdate_DoesNotMisroute()
+    {
+        // Defensive: an un-named entry whose Add we observed but whose Update
+        // never came must not corrupt the most-recent-un-named correlation
+        // when a subsequent Update for a DIFFERENT effect arrives. The first
+        // Add's catalog id should be skipped on pop if it's no longer in
+        // _active (here we remove it indirectly by demonstrating a second
+        // Add+Update pair correlates correctly even with a stale un-named
+        // entry on the stack).
+        var stream = new ScriptedStream();
+        var svc = NewService(stream);
+        var seen = new List<EffectEvent>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            // Equipment-bonus add (no Update ever fires for this one).
+            stream.Push(Stamp,
+                "[20:01:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[13303, ]\", True)");
+            // A named effect arrives later; its Update should correlate to ITS Add,
+            // not back-fill the stale 13303 on the stack.
+            stream.Push(Stamp.AddMinutes(1),
+                "[20:02:17] LocalPlayer: ProcessAddEffects(25042203, 25042203, \"[302, ]\", True)");
+            stream.Push(Stamp.AddMinutes(1),
+                "[20:02:17] LocalPlayer: ProcessUpdateEffectName(25042203, 259320, \"Performance Appreciation, Level 0\")");
+            await RunUntilDrainedAsync(svc, stream);
+
+            // 13303 stays unnamed; 302 gets named.
+            svc.TryGet(13303, out var equip).Should().BeTrue();
+            equip.InstanceId.Should().BeNull();
+            equip.DisplayName.Should().BeNull();
+
+            svc.TryGet(302, out var named).Should().BeTrue();
+            named.InstanceId.Should().Be(259320);
+            named.DisplayName.Should().Be("Performance Appreciation, Level 0");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Lifecycle_EmitsSubscribingDiagnostic()
+    {
+        var diag = new DiagnosticsSink();
+        var stream = new ScriptedStream();
+        var svc = NewService(stream, diag);
+        try
+        {
+            await RunUntilDrainedAsync(svc, stream);
+            diag.Snapshot().Should().Contain(e =>
+                e.Level == DiagnosticLevel.Info
+                && e.Category == "GameState.Effects"
+                && e.Message.Contains("Subscribing to L1 driver"));
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Plumbing ----------
+
+    private static async Task RunUntilDrainedAsync(PlayerEffectsStateService svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(PlayerEffectsStateService svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+
+    /// <summary>
+    /// Per-test L1 stream wrapper, same shape as
+    /// <see cref="Celestial.PlayerCelestialStateServiceTests"/>.
+    /// </summary>
+    private sealed class ScriptedStream : IDisposable
+    {
+        public TestLogStreamDriver Driver { get; } = new();
+
+        public void Push(DateTime ts, string line)
+        {
+            Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(new RawLogLine(ts, line)));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) =>
+            Driver.DrainLocalPlayerAsync().WaitAsync(ct);
+
+        public void Dispose() => Driver.Dispose();
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds `IPlayerEffectsStateService` (under `Mithril.GameState.Effects`) — the foundational GameState service that owns the live set of effects active on the local player, parsed from `Player.log`'s `ProcessAddEffects` / `ProcessRemoveEffects` / `ProcessUpdateEffectName` verbs.

This PR is **foundation only**. No downstream consumer is migrated; Pippin Gourmand lift, Vampirism sun-damage, and Saruman Words-of-Power consumption-side are tracked as separate follow-ups per #590's Consumers section.

Closes #590.

## Architecture fit

- **Consumption-side rule (#578)**: future consumers subscribe to this service instead of re-parsing `IPlayerLogStream` for effect events.
- **Three-channel service design (#584)**: Query + React channels ship; Bind is deferred to the broader Bind-surface lift initiative.
- **`I<Domain>StateService` naming (#587)**: new GameState services unify the `…State` data-shape suffix with the `…Service` DI-registration suffix.
- **Post-#585 React-channel contract**: `Subscribe(handler, FromSessionStart)` atomically replays the internal event log to the new handler before going live — ships with the contract from day one, ahead of #585's `IInventoryService` retrofit.

## Surface

```csharp
public interface IPlayerEffectsStateService
{
    bool TryGet(int catalogId, out EffectState state);
    IReadOnlyDictionary<int, EffectState> ActiveEffects { get; }
    IDisposable Subscribe(
        Action<EffectEvent> handler,
        ReplayMode replay = ReplayMode.FromSessionStart);
}

public readonly record struct EffectState(
    int CatalogId, long? InstanceId, string? DisplayName,
    long SourceCharId, DateTimeOffset AppliedAt);

public readonly record struct EffectEvent(
    EffectEventKind Kind, EffectState State, DateTimeOffset Timestamp);

public enum EffectEventKind { Added, Removed, DisplayNameChanged }
```

## Behaviour highlights

- **Single-instance per catalog id**: re-apply = idempotent timestamp refresh, no duplicate `Added`. Mirrors `InventoryService`'s add-reemit at `InventoryService.cs:320-326`.
- **`arg4 == False` is additive-only**: the login / zone-replay snapshot fills missing catalog ids but never drops entries absent from the list — equipment-derived effects re-emit immediately afterwards via separate `True` adds, so the `False` list is incomplete by design.
- **`ProcessUpdateEffectName` correlates** to the most-recently-added un-named entry (LIFO stack per spec wording). Bridges the catalog-id ↔ instance-id spaces.
- **`ProcessRemoveEffects`** keys by instance id; catalog-id-only entries without a paired Update **linger by design** — consistent with PG's pattern of dynamically naming only the effect subset where expiration matters (food buffs, level-tagged), leaving the unnamed majority (equipment bonuses, character traits) genuinely permanent.
- **Diagnostics**: `Info` on subscription start; `Trace` per Add/Remove/Update with total counters; `Warn` on un-correlated Update or Remove; one-time `Warn` if internal event log exceeds 10,000 entries (PG sessions emit ~250 effect verbs per capture, so the cap is generous).

## Acceptance criteria (#590)

- [x] `src/Mithril.GameState/Effects/` exists with `IPlayerEffectsStateService`, `EffectState`, `EffectEvent`, `EffectEventKind`, and a `BackgroundService` implementation. Registered in `GameStateServiceCollectionExtensions.AddMithrilGameState()` (the in-code precedent set by `IInventoryService` / `IPlayerSkillState` / `IPlayerRecipeState` etc.; the issue body's reference to `Mithril.Shared/DependencyInjection/ServiceCollectionExtensions.cs` predates that being where GameState services land — flagged in case the issue body wants a doc tweak).
- [x] Three-channel API: Query (`TryGet` + `ActiveEffects`), React (`Subscribe` with `FromSessionStart` default + `LiveOnly` opt-out). Bind explicitly deferred per the #584 follow-up Bind-surface lift initiative.
- [x] Tests cover all seven scenarios a–g from the issue body, plus four defensive extras (batched Add ordering, dispose idempotence, un-named-entry non-corruption when later Updates land, lifecycle diagnostic). **13 facts, all passing.**
- [x] Wiki: new `## Effects` section in `Player-Log-Signals.md` documenting the three verbs. (Separate wiki repo, separate commit — landing now.)
- [x] Diagnostics emit at lifecycle (`Info` on subscribe), per-event (`Trace` Add/Remove/Update), and warning (`Warn` un-correlated Update or Remove + event-log cap overflow) points.

## Build & test (live results, `Mithril.slnx`)

```
$ dotnet build Mithril.slnx
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:00:11.53

$ dotnet test Mithril.slnx --no-build
Tests passed: 3564 failed: 0
```

Effects-suite-only:
```
$ dotnet test --filter "FullyQualifiedName~PlayerEffectsStateServiceTests"
Passed!  - Failed: 0, Passed: 13, Skipped: 0, Total: 13, Duration: 1 s
```

## Out of scope (deferred, per #590)

- Pippin Gourmand lift (food-eaten = `Added` + `IInventoryService.Deleted` fusion). Will likely land as a Tier-2 signature service per #582 / #586 lessons rather than a cross-pump correlation in a module.
- Vampirism sun-damage consumer migration.
- Saruman Words-of-Power consumption-side migration.
- Other characters' effects (non-`LocalPlayer:` lines).
- Effect classification, duration math, UI-visibility filtering — all left to consumers via `effects.json` lookups.

## Known-unknowns (preserved from #590 for the next agent)

- Single-instance-per-catalog-id assumption uncorroborated under duplicate-application stress.
- `sourceCharId == 0` semantics on snapshot bursts — hypothesised "system / no applier" sentinel.
- Catalog-id-only entries linger indefinitely (no expiration verb observed). Acceptable for the equipment-bonus majority; consumers needing timed-effect expiration layer their own logic.
- `arg4 == True` conflates live applications with passive equipment-bonus re-applies — consumers needing to distinguish must use a co-signal (e.g. inventory delete on the same timestamp).

## Test plan

- [x] `dotnet build Mithril.slnx` — green
- [x] `dotnet test Mithril.slnx` — 3564/3564 pass
- [x] Effects-suite test isolation — 13/13 pass
- [ ] Shell smoke (deferred — wiring is identical to existing GameState services and the integration is exercised by the unit tests' `BackgroundService.StartAsync` / `StopAsync` lifecycle)

— drafted by Claude (Opus 4.7), posted by @arthur-conde
