### PR TITLE
refactor(legolas): migrate MotherlodeMeasurementCoordinator to single-source Player.log (#604)

### DIFF
--- a/docs/cross-source-correlation.md
+++ b/docs/cross-source-correlation.md
@@ -120,27 +120,29 @@ maps in sequence), bind responses **k-th-to-slot-k in arrival order** — see
 the `MotherlodeMeasurementCoordinator` "label-agnostic temporal pairing" rule
 for the canonical pattern.
 
-**In-repo reference.**
-[`Legolas.Services.MotherlodeMeasurementCoordinator`](../src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs)
-binds the request — `LocalPlayer: ProcessDoDelayLoop("Using <Map>")`, parsed
-from **Player.log** by `PlayerLogParser` into `MotherlodeUseDetected` — to
-the response — chat `[Status] The treasure is N meters from here.`, parsed
-from the **chat log** by `ChatLogParser.MotherlodeRegex` into
-`MotherlodeDistance`. So this consumer is **currently cross-source** (Player.log
-request ↔ chat response, ~1 s offset between them), and the same-game-second
-tiebreaker risk that Tier-3 will eventually mitigate applies.
+**In-repo reference.** None — the only Tier-2 reference,
+[`Legolas.Services.MotherlodeMeasurementCoordinator`](../src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs),
+was migrated to single-source in
+[#604](https://github.com/moumantai-gg/mithril/issues/604). The request
+(`LocalPlayer: ProcessDoDelayLoop("Using <Map>")`) and the response
+(`LocalPlayer: ProcessScreenText(ImportantInfo, "The treasure is N meters from here.")`)
+now both flow from **Player.log**, parsed by `PlayerLogParser` into
+`MotherlodeUseDetected` and `MotherlodeDistance` respectively and dispatched by
+`PlayerLogIngestionService` to the same coordinator API
+(`OnUse` / `OnDistance`). Pairing is therefore intra-stream — a single
+`Sequence`-ordered stream, no cross-source tiebreaker risk.
 
-PG also emits the same distance readout in Player.log as
-`LocalPlayer: ProcessScreenText(ImportantInfo, "The treasure is N meters from here.")`
-— see the [Player-Log-Signals wiki capture (Motherlode maps → Source)](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#source--playerlog-is-canonical-the-chat-mirror-is-redundant)
-documenting the same-source emission evidence. Migrating the consumer to read
-the Player.log line instead of the chat one would strip the cross-source
-coupling and let the SM operate on a single stream's well-defined
-`Sequence` ordering — but that migration is a **separate planned change**
-([#541](https://github.com/moumantai-gg/mithril/pull/541)'s PR body called it
-explicitly out-of-scope; #511 deliverable 6 is the structural home). Until it
-lands, the consumer is the canonical example of a *Tier-2 SM operating on a
-cross-source pair*, not a same-source one.
+The pattern stays documented here because the k-th-to-slot-k temporal binding
+the coordinator implements is still a Tier-2 protocol SM in shape — request +
+response with no shared join key, paired by arrival order within a TTL window.
+A future cross-source request/response consumer that needs a TTL gate without
+a shared key falls back to this section and the coordinator's source as the
+template; the only thing that changed in #604 is which stream the response
+arrives on.
+
+PG's emission evidence — both Player.log and chat carried the distance, with
+Player.log landing ~1 s earlier — is captured in
+[Player-Log-Signals (Motherlode → Source)](https://github.com/moumantai-gg/mithril/wiki/Player-Log-Signals#source--playerlog-is-canonical-the-chat-mirror-is-redundant).
 
 **Why no shared primitive.** Tier-2 SMs have heterogeneous state
 (per-consumer unmatched policies, batching contracts, response shapes,
@@ -242,11 +244,15 @@ If one ever does, this section gets the first reference.
 |---|---|---|
 | `InventoryService` (`ProcessAddItem` ↔ chat `[Status] added`) | 1 | Keyed by `InternalName`, 5 s TTL |
 | `Legolas.Services.LogIngestionService` (chat `added` ↔ chat `collected!`) | 1 | Keyed by item name, 5 s TTL; credit-0 + warn on unmatched takes; Trace on TTL eviction (post-#541) |
-| `Legolas.Services.MotherlodeMeasurementCoordinator` (Player.log `ProcessDoDelayLoop` ↔ chat `[Status] The treasure is N meters`) | 2 | Currently cross-source; k-th-to-slot-k binding; label-agnostic temporal pairing. Same-source migration to Player.log `ProcessScreenText(ImportantInfo, …)` is feasible but deferred to #511 deliverable 6 |
+| *(no in-repo consumer)* | 2 | Tier-2 lost its in-repo reference in [#604](https://github.com/moumantai-gg/mithril/issues/604) — `Legolas.Services.MotherlodeMeasurementCoordinator` migrated to single-source Player.log (`ProcessDoDelayLoop` ↔ `ProcessScreenText(ImportantInfo, …)`), so the protocol SM now operates intra-stream. The pattern stays documented; the next consumer that needs a TTL-gated request/response without a shared key gets the first new reference. |
 | *(no in-repo consumer)* | 3 | Tier-3 mechanism is available (L1 ships `LogEnvelope<T>.IsReplay`, PR #554) but unused — the four #556 candidates resolved via the unified pipe (Pin/Weather/Position) or Tier 1 (Inventory). Slot reserved for a future cross-source same-game-second tiebreak need. |
 
 ## Open questions / future work
 
+- **First post-#604 Tier-2 consumer**, if one ever surfaces (cross-source
+  request/response, no shared join key, TTL-gated arrival pairing), gets the
+  new in-repo reference in §Tier 2 — the pattern catalog already documents the
+  shape via `MotherlodeMeasurementCoordinator`'s pre-migration history.
 - **First Tier-3 consumer**, if one ever surfaces (cross-source pair, no
   shared key, no causal request/response, same-game-second tiebreak
   required), gets the first in-repo reference in §Tier 3 — the mechanism

--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -54,6 +54,16 @@ public sealed record ItemAddedToInventory(
     string Name,
     int Count) : GameEvent(Timestamp);
 
+/// <summary>
+/// The motherlode-map distance readout — <c>"The treasure is N meters from here."</c>
+/// As of #604 this is parsed from <b>Player.log</b>
+/// (<c>LocalPlayer: ProcessScreenText(ImportantInfo, "The treasure is N meters from here.")</c>)
+/// by <see cref="PlayerLogParser"/>, retiring the prior chat-log source. PG emits the
+/// banner on Player.log first; the chat mirror was redundant. The migration collapses the
+/// canonical Tier-2 cross-source coordinator (see <c>docs/cross-source-correlation.md</c>)
+/// into a single-source intra-PlayerWorld pairing; the k-th-to-slot-k temporal binding in
+/// <see cref="MotherlodeMeasurementCoordinator"/> is unchanged.
+/// </summary>
 public sealed record MotherlodeDistance(
     DateTime Timestamp,
     int DistanceMetres) : GameEvent(Timestamp);
@@ -62,7 +72,7 @@ public sealed record MotherlodeDistance(
 /// Player.log <c>LocalPlayer: ProcessDoDelayLoop(&lt;sec&gt;, &lt;verb&gt;,
 /// "Using … Motherlode Map", …)</c> — the player clicked a carried metal-slab
 /// (Motherlode) map. The <b>use gesture</b> the measurement coordinator
-/// temporally correlates a position feeder fix and the following ChatLog
+/// temporally correlates a position feeder fix and the following
 /// <see cref="MotherlodeDistance"/> line(s) against (#488). Pairing/binding is
 /// still order-based, not name-based — the use-line name is the map <i>type</i>
 /// (identical across a same-type stack, no per-map identity), carried only as a

--- a/src/Legolas.Module/Services/ChatLogParser.cs
+++ b/src/Legolas.Module/Services/ChatLogParser.cs
@@ -25,13 +25,11 @@ public sealed partial class ChatLogParser : IChatLogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant)]
     private static partial Regex InventoryAddRegex();
 
-    // Motherlode discriminator: "The treasure is <N> meters from here" with NO
-    // direction token (regular survey emits "[Status] The X is Ym DIR …", which
-    // SurveyRegex requires the DIR for — the two cannot collide). PG's live line
-    // uses US "meters"; accept the "metres" spelling too for robustness (#488).
-    [GeneratedRegex(@"The treasure is (?<dist>\d+) met(?:er|re)s from here",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
-    private static partial Regex MotherlodeRegex();
+    // #604: the chat motherlode-distance discriminator retired here. The same
+    // banner now flows from Player.log ProcessScreenText(ImportantInfo, …),
+    // parsed by PlayerLogParser.MotherlodeDistanceRx, so the coordinator pairs
+    // request + response from one stream — see PlayerLogParser docs and
+    // docs/cross-source-correlation.md for the structural reason.
 
     // Area banner: a run of asterisks then "Entering Area: <FriendlyName>".
     // The name runs to end-of-line; trim trailing whitespace via the lazy group
@@ -97,13 +95,6 @@ public sealed partial class ChatLogParser : IChatLogParser
                 collectMatch.Groups["name"].Value.Trim(),
                 count,
                 bonus);
-        }
-
-        var motherlodeMatch = MotherlodeRegex().Match(line);
-        if (motherlodeMatch.Success
-            && int.TryParse(motherlodeMatch.Groups["dist"].ValueSpan, out var mlDist))
-        {
-            return new MotherlodeDistance(timestamp, mlDist);
         }
 
         var areaMatch = AreaEnteredRegex().Match(line);

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -13,8 +13,12 @@ namespace Legolas.Services;
 /// Background service that consumes chat-log lines from <see cref="IChatLogStream"/>,
 /// parses them via <see cref="IChatLogParser"/>, and pumps resulting events into the
 /// session: SurveyDetected adds slots, ItemCollected marks the matching slot
-/// collected, MotherlodeDistance + Metal-Slab collection forward to the
-/// <see cref="MotherlodeMeasurementCoordinator"/> (#488).
+/// collected, AreaEntered feeds the calibration service as a fallback (the
+/// Player.log <c>LOADING LEVEL</c> banner is the primary source). The Motherlode
+/// distance pairing was migrated to Player.log <c>ProcessScreenText</c> in #604,
+/// so the chat distance subscription previously hosted here is gone — the
+/// coordinator now pairs request + response from <see cref="PlayerLogIngestionService"/>
+/// alone.
 /// </summary>
 public sealed class LogIngestionService : BackgroundService
 {
@@ -22,7 +26,6 @@ public sealed class LogIngestionService : BackgroundService
     private readonly IChatLogParser _parser;
     private readonly ModuleGates _gates;
     private readonly SessionState _session;
-    private readonly MotherlodeMeasurementCoordinator _motherlode;
     private readonly IAreaCalibrationService _areaCalibration;
     private readonly IDiagnosticsSink? _diag;
     private readonly ThrottledWarn _warn;
@@ -32,7 +35,6 @@ public sealed class LogIngestionService : BackgroundService
         IChatLogParser parser,
         ModuleGates gates,
         SessionState session,
-        MotherlodeMeasurementCoordinator motherlode,
         IAreaCalibrationService areaCalibration,
         IDiagnosticsSink? diag = null,
         TimeProvider? time = null)
@@ -41,7 +43,6 @@ public sealed class LogIngestionService : BackgroundService
         _parser = parser;
         _gates = gates;
         _session = session;
-        _motherlode = motherlode;
         _areaCalibration = areaCalibration;
         _diag = diag;
         var clock = time ?? TimeProvider.System;
@@ -109,12 +110,6 @@ public sealed class LogIngestionService : BackgroundService
                 case ItemCollected ic:
                     HandleItemCollected(ic);
                     break;
-                case MotherlodeDistance md when _session.Mode == SessionMode.Motherlode:
-                    // md.Timestamp was carried through as raw.Timestamp.UtcDateTime
-                    // at the parser boundary above, so it is Kind=Utc; lift to a
-                    // DateTimeOffset with offset 0 for the coordinator's API.
-                    _motherlode.OnDistance(md.DistanceMetres, new DateTimeOffset(md.Timestamp, TimeSpan.Zero));
-                    break;
                 case AreaEntered ae:
                     _areaCalibration.OnAreaEntered(ae.AreaFriendlyName);
                     break;
@@ -128,7 +123,6 @@ public sealed class LogIngestionService : BackgroundService
         ItemAddedToInventory ia => $"Added: {ia.Name} x{ia.Count}",
         ItemCollected ic when ic.SpeedBonusItem is not null => $"Collected: {ic.Name} (+ {ic.SpeedBonusItem} speed bonus)",
         ItemCollected ic => $"Collected: {ic.Name}",
-        MotherlodeDistance md => $"Motherlode: {md.DistanceMetres}m",
         AreaEntered ae => $"Area: {ae.AreaFriendlyName}",
         UnknownLine ul => $"Unknown: {ul.RawLine}",
         _ => evt.GetType().Name,

--- a/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
+++ b/src/Legolas.Module/Services/MotherlodeMeasurementCoordinator.cs
@@ -41,12 +41,14 @@ public sealed record MotherlodeStatus(
 /// per-map identity (type name only) and the inventory slot ≠ the grid the
 /// player arranges by, so read→treasure binding cannot be derived from the log.
 ///
-/// <para>This is the canonical <b>Tier-2 (causal protocol state machine)</b>
-/// reference in the cross-source-correlation hierarchy — see
-/// <c>docs/cross-source-correlation.md</c>. The use-line (request) and
+/// <para>Shape is Tier-2 (causal protocol state machine, see
+/// <c>docs/cross-source-correlation.md</c>): the use-line (request) and
 /// distance-line (response) carry no shared join key; the SM pairs them by
 /// arrival order within a TTL window (k-th-to-slot-k label-agnostic temporal
-/// binding) rather than by label.</para>
+/// binding) rather than by label. Post-#604, both request and response flow
+/// from Player.log (<c>ProcessDoDelayLoop</c> + <c>ProcessScreenText(ImportantInfo, …)</c>),
+/// so the pairing is intra-stream — the cross-source coupling that prior
+/// versions documented is gone, but the k-th-to-slot-k logic is unchanged.</para>
 ///
 /// <para><b>Create-on-use, not on stock.</b> A working slot is created lazily
 /// by a <i>reading</i>, never by holding inventory — so carrying 100+ maps
@@ -371,8 +373,11 @@ public sealed class MotherlodeMeasurementCoordinator : IDisposable
         if (changed) Raise();
     }
 
-    /// <summary>A ChatLog distance reading. Creates/binds the slot the current
-    /// mode + per-spot ordinal selects, then re-solves it.</summary>
+    /// <summary>A Player.log distance reading (#604: previously a ChatLog
+    /// reading; migrated to <c>ProcessScreenText(ImportantInfo, "The treasure is
+    /// N meters from here.")</c> so request + response share one stream).
+    /// Creates/binds the slot the current mode + per-spot ordinal selects,
+    /// then re-solves it.</summary>
     public void OnDistance(int metres, DateTimeOffset at)
     {
         lock (_gate)

--- a/src/Legolas.Module/Services/PlayerLogIngestionService.cs
+++ b/src/Legolas.Module/Services/PlayerLogIngestionService.cs
@@ -186,8 +186,10 @@ public sealed class PlayerLogIngestionService : BackgroundService
 
                 // Map pins (ProcessMapPin{Add,Remove}) are owned by the
                 // GameState-tier PlayerPinTracker (#468); this service handles
-                // ProcessMapFx absolute targets (#454) and the
-                // ProcessDoDelayLoop Motherlode-map use gesture (#488).
+                // ProcessMapFx absolute targets (#454), the ProcessDoDelayLoop
+                // Motherlode-map use gesture (#488), and — post-#604 — the
+                // ProcessScreenText motherlode distance readout (migrated from
+                // the chat log so the coordinator is intra-PlayerWorld).
                 switch (_parser.TryParse(line, ts))
                 {
                     case MapTargetDetected mt:
@@ -201,10 +203,26 @@ public sealed class PlayerLogIngestionService : BackgroundService
                     // a prior Mithril session.
                     case MotherlodeUseDetected use
                         when _session.Mode == SessionMode.Motherlode:
+                    {
                         var at = new DateTimeOffset(
                             DateTime.SpecifyKind(use.Timestamp, DateTimeKind.Utc));
                         _motherlode.OnUse(at, use.MapName);
                         break;
+                    }
+
+                    // #604: distance readout migrated from chat. Same coordinator
+                    // entry point (OnDistance) — the k-th-to-slot-k temporal
+                    // pairing logic is unchanged; only the source stream is. The
+                    // request side (MotherlodeUseDetected above) and response
+                    // side (this case) are now both Player.log-resident.
+                    case MotherlodeDistance md
+                        when _session.Mode == SessionMode.Motherlode:
+                    {
+                        var at = new DateTimeOffset(
+                            DateTime.SpecifyKind(md.Timestamp, DateTimeKind.Utc));
+                        _motherlode.OnDistance(md.DistanceMetres, at);
+                        break;
+                    }
                 }
 
                 // Update the high-water AFTER successful handling so a

--- a/src/Legolas.Module/Services/PlayerLogParser.cs
+++ b/src/Legolas.Module/Services/PlayerLogParser.cs
@@ -8,27 +8,29 @@ namespace Legolas.Services;
 /// <summary>
 /// Player.log analog of <see cref="ChatLogParser"/> — pure line→event. #454:
 /// <c>ProcessMapFx</c> (absolute survey/treasure-map targets); #488:
-/// <c>ProcessDoDelayLoop</c> Motherlode-map use gesture. Map-pin lifecycle
-/// parsing moved to the GameState-tier <c>MapPinParser</c> /
+/// <c>ProcessDoDelayLoop</c> Motherlode-map use gesture; #604:
+/// <c>ProcessScreenText(ImportantInfo, "The treasure is N meters from here.")</c>
+/// Motherlode distance readout (migrated from <see cref="ChatLogParser"/> so the
+/// coordinator becomes a single-source intra-PlayerWorld state machine). Map-pin
+/// lifecycle parsing moved to the GameState-tier <c>MapPinParser</c> /
 /// <c>PlayerPinTracker</c> (#468) — same promotion pattern as
 /// <c>AreaTransitionParser</c> (#456).
 ///
 /// <para>Real captured grammar (live Player.log, 2026-05-18):</para>
 /// <code>
 /// [08:25:39] LocalPlayer: ProcessMapFx((1236.00, 38.17, 2528.00), 25, 1, "Good Metal Slab is here", ImportantInfo, "The Good Metal Slab is 67m west and 1181m south.")
+/// [22:09:22] LocalPlayer: ProcessScreenText(ImportantInfo, "The treasure is 1285 meters from here.")
 /// </code>
-/// The two middle integers vary; the regex skips them non-greedily and anchors
-/// on the leading coord triple plus the trailing <c>"short", Category,
-/// "msg")</c> structure. Coordinates are <b>signed</b> (negative X/Z are
-/// common — see <see cref="WorldCoord"/>). Lines that aren't
-/// <c>ProcessMapFx</c> (incl. Motherlode's <c>ProcessScreenText</c>) fast-path
-/// to null, so Motherlode is excluded with no special-casing.
+/// The two middle integers on <c>ProcessMapFx</c> vary; that regex skips them
+/// non-greedily and anchors on the leading coord triple plus the trailing
+/// <c>"short", Category, "msg")</c> structure. Coordinates are <b>signed</b>
+/// (negative X/Z are common — see <see cref="WorldCoord"/>).
 ///
 /// <para>Post-#550 L1 migration: consumes the envelope-stripped
 /// <see cref="LocalPlayerLogLine.Data"/> payload — L0.5 (#532) has already
 /// classified the line as <c>LocalPlayer:</c>-actored and eaten the envelope,
-/// so the <c>MotherlodeUseRx</c> guard no longer re-anchors on it. Same
-/// pattern as the GameState parsers post-#555.</para>
+/// so the per-line guards no longer re-anchor on it. Same pattern as the
+/// GameState parsers post-#555.</para>
 /// </summary>
 public sealed partial class PlayerLogParser : ILogParser
 {
@@ -50,6 +52,19 @@ public sealed partial class PlayerLogParser : ILogParser
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
     private static partial Regex MotherlodeUseRx();
 
+    // #604: Motherlode distance readout — the player-facing banner emitted on
+    // each measuring read of a carried Motherlode map. PG also mirrors this to
+    // ChatLogs as "[Status] The treasure is N meters from here.", but the
+    // Player.log emission lands ~1 s earlier and lets the coordinator pair the
+    // distance with its use gesture from a single source (no cross-stream
+    // ordering hazard). Accepts the US spelling ("meters") and the British
+    // ("metres") for robustness. ImportantInfo is the only observed banner
+    // namespace for this line; pin it so unrelated banners don't false-positive.
+    [GeneratedRegex(
+        """ProcessScreenText\(\s*ImportantInfo\s*,\s*"The treasure is (?<dist>\d+) met(?:er|re)s from here\.?"\s*\)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex MotherlodeDistanceRx();
+
     private static string? NormalizeMapName(string raw)
     {
         var s = raw.Trim();
@@ -69,6 +84,17 @@ public sealed partial class PlayerLogParser : ILogParser
         {
             return new MotherlodeUseDetected(
                 timestamp, NormalizeMapName(use.Groups["map"].Value));
+        }
+
+        // #604: ProcessScreenText banner — must be tried before ProcessMapFx
+        // because ScreenText also carries an "ImportantInfo" category, but
+        // ProcessMapFx is the parenthesised-coord form. Anchor on the literal
+        // substring before the regex to keep the hot-path branch cheap.
+        if (line.Contains("ProcessScreenText", StringComparison.Ordinal)
+            && MotherlodeDistanceRx().Match(line) is { Success: true } d
+            && int.TryParse(d.Groups["dist"].ValueSpan, out var metres))
+        {
+            return new MotherlodeDistance(timestamp, metres);
         }
 
         if (line.Contains("ProcessMapFx", StringComparison.Ordinal)

--- a/src/Mithril.Shared/Reference/log-patterns.json
+++ b/src/Mithril.Shared/Reference/log-patterns.json
@@ -257,20 +257,6 @@
         { "name": "bonus", "group": "bonus", "type": "string" }
       ]
     },
-    "legolas.ChatLogParser.MotherlodeRegex": {
-      "pattern": "The treasure is (?<dist>\\d+) met(?:er|re)s from here",
-      "source": "chat",
-      "module": "legolas",
-      "csharp": {
-        "type": "Legolas.Services.ChatLogParser",
-        "method": "MotherlodeRegex",
-        "options": ["Compiled", "CultureInvariant"]
-      },
-      "eventType": "legolas.MotherlodeDistance",
-      "fields": [
-        { "name": "dist", "group": "dist", "type": "int" }
-      ]
-    },
     "shared.InventoryStatusChatParser.CountedRx": {
       "pattern": "\\[Status\\]\\s+(?<name>.+?)\\s+x(?<count>\\d+)\\s+added to inventory\\.",
       "source": "chat",

--- a/tests/Legolas.Tests/LogTail/LogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/LogParserTests.cs
@@ -66,12 +66,15 @@ public class LogParserTests
     }
 
     [Fact]
-    public void Parses_motherlode_distance()
+    public void Chat_no_longer_parses_motherlode_distance_post_604()
     {
+        // #604 migrated the motherlode distance readout to Player.log
+        // ProcessScreenText. The chat parser now treats the line as an
+        // unrecognised banner and falls through to UnknownLine. The Player.log
+        // half of this contract is asserted in MotherlodeParserTests.
         var evt = _parser.TryParse("The treasure is 43 metres from here", FixedTime);
 
-        evt.Should().BeOfType<MotherlodeDistance>()
-            .Which.DistanceMetres.Should().Be(43);
+        evt.Should().NotBeOfType<MotherlodeDistance>();
     }
 
     [Theory]

--- a/tests/Legolas.Tests/LogTail/MotherlodeParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/MotherlodeParserTests.cs
@@ -5,8 +5,10 @@ using Legolas.Services;
 namespace Legolas.Tests.LogTail;
 
 /// <summary>
-/// #488 — the ChatLog motherlode-distance discriminator (no DIR token ⇒
-/// motherlode) and the Player.log ProcessDoDelayLoop use gesture.
+/// #488 — the Player.log ProcessDoDelayLoop use gesture. #604 — the
+/// Player.log ProcessScreenText distance readout (migrated here from
+/// ChatLogParser so the motherlode coordinator pairs request + response from a
+/// single source).
 /// </summary>
 public class MotherlodeParserTests
 {
@@ -15,27 +17,65 @@ public class MotherlodeParserTests
     private readonly PlayerLogParser _player = new();
 
     [Theory]
-    [InlineData("The treasure is 1285 meters from here.", 1285)]   // live capture (US spelling)
-    [InlineData("The treasure is 67 metres from here", 67)]        // British spelling
-    [InlineData("[Status] The treasure is 940 meters from here.", 940)]
+    // Live capture (US spelling, with trailing period) and the British spelling
+    // accepted for robustness. The full LocalPlayer: actor envelope is stripped
+    // by L0.5 upstream, so the parser receives the bare ProcessScreenText
+    // payload — pin both shapes (with and without an envelope-style prefix) so
+    // a future upstream tweak can't silently regress.
+    [InlineData("""ProcessScreenText(ImportantInfo, "The treasure is 1285 meters from here.")""", 1285)]
+    [InlineData("""ProcessScreenText(ImportantInfo, "The treasure is 67 metres from here.")""", 67)]
+    [InlineData("""[09:03:31] LocalPlayer: ProcessScreenText(ImportantInfo, "The treasure is 940 meters from here.")""", 940)]
     public void Parses_motherlode_distance(string line, int expected)
     {
-        var evt = _chat.TryParse(line, FixedTime);
+        var evt = _player.TryParse(line, FixedTime);
 
         evt.Should().BeOfType<MotherlodeDistance>()
            .Which.DistanceMetres.Should().Be(expected);
     }
 
     [Theory]
-    // A regular survey [Status] line carries DIR tokens — it must NOT be
-    // mistaken for a motherlode distance (the no-DIR discriminator).
+    // Other ProcessScreenText categories must NOT false-positive — the
+    // discriminator anchors on ImportantInfo + the literal banner text.
+    [InlineData("""ProcessScreenText(GeneralInfo, "You've already looted this chest! (It will refill 3 hours after you looted it.)")""")]
+    [InlineData("""ProcessScreenText(ErrorMessage, "You've already milked Bessie in the past hour.")""")]
+    // A survey [Status] line in chat that mentions "treasure" must NOT match
+    // the Player.log parser at all — that grammar lives in ChatLogParser and
+    // the regex literal of the motherlode banner here doesn't even share a
+    // prefix with chat lines. Pinned so a refactor can't widen accidentally.
+    [InlineData("[Status] The Bloodstone is 528m west and 202m north.")]
+    public void Other_screen_text_categories_are_not_a_motherlode_distance(string line)
+    {
+        var evt = _player.TryParse(line, FixedTime);
+
+        // Player.log parser returns null on non-matches; chat ChatLogParser
+        // produces an UnknownLine. Either way, never a MotherlodeDistance.
+        (evt is null || evt is not MotherlodeDistance).Should().BeTrue();
+    }
+
+    [Theory]
+    // A regular survey [Status] line carries DIR tokens — chat parser routes
+    // it to SurveyDetected; pinning here so the chat-side regex isn't
+    // confused for a motherlode emitter post-#604.
     [InlineData("[Status] The Bloodstone is 528m west and 202m north.")]
     [InlineData("[Status] The Diamond is 20m east and 14m south.")]
-    public void Survey_status_line_is_not_a_motherlode_distance(string line)
+    public void Survey_status_line_is_a_survey_not_a_motherlode_distance(string line)
     {
         var evt = _chat.TryParse(line, FixedTime);
 
         evt.Should().BeOfType<SurveyDetected>();
+        evt.Should().NotBeOfType<MotherlodeDistance>();
+    }
+
+    [Theory]
+    // Post-#604: the chat parser no longer emits MotherlodeDistance — the
+    // grammar moved to PlayerLogParser. A "[Status] The treasure is N meters
+    // from here." line now falls through to UnknownLine on the chat side.
+    [InlineData("[Status] The treasure is 1285 meters from here.")]
+    [InlineData("The treasure is 67 metres from here.")]
+    public void Chat_treasure_line_no_longer_emits_motherlode_distance(string line)
+    {
+        var evt = _chat.TryParse(line, FixedTime);
+
         evt.Should().NotBeOfType<MotherlodeDistance>();
     }
 
@@ -49,7 +89,8 @@ public class MotherlodeParserTests
 
     [Theory]
     // Non-motherlode delay loops aren't a use gesture — the Player.log parser
-    // returns null for them (it only emits MapFx targets + the use gesture).
+    // returns null for them (it only emits MapFx targets + the use gesture
+    // and the #604 ProcessScreenText distance readout).
     [InlineData("""LocalPlayer: ProcessDoDelayLoop(1.5, Eat, "Using Ranalon Salad", 5820, AbortIfAttacked)""")]
     [InlineData("""LocalPlayer: ProcessDoDelayLoop(3, Gather, "Collecting Fruit...", 0, AbortIfAttacked, IsInteractorDelayLoop)""")]
     public void Other_delay_loops_are_not_a_use_gesture(string line)

--- a/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/PlayerLogParserTests.cs
@@ -53,10 +53,11 @@ public class PlayerLogParserTests
     }
 
     [Theory]
-    // The motherlode distance itself is ProcessScreenText (mirrored to ChatLog,
-    // where ChatLogParser picks it up) — never ProcessMapFx; the Player.log
-    // parser ignores it. A non-motherlode survey delay-loop is also ignored.
-    [InlineData("[09:03:31] LocalPlayer: ProcessScreenText(ImportantInfo, \"The treasure is 1285 meters from here.\")")]
+    // A non-motherlode survey delay-loop, a level marker, and the empty line
+    // are all ignored by this parser. Pre-#604 the motherlode distance
+    // ProcessScreenText also returned null here (it was a chat-only signal);
+    // it now produces a MotherlodeDistance and is asserted in
+    // MotherlodeParserTests.
     [InlineData("[08:25:38] LocalPlayer: ProcessDoDelayLoop(0.5, Unset, \"Using Eltibule Good Mining Survey\", 5305, AbortIfAttacked)")]
     [InlineData("LOADING LEVEL AreaEltibule")]
     [InlineData("")]

--- a/tests/Legolas.Tests/Services/LogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/LogIngestionServiceTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Channels;
 using FluentAssertions;
 using Legolas.Domain;
-using Legolas.Flow;
 using Legolas.Services;
 using Legolas.ViewModels;
 using Mithril.Shared.Diagnostics;
@@ -43,20 +42,15 @@ public sealed class LogIngestionServiceTests
         gates.For("legolas").Open();
         var sink = new CapturingSink();
         var clock = new ManualTimeProvider(new DateTime(2026, 5, 20, 14, 0, 0, DateTimeKind.Utc));
-        // The motherlode coordinator and area-calibration service aren't
-        // exercised by add/collect pathways, but the ctor needs concrete
-        // references. Reuse the test stubs other fixtures already ship.
-        var motherlode = new MotherlodeMeasurementCoordinator(
-            new MultilaterationSolver(),
-            new MotherlodeFlowController(session),
-            new FakePlayerPositionTracker(),
-            new FakePlayerPinTracker());
+        // #604: the chat motherlode distance subscription retired here — the
+        // motherlode coordinator is now driven entirely by PlayerLogIngestionService.
+        // The area-calibration service is the only remaining non-add/collect
+        // collaborator and a fake is plenty.
         var svc = new LogIngestionService(
             stream,
             new ChatLogParser(),
             gates,
             session,
-            motherlode,
             new FakeAreaCalibrationService(),
             diag: sink,
             time: clock);


### PR DESCRIPTION
## Summary

Closes #604. Part of #601 (world-simulator architecture migration umbrella) — retires the only in-repo Tier-2 cross-source reference per the design-notebook §Migration path #3.

- **PlayerLogParser** gains a `ProcessScreenText(ImportantInfo, "The treasure is N meters from here.")` recognizer (`MotherlodeDistanceRx`) that emits the existing `MotherlodeDistance` event. The wiki capture (`Player-Log-Signals.md` line 1686, 1713) confirms PG emits this banner on Player.log ~1 s before the chat mirror.
- **PlayerLogIngestionService** dispatches the new event to the coordinator via the unchanged `OnDistance(metres, at)` API. The k-th-to-slot-k temporal pairing logic, the `DistanceWindowSeconds` gate, all `MotherlodeMeasurementCoordinator` internals — untouched.
- **LogIngestionService** no longer takes the coordinator and no longer routes any chat line to it. `ChatLogParser.MotherlodeRegex` is deleted; the chat treasure line now falls through to `UnknownLine`.
- **`docs/cross-source-correlation.md`** Tier-2 in-repo reference is retired; the pattern catalog stays for the next cross-source request/response consumer. Consumer-to-tier mapping table updated.
- **`log-patterns.json`** chat MotherlodeRegex entry removed (catalog is chat-only per the wiki convention; the new Player.log emission lives outside the catalog).

Result: the canonical Tier-2 SM now operates on a single `Sequence`-ordered Player.log stream — same intra-source determinism as the post-#454 absolute-target path. No `IChatLogStream` removal here (other chat verbs still flow through `LogIngestionService`); that's tracked separately under #601's full chat retirement.

## Test plan

- [x] `dotnet build Mithril.slnx` — clean (0 warnings, 0 errors).
- [x] `dotnet test tests/Legolas.Tests` — 469 passed, 0 failed (was 465 pre-#604; +4 new theory rows in `MotherlodeParserTests` for the Player.log ProcessScreenText shapes and the chat-side retirement assertion).
- [x] `dotnet test tests/Mithril.Shared.Tests` — 1246 passed, 0 failed. The `LogPatternCatalogParityTests` ran clean (the chat MotherlodeRegex entry removal lines up with its catalog removal).
- [x] Full solution test pass: ~3700 tests across all module fixtures, 0 failures.
- [x] All Motherlode coordinator unit tests (`MotherlodeMeasurementCoordinatorTests`) pass unchanged — the coordinator's behavioral contract is preserved.

## Manual verification owed (post-merge)

- Run a real Motherlode session against live PG: at least 3 reads from distinct positions, confirm the solver still resolves the treasure. The pairing window (20 s) and per-spot ordinal logic are untouched, but the response now arrives ~1 s sooner than before (Player.log lands before its chat mirror), which is harmless — `DistanceWindowSeconds = 20` is comfortably above the new request→response gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
