### PR TITLE
feat(gamestate): IGiftSignalService — Tier-2 signature for accepted gifts (#596)

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Mithril.GameState.Areas.Parsing;
 using Mithril.GameState.Celestial;
 using Mithril.GameState.Celestial.Parsing;
 using Mithril.GameState.Effects;
+using Mithril.GameState.Gifting;
 using Mithril.GameState.Inventory;
 using Mithril.GameState.Movement;
 using Mithril.GameState.Pins;
@@ -56,6 +57,19 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<PlayerEffectsStateService>()
             .AddSingleton<IPlayerEffectsStateService>(sp => sp.GetRequiredService<PlayerEffectsStateService>())
             .AddHostedService(sp => sp.GetRequiredService<PlayerEffectsStateService>());
+
+        // Tier-2 signature service: emits GiftAccepted whenever the local
+        // player gives an item to an NPC and the NPC accepts. Lifts Arwen's
+        // CalibrationService verb-sequence correlator into GameState
+        // (#594 umbrella; first sub-issue is #596). Owns its own
+        // LocalPlayer L1 subscription AND its own instanceId → InternalName
+        // map populated from ProcessAddItem — explicitly does NOT consume
+        // IInventoryService.TryResolve, to retire the cross-pump race
+        // documented in #582's "Replay correctness" section.
+        services
+            .AddSingleton<GiftSignalService>()
+            .AddSingleton<IGiftSignalService>(sp => sp.GetRequiredService<GiftSignalService>())
+            .AddHostedService(sp => sp.GetRequiredService<GiftSignalService>());
 
         // Area tracking is shared live game-state (Gandalf chest-area
         // stamping, Legolas per-area survey calibration, …). One parser,

--- a/src/Mithril.GameState/Gifting/GiftAccepted.cs
+++ b/src/Mithril.GameState/Gifting/GiftAccepted.cs
@@ -1,0 +1,50 @@
+namespace Mithril.GameState.Gifting;
+
+/// <summary>
+/// Tier-2 domain event emitted by <see cref="IGiftSignalService"/> when the
+/// local player gives an item to an NPC and the NPC accepts. Synthesized from
+/// the L1 verb pair (<c>ProcessDeleteItem(instanceId)</c>,
+/// <c>ProcessDeltaFavor(npcKey, delta)</c>) inside an active
+/// <c>ProcessStartInteraction</c> window — resolution fires at the later of
+/// the two verbs regardless of arrival order.
+///
+/// <para><b>Three load-bearing timestamps are carried, not derived:</b></para>
+/// <list type="bullet">
+///   <item><see cref="Timestamp"/> — the <c>ProcessDeltaFavor</c> log-line
+///   timestamp. This is the resolve point, matching today's Arwen
+///   <c>RecordObservation(... timestamp)</c> behaviour (the DeltaFavor stamp
+///   wins regardless of whether DeleteItem or DeltaFavor arrived first).</item>
+///   <item><see cref="InteractionStartedAt"/> — the
+///   <c>ProcessStartInteraction</c> log-line timestamp captured at
+///   window-open. Threaded through to emission so downstream attribution can
+///   correlate gifts across an interaction window. New field vs Arwen's
+///   in-place SM, which dropped the StartInteraction timestamp.</item>
+///   <item>(<see cref="ItemInstanceId"/> / <see cref="ItemInternalName"/>
+///   together identify the gifted item.) The <see cref="ItemInternalName"/>
+///   is resolved from the signature service's OWN <c>instanceId →
+///   InternalName</c> map — populated by its own <c>ProcessAddItem</c>
+///   ingestion — never via a cross-pump call to
+///   <c>IInventoryService.TryResolve</c>. This is the Tier-2 frame-determinism
+///   commitment: a Tier-2 service consumes only L1 directly so the cross-pump
+///   race documented in <a href="https://github.com/moumantai-gg/mithril/issues/582">#582</a>
+///   can't re-appear at a different scope.</item>
+/// </list>
+///
+/// <para><b>Stack-size resolution is the consumer's job</b>, intentionally —
+/// <see cref="ItemInstanceId"/> + <see cref="ItemInternalName"/> are
+/// sufficient for a downstream consumer (Arwen) to look up the pre-delete
+/// stack size via <see cref="Mithril.GameState.Inventory.IInventoryService.TryGetStackSize"/>
+/// at observation-record time. Hoisting stack size onto the event here would
+/// inherit InventoryService's chat-correlation race without giving the consumer
+/// any new lever, so the boundary stays at "item identity, item value, favor
+/// delta, timestamps". See issue
+/// <a href="https://github.com/moumantai-gg/mithril/issues/596">#596</a>
+/// "Stack-size resolution" out-of-scope note.</para>
+/// </summary>
+public readonly record struct GiftAccepted(
+    string NpcKey,
+    long ItemInstanceId,
+    string ItemInternalName,
+    double DeltaFavor,
+    DateTimeOffset Timestamp,
+    DateTimeOffset InteractionStartedAt);

--- a/src/Mithril.GameState/Gifting/GiftSignalService.cs
+++ b/src/Mithril.GameState/Gifting/GiftSignalService.cs
@@ -1,0 +1,455 @@
+using System.Text.RegularExpressions;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Gifting;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IGiftSignalService"/>. Owns a
+/// single <see cref="LocalPlayerLogLine"/> subscription with
+/// <see cref="ReplayMode.FromSessionStart"/> and feeds every verb the SM
+/// consumes through it. Mirrors
+/// <see cref="Mithril.GameState.Inventory.InventoryService"/>'s shape for
+/// registration, L1 subscription, internal event log, and replay-on-Subscribe.
+///
+/// <para><b>State machine (lifted verbatim from Arwen's
+/// <c>CalibrationService</c>'s <c>_activeNpcKey</c> / <c>_pendingDeletedItem</c>
+/// / <c>_pendingDelta</c> logic):</b></para>
+/// <list type="bullet">
+///   <item><c>ProcessStartInteraction(entityId, _, _, _, "NPC_&lt;key&gt;")</c>
+///   → arm window: capture <c>_activeNpcKey</c>, <c>_activeEntityId</c>,
+///   <c>_interactionStartedAt</c>; clear both pending tuples.</item>
+///   <item><c>ProcessDeleteItem(instanceId)</c> → if window is closed,
+///   ignore. Otherwise resolve <c>instanceId</c> to InternalName from
+///   <see cref="_instanceMap"/> (Trace-and-skip on miss). If
+///   <c>_pendingDelta</c> is set, EMIT with the pending DeltaFavor stamp;
+///   otherwise stash <c>_pendingDeletedItem</c>.</item>
+///   <item><c>ProcessDeltaFavor("NPC_&lt;key&gt;", delta)</c> → if
+///   <c>delta &lt;= 0</c> or the NpcKey doesn't match
+///   <c>_activeNpcKey</c>, ignore. If <c>_pendingDeletedItem</c> is set,
+///   EMIT; otherwise stash <c>_pendingDelta</c>.</item>
+///   <item><c>ProcessEndInteraction(entityId)</c> → if it matches
+///   <c>_activeEntityId</c>, clear all transient state. (New vs the original
+///   Arwen SM, which never explicitly cleared on EndInteraction; benign
+///   defensive cleanup.)</item>
+///   <item><c>ProcessAddItem(InternalName(instanceId), …)</c> → upsert
+///   <c>_instanceMap[instanceId] = InternalName</c>. Never evict — matches
+///   <see cref="Mithril.GameState.Inventory.InventoryService"/>'s retention
+///   of deleted entries so a Delete-then-resolve lookup still succeeds.</item>
+/// </list>
+///
+/// <para><b>Frame-determinism contract (per
+/// <a href="https://github.com/moumantai-gg/mithril/issues/594">#594</a>).</b>
+/// One L1 subscription, one pump; emission timestamps are L1 envelope
+/// timestamps (not <see cref="DateTimeOffset.UtcNow"/>); identical L1 input
+/// sequences produce identical <see cref="GiftAccepted"/> sequences regardless
+/// of when subscribers attach; the React-channel event log is appended under
+/// the same lock <see cref="Subscribe"/> takes for replay so the
+/// replay-then-live boundary is race-free.</para>
+///
+/// <para><b>Known SM quirk (preserved verbatim).</b> A non-gift
+/// <c>ProcessDeltaFavor</c> arriving inside an active interaction (e.g. a
+/// quest-turnin favor reward landing right at talk-open, as captured at
+/// 02:12:18 in the May-2026 NPC_Way capture) sets <c>_pendingDelta</c>; the
+/// next <c>ProcessDeleteItem</c> claims it and misattributes the first gift's
+/// delta. Verified intentional per
+/// <a href="https://github.com/moumantai-gg/mithril/issues/596">#596</a>
+/// <i>Out of scope → SM behavioural fixes</i>; the recorded-session fixture
+/// asserts on this exact behaviour.</para>
+/// </summary>
+public sealed partial class GiftSignalService : BackgroundService, IGiftSignalService
+{
+    // ProcessStartInteraction(entityId, ?, absoluteFavor, bool, "NPC_Key")
+    // Borrowed shape from Arwen/Parsing/FavorLogParser.cs:24 — we tighten the
+    // capture to (entityId, npcKey) since the favor + bool args aren't load-
+    // bearing here.
+    [GeneratedRegex(
+        @"ProcessStartInteraction\((\d+),\s*[\d.\-]+,\s*[\d.\-]+,\s*\w+,\s*""(NPC_\w+)""\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex StartInteractionRx();
+
+    // ProcessEndInteraction(entityId)
+    [GeneratedRegex(@"ProcessEndInteraction\((\d+)\)", RegexOptions.CultureInvariant)]
+    private static partial Regex EndInteractionRx();
+
+    // ProcessDeltaFavor(entityId, "NPC_Key", delta, bool)
+    // Shape lifted from Arwen/Parsing/FavorLogParser.cs:28.
+    [GeneratedRegex(
+        @"ProcessDeltaFavor\(\d+,\s*""(NPC_\w+)"",\s*([\d.\-]+),\s*\w+\)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex DeltaFavorRx();
+
+    // ProcessDeleteItem(instanceId). Shape lifted from
+    // src/Mithril.GameState/Inventory/InventoryService.cs:64.
+    [GeneratedRegex(@"ProcessDeleteItem\((\d+)\)", RegexOptions.CultureInvariant)]
+    private static partial Regex DeleteItemRx();
+
+    // ProcessAddItem(InternalName(instanceId), slot, bool). Shape lifted from
+    // src/Mithril.GameState/Inventory/InventoryService.cs:60.
+    [GeneratedRegex(@"ProcessAddItem\((\w+)\((\d+)\),", RegexOptions.CultureInvariant)]
+    private static partial Regex AddItemRx();
+
+    /// <summary>
+    /// Soft cap on the internal event-log size. Gifts are rare in absolute
+    /// terms (PG sessions emit a handful per active hour at most), so 10,000
+    /// is generous (a couple orders of magnitude above expected). One-time
+    /// <see cref="DiagnosticLevel.Warn"/> if exceeded — the cap protects the
+    /// log from unbounded growth on a degenerate stream, not from normal use.
+    /// Matches the shape <c>PlayerEffectsStateService</c> adopts in #590.
+    /// </summary>
+    internal const int EventLogSoftCap = 10_000;
+
+    private readonly ILogStreamDriver _driver;
+    private readonly IDiagnosticsSink? _diag;
+
+    // _lock guards _instanceMap, _eventLog, _handlers, _activeNpcKey,
+    // _activeEntityId, _interactionStartedAt, _pendingDeletedItem,
+    // _pendingDelta. Subscribe takes it for replay-then-attach; the L1 pump
+    // takes it around every verb-handler so the SM transitions, the
+    // _eventLog append, and the live-handler dispatch are atomic with
+    // respect to subscriber attach.
+    private readonly object _lock = new();
+
+    // Service-owned instanceId → InternalName map. Populated from
+    // ProcessAddItem on the SAME L1 subscription as the rest of the SM —
+    // explicitly NOT consulted from IInventoryService.TryResolve. This is
+    // the load-bearing Tier-2 commitment per #596's "Own ProcessAddItem too"
+    // section: routing the DeleteItem half through IInventoryService would
+    // re-introduce the cross-pump race documented in #582. Map is
+    // append-only (never evict) so a DeleteItem whose AddItem fired earlier
+    // in the same session resolves cleanly, mirroring InventoryService's
+    // retention-on-delete pattern.
+    private readonly Dictionary<long, string> _instanceMap = new();
+
+    // React-channel event log — every emitted GiftAccepted is appended,
+    // bounded by EventLogSoftCap.
+    private readonly List<GiftAccepted> _eventLog = new();
+
+    // Handlers carry their replay mode so live dispatch can include or skip
+    // by mode if we ever extend that surface. Today every handler receives
+    // every live event (replay was decided at attach time); the per-handler
+    // mode is retained for future extension. Mirrors
+    // PlayerEffectsStateService's handler shape.
+    private readonly List<(Action<GiftAccepted> Handler, ReplayMode Replay)> _handlers = new();
+
+    // Transient SM state. Both pending tuples carry the L1 envelope
+    // timestamp captured at the half-event for symmetry, even though emit
+    // always uses the DeltaFavor side's timestamp (matches the in-Arwen
+    // behaviour at CalibrationService.cs:195).
+    private string? _activeNpcKey;
+    private long? _activeEntityId;
+    private DateTimeOffset _interactionStartedAt;
+    private (long InstanceId, string InternalName, DateTimeOffset Timestamp)? _pendingDeletedItem;
+    private (string NpcKey, double Delta, DateTimeOffset Timestamp)? _pendingDelta;
+
+    private ILogSubscription? _subscription;
+    private bool _eventLogCapWarned;
+
+    public GiftSignalService(ILogStreamDriver driver, IDiagnosticsSink? diag = null)
+    {
+        _driver = driver;
+        _diag = diag;
+    }
+
+    public IDisposable Subscribe(
+        Action<GiftAccepted> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (_lock)
+        {
+            // React-channel contract (post-#585 shape): default replay is the
+            // full in-session event log, atomically under _lock so the
+            // replay-then-live boundary is race-free with concurrent Fire()s.
+            // SinceSubscribe is treated like LiveOnly — the service has no
+            // notion of an arbitrary "since timestamp T" today, same shape
+            // InventoryService.Subscribe uses.
+            if (replay == ReplayMode.FromSessionStart)
+            {
+                foreach (var evt in _eventLog)
+                    Invoke(handler, evt);
+            }
+            _handlers.Add((handler, replay));
+            return new Subscription(this, handler);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info("GameState.Gifting",
+            "Subscribing to L1 driver (LocalPlayer pipe) for "
+            + "ProcessStartInteraction / ProcessDeleteItem / ProcessDeltaFavor / "
+            + "ProcessEndInteraction / ProcessAddItem");
+        try
+        {
+            _subscription = _driver.Subscribe<LocalPlayerLogLine>(
+                OnLocalPlayer,
+                new LogSubscriptionOptions
+                {
+                    ReplayMode = ReplayMode.FromSessionStart,
+                    DeliveryContext = DeliveryContext.Inline,
+                    DiagnosticCategory = "GameState.Gifting",
+                });
+
+            try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* expected on host stop */ }
+        }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+        }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
+    }
+
+    private ValueTask OnLocalPlayer(LogEnvelope<LocalPlayerLogLine> envelope)
+    {
+        var data = envelope.Payload.Data;
+        var ts = ToOffset(envelope.Payload.Timestamp);
+
+        // Order checks cheap-first: AddItem dominates Player.log by volume
+        // (every loot pickup, every crafting product, every NPC drop). Keep
+        // it ahead of the rarer verbs to short-circuit the per-line cost.
+        var add = AddItemRx().Match(data);
+        if (add.Success && long.TryParse(add.Groups[2].ValueSpan, out var addId))
+        {
+            HandleAddItem(addId, add.Groups[1].Value);
+            return ValueTask.CompletedTask;
+        }
+
+        var del = DeleteItemRx().Match(data);
+        if (del.Success && long.TryParse(del.Groups[1].ValueSpan, out var delId))
+        {
+            HandleDeleteItem(delId, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var delta = DeltaFavorRx().Match(data);
+        if (delta.Success
+            && double.TryParse(delta.Groups[2].ValueSpan, out var deltaValue))
+        {
+            HandleDeltaFavor(delta.Groups[1].Value, deltaValue, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var start = StartInteractionRx().Match(data);
+        if (start.Success && long.TryParse(start.Groups[1].ValueSpan, out var startEntity))
+        {
+            HandleStartInteraction(startEntity, start.Groups[2].Value, ts);
+            return ValueTask.CompletedTask;
+        }
+
+        var end = EndInteractionRx().Match(data);
+        if (end.Success && long.TryParse(end.Groups[1].ValueSpan, out var endEntity))
+        {
+            HandleEndInteraction(endEntity);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    private void HandleAddItem(long instanceId, string internalName)
+    {
+        lock (_lock)
+        {
+            // Never evict. Matches InventoryService.HandleDeleteItem's
+            // retain-on-delete semantics — a downstream DeleteItem for an id
+            // we've already seen still resolves to its InternalName even if
+            // PG never re-emits the AddItem.
+            _instanceMap[instanceId] = internalName;
+        }
+    }
+
+    private void HandleStartInteraction(long entityId, string npcKey, DateTimeOffset timestamp)
+    {
+        lock (_lock)
+        {
+            _activeNpcKey = npcKey;
+            _activeEntityId = entityId;
+            _interactionStartedAt = timestamp;
+            _pendingDeletedItem = null;
+            _pendingDelta = null;
+            _diag?.Trace("GameState.Gifting",
+                $"StartInteraction npc={npcKey} entity={entityId} @ {timestamp:O}");
+        }
+    }
+
+    private void HandleEndInteraction(long entityId)
+    {
+        lock (_lock)
+        {
+            // Only clear when EndInteraction matches the entity we armed on.
+            // PG can emit EndInteraction for windows the SM never armed
+            // (e.g. interactions with "" NpcKey targets — graves, doors —
+            // which never set _activeNpcKey); those must not stomp an
+            // active gift-eligible window.
+            if (_activeEntityId is null || entityId != _activeEntityId.Value) return;
+
+            _diag?.Trace("GameState.Gifting",
+                $"EndInteraction entity={entityId} (npc={_activeNpcKey})");
+            _activeNpcKey = null;
+            _activeEntityId = null;
+            _pendingDeletedItem = null;
+            _pendingDelta = null;
+        }
+    }
+
+    private void HandleDeleteItem(long instanceId, DateTimeOffset timestamp)
+    {
+        lock (_lock)
+        {
+            if (_activeNpcKey is null) return; // no armed window
+
+            if (!_instanceMap.TryGetValue(instanceId, out var internalName))
+            {
+                // No AddItem ingested for this id — could be a carryover from a
+                // prior PG session whose AddItem isn't in this log's replay
+                // buffer. Trace and skip; don't half-arm pendingDeletedItem
+                // with an empty name.
+                _diag?.Trace("GameState.Gifting",
+                    $"DeleteItem id={instanceId} unresolved while talking to {_activeNpcKey} — skipping");
+                return;
+            }
+
+            if (_pendingDelta is { } pendingDelta)
+            {
+                // DeltaFavor-first resolved: emit, clear, and (for the
+                // DeleteItem stash) skip — same as Arwen
+                // CalibrationService.OnItemDeleted at line 192.
+                _pendingDelta = null;
+                Emit(new GiftAccepted(
+                    NpcKey: pendingDelta.NpcKey,
+                    ItemInstanceId: instanceId,
+                    ItemInternalName: internalName,
+                    DeltaFavor: pendingDelta.Delta,
+                    Timestamp: pendingDelta.Timestamp,
+                    InteractionStartedAt: _interactionStartedAt));
+                return;
+            }
+
+            _pendingDeletedItem = (instanceId, internalName, timestamp);
+            _diag?.Trace("GameState.Gifting",
+                $"DeleteItem id={instanceId} name={internalName} pending under npc={_activeNpcKey}");
+        }
+    }
+
+    private void HandleDeltaFavor(string npcKey, double delta, DateTimeOffset timestamp)
+    {
+        lock (_lock)
+        {
+            if (delta <= 0) return;
+            if (_activeNpcKey is null) return;          // no armed window
+            if (_activeNpcKey != npcKey) return;        // talking to A, delta for B → not this gift
+
+            if (_pendingDeletedItem is { } pending)
+            {
+                // DeleteItem-first resolved: emit, clear both pending slots.
+                _pendingDeletedItem = null;
+                _pendingDelta = null;
+                Emit(new GiftAccepted(
+                    NpcKey: npcKey,
+                    ItemInstanceId: pending.InstanceId,
+                    ItemInternalName: pending.InternalName,
+                    DeltaFavor: delta,
+                    Timestamp: timestamp,
+                    InteractionStartedAt: _interactionStartedAt));
+                return;
+            }
+
+            _pendingDelta = (npcKey, delta, timestamp);
+            _diag?.Trace("GameState.Gifting",
+                $"DeltaFavor npc={npcKey} delta={delta} pending");
+        }
+    }
+
+    /// <summary>
+    /// MUST be called with <see cref="_lock"/> held. Appends to the
+    /// React-channel event log and dispatches to every currently-attached
+    /// handler. Holding the lock around both is what makes the
+    /// Subscribe-vs-live-event race impossible — same shape
+    /// <see cref="Mithril.GameState.Inventory.InventoryService"/> uses (and
+    /// the post-#590 <c>PlayerEffectsStateService</c> mirrors).
+    /// </summary>
+    private void Emit(GiftAccepted evt)
+    {
+        AppendEventLog(evt);
+        _diag?.Info("GameState.Gifting",
+            $"GiftAccepted npc={evt.NpcKey} item={evt.ItemInternalName} (id={evt.ItemInstanceId}) "
+            + $"delta={evt.DeltaFavor} @ {evt.Timestamp:O} (interaction started @ {evt.InteractionStartedAt:O})");
+        foreach (var (handler, _) in _handlers) Invoke(handler, evt);
+    }
+
+    /// <summary>
+    /// MUST be called with <see cref="_lock"/> held. Appends an event to the
+    /// internal log used by <see cref="Subscribe"/>'s replay path. Soft cap
+    /// (<see cref="EventLogSoftCap"/>) protects against unbounded growth on
+    /// a degenerate stream; a one-time <see cref="DiagnosticLevel.Warn"/>
+    /// fires the first time the cap is exceeded. Past the cap the log keeps
+    /// growing — dropping events would silently break the replay contract.
+    /// Same shape the post-#590 <c>PlayerEffectsStateService</c> uses;
+    /// InventoryService's chunk-trim variant is a perf optimization for a
+    /// higher-volume stream we don't need here (gifts are rare).
+    /// </summary>
+    private void AppendEventLog(GiftAccepted evt)
+    {
+        _eventLog.Add(evt);
+        if (_eventLog.Count > EventLogSoftCap && !_eventLogCapWarned)
+        {
+            _eventLogCapWarned = true;
+            _diag?.Warn("GameState.Gifting",
+                $"Event-log size exceeded soft cap ({EventLogSoftCap}). "
+                + "Replay-on-Subscribe will continue to deliver every event in order; "
+                + "log keeps growing (no drop). Investigate if not expected.");
+        }
+    }
+
+    private void Invoke(Action<GiftAccepted> handler, GiftAccepted evt)
+    {
+        try { handler(evt); }
+        catch (Exception ex) { _diag?.Warn("GameState.Gifting", $"Subscriber threw: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// Defensive offset normalization. L1 envelopes carry
+    /// <see cref="DateTimeOffset"/> already; we stamp the kind explicitly so
+    /// downstream consumers see UTC offset +00:00 regardless of how the
+    /// upstream synthesised it.
+    /// </summary>
+    private static DateTimeOffset ToOffset(DateTimeOffset ts) =>
+        ts.Offset == TimeSpan.Zero ? ts : ts.ToUniversalTime();
+
+    private sealed class Subscription : IDisposable
+    {
+        private GiftSignalService? _owner;
+        private readonly Action<GiftAccepted> _handler;
+
+        public Subscription(GiftSignalService owner, Action<GiftAccepted> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            var owner = Interlocked.Exchange(ref _owner, null);
+            if (owner is null) return;
+            lock (owner._lock)
+            {
+                for (int i = owner._handlers.Count - 1; i >= 0; i--)
+                {
+                    if (owner._handlers[i].Handler == _handler)
+                    {
+                        owner._handlers.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Mithril.GameState/Gifting/IGiftSignalService.cs
+++ b/src/Mithril.GameState/Gifting/IGiftSignalService.cs
@@ -1,0 +1,116 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Gifting;
+
+/// <summary>
+/// Tier-2 signature service for accepted player gifts. Emits a
+/// <see cref="GiftAccepted"/> event whenever the local player gives an item
+/// to an NPC and the NPC accepts — synthesised from the L1 verb pair
+/// (<c>ProcessDeleteItem(instanceId)</c>,
+/// <c>ProcessDeltaFavor(npcKey, delta)</c>) inside an active
+/// <c>ProcessStartInteraction</c> window. The state machine handles both
+/// arrival orders (DeleteItem-first and DeltaFavor-first).
+///
+/// <para><b>Architectural position.</b> This is the first sibling under the
+/// Tier-2 signature umbrella
+/// (<a href="https://github.com/moumantai-gg/mithril/issues/594">#594</a>);
+/// the naming convention <c>I&lt;Domain&gt;SignalService</c> locks here. The
+/// in-Arwen verb-sequence correlator
+/// (<c>CalibrationService._activeNpcKey</c> / <c>_pendingDeletedItem</c> /
+/// <c>_pendingDelta</c>) lifts here verbatim — Arwen's consumer migration is a
+/// separate downstream issue (<a href="https://github.com/moumantai-gg/mithril/issues/582">#582</a>
+/// reframes onto consuming this service).</para>
+///
+/// <para><b>Three channels (per <a href="https://github.com/moumantai-gg/mithril/pull/584">#584</a>).</b></para>
+/// <list type="bullet">
+///   <item><b>React</b> — <see cref="Subscribe"/> delivers the full
+///   <see cref="GiftAccepted"/> stream. Default
+///   <see cref="ReplayMode.FromSessionStart"/> atomically replays every
+///   resolved gift event from session start (in original order) before
+///   delivering live events; <see cref="ReplayMode.LiveOnly"/> skips the
+///   replay. Same shape <c>IInventoryService.Subscribe</c> adopted under
+///   #585.</item>
+///   <item><b>Query</b> — none today. No identified v1 consumer needs a
+///   point-in-time snapshot ("what gifts have landed?"); the React channel
+///   covers the use case. Can be added later if a consumer surfaces.</item>
+///   <item><b>Bind</b> — none today. Same reasoning as Query. Consumers
+///   wanting an observable collection can wrap <see cref="Subscribe"/> at the
+///   call site (the same pattern Palantir's <c>LiveInventoryViewModel</c>
+///   uses over <c>IInventoryService</c>).</item>
+/// </list>
+///
+/// <para><b>Frame-determinism (per <a href="https://github.com/moumantai-gg/mithril/issues/594">#594</a>).</b>
+/// All five verbs the SM consumes flow through a single
+/// <see cref="LocalPlayerLogLine"/> subscription with
+/// <see cref="ReplayMode.FromSessionStart"/> and
+/// <see cref="DeliveryContext.Inline"/>. The service maintains its OWN
+/// <c>instanceId → InternalName</c> map (populated from
+/// <c>ProcessAddItem</c> on the same subscription) and resolves
+/// <see cref="GiftAccepted.ItemInternalName"/> from that map — never via
+/// <c>IInventoryService.TryResolve</c>. This is load-bearing: routing the
+/// DeleteItem half through <c>IInventoryService</c> would re-introduce the
+/// cross-pump race documented in
+/// <a href="https://github.com/moumantai-gg/mithril/issues/582">#582</a>'s
+/// <i>Replay correctness</i> section, making the lift worse than the status
+/// quo.</para>
+///
+/// <para><b>Out-of-scope, intentionally.</b></para>
+/// <list type="bullet">
+///   <item><b>Stack size on the event.</b> The consumer (Arwen) resolves
+///   stack size via <c>IInventoryService.TryGetStackSize(ItemInstanceId)</c>
+///   at observation-record time — the inventory service retains last-known
+///   sizes for deleted entries specifically for this lookup path. See
+///   <see cref="GiftAccepted"/> remarks.</item>
+///   <item><b>Persistence.</b> Session-fresh — the React channel replays from
+///   session start on every Mithril attach. Consumers (Arwen's
+///   <c>observations.json</c>) persist downstream.</item>
+///   <item><b>Gift refusals.</b> The NPC-rejects-the-item path is a different
+///   verb sequence (no DeltaFavor); a future signature if a consumer asks.</item>
+///   <item><b>SM behavioural fixes.</b> The lifted SM has a known
+///   interloper-DeltaFavor quirk preserved verbatim — a non-gift DeltaFavor
+///   arriving inside an active interaction will be claimed by the next
+///   DeleteItem. See <see cref="GiftSignalService"/> remarks and
+///   <a href="https://github.com/moumantai-gg/mithril/issues/596">#596</a>
+///   <i>Out of scope → SM behavioural fixes</i>. Candidate refinements (a
+///   <c>ProcessPromptForItem("Give Gift", …)</c> discriminator, a DeltaFavor
+///   staleness window) are deferred to a follow-up.</item>
+/// </list>
+/// </summary>
+public interface IGiftSignalService
+{
+    /// <summary>
+    /// React-channel subscription. Attach a handler that receives every
+    /// <see cref="GiftAccepted"/> event the service emits.
+    ///
+    /// <para><b>Default replay shape (<see cref="ReplayMode.FromSessionStart"/>).</b>
+    /// On attach, the service atomically replays the full in-session
+    /// <see cref="GiftAccepted"/> log to the handler (every event emitted
+    /// since startup, in original order) before delivering live events. The
+    /// replay and live-attach happen under the same internal lock the
+    /// emission path holds, so a live event arriving during attach either
+    /// fires after the replay finishes (and is delivered to the live
+    /// handler) or fires before (and is in the replay) — never both, never
+    /// neither.</para>
+    ///
+    /// <para><b>Live-only subscriptions.</b>
+    /// <see cref="ReplayMode.LiveOnly"/> skips the replay. Only events fired
+    /// after the subscription is established are delivered.
+    /// <see cref="ReplayMode.SinceSubscribe"/> is treated like
+    /// <see cref="ReplayMode.LiveOnly"/> — same shape
+    /// <c>InventoryService.Subscribe</c> uses.</para>
+    ///
+    /// <para><b>Threading.</b> The handler is invoked synchronously under
+    /// the internal lock both during replay (on the subscribing thread) and
+    /// during live dispatch (on the L1 pump thread). Subscribers doing
+    /// non-trivial work should marshal off-thread immediately.</para>
+    ///
+    /// <para>Dispose the returned token to stop receiving further events.</para>
+    /// </summary>
+    /// <param name="handler">Event handler. Must not be null.</param>
+    /// <param name="replay">Backlog policy. Default
+    /// <see cref="ReplayMode.FromSessionStart"/> replays the full session log;
+    /// <see cref="ReplayMode.LiveOnly"/> skips it.</param>
+    IDisposable Subscribe(
+        Action<GiftAccepted> handler,
+        ReplayMode replay = ReplayMode.FromSessionStart);
+}

--- a/tests/Mithril.GameState.Tests/Gifting/GiftSignalServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Gifting/GiftSignalServiceTests.cs
@@ -1,0 +1,636 @@
+using FluentAssertions;
+using Mithril.GameState.Gifting;
+using Mithril.GameState.Tests.TestSupport;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Gifting;
+
+/// <summary>
+/// Acceptance suite for <see cref="GiftSignalService"/> per issue
+/// <a href="https://github.com/moumantai-gg/mithril/issues/596">#596</a>.
+/// Mirrors the <c>PlayerCelestialStateServiceTests</c> shape
+/// (per-test L1 driver, push raw Player.log lines, drain the LocalPlayer
+/// pipe) and exhausts the issue's <i>Test plan</i> checklist:
+///
+/// <list type="bullet">
+///   <item>Happy path (DeleteItem → DeltaFavor).</item>
+///   <item>Reverse order (DeltaFavor → DeleteItem).</item>
+///   <item>NpcKey mismatch on DeltaFavor → no emission.</item>
+///   <item>DeleteItem outside an active interaction → no emission.</item>
+///   <item>Multiple gifts in one interaction.</item>
+///   <item>EndInteraction clears the window.</item>
+///   <item>Late-subscriber FromSessionStart replay.</item>
+///   <item>LiveOnly subscribe skips replay.</item>
+///   <item>DeleteItem for an unknown instanceId (no AddItem) → no emission.</item>
+///   <item>Recorded-session replay against the captured NPC_Way 2026-05-20 fixture.</item>
+/// </list>
+/// </summary>
+public sealed class GiftSignalServiceTests
+{
+    private static readonly DateTime Stamp = new(2026, 5, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    // ---------- Happy path ----------
+
+    [Fact]
+    public async Task DeleteThenFavor_EmitsGiftAccepted_WithCorrectFields()
+    {
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().ContainSingle();
+            var evt = seen[0];
+            evt.NpcKey.Should().Be("NPC_Way");
+            evt.ItemInstanceId.Should().Be(42);
+            evt.ItemInternalName.Should().Be("RubberyTongue");
+            evt.DeltaFavor.Should().Be(6.72);
+            evt.Timestamp.Should().Be(new DateTimeOffset(Stamp.AddSeconds(3)),
+                "resolve point is the DeltaFavor log-line timestamp");
+            evt.InteractionStartedAt.Should().Be(new DateTimeOffset(Stamp.AddSeconds(1)),
+                "StartInteraction timestamp threads through to the resolved event");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Reverse order ----------
+
+    [Fact]
+    public async Task FavorThenDelete_EmitsIdenticalGiftAccepted()
+    {
+        // Both arrival orders must produce one GiftAccepted with the same
+        // content — the SM's existing both-orders support is what this
+        // verifies survived the lift. The DeltaFavor timestamp wins regardless
+        // of which half arrived first, matching CalibrationService.cs:195.
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeleteItem(42)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().ContainSingle();
+            var evt = seen[0];
+            evt.NpcKey.Should().Be("NPC_Way");
+            evt.ItemInstanceId.Should().Be(42);
+            evt.ItemInternalName.Should().Be("RubberyTongue");
+            evt.DeltaFavor.Should().Be(6.72);
+            evt.Timestamp.Should().Be(new DateTimeOffset(Stamp.AddSeconds(2)),
+                "DeltaFavor's timestamp wins regardless of arrival order");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- NpcKey mismatch ----------
+
+    [Fact]
+    public async Task DeltaFavor_ForDifferentNpcKey_DoesNotEmit()
+    {
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            // DeltaFavor for an entirely different NPC — must be ignored, the
+            // pending DeleteItem must remain unresolved.
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(9999, \"NPC_Else\", 6.72, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().BeEmpty();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- No active interaction ----------
+
+    [Fact]
+    public async Task DeleteItem_OutsideInteraction_DoesNotEmit_AndDoesNotLeakIntoNextInteraction()
+    {
+        // Without an armed window, DeleteItem must be ignored — and crucially,
+        // _pendingDeletedItem must not carry across a future StartInteraction
+        // so a subsequent matching DeltaFavor for the second NPC can't
+        // mis-claim the orphan delete.
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            // Orphan delete — no active interaction.
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessDeleteItem(42)");
+            // Now start an interaction and emit a positive DeltaFavor —
+            // without a matching DeleteItem inside this window, no event
+            // fires.
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().BeEmpty(
+                "the orphan delete must not carry across into the next interaction window");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Multiple gifts in one interaction ----------
+
+    [Fact]
+    public async Task TwoGiftsInOneInteraction_EmitTwoEvents_WithCorrectPerGiftFields()
+    {
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(Painting4A(99), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessDeleteItem(99)");
+            stream.Push(Stamp.AddSeconds(5),
+                "[12:00:05] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 1.0752, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(2);
+            seen[0].ItemInstanceId.Should().Be(42);
+            seen[0].ItemInternalName.Should().Be("RubberyTongue");
+            seen[0].DeltaFavor.Should().Be(6.72);
+            seen[1].ItemInstanceId.Should().Be(99);
+            seen[1].ItemInternalName.Should().Be("Painting4A");
+            seen[1].DeltaFavor.Should().Be(1.0752);
+            // Both gifts share the same StartInteraction timestamp.
+            seen.Should().AllSatisfy(e =>
+                e.InteractionStartedAt.Should().Be(new DateTimeOffset(Stamp.AddSeconds(1))));
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- EndInteraction clears ----------
+
+    [Fact]
+    public async Task EndInteraction_ClosesWindow_NoEmissionForLaterDelete()
+    {
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessEndInteraction(8887)");
+            // Stragglers after EndInteraction: window is closed → ignored.
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().BeEmpty();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task EndInteraction_ForUnrelatedEntity_DoesNotClearActiveWindow()
+    {
+        // An EndInteraction for an entity we never armed on (e.g. a graveyard
+        // interaction the SM didn't track) must NOT stomp the active
+        // gift-eligible window. Defensive against PG sequences where short
+        // unrelated interactions interleave with a longer favor session.
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            // Unrelated EndInteraction — different entity id, must NOT clear.
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessEndInteraction(25237464)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().ContainSingle();
+            seen[0].NpcKey.Should().Be("NPC_Way");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- DeleteItem for unknown instanceId ----------
+
+    [Fact]
+    public async Task DeleteItem_NoPriorAddItem_DoesNotEmit_AndDoesNotMutateMap()
+    {
+        // If the service's instanceId map doesn't know the id (because no
+        // ProcessAddItem ingested it — e.g. it pre-dates the session log
+        // window), we can't resolve InternalName. Drop the line with a
+        // Trace and skip; don't half-arm _pendingDeletedItem with an empty
+        // name.
+        var diag = new DiagnosticsSink();
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver, diag);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessDeleteItem(99999)");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().BeEmpty();
+            diag.Snapshot().Should().Contain(e =>
+                e.Category == "GameState.Gifting"
+                && e.Message.Contains("unresolved"));
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Late subscriber: FromSessionStart replay ----------
+
+    [Fact]
+    public async Task LateSubscribe_FromSessionStart_ReplaysFullEventLog_InOrder()
+    {
+        // The post-#585 React-channel contract: a consumer attaching after
+        // the L1 driver has already drained must receive every GiftAccepted
+        // emitted in this session, in original order, before any live event.
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(Painting4A(99), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessDeleteItem(99)");
+            stream.Push(Stamp.AddSeconds(5),
+                "[12:00:05] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 1.0752, True)");
+            await RunUntilDrainedAsync(svc, stream);
+
+            var replayed = new List<GiftAccepted>();
+            using var sub = svc.Subscribe(replayed.Add);
+
+            replayed.Should().HaveCount(2);
+            replayed[0].ItemInstanceId.Should().Be(42);
+            replayed[1].ItemInstanceId.Should().Be(99);
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Live-only subscriber ----------
+
+    [Fact]
+    public async Task LateSubscribe_LiveOnly_DoesNotReplay_AndOnlyDeliversFutureEvents()
+    {
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            // Pre-attach: fire one gift.
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<GiftAccepted>();
+            using var sub = svc.Subscribe(seen.Add, ReplayMode.LiveOnly);
+            seen.Should().BeEmpty("LiveOnly skips the event-log replay");
+
+            // Fire a second gift after attach; only this one should land.
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessAddItem(Painting4A(99), -1, True)");
+            stream.Push(Stamp.AddSeconds(5),
+                "[12:00:05] LocalPlayer: ProcessDeleteItem(99)");
+            stream.Push(Stamp.AddSeconds(6),
+                "[12:00:06] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 1.0752, True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().ContainSingle();
+            seen[0].ItemInstanceId.Should().Be(99);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch { }
+            _ = runTask;
+            await StopAsync(svc);
+        }
+    }
+
+    // ---------- Live event arriving between Subscribe and Push ----------
+
+    [Fact]
+    public async Task LateSubscribe_FromSessionStart_ThenLiveGift_DeliversBothAtomicallyOrdered()
+    {
+        // The Subscribe path runs replay under the same lock Emit takes; a
+        // live gift arriving between Subscribe return and the next handler
+        // dispatch cannot interleave with the replay. Same shape as
+        // PlayerEffectsStateServiceTests.LateSubscribe_FromSessionStart_ThenLiveEvent_DeliversBoth_AtomicallyOrdered.
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            var seen = new List<GiftAccepted>();
+            using var sub = svc.Subscribe(seen.Add); // default = FromSessionStart
+            seen.Should().ContainSingle(
+                "the pre-existing gift must replay synchronously before Subscribe returns");
+
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessAddItem(Painting4A(99), -1, True)");
+            stream.Push(Stamp.AddSeconds(5),
+                "[12:00:05] LocalPlayer: ProcessDeleteItem(99)");
+            stream.Push(Stamp.AddSeconds(6),
+                "[12:00:06] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 1.0752, True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().HaveCount(2);
+            seen[0].ItemInstanceId.Should().Be(42);
+            seen[1].ItemInstanceId.Should().Be(99);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch { }
+            _ = runTask;
+            await StopAsync(svc);
+        }
+    }
+
+    // ---------- Dispose ----------
+
+    [Fact]
+    public async Task DisposeSubscription_StopsFurtherEvents()
+    {
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            var seen = new List<GiftAccepted>();
+            var sub = svc.Subscribe(seen.Add, ReplayMode.LiveOnly);
+
+            stream.Push(Stamp,
+                "[12:00:00] LocalPlayer: ProcessAddItem(RubberyTongue(42), -1, True)");
+            stream.Push(Stamp.AddSeconds(1),
+                "[12:00:01] LocalPlayer: ProcessStartInteraction(8887, 7, 100.0, True, \"NPC_Way\")");
+            stream.Push(Stamp.AddSeconds(2),
+                "[12:00:02] LocalPlayer: ProcessDeleteItem(42)");
+            stream.Push(Stamp.AddSeconds(3),
+                "[12:00:03] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            await stream.WaitForDrainAsync(cts.Token);
+            seen.Should().ContainSingle();
+
+            sub.Dispose();
+            sub.Dispose(); // idempotent
+
+            stream.Push(Stamp.AddSeconds(4),
+                "[12:00:04] LocalPlayer: ProcessAddItem(Painting4A(99), -1, True)");
+            stream.Push(Stamp.AddSeconds(5),
+                "[12:00:05] LocalPlayer: ProcessDeleteItem(99)");
+            stream.Push(Stamp.AddSeconds(6),
+                "[12:00:06] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 1.0752, True)");
+            await stream.WaitForDrainAsync(cts.Token);
+
+            seen.Should().ContainSingle("the disposed subscription must not receive further events");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch { }
+            _ = runTask;
+            await StopAsync(svc);
+        }
+    }
+
+    // ---------- Recorded-session replay ----------
+
+    [Fact]
+    public async Task RecordedSession_NpcWayCapture_EmitsThreeGifts_PreservingInterloperQuirk()
+    {
+        // From I:/src/mithril-logs/sessions/2026-05/Player-2026-05-20-0400.log
+        // at 02:09:31 (AddItem re-emit on zone entry) through 02:12:21 (final
+        // gift). The 02:12:18 ProcessDeltaFavor(84) is a non-gift interloper
+        // (likely a quest-turnin landing right at talk-open); the SM lifted
+        // verbatim from CalibrationService claims it for the first DeleteItem
+        // — see issue #596's "Out of scope → SM behavioural fixes" note. This
+        // test PINS the existing behaviour: any future SM refinement that
+        // changes attribution updates this assertion deliberately, not by
+        // accident.
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver);
+        var seen = new List<GiftAccepted>();
+        using var sub = svc.Subscribe(seen.Add);
+
+        try
+        {
+            // ProcessAddItem re-emit burst at zone entry (02:09:31).
+            stream.Push(new DateTime(2026, 5, 20, 2, 9, 31, DateTimeKind.Utc),
+                "[02:09:31] LocalPlayer: ProcessAddItem(RubberyTongue(134693667), -1, False)");
+            stream.Push(new DateTime(2026, 5, 20, 2, 9, 31, DateTimeKind.Utc),
+                "[02:09:31] LocalPlayer: ProcessAddItem(Painting4A(134810549), -1, False)");
+            stream.Push(new DateTime(2026, 5, 20, 2, 9, 31, DateTimeKind.Utc),
+                "[02:09:31] LocalPlayer: ProcessAddItem(PieceOfGreenGlass(135331202), -1, False)");
+
+            // StartInteraction at 02:12:14.
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 14, DateTimeKind.Utc),
+                "[02:12:14] LocalPlayer: ProcessStartInteraction(8887, 7, 761.9012, True, \"NPC_Way\")");
+
+            // The interloper DeltaFavor at 02:12:18 (likely quest reward).
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 18, DateTimeKind.Utc),
+                "[02:12:18] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 84, True)");
+            // First DeleteItem at 02:12:18 — claims the interloper delta.
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 18, DateTimeKind.Utc),
+                "[02:12:18] LocalPlayer: ProcessDeleteItem(134693667)");
+
+            // Gift 1's actual outcome at 02:12:20.
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 20, DateTimeKind.Utc),
+                "[02:12:20] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 6.72, True)");
+            // Second DeleteItem at 02:12:20.
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 20, DateTimeKind.Utc),
+                "[02:12:20] LocalPlayer: ProcessDeleteItem(134810549)");
+
+            // Final DeltaFavor + DeleteItem pair at 02:12:21.
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 21, DateTimeKind.Utc),
+                "[02:12:21] LocalPlayer: ProcessDeltaFavor(8887, \"NPC_Way\", 1.0752, True)");
+            stream.Push(new DateTime(2026, 5, 20, 2, 12, 21, DateTimeKind.Utc),
+                "[02:12:21] LocalPlayer: ProcessDeleteItem(135331202)");
+
+            await RunUntilDrainedAsync(svc, stream);
+
+            seen.Should().HaveCount(3,
+                "the SM emits three GiftAccepted events for the three DeleteItem verbs in the active interaction");
+
+            // Preserved-quirk pin: the interloper +84 is claimed by the first
+            // gift (RubberyTongue). Real game truth is that the +84 was
+            // probably a quest reward and RubberyTongue actually gave +6.72,
+            // but the lifted SM doesn't distinguish — this is the bug
+            // documented in #596's "SM behavioural fixes" out-of-scope note.
+            seen[0].NpcKey.Should().Be("NPC_Way");
+            seen[0].ItemInstanceId.Should().Be(134693667);
+            seen[0].ItemInternalName.Should().Be("RubberyTongue");
+            seen[0].DeltaFavor.Should().Be(84,
+                "preserved-quirk pin: the interloper delta is claimed by the first DeleteItem");
+
+            seen[1].ItemInstanceId.Should().Be(134810549);
+            seen[1].ItemInternalName.Should().Be("Painting4A");
+            seen[1].DeltaFavor.Should().Be(6.72);
+
+            seen[2].ItemInstanceId.Should().Be(135331202);
+            seen[2].ItemInternalName.Should().Be("PieceOfGreenGlass");
+            seen[2].DeltaFavor.Should().Be(1.0752);
+
+            // All three share the same StartInteraction stamp.
+            seen.Should().AllSatisfy(e =>
+                e.InteractionStartedAt.Should().Be(
+                    new DateTimeOffset(new DateTime(2026, 5, 20, 2, 12, 14, DateTimeKind.Utc))));
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Lifecycle diagnostic ----------
+
+    [Fact]
+    public async Task Lifecycle_EmitsSubscribingDiagnostic()
+    {
+        var diag = new DiagnosticsSink();
+        var stream = new ScriptedStream();
+        var svc = new GiftSignalService(stream.Driver, diag);
+        try
+        {
+            await RunUntilDrainedAsync(svc, stream);
+            diag.Snapshot().Should().Contain(e =>
+                e.Level == DiagnosticLevel.Info
+                && e.Category == "GameState.Gifting"
+                && e.Message.Contains("Subscribing to L1 driver"));
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    // ---------- Plumbing ----------
+
+    private static async Task RunUntilDrainedAsync(GiftSignalService svc, ScriptedStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await stream.WaitForDrainAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(GiftSignalService svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+
+    /// <summary>
+    /// Per-test L1 stream wrapper, matching the
+    /// <c>PlayerCelestialStateServiceTests</c> shape.
+    /// </summary>
+    private sealed class ScriptedStream : IDisposable
+    {
+        public TestLogStreamDriver Driver { get; } = new();
+
+        public void Push(DateTime ts, string line)
+        {
+            Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(new RawLogLine(ts, line)));
+        }
+
+        public Task WaitForDrainAsync(CancellationToken ct) =>
+            Driver.DrainLocalPlayerAsync().WaitAsync(ct);
+
+        public void Dispose() => Driver.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

First sub-issue of the Tier-2 GameState signature catalogue
([#594](https://github.com/moumantai-gg/mithril/issues/594));
closes [#596](https://github.com/moumantai-gg/mithril/issues/596).

Lifts Arwen's verb-sequence correlator
(`CalibrationService._activeNpcKey` / `_pendingDeletedItem` /
`_pendingDelta`) into a new GameState service under the
`I<Domain>SignalService` naming convention that locks here. The service
emits a `GiftAccepted` domain event whenever the local player gives an
item to an NPC and the NPC accepts — synthesised from the
`ProcessDeleteItem` + `ProcessDeltaFavor` pair inside an active
`ProcessStartInteraction` window. Both arrival orders (DeleteItem-first
and DeltaFavor-first) are supported, mirroring the in-Arwen SM.

**Load-bearing decision (per #596 *Own ProcessAddItem too*):** the
service owns its OWN `instanceId → InternalName` map populated from
`ProcessAddItem` on the same L1 subscription. It does NOT consume
`IInventoryService.TryResolve` for the DeleteItem half — routing the
DeleteItem through `IInventoryService` would re-introduce the
cross-pump race documented in
[#582](https://github.com/moumantai-gg/mithril/issues/582)'s *Replay
correctness* section. Tier-2 dissolves that race by giving each
signature service one L1 pump and an internal event-log replay.

Arwen's consumer migration ([#582](https://github.com/moumantai-gg/mithril/issues/582)
reframes onto this) is a separate downstream issue, deferred to
post-merge per the orchestrator's owner-call.

## Scope

File-by-file:

- **`src/Mithril.GameState/Gifting/GiftAccepted.cs`** (new) — the
  Tier-2 domain event record struct. Carries `NpcKey`,
  `ItemInstanceId`, `ItemInternalName`, `DeltaFavor`, `Timestamp` (the
  DeltaFavor stamp — the resolve point), and `InteractionStartedAt`
  (the StartInteraction stamp threaded through; new vs Arwen's in-place
  SM, which dropped it). Stack size resolution stays the consumer's
  job — Arwen continues to call `IInventoryService.TryGetStackSize` at
  observation-record time per #596's out-of-scope note.

- **`src/Mithril.GameState/Gifting/IGiftSignalService.cs`** (new) — the
  React-channel surface. Single method:
  `Subscribe(Action<GiftAccepted>, ReplayMode = FromSessionStart)`.
  No Query or Bind channels in v1 (no identified consumer); the issue
  body's *Service surface* section spells this out.

- **`src/Mithril.GameState/Gifting/GiftSignalService.cs`** (new) — the
  hosted-service implementation. Mirrors `InventoryService` /
  `PlayerEffectsStateService` for L1 subscription + internal event log
  + atomic replay-then-live under a single `_lock`. Five `[GeneratedRegex]`
  matchers (`ProcessStartInteraction`, `ProcessEndInteraction`,
  `ProcessDeltaFavor`, `ProcessDeleteItem`, `ProcessAddItem`) lifted
  from `FavorLogParser` / `InventoryService`. SM transitions are
  lifted verbatim from `CalibrationService:64-220`, with two tiny
  additions called out in the issue body: (a) capture
  `_interactionStartedAt` to thread through to the event, and (b) clear
  transient state on a matching `ProcessEndInteraction`. EndInteraction
  is defensive — it only clears when the entity id matches the armed
  one, so unrelated short interactions (graves, doors with empty
  NpcKey) can't stomp an active gift-eligible window.

- **`src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs`**
  (modified) — registers `GiftSignalService` as singleton +
  `IGiftSignalService` + `IHostedService` (the standard three-way
  registration the other GameState services use).

- **`tests/Mithril.GameState.Tests/Gifting/GiftSignalServiceTests.cs`**
  (new) — 14 xunit + FluentAssertions tests exhausting #596's *Test plan*.

## Test plan

Mirroring #596's checklist:

- [x] **Happy path:** StartInteraction → AddItem → DeleteItem →
  DeltaFavor emits one `GiftAccepted` with correct fields.
- [x] **Reverse order:** StartInteraction → AddItem → DeltaFavor →
  DeleteItem emits one `GiftAccepted` with identical content. (The
  DeltaFavor's timestamp wins regardless of arrival order, matching
  `CalibrationService.cs:195`.)
- [x] **NpcKey mismatch on DeltaFavor:** different NpcKey on the
  DeltaFavor inside an active interaction → no emission.
- [x] **No active interaction:** orphan DeleteItem with no prior
  StartInteraction → no emission, and the orphan must NOT leak into
  a subsequent StartInteraction window (covered explicitly).
- [x] **Multiple gifts in one interaction:** two AddItem + DeleteItem
  + DeltaFavor cycles emit two events with correct per-gift
  `ItemInstanceId` / `ItemInternalName` / `DeltaFavor`, and both share
  the same `InteractionStartedAt`.
- [x] **EndInteraction clears:** StartInteraction → EndInteraction →
  DeleteItem → DeltaFavor → no emission.
- [x] **EndInteraction for unrelated entity:** must NOT close the
  active window (defensive against PG sequences where short unrelated
  interactions interleave with a longer favor session).
- [x] **DeleteItem for unknown instanceId:** no `ProcessAddItem`
  ingested for that id → no emission, no `_pendingDeletedItem`
  mutation, Trace diagnostic emitted.
- [x] **Late-subscriber replay (`FromSessionStart`):** subscribe after
  drain; replayed events match what live subscribers saw, in order.
- [x] **Atomic replay-then-live:** late `FromSessionStart` subscriber
  + a follow-up live gift land in the right order with no duplicate
  or lost events.
- [x] **Live-only subscriber (`ReplayMode.LiveOnly`):** subscribe
  after drain; receives no replay, only events fired after attach.
- [x] **Subscription disposal stops further events** (idempotent
  `Dispose`).
- [x] **Lifecycle diagnostic:** the "Subscribing to L1 driver" Info
  fires on startup.
- [x] **Recorded-session replay:** the captured NPC_Way 2026-05-20
  sequence (`I:/src/mithril-logs/sessions/2026-05/Player-2026-05-20-0400.log`
  at 02:09:31–02:12:21, 3 gifts with the documented interloper
  DeltaFavor at 02:12:18) feeds through and produces three
  `GiftAccepted` events. The test PINS the existing SM behaviour
  (interloper-DeltaFavor mis-attribution preserved per #596's
  *Out of scope → SM behavioural fixes* note) so any future SM
  refinement updates this assertion deliberately, not by accident.

## Verification owed

`dotnet build Mithril.slnx`:

```
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:03.86
```

(Initial cold build was 16.37s; the figure above is a warm re-run for
the PR body.)

`dotnet test Mithril.slnx --no-build` (20 test projects, summed):

| Project | Passed | Failed | Skipped |
|---|---|---|---|
| Palantir.Tests | 29 | 0 | 0 |
| Mithril.Leveling.Tests | 12 | 0 | 0 |
| Mithril.Planning.Tests | 23 | 0 | 0 |
| Bilbo.Tests | 31 | 0 | 0 |
| Mithril.LogSanitizer.Tests | 34 | 0 | 0 |
| Elrond.Tests | 53 | 0 | 0 |
| Pippin.Tests | 46 | 0 | 0 |
| Celebrimbor.Tests | 87 | 0 | 0 |
| Smaug.Tests | 33 | 0 | 0 |
| Mithril.GameState.Tests | 302 | 0 | 0 |
| Arwen.Tests | 85 | 0 | 0 |
| Saruman.Tests | 31 | 0 | 0 |
| Gandalf.Tests | 306 | 0 | 0 |
| Samwise.Tests | 114 | 0 | 0 |
| Legolas.Tests | 465 | 0 | 0 |
| Mithril.Reference.Tests | 105 | 0 | 0 |
| RefreshAndValidate.Tests | 5 | 0 | 0 |
| Silmarillion.Tests | 556 | 0 | 0 |
| Mithril.Shared.Tests | 1246 | 0 | 0 |
| Mithril.Shell.Tests | 2 | 0 | 0 |
| **Total** | **3,565** | **0** | **0** |

The new `GiftSignalServiceTests` contributes 14 of the 302
`Mithril.GameState.Tests` total. Wall-time for the full suite is
roughly ~90 s (longest individual project is `Mithril.Shell.Tests`
at 32 s due to host bootstrap overhead).

## Follow-ups (not blocking this PR)

- **Wiki `## Gifting` section** on
  [Player-Log-Signals](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals)
  per #596's *L1 input grammar* section. Same pattern as #590's
  `## Effects` promotion; proposed as a follow-up so this PR stays
  focused on code.
- **Arwen consumer migration ([#582](https://github.com/moumantai-gg/mithril/issues/582))**
  — the close-vs-respec call belongs to the post-merge orchestrator
  per #596's *Reframe note for #582*.

## Branch base note

This PR branches from `origin/main` (eb5bd7c at the time of writing).
The PR #593 (`feat/effects-state-service`, issue #590) is still open
and not yet merged to `origin/main`; this PR is independent of it
code-wise (only architecturally references it via inline comments).
The doc references to `PlayerEffectsStateService` in this PR's source
are kept as plain `<c>...</c>` text refs (not `<see cref=...>`) so the
warnings-as-errors build stays clean against today's `main`.

## References

- Issue: [#596](https://github.com/moumantai-gg/mithril/issues/596)
- Umbrella: [#594](https://github.com/moumantai-gg/mithril/issues/594)
- Cross-source correlation contract: [`docs/cross-source-correlation.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/cross-source-correlation.md)
- Module charters / cross-cutting ownership: [`docs/module-charters.md`](https://github.com/moumantai-gg/mithril/blob/main/docs/module-charters.md)
- Closest service-shape template: [`src/Mithril.GameState/Inventory/InventoryService.cs`](https://github.com/moumantai-gg/mithril/blob/main/src/Mithril.GameState/Inventory/InventoryService.cs)
- Lifted SM source: [`src/Arwen.Module/Domain/CalibrationService.cs:64-220`](https://github.com/moumantai-gg/mithril/blob/main/src/Arwen.Module/Domain/CalibrationService.cs#L64-L220)

— drafted by Claude (Opus 4.7), posted by @arthur-conde
