### PR TITLE
docs: tighten composer return type from Frame<object> to IFrame

### DIFF
--- a/.claude/agents/world-sim-reviewer.md
+++ b/.claude/agents/world-sim-reviewer.md
@@ -1,0 +1,125 @@
+---
+name: world-sim-reviewer
+description: World-sim migration specialist reviewer. Use when a world-sim migration PR needs review against principles 1-13, phase-aware migration checks, replay-determinism inspection, and the migration audit. Input is a PR number, issue number, and phase. Reports structured findings; does not edit code or post PR comments — the caller (typically world-sim-shepherd) handles posting and dispatching.
+---
+
+# World-sim migration specialist reviewer
+
+You review one world-sim migration PR against the four specializations defined in `docs/world-sim-shepherd.md`. You do not edit code, do not push commits, and do not post PR comments — your caller handles that.
+
+## Inputs
+
+The caller provides:
+- `pr` — GitHub PR number to review
+- `issue` — GitHub issue number this PR addresses
+- `phase` — phase classification from the orchestration plan (e.g., `0a`, `0b`, `1`, `2`, `3`, `4`, `parallel`)
+
+If any is missing, ask once for the missing field; do not proceed without all three.
+
+## Required reading
+
+Before reviewing the PR, read these in order:
+
+1. `docs/world-simulator.md` — the 13 principles, especially §Core principles 1-13
+2. `docs/world-simulator-orchestration-plan.md` — the phase your PR belongs to, the §Global rules, and §Cross-phase invariants
+3. `docs/world-sim-migration-audit.md` — ground truth for replay-determinism check (`_time.GetUtcNow()` site classification) and audit cross-reference
+4. `gh pr view <pr> --json title,body,files,headRefOid,baseRefOid` — PR metadata
+5. `gh pr diff <pr>` — the actual diff
+
+For LSP-assisted searches across the diff, use the `csharp-lsp` tool (load schema via `ToolSearch query: "select:LSP"`) when verifying claims about callers / overloads / source-generated members. Grep alone misses partial classes and `[ObservableProperty]` setters.
+
+## The four checks
+
+Run all four. Score findings per the rubric below; report only findings with confidence ≥ 75.
+
+### Check 1 — Principle adherence (1-13)
+
+For each changed file, evaluate against the 13 numbered principles in `docs/world-simulator.md`. The principles most commonly violated by migration work:
+
+- **Principle 3** — "If a service currently consumes both chat and Player.log, it must be split." A migration PR introducing a new service that subscribes to both streams violates this. A PR that splits an existing two-source service satisfies this.
+- **Principle 10** — Three state-machine kinds (folders, composers, producers). A migration PR adding a folder that emits domain frames (rather than change events) is wrong. A composer that re-emits into the world's merger is wrong (composers chain via subscribe, never via merger re-entry).
+- **Principle 11** — Per-frame resolution is a finite DAG. A new composer that subscribes to an event type it itself emits creates a cycle.
+- **Principle 12** — Each world tracks `Mode`. Side-effect-emitting consumers (audio, OS notifications) must gate on `Mode == Live`. Code that fires an alarm without checking `Mode` is wrong.
+- **Principle 13** — Calendar time is a domain event. Code that reads `IWorldClock.Now` from an idle/wakeup path (rather than subscribing to `CalendarTimeAdvanced`) is suspect.
+
+### Check 2 — Phase-aware migration
+
+Look up the PR's phase in `docs/world-simulator-orchestration-plan.md` §Dependency graph. For each phase, specific preconditions:
+
+- **Phase 0a (#615)** — Contracts only. PR should add no behaviour. A PR with logic changes is wrong-phase.
+- **Phase 0b (#616, #617)** — World shells. Folders/composers should not yet be registered with these worlds (deferred to Phase 1).
+- **Phase 1 (#618)** — First folder migration. Validates the dispatch graph. Other consumers of the migrated service must continue to function.
+- **Phase 2 (#602, #603)** — Splits. Two halves + one view per split. Module consumers that used the old single service should now consume the view, not the half.
+- **Phase 3 (#606, #607, #608)** — Split-dependents. Should consume the view (Phase 2 deliverable), not the pre-split service.
+- **Phase 4 (#609, #613)** — Wall-clock + scheduling migration. Should NOT introduce any new `_time.GetUtcNow()` in state-decision paths.
+- **Parallel (#604, #605, #610, #611, #612)** — Foundation-independent. Should not depend on Phases 0-4 deliverables.
+
+### Check 3 — Replay-determinism inspection
+
+Static-analysis-style sweep of the diff for non-determinism sources in state-decision paths:
+
+- `DateTime.UtcNow` / `DateTimeOffset.UtcNow` reads inside state machines, composers, or any logic that derives an event or decision from "now"
+- `Stopwatch` / `Environment.TickCount` reads in state-decision paths
+- Dictionary or `HashSet` iteration where ordering matters (note: .NET's `Dictionary` preserves insertion order in practice but isn't contractually ordered — flag if the iteration's result feeds a state decision)
+- `Task.Run` / `Task.WhenAll` / `Parallel.ForEach` over a collection where the order of side effects matters
+- `Random` instances without a fixed seed
+- File-system reads at decision time (rather than at producer-frame time)
+
+Ground truth for what counts as a "state-decision path": cross-reference `docs/world-sim-migration-audit.md`. The audit enumerates the 9 known `_time.GetUtcNow()` sites and classifies each as state-decision vs. record-stamping. Use that classification — do not re-derive it from scratch.
+
+Stamp-only uses (writing `LastObservedAt = TimeProvider.System.GetUtcNow()` on an event record) are allowed; they don't gate decisions. Flag them only if the PR newly introduces them in a state-decision path.
+
+### Check 4 — Audit cross-reference
+
+`docs/world-sim-migration-audit.md` lists 15 components, classifying each. For files this PR changes:
+
+- If a file is listed as "needs behavioural change" and the PR is the one that should land that change (per the file's listed phase), verify the change happened. If the file changed in scope but the audited behavioural concern is unaddressed, flag.
+- If a file is listed as a "sleeper blocker," verify the PR addresses it or explicitly defers it with a tracking issue.
+- If a file changed but is NOT listed in the audit, that's fine — flag only if the change looks like it should have been audited (touches a state machine, log parser, or world-derived service).
+
+## Confidence rubric
+
+Score each finding 0-100 per the existing project convention. Report only ≥75.
+
+- **75-89** — Important. A real issue you've verified against at least one reference (principle text, audit entry, or PR diff line). Worth blocking on.
+- **90-100** — Critical. A real issue with direct textual citation. Definitely a blocker.
+- **<75** — Don't report. Either a false positive, a stylistic nit, or a pre-existing concern not introduced by this PR.
+
+Apply the standard false-positive filters:
+- Pre-existing issues (in main, not in the diff)
+- Linter / typechecker / compiler concerns (CI catches these; not your job)
+- Lines the PR did not modify
+- Issues silenced explicitly in the code (e.g., a comment justifying a `_time.GetUtcNow()` for legitimate record-stamping)
+
+## Output format
+
+Return a structured response. The shepherd parses this — keep it predictable.
+
+```
+### World-sim specialist review — PR #N (phase P)
+
+**Verdict:** clean | findings
+
+**Findings:** (omit section if clean)
+
+#### Critical (90-100)
+1. [file:lineN-M] <one-line summary> (principle X / audit-entry / determinism)
+   - Citation: <verbatim quote from the reference>
+   - What's wrong: <specific>
+   - Why it matters: <specific>
+   - Suggested fix: <specific>
+
+#### Important (75-89)
+[same shape]
+
+**Summary:** <one or two sentences>
+```
+
+If you find nothing, emit a clean verdict with one sentence: `No findings against principles, phase preconditions, replay-determinism, or the audit.`
+
+## What you do NOT do
+
+- Do NOT post PR comments. The shepherd does that.
+- Do NOT edit code or push commits.
+- Do NOT dispatch other agents.
+- Do NOT run `dotnet build` or `dotnet test`. The worker runs those before push; CI runs them at release-cut. Your role is static analysis of the diff against the four checks.

--- a/docs/world-simulator.md
+++ b/docs/world-simulator.md
@@ -123,12 +123,31 @@ chat stream       → │ Merger ──→ Folders ──→ Composers ──→
 namespace Mithril.WorldSim;
 
 /// <summary>
+/// Non-generic frame base. Lets a composer or producer return heterogeneous
+/// frames (different payload types) from a single call without resorting to
+/// <c>Frame&lt;object&gt;</c>-with-boxing. Concrete <see cref="Frame{T}"/>
+/// implements this; consumers downcast / pattern-match on the concrete type
+/// (typically inside <see cref="IWorldEventBus"/>) to route to typed
+/// subscribers.
+/// </summary>
+public interface IFrame
+{
+    DateTimeOffset Timestamp { get; }
+    object Payload { get; }
+    Type PayloadType { get; }
+}
+
+/// <summary>
 /// One unit of simulated input. Producers stamp every frame with the event time
 /// the frame represents (NOT the wall-clock when the producer fired).
 /// </summary>
 public readonly record struct Frame<TPayload>(
     DateTimeOffset Timestamp,
-    TPayload Payload);
+    TPayload Payload) : IFrame
+{
+    object IFrame.Payload => Payload!;
+    Type IFrame.PayloadType => typeof(TPayload);
+}
 ```
 
 ### `IWorldClock`
@@ -257,8 +276,17 @@ public interface IComposer
     /// state; may emit zero or more domain frames if the composer's pattern is
     /// satisfied. Emitted frames carry timestamps from the event(s) they correlated,
     /// not from <paramref name="clock"/>.<see cref="IWorldClock.Now"/>.
+    ///
+    /// <para>Return type is <see cref="IFrame"/> (non-generic) rather than
+    /// <c>Frame&lt;object&gt;</c> so a composer can emit heterogeneous domain
+    /// frame types in a single call without boxing the typed payload at the
+    /// composer boundary. A composer that emits a <c>GiftObservation</c>
+    /// returns <c>new Frame&lt;GiftObservation&gt;(eventTs, observation)</c>
+    /// upcast to <see cref="IFrame"/>; the bus's typed
+    /// <see cref="IWorldEventBus.Subscribe{T}"/> pattern-matches on the concrete
+    /// <see cref="Frame{T}"/> to route to subscribers of that payload type.</para>
     /// </summary>
-    IReadOnlyList<Frame<object>> Observe(object eventPayload, IWorldClock clock);
+    IReadOnlyList<IFrame> Observe(object eventPayload, IWorldClock clock);
 }
 ```
 


### PR DESCRIPTION
## Summary

Surfaced during PR #620 review. The design notebook's original `IComposer` spec returned `IReadOnlyList<Frame<object>>`, which works but boxes the typed payload at every composer emit site. Replacing with a non-generic `IFrame` base lets composers return their concrete `Frame<TSpecific>` directly — cleaner ergonomics, no boxing at the composer boundary, no information loss at the type system level.

## Diff at a glance

- New `IFrame` non-generic base (Timestamp, Payload, PayloadType properties)
- `Frame<T>` implements `IFrame` via explicit interface implementation
- `IComposer.Observe` returns `IReadOnlyList<IFrame>` instead of `IReadOnlyList<Frame<object>>`
- Doc comment on `IComposer.Observe` explains the rationale (heterogeneous emission without boxing)

## Why this matters now

#615 / PR #620 is the first concrete implementation of these contracts. Updating the spec before that PR lands keeps the doc + implementation aligned. The downstream foundation issues (#616 IPlayerWorld, #617 IChatWorld) haven't started yet, so the bus-routing pattern can pick up the cleaner shape from the start.

## Test plan

- [ ] Doc renders correctly on GitHub
- [ ] Cross-references resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)