### PR TITLE
feat(world-sim): per-PR shepherd + specialist reviewer subagents

### DIFF
--- a/.claude/agents/world-sim-reviewer.md
+++ b/.claude/agents/world-sim-reviewer.md
@@ -5,7 +5,7 @@ description: World-sim migration specialist reviewer. Use when a world-sim migra
 
 # World-sim migration specialist reviewer
 
-You review one world-sim migration PR against the four specializations defined in `docs/world-sim-shepherd.md`. You do not edit code, do not push commits, and do not post PR comments — your caller handles that.
+You review one world-sim migration PR against the four checks defined below. You do not edit code, do not push commits, and do not post PR comments — your caller handles that.
 
 ## Inputs
 
@@ -14,7 +14,7 @@ The caller provides:
 - `issue` — GitHub issue number this PR addresses
 - `phase` — phase classification from the orchestration plan (e.g., `0a`, `0b`, `1`, `2`, `3`, `4`, `parallel`)
 
-If any is missing, ask once for the missing field; do not proceed without all three.
+If `pr`, `issue`, or `phase` is missing, ask once for the missing field; do not proceed without all three.
 
 ## Required reading
 
@@ -40,7 +40,7 @@ For each changed file, evaluate against the 13 numbered principles in `docs/worl
 - **Principle 10** — Three state-machine kinds (folders, composers, producers). A migration PR adding a folder that emits domain frames (rather than change events) is wrong. A composer that re-emits into the world's merger is wrong (composers chain via subscribe, never via merger re-entry).
 - **Principle 11** — Per-frame resolution is a finite DAG. A new composer that subscribes to an event type it itself emits creates a cycle.
 - **Principle 12** — Each world tracks `Mode`. Side-effect-emitting consumers (audio, OS notifications) must gate on `Mode == Live`. Code that fires an alarm without checking `Mode` is wrong.
-- **Principle 13** — Calendar time is a domain event. Code that reads `IWorldClock.Now` from an idle/wakeup path (rather than subscribing to `CalendarTimeAdvanced`) is suspect.
+- **Principle 13** — Calendar time is a domain event. Code that polls real wall-clock (`DateTime.UtcNow`, `Stopwatch`) to drive scheduling or idle wake-ups, rather than subscribing to `CalendarTimeAdvanced`, is suspect. Reading `IWorldClock.Now` (simulated time) is fine — that is what the architecture provides; the principle catches real-time leaks, not simulated-clock reads.
 
 ### Check 2 — Phase-aware migration
 
@@ -96,7 +96,7 @@ Apply the standard false-positive filters:
 Return a structured response. The shepherd parses this — keep it predictable.
 
 ```
-### World-sim specialist review — PR #N (phase P)
+### World-sim specialist review — PR #N / issue #I (phase P)
 
 **Verdict:** clean | findings
 

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -57,9 +57,11 @@ loop:
   if any review or comment with created_at > state.last_iteration_at by a non-bot account:
     return verdict("needs-human", reason: "human_review")
 
-  # Run reviewers in parallel (single message, two Agent calls)
+  # Run reviewers in parallel (single message, two Agent calls).
+  # The generic reviewer is dispatched as a general-purpose subagent with an
+  # inlined prompt template (see "Generic code review prompt" section below).
   review_results = parallel(
-    Agent(subagent_type: "code-reviewer", prompt: <generic-review prompt with pr=N>),
+    Agent(subagent_type: "general-purpose", prompt: <generic-review template with pr=N>),
     Agent(subagent_type: "world-sim-reviewer", prompt: <pr, issue, phase>)
   )
 
@@ -151,11 +153,48 @@ Final message includes a fenced JSON block the caller (orchestrator) parses:
 
 After the JSON block, include human-readable prose: a paragraph summarizing what happened, citing the final review's findings if `needs-human`. The orchestrator surfaces this verbatim when escalating.
 
+## Generic code review prompt
+
+When dispatching the generic reviewer Agent call in the loop, use this template (inline the PR number and a one-sentence framing):
+
+```
+You are doing a generic code review of a single PR.
+
+PR: #<N>
+
+Read:
+- `gh pr view <N> --json title,body,files,headRefOid,baseRefOid`
+- `gh pr diff <N>`
+- The root CLAUDE.md and any CLAUDE.md files in directories the PR touches
+
+Check:
+- Bugs (logic errors, null handling, race conditions, off-by-one)
+- CLAUDE.md compliance (project conventions, import patterns, error handling, naming)
+- Significant code-quality issues (duplication, missing critical error handling)
+
+Filter aggressively — confidence ≥ 80 only. Standard false-positive filters apply:
+- Pre-existing issues in main, not in this diff
+- Linter / typechecker / compiler concerns (CI catches these)
+- Lines the PR did not modify
+- Issues silenced explicitly in code (e.g., lint-ignore comments with justification)
+
+Output format:
+### Generic code review — PR #N
+
+**Verdict:** clean | findings
+
+[For each issue: file:line range, confidence score, one-line citation from CLAUDE.md if applicable, suggested fix]
+
+**Summary:** <one or two sentences>
+
+Do NOT run `dotnet build` or `dotnet test`. Do NOT post PR comments. Do NOT edit code.
+```
+
 ## Tools you use
 
 - `Read`, `Grep`, `Glob` — read the design doc, audit, orchestration plan, and any code referenced by review findings
 - `Bash` (constrained to `gh`) — `gh pr view`, `gh pr comment`, `gh pr diff`
-- `Agent` — dispatch `code-reviewer` (from pr-review-toolkit), `world-sim-reviewer` (the specialist), and `general-purpose` workers
+- `Agent` — dispatch `general-purpose` (for the generic reviewer with the inlined prompt above, and for workers) and `world-sim-reviewer` (the specialist)
 
 You do NOT have `Edit` or `Write`. You do NOT touch code. If you want a fix made, dispatch a worker; if the worker fails to push, escalate.
 

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -1,0 +1,163 @@
+---
+name: world-sim-shepherd
+description: Per-PR babysitter for world-sim migration PRs. Use when the world-sim orchestrator (or a human) hands a PR off for end-to-end review-fix-rereview management. The shepherd owns the PR until it is ready to merge or needs human attention; it dispatches reviewers and workers as needed and returns a structured verdict. Input is a PR number, issue number, phase, risk, and a worker-dispatch template.
+---
+
+# World-sim shepherd
+
+You own one world-sim migration PR from intake through a terminal verdict. You dispatch the generic reviewer and the world-sim specialist each iteration, post the combined review comment on the PR, dispatch a fresh worker to address findings, and verify progress. You exit with one of three structured verdicts: `ready-to-merge`, `needs-human`, or `conflict`.
+
+You do NOT edit code, do NOT push commits, and do NOT call `gh pr merge`. You signal only.
+
+## Inputs
+
+The caller provides:
+- `pr` — GitHub PR number to babysit
+- `issue` — GitHub issue number this PR addresses
+- `phase` — phase classification (e.g., `2`, `3`, `parallel`)
+- `risk` — risk classification (`low`, `medium`, `high`)
+- `worker_template` — verbatim text the orchestrator would pass to a fresh worker for this issue
+- `max_iterations` (optional, default `3`) — review-fix cycle ceiling
+
+If any required field is missing, ask once and wait. Do not proceed without `pr`, `issue`, `phase`, `worker_template`.
+
+## Required reading on intake
+
+Before starting the loop:
+
+1. `docs/world-sim-shepherd.md` — the design this implements (especially §The shepherd loop, §Termination policy, §Output contract)
+2. `docs/world-simulator-orchestration-plan.md` — §Global rules (commit/branch policy), §Stop conditions
+3. `gh pr view <pr> --json title,body,headRefOid,baseRefOid,state,reviews,comments,mergeable` — current PR state
+
+## The loop
+
+```
+state = {
+  iterations: 0,
+  last_head_sha: gh pr view headRefOid,
+  last_review: null,
+}
+
+loop:
+  pr_state = gh pr view <pr> --json state,headRefOid,reviews,comments,mergeable
+
+  # Terminal-state short-circuits
+  if pr_state.state == "MERGED":
+    return verdict("ready-to-merge", reason: "already merged")
+  if pr_state.state == "CLOSED":
+    return verdict("needs-human", reason: "PR closed without merge")
+  if pr_state.mergeable == "CONFLICTING":
+    return verdict("conflict", reason: "merge conflict against base")
+
+  # Human-comment guard — do not bulldoze human input
+  if any review or comment newer than state.last_head_sha by a non-bot account:
+    return verdict("needs-human", reason: "human_review")
+
+  # Run reviewers in parallel (single message, two Agent calls)
+  review_results = parallel(
+    Agent(subagent_type: "code-reviewer", prompt: <generic-review prompt with pr=N>),
+    Agent(subagent_type: "world-sim-reviewer", prompt: <pr, issue, phase>)
+  )
+
+  # Post the combined comment on the PR
+  gh pr comment <pr> --body-file <temp-file-with-combined-review>
+
+  # If both reviewers clean → terminal success
+  if review_results.generic.verdict == "clean"
+     and review_results.specialist.verdict == "clean":
+    return verdict("ready-to-merge", reason: null)
+
+  state.iterations += 1
+
+  # Iteration ceiling
+  if state.iterations > max_iterations:
+    return verdict("needs-human", reason: "max_iterations")
+
+  # Same-class-of-issue guard
+  if state.last_review is not null
+     and same_issue_class(state.last_review, review_results):
+    return verdict("needs-human", reason: "same_issue_class")
+
+  state.last_review = review_results
+
+  # Dispatch worker via Agent tool (blocks until worker returns)
+  worker_prompt = build_worker_prompt(
+    template: <input.worker_template>,
+    feedback: review_results,
+    pr: <pr>
+  )
+  Agent(subagent_type: "general-purpose", prompt: worker_prompt)
+
+  # Verify worker actually pushed commits
+  new_head = gh pr view <pr> --json headRefOid
+  if new_head == state.last_head_sha:
+    return verdict("needs-human", reason: "worker_no_progress")
+
+  state.last_head_sha = new_head
+  # loop iterates
+```
+
+## "Same class of issue" detection
+
+After each iteration, compare this iteration's review findings against the previous iteration's. Escalate to `needs-human` if either:
+
+1. **A file:line range from iteration N's review appears in iteration N+1's review.** The worker touched that location but didn't fix the root cause.
+2. **A principle number (e.g., "principle 12") is cited in two consecutive iterations' findings.** The worker isn't addressing the same kind of feedback.
+
+Implement as plain string-matching against the structured review output. Tolerate small line-number shifts (±5 lines) when matching file:line ranges, since fix-up commits may shift adjacent code.
+
+## Posting the combined review comment
+
+Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed:
+
+```
+### Shepherd iteration N — review verdict
+
+**Generic review** (`code-reviewer`):
+<verbatim generic-review output, indented one level>
+
+**World-sim specialist** (`world-sim-reviewer`):
+<verbatim specialist output, indented one level>
+
+**Verdict:** dispatching worker | ready-to-merge | needs-human
+
+— posted by world-sim-shepherd
+```
+
+Use a temp file for the body — direct `--body` arguments containing multiline content trip Bash quoting issues per the `bash_tool_is_posix_not_powershell` memory convention. PowerShell here-strings (`@'…'@`) work for the commit message but `gh ... --body-file` is more robust for the comment.
+
+## Output contract
+
+Final message includes a fenced JSON block the caller (orchestrator) parses:
+
+```json
+{
+  "verdict": "ready-to-merge" | "needs-human" | "conflict",
+  "pr": <int>,
+  "issue": <int>,
+  "head_sha": "<sha>",
+  "iterations": <int>,
+  "escalation_reason": "max_iterations" | "human_review" | "same_issue_class" | "worker_no_progress" | "merge_conflict" | "closed_without_merge" | null,
+  "summary": "<1-2 sentences>"
+}
+```
+
+`escalation_reason` is `null` only when `verdict == "ready-to-merge"`.
+
+After the JSON block, include human-readable prose: a paragraph summarizing what happened, citing the final review's findings if `needs-human`. The orchestrator surfaces this verbatim when escalating.
+
+## Tools you use
+
+- `Read`, `Grep`, `Glob` — read the design doc, audit, orchestration plan, and any code referenced by review findings
+- `Bash` (constrained to `gh`) — `gh pr view`, `gh pr comment`, `gh pr diff`
+- `Agent` — dispatch `code-reviewer` (from pr-review-toolkit), `world-sim-reviewer` (the specialist), and `general-purpose` workers
+
+You do NOT have `Edit` or `Write`. You do NOT touch code. If you want a fix made, dispatch a worker; if the worker fails to push, escalate.
+
+## What you do NOT do
+
+- Do NOT call `gh pr merge`. Signal `ready-to-merge` and exit.
+- Do NOT edit code in the PR. Dispatch a worker.
+- Do NOT post a review approval (`gh pr review --approve`). Your comment trail is sufficient signal.
+- Do NOT loop past `max_iterations`. Escalate honestly.
+- Do NOT silence or override human review comments. The first non-bot review/comment newer than your last iteration is a hard escalation.

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -120,7 +120,7 @@ Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed:
 ```
 ### Shepherd iteration N — review verdict
 
-**Generic review** (`code-reviewer`):
+**Generic review**:
 <verbatim generic-review output, indented one level>
 
 **World-sim specialist** (`world-sim-reviewer`):

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -35,6 +35,7 @@ Before starting the loop:
 state = {
   iterations: 0,
   last_head_sha: gh pr view headRefOid,
+  last_iteration_at: now (real wall-clock; only used for the human-comment guard),
   last_review: null,
 }
 
@@ -43,14 +44,17 @@ loop:
 
   # Terminal-state short-circuits
   if pr_state.state == "MERGED":
-    return verdict("ready-to-merge", reason: "already merged")
+    return verdict("ready-to-merge", reason: null)
   if pr_state.state == "CLOSED":
-    return verdict("needs-human", reason: "PR closed without merge")
+    return verdict("needs-human", reason: "closed_without_merge")
   if pr_state.mergeable == "CONFLICTING":
-    return verdict("conflict", reason: "merge conflict against base")
+    return verdict("conflict", reason: "merge_conflict")
 
-  # Human-comment guard — do not bulldoze human input
-  if any review or comment newer than state.last_head_sha by a non-bot account:
+  # Human-comment guard — do not bulldoze human input.
+  # Compare against state.last_iteration_at (initialized to "now" at loop entry,
+  # updated at the top of each iteration). The shepherd's own comments are bot-
+  # authored and excluded by the non-bot filter.
+  if any review or comment with created_at > state.last_iteration_at by a non-bot account:
     return verdict("needs-human", reason: "human_review")
 
   # Run reviewers in parallel (single message, two Agent calls)
@@ -94,6 +98,7 @@ loop:
     return verdict("needs-human", reason: "worker_no_progress")
 
   state.last_head_sha = new_head
+  state.last_iteration_at = now
   # loop iterates
 ```
 

--- a/docs/world-sim-shepherd.md
+++ b/docs/world-sim-shepherd.md
@@ -32,7 +32,7 @@ Two new subagents and one set of edits to the orchestration plan.
 3. **Replay-determinism inspection** — static-analysis-style sweep for non-determinism sources: `DateTime.UtcNow`/`Stopwatch` in state-decision paths, dictionary-iteration-order assumptions, `Task.Run` / `Task.WhenAll` that could reorder side effects, etc.
 4. **Audit cross-reference** — cross-checks the PR's changed files against [`world-sim-migration-audit.md`](world-sim-migration-audit.md). If a file is listed as "needs behavioural change" and this PR is supposed to land that change, verify the change happened; if "sleeper blocker," verify it was addressed.
 
-**Generic review.** The shepherd also dispatches the existing `code-reviewer` subagent from `pr-review-toolkit` in parallel with `world-sim-reviewer` each iteration. The pr-review-toolkit reviewer covers generic bug-scanning, CLAUDE.md adherence, git-history context — work the specialist doesn't need to reproduce.
+**Generic review.** The shepherd also dispatches a `general-purpose` subagent with an inlined code-review prompt template (see the shepherd agent file's §Generic code review prompt section) in parallel with `world-sim-reviewer` each iteration. The inlined prompt covers generic bug-scanning, CLAUDE.md adherence, git-history context — work the specialist doesn't need to reproduce. (The `pr-review-toolkit` plugin's `code-reviewer` agent would have been a natural fit, but it isn't installed in this environment; the inlined-prompt-on-general-purpose pattern is the project's existing convention for Agent-dispatchable review.)
 
 ---
 
@@ -154,7 +154,7 @@ Optional follow-on (separate PR):
 
 ## Open considerations
 
-1. **Generic reviewer wart.** The existing `/code-review` is a slash command, not a callable subagent. The shepherd uses the `code-reviewer` subagent from the `pr-review-toolkit` plugin instead, which is `Agent`-dispatchable. If `pr-review-toolkit` ever changes that subagent's contract, the shepherd's invocation needs to follow.
+1. **Generic reviewer wart.** The existing `/code-review` is a slash command, not a `Agent`-callable subagent. The `pr-review-toolkit` plugin provides a `code-reviewer` agent that would be a clean fit but isn't installed in this environment. The shepherd works around this by dispatching `general-purpose` with an inlined code-review prompt template embedded in the shepherd agent file. If `pr-review-toolkit` ever gets installed, switching the dispatch to that subagent (and dropping the inline template) is a one-line change.
 
 2. **Concurrent shepherds on overlapping PRs.** If the orchestrator dispatches two shepherds on PRs that touch the same file, the second worker's commit could clobber the first. The shepherd doesn't detect this proactively; it falls back to the `conflict` verdict if a merge conflict appears. The orchestration plan's Stop Condition #6 (conflicting concurrent work → serialize) covers the policy side.
 

--- a/docs/world-sim-shepherd.md
+++ b/docs/world-sim-shepherd.md
@@ -13,7 +13,7 @@ A per-PR babysitter agent the world-sim orchestrator hands a PR to. The shepherd
 
 ## Why this exists
 
-The orchestration plan defines the dispatch loop for workers but leaves review undefined. Its Stop Condition #2 ("If a code review flags blocking concerns, the orchestrator pauses pending resolution") references the generic `code-review` skill as one input, but doesn't say who runs it, when, or how the orchestrator consumes the result. The plan also doesn't model the iterative "review → fix → re-review" cycle the orchestrator currently expects a human to drive.
+Before this design landed, the orchestration plan defined the dispatch loop for workers but left review undefined. Its Stop Condition #2 referenced the generic `code-review` skill as one input, but didn't say who ran it, when, or how the orchestrator consumed the result. The plan also didn't model the iterative "review → fix → re-review" cycle the orchestrator otherwise expected a human to drive.
 
 The shepherd fills that gap. It owns one PR end-to-end: runs reviewers, dispatches workers to address findings, escalates to a human only when the PR can't progress hands-free.
 
@@ -138,14 +138,14 @@ The shepherd reads the issue body itself — the orchestration plan's `spawned_s
 
 ---
 
-## Files added when this lands
+## Files this design produced
 
 1. `.claude/agents/world-sim-shepherd.md` — shepherd subagent definition
 2. `.claude/agents/world-sim-reviewer.md` — specialist reviewer subagent
 3. Edits to [`world-simulator-orchestration-plan.md`](world-simulator-orchestration-plan.md):
    - **Dispatch flow.** New step between "worker opens PR" and "orchestrator dispatches next task": orchestrator hands off to the shepherd.
-   - **Verification gates.** Add the shepherd as part of the per-PR gate alongside Tier 1 (build) and Tier 2 (test). Currently the plan has no inline code-review tier.
-   - **Stop conditions.** Stop Condition #2 ("code-review flags blocking concerns") becomes "shepherd returns `needs-human`" — the shepherd encapsulates the existing escalation rule.
+   - **Verification gates.** Shepherd review is now §Tier 2.5, sitting between Tier 2 (Test) and Tier 3 (System).
+   - **Stop conditions.** Stop Condition #2 references the shepherd's `needs-human` verdict; the generic `code-review` skill reference is gone.
 
 Optional follow-on (separate PR):
 - `tests/Mithril.WorldSim.Shepherd.Tests` — pure-function unit tests over a `ShepherdState` decision function (loop logic extracted into a plain C# library). The Agent/GitHub plumbing isn't unit-testable; the decision logic is.

--- a/docs/world-sim-shepherd.md
+++ b/docs/world-sim-shepherd.md
@@ -48,7 +48,7 @@ loop {
                                               (never bulldoze human input)
 
   run reviewers in parallel:
-    - code-reviewer (pr-review-toolkit, generic)
+    - general-purpose (inlined code-review prompt)
     - world-sim-reviewer (specialist)
   post combined review comment on PR
 
@@ -113,7 +113,7 @@ Plus human-readable prose the agent emits as its return value (which the orchest
 
 ```
 ### Shepherd iteration N — review verdict
-Generic review (pr-review-toolkit/code-reviewer): [inline or link]
+Generic review: [inline or link]
 World-sim specialist (world-sim-reviewer): [inline or link]
 Verdict: dispatching worker | ready-to-merge | needs-human
 ```

--- a/docs/world-simulator-orchestration-plan.md
+++ b/docs/world-simulator-orchestration-plan.md
@@ -299,6 +299,29 @@ tasks:
 
 ---
 
+## Per-PR shepherding
+
+After a worker opens its PR, the orchestrator hands off to a per-PR shepherd subagent instead of polling the PR itself. The shepherd babysits one PR end-to-end and returns a structured verdict.
+
+Dispatch the shepherd via the `Agent` tool with:
+
+```
+subagent_type: world-sim-shepherd
+prompt: |
+  Babysit PR #<pr>. Issue: #<issue>. Phase: <phase>. Risk: <risk>.
+  Worker dispatch template:
+  <verbatim worker template the orchestrator would use for a fresh dispatch>
+  max_iterations: 3
+```
+
+The shepherd returns one of three verdicts (parseable from a fenced JSON block in its final message):
+
+- `ready-to-merge` — the orchestrator does the actual `gh pr merge` per its merge policy.
+- `needs-human` — the orchestrator surfaces the shepherd's escalation reason + summary to the user. This is Stop Condition #2; do not auto-retry.
+- `conflict` — merge conflict detected; the orchestrator serializes work per Stop Condition #6 and dispatches a rebase task.
+
+Design rationale: [`world-sim-shepherd.md`](world-sim-shepherd.md).
+
 ## Verification gates
 
 Verification has three tiers — `build`, `test`, and `system`. The orchestrator runs all three before marking a task done.
@@ -324,6 +347,10 @@ dotnet test Mithril.slnx
 ```
 
 All 20-ish test projects, no failures, no skips. This catches cross-project regressions.
+
+### Tier 2.5 — Shepherd review (every PR)
+
+After the worker opens its PR and before the orchestrator considers system-tier checks, the per-PR shepherd runs (see [§Per-PR shepherding](#per-pr-shepherding)). The shepherd dispatches the generic code reviewer and the world-sim specialist in parallel each iteration; findings flow back as a structured verdict. The shepherd handles its own iteration: a `needs-human` verdict is the only signal the orchestrator routes on.
 
 ### Tier 3 — System (selective tasks, per the task's `risk` level)
 
@@ -393,7 +420,7 @@ Run between phases as a checkpoint. These are "is the system still cohesive" ass
 The orchestrator pauses for human review under any of these conditions. Do NOT auto-retry; do NOT auto-merge past them.
 
 1. **CI failure on a task PR.** Worker may attempt one fix-up commit if the cause is obviously a flake (e.g., `RG1000 BAML dup-key` per `mithril_rg1000_baml_dupkey_flake` memory — known build flake). If failure repeats or is non-trivial, escalate.
-2. **Review comments on a task PR.** If a code review (human or automated like `code-review` skill) flags blocking concerns, the orchestrator pauses pending resolution.
+2. **Shepherd returns `needs-human`.** The per-PR shepherd (see [§Per-PR shepherding](#per-pr-shepherding)) encapsulates review-and-iterate. Its `needs-human` verdict — fired by max_iterations exceeded, human review comment, same-issue-class detection, or worker_no_progress — is a hard pause. The shepherd's prose summary explains which specific reason triggered.
 3. **Cross-phase invariant fails.** If running the post-phase checks reveals a regression, do not unlock the next phase. Escalate.
 4. **Performance regression beyond threshold.** If a Tier-3 benchmark exceeds 10% regression, escalate. Don't merge.
 5. **Replay-determinism test fails.** If a replay test shows non-identical trajectories where it should match, escalate.

--- a/docs/world-simulator-orchestration-plan.md
+++ b/docs/world-simulator-orchestration-plan.md
@@ -12,7 +12,7 @@ Machine-actionable scheduling plan for the world-simulator migration. Pairs with
 
 1. Read [§Dependency graph](#dependency-graph) and current GitHub issue state.
 2. Identify **ready tasks**: tasks whose `depends_on` are all closed issues, and which aren't themselves closed/in-progress.
-3. For each ready task: spawn the [agent type](#per-task-orchestration-metadata) listed, hand over the issue body verbatim (per `spawned_session_handoff_self_contained` memory convention), and observe.
+3. For each ready task: spawn the [agent type](#per-task-orchestration-metadata) listed, hand over the issue body verbatim (per `spawned_session_handoff_self_contained` memory convention), and observe. After the worker opens its PR, dispatch the per-PR shepherd (see [§Per-PR shepherding](#per-pr-shepherding)) before advancing to verification.
 4. Verify completion using [§Verification gates](#verification-gates) before treating a task as done. The issue's own acceptance criteria are one input; cross-task invariants are another.
 5. Honor [§Stop conditions](#stop-conditions): pause for human review under specific failure modes; do not blindly retry.
 6. On a clean phase transition, run [§Cross-phase invariants](#cross-phase-invariants) before unlocking the next phase.
@@ -318,7 +318,7 @@ The shepherd returns one of three verdicts (parseable from a fenced JSON block i
 
 - `ready-to-merge` — the orchestrator does the actual `gh pr merge` per its merge policy.
 - `needs-human` — the orchestrator surfaces the shepherd's escalation reason + summary to the user. This is Stop Condition #2; do not auto-retry.
-- `conflict` — merge conflict detected; the orchestrator serializes work per Stop Condition #6 and dispatches a rebase task.
+- `conflict` — merge conflict detected; the orchestrator serializes per Stop Condition #6 (which has the later concurrent task rebase before re-dispatch).
 
 Design rationale: [`world-sim-shepherd.md`](world-sim-shepherd.md).
 
@@ -348,7 +348,7 @@ dotnet test Mithril.slnx
 
 All 20-ish test projects, no failures, no skips. This catches cross-project regressions.
 
-### Tier 2.5 — Shepherd review (every PR)
+### Tier 2.5 — Shepherd review (every task)
 
 After the worker opens its PR and before the orchestrator considers system-tier checks, the per-PR shepherd runs (see [§Per-PR shepherding](#per-pr-shepherding)). The shepherd dispatches the generic code reviewer and the world-sim specialist in parallel each iteration; findings flow back as a structured verdict. The shepherd handles its own iteration: a `needs-human` verdict is the only signal the orchestrator routes on.
 


### PR DESCRIPTION
## Summary

Closes #623. Adds the per-PR shepherd + specialist reviewer subagents the world-sim orchestrator dispatches per migration PR, plus the orchestration-plan edits that wire them in.

- **`.claude/agents/world-sim-shepherd.md`** — per-PR babysitter. Owns the review-fix-rereview loop end-to-end. Dispatches the generic reviewer (a `general-purpose` agent with an inlined code-review prompt — `pr-review-toolkit/code-reviewer` would be the natural fit but isn't installed in this environment) and the world-sim specialist in parallel each iteration, posts the combined review on the PR, dispatches a fresh worker to address findings, and verifies progress via head-SHA check. Signal-only — returns a structured JSON verdict (`ready-to-merge` / `needs-human` / `conflict`) but does not call `gh pr merge`.
- **`.claude/agents/world-sim-reviewer.md`** — the specialist reviewer commit `8290dea` lands code-quality fixes on top of the initial version that was bundled into #624. Adjustments: Principle 13 bullet rewritten to target real wall-clock leaks (not `IWorldClock.Now` reads); output header includes the issue number; opening paragraph self-references the four checks rather than the design notebook; input guard clause names the specific fields.
- **`docs/world-simulator-orchestration-plan.md`** — three coordinated edits wiring the shepherd in: new §Per-PR shepherding section, new §Tier 2.5 — Shepherd review under Verification gates, and Stop Condition #2 rewritten to reference the shepherd's `needs-human` verdict.
- **`docs/world-sim-shepherd.md`** — small tense cleanup. "Why this exists" and "Files this design produced" sections now read in past tense since the wire-up has landed.

## Test plan

- [x] `Test-Path .claude\agents\world-sim-shepherd.md` returns `True`.
- [x] Both agent files have YAML frontmatter with only `name` and `description` (matching the `growth-calibration.md` pattern).
- [x] Orchestration plan contains §Per-PR shepherding, §Tier 2.5, and the rewritten Stop Condition #2 (Select-String checks pass).
- [x] No residual `code-reviewer` or `pr-review-toolkit` references in templates or pseudocode — only in rationale prose explaining the workaround.
- [x] Output contract JSON enum tokens (`max_iterations`, `human_review`, `same_issue_class`, `worker_no_progress`, `merge_conflict`, `closed_without_merge`) match exactly across shepherd pseudocode, design notebook termination policy, and orchestration plan Stop Condition #2.
- [ ] Manual smoke run against a contrived PR (Task 6 from #623) — owner-driven, deferred.

## Per-task review trail

Each commit went through spec-compliance + code-quality review per the `subagent-driven-development` skill:

1. `8290dea` — Task 1 code-quality fixes to world-sim-reviewer.md (Principle 13 bullet, output header, self-reference, guard clause).
2. `c33e049` — initial shepherd subagent.
3. `43ab601` — Task 2 fixes: loop reasons match enum (`closed_without_merge`, `merge_conflict`), `ready-to-merge` reason set to `null`, human-comment guard uses timestamp not SHA.
4. `c547735` — orchestration plan wire-up.
5. `a6df961` — wire-up fixes: removed undefined "rebase task" phrasing, label consistency, top-level instructions reference the shepherd, design-notebook tense cleanup.
6. `fa15f80` — final-review fix: switch generic reviewer from `code-reviewer` (subagent doesn't exist here) to `general-purpose` with inlined prompt template; design notebook updated to match.
7. `529f881` — clean stale `code-reviewer` labels in PR-comment template and design-notebook pseudocode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
