### PR TITLE
feat(gamestate): add ServerCatalogParser → IServerCatalogService (#610)

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -11,6 +11,8 @@ using Mithril.GameState.Recipes;
 using Mithril.GameState.Recipes.Parsing;
 using Mithril.GameState.Quests;
 using Mithril.GameState.Quests.Parsing;
+using Mithril.GameState.Servers;
+using Mithril.GameState.Servers.Parsing;
 using Mithril.GameState.Sessions;
 using Mithril.GameState.Skills;
 using Mithril.GameState.Skills.Parsing;
@@ -158,6 +160,19 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<PlayerWeatherTracker>()
             .AddSingleton<IPlayerWeatherTracker>(sp => sp.GetRequiredService<PlayerWeatherTracker>())
             .AddHostedService(sp => sp.GetRequiredService<PlayerWeatherTracker>());
+
+        // PG world server catalog parsed from Player.log's `Servers: [ … ]`
+        // startup line (#610). Reference-scope (immutable per attach) — the
+        // join target for ConnectionEventParser (#611) which augments
+        // IGameSessionService with a Server field. Catalog stays empty when
+        // Mithril cold-starts mid-PG-session (L0's seed skips the preamble);
+        // populates on a PG-restart-while-Mithril-runs (truncation re-seeds
+        // L0 from byte 0). Consumers handle the empty case explicitly.
+        services.AddSingleton<ServerCatalogParser>();
+        services
+            .AddSingleton<ServerCatalogService>()
+            .AddSingleton<IServerCatalogService>(sp => sp.GetRequiredService<ServerCatalogService>())
+            .AddHostedService(sp => sp.GetRequiredService<ServerCatalogService>());
 
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();

--- a/src/Mithril.GameState/Servers/IServerCatalogService.cs
+++ b/src/Mithril.GameState/Servers/IServerCatalogService.cs
@@ -1,0 +1,47 @@
+namespace Mithril.GameState.Servers;
+
+/// <summary>
+/// Reference-scope catalog of PG world servers, parsed once at attach from
+/// Player.log's <c>Servers: [ … ]</c> startup line. Immutable for the
+/// Mithril attach lifetime — PG re-emits the same catalog every launch and
+/// the set is stable across PG patches, so the service exposes lookup +
+/// enumeration only, not mutation or change notifications.
+///
+/// <para><b>The join target for #611.</b> <c>ConnectionEventParser</c>
+/// observes <c>EVENT(Ok): connected, url=&lt;url&gt;</c> lines and looks up
+/// the matching <see cref="ServerEntry"/> here to derive the
+/// <c>GameSession.Server</c> name. <c>Get(url)</c>'s nullable return
+/// reflects the only honest behaviour: when Mithril cold-starts mid-PG-
+/// session, L0's seed strategy seeks past the preamble (the <c>Servers:</c>
+/// line lives there) and the catalog stays empty for the attach lifetime
+/// — a consumer trying to resolve <c>connected, url=…</c> in that mode
+/// gets <c>null</c> rather than a fabricated default. The catalog
+/// populates when Mithril attaches BEFORE PG launches, or when PG restarts
+/// while Mithril is running (file truncation re-seeds L0 from byte 0).</para>
+///
+/// <para>Five servers are observed in current logs (s0=Arisetsu …
+/// s4=Laeth). The shape is intentionally reference-data-like; an
+/// alternative implementation could ship a bundled fallback in
+/// <c>Mithril.Reference</c>. The log-derived path is the canonical input,
+/// per #610's spec.</para>
+/// </summary>
+public interface IServerCatalogService
+{
+    /// <summary>
+    /// Look up a server by its connection host (e.g.
+    /// <c>"s4.projectgorgon.com"</c>). Case-insensitive — PG canonicalizes
+    /// hostnames to lowercase but consumers' <c>connected, url=…</c>
+    /// strings may have either case in principle. Returns <c>null</c> if
+    /// no entry matches, including the empty-catalog case described on the
+    /// interface summary.
+    /// </summary>
+    ServerEntry? Get(string url);
+
+    /// <summary>
+    /// All known server entries in PG's emission order (which happens to be
+    /// highest-id first in current logs, but the order is not contractual).
+    /// Empty until the parser has observed a <c>Servers:</c> line; once
+    /// populated, stable for the attach lifetime.
+    /// </summary>
+    IReadOnlyCollection<ServerEntry> All { get; }
+}

--- a/src/Mithril.GameState/Servers/Parsing/ServerCatalogEvent.cs
+++ b/src/Mithril.GameState/Servers/Parsing/ServerCatalogEvent.cs
@@ -1,0 +1,13 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Servers.Parsing;
+
+/// <summary>
+/// The parsed <c>Servers: [ … ]</c> startup line. Carries the full catalog
+/// — PG always emits all servers in one line, so each event represents a
+/// complete snapshot rather than an incremental delta. <see cref="Entries"/>
+/// is ordered exactly as PG emitted it (which happens to be highest-id
+/// first in current logs, but the parser does not depend on that).
+/// </summary>
+public sealed record ServerCatalogEvent(DateTime Timestamp, IReadOnlyList<ServerEntry> Entries)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Servers/Parsing/ServerCatalogParser.cs
+++ b/src/Mithril.GameState/Servers/Parsing/ServerCatalogParser.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Servers.Parsing;
+
+/// <summary>
+/// Parses the <c>Servers: [ … ]</c> startup line PG emits after fetching
+/// <c>clientconfig.json</c>. Consumes the envelope-stripped payload from
+/// <see cref="SystemSignalLogLine.Data"/> (L0.5 classifier eats the
+/// <c>Servers: </c> prefix per <see cref="SystemSignalKind.Servers"/>) so
+/// the parser sees only the JSON array body:
+///
+/// <code>
+/// [ { "AllowGuests" : true, "Port" : 9002, "Description" : "&lt;b&gt;Laeth - …&lt;/b&gt;\n…", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" }, … ]
+/// </code>
+///
+/// <para>The JSON shape is PG-canonical — single line, all entries
+/// present, fields not in a fixed order across entries. We use
+/// <c>System.Text.Json</c> rather than the live-log regex idiom because:</para>
+/// <list type="bullet">
+///   <item>The payload is real JSON (not a verb-style <c>Verb(arg, arg)</c>
+///   shape); a hand regex would have to re-implement string-escape handling.</item>
+///   <item>Field ordering varies; a positional regex would be fragile.</item>
+///   <item>The line is parsed once per attach, not per frame; allocation
+///   cost is negligible.</item>
+/// </list>
+///
+/// <para>Unrelated lines fast-path to <c>null</c>. Malformed JSON (truncated
+/// payload, missing required fields, non-numeric port) returns <c>null</c>
+/// rather than throwing — the parser never throws on production input.
+/// All-or-nothing semantics: if any entry fails to parse, the whole event
+/// is dropped. PG emits the catalog atomically; a partial parse would be
+/// misleading.</para>
+/// </summary>
+public sealed class ServerCatalogParser : ILogParser
+{
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(line)) return null;
+
+        // The L0.5 classifier strips the "Servers: " prefix for SystemSignal
+        // payloads, so the production caller passes the bare "[ { … } ]"
+        // body. Defensively accept the prefixed form too — test fixtures
+        // and ad-hoc callers occasionally pass the raw line.
+        var payload = line;
+        if (line.StartsWith("Servers: ", StringComparison.Ordinal))
+        {
+            payload = line.Substring("Servers: ".Length);
+        }
+
+        var trimmed = payload.AsSpan().TrimStart();
+        if (trimmed.IsEmpty || trimmed[0] != '[') return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+
+            var entries = new List<ServerEntry>(doc.RootElement.GetArrayLength());
+            foreach (var item in doc.RootElement.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) return null;
+                if (!TryReadEntry(item, out var entry)) return null;
+                entries.Add(entry);
+            }
+
+            return new ServerCatalogEvent(timestamp, entries);
+        }
+        catch (JsonException)
+        {
+            // Truncated payload, embedded control character PG escaped
+            // incorrectly, etc. Treat as "not a catalog line".
+            return null;
+        }
+    }
+
+    private static bool TryReadEntry(JsonElement obj, out ServerEntry entry)
+    {
+        entry = null!;
+
+        if (!obj.TryGetProperty("ID", out var idEl) || idEl.ValueKind != JsonValueKind.String) return false;
+        if (!obj.TryGetProperty("Name", out var nameEl) || nameEl.ValueKind != JsonValueKind.String) return false;
+        if (!obj.TryGetProperty("Url", out var urlEl) || urlEl.ValueKind != JsonValueKind.String) return false;
+        if (!obj.TryGetProperty("Port", out var portEl) || portEl.ValueKind != JsonValueKind.Number) return false;
+        if (!portEl.TryGetInt32(out var port)) return false;
+        // Description is allowed to be absent or empty — PG always emits it
+        // today, but treat it as best-effort metadata rather than a hard
+        // requirement so a future PG patch that drops the field doesn't
+        // break the catalog.
+        var description = obj.TryGetProperty("Description", out var descEl)
+                            && descEl.ValueKind == JsonValueKind.String
+            ? descEl.GetString() ?? string.Empty
+            : string.Empty;
+
+        var id = idEl.GetString();
+        var name = nameEl.GetString();
+        var url = urlEl.GetString();
+        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(name) || string.IsNullOrEmpty(url))
+            return false;
+
+        entry = new ServerEntry(id, name, url, port, description);
+        return true;
+    }
+}

--- a/src/Mithril.GameState/Servers/ServerCatalogService.cs
+++ b/src/Mithril.GameState/Servers/ServerCatalogService.cs
@@ -1,0 +1,150 @@
+using Mithril.GameState.Servers.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace Mithril.GameState.Servers;
+
+/// <summary>
+/// Hosted-service implementation of <see cref="IServerCatalogService"/>.
+/// Subscribes to the L1 (#550) driver's unified classified pipe filtered
+/// for <see cref="SystemSignalKind.Servers"/> envelopes (#610), parses each
+/// via <see cref="ServerCatalogParser"/>, and folds the result into a
+/// <c>Url → ServerEntry</c> dictionary.
+///
+/// <para><b>Last-writer-wins.</b> PG emits the catalog once per launch.
+/// If the service observes a second emission (PG-restart-while-Mithril-
+/// runs), the new catalog atomically replaces the prior one — the live
+/// PG client's view is always more recent. Subsequent <see cref="Get"/>
+/// calls reflect the new view immediately.</para>
+///
+/// <para><b>Reference-scope, no <c>Subscribe(…)</c>.</b> Unlike
+/// <see cref="Mithril.GameState.Celestial.IPlayerCelestialState"/> or
+/// <see cref="Mithril.GameState.Movement.IPlayerPositionTracker"/>, the
+/// catalog is not live state consumers react to — it's a lookup table.
+/// A future consumer that needs change notifications can add the same
+/// replay-on-Subscribe pattern; #611 (ConnectionEventParser) does not need
+/// it because connect-events arrive after the catalog is populated when
+/// it's going to be populated at all.</para>
+///
+/// <para><b>Threading.</b> The L1 driver delivers envelopes on its pump
+/// thread (archetype-A default = <c>DeliveryContext.Inline</c>); reads of
+/// <see cref="All"/> and <see cref="Get"/> happen under <c>_lock</c>. Both
+/// are O(1) / O(n) over a fixed-size catalog, so contention is negligible.</para>
+/// </summary>
+public sealed class ServerCatalogService : BackgroundService, IServerCatalogService
+{
+    private readonly ILogStreamDriver _driver;
+    private readonly ServerCatalogParser _parser;
+    private readonly IDiagnosticsSink? _diag;
+
+    private readonly object _lock = new();
+    // Url → entry, case-insensitive on lookup. The dictionary is replaced
+    // wholesale on each parse so readers never see a partially-populated
+    // catalog.
+    private Dictionary<string, ServerEntry> _byUrl = new(StringComparer.OrdinalIgnoreCase);
+    private IReadOnlyCollection<ServerEntry> _allView = Array.Empty<ServerEntry>();
+    private ILogSubscription? _subscription;
+
+    private const string DiagCategory = "GameState.ServerCatalog";
+
+    public ServerCatalogService(
+        ILogStreamDriver driver,
+        ServerCatalogParser parser,
+        IDiagnosticsSink? diag = null)
+    {
+        _driver = driver;
+        _parser = parser;
+        _diag = diag;
+    }
+
+    /// <inheritdoc/>
+    public ServerEntry? Get(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return null;
+        lock (_lock)
+        {
+            return _byUrl.TryGetValue(url, out var entry) ? entry : null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<ServerEntry> All
+    {
+        get { lock (_lock) return _allView; }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _diag?.Info(DiagCategory,
+            "Subscribing to L1 driver (SystemSignal pipe) for Servers: catalog line");
+        // archetype-A defaults — FromSessionStart replay + Inline delivery.
+        // The classifier strips "Servers: " so envelope.Payload.Data is the
+        // bare JSON array body.
+        _subscription = _driver.Subscribe<SystemSignalLogLine>(
+            envelope =>
+            {
+                var signal = envelope.Payload;
+                if (signal.Kind != SystemSignalKind.Servers) return ValueTask.CompletedTask;
+
+                var ts = signal.Timestamp.UtcDateTime;
+                if (_parser.TryParse(signal.Data, ts) is ServerCatalogEvent evt)
+                {
+                    UpdateCatalog(evt);
+                    _diag?.Info(DiagCategory,
+                        $"Parsed {evt.Entries.Count} server(s): " +
+                        string.Join(", ", evt.Entries.Select(e => $"{e.Id}={e.Name}")));
+                }
+                else
+                {
+                    _diag?.Warn(DiagCategory,
+                        $"Failed to parse Servers: payload (length {signal.Data.Length}); " +
+                        "catalog unchanged. Sample: " +
+                        (signal.Data.Length > 160 ? signal.Data.Substring(0, 160) + "…" : signal.Data));
+                }
+
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = DiagCategory,
+            });
+
+        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected on host stop */ }
+        finally
+        {
+            _subscription?.Dispose();
+            _subscription = null;
+        }
+    }
+
+    public override void Dispose()
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        base.Dispose();
+    }
+
+    private void UpdateCatalog(ServerCatalogEvent evt)
+    {
+        // Build the new dictionary outside the lock; swap atomically under
+        // the lock. Readers always see either the old or the new map —
+        // never a half-populated transition state.
+        var next = new Dictionary<string, ServerEntry>(
+            evt.Entries.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in evt.Entries)
+        {
+            // Duplicate URL would be a PG bug; last-wins is harmless.
+            next[entry.Url] = entry;
+        }
+        var view = evt.Entries.ToArray();
+        lock (_lock)
+        {
+            _byUrl = next;
+            _allView = view;
+        }
+    }
+}

--- a/src/Mithril.GameState/Servers/ServerEntry.cs
+++ b/src/Mithril.GameState/Servers/ServerEntry.cs
@@ -1,0 +1,36 @@
+namespace Mithril.GameState.Servers;
+
+/// <summary>
+/// One PG world server, parsed from the <c>Servers: [ { … }, … ]</c> JSON
+/// array PG emits at startup. The catalog is the join target for
+/// <c>ConnectionEventParser</c> (#611) — incoming <c>EVENT(Ok): connected,
+/// url=…</c> lines look up the server by <see cref="Url"/> to resolve the
+/// human-facing <see cref="Name"/> for <c>IGameSessionService.Server</c>.
+///
+/// <para>Five servers exist in the corpus today (<c>s0</c>=Arisetsu …
+/// <c>s4</c>=Laeth); the set is stable across PG patches but not part of
+/// any bundled reference data — the catalog is purely log-derived per #610
+/// so a future server addition surfaces automatically the next time
+/// Mithril observes the <c>Servers:</c> line.</para>
+///
+/// <para><see cref="Description"/> carries PG's marketing copy verbatim
+/// (BBCode + JSON-escaped newlines included). It is preserved for the rare
+/// debug surface; production consumers should display <see cref="Name"/>.</para>
+/// </summary>
+/// <param name="Id">PG server id (<c>s0</c>–<c>s4</c>). Stable across the
+/// catalog's lifetime; safe to use as a dictionary key alongside
+/// <see cref="Url"/>.</param>
+/// <param name="Name">Human-facing world name (<c>Arisetsu</c>, <c>Dreva</c>,
+/// <c>Strekios</c>, <c>Miraverre</c>, <c>Laeth</c>, …). The value populated
+/// into <c>GameSession.Server</c> by #611.</param>
+/// <param name="Url">Connection host (e.g. <c>s4.projectgorgon.com</c>). The
+/// join key for <c>EVENT(Ok): connected, url=…</c> events.</param>
+/// <param name="Port">TCP port the client connects to.</param>
+/// <param name="Description">PG's marketing description for the world.
+/// Verbatim — BBCode tags and embedded newlines preserved.</param>
+public sealed record ServerEntry(
+    string Id,
+    string Name,
+    string Url,
+    int Port,
+    string Description);

--- a/src/Mithril.Shared/Logging/PlayerLogLineClassifier.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogLineClassifier.cs
@@ -86,6 +86,19 @@ internal static class PlayerLogLineClassifier
             return new Result(LineKind.Discard, -1, 0, default);
         }
 
+        // Servers: [ { … } ] — no [ts], preamble-territory system signal.
+        // PG emits this once per launch after fetching clientconfig.json,
+        // before the login banner. The trailing `[ ` discriminator keeps the
+        // rule narrow — a prose log line that happened to start with the
+        // word "Servers:" would not match. Consumed by ServerCatalogService
+        // (#610) to populate the Url→ServerEntry catalog ConnectionEvent-
+        // Parser (#611) joins against.
+        if (StartsWithLiteral(line, "Servers: ["))
+        {
+            const int dataStart = 9; // length of "Servers: "
+            return new Result(LineKind.SystemSignal, dataStart, 0, SystemSignalKind.Servers);
+        }
+
         // EVENT(Ok): lifecycle phases — no [ts], system-signal pipe.
         // Verify the EVENT( prefix and (Ok) parens, then look at the verb
         // after the colon-space.

--- a/src/Mithril.Shared/Logging/SystemSignalKind.cs
+++ b/src/Mithril.Shared/Logging/SystemSignalKind.cs
@@ -37,4 +37,18 @@ public enum SystemSignalKind
     /// window and is handled by #514's seed facility, not here.
     /// </summary>
     SessionLifecycle,
+
+    /// <summary>
+    /// <c>Servers: [ { … }, … ]</c> — the JSON array of PG world servers
+    /// emitted once at startup after the client fetches
+    /// <c>clientconfig.json</c>. No <c>[ts]</c> prefix; lives in the preamble
+    /// before the login banner. Consumed by <c>ServerCatalogService</c>
+    /// (#610) to populate the <c>Url → ServerEntry</c> catalog that
+    /// <c>ConnectionEventParser</c> (#611) joins against. Only reaches L0.5
+    /// when L0's session-replay window opens at byte 0 (Mithril attached
+    /// before PG launched, or PG-truncation-while-Mithril-runs); a Mithril
+    /// cold-start mid-PG-session seeks past the preamble and never sees it,
+    /// in which case the catalog stays empty for the attach lifetime.
+    /// </summary>
+    Servers,
 }

--- a/tests/Mithril.GameState.Tests/Servers/ServerCatalogParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Servers/ServerCatalogParserTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using Mithril.GameState.Servers;
+using Mithril.GameState.Servers.Parsing;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Servers;
+
+public sealed class ServerCatalogParserTests
+{
+    private static readonly ServerCatalogParser Parser = new();
+    private static readonly DateTime Ts = new(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Real Player.log payload (this machine, 2026-05-21) — five PG worlds
+    /// in PG's actual emission order (s4..s0). Envelope-stripped per the
+    /// L0.5 classifier (SystemSignalKind.Servers eats the "Servers: "
+    /// prefix). Kept verbatim so a PG patch that changes the shape shows
+    /// up as a test diff.
+    /// </summary>
+    private const string RealStrippedPayload =
+        """[ { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Laeth - \"Time and Space\"</b>\nA brand new world! Help forge a new community that can withstand the onslaught of the coming demon army.", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Miraverre - \"Dreams\"</b>\nA brand new world! Help forge a new community that can withstand the onslaught of the coming demon army.", "Url" : "s3.projectgorgon.com", "ID" : "s3", "Name" : "Miraverre" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Strekios - \"Self Improvement\"</b>\nA brand new world! Help forge a new community that can withstand the onslaught of the coming demon army.", "Url" : "s2.projectgorgon.com", "ID" : "s2", "Name" : "Strekios" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Dreva - \"Balance\"</b>\nAn almost-brand-new world! Help forge a new community that can withstand the onslaught of the coming demon army.", "Url" : "s1.projectgorgon.com", "ID" : "s1", "Name" : "Dreva" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Arisetsu - \"Hope and Warmth\"</b>\nPlay on the original server from pre-launch. With more unlocked resources and a friendly established community, this is the easiest world for new players to start on.", "Url" : "s0.projectgorgon.com", "ID" : "s0", "Name" : "Arisetsu" } ]""";
+
+    [Fact]
+    public void Real_payload_parses_all_five_servers_in_emission_order()
+    {
+        var evt = Parser.TryParse(RealStrippedPayload, Ts)
+            .Should().BeOfType<ServerCatalogEvent>().Subject;
+
+        evt.Timestamp.Should().Be(Ts);
+        evt.Entries.Should().HaveCount(5);
+
+        var entries = evt.Entries.ToArray();
+        entries[0].Should().BeEquivalentTo(new ServerEntry(
+            "s4", "Laeth", "s4.projectgorgon.com", 9002,
+            "<b>Laeth - \"Time and Space\"</b>\nA brand new world! Help forge a new community that can withstand the onslaught of the coming demon army."));
+        entries[1].Id.Should().Be("s3");
+        entries[1].Name.Should().Be("Miraverre");
+        entries[2].Id.Should().Be("s2");
+        entries[2].Name.Should().Be("Strekios");
+        entries[3].Id.Should().Be("s1");
+        entries[3].Name.Should().Be("Dreva");
+        entries[4].Should().BeEquivalentTo(new ServerEntry(
+            "s0", "Arisetsu", "s0.projectgorgon.com", 9002,
+            "<b>Arisetsu - \"Hope and Warmth\"</b>\nPlay on the original server from pre-launch. With more unlocked resources and a friendly established community, this is the easiest world for new players to start on."));
+    }
+
+    [Fact]
+    public void Description_bbcode_and_embedded_newlines_are_preserved_verbatim()
+    {
+        var evt = Parser.TryParse(RealStrippedPayload, Ts)
+            .Should().BeOfType<ServerCatalogEvent>().Subject;
+
+        // The JSON decoder unescapes `\"` and `\n`; the surviving Description
+        // string should contain the literal characters PG intended.
+        evt.Entries.First(e => e.Id == "s4").Description.Should().Contain("\"Time and Space\"");
+        evt.Entries.First(e => e.Id == "s4").Description.Should().Contain("\n"); // real newline
+    }
+
+    [Fact]
+    public void Raw_prefixed_form_is_accepted_for_ad_hoc_callers()
+    {
+        // Defensive — production callers pass the L0.5-stripped form, but a
+        // test or REPL caller may hand the full "Servers: [ … ]" line.
+        var raw = "Servers: " + RealStrippedPayload;
+        var evt = Parser.TryParse(raw, Ts)
+            .Should().BeOfType<ServerCatalogEvent>().Subject;
+        evt.Entries.Should().HaveCount(5);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("LOADING LEVEL AreaSerbule")]
+    [InlineData("Servers: not-an-array")]
+    [InlineData("[ { \"Url\": \"s9.projectgorgon.com\" } ]")] // missing required ID/Name/Port
+    [InlineData("[ ")] // truncated JSON
+    [InlineData("[ { \"ID\": \"sX\", \"Name\": \"X\", \"Url\": \"s.foo\", \"Port\": \"nope\" } ]")] // non-numeric port
+    public void Returns_null_for_unrelated_or_malformed_lines(string line)
+    {
+        Parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_when_any_entry_is_invalid_so_partial_catalogs_never_publish()
+    {
+        // First entry is fine, second is missing Url — entire event should be
+        // dropped rather than publish a partial catalog.
+        const string partiallyBad =
+            """[ { "ID": "s0", "Name": "Arisetsu", "Url": "s0.projectgorgon.com", "Port": 9002, "Description": "..." }, { "ID": "s1", "Name": "Dreva", "Port": 9002, "Description": "..." } ]""";
+        Parser.TryParse(partiallyBad, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void Description_is_optional_to_survive_PG_dropping_the_field()
+    {
+        const string descLess =
+            """[ { "ID": "s0", "Name": "Arisetsu", "Url": "s0.projectgorgon.com", "Port": 9002 } ]""";
+        var evt = Parser.TryParse(descLess, Ts)
+            .Should().BeOfType<ServerCatalogEvent>().Subject;
+
+        evt.Entries.Should().ContainSingle()
+            .Which.Description.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Empty_array_parses_to_empty_catalog()
+    {
+        // PG never emits this in practice but the parser shouldn't choke.
+        var evt = Parser.TryParse("[]", Ts)
+            .Should().BeOfType<ServerCatalogEvent>().Subject;
+        evt.Entries.Should().BeEmpty();
+    }
+}

--- a/tests/Mithril.GameState.Tests/Servers/ServerCatalogServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Servers/ServerCatalogServiceTests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using Mithril.GameState.Servers;
+using Mithril.GameState.Servers.Parsing;
+using Mithril.GameState.Tests.TestSupport;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Servers;
+
+public sealed class ServerCatalogServiceTests
+{
+    private static readonly DateTimeOffset Stamp = new(2026, 5, 21, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Real Player.log payload, envelope-stripped per L0.5
+    /// (SystemSignalKind.Servers eats the "Servers: " prefix).
+    /// </summary>
+    private const string RealStrippedPayload =
+        """[ { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Laeth - \"Time and Space\"</b>\nA brand new world!", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Arisetsu - \"Hope and Warmth\"</b>\nPlay on the original.", "Url" : "s0.projectgorgon.com", "ID" : "s0", "Name" : "Arisetsu" } ]""";
+
+    private const string UpdatedPayload =
+        """[ { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Laeth - \"Time and Space\"</b>\nA brand new world!", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" } ]""";
+
+    private static ServerCatalogService NewService(
+        TestLogStreamDriver driver, IDiagnosticsSink? diag = null) =>
+        new(driver, new ServerCatalogParser(), diag);
+
+    private static SystemSignalLogLine MakeServersSignal(string strippedPayload) =>
+        new(Stamp, SystemSignalKind.Servers, strippedPayload,
+            Sequence: 0, ReadMonotonicTicks: 0);
+
+    [Fact]
+    public async Task Cold_start_catalog_is_empty()
+    {
+        using var driver = new TestLogStreamDriver();
+        var svc = NewService(driver);
+        try
+        {
+            // Push an unrelated SystemSignal so the pump has something to drain.
+            driver.PushLive(new SystemSignalLogLine(
+                Stamp, SystemSignalKind.AreaLoading, "LOADING LEVEL AreaSerbule",
+                Sequence: 0, ReadMonotonicTicks: 0));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.All.Should().BeEmpty();
+            svc.Get("s0.projectgorgon.com").Should().BeNull();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Servers_signal_populates_catalog_and_lookup_resolves()
+    {
+        using var driver = new TestLogStreamDriver();
+        var svc = NewService(driver);
+        try
+        {
+            driver.PushLive(MakeServersSignal(RealStrippedPayload));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.All.Should().HaveCount(2);
+            svc.Get("s4.projectgorgon.com").Should().NotBeNull();
+            svc.Get("s4.projectgorgon.com")!.Name.Should().Be("Laeth");
+            svc.Get("s0.projectgorgon.com").Should().NotBeNull();
+            svc.Get("s0.projectgorgon.com")!.Id.Should().Be("s0");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Get_is_case_insensitive_on_url()
+    {
+        // PG canonicalizes hostnames to lowercase, but a future consumer
+        // might pass an uppercased form (e.g. raw EVENT line). The lookup
+        // should still resolve.
+        using var driver = new TestLogStreamDriver();
+        var svc = NewService(driver);
+        try
+        {
+            driver.PushLive(MakeServersSignal(RealStrippedPayload));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Get("S4.ProjectGorgon.com").Should().NotBeNull();
+            svc.Get("S4.ProjectGorgon.com")!.Id.Should().Be("s4");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Get_returns_null_for_unknown_url()
+    {
+        using var driver = new TestLogStreamDriver();
+        var svc = NewService(driver);
+        try
+        {
+            driver.PushLive(MakeServersSignal(RealStrippedPayload));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Get("s9.projectgorgon.com").Should().BeNull();
+            svc.Get("").Should().BeNull();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Second_emission_replaces_catalog_atomically()
+    {
+        // PG-restart-while-Mithril-runs: a fresh Servers: line arrives;
+        // the new catalog wins. Older entries that aren't in the new payload
+        // disappear; lookups for them return null again.
+        using var driver = new TestLogStreamDriver();
+        var svc = NewService(driver);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            driver.PushLive(MakeServersSignal(RealStrippedPayload));
+            await driver.DrainSystemAsync().WaitAsync(cts.Token);
+            svc.All.Should().HaveCount(2);
+
+            driver.PushLive(MakeServersSignal(UpdatedPayload));
+            await driver.DrainSystemAsync().WaitAsync(cts.Token);
+
+            svc.All.Should().ContainSingle().Which.Id.Should().Be("s4");
+            svc.Get("s0.projectgorgon.com").Should().BeNull(
+                "the second emission omitted s0, so the prior entry must be evicted");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Other_system_signals_are_ignored()
+    {
+        using var driver = new TestLogStreamDriver();
+        var svc = NewService(driver);
+        try
+        {
+            driver.PushLive(new SystemSignalLogLine(
+                Stamp, SystemSignalKind.AreaLoading, "LOADING LEVEL AreaSerbule", 0, 0));
+            driver.PushLive(new SystemSignalLogLine(
+                Stamp, SystemSignalKind.LoginBanner, "Logged in as character Emraell. Time UTC=...", 0, 0));
+            driver.PushLive(new SystemSignalLogLine(
+                Stamp, SystemSignalKind.SessionLifecycle, "EVENT(Ok): playing", 0, 0));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.All.Should().BeEmpty();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Malformed_servers_payload_leaves_catalog_unchanged_and_warns()
+    {
+        using var driver = new TestLogStreamDriver();
+        var diag = new DiagnosticsSink();
+        var svc = NewService(driver, diag);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            // First: real payload populates the catalog.
+            driver.PushLive(MakeServersSignal(RealStrippedPayload));
+            await driver.DrainSystemAsync().WaitAsync(cts.Token);
+            svc.All.Should().HaveCount(2);
+
+            // Then: a malformed line. Catalog must stay populated (the prior
+            // good view); a warn diagnostic surfaces the failure.
+            driver.PushLive(MakeServersSignal("[ totally not json"));
+            await driver.DrainSystemAsync().WaitAsync(cts.Token);
+
+            svc.All.Should().HaveCount(2, "the malformed payload must NOT clear the prior catalog");
+            diag.Snapshot().Should().Contain(e =>
+                e.Level == DiagnosticLevel.Warn
+                && e.Category == "GameState.ServerCatalog"
+                && e.Message.Contains("Failed to parse"));
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Replay_envelope_is_processed_same_as_live()
+    {
+        // Production attaches with ReplayMode.FromSessionStart, so the Servers:
+        // line typically arrives as IsReplay=true. The service must treat it
+        // identically.
+        using var driver = new TestLogStreamDriver();
+        driver.PushReplay(MakeServersSignal(RealStrippedPayload));
+        var svc = NewService(driver);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var runTask = svc.StartAsync(cts.Token);
+            await driver.DrainSystemAsync().WaitAsync(cts.Token);
+
+            svc.All.Should().HaveCount(2);
+            svc.Get("s4.projectgorgon.com")!.Name.Should().Be("Laeth");
+
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+        }
+        finally { svc.Dispose(); }
+    }
+
+    private static async Task RunUntilDrainedAsync(ServerCatalogService svc, TestLogStreamDriver driver)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var runTask = svc.StartAsync(cts.Token);
+        await driver.DrainSystemAsync().WaitAsync(cts.Token);
+        await cts.CancelAsync();
+        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        _ = runTask;
+    }
+
+    private static async Task StopAsync(ServerCatalogService svc)
+    {
+        try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
+        catch { /* test cleanup */ }
+        svc.Dispose();
+    }
+}

--- a/tests/Mithril.Shared.Tests/Logging/Fixtures/per-rule/system-signals.log
+++ b/tests/Mithril.Shared.Tests/Logging/Fixtures/per-rule/system-signals.log
@@ -2,6 +2,7 @@
 [20:01:14] LOADING LEVEL AreaKurMountains
 [20:01:14] Logged in as character <CHARACTER>. Time UTC=05/19/2026 20:01:14. Timezone Offset 01:00:00
 [21:04:45] Logged in as character <CHARACTER>. Time UTC=05/19/2026 21:04:45. Timezone Offset 01:00:00
+Servers: [ { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Laeth - \"Time and Space\"</b>\nA brand new world!", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Arisetsu - \"Hope and Warmth\"</b>\nPlay on the original.", "Url" : "s0.projectgorgon.com", "ID" : "s0", "Name" : "Arisetsu" } ]
 EVENT(Ok): loginCharacter, numChars=2
 EVENT(Ok): sessionUpdate, playTime=300
 EVENT(Ok): playing

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogLineClassifierTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogLineClassifierTests.cs
@@ -129,6 +129,34 @@ public sealed class PlayerLogLineClassifierTests
         kinds.Should().Contain(SystemSignalKind.LoginBanner);
         kinds.Should().Contain(SystemSignalKind.PlayerAdded);
         kinds.Should().Contain(SystemSignalKind.SessionLifecycle);
+        kinds.Should().Contain(SystemSignalKind.Servers);
+    }
+
+    [Fact]
+    public void Servers_line_classifies_as_SystemSignal_and_eats_prefix()
+    {
+        // The no-[ts] preamble line PG emits after fetching clientconfig.json.
+        const string line =
+            """Servers: [ { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Laeth</b>", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" } ]""";
+        var r = PlayerLogLineClassifier.Classify(line);
+
+        r.Kind.Should().Be(PlayerLogLineClassifier.LineKind.SystemSignal);
+        r.SystemKind.Should().Be(SystemSignalKind.Servers);
+        // The "Servers: " envelope must be eaten; the payload begins with `[`.
+        r.DataStart.Should().Be("Servers: ".Length);
+        line[r.DataStart..].Should().StartWith("[");
+    }
+
+    [Fact]
+    public void Servers_prefix_without_array_does_not_match()
+    {
+        // Narrow trigger — anything not `Servers: [` falls through to other
+        // rules (or to Anomaly). Guards against absorbing unrelated lines
+        // that happen to begin with "Servers:".
+        PlayerLogLineClassifier.Classify("Servers: <not-an-array>").Kind
+            .Should().NotBe(PlayerLogLineClassifier.LineKind.SystemSignal);
+        PlayerLogLineClassifier.Classify("Servers:").Kind
+            .Should().NotBe(PlayerLogLineClassifier.LineKind.SystemSignal);
     }
 
     // --- Merged corpus: bucket distribution + anomaly cap ---


### PR DESCRIPTION
## Summary

Implements #610 — the standalone parallel-track parser for PG's `Servers: [ … ]` startup line. Adds `IServerCatalogService` (Url → `ServerEntry`) as the join target #611 (`ConnectionEventParser`) will need to derive `GameSession.Server` from `EVENT(Ok): connected, url=…`.

Five PG worlds parsed from real Player.log: s0=Arisetsu, s1=Dreva, s2=Strekios, s3=Miraverre, s4=Laeth. Reference-scope, immutable per attach.

## Design decision: GameState service, not Mithril.Reference entry

The spec offered two homes for the catalog. I picked the GameState service for these reasons:

- **The spec mandates a parser** ("Parser implemented for the `Servers: [ … ]` startup line"). Treating this as static reference data would invert that requirement — the log is the canonical input.
- **Co-location with the consumer.** #611 (`ConnectionEventParser`) is the immediate consumer; folding the service into `IGameSessionService`'s neighbourhood beats a cross-assembly hop.
- **`Mithril.Reference` is for CDN-versioned game data** (items, recipes, NPCs) — not log-derived sessionful state. The `reference_data_refresh_vs_bundled` heuristic prefers bundling for "stable-across-patches" data, but a bundled fallback can land as a follow-up if we ever want one; it's orthogonal to this parser.

**Trade-off this picks up:** when Mithril cold-starts mid-PG-session, L0's `SeedToSessionStart` seeks past the preamble (`Servers:` lives before the `Logged in as character` marker), so the catalog stays empty for the attach lifetime. Consumers handle `Get(url) == null` explicitly — honest about what we observed, no fabricated default. The catalog populates when:
- Mithril attaches **before** PG launches (the natural startup-companion case), or
- PG restarts while Mithril is running (file truncation re-seeds L0 from byte 0).

A bundled fallback (5 hard-coded servers in `Mithril.Reference`) is a small future enhancement if the empty-catalog case proves user-visible. The XMLDoc on `IServerCatalogService` flags this and the issue body documents the eventual `Mithril.Reference` option remains open.

## What's in the diff

**`Mithril.Shared` (classifier)**
- `SystemSignalKind.Servers` — new enum value
- `PlayerLogLineClassifier` rule for the no-`[ts]` `Servers: [` preamble shape (mirrors the existing `EVENT(Ok):` no-`[ts]` rule structurally)
- Fixture line + two classifier tests (kind + narrow-trigger)

**`Mithril.GameState/Servers/`**
- `ServerEntry` record — Id, Name, Url, Port, Description
- `ServerCatalogEvent : LogEvent` — parsed snapshot (PG emits the whole catalog atomically)
- `ServerCatalogParser` — `System.Text.Json` on the stripped payload; total `TryParse` (never throws, malformed → null); all-or-nothing on partial parses; tolerates missing optional `Description`
- `IServerCatalogService` + `ServerCatalogService` (BackgroundService) — L1 driver subscription filtered for `SystemSignalKind.Servers`, last-writer-wins, atomic dictionary swap, case-insensitive Url lookup

**Tests** (`tests/Mithril.GameState.Tests/Servers/`)
- Parser: real-corpus payload, BBCode/newlines preservation, raw-prefix tolerance, malformed/partial/missing-field paths, empty-array edge
- Service: cold-start empty, single emission, atomic catalog replacement, case-insensitive lookup, kind filtering, malformed payload preserves prior view + warns, replay envelope parity

## Test plan

- [x] `dotnet build Mithril.slnx` clean (no warnings, warnings-as-errors enforced)
- [x] `dotnet test tests/Mithril.GameState.Tests` — 345/345 pass (21 new Servers tests)
- [x] `dotnet test tests/Mithril.Shared.Tests` — 1248/1248 pass (classifier changes covered)
- [x] `dotnet test Mithril.slnx` — full solution green
- [ ] Manual smoke (deferred to reviewer / next launch): start Mithril before PG, confirm catalog populates from log; restart PG, confirm last-writer-wins

## References

- Spec: #610 issue body
- Umbrella: #601 (world-simulator architecture migration)
- Design notebook: `docs/world-simulator.md` §Migration path #9
- Module signal map: `docs/module-signal-map.md` §`IServerCatalogService` (planned)
- Unblocks: #611 (ConnectionEventParser)

Closes #610.
