### PR TITLE
feat(gamestate): IInventoryService.Subscribe full event-log replay (#585)

### DIFF
--- a/src/Mithril.GameState/Inventory/IInventoryService.cs
+++ b/src/Mithril.GameState/Inventory/IInventoryService.cs
@@ -7,14 +7,14 @@ namespace Mithril.GameState.Inventory;
 /// unique id emitted by <c>ProcessAddItem</c> / <c>ProcessDeleteItem</c>.
 /// <paramref name="InternalName"/> maps to
 /// <see cref="Mithril.Reference.Models.Items.Item.InternalName"/>.
-/// <paramref name="Timestamp"/> is the source log line''s timestamp (UTC), not
-/// wall-clock — consumers with time-window logic (e.g. Samwise''s plant-resolve
+/// <paramref name="Timestamp"/> is the source log line's timestamp (UTC), not
+/// wall-clock — consumers with time-window logic (e.g. Samwise's plant-resolve
 /// window) need the in-game timeline.
 /// <paramref name="StackSize"/> is the stack size at the moment of the event:
-/// for <see cref="InventoryEventKind.Added"/> it''s the size known when the
+/// for <see cref="InventoryEventKind.Added"/> it's the size known when the
 /// item entered the map (1 if no chat correlation has landed yet);
-/// for <see cref="InventoryEventKind.Deleted"/> it''s the last-known size
-/// before removal; for <see cref="InventoryEventKind.StackChanged"/> it''s
+/// for <see cref="InventoryEventKind.Deleted"/> it's the last-known size
+/// before removal; for <see cref="InventoryEventKind.StackChanged"/> it's
 /// the new size.
 /// <paramref name="SizeConfirmed"/> is the same bit
 /// <see cref="IInventoryService.TryGetStackSize"/> consults — false when the
@@ -52,20 +52,20 @@ public enum InventoryEventKind
 /// chat <c>[Status]</c> channel via <c>IChatLogStream</c> for stack-size
 /// correlation on fresh additions.
 ///
-/// <para><b>Three channels (per <a href="https://github.com/moumantai-gg/mithril/pull/584">#584</a>''s
+/// <para><b>Three channels (per <a href="https://github.com/moumantai-gg/mithril/pull/584">#584</a>'s
 /// service-design rule).</b></para>
 /// <list type="bullet">
 ///   <item><b>Query</b> — <see cref="TryResolve"/> and
-///   <see cref="TryGetStackSize"/> answer "what''s in inventory right now?"
-///   (including last-known state for deleted entries — Arwen''s
+///   <see cref="TryGetStackSize"/> answer "what's in inventory right now?"
+///   (including last-known state for deleted entries — Arwen's
 ///   gift-attribution path needs the pre-delete name/size).</item>
 ///   <item><b>React</b> — <see cref="Subscribe(Action{InventoryEvent}, ReplayMode)"/>
 ///   delivers the full session <see cref="InventoryEvent"/> log. The default
 ///   <see cref="ReplayMode.FromSessionStart"/> replays every Added / Deleted /
 ///   StackChanged event the service has emitted in this session (in order)
 ///   before going live; <see cref="ReplayMode.LiveOnly"/> skips the replay
-///   for consumers that genuinely don''t care about history. The contract
-///   matches <see cref="Mithril.Shared.Logging.ILogStreamDriver"/>''s
+///   for consumers that genuinely don't care about history. The contract
+///   matches <see cref="Mithril.Shared.Logging.ILogStreamDriver"/>'s
 ///   default replay-then-live shape.</item>
 ///   <item><b>Bind</b> — not exposed today. Consumers that want an
 ///   observable <c>Items</c> collection wrap <see cref="Subscribe"/> at the
@@ -84,7 +84,7 @@ public interface IInventoryService
     /// <summary>
     /// Resolve an instance id to its internal item name, if known. Returns
     /// true even for ids that have been deleted — the entry is retained so
-    /// late lookups (e.g. Arwen''s gift-attribution path) still succeed.
+    /// late lookups (e.g. Arwen's gift-attribution path) still succeed.
     /// </summary>
     bool TryResolve(long instanceId, out string internalName);
 
@@ -95,7 +95,7 @@ public interface IInventoryService
     /// export seeding, or export reconcile. Returns false when:
     /// <list type="bullet">
     ///   <item>The instance has never been observed (carryover from a prior
-    ///   game session whose AddItem isn''t in this log''s replay buffer).</item>
+    ///   game session whose AddItem isn't in this log's replay buffer).</item>
     ///   <item>The instance is in the map but its size is still the
     ///   unconfirmed default of 1 (a session-replayed AddItem with no
     ///   chat status in the correlation window). A real stack of 1 is
@@ -104,7 +104,7 @@ public interface IInventoryService
     ///   <c>true, 1</c>.</item>
     /// </list>
     /// Like <see cref="TryResolve"/>, returns the last-known confirmed size
-    /// for entries that have been deleted in this session — Arwen''s
+    /// for entries that have been deleted in this session — Arwen's
     /// gift-attribution path needs the pre-delete size.
     /// </summary>
     bool TryGetStackSize(long instanceId, out int stackSize);
@@ -125,7 +125,7 @@ public interface IInventoryService
     /// during this session now receives the Deleted (and any interim
     /// StackChanged) events for those items, not just the survivors.</para>
     ///
-    /// <para><b>Live-only subscriptions.</b> Callers that genuinely don''t
+    /// <para><b>Live-only subscriptions.</b> Callers that genuinely don't
     /// care about session history (e.g. a UI that only renders events from
     /// "now" forward) pass <see cref="ReplayMode.LiveOnly"/>. Replay is
     /// skipped; the handler only sees events fired after the subscription
@@ -134,7 +134,7 @@ public interface IInventoryService
     /// <para><b>Atomicity.</b> Replay and live-attach are atomic — under an
     /// internal lock — so no event is lost, duplicated, or reordered
     /// relative to the canonical map. A live event firing during another
-    /// handler''s replay either runs after replay completes (and is
+    /// handler's replay either runs after replay completes (and is
     /// delivered live) or runs before (and is in the replay), never both
     /// and never neither.</para>
     ///
@@ -144,7 +144,7 @@ public interface IInventoryService
     /// that do non-trivial work should dispatch off-thread immediately to
     /// avoid blocking ingestion.</para>
     ///
-    /// <para><b>Query vs. React.</b> For "what''s in inventory right now?"
+    /// <para><b>Query vs. React.</b> For "what's in inventory right now?"
     /// use the Query channel — <see cref="TryResolve"/> /
     /// <see cref="TryGetStackSize"/>. Subscribe is the React channel: a
     /// log of what happened, in order, including the Deleted events the

--- a/src/Mithril.GameState/Inventory/IInventoryService.cs
+++ b/src/Mithril.GameState/Inventory/IInventoryService.cs
@@ -1,3 +1,5 @@
+using Mithril.Shared.Logging;
+
 namespace Mithril.GameState.Inventory;
 
 /// <summary>
@@ -5,14 +7,14 @@ namespace Mithril.GameState.Inventory;
 /// unique id emitted by <c>ProcessAddItem</c> / <c>ProcessDeleteItem</c>.
 /// <paramref name="InternalName"/> maps to
 /// <see cref="Mithril.Reference.Models.Items.Item.InternalName"/>.
-/// <paramref name="Timestamp"/> is the source log line's timestamp (UTC), not
-/// wall-clock — consumers with time-window logic (e.g. Samwise's plant-resolve
+/// <paramref name="Timestamp"/> is the source log line''s timestamp (UTC), not
+/// wall-clock — consumers with time-window logic (e.g. Samwise''s plant-resolve
 /// window) need the in-game timeline.
 /// <paramref name="StackSize"/> is the stack size at the moment of the event:
-/// for <see cref="InventoryEventKind.Added"/> it's the size known when the
+/// for <see cref="InventoryEventKind.Added"/> it''s the size known when the
 /// item entered the map (1 if no chat correlation has landed yet);
-/// for <see cref="InventoryEventKind.Deleted"/> it's the last-known size
-/// before removal; for <see cref="InventoryEventKind.StackChanged"/> it's
+/// for <see cref="InventoryEventKind.Deleted"/> it''s the last-known size
+/// before removal; for <see cref="InventoryEventKind.StackChanged"/> it''s
 /// the new size.
 /// <paramref name="SizeConfirmed"/> is the same bit
 /// <see cref="IInventoryService.TryGetStackSize"/> consults — false when the
@@ -50,19 +52,39 @@ public enum InventoryEventKind
 /// chat <c>[Status]</c> channel via <c>IChatLogStream</c> for stack-size
 /// correlation on fresh additions.
 ///
-/// Owning this centrally (rather than having each module rebuild its own map
-/// from the stream) avoids the late-subscribe race: modules either query the
-/// live map at use-time via <see cref="TryResolve"/> or
-/// <see cref="TryGetStackSize"/>, or subscribe via <see cref="Subscribe"/> which
-/// atomically replays the current map state to the new handler before delivering
-/// live events.
+/// <para><b>Three channels (per <a href="https://github.com/moumantai-gg/mithril/pull/584">#584</a>''s
+/// service-design rule).</b></para>
+/// <list type="bullet">
+///   <item><b>Query</b> — <see cref="TryResolve"/> and
+///   <see cref="TryGetStackSize"/> answer "what''s in inventory right now?"
+///   (including last-known state for deleted entries — Arwen''s
+///   gift-attribution path needs the pre-delete name/size).</item>
+///   <item><b>React</b> — <see cref="Subscribe(Action{InventoryEvent}, ReplayMode)"/>
+///   delivers the full session <see cref="InventoryEvent"/> log. The default
+///   <see cref="ReplayMode.FromSessionStart"/> replays every Added / Deleted /
+///   StackChanged event the service has emitted in this session (in order)
+///   before going live; <see cref="ReplayMode.LiveOnly"/> skips the replay
+///   for consumers that genuinely don''t care about history. The contract
+///   matches <see cref="Mithril.Shared.Logging.ILogStreamDriver"/>''s
+///   default replay-then-live shape.</item>
+///   <item><b>Bind</b> — not exposed today. Consumers that want an
+///   observable <c>Items</c> collection wrap <see cref="Subscribe"/> at the
+///   call site (see <c>Palantir.LiveInventoryViewModel</c>).</item>
+/// </list>
+///
+/// <para>Owning this centrally (rather than having each module rebuild its
+/// own map from the stream) avoids the late-subscribe race: modules either
+/// query the live map at use-time via <see cref="TryResolve"/> or
+/// <see cref="TryGetStackSize"/>, or subscribe via <see cref="Subscribe"/>
+/// which atomically replays the full event log to the new handler before
+/// delivering live events.</para>
 /// </summary>
 public interface IInventoryService
 {
     /// <summary>
     /// Resolve an instance id to its internal item name, if known. Returns
     /// true even for ids that have been deleted — the entry is retained so
-    /// late lookups (e.g. Arwen's gift-attribution path) still succeed.
+    /// late lookups (e.g. Arwen''s gift-attribution path) still succeed.
     /// </summary>
     bool TryResolve(long instanceId, out string internalName);
 
@@ -73,7 +95,7 @@ public interface IInventoryService
     /// export seeding, or export reconcile. Returns false when:
     /// <list type="bullet">
     ///   <item>The instance has never been observed (carryover from a prior
-    ///   game session whose AddItem isn't in this log's replay buffer).</item>
+    ///   game session whose AddItem isn''t in this log''s replay buffer).</item>
     ///   <item>The instance is in the map but its size is still the
     ///   unconfirmed default of 1 (a session-replayed AddItem with no
     ///   chat status in the correlation window). A real stack of 1 is
@@ -82,31 +104,61 @@ public interface IInventoryService
     ///   <c>true, 1</c>.</item>
     /// </list>
     /// Like <see cref="TryResolve"/>, returns the last-known confirmed size
-    /// for entries that have been deleted in this session — Arwen's
+    /// for entries that have been deleted in this session — Arwen''s
     /// gift-attribution path needs the pre-delete size.
     /// </summary>
     bool TryGetStackSize(long instanceId, out int stackSize);
 
     /// <summary>
-    /// Attach a handler that receives every live (non-deleted) item currently
-    /// in the map (as synthesized <see cref="InventoryEventKind.Added"/>
-    /// events) followed by every live add/delete. Replay and live-attach are
-    /// atomic — no event is lost, duplicated, or reordered relative to the
-    /// canonical map.
+    /// React-channel subscription. Attach a handler that receives every
+    /// <see cref="InventoryEvent"/> the service emits.
     ///
-    /// The handler is invoked synchronously under an internal lock both during
-    /// replay (on the subscribing thread) and during live dispatch (on the
-    /// ingestion-loop thread). Subscribers that do non-trivial work should
-    /// dispatch off-thread immediately to avoid blocking ingestion.
+    /// <para><b>Default replay shape (<see cref="ReplayMode.FromSessionStart"/>).</b>
+    /// On attach, the service replays the full in-session event log to the
+    /// handler (every Added / Deleted / StackChanged event it has emitted
+    /// since startup, in original order) before delivering live events.
+    /// This is the same contract <see cref="Mithril.Shared.Logging.ILogStreamDriver"/>
+    /// offers for L1 subscriptions and resolves the late-subscribe class of
+    /// bug surfaced by audits <a href="https://github.com/moumantai-gg/mithril/issues/579">#579</a>
+    /// / <a href="https://github.com/moumantai-gg/mithril/issues/588">#588</a>:
+    /// a consumer attaching after some items have been added-and-deleted
+    /// during this session now receives the Deleted (and any interim
+    /// StackChanged) events for those items, not just the survivors.</para>
     ///
-    /// Stack-size mutations (split, merge, plant-consume, vault transfer,
-    /// chat back-fill of a previously-defaulted Add) are surfaced as
-    /// <see cref="InventoryEventKind.StackChanged"/> events. The replayed
-    /// <see cref="InventoryEventKind.Added"/> events carry the current size,
-    /// so a fresh subscriber doesn't need to poll <see cref="TryGetStackSize"/>
-    /// for steady-state rendering.
+    /// <para><b>Live-only subscriptions.</b> Callers that genuinely don''t
+    /// care about session history (e.g. a UI that only renders events from
+    /// "now" forward) pass <see cref="ReplayMode.LiveOnly"/>. Replay is
+    /// skipped; the handler only sees events fired after the subscription
+    /// is established.</para>
     ///
-    /// Dispose the returned subscription to stop receiving further events.
+    /// <para><b>Atomicity.</b> Replay and live-attach are atomic — under an
+    /// internal lock — so no event is lost, duplicated, or reordered
+    /// relative to the canonical map. A live event firing during another
+    /// handler''s replay either runs after replay completes (and is
+    /// delivered live) or runs before (and is in the replay), never both
+    /// and never neither.</para>
+    ///
+    /// <para><b>Threading.</b> The handler is invoked synchronously under
+    /// the internal lock both during replay (on the subscribing thread) and
+    /// during live dispatch (on the ingestion-loop thread). Subscribers
+    /// that do non-trivial work should dispatch off-thread immediately to
+    /// avoid blocking ingestion.</para>
+    ///
+    /// <para><b>Query vs. React.</b> For "what''s in inventory right now?"
+    /// use the Query channel — <see cref="TryResolve"/> /
+    /// <see cref="TryGetStackSize"/>. Subscribe is the React channel: a
+    /// log of what happened, in order, including the Deleted events the
+    /// pre-#585 contract silently dropped for fresh subscribers.</para>
+    ///
+    /// <para>Dispose the returned subscription to stop receiving further
+    /// events.</para>
     /// </summary>
-    IDisposable Subscribe(Action<InventoryEvent> handler);
+    /// <param name="handler">Event handler. Must not be null.</param>
+    /// <param name="replay">Backlog policy. Default
+    /// <see cref="ReplayMode.FromSessionStart"/> replays the full session
+    /// event log atomically before going live;
+    /// <see cref="ReplayMode.LiveOnly"/> skips the replay.</param>
+    IDisposable Subscribe(
+        Action<InventoryEvent> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart);
 }

--- a/src/Mithril.GameState/Inventory/InventoryService.cs
+++ b/src/Mithril.GameState/Inventory/InventoryService.cs
@@ -86,6 +86,14 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     private ILogSubscription? _playerSubscription;
     private ILogSubscription? _chatSubscription;
 
+    // One-shot guard for the SinceSubscribe coercion diag. Subscribe treats
+    // SinceSubscribe as LiveOnly today (no "since timestamp T" window
+    // implemented); we emit a single Trace per process so the spurious knob
+    // is observable without flooding diagnostics on repeated subscribes.
+    // Mirrors LogStreamDriver's chat-pipe ReplayMode-mismatch diagnostic
+    // (LogStreamDriver.cs ReplayMode != LiveOnly branch).
+    private static int s_sinceSubscribeDiagFired;
+
     // _subLock guards _map, _handlers, _eventLog, and _eventLogOverflowWarned.
     // _pendingChat / _pendingAdd are PendingCorrelator instances that are
     // independently thread-safe via their own internal _gate; they don't require
@@ -218,14 +226,27 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
         ReplayMode replay = ReplayMode.FromSessionStart)
     {
         ArgumentNullException.ThrowIfNull(handler);
+        // SinceSubscribe is treated like LiveOnly here — InventoryService
+        // has no notion of an arbitrary "since timestamp T" window today
+        // (mirrors LogStreamDriver's current behaviour for that mode).
+        // Emit a one-shot Trace per process for symmetry with the
+        // LogStreamDriver chat-pipe ReplayMode-mismatch diagnostic, so the
+        // spurious knob doesn't go unnoticed. Fired outside _subLock — the
+        // diagnostics sink is independently thread-safe and this avoids
+        // re-entering the sink while holding the subscription lock.
+        if (replay == ReplayMode.SinceSubscribe
+            && Interlocked.CompareExchange(ref s_sinceSubscribeDiagFired, 1, 0) == 0)
+        {
+            _diag?.Trace(
+                "GameState.Inventory",
+                "ReplayMode.SinceSubscribe is not yet implemented for IInventoryService; treating as LiveOnly. " +
+                "This diagnostic fires once per process.");
+        }
         lock (_subLock)
         {
             // React-channel contract (#585): default replay is the full
             // in-session event log, atomically under _subLock so the
             // replay-then-live boundary is race-free with concurrent Fire()s.
-            // SinceSubscribe is treated like LiveOnly here — InventoryService
-            // has no notion of an arbitrary "since timestamp T" window today
-            // (mirrors LogStreamDriver's current behaviour for that mode).
             if (replay == ReplayMode.FromSessionStart)
             {
                 foreach (var evt in _eventLog)

--- a/src/Mithril.GameState/Inventory/InventoryService.cs
+++ b/src/Mithril.GameState/Inventory/InventoryService.cs
@@ -86,16 +86,33 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     private ILogSubscription? _playerSubscription;
     private ILogSubscription? _chatSubscription;
 
-    // _subLock guards _map and _handlers. _pendingChat / _pendingAdd are
-    // PendingCorrelator instances that are independently thread-safe via their own
-    // internal _gate; they don't require _subLock for correctness, but both L1
-    // subscription handlers (OnLocalPlayer, OnChat) take _subLock around correlator
-    // calls anyway so the drain-then-mutate-_map sequence stays atomic within a
-    // handler. The two subscriptions have independent pump threads, so _subLock is
-    // load-bearing for cross-pipe serialization too.
+    // _subLock guards _map, _handlers, _eventLog, and _eventLogOverflowWarned.
+    // _pendingChat / _pendingAdd are PendingCorrelator instances that are
+    // independently thread-safe via their own internal _gate; they don't require
+    // _subLock for correctness, but both L1 subscription handlers (OnLocalPlayer,
+    // OnChat) take _subLock around correlator calls anyway so the
+    // drain-then-mutate-_map sequence stays atomic within a handler. The two
+    // subscriptions have independent pump threads, so _subLock is load-bearing for
+    // cross-pipe serialization too.
     private readonly object _subLock = new();
     private readonly Dictionary<long, MapEntry> _map = new();
     private readonly List<Action<InventoryEvent>> _handlers = new();
+
+    // React-channel event log (#585). Every InventoryEvent the service emits
+    // is appended here so a late subscriber asking for the default
+    // ReplayMode.FromSessionStart replay receives the full session, including
+    // Deleted events for items that were added-and-deleted before it attached.
+    // Soft-capped at EventLogSoftCap: when exceeded the oldest entries are
+    // dropped to bound memory (~50 bytes/entry x 50k ~= 2.5 MB worst case) and
+    // a single Warn fires so the situation is observable rather than silent.
+    // The cap exists for pathological sessions; typical PG sessions produce
+    // well under it.
+    private const int EventLogSoftCap = 50_000;
+    // When trimming, drop this many entries at once so we amortize the
+    // shift cost across many appends rather than a one-at-a-time slide.
+    private const int EventLogTrimChunk = 4_096;
+    private readonly List<InventoryEvent> _eventLog = new();
+    private bool _eventLogOverflowWarned;
 
     // Bidirectional chat/AddItem correlation. Either signal can arrive first within
     // the same second:
@@ -196,19 +213,23 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
         return false;
     }
 
-    public IDisposable Subscribe(Action<InventoryEvent> handler)
+    public IDisposable Subscribe(
+        Action<InventoryEvent> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart)
     {
         ArgumentNullException.ThrowIfNull(handler);
         lock (_subLock)
         {
-            // Replay current live map state to this handler only. Skip
-            // entries marked Deleted — they're retained for TryResolve but
-            // shouldn't surface as Added events to a fresh subscriber.
-            foreach (var (id, entry) in _map)
+            // React-channel contract (#585): default replay is the full
+            // in-session event log, atomically under _subLock so the
+            // replay-then-live boundary is race-free with concurrent Fire()s.
+            // SinceSubscribe is treated like LiveOnly here — InventoryService
+            // has no notion of an arbitrary "since timestamp T" window today
+            // (mirrors LogStreamDriver's current behaviour for that mode).
+            if (replay == ReplayMode.FromSessionStart)
             {
-                if (entry.Deleted) continue;
-                Invoke(handler, new InventoryEvent(
-                    InventoryEventKind.Added, id, entry.InternalName, entry.Timestamp, entry.StackSize, entry.SizeConfirmed));
+                foreach (var evt in _eventLog)
+                    Invoke(handler, evt);
             }
             _handlers.Add(handler);
             return new Subscription(this, handler);
@@ -708,15 +729,48 @@ public sealed partial class InventoryService : BackgroundService, IInventoryServ
     }
 
     /// <summary>
-    /// MUST be called with <see cref="_subLock"/> held. Dispatches an event to
-    /// every currently-attached handler. Holding the lock during dispatch is
-    /// what makes the Subscribe-vs-live-event race impossible: a new
-    /// subscriber either ran its replay before this Fire (and will receive
-    /// the live event) or runs after (and saw the entry in its replay).
+    /// MUST be called with <see cref="_subLock"/> held. Appends to the
+    /// React-channel event log (#585) and dispatches to every currently
+    /// attached handler. Holding the lock around both is what makes the
+    /// Subscribe-vs-live-event race impossible: a new subscriber either ran
+    /// its replay before this Fire (and will receive the live event because
+    /// the handler is in <see cref="_handlers"/>) or runs after (and saw
+    /// the event in its replay of <see cref="_eventLog"/>).
     /// </summary>
     private void Fire(InventoryEvent evt)
     {
+        AppendToEventLog(evt);
         foreach (var h in _handlers) Invoke(h, evt);
+    }
+
+    /// <summary>
+    /// MUST be called with <see cref="_subLock"/> held. Appends an event to
+    /// the React-channel log, enforcing the soft cap by dropping oldest
+    /// entries in <see cref="EventLogTrimChunk"/>-sized chunks. The first
+    /// time the cap is exceeded a single <c>Warn</c> fires so the situation
+    /// surfaces in diagnostics rather than silently truncating session
+    /// history. Subsequent overflows are bounded but not logged again to
+    /// avoid noise in pathological sessions.
+    /// </summary>
+    private void AppendToEventLog(InventoryEvent evt)
+    {
+        if (_eventLog.Count >= EventLogSoftCap)
+        {
+            // Trim a chunk from the head. RemoveRange is O(n) on List<T>, but
+            // amortizes to O(1) per Append once Count rounds the cap because
+            // we trim a chunk at a time, not one element at a time.
+            var trim = Math.Min(EventLogTrimChunk, _eventLog.Count);
+            _eventLog.RemoveRange(0, trim);
+            if (!_eventLogOverflowWarned)
+            {
+                _eventLogOverflowWarned = true;
+                _diag?.Warn("GameState.Inventory",
+                    $"React-channel event log exceeded soft cap ({EventLogSoftCap}); " +
+                    $"dropping oldest entries. Late subscribers will see a bounded session history. " +
+                    $"This is the first overflow this session; further overflows are silent.");
+            }
+        }
+        _eventLog.Add(evt);
     }
 
     private void Invoke(Action<InventoryEvent> handler, InventoryEvent evt)

--- a/tests/Arwen.Tests/FakeInventory.cs
+++ b/tests/Arwen.Tests/FakeInventory.cs
@@ -1,4 +1,5 @@
 using Mithril.GameState.Inventory;
+using Mithril.Shared.Logging;
 
 namespace Arwen.Tests;
 
@@ -27,7 +28,9 @@ internal sealed class FakeInventory : IInventoryService
         stackSize = 0;
         return false;
     }
-    public IDisposable Subscribe(Action<InventoryEvent> handler) => NoopSubscription.Instance;
+    public IDisposable Subscribe(
+        Action<InventoryEvent> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart) => NoopSubscription.Instance;
 
     private sealed class NoopSubscription : IDisposable
     {

--- a/tests/Legolas.Tests/FakeInventoryService.cs
+++ b/tests/Legolas.Tests/FakeInventoryService.cs
@@ -1,15 +1,16 @@
 using Mithril.GameState.Inventory;
 using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
+using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 
 namespace Legolas.Tests;
 
 /// <summary>
 /// Test double for <see cref="IInventoryService"/> (#488). <see cref="Subscribe"/>
-/// atomically replays the current live (non-deleted) items as
-/// <see cref="InventoryEventKind.Added"/> then delivers live add/delete, like
-/// the real service. <see cref="Add"/>/<see cref="Delete"/> drive the stream.
+/// atomically replays the full session event log (Added / Deleted, in order)
+/// then delivers live add/delete — mirrors the real service's #585 React-channel
+/// contract. <see cref="Add"/>/<see cref="Delete"/> drive the stream.
 /// </summary>
 public sealed class FakeInventoryService : IInventoryService
 {
@@ -18,15 +19,15 @@ public sealed class FakeInventoryService : IInventoryService
     private readonly List<long> _order = new();
     private readonly Dictionary<long, Entry> _map = new();
     private readonly List<Action<InventoryEvent>> _handlers = new();
+    private readonly List<InventoryEvent> _eventLog = new();
 
-    public IDisposable Subscribe(Action<InventoryEvent> handler)
+    public IDisposable Subscribe(
+        Action<InventoryEvent> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart)
     {
-        foreach (var id in _order)
+        if (replay == ReplayMode.FromSessionStart)
         {
-            var e = _map[id];
-            if (e.Deleted) continue;
-            handler(new InventoryEvent(InventoryEventKind.Added, id, e.InternalName,
-                DateTime.UtcNow, 1, true));
+            foreach (var evt in _eventLog) handler(evt);
         }
         _handlers.Add(handler);
         return new Sub(this, handler);
@@ -46,12 +47,15 @@ public sealed class FakeInventoryService : IInventoryService
     }
 
     /// <summary>Seed an item already in inventory before anyone subscribes
-    /// (mimics login replay) — raises no live event.</summary>
+    /// (mimics login replay) — appended to the event log so late subscribers
+    /// see it during their replay, but raises no live event.</summary>
     public void Seed(long instanceId, string internalName)
     {
         if (_map.ContainsKey(instanceId)) return;
         _order.Add(instanceId);
         _map[instanceId] = new Entry(internalName, false);
+        _eventLog.Add(new InventoryEvent(InventoryEventKind.Added, instanceId, internalName,
+            DateTime.UtcNow, 1, true));
     }
 
     public void Add(long instanceId, string internalName, DateTime? at = null)
@@ -72,6 +76,7 @@ public sealed class FakeInventoryService : IInventoryService
 
     private void Raise(InventoryEvent e)
     {
+        _eventLog.Add(e);
         foreach (var h in _handlers.ToArray()) h(e);
     }
 

--- a/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/InventoryServiceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using FluentAssertions;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Tests.TestSupport;
+using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Game;
 using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
@@ -83,12 +84,12 @@ public sealed class InventoryServiceTests
     }
 
     [Fact]
-    public async Task SubscribeAfterAdd_ReplaysCurrentMapAsAddedEvents()
+    public async Task SubscribeAfterAdd_ReplaysFullEventLog()
     {
-        // The late-subscribe race that caused issue #7: the seed AddItem fires
-        // during PlayerLogStream's session-replay flush, before the gated module
-        // attaches its handler. Subscribe must replay the live map so the new
-        // subscriber sees the same history as one that was attached upfront.
+        // The late-subscribe race that #585 closed: a consumer attaching after
+        // session-replay AddItem events have already been processed must see
+        // those Added events, not be told inventory is empty. Per the React-
+        // channel contract Subscribe now replays the full event log in order.
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessAddItem(BarleySeeds(7), -1, True)");
@@ -100,7 +101,9 @@ public sealed class InventoryServiceTests
 
         replayed.Should().HaveCount(2);
         replayed.Should().AllSatisfy(e => e.Kind.Should().Be(InventoryEventKind.Added));
-        replayed.Select(e => (e.InstanceId, e.InternalName)).Should().BeEquivalentTo(new[]
+        // Event-log replay preserves the original Fire order — a late subscriber
+        // observes the same sequence an upfront subscriber would have.
+        replayed.Select(e => (e.InstanceId, e.InternalName)).Should().Equal(new[]
         {
             (42L, "Moonstone"),
             (7L, "BarleySeeds"),
@@ -108,11 +111,15 @@ public sealed class InventoryServiceTests
     }
 
     [Fact]
-    public async Task SubscribeAfterDelete_DoesNotReplayDeletedEntry()
+    public async Task SubscribeAfterDelete_ReplaysAddThenDelete()
     {
-        // Deleted entries are retained for TryResolve, but a brand-new subscriber
-        // shouldn't be told an item exists that's already gone. Otherwise Samwise
-        // would treat a stale id as a candidate seed for the next plant.
+        // #585: under the React-channel contract, a brand-new subscriber sees the
+        // full event log, including Deleted events for items that were
+        // added-and-deleted before it attached. Pre-#585 Subscribe silently
+        // dropped these (only replayed live items as Added), which was the
+        // bug class flagged by audits #579/#588 — Legolas/Motherlode would
+        // miss dig-completion signals from before Mithril attached, Arwen
+        // would miss gifts made in the same session-replay window, etc.
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
             "[00:00:02] LocalPlayer: ProcessDeleteItem(42)");
@@ -122,7 +129,13 @@ public sealed class InventoryServiceTests
         var replayed = new List<InventoryEvent>();
         using var sub = svc.Subscribe(replayed.Add);
 
-        replayed.Should().BeEmpty();
+        replayed.Should().HaveCount(2);
+        replayed[0].Kind.Should().Be(InventoryEventKind.Added);
+        replayed[0].InstanceId.Should().Be(42);
+        replayed[0].InternalName.Should().Be("Moonstone");
+        replayed[1].Kind.Should().Be(InventoryEventKind.Deleted);
+        replayed[1].InstanceId.Should().Be(42);
+        replayed[1].InternalName.Should().Be("Moonstone");
         // TryResolve still returns the name (Arwen's gift-attribution path).
         svc.TryResolve(42, out var name).Should().BeTrue();
         name.Should().Be("Moonstone");
@@ -176,11 +189,14 @@ public sealed class InventoryServiceTests
     }
 
     [Fact]
-    public async Task SubscribeReplay_CarriesCurrentStackSize()
+    public async Task SubscribeReplay_DeliversAddThenStackChanged()
     {
-        // Once a stack has been mutated by UpdateItemCode, a fresh subscriber must
-        // see the post-mutation size on the synthesized Added event so the view
-        // doesn't render a stale "1" until the next live event.
+        // #585: the React-channel replay delivers the actual event log, not a
+        // synthesized "current state" snapshot. A late subscriber sees the
+        // Added (size 1) and the subsequent StackChanged (size 4) in order —
+        // same shape an upfront subscriber would have observed. Consumers that
+        // want "what's in inventory right now?" go through the Query channel
+        // (TryGetStackSize), not the React channel.
         var stream = new ScriptedStream(
             "[00:00:01] LocalPlayer: ProcessAddItem(Guava(100), -1, True)",
             "[00:00:02] LocalPlayer: ProcessUpdateItemCode(100, 201920, True)"); // size 4
@@ -190,10 +206,16 @@ public sealed class InventoryServiceTests
         var replayed = new List<InventoryEvent>();
         using var sub = svc.Subscribe(replayed.Add);
 
-        replayed.Should().ContainSingle();
+        replayed.Should().HaveCount(2);
         replayed[0].Kind.Should().Be(InventoryEventKind.Added);
         replayed[0].InstanceId.Should().Be(100);
-        replayed[0].StackSize.Should().Be(4);
+        replayed[0].StackSize.Should().Be(1);
+        replayed[1].Kind.Should().Be(InventoryEventKind.StackChanged);
+        replayed[1].InstanceId.Should().Be(100);
+        replayed[1].StackSize.Should().Be(4);
+        // Query channel reports the post-mutation size.
+        svc.TryGetStackSize(100, out var size).Should().BeTrue();
+        size.Should().Be(4);
     }
 
     [Fact]
@@ -613,6 +635,213 @@ public sealed class InventoryServiceTests
 
         await svc.StopAsync(CancellationToken.None);
         _ = runTask;
+    }
+
+    // ---- #585 React-channel contract: full event-log replay ----------------
+
+    [Fact]
+    public async Task Subscribe_FullEventLogReplay_PreservesAddDeleteAddDeleteOrder()
+    {
+        // #585 acceptance test: a sequence of Add → Delete → Add → Delete fired
+        // before subscription must replay in order. The pre-#585 contract
+        // synthesized at most one Added per surviving live entry, so this
+        // sequence would have replayed as zero events (both items deleted).
+        var stream = new ScriptedStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessDeleteItem(42)",
+            "[00:00:03] LocalPlayer: ProcessAddItem(BarleySeeds(7), -1, True)",
+            "[00:00:04] LocalPlayer: ProcessDeleteItem(7)");
+        var svc = new InventoryService(stream.Driver);
+        await RunUntilDrainedAsync(svc, stream);
+
+        var replayed = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(replayed.Add);
+
+        replayed.Should().HaveCount(4);
+        replayed.Select(e => (e.Kind, e.InstanceId)).Should().Equal(new[]
+        {
+            (InventoryEventKind.Added, 42L),
+            (InventoryEventKind.Deleted, 42L),
+            (InventoryEventKind.Added, 7L),
+            (InventoryEventKind.Deleted, 7L),
+        });
+    }
+
+    [Fact]
+    public async Task Subscribe_LiveOnly_SkipsBacklogAndDeliversSubsequentEvents()
+    {
+        // Opt-out path for consumers that genuinely don't care about
+        // pre-attach history. Replay is skipped; only events fired AFTER
+        // Subscribe is established are delivered.
+        var stream = new ScriptedStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessDeleteItem(42)");
+        var svc = new InventoryService(stream.Driver);
+        var runTask = svc.StartAsync(CancellationToken.None);
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(5));
+
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add, ReplayMode.LiveOnly);
+        events.Should().BeEmpty("LiveOnly skips the session backlog");
+
+        stream.Push("[00:00:03] LocalPlayer: ProcessAddItem(BarleySeeds(7), -1, True)");
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+
+        events.Should().ContainSingle();
+        events[0].Kind.Should().Be(InventoryEventKind.Added);
+        events[0].InstanceId.Should().Be(7);
+
+        await svc.StopAsync(CancellationToken.None);
+        _ = runTask;
+    }
+
+    [Fact]
+    public async Task Subscribe_DefaultReplayMode_IsFromSessionStart()
+    {
+        // The zero-arg overload must default to full-log replay — this is the
+        // contract every existing in-tree consumer (Samwise, Palantir,
+        // Legolas/Motherlode) relies on after #585.
+        var stream = new ScriptedStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessDeleteItem(42)");
+        var svc = new InventoryService(stream.Driver);
+        await RunUntilDrainedAsync(svc, stream);
+
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add); // no ReplayMode arg
+
+        events.Should().HaveCount(2);
+        events[0].Kind.Should().Be(InventoryEventKind.Added);
+        events[1].Kind.Should().Be(InventoryEventKind.Deleted);
+    }
+
+    [Fact]
+    public async Task Subscribe_AtomicReplayThenLive_NoDuplicateOrLostEvents()
+    {
+        // The lock-around-Fire-and-Append discipline must hold: an event fired
+        // after Subscribe returns is delivered exactly once (live), not also
+        // re-delivered as part of a stale replay snapshot, and not missed
+        // because the replay snapshot was taken before append.
+        //
+        // Drive backlog → subscribe → fire a live event under the same drain
+        // gate. The subscriber should see exactly: backlog Added + live Added.
+        var stream = new ScriptedStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(Moonstone(42), -1, True)");
+        var svc = new InventoryService(stream.Driver);
+        var runTask = svc.StartAsync(CancellationToken.None);
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(5));
+
+        var events = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(events.Add);
+        events.Should().ContainSingle("backlog Moonstone Added replays atomically");
+
+        stream.Push("[00:00:02] LocalPlayer: ProcessAddItem(BarleySeeds(7), -1, True)");
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
+
+        events.Should().HaveCount(2,
+            "live event is delivered exactly once via the live-handler path, not duplicated through replay");
+        events[0].InstanceId.Should().Be(42);
+        events[1].InstanceId.Should().Be(7);
+
+        await svc.StopAsync(CancellationToken.None);
+        _ = runTask;
+    }
+
+    [Fact]
+    public async Task LateSubscriber_ReceivesDeletedEventsSynthesizedBeforeAttach()
+    {
+        // The cross-pump-race scenario from #585: a Motherlode-style consumer
+        // attaches AFTER the L1 driver has already pumped session-replay
+        // AddItem + DeleteItem pairs through InventoryService. The pre-#585
+        // contract dropped those Deleted events entirely (the live map was
+        // empty by the time Subscribe ran). The new contract replays them
+        // from the event log so the consumer's Deleted-handler (the
+        // dig-completion signal for Legolas, the gift-attribution signal
+        // for Arwen) fires correctly.
+        var stream = new ScriptedStream(
+            "[00:00:01] LocalPlayer: ProcessAddItem(MotherlodeMap_Mine(42), -1, True)",
+            "[00:00:02] LocalPlayer: ProcessDeleteItem(42)",
+            "[00:00:03] LocalPlayer: ProcessAddItem(MotherlodeMap_Mine(43), -1, True)",
+            "[00:00:04] LocalPlayer: ProcessDeleteItem(43)");
+        var svc = new InventoryService(stream.Driver);
+        await RunUntilDrainedAsync(svc, stream);
+
+        // Late subscriber that only cares about deletes (Motherlode pattern).
+        var deletes = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(e =>
+        {
+            if (e.Kind == InventoryEventKind.Deleted) deletes.Add(e);
+        });
+
+        deletes.Should().HaveCount(2,
+            "both dig-completion signals must reach the late subscriber even though both maps were already consumed before attach");
+        deletes.Select(e => e.InstanceId).Should().Equal(42L, 43L);
+    }
+
+    [Fact]
+    public async Task EventLog_ExceedsSoftCap_DropsOldestAndWarnsOnce()
+    {
+        // Pathological session: a long-running Mithril instance accumulates
+        // tens of thousands of inventory events. The log soft-caps at
+        // EventLogSoftCap (50,000) by dropping oldest entries in chunks; a
+        // single Warn fires the first time the cap is exceeded so the
+        // truncation isn't silent. The trim chunk is large (4096) so the
+        // log oscillates between cap − chunk and cap, not at cap exactly.
+        const int over = 60_000;
+        var stream = new ScriptedStream(Array.Empty<string>());
+        var diag = new RecordingDiagnostics();
+        var svc = new InventoryService(stream.Driver, diag: diag);
+        var runTask = svc.StartAsync(CancellationToken.None);
+
+        for (int i = 0; i < over; i++)
+            stream.Push($"[00:00:01] LocalPlayer: ProcessAddItem(BarleySeeds({i}), -1, True)");
+        await stream.WaitForDrainAsync(TimeSpan.FromSeconds(30));
+
+        // Late subscriber sees a bounded replay (the cap, not all 60k events).
+        var replayed = new List<InventoryEvent>();
+        using var sub = svc.Subscribe(replayed.Add);
+
+        replayed.Count.Should().BeLessThan(over,
+            "the event log must be soft-capped — late subscribers receive bounded history");
+        replayed.Count.Should().BeLessThanOrEqualTo(50_000,
+            "soft cap = 50_000; trim brings the log under-or-equal to cap");
+        replayed.Count.Should().BeGreaterThan(40_000,
+            "trim chunk is bounded so the log stays close to (not far below) the cap");
+
+        // Exactly one overflow Warn, emitted the first time the cap was hit.
+        var overflowWarns = diag.Warns
+            .Where(w => w.Category == "GameState.Inventory" && w.Message.Contains("soft cap"))
+            .ToList();
+        overflowWarns.Should().ContainSingle(
+            "the overflow Warn is one-shot — pathological sessions shouldn't spam diagnostics");
+
+        await svc.StopAsync(CancellationToken.None);
+        _ = runTask;
+    }
+
+    private sealed class RecordingDiagnostics : IDiagnosticsSink
+    {
+        public List<(string Category, string Message)> Warns { get; } = new();
+        private readonly object _gate = new();
+        private readonly List<DiagnosticEntry> _entries = new();
+
+        public event EventHandler<DiagnosticEntry>? EntryAdded;
+
+        public void Write(DiagnosticLevel level, string category, string message)
+        {
+            var entry = new DiagnosticEntry(DateTime.UtcNow, level, category, message);
+            lock (_gate)
+            {
+                _entries.Add(entry);
+                if (level == DiagnosticLevel.Warn) Warns.Add((category, message));
+            }
+            EntryAdded?.Invoke(this, entry);
+        }
+
+        public IReadOnlyList<DiagnosticEntry> Snapshot()
+        {
+            lock (_gate) return _entries.ToArray();
+        }
     }
 
     [Fact]

--- a/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
+++ b/tests/Palantir.Tests/LiveInventoryViewModelTests.cs
@@ -2,6 +2,7 @@ using Mithril.Reference.Models.Items;
 using Mithril.Reference.Models.Recipes;
 using FluentAssertions;
 using Mithril.GameState.Inventory;
+using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Palantir.ViewModels;
 using Xunit;
@@ -137,9 +138,12 @@ public sealed class LiveInventoryViewModelTests
         public bool TryResolve(long instanceId, out string internalName) { internalName = ""; return false; }
         public bool TryGetStackSize(long instanceId, out int stackSize) { stackSize = 0; return false; }
 
-        public IDisposable Subscribe(Action<InventoryEvent> handler)
+        public IDisposable Subscribe(
+            Action<InventoryEvent> handler,
+            ReplayMode replay = ReplayMode.FromSessionStart)
         {
-            foreach (var e in _initial) handler(e);
+            if (replay == ReplayMode.FromSessionStart)
+                foreach (var e in _initial) handler(e);
             _handler = handler;
             return new Sub(this);
         }


### PR DESCRIPTION
## Summary

Closes #585.

Rewrites `IInventoryService.Subscribe` to honor the React-channel contract landed in #584: every subscriber receives the full in-session event log (Added / Deleted / StackChanged in order) before going live. Default `ReplayMode.FromSessionStart`; `ReplayMode.LiveOnly` opts out. Same shape `IPlayerLogStream` and `ILogStreamDriver` already offer for L1 subscriptions.

## Why

Audit #579 / #588 surfaced a class of late-subscribe bug: the pre-#585 `Subscribe` synthesized at most one `Added` per *surviving* live entry and silently dropped every `Deleted` (plus interim `StackChanged`) for items added-and-deleted before attach. Under the cross-pump race — `InventoryService` processes session-replay `ProcessAddItem` + `ProcessDeleteItem` before a gated module's `Subscribe` runs — the late subscriber permanently lost the Deleted signal.

Real-world victims today:

- **`Legolas.MotherlodeMeasurementCoordinator`** — filters for `Kind == Deleted` as the dig-completion signal. Lost every map consumed before Mithril attached.
- **`Samwise.GardenIngestionService`** — pre-attach Add+Delete pairs left holes in the `_itemIdToCrop` map, breaking harvest-confirmation crop-type resolution.
- **Arwen calibration migration (#582)** — would have lost gifts made before Mithril attached. Resolved structurally by this change.

All three are correctness regressions today, silent (no warn, no error, just missing data). The fix is at the contract level — no per-consumer code change needed; each consumer gets a behavioural improvement on the new default.

Background: memory note `playerlogstream_replay_drain_late_subscriber` documents the existing `IPlayerLogStream` replay contract this change brings `IInventoryService` into alignment with.

## What changed

- `IInventoryService.Subscribe(handler)` → `Subscribe(handler, ReplayMode = FromSessionStart)`. The interface XML doc spells out Query / React / Bind channels explicitly so future consumers don't re-discover the contract.
- `InventoryService` maintains an internal `List<InventoryEvent> _eventLog` appended on every `Fire`. Soft cap = 50,000 entries (~2.5 MB worst case); overflow trims 4096 entries at a time and emits one Warn the first time the cap is exceeded so the truncation is observable, not silent.
- Atomicity preserved: replay + handler-add happen under `_subLock`, same lock `Fire` takes. Lock-around-Fire-and-Append means a live event fired during another subscriber's replay either runs after replay completes (delivered live) or runs before (in the replay), never both, never neither.
- Test doubles updated to the new signature: `tests/Arwen.Tests/FakeInventory.cs`, `tests/Legolas.Tests/FakeInventoryService.cs`, `tests/Palantir.Tests/LiveInventoryViewModelTests.cs`'s inline fake.

## Tests

- 6 new tests in `InventoryServiceTests.cs` covering: full-log replay (Add→Delete→Add→Delete order), `LiveOnly` opt-out, default-replay-mode, atomic-replay-then-live no-duplicate-no-loss, the cross-pump-race scenario (`LateSubscriber_ReceivesDeletedEventsSynthesizedBeforeAttach`), and the 50K soft-cap with one-shot Warn.
- 3 existing tests rewritten to match the new contract:
  - `SubscribeAfterAdd_ReplaysCurrentMapAsAddedEvents` → `SubscribeAfterAdd_ReplaysFullEventLog` (same shape, asserts event-log order)
  - `SubscribeAfterDelete_DoesNotReplayDeletedEntry` → `SubscribeAfterDelete_ReplaysAddThenDelete` (this is the bug-fix test)
  - `SubscribeReplay_CarriesCurrentStackSize` → `SubscribeReplay_DeliversAddThenStackChanged` (replay = real event log, not synthesized snapshot)

## Out of scope

- Consumer migrations: **#582 Arwen** and **#586 Gandalf** — blocked on a separate Tier-2 design call. They get the behavioural improvement automatically via the new default; per-consumer code changes are filed separately.
- `TryResolve` / `TryGetStackSize` (Query channel) — unchanged; they were already correct.
- A separate `Bind` channel exposing `Items` as an observable collection — Tier-2 work, filed when prioritized.
- Other GameState services (`IPlayerSkillState`, `IPlayerPinTracker`, etc.) — different patterns (snapshot + deltas; collection-state events) that don't have the same Query/React conflation.

## Verification

```text
dotnet build Mithril.slnx
  Build succeeded.
      0 Warning(s)
      0 Error(s)

dotnet test Mithril.slnx --no-build
  3557 passed / 0 failed across 20 test assemblies
  Mithril.GameState.Tests: 294 passed (was 288 on main; +6 new React-channel tests)
  All existing consumers green: Samwise, Palantir, Legolas/Motherlode, Arwen
```

## Test plan

- [x] Unit: `Subscribe(handler, FromSessionStart)` after Add → Delete → Add → Delete: 4 events in order
- [x] Unit: `Subscribe(handler, LiveOnly)` after Add → Delete: nothing on attach; new events delivered live
- [x] Unit: default `Subscribe(handler)` (no `ReplayMode` arg) defaults to `FromSessionStart`
- [x] Unit: atomic-replay-then-live — live event neither duplicated nor missed
- [x] Unit: memory cap — after 60K events, log bounded ≤50K and one Warn fires
- [x] Regression: existing `InventoryServiceTests` updated where the contract changed; full pass
- [x] Regression: existing `LiveInventoryViewModelTests` pass
- [x] Behavioural: pre-attach Add+Delete pair visible to a later-attaching subscriber (the bug-fix)
- [x] `dotnet build Mithril.slnx` clean
- [x] `dotnet test Mithril.slnx` full pass

— drafted by Claude (Opus 4.7), posted by @arthur-conde