### PR TITLE
feat(gamestate): add ConnectionEventParser → GameSession.Server (#611)

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -38,6 +38,11 @@ public static class GameStateServiceCollectionExtensions
         // ISessionAnchor is registered in AddMithrilGameServices as a leaf
         // (SessionAnchor). GameSessionService pushes to it on every parsed
         // banner — see SessionAnchor.cs and GameSessionService.Publish.
+        // Also injects IServerCatalogService (#610) so the per-session
+        // EVENT(Ok): connected URL can be joined against the catalog to
+        // populate GameSession.Server (#611). The catalog is registered
+        // below; both are singletons so order of AddSingleton calls is
+        // irrelevant for resolution.
         services
             .AddSingleton<GameSessionService>()
             .AddSingleton<IGameSessionService>(sp => sp.GetRequiredService<GameSessionService>())

--- a/src/Mithril.GameState/Sessions/GameSession.cs
+++ b/src/Mithril.GameState/Sessions/GameSession.cs
@@ -1,3 +1,5 @@
+using Mithril.GameState.Servers;
+
 namespace Mithril.GameState.Sessions;
 
 /// <summary>
@@ -11,8 +13,49 @@ namespace Mithril.GameState.Sessions;
 /// same physical login to the same id and downstream services short-circuit
 /// duplicate writes.
 /// </summary>
+/// <param name="SessionId">
+/// Stable, parser-derived natural key for the session — collapses to the
+/// same value across replays of the same physical login. Independent of
+/// <see cref="Server"/>: two replays of the same banner mint the same id
+/// even if the server identity changes between observations (which doesn't
+/// happen in PG, but the contract isolates the two concerns).
+/// </param>
+/// <param name="CharacterName">
+/// The character logged in, as PG emitted it in the banner.
+/// </param>
+/// <param name="LoggedInUtc">
+/// The login instant, in UTC, parsed from the banner's <c>Time UTC=…</c>
+/// field. The authoritative date source for <see cref="Mithril.Shared.Logging.PlayerLogClock"/>.
+/// </param>
+/// <param name="TimezoneOffset">
+/// The host's local TZ offset at the time PG wrote the banner. Closes the
+/// Player.log-UTC vs ChatLogs-local asymmetry documented in
+/// <c>pg_log_timezones</c>.
+/// </param>
+/// <param name="Server">
+/// The PG world server for this session, resolved by joining the per-session
+/// <c>EVENT(Ok): connected, url=…, port=…</c> preamble line against
+/// <see cref="IServerCatalogService"/>. Added by #611.
+///
+/// <para><b>May be <c>null</c>.</b> The connect line lives in the L0
+/// preamble, before the login banner. When Mithril cold-starts mid-PG-
+/// session, L0's seed strategy seeks past the preamble to the most-recent
+/// session marker (banner / <c>ProcessAddPlayer</c>), so neither the
+/// <c>Servers:</c> catalog line nor <c>EVENT(Ok): connected</c> reaches
+/// L0.5 — server identity is unknown for that attach lifetime, and
+/// <see cref="Server"/> stays <c>null</c>. Consumers must handle this
+/// explicitly rather than expect a fabricated default.</para>
+///
+/// <para>Even when the preamble IS in the replay window, the catalog may
+/// be empty if the <c>Servers:</c> line failed to parse (a future PG
+/// patch breaking the JSON shape) — in that case
+/// <see cref="IServerCatalogService.Get"/> returns <c>null</c> and the
+/// field stays <c>null</c> for the session. The connect URL itself is
+/// recorded in diagnostics for that path.</para>
+/// </param>
 public sealed record GameSession(
     string SessionId,
     string CharacterName,
     DateTime LoggedInUtc,
-    TimeSpan TimezoneOffset);
+    TimeSpan TimezoneOffset,
+    ServerEntry? Server = null);

--- a/src/Mithril.GameState/Sessions/GameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/GameSessionService.cs
@@ -1,3 +1,5 @@
+using Mithril.GameState.Servers;
+using Mithril.GameState.Sessions.Parsing;
 using Mithril.Shared.Diagnostics;
 using Mithril.Shared.Logging;
 using Microsoft.Extensions.Hosting;
@@ -8,11 +10,19 @@ namespace Mithril.GameState.Sessions;
 /// Hosted-service implementation of <see cref="IGameSessionService"/>.
 /// Consumes the L0.5 (#532) <see cref="ISystemSignalLogStream"/> via the L1
 /// (#550) <see cref="ILogStreamDriver"/> — subscribes for
-/// <see cref="SystemSignalLogLine"/>, filters for
-/// <see cref="SystemSignalKind.LoginBanner"/>, parses the banner body via
-/// <see cref="LoginBannerParser"/>, and publishes session transitions to
-/// subscribers + the shared <see cref="SessionAnchor"/> consumer. This is the
-/// L0.5 migration reference; pre-L0.5 the service consumed
+/// <see cref="SystemSignalLogLine"/>, dispatches on
+/// <see cref="SystemSignalKind"/>:
+/// <list type="bullet">
+///   <item><see cref="SystemSignalKind.LoginBanner"/> — parses the banner
+///   via <see cref="LoginBannerParser"/>, joins against the pending
+///   connect-event URL (if any) and the
+///   <see cref="IServerCatalogService"/> catalog, publishes the session.</item>
+///   <item><see cref="SystemSignalKind.ConnectionEvent"/> — parses the
+///   preamble <c>EVENT(Ok): connected, url=…, port=…</c> line via
+///   <see cref="ConnectionEventParser"/> and stashes the URL as a pending
+///   "next session's server hint" for the banner observation that follows.</item>
+/// </list>
+/// This is the L0.5 migration reference; pre-L0.5 the service consumed
 /// <see cref="IPlayerLogStream"/> and matched the banner shape itself.
 ///
 /// <para>The anchor is pushed-to, not implemented-by, to avoid a DI cycle:
@@ -28,6 +38,18 @@ namespace Mithril.GameState.Sessions;
 /// (on the subscriber's thread) and during live publish (on the pump
 /// thread). Subscribers doing non-trivial work should dispatch off-thread
 /// immediately.</para>
+///
+/// <para><b>Server identity (#611).</b> The connect line arrives first
+/// (preamble, ~17 minutes before the banner in some captures); the banner
+/// lands later. The service pairs them within a session adjacency: a
+/// connect-event URL captured during replay/live is held as
+/// <see cref="_pendingConnectUrl"/> and consumed by the next banner
+/// observation. A banner that arrives without a preceding connect (cold-
+/// start mid-PG-session, where L0's seed skips the preamble) publishes a
+/// session with <c>Server = null</c>; a connect that arrives without a
+/// matching catalog entry (PG patch breaking the JSON, or the same
+/// cold-start case) also publishes <c>null</c>. Both honest-empty paths
+/// surface on diagnostics.</para>
 ///
 /// <para>Idempotency: a banner whose parsed <see cref="GameSession.SessionId"/>
 /// equals the current one (replay-on-relaunch within the same PG session) is
@@ -45,6 +67,8 @@ namespace Mithril.GameState.Sessions;
 public sealed class GameSessionService : BackgroundService, IGameSessionService
 {
     private readonly ILogStreamDriver _driver;
+    private readonly IServerCatalogService? _serverCatalog;
+    private readonly ConnectionEventParser _connectionParser;
     private readonly SessionAnchor? _anchor;
     private readonly IDiagnosticsSink? _diag;
 
@@ -53,12 +77,22 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
     private GameSession? _current;
     private ILogSubscription? _subscription;
 
+    // Set by the most-recently-observed EVENT(Ok): connected line. Consumed
+    // by the next banner publication, then cleared. Guarded by _lock.
+    // Stays null when the L0 seed skipped the preamble (cold-start mid-
+    // PG-session) — that's the documented "Server = null" path.
+    private string? _pendingConnectUrl;
+    private int? _pendingConnectPort;
+
     public GameSessionService(
         ILogStreamDriver driver,
+        IServerCatalogService? serverCatalog = null,
         SessionAnchor? anchor = null,
         IDiagnosticsSink? diag = null)
     {
         _driver = driver;
+        _serverCatalog = serverCatalog;
+        _connectionParser = new ConnectionEventParser();
         _anchor = anchor;
         _diag = diag;
     }
@@ -86,7 +120,7 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _diag?.Info("Session", "Subscribing to L1 driver (SystemSignal pipe) for login banner");
+        _diag?.Info("Session", "Subscribing to L1 driver (SystemSignal pipe) for login banner + connection event");
         // archetype-A defaults — FromSessionStart replay + Inline delivery.
         // Containment is owned by the driver; no per-service try/catch around
         // the handler body (capability C of #550). A degraded subscription
@@ -95,13 +129,20 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
             envelope =>
             {
                 var signal = envelope.Payload;
-                // L0.5 already classified the line as a system signal — we only
-                // care about LoginBanner here. Other kinds (AreaLoading,
-                // PlayerAdded, SessionLifecycle) flow past without us.
-                if (signal.Kind != SystemSignalKind.LoginBanner) return ValueTask.CompletedTask;
-                if (LoginBannerParser.TryParse(signal.Data, out var session))
+                switch (signal.Kind)
                 {
-                    Publish(session);
+                    case SystemSignalKind.ConnectionEvent:
+                        HandleConnectionEvent(signal);
+                        break;
+                    case SystemSignalKind.LoginBanner:
+                        if (LoginBannerParser.TryParse(signal.Data, out var session))
+                        {
+                            Publish(session);
+                        }
+                        break;
+                    // Other kinds (AreaLoading, PlayerAdded, SessionLifecycle,
+                    // Servers) flow past without us — they're handled by their
+                    // dedicated services.
                 }
                 return ValueTask.CompletedTask;
             },
@@ -130,33 +171,87 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
         base.Dispose();
     }
 
+    private void HandleConnectionEvent(SystemSignalLogLine signal)
+    {
+        // The L0.5 classifier strips the "EVENT(Ok): " envelope, so the
+        // parser sees the bare "connected, url=…, port=…" body. The signal's
+        // timestamp is a best-effort wall-clock stamp from the L0 source
+        // clock (no [ts] prefix on preamble lines); we only need the
+        // url + port so the stamp is informational.
+        var ts = signal.Timestamp.UtcDateTime;
+        if (_connectionParser.TryParse(signal.Data, ts) is not ConnectionEvent evt)
+        {
+            _diag?.Warn("Session",
+                "Failed to parse EVENT(Ok): connected payload; server identity will be unknown for the next banner. " +
+                "Sample: " +
+                (signal.Data.Length > 160 ? signal.Data.Substring(0, 160) + "…" : signal.Data));
+            return;
+        }
+
+        lock (_lock)
+        {
+            _pendingConnectUrl = evt.Url;
+            _pendingConnectPort = evt.Port;
+        }
+        _diag?.Info("Session", $"Connect observed: url={evt.Url} port={evt.Port}");
+    }
+
     private void Publish(GameSession session)
     {
         Action<GameSession>[] toFire;
         EventHandler<GameSession>? sessionStartedSnapshot;
+        GameSession resolved;
+
         lock (_lock)
         {
-            if (_current is not null && _current.SessionId == session.SessionId)
+            // Resolve the server identity (if any) and clear the pending
+            // connect under the same lock so a concurrent ConnectionEvent
+            // observation can't race with the banner publication.
+            ServerEntry? server = null;
+            var connectUrl = _pendingConnectUrl;
+            _pendingConnectUrl = null;
+            _pendingConnectPort = null;
+
+            if (connectUrl is not null && _serverCatalog is not null)
+            {
+                server = _serverCatalog.Get(connectUrl);
+                if (server is null)
+                {
+                    _diag?.Warn("Session",
+                        $"Connect URL '{connectUrl}' has no matching ServerCatalog entry; " +
+                        "GameSession.Server will be null for this session. " +
+                        "(Catalog may be empty if Mithril attached mid-PG-session — L0 seed skips the preamble.)");
+                }
+            }
+            resolved = session with { Server = server };
+
+            if (_current is not null && _current.SessionId == resolved.SessionId)
             {
                 // Replay of an already-known banner. Idempotent: no event,
-                // no anchor flip, no subscriber dispatch.
+                // no anchor flip, no subscriber dispatch. Note that the
+                // resolved.Server may differ from _current.Server in a
+                // pathological case (catalog re-populated after the first
+                // observation); we preserve the first observation under
+                // SessionId-equality semantics — Server is part of the same
+                // logical session.
                 return;
             }
 
-            _current = session;
+            _current = resolved;
             toFire = _handlers.ToArray();
             sessionStartedSnapshot = SessionStarted;
             _diag?.Info("Session",
-                $"Login observed: {session.CharacterName} at {session.LoggedInUtc:O} (offset {session.TimezoneOffset})");
+                $"Login observed: {resolved.CharacterName} at {resolved.LoggedInUtc:O} (offset {resolved.TimezoneOffset})" +
+                (resolved.Server is not null ? $" on {resolved.Server.Name} ({resolved.Server.Url})" : " (server unknown)"));
         }
 
         // Push to the shared anchor so the sequencer re-anchors the date for
         // subsequent log lines. SessionAnchor.SetLoggedInUtc is no-op when the
         // value is unchanged, so we don't need to gate it here.
-        _anchor?.SetLoggedInUtc(session.LoggedInUtc);
+        _anchor?.SetLoggedInUtc(resolved.LoggedInUtc);
 
-        foreach (var h in toFire) Invoke(h, session);
-        sessionStartedSnapshot?.Invoke(this, session);
+        foreach (var h in toFire) Invoke(h, resolved);
+        sessionStartedSnapshot?.Invoke(this, resolved);
     }
 
     private void Invoke(Action<GameSession> handler, GameSession session)

--- a/src/Mithril.GameState/Sessions/Parsing/ConnectionEvent.cs
+++ b/src/Mithril.GameState/Sessions/Parsing/ConnectionEvent.cs
@@ -1,0 +1,36 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Sessions.Parsing;
+
+/// <summary>
+/// The parsed <c>EVENT(Ok): connected, url=&lt;host&gt;, port=&lt;port&gt;</c>
+/// preamble line PG emits when the client establishes its game-server TCP
+/// connection. Carries the connection's host + port; the
+/// <c>GameSessionService</c> consumer joins <see cref="Url"/> against
+/// <see cref="Mithril.GameState.Servers.IServerCatalogService"/> to derive
+/// the friendly server name surfaced on <c>GameSession.Server</c>.
+///
+/// <para>PG emits this once per session, in the preamble before the
+/// <c>Logged in as character</c> banner (~17 minutes earlier in some
+/// captures, due to character-select / area-load latency). It only reaches
+/// L0.5 when the L0 seed opens at byte 0 — see <c>SystemSignalKind.ConnectionEvent</c>.</para>
+/// </summary>
+/// <param name="Timestamp">
+/// The wall-clock instant PG emitted the line. Preamble lines have no
+/// <c>[ts]</c> prefix, so this comes from the L0 source clock's best-effort
+/// stamp at the time the line was read (file mtime fallback, since no
+/// in-line date is available pre-banner).
+/// </param>
+/// <param name="Url">
+/// The connection host as PG wrote it (e.g. <c>s4.projectgorgon.com</c>).
+/// The join key for <see cref="Mithril.GameState.Servers.IServerCatalogService.Get"/>;
+/// preserved verbatim so a lookup-against-catalog reproduces PG's exact
+/// host string.
+/// </param>
+/// <param name="Port">
+/// The TCP port the client connected to. Currently always 9002 in observed
+/// PG traffic, but the parser preserves whatever PG emitted so a future PG
+/// patch that uses a different port surfaces unchanged.
+/// </param>
+public sealed record ConnectionEvent(DateTime Timestamp, string Url, int Port)
+    : LogEvent(Timestamp);

--- a/src/Mithril.GameState/Sessions/Parsing/ConnectionEventParser.cs
+++ b/src/Mithril.GameState/Sessions/Parsing/ConnectionEventParser.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using Mithril.Shared.Logging;
+
+namespace Mithril.GameState.Sessions.Parsing;
+
+/// <summary>
+/// Parses the <c>EVENT(Ok): connected, url=&lt;host&gt;, port=&lt;port&gt;</c>
+/// preamble line PG emits when the client establishes its game-server TCP
+/// connection. Consumes the envelope-stripped payload from
+/// <see cref="SystemSignalLogLine.Data"/> (L0.5 classifier eats the
+/// <c>EVENT(Ok): </c> prefix per <see cref="SystemSignalKind.ConnectionEvent"/>),
+/// so the parser sees the bare <c>connected, url=…, port=…</c> body.
+///
+/// <para>The grammar is structurally simpler than the <c>Servers:</c> JSON
+/// blob — comma-delimited <c>key=value</c> pairs, no quoting, no nesting.
+/// Tokenised with hand-rolled span splits; the cost profile (~one event
+/// per session) is negligible either way, but the shape is uniform with
+/// the other live-log idioms in this assembly.</para>
+///
+/// <para>Unrelated lines fast-path to <c>null</c>. Malformed input
+/// (missing url, non-numeric port, extra/missing fields) also returns
+/// <c>null</c> rather than throwing — the parser never throws on
+/// production input. Defensively accepts the raw prefixed form
+/// (<c>"EVENT(Ok): connected, …"</c>) for ad-hoc / test callers in
+/// addition to the L0.5-stripped form.</para>
+///
+/// <para>Per #611, the host is preserved verbatim (no lowercasing) so a
+/// catalog lookup reproduces PG's exact string;
+/// <see cref="Mithril.GameState.Servers.IServerCatalogService.Get"/>
+/// performs case-insensitive matching on its side.</para>
+/// </summary>
+public sealed class ConnectionEventParser : ILogParser
+{
+    // The stripped payload is "connected, url=<host>, port=<port>".
+    // The prefixed form is "EVENT(Ok): connected, url=<host>, port=<port>".
+    private const string StrippedPrefix = "connected,";
+    private const string RawPrefix = "EVENT(Ok): connected,";
+
+    public LogEvent? TryParse(string line, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(line)) return null;
+
+        // Accept either the L0.5-stripped form (production path) or the raw
+        // prefixed form (test fixtures, REPL probes). The body shape is
+        // identical from "connected," onwards.
+        ReadOnlySpan<char> body;
+        if (line.StartsWith(StrippedPrefix, StringComparison.Ordinal))
+        {
+            body = line.AsSpan(StrippedPrefix.Length);
+        }
+        else if (line.StartsWith(RawPrefix, StringComparison.Ordinal))
+        {
+            body = line.AsSpan(RawPrefix.Length);
+        }
+        else
+        {
+            return null;
+        }
+
+        // body is now " url=<host>, port=<port>" (with a possible leading space).
+        // Tolerate either ", " or "," between fields and any surrounding
+        // whitespace — keep the parser shape-tolerant within the literal
+        // grammar PG emits.
+        string? url = null;
+        int? port = null;
+
+        var remaining = body;
+        while (!remaining.IsEmpty)
+        {
+            // Find the next comma (or end-of-input).
+            var commaIdx = remaining.IndexOf(',');
+            ReadOnlySpan<char> field;
+            if (commaIdx < 0)
+            {
+                field = remaining;
+                remaining = ReadOnlySpan<char>.Empty;
+            }
+            else
+            {
+                field = remaining.Slice(0, commaIdx);
+                remaining = remaining.Slice(commaIdx + 1);
+            }
+            field = field.Trim();
+            if (field.IsEmpty) continue;
+
+            var eq = field.IndexOf('=');
+            if (eq <= 0) return null; // malformed pair, drop the whole event
+            var key = field.Slice(0, eq).Trim();
+            var value = field.Slice(eq + 1).Trim();
+
+            if (key.SequenceEqual("url"))
+            {
+                if (value.IsEmpty) return null;
+                url = value.ToString();
+            }
+            else if (key.SequenceEqual("port"))
+            {
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var p))
+                    return null;
+                if (p <= 0 || p > 65535) return null;
+                port = p;
+            }
+            // Unknown keys are ignored — a future PG patch could add fields
+            // without breaking the parser. Strictness on required fields
+            // (url + port) is checked after the enumeration.
+        }
+
+        if (url is null || port is null) return null;
+        return new ConnectionEvent(timestamp, url, port.Value);
+    }
+}

--- a/src/Mithril.Shared/Logging/PlayerLogLineClassifier.cs
+++ b/src/Mithril.Shared/Logging/PlayerLogLineClassifier.cs
@@ -105,16 +105,23 @@ internal static class PlayerLogLineClassifier
         if (StartsWithLiteral(line, "EVENT(Ok): "))
         {
             const int dataStart = 11; // length of "EVENT(Ok): "
-            // The lifecycle phases we route: loginCharacter | playing | sessionUpdate.
-            // (The pre-login preamble's EVENT(Ok): connected sits outside the
-            // L0 replay window and is #514's seed-facility territory.)
+            // The lifecycle phases we route as SessionLifecycle: loginCharacter |
+            // playing | sessionUpdate. EVENT(Ok): connected is its own kind
+            // (ConnectionEvent, #611) because it carries the url+port payload
+            // that ConnectionEventParser joins against IServerCatalogService.
+            // Like Servers: above, connect sits in the preamble before the
+            // banner — only reaches L0.5 when the seed opens at byte 0.
+            if (StartsWithLiteral(line, "EVENT(Ok): connected"))
+            {
+                return new Result(LineKind.SystemSignal, dataStart, 0, SystemSignalKind.ConnectionEvent);
+            }
             if (StartsWithLiteral(line, "EVENT(Ok): loginCharacter")
                 || StartsWithLiteral(line, "EVENT(Ok): playing")
                 || StartsWithLiteral(line, "EVENT(Ok): sessionUpdate"))
             {
                 return new Result(LineKind.SystemSignal, dataStart, 0, SystemSignalKind.SessionLifecycle);
             }
-            // EVENT(Ok): connected and any other unknown phase falls to anomaly.
+            // Any other unknown phase falls to anomaly.
             return new Result(LineKind.Anomaly, -1, 0, default);
         }
 

--- a/src/Mithril.Shared/Logging/SystemSignalKind.cs
+++ b/src/Mithril.Shared/Logging/SystemSignalKind.cs
@@ -33,8 +33,11 @@ public enum SystemSignalKind
     /// <summary>
     /// <c>EVENT(Ok): loginCharacter | playing | sessionUpdate</c> — in-window,
     /// no-<c>[ts]</c> session-lifecycle phases. The pre-login preamble's
-    /// <c>EVENT(Ok): connected</c> is structurally outside the L0 replay
-    /// window and is handled by #514's seed facility, not here.
+    /// <c>EVENT(Ok): connected</c> is routed to
+    /// <see cref="ConnectionEvent"/> separately (#611). Only reaches L0.5
+    /// when L0's session-replay window opens at byte 0 (Mithril attached
+    /// before PG launched, or PG-truncation-while-Mithril-runs); a Mithril
+    /// cold-start mid-PG-session seeks past the preamble and never sees it.
     /// </summary>
     SessionLifecycle,
 
@@ -51,4 +54,19 @@ public enum SystemSignalKind
     /// in which case the catalog stays empty for the attach lifetime.
     /// </summary>
     Servers,
+
+    /// <summary>
+    /// <c>EVENT(Ok): connected, url=&lt;host&gt;, port=&lt;port&gt;</c> — the
+    /// per-session connect line PG emits when the client establishes its
+    /// game-server TCP connection. No <c>[ts]</c> prefix; lives in the
+    /// preamble before the login banner (~17 minutes earlier in some
+    /// captures, due to character-select / area-load latency). Consumed by
+    /// <c>ConnectionEventParser</c> + <c>GameSessionService</c> (#611) to
+    /// derive the per-session server identity by joining against
+    /// <c>IServerCatalogService</c> (#610). Same preamble caveat as
+    /// <see cref="Servers"/>: only reaches L0.5 when the seed opens at
+    /// byte 0; a Mithril cold-start mid-PG-session seeks past it and
+    /// <c>GameSession.Server</c> stays <c>null</c> for the attach lifetime.
+    /// </summary>
+    ConnectionEvent,
 }

--- a/tests/Mithril.GameState.Tests/Sessions/ConnectionEventParserTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/ConnectionEventParserTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Mithril.GameState.Sessions.Parsing;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Sessions;
+
+public sealed class ConnectionEventParserTests
+{
+    private static readonly ConnectionEventParser Parser = new();
+    private static readonly DateTime Ts = new(2026, 5, 21, 19, 59, 36, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Real Player.log payload (this machine, 2026-05-21), envelope-stripped
+    /// per the L0.5 classifier (SystemSignalKind.ConnectionEvent eats the
+    /// "EVENT(Ok): " prefix). Kept verbatim so a PG patch that changes the
+    /// shape shows up as a test diff.
+    /// </summary>
+    private const string RealStrippedPayload = "connected, url=s4.projectgorgon.com, port=9002";
+
+    [Fact]
+    public void Real_payload_parses_url_and_port()
+    {
+        var evt = Parser.TryParse(RealStrippedPayload, Ts)
+            .Should().BeOfType<ConnectionEvent>().Subject;
+
+        evt.Timestamp.Should().Be(Ts);
+        evt.Url.Should().Be("s4.projectgorgon.com");
+        evt.Port.Should().Be(9002);
+    }
+
+    [Fact]
+    public void Raw_prefixed_form_is_accepted_for_ad_hoc_callers()
+    {
+        // Defensive — production callers pass the L0.5-stripped form, but a
+        // test or REPL caller may hand the full "EVENT(Ok): connected, …" line.
+        var raw = "EVENT(Ok): " + RealStrippedPayload;
+        var evt = Parser.TryParse(raw, Ts)
+            .Should().BeOfType<ConnectionEvent>().Subject;
+
+        evt.Url.Should().Be("s4.projectgorgon.com");
+        evt.Port.Should().Be(9002);
+    }
+
+    [Fact]
+    public void Url_is_preserved_verbatim_no_case_normalisation()
+    {
+        // PG canonicalizes to lowercase, but we don't second-guess — the
+        // catalog lookup does case-insensitive matching, so the parser keeps
+        // PG's exact string.
+        var evt = Parser.TryParse("connected, url=S4.ProjectGorgon.com, port=9002", Ts)
+            .Should().BeOfType<ConnectionEvent>().Subject;
+        evt.Url.Should().Be("S4.ProjectGorgon.com");
+    }
+
+    [Theory]
+    [InlineData("connected, url=s0.projectgorgon.com, port=9002", "s0.projectgorgon.com", 9002)]
+    [InlineData("connected, url=s1.projectgorgon.com, port=9002", "s1.projectgorgon.com", 9002)]
+    [InlineData("connected, url=s4.projectgorgon.com, port=12345", "s4.projectgorgon.com", 12345)]
+    public void Various_realistic_payloads_parse(string line, string expectedUrl, int expectedPort)
+    {
+        var evt = Parser.TryParse(line, Ts).Should().BeOfType<ConnectionEvent>().Subject;
+        evt.Url.Should().Be(expectedUrl);
+        evt.Port.Should().Be(expectedPort);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("LOADING LEVEL AreaSerbule")]
+    [InlineData("loginCharacter, numChars=2")] // EVENT(Ok): loginCharacter body — not our event
+    [InlineData("playing")]
+    [InlineData("disconnected, url=s4.projectgorgon.com, port=9002")] // different verb
+    [InlineData("connected")] // missing fields entirely (no comma after verb)
+    [InlineData("connected,")] // empty body
+    [InlineData("connected, port=9002")] // missing url
+    [InlineData("connected, url=s4.projectgorgon.com")] // missing port
+    [InlineData("connected, url=, port=9002")] // empty url
+    [InlineData("connected, url=s4.projectgorgon.com, port=nope")] // non-numeric port
+    [InlineData("connected, url=s4.projectgorgon.com, port=-1")] // out-of-range port
+    [InlineData("connected, url=s4.projectgorgon.com, port=99999")] // out-of-range port
+    public void Returns_null_for_unrelated_or_malformed_lines(string line)
+    {
+        Parser.TryParse(line, Ts).Should().BeNull();
+    }
+
+    [Fact]
+    public void Unknown_extra_fields_are_tolerated_so_future_PG_additions_dont_break_parser()
+    {
+        // A future PG patch could add a "region=NA" or similar field. As
+        // long as url+port are still present, the parser must succeed; the
+        // unknown field is ignored.
+        var evt = Parser.TryParse(
+            "connected, url=s4.projectgorgon.com, port=9002, region=NA",
+            Ts).Should().BeOfType<ConnectionEvent>().Subject;
+        evt.Url.Should().Be("s4.projectgorgon.com");
+        evt.Port.Should().Be(9002);
+    }
+
+    [Fact]
+    public void Whitespace_around_equals_is_tolerated()
+    {
+        // PG emits "key=value" tightly today, but the parser shouldn't
+        // choke on cosmetic whitespace if the grammar drifts a touch.
+        var evt = Parser.TryParse(
+            "connected, url = s4.projectgorgon.com , port = 9002",
+            Ts).Should().BeOfType<ConnectionEvent>().Subject;
+        evt.Url.Should().Be("s4.projectgorgon.com");
+        evt.Port.Should().Be(9002);
+    }
+
+    [Fact]
+    public void Timestamp_is_passed_through()
+    {
+        var custom = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var evt = Parser.TryParse(RealStrippedPayload, custom)
+            .Should().BeOfType<ConnectionEvent>().Subject;
+        evt.Timestamp.Should().Be(custom);
+    }
+}

--- a/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Sessions/GameSessionServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Mithril.GameState.Servers;
 using Mithril.GameState.Sessions;
 using Mithril.GameState.Tests.TestSupport;
 using Mithril.Shared.Logging;
@@ -19,12 +20,20 @@ public sealed class GameSessionServiceTests
     private const string BannerOtherCharacter =
         "[14:00:00] Logged in as character Frodo. Time UTC=05/11/2026 14:00:00. Timezone Offset 01:00:00";
 
+    private const string ConnectS4 = "connected, url=s4.projectgorgon.com, port=9002";
+    private const string ConnectS0 = "connected, url=s0.projectgorgon.com, port=9002";
+
+    private static readonly ServerEntry Laeth = new(
+        "s4", "Laeth", "s4.projectgorgon.com", 9002, "Laeth desc");
+    private static readonly ServerEntry Arisetsu = new(
+        "s0", "Arisetsu", "s0.projectgorgon.com", 9002, "Arisetsu desc");
+
     [Fact]
     public async Task First_banner_populates_Current_and_raises_SessionStarted_and_pushes_to_anchor()
     {
         using var driver = new TestLogStreamDriver();
         var anchor = new SessionAnchor();
-        var svc = new GameSessionService(driver, anchor);
+        var svc = new GameSessionService(driver, anchor: anchor);
         try
         {
             GameSession? captured = null;
@@ -49,7 +58,7 @@ public sealed class GameSessionServiceTests
     {
         using var driver = new TestLogStreamDriver();
         var anchor = new SessionAnchor();
-        var svc = new GameSessionService(driver, anchor);
+        var svc = new GameSessionService(driver, anchor: anchor);
         try
         {
             var startedCount = 0;
@@ -282,4 +291,259 @@ public sealed class GameSessionServiceTests
 
     private static SystemSignalLogLine MakeSignal(SystemSignalKind kind, string data) =>
         new(DateTimeOffset.UtcNow, kind, data, Sequence: 0, ReadMonotonicTicks: 0);
+
+    private static SystemSignalLogLine MakeConnect(string body) =>
+        new(DateTimeOffset.UtcNow, SystemSignalKind.ConnectionEvent, body,
+            Sequence: 0, ReadMonotonicTicks: 0);
+
+    // --- #611: Server identity (ConnectionEvent + catalog join) ---
+
+    [Fact]
+    public async Task Connect_then_banner_resolves_Server_from_catalog()
+    {
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth, Arisetsu);
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server.Should().NotBeNull();
+            svc.Current.Server!.Id.Should().Be("s4");
+            svc.Current.Server.Name.Should().Be("Laeth");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Banner_without_preceding_connect_publishes_Server_null()
+    {
+        // Cold-start mid-PG-session: L0 seed seeks past the preamble, so
+        // the EVENT(Ok): connected line never reaches L0.5 and the catalog
+        // is empty. The banner arrives, gets minted with Server = null.
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(); // empty catalog
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server.Should().BeNull();
+            svc.Current.CharacterName.Should().Be("Emraell");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Connect_with_unknown_url_publishes_Server_null()
+    {
+        // Catalog is populated but the connect URL isn't in it (e.g. a new
+        // PG server that's not yet in the corpus, or a catalog that failed
+        // to parse). Server resolution returns null; the session is still
+        // minted with the rest of its banner fields intact.
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Arisetsu); // s0 only, no s4
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server.Should().BeNull();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task SessionStarted_payload_carries_resolved_Server()
+    {
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth);
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            GameSession? captured = null;
+            svc.SessionStarted += (_, s) => captured = s;
+
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            captured.Should().NotBeNull();
+            captured!.Server.Should().NotBeNull();
+            captured.Server!.Name.Should().Be("Laeth");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Subscribe_replay_carries_resolved_Server()
+    {
+        // Late subscriber observes Current via replay — Server must be on
+        // the replayed session (not just live deliveries).
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth);
+        var svc = new GameSessionService(driver, catalog);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = svc.StartAsync(cts.Token);
+        try
+        {
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await driver.DrainSystemAsync();
+
+            GameSession? replayed = null;
+            using var sub = svc.Subscribe(s => replayed = s);
+
+            replayed.Should().NotBeNull();
+            replayed!.Server.Should().NotBeNull();
+            replayed.Server!.Id.Should().Be("s4");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+            _ = runTask;
+            svc.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Pending_connect_is_consumed_by_banner_not_reused()
+    {
+        // A connect-then-banner pair publishes one session with Server set.
+        // A subsequent banner (PG re-login same Mithril run) without its
+        // own connect must publish Server = null — the prior connect was
+        // for the prior session and is one-shot per banner.
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth);
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            var sessions = new List<GameSession>();
+            svc.SessionStarted += (_, s) => sessions.Add(s);
+
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            driver.PushLive(MakeBanner(BannerSecond)); // re-login, no new connect
+            await RunUntilDrainedAsync(svc, driver);
+
+            sessions.Should().HaveCount(2);
+            sessions[0].Server.Should().NotBeNull();
+            sessions[0].Server!.Id.Should().Be("s4");
+            sessions[1].Server.Should().BeNull("the connect URL is one-shot per banner");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Connect_after_banner_does_not_retroactively_attach_to_current()
+    {
+        // PG always emits connect before banner. A reverse-order observation
+        // (defensive guard) does NOT mutate the already-published session —
+        // _current is captured-by-value once the banner publishes.
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth);
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            driver.PushLive(MakeBanner(BannerEmraell));
+            driver.PushLive(MakeConnect(ConnectS4));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server.Should().BeNull(
+                "connect arriving after the banner doesn't retroactively populate");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Most_recent_connect_wins_when_multiple_arrive_before_banner()
+    {
+        // Defensive: if two EVENT(Ok): connected lines arrive without an
+        // intervening banner (PG re-emit, or a corner-case L0 replay),
+        // the last one wins — it's the one the next session connected on.
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth, Arisetsu);
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeConnect(ConnectS0));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server!.Id.Should().Be("s0");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task No_catalog_injected_publishes_Server_null_without_throwing()
+    {
+        // Defensive: if the service is constructed without an
+        // IServerCatalogService (DI race, test scaffolding), connect
+        // observations are stashed but resolution skips — Server stays null,
+        // no throw.
+        using var driver = new TestLogStreamDriver();
+        var svc = new GameSessionService(driver, serverCatalog: null);
+        try
+        {
+            driver.PushLive(MakeConnect(ConnectS4));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server.Should().BeNull();
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    [Fact]
+    public async Task Malformed_connect_payload_does_not_break_subsequent_banner()
+    {
+        // A garbled connect line is dropped (parser returns null), the
+        // pending URL stays empty, the next banner publishes with Server
+        // = null. Verifies the malformed-input containment path.
+        using var driver = new TestLogStreamDriver();
+        var catalog = new FakeServerCatalog(Laeth);
+        var svc = new GameSessionService(driver, catalog);
+        try
+        {
+            driver.PushLive(MakeConnect("totally not a connect payload"));
+            driver.PushLive(MakeBanner(BannerEmraell));
+            await RunUntilDrainedAsync(svc, driver);
+
+            svc.Current.Should().NotBeNull();
+            svc.Current!.Server.Should().BeNull();
+            svc.Current.CharacterName.Should().Be("Emraell");
+        }
+        finally { await StopAsync(svc); }
+    }
+
+    private sealed class FakeServerCatalog : IServerCatalogService
+    {
+        private readonly Dictionary<string, ServerEntry> _byUrl;
+        private readonly IReadOnlyCollection<ServerEntry> _all;
+
+        public FakeServerCatalog(params ServerEntry[] entries)
+        {
+            _byUrl = entries.ToDictionary(e => e.Url, StringComparer.OrdinalIgnoreCase);
+            _all = entries;
+        }
+
+        public ServerEntry? Get(string url) =>
+            !string.IsNullOrEmpty(url) && _byUrl.TryGetValue(url, out var e) ? e : null;
+
+        public IReadOnlyCollection<ServerEntry> All => _all;
+    }
 }

--- a/tests/Mithril.Shared.Tests/Logging/Fixtures/per-rule/system-signals.log
+++ b/tests/Mithril.Shared.Tests/Logging/Fixtures/per-rule/system-signals.log
@@ -3,6 +3,7 @@
 [20:01:14] Logged in as character <CHARACTER>. Time UTC=05/19/2026 20:01:14. Timezone Offset 01:00:00
 [21:04:45] Logged in as character <CHARACTER>. Time UTC=05/19/2026 21:04:45. Timezone Offset 01:00:00
 Servers: [ { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Laeth - \"Time and Space\"</b>\nA brand new world!", "Url" : "s4.projectgorgon.com", "ID" : "s4", "Name" : "Laeth" }, { "AllowGuests" : true, "Port" : 9002, "Description" : "<b>Arisetsu - \"Hope and Warmth\"</b>\nPlay on the original.", "Url" : "s0.projectgorgon.com", "ID" : "s0", "Name" : "Arisetsu" } ]
+EVENT(Ok): connected, url=s4.projectgorgon.com, port=9002
 EVENT(Ok): loginCharacter, numChars=2
 EVENT(Ok): sessionUpdate, playTime=300
 EVENT(Ok): playing

--- a/tests/Mithril.Shared.Tests/Logging/PlayerLogLineClassifierTests.cs
+++ b/tests/Mithril.Shared.Tests/Logging/PlayerLogLineClassifierTests.cs
@@ -130,6 +130,39 @@ public sealed class PlayerLogLineClassifierTests
         kinds.Should().Contain(SystemSignalKind.PlayerAdded);
         kinds.Should().Contain(SystemSignalKind.SessionLifecycle);
         kinds.Should().Contain(SystemSignalKind.Servers);
+        kinds.Should().Contain(SystemSignalKind.ConnectionEvent);
+    }
+
+    [Fact]
+    public void Connect_line_classifies_as_SystemSignal_and_eats_prefix()
+    {
+        // The no-[ts] preamble line PG emits when the client connects to a
+        // game server. Distinguished from the other EVENT(Ok): phases by
+        // the `connected` verb after the colon-space.
+        const string line = "EVENT(Ok): connected, url=s4.projectgorgon.com, port=9002";
+        var r = PlayerLogLineClassifier.Classify(line);
+
+        r.Kind.Should().Be(PlayerLogLineClassifier.LineKind.SystemSignal);
+        r.SystemKind.Should().Be(SystemSignalKind.ConnectionEvent);
+        // The "EVENT(Ok): " envelope must be eaten; the payload begins with `connected,`.
+        r.DataStart.Should().Be("EVENT(Ok): ".Length);
+        line[r.DataStart..].Should().StartWith("connected,");
+    }
+
+    [Fact]
+    public void Other_EVENT_phases_do_not_absorb_into_ConnectionEvent()
+    {
+        // Narrow trigger — `EVENT(Ok): conn…` without the full `connected`
+        // literal must NOT route to ConnectionEvent. The classifier
+        // requires the exact `connected` token; siblings (`connecting`,
+        // `connection`) fall to the SessionLifecycle/Anomaly paths below.
+        var connecting = PlayerLogLineClassifier.Classify("EVENT(Ok): connecting, url=x");
+        connecting.SystemKind.Should().NotBe(SystemSignalKind.ConnectionEvent);
+
+        // The known sibling phases continue to route to SessionLifecycle.
+        var loginCh = PlayerLogLineClassifier.Classify("EVENT(Ok): loginCharacter, numChars=2");
+        loginCh.Kind.Should().Be(PlayerLogLineClassifier.LineKind.SystemSignal);
+        loginCh.SystemKind.Should().Be(SystemSignalKind.SessionLifecycle);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements #611: surfaces per-session server identity on `IGameSessionService` by parsing the preamble `EVENT(Ok): connected, url=<host>, port=<port>` line and joining it against `IServerCatalogService` (#610).

- New `SystemSignalKind.ConnectionEvent` + classifier rule (was Anomaly for `EVENT(Ok): connected`).
- `ConnectionEvent` record + `ConnectionEventParser` — tolerant comma-delimited `key=value` parse; unknown keys ignored for forward-compat.
- `GameSession.Server : ServerEntry?` — nullable by design (cold-start mid-PG-session: L0 seed skips the preamble, catalog stays empty, server identity is unknown).
- `GameSessionService` pairs the connect → banner adjacency: most-recent connect URL stashed as a pending one-shot, consumed by the next banner publish under the same lock; honest-nullable + diagnostic warn on every null-resolution path.
- 12 new tests (parser + catalog-join + cold-start nulls + pending-URL one-shot + DI-omitted catalog).

## Cross-source agreement check — deferred

Acceptance bullet 4 (Player.log connect-event server vs chat banner server) is intentionally deferred. The chat-side banner is parsed inside `ChatLogClock` as a private static — extracting the server name would lift the explicit "deferred abstraction (no `IChatSessionAnchor`)" stance documented in `ChatLogClock.cs`, and the world-sim design's principle 3 ("no service spans both sources") puts this verification squarely in the future view layer. A view-layer composer can do the check trivially once both worlds expose their banner observations.

## Test plan

- [x] `dotnet build Mithril.slnx` — 0 warnings, 0 errors
- [x] `dotnet test tests/Mithril.GameState.Tests` — 378 passed (12 new)
- [x] `dotnet test tests/Mithril.Shared.Tests` — 1250 passed (classifier kind + connect fixture line)
- [x] `dotnet test Mithril.slnx` — all green (Smaug/Arwen consumers of `GameSession` unaffected; trailing-default param keeps positional ctors working)

Closes #611.

— drafted by Claude (Opus 4.7), posted by @arthur-conde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
