### PR TITLE
feat(worldsim): Mithril.WorldSim.Core contracts (#615)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/Mithril.Reference/Mithril.Reference.csproj" />
     <Project Path="src/Mithril.Shared/Mithril.Shared.csproj" />
+    <Project Path="src/Mithril.WorldSim.Core/Mithril.WorldSim.Core.csproj" />
     <Project Path="src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj" />
     <Project Path="src/Mithril.GameState/Mithril.GameState.csproj" />
     <Project Path="src/Mithril.Leveling/Mithril.Leveling.csproj" />

--- a/src/Mithril.WorldSim.Core/Frame.cs
+++ b/src/Mithril.WorldSim.Core/Frame.cs
@@ -1,0 +1,16 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// One unit of simulated input (principle 1 — "frame = (timestamp, payload)" — the
+/// unifying primitive of the world-simulator architecture). Producers stamp every
+/// frame with the event time the frame represents (NOT the wall-clock when the
+/// producer fired), so a replay against a recorded source stream reconstructs the
+/// same trajectory the live run produced.
+/// </summary>
+/// <typeparam name="TPayload">
+/// The payload type carried by this frame. The world's merger routes a
+/// <see cref="Frame{TPayload}"/> to its registered folder by the payload type.
+/// </typeparam>
+public readonly record struct Frame<TPayload>(
+    DateTimeOffset Timestamp,
+    TPayload Payload);

--- a/src/Mithril.WorldSim.Core/Frame.cs
+++ b/src/Mithril.WorldSim.Core/Frame.cs
@@ -1,6 +1,37 @@
 namespace Mithril.WorldSim;
 
 /// <summary>
+/// Non-generic frame base. Lets a composer or producer return heterogeneous
+/// frames (different payload types) from a single call without resorting to
+/// <c>Frame&lt;object&gt;</c>-with-boxing. Concrete <see cref="Frame{TPayload}"/>
+/// implements this; consumers downcast / pattern-match on the concrete type
+/// (typically inside <see cref="IWorldEventBus"/>) to route to typed
+/// subscribers.
+/// </summary>
+public interface IFrame
+{
+    /// <summary>
+    /// Event time the frame represents (principle 1 — NOT the wall-clock when
+    /// the producer / composer emitted the frame).
+    /// </summary>
+    DateTimeOffset Timestamp { get; }
+
+    /// <summary>
+    /// Payload boxed to <see cref="object"/>. Concrete callers should usually
+    /// pattern-match on <see cref="Frame{TPayload}"/> instead of reading this
+    /// directly — that route keeps the typed payload unboxed at the consumer.
+    /// </summary>
+    object Payload { get; }
+
+    /// <summary>
+    /// Compile-time payload type carried by the underlying <see cref="Frame{TPayload}"/>.
+    /// Used by the world's bus to route heterogeneous <see cref="IFrame"/>
+    /// emissions to typed subscribers.
+    /// </summary>
+    Type PayloadType { get; }
+}
+
+/// <summary>
 /// One unit of simulated input (principle 1 — "frame = (timestamp, payload)" — the
 /// unifying primitive of the world-simulator architecture). Producers stamp every
 /// frame with the event time the frame represents (NOT the wall-clock when the
@@ -13,4 +44,8 @@ namespace Mithril.WorldSim;
 /// </typeparam>
 public readonly record struct Frame<TPayload>(
     DateTimeOffset Timestamp,
-    TPayload Payload);
+    TPayload Payload) : IFrame
+{
+    object IFrame.Payload => Payload!;
+    Type IFrame.PayloadType => typeof(TPayload);
+}

--- a/src/Mithril.WorldSim.Core/IChangeEvent.cs
+++ b/src/Mithril.WorldSim.Core/IChangeEvent.cs
@@ -1,0 +1,13 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// Marker for change events emitted by <see cref="IFolder{TPayload}"/> instances
+/// after applying a frame (principle 10 — folders consume frames and emit change
+/// events). Change events are world-internal: they flow to intra-world composers
+/// during a frame's resolution, but never cross the world boundary. Cross-world
+/// consumers (views) see only the domain frames the world's composers chose to
+/// publish to the bus.
+/// </summary>
+public interface IChangeEvent
+{
+}

--- a/src/Mithril.WorldSim.Core/IComposer.cs
+++ b/src/Mithril.WorldSim.Core/IComposer.cs
@@ -1,0 +1,33 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// One of three state-machine kinds (principle 10). Composers consume change
+/// events (and/or domain frames from upstream composers) and emit domain frames
+/// when their multi-frame pattern is satisfied. They <em>recognize</em> multi-
+/// frame patterns in events PG already emits; they do not anticipate or
+/// synthesize PG behavior.
+///
+/// <para>Composers chain via subscribe within a frame's resolution — they never
+/// re-emit into the world's merger (principle 11 — per-frame resolution is a
+/// finite DAG traversal; no cycles, no merger re-entry). Future-time emission
+/// is the producer interface's job.</para>
+/// </summary>
+public interface IComposer
+{
+    /// <summary>
+    /// Declared input event types (change events from folders, or domain frames
+    /// from upstream composers). The world's resolution loop uses these to
+    /// topologically order composer dispatch within a frame (principle 11).
+    /// </summary>
+    IReadOnlyCollection<Type> Subscribes { get; }
+
+    /// <summary>
+    /// Observe one event from a declared input type. May update internal pending
+    /// state; may emit zero or more domain frames if the composer's pattern is
+    /// satisfied. Emitted frames carry timestamps from the event(s) they
+    /// correlated, not from <paramref name="clock"/>.<see cref="IWorldClock.Now"/>
+    /// — this preserves the principle 1 contract that a frame's timestamp is the
+    /// event time it represents.
+    /// </summary>
+    IReadOnlyList<Frame<object>> Observe(object eventPayload, IWorldClock clock);
+}

--- a/src/Mithril.WorldSim.Core/IComposer.cs
+++ b/src/Mithril.WorldSim.Core/IComposer.cs
@@ -28,6 +28,16 @@ public interface IComposer
     /// correlated, not from <paramref name="clock"/>.<see cref="IWorldClock.Now"/>
     /// — this preserves the principle 1 contract that a frame's timestamp is the
     /// event time it represents.
+    ///
+    /// <para>Return type is <see cref="IFrame"/> (non-generic) rather than
+    /// <c>Frame&lt;object&gt;</c> so a composer can emit heterogeneous domain
+    /// frame types in a single call without boxing the typed payload at the
+    /// composer boundary. A composer that emits a <c>GiftObservation</c> returns
+    /// <c>new Frame&lt;GiftObservation&gt;(eventTs, observation)</c> upcast to
+    /// <see cref="IFrame"/>; the bus's typed
+    /// <see cref="IWorldEventBus.Subscribe{T}(Action{Frame{T}})"/> surface
+    /// pattern-matches on the concrete <see cref="Frame{TPayload}"/> to route
+    /// to subscribers of that payload type.</para>
     /// </summary>
-    IReadOnlyList<Frame<object>> Observe(object eventPayload, IWorldClock clock);
+    IReadOnlyList<IFrame> Observe(object eventPayload, IWorldClock clock);
 }

--- a/src/Mithril.WorldSim.Core/IFolder.cs
+++ b/src/Mithril.WorldSim.Core/IFolder.cs
@@ -1,0 +1,25 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// One of three state-machine kinds (principle 10). Folders consume frames and
+/// emit change events. One frame is dispatched to exactly one folder, determined
+/// by the frame's payload type. Folders mutate world state; they live inside one
+/// world's runtime.
+/// </summary>
+/// <typeparam name="TPayload">
+/// The frame payload type this folder accepts. A world has at most one folder
+/// per payload type (registering a second throws — see
+/// <see cref="IWorld.RegisterFolder{T}"/>).
+/// </typeparam>
+public interface IFolder<TPayload>
+{
+    /// <summary>
+    /// Apply one frame to internal state. Returns the change events the mutation
+    /// produced (empty if no observable change). Mutations must depend only on
+    /// the frame's payload and the folder's own prior state. Folders never read
+    /// <see cref="DateTime.UtcNow"/> or any other real-time source; they use
+    /// <paramref name="clock"/> for "now" so the application is replay-
+    /// deterministic (principle 5 + principle 13).
+    /// </summary>
+    IReadOnlyList<IChangeEvent> Apply(Frame<TPayload> frame, IWorldClock clock);
+}

--- a/src/Mithril.WorldSim.Core/IFrameProducer.cs
+++ b/src/Mithril.WorldSim.Core/IFrameProducer.cs
@@ -1,0 +1,34 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// A source of external-input frames feeding a world (principle 10). Implementers
+/// are sources of real-world inputs only: the L1 classified-pipe reader (Player.log
+/// frames), the chat tail (chat frames). Future possibilities: filesystem reconcile
+/// emitting frames stamped with export payload timestamps. Producers are NOT a
+/// mechanism for user-driven scheduling — user-side wake-at-T concerns consume
+/// world domain events and run module-internal logic against them; they do not
+/// register producers in a world's merger. The world is sealed at its input.
+/// </summary>
+/// <typeparam name="TPayload">
+/// The payload type of frames this producer emits. Pairs with the folder
+/// registered for the same payload type.
+/// </typeparam>
+public interface IFrameProducer<TPayload>
+{
+    /// <summary>
+    /// Emits frames in ascending timestamp order. The world's merger is a
+    /// priority queue keyed by <see cref="Frame{TPayload}.Timestamp"/>;
+    /// producers must not emit out-of-order frames. Late-stamped frames
+    /// (timestamp earlier than the world's clock) are clamped + warned by the
+    /// world.
+    /// </summary>
+    IAsyncEnumerable<Frame<TPayload>> SubscribeAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Used by the world's merger to break ties when two producers emit frames
+    /// with identical timestamps. Lower priority dispatches first. Producer
+    /// priorities must be declared at registration time; the world's tie-
+    /// breaking is replay-deterministic over the producer set.
+    /// </summary>
+    int Priority { get; }
+}

--- a/src/Mithril.WorldSim.Core/IWorld.cs
+++ b/src/Mithril.WorldSim.Core/IWorld.cs
@@ -1,0 +1,55 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// Shared contract for both worlds (PlayerWorld, ChatWorld — principle 2 —
+/// "two worlds with sealed output boundaries; views consume across them").
+/// Each world owns its own producers, folders, composers, clock, frame merger,
+/// and output bus. Worlds don't query each other and don't send messages to
+/// each other — they're sealed at the bus. Cross-world consumption goes
+/// through a view layer one level up (principle 4).
+/// </summary>
+public interface IWorld
+{
+    /// <summary>
+    /// This world's simulated wall-clock. Advances by the timestamp of the most
+    /// recently applied frame; see <see cref="IWorldClock"/>.
+    /// </summary>
+    IWorldClock Clock { get; }
+
+    /// <summary>
+    /// Output bus for this world's domain frames. View-layer composers subscribe
+    /// here; consumers outside the world never see change events directly — only
+    /// the domain frames the world's composers chose to emit.
+    /// </summary>
+    IWorldEventBus Bus { get; }
+
+    /// <summary>
+    /// Register a producer (log tail, filesystem reconcile, …). Must be called
+    /// before <see cref="StartAsync"/>. The world's merger consumes from every
+    /// registered producer and merges their frames by timestamp, breaking ties
+    /// by <see cref="IFrameProducer{TPayload}.Priority"/>.
+    /// </summary>
+    void RegisterProducer<T>(IFrameProducer<T> producer);
+
+    /// <summary>
+    /// Register a folder for a frame payload type. The world routes frames of
+    /// that type to this folder. Exactly one folder per payload type
+    /// (registering a second throws).
+    /// </summary>
+    void RegisterFolder<T>(IFolder<T> folder);
+
+    /// <summary>
+    /// Register a composer. The world dispatches
+    /// <see cref="IComposer.Observe(object, IWorldClock)"/> for each input event
+    /// type the composer declares, in topologically-ordered fashion within each
+    /// frame's resolution (principle 11).
+    /// </summary>
+    void RegisterComposer(IComposer composer);
+
+    /// <summary>
+    /// Begin frame application. Closes the registration set; from here forward
+    /// the world drains producers in timestamp order, dispatches to folders,
+    /// resolves composers, publishes domain frames to <see cref="Bus"/>.
+    /// </summary>
+    Task StartAsync(CancellationToken ct);
+}

--- a/src/Mithril.WorldSim.Core/IWorldClock.cs
+++ b/src/Mithril.WorldSim.Core/IWorldClock.cs
@@ -1,0 +1,40 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// A world's simulated wall-clock. <see cref="Now"/> is always the timestamp of
+/// the most recently applied frame — there is no live-mode interpolation, no
+/// continuous-time abstraction (principle 13 — "calendar time is a domain event,
+/// not a clock read"). Consumers that care about time progression subscribe to
+/// <c>CalendarTimeAdvanced</c> domain events on the world's bus instead of polling
+/// this clock. Real wall-clock (<see cref="TimeProvider.System"/>) is used only
+/// inside the world's merger for blocking on the live source-stream tail; never
+/// by folders, composers, views, or modules.
+/// </summary>
+public interface IWorldClock
+{
+    /// <summary>
+    /// Simulated wall-clock = timestamp of the most recently applied frame.
+    /// Weakly monotonic at 1-second resolution (PG's timestamp precision).
+    /// Multiple frames may share the same value. Reads during live-mode idle
+    /// return the same value as immediately after the last frame applied
+    /// (principle 5 — frame-driven advancement, no continuous-time read).
+    /// </summary>
+    DateTimeOffset Now { get; }
+
+    /// <summary>
+    /// Strictly-monotonic frame index. Ticks once per applied frame.
+    /// Identifies a unique point in the trajectory; tie-breaks within a
+    /// wall-clock second; pairs with <see cref="Now"/> as the full identity
+    /// of a simulated moment (principle 5).
+    /// </summary>
+    long Frame { get; }
+
+    /// <summary>
+    /// Current world mode. <see cref="WorldMode.Replaying"/> while draining
+    /// recorded frames toward the live tail; <see cref="WorldMode.Live"/>
+    /// once caught up. Transition emits a <c>ModeChanged</c> domain event on
+    /// the bus. Side-effect-emitting consumers gate on <c>Mode == Live</c>
+    /// (principle 12).
+    /// </summary>
+    WorldMode Mode { get; }
+}

--- a/src/Mithril.WorldSim.Core/IWorldEventBus.cs
+++ b/src/Mithril.WorldSim.Core/IWorldEventBus.cs
@@ -1,0 +1,20 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// Typed pub-sub for a world's domain frames. Subscribers see emissions in
+/// resolution order (deterministic over the source stream — principle 2 +
+/// principle 11). One bus per world; cross-world consumers (views) subscribe
+/// to both world buses (principle 4 — "cross-source composition lives in a
+/// view layer above the worlds").
+/// </summary>
+public interface IWorldEventBus
+{
+    /// <summary>
+    /// Subscribe to domain frames of payload type <typeparamref name="T"/>.
+    /// Returns an <see cref="IDisposable"/> handle that, when disposed, removes
+    /// the subscription. Handlers are invoked synchronously during the world's
+    /// frame resolution loop on the world's dispatch thread — subscribers must
+    /// not block.
+    /// </summary>
+    IDisposable Subscribe<T>(Action<Frame<T>> handler);
+}

--- a/src/Mithril.WorldSim.Core/Mithril.WorldSim.Core.csproj
+++ b/src/Mithril.WorldSim.Core/Mithril.WorldSim.Core.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Mithril.WorldSim</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/src/Mithril.WorldSim.Core/WorldMode.cs
+++ b/src/Mithril.WorldSim.Core/WorldMode.cs
@@ -1,0 +1,27 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// Whether a world is draining recorded frames toward the live tail
+/// (<see cref="Replaying"/>) or has caught up and is blocking on the live
+/// source-stream tail (<see cref="Live"/>). State derivation is mode-agnostic
+/// (folders, composers, and views update internal state identically in both
+/// modes); side-effect-emitting consumers (audio alarms, window flash, OS
+/// notifications) gate on <c>Mode == Live</c> to avoid blasting the user with
+/// replays of yesterday's alarms when Mithril restarts (principle 12).
+/// </summary>
+public enum WorldMode
+{
+    /// <summary>
+    /// The world is draining recorded backlog frames from its producers
+    /// toward the live tail. State updates apply; user-facing side effects
+    /// do not fire.
+    /// </summary>
+    Replaying,
+
+    /// <summary>
+    /// The world has caught up to its source-stream tail and is now blocking
+    /// on the next live append. State updates apply; user-facing side effects
+    /// fire.
+    /// </summary>
+    Live,
+}


### PR DESCRIPTION
## Summary

Foundation layer for the world-simulator architecture (issue #615, foundation umbrella #614, architecture umbrella #601).

New assembly `Mithril.WorldSim.Core` — contracts only, no implementations. Per the design notebook `docs/world-simulator.md` §Contracts:

- `Frame<TPayload>` — record struct `(DateTimeOffset Timestamp, TPayload Payload)`, the unifying primitive (principle 1).
- `WorldMode` enum — `Replaying` / `Live` (principle 12).
- `IWorldClock` — `Now` / `Frame` / `Mode`; frame-driven advancement, no real-wall-clock interpolation (principles 5 + 13).
- `IChangeEvent` — marker for folder outputs (principle 10).
- `IFolder<TPayload>` — `Apply(Frame<TPayload>, IWorldClock)` returning change events (principle 10).
- `IComposer` — `Subscribes` + `Observe`; emits domain frames when the pattern is satisfied (principles 10 + 11).
- `IFrameProducer<TPayload>` — `SubscribeAsync` + `Priority`; sealed input source for a world's merger (principle 10).
- `IWorld` — `Clock` / `Bus` / `RegisterProducer` / `RegisterFolder` / `RegisterComposer` / `StartAsync` (principle 2).
- `IWorldEventBus` — `Subscribe<T>(Action<Frame<T>>)`; per-world domain-frame pub-sub (principles 2 + 4).

Each interface's XML doc references the originating principle so a consumer reading the contract sees *why* the shape exists.

This is the first task of Phase 0a per `docs/world-simulator-orchestration-plan.md`. Phase 0b (`IPlayerWorld` / `IChatWorld` concrete shells — #616, #617) unblocks once this lands.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, 0 warnings, 0 errors (warnings-as-errors enforced).
- [x] New assembly is reachable from the solution (the slnx update is included).
- No tests required for this task per the orchestration plan: "Contracts only — no behaviour. Tests not required for this task; the assembly just needs to compile and be reference-able by downstream issues."

Downstream verification (next phase): the `IPlayerWorld` / `IChatWorld` shells reference this assembly; phase-1 validation (#618) converts `IPlayerSkillStateService` to `IFolder<T>` against these contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
