### PR TITLE
refactor(legolas): drop chat AreaCalibrationService dependency, use PlayerAreaTracker (#605)

### DIFF
--- a/src/Legolas.Module/Domain/GameEvent.cs
+++ b/src/Legolas.Module/Domain/GameEvent.cs
@@ -82,17 +82,11 @@ public sealed record MotherlodeUseDetected(
     DateTime Timestamp,
     string? MapName = null) : GameEvent(Timestamp);
 
-/// <summary>
-/// The chat-log area banner (<c>"******* Entering Area: Eltibule"</c>). Carries
-/// the area's <em>friendly</em> name; the calibration service resolves it to the
-/// internal area key. A <b>complementary</b> signal: Player.log <i>does</i> have
-/// an area marker (<c>LOADING LEVEL Area&lt;Name&gt;</c>, parsed by the shared
-/// <c>PlayerAreaTracker</c> — #454/#456), which is the authoritative key source;
-/// this chat banner is the fallback when the Player.log seed missed.
-/// </summary>
-public sealed record AreaEntered(
-    DateTime Timestamp,
-    string AreaFriendlyName) : GameEvent(Timestamp);
+// The chat-log area banner ("******* Entering Area: <FriendlyName>") was
+// retired in #605. PlayerAreaTracker (Mithril.GameState.Areas) is the
+// authoritative area-key source, fed by Player.log's LOADING LEVEL line, and
+// PlayerLogIngestionService.ApplyAreaIfChanged drives the calibration service
+// directly. See #531 for the redundancy analysis.
 
 public sealed record UnknownLine(
     DateTime Timestamp,

--- a/src/Legolas.Module/Services/AreaCalibrationService.cs
+++ b/src/Legolas.Module/Services/AreaCalibrationService.cs
@@ -37,16 +37,12 @@ public interface IAreaCalibrationService
     event EventHandler? Changed;
 
     /// <summary>
-    /// Handle the chat banner. Resolves the friendly name to an internal area
-    /// key; if a calibration is already persisted for it, applies it to the
-    /// projector immediately so the first survey/treasure projects correctly.
-    /// </summary>
-    void OnAreaEntered(string areaFriendlyName);
-
-    /// <summary>
-    /// Manually set the current area by internal key (the area-picker path).
-    /// Same effect as <see cref="OnAreaEntered"/> but bypasses friendly-name
-    /// resolution — used when the chat banner was missed.
+    /// Set the current area by internal key. The Player.log-driven
+    /// <c>PlayerLogIngestionService.ApplyAreaIfChanged</c> bridge calls this
+    /// whenever <see cref="Mithril.GameState.Areas.PlayerAreaTracker.CurrentArea"/>
+    /// changes (#605 — the prior chat <c>Entering Area:</c> banner path is gone;
+    /// <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/> is the
+    /// authoritative source). Also used by the manual area-picker UI.
     /// </summary>
     void SelectArea(string areaKey);
 
@@ -81,12 +77,19 @@ public interface IAreaCalibrationService
 }
 
 /// <summary>
-/// Owns the per-area calibration lifecycle: chat-banner area detection &#8594;
-/// internal-key resolution &#8594; apply persisted <see cref="AreaCalibration"/> on
-/// entry, and the solve/persist path the calibration window drives. Reference
-/// points come from <see cref="IReferenceDataService"/> (landmarks + NPCs with a
+/// Owns the per-area calibration lifecycle: area-key handoff (from the
+/// <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/>-driven
+/// <c>PlayerLogIngestionService.ApplyAreaIfChanged</c> bridge or the manual
+/// area-picker UI) &#8594; apply persisted <see cref="AreaCalibration"/> on entry,
+/// and the solve/persist path the calibration window drives. Reference points
+/// come from <see cref="IReferenceDataService"/> (landmarks + NPCs with a
 /// parseable <c>Pos</c>), which is the same engine-unit world frame the game
 /// positions the player in (verified 2026-05-18).
+///
+/// <para>The chat-log <c>Entering Area:</c> banner path was retired in #605 —
+/// per #531, <see cref="Mithril.GameState.Areas.PlayerAreaTracker"/> already
+/// exposes the same signal authoritatively from Player.log's
+/// <c>LOADING LEVEL</c> line.</para>
 /// </summary>
 public sealed class AreaCalibrationService : IAreaCalibrationService
 {
@@ -127,14 +130,6 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
             .ToList();
 
     public event EventHandler? Changed;
-
-    public void OnAreaEntered(string areaFriendlyName)
-    {
-        if (string.IsNullOrWhiteSpace(areaFriendlyName)) return;
-        // Even if the key can't be resolved (unknown / missing reference data),
-        // record the raw friendly name so the UI can show it.
-        SetArea(ResolveAreaKey(areaFriendlyName), areaFriendlyName.Trim());
-    }
 
     public void SelectArea(string areaKey)
     {
@@ -201,27 +196,6 @@ public sealed class AreaCalibrationService : IAreaCalibrationService
             _saver.Touch();
             Changed?.Invoke(this, EventArgs.Empty);
         }
-    }
-
-    /// <summary>
-    /// Friendly name &#8594; internal area key. Matches <see cref="AreaEntry.FriendlyName"/>
-    /// first, then <see cref="AreaEntry.ShortFriendlyName"/>, case-insensitively.
-    /// </summary>
-    private string? ResolveAreaKey(string friendlyName)
-    {
-        var name = friendlyName.Trim();
-        foreach (var area in _refData.Areas.Values)
-        {
-            if (string.Equals(area.FriendlyName, name, StringComparison.OrdinalIgnoreCase))
-                return area.Key;
-        }
-        foreach (var area in _refData.Areas.Values)
-        {
-            if (!string.IsNullOrEmpty(area.ShortFriendlyName)
-                && string.Equals(area.ShortFriendlyName, name, StringComparison.OrdinalIgnoreCase))
-                return area.Key;
-        }
-        return null;
     }
 
     private IReadOnlyList<CalibrationReference> BuildReferences(string areaKey)

--- a/src/Legolas.Module/Services/ChatLogParser.cs
+++ b/src/Legolas.Module/Services/ChatLogParser.cs
@@ -31,12 +31,10 @@ public sealed partial class ChatLogParser : IChatLogParser
     // request + response from one stream — see PlayerLogParser docs and
     // docs/cross-source-correlation.md for the structural reason.
 
-    // Area banner: a run of asterisks then "Entering Area: <FriendlyName>".
-    // The name runs to end-of-line; trim trailing whitespace via the lazy group
-    // plus an explicit \s* tail so a trailing CR/space doesn't bleed into it.
-    [GeneratedRegex(@"Entering Area:\s*(?<area>.+?)\s*$",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
-    private static partial Regex AreaEnteredRegex();
+    // #605: the chat "Entering Area:" banner retired here. PlayerAreaTracker
+    // (Mithril.GameState.Areas) is the authoritative area-key source, fed by
+    // Player.log's LOADING LEVEL line; PlayerLogIngestionService.ApplyAreaIfChanged
+    // drives IAreaCalibrationService.SelectArea on every change. See #531.
 
     public LogEvent? TryParse(string line, DateTime timestamp)
     {
@@ -95,14 +93,6 @@ public sealed partial class ChatLogParser : IChatLogParser
                 collectMatch.Groups["name"].Value.Trim(),
                 count,
                 bonus);
-        }
-
-        var areaMatch = AreaEnteredRegex().Match(line);
-        if (areaMatch.Success)
-        {
-            var area = areaMatch.Groups["area"].Value.Trim();
-            if (!string.IsNullOrEmpty(area))
-                return new AreaEntered(timestamp, area);
         }
 
         return new UnknownLine(timestamp, line);

--- a/src/Legolas.Module/Services/LogIngestionService.cs
+++ b/src/Legolas.Module/Services/LogIngestionService.cs
@@ -13,12 +13,12 @@ namespace Legolas.Services;
 /// Background service that consumes chat-log lines from <see cref="IChatLogStream"/>,
 /// parses them via <see cref="IChatLogParser"/>, and pumps resulting events into the
 /// session: SurveyDetected adds slots, ItemCollected marks the matching slot
-/// collected, AreaEntered feeds the calibration service as a fallback (the
-/// Player.log <c>LOADING LEVEL</c> banner is the primary source). The Motherlode
-/// distance pairing was migrated to Player.log <c>ProcessScreenText</c> in #604,
-/// so the chat distance subscription previously hosted here is gone — the
-/// coordinator now pairs request + response from <see cref="PlayerLogIngestionService"/>
-/// alone.
+/// collected. The Motherlode distance pairing was migrated to Player.log
+/// <c>ProcessScreenText</c> in #604, and the redundant chat <c>Entering Area:</c>
+/// fallback was retired in #605 (<see cref="Mithril.GameState.Areas.PlayerAreaTracker"/>
+/// already exposes the area key authoritatively from Player.log's
+/// <c>LOADING LEVEL</c> line, and <c>PlayerLogIngestionService.ApplyAreaIfChanged</c>
+/// drives <see cref="IAreaCalibrationService.SelectArea"/> on every change).
 /// </summary>
 public sealed class LogIngestionService : BackgroundService
 {
@@ -110,9 +110,6 @@ public sealed class LogIngestionService : BackgroundService
                 case ItemCollected ic:
                     HandleItemCollected(ic);
                     break;
-                case AreaEntered ae:
-                    _areaCalibration.OnAreaEntered(ae.AreaFriendlyName);
-                    break;
             }
         });
     }
@@ -123,7 +120,6 @@ public sealed class LogIngestionService : BackgroundService
         ItemAddedToInventory ia => $"Added: {ia.Name} x{ia.Count}",
         ItemCollected ic when ic.SpeedBonusItem is not null => $"Collected: {ic.Name} (+ {ic.SpeedBonusItem} speed bonus)",
         ItemCollected ic => $"Collected: {ic.Name}",
-        AreaEntered ae => $"Area: {ae.AreaFriendlyName}",
         UnknownLine ul => $"Unknown: {ul.RawLine}",
         _ => evt.GetType().Name,
     };

--- a/tests/Legolas.Tests/FakeAreaCalibrationService.cs
+++ b/tests/Legolas.Tests/FakeAreaCalibrationService.cs
@@ -43,7 +43,6 @@ public sealed class FakeAreaCalibrationService : IAreaCalibrationService
     public event EventHandler? Changed;
     public event EventHandler<CalibrationSurveyObservation>? SurveyObserved;
 
-    public void OnAreaEntered(string areaFriendlyName) { }
     public void SelectArea(string areaKey) { }
     public AreaCalibration? CalibrateCurrentArea(
         IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0) => null;

--- a/tests/Legolas.Tests/LogTail/LogParserTests.cs
+++ b/tests/Legolas.Tests/LogTail/LogParserTests.cs
@@ -78,26 +78,19 @@ public class LogParserTests
     }
 
     [Theory]
-    [InlineData("******************** Entering Area: Eltibule", "Eltibule")]
-    [InlineData("*** Entering Area: Serbule Hills", "Serbule Hills")]
-    [InlineData("Entering Area: Kur Mountains ", "Kur Mountains")]
-    public void Parses_area_entered(string line, string expectedArea)
+    [InlineData("******************** Entering Area: Eltibule")]
+    [InlineData("*** Entering Area: Serbule Hills")]
+    [InlineData("Entering Area: Kur Mountains ")]
+    public void Chat_no_longer_parses_area_entered_post_605(string line)
     {
+        // #605 retired the chat "Entering Area:" banner: PlayerAreaTracker (fed
+        // by Player.log's LOADING LEVEL line) is the authoritative source, and
+        // PlayerLogIngestionService.ApplyAreaIfChanged drives the calibration
+        // service directly. The chat parser now treats the banner as an
+        // unrecognised line and falls through to UnknownLine.
         var evt = _parser.TryParse(line, FixedTime);
 
-        evt.Should().BeOfType<AreaEntered>()
-            .Which.AreaFriendlyName.Should().Be(expectedArea);
-    }
-
-    [Fact]
-    public void Survey_line_still_parses_as_survey_not_area()
-    {
-        // Precedence guard: the survey grammar must win over the area banner
-        // for a normal survey line (no "Entering Area:" substring anyway, but
-        // pin the intent so a future regex tweak can't regress it).
-        var evt = _parser.TryParse("[Status] The Iron Vein is 50m east and 30m north.", FixedTime);
-
-        evt.Should().BeOfType<SurveyDetected>().Which.Name.Should().Be("Iron Vein");
+        evt.Should().BeOfType<UnknownLine>().Which.RawLine.Should().Be(line);
     }
 
     [Theory]

--- a/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
+++ b/tests/Legolas.Tests/Services/AreaCalibrationServiceTests.cs
@@ -24,34 +24,18 @@ public class AreaCalibrationServiceTests
     }
 
     [Fact]
-    public void Resolves_area_key_by_friendly_name_then_short_name()
+    public void Unknown_area_key_records_key_as_friendly_name_with_no_refs()
     {
-        var refData = new FakeRefData
-        {
-            AreasByKey =
-            {
-                ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", ""),
-                ["AreaSerbule2"] = new AreaEntry("AreaSerbule2", "Serbule Hills", "Beneath Serbule"),
-            },
-        };
-        var (svc, _, _) = Build(refData);
-
-        svc.OnAreaEntered("Eltibule");
-        svc.CurrentAreaKey.Should().Be("AreaEltibule");
-
-        svc.OnAreaEntered("Beneath Serbule"); // ShortFriendlyName match
-        svc.CurrentAreaKey.Should().Be("AreaSerbule2");
-    }
-
-    [Fact]
-    public void Unknown_area_records_friendly_name_but_null_key()
-    {
+        // SelectArea with a key that isn't in the gazetteer falls back to using
+        // the key as the friendly name verbatim — the area-picker bypass path
+        // (PlayerAreaTracker keys are always in-game-real, but a test/dev key
+        // shouldn't crash the consumer).
         var (svc, _, _) = Build(new FakeRefData());
 
-        svc.OnAreaEntered("Nowheresville");
+        svc.SelectArea("AreaNowheresville");
 
-        svc.CurrentAreaKey.Should().BeNull();
-        svc.CurrentAreaFriendlyName.Should().Be("Nowheresville");
+        svc.CurrentAreaKey.Should().Be("AreaNowheresville");
+        svc.CurrentAreaFriendlyName.Should().Be("AreaNowheresville");
         svc.CurrentAreaReferences.Should().BeEmpty();
         svc.IsCurrentAreaCalibrated.Should().BeFalse();
     }
@@ -67,7 +51,9 @@ public class AreaCalibrationServiceTests
         var persisted = new AreaCalibration(3.0, 0.5, 11, 22, 4, 0.9);
         settings.AreaCalibrations["AreaEltibule"] = persisted;
 
-        svc.OnAreaEntered("Eltibule");
+        // PlayerLogIngestionService.ApplyAreaIfChanged drives SelectArea with
+        // the internal area key from PlayerAreaTracker — exercise that path.
+        svc.SelectArea("AreaEltibule");
 
         svc.IsCurrentAreaCalibrated.Should().BeTrue();
         svc.CurrentCalibration.Should().Be(persisted);
@@ -97,7 +83,7 @@ public class AreaCalibrationServiceTests
         };
         var (svc, proj, _) = Build(refData);
 
-        svc.OnAreaEntered("Eltibule");
+        svc.SelectArea("AreaEltibule");
 
         proj.LastApplied.Should().BeNull(); // no persisted calibration → projector untouched
         svc.CurrentAreaReferences.Select(r => r.Name)
@@ -114,7 +100,7 @@ public class AreaCalibrationServiceTests
             AreasByKey = { ["AreaEltibule"] = new AreaEntry("AreaEltibule", "Eltibule", "") },
         };
         var (svc, proj, settings) = Build(refData);
-        svc.OnAreaEntered("Eltibule");
+        svc.SelectArea("AreaEltibule");
 
         var changed = 0;
         svc.Changed += (_, _) => changed++;
@@ -154,7 +140,7 @@ public class AreaCalibrationServiceTests
             (new WorldCoord(1, 0, 1), new PixelPoint(1, 1)),
         }).Should().BeNull();
 
-        svc.OnAreaEntered("Eltibule");
+        svc.SelectArea("AreaEltibule");
         svc.CalibrateCurrentArea(new (WorldCoord, PixelPoint)[]
         {
             (new WorldCoord(0, 0, 0), new PixelPoint(0, 0)),
@@ -224,7 +210,7 @@ public class AreaCalibrationServiceTests
         };
         var (svc, _, settings) = Build(refData);
         settings.AreaCalibrations["AreaEltibule"] = new AreaCalibration(1, 0, 0, 0, 2, 0);
-        svc.OnAreaEntered("Eltibule");
+        svc.SelectArea("AreaEltibule");
         svc.IsCurrentAreaCalibrated.Should().BeTrue();
 
         var changed = 0;

--- a/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
+++ b/tests/Legolas.Tests/Services/PinCalibrationCoordinatorTests.cs
@@ -346,7 +346,6 @@ public class PinCalibrationCoordinatorTests
         public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
         public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
         public event EventHandler? Changed;
-        public void OnAreaEntered(string areaFriendlyName) { }
         public void SelectArea(string areaKey) { }
         public void ClearCurrentAreaCalibration() { }
         public void NoteSurvey(string name, MetreOffset offset) { }

--- a/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
+++ b/tests/Legolas.Tests/Services/PlayerLogIngestionServiceTests.cs
@@ -578,7 +578,6 @@ public sealed class PlayerLogIngestionServiceTests : IDisposable
             Array.Empty<CalibrationReference>();
         public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
         public event EventHandler? Changed { add { } remove { } }
-        public void OnAreaEntered(string areaFriendlyName) { }
         public AreaCalibration? CalibrateCurrentArea(
             IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements,
             double calibrationZoom = 1.0) => null;

--- a/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/CalibrationSessionViewModelTests.cs
@@ -754,8 +754,6 @@ public class CalibrationSessionViewModelTests
         public IReadOnlyList<AreaEntry> AllAreas => Areas;
         public event EventHandler? Changed;
 
-        public void OnAreaEntered(string areaFriendlyName) => Changed?.Invoke(this, EventArgs.Empty);
-
         public void SelectArea(string areaKey)
         {
             SelectedAreaKey = areaKey;

--- a/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/LegolasWizardViewModelTests.cs
@@ -30,7 +30,6 @@ public class LegolasWizardViewModelTests
         public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
         public IReadOnlyList<Mithril.Shared.Reference.AreaEntry> AllAreas => Array.Empty<Mithril.Shared.Reference.AreaEntry>();
         public event EventHandler? Changed;
-        public void OnAreaEntered(string areaFriendlyName) { }
         public void SelectArea(string areaKey) { }
         public AreaCalibration? CalibrateCurrentArea(
             IReadOnlyList<(WorldCoord World, PixelPoint Pixel)> placements, double calibrationZoom = 1.0)

--- a/tests/Legolas.Tests/ViewModels/NudgePadViewModelTests.cs
+++ b/tests/Legolas.Tests/ViewModels/NudgePadViewModelTests.cs
@@ -91,7 +91,6 @@ public class NudgePadViewModelTests
         public IReadOnlyList<CalibrationReference> CurrentAreaReferences => Array.Empty<CalibrationReference>();
         public IReadOnlyList<AreaEntry> AllAreas => Array.Empty<AreaEntry>();
         public event EventHandler? Changed { add { } remove { } }
-        public void OnAreaEntered(string areaFriendlyName) { }
         public void SelectArea(string areaKey) { }
         public void ClearCurrentAreaCalibration() { }
         public void NoteSurvey(string name, MetreOffset offset) { }


### PR DESCRIPTION
## Summary

- `PlayerAreaTracker` (Mithril.GameState.Areas) already exposes the area key authoritatively from Player.log's `LOADING LEVEL` line, and `PlayerLogIngestionService.ApplyAreaIfChanged` drives `IAreaCalibrationService.SelectArea` on every change. The chat `Entering Area:` banner path was a redundant fallback per #531.
- Removes the chat-side area subscription: `IAreaCalibrationService.OnAreaEntered` (and the `ResolveAreaKey` friendly-name helper), the `AreaEntered` case branch in `LogIngestionService`, `ChatLogParser.AreaEnteredRegex`, and the `AreaEntered` record from `Legolas.Domain.GameEvent`.
- Migrates `AreaCalibrationServiceTests` to exercise `SelectArea` (the PlayerLog-driven entry point). `LogParserTests` pins the new behaviour: chat `Entering Area:` lines fall through to `UnknownLine`. Removes `OnAreaEntered` stubs from test fakes.
- `AreaEnteredRegex` was not catalogued in `log-patterns.json`, so no parity update was needed.

User-visible behaviour is unchanged: calibration on area entry continues to work via the existing `PlayerLogIngestionService` bridge, which has covered this path since #514 self-seeded `PlayerAreaTracker`.

Part of #601 (world-simulator architecture migration umbrella).

## Test plan

- [x] `dotnet build Mithril.slnx` — clean, zero warnings
- [x] `dotnet test tests/Legolas.Tests` — 467 pass
- [x] `dotnet test Mithril.slnx` — full sweep passes (Mithril.GameState, Legolas, Mithril.Shared, all module tests)
- [x] LogPatternCatalogParityTests still pass (no catalog entry removed)

Closes #605
