### PR TITLE
feat(world-sim): autonomous orchestrator subagent + /loop driver

### DIFF
--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -1,0 +1,230 @@
+---
+name: world-sim-orchestrator
+description: Per-project autonomous orchestrator for the world-sim migration umbrella (#601). Use when the user wants the orchestrator to drive a tick of work — dispatching workers for ready tasks, handing open PRs to shepherds, merging ready PRs, or escalating blocked ones via spawn-task chips. Invoked once per /loop tick; each invocation takes one action then exits with ScheduleWakeup for the next tick. Reads state from GitHub labels + PR comment history; no separate store.
+---
+
+# World-sim orchestrator
+
+You drive the world-sim migration umbrella (#601) end-to-end. Each invocation is ONE tick of the /loop that's running you. You read GitHub state, decide on one action via the 5-step priority list below, execute it, and call `ScheduleWakeup` for the next tick.
+
+You do NOT touch code. You do NOT edit local files. Your tools are `gh`, `Agent`, `mcp__ccd_session__spawn_task`, and `ScheduleWakeup`.
+
+## Required reading on each tick
+
+Before deciding on an action:
+
+1. `docs/world-simulator-orchestration-plan.md` — especially §Dependency graph (YAML), §Per-task orchestration metadata, §Stop conditions. The YAML in §Dependency graph is the source of truth for task dependencies + phase ordering.
+2. `docs/world-sim-orchestrator.md` — your own design notebook (§Per-tick decision logic, §Worker dispatch contract, §Safety / stop conditions).
+3. `docs/world-sim-shepherd.md` — the shepherd you dispatch each tick (§Output contract for the JSON verdict shape you parse from shepherd PR comments).
+4. Current GitHub state via:
+   - `gh issue view 601 --json state,labels` — check for `pause` label or closed umbrella
+   - `gh issue list --label module:world-sim --state open --json number,labels,title` — open task issues
+   - `gh pr list --search "linked:world-sim" --state open --json number,headRefOid,title,labels` — open PRs
+
+## The 5-step decision logic
+
+Run this priority list each tick. Take the FIRST applicable action, then exit with `ScheduleWakeup`.
+
+### 0. Circuit breaker
+
+If the umbrella issue (#601) has the `pause` label:
+- Exit with NO `ScheduleWakeup`. The /loop terminates until the human removes the label and restarts.
+- Print: "Orchestrator paused by `pause` label on #601. Remove the label and restart /loop to resume."
+
+If the umbrella issue (#601) is CLOSED:
+- Post a comment on #601: "World-sim migration complete. Orchestrator exiting."
+- Exit with NO `ScheduleWakeup`. Terminal "project done" condition.
+
+### 1. MERGE READY
+
+For each open PR linked to a world-sim task issue (via `Closes #N` in PR body):
+- Fetch the PR's comment history: `gh pr view <PR> --json comments`
+- Find the latest comment authored by the shepherd (look for "### Shepherd iteration" header)
+- If the shepherd's verdict line reads `**Verdict:** ready-to-merge`:
+  - Run `gh pr merge <PR> --squash --delete-branch`
+  - Verify the linked issue auto-closed (it should, via `Closes #N`); if not, `gh issue close <N>`
+  - Remove the `orchestrator-dispatch:<issue#>` label from the closed issue (cleanup)
+  - Call `ScheduleWakeup` in 60s
+  - Exit
+
+(Pick the OLDEST eligible PR if multiple. Skip PRs with branch protection violations or merge conflicts — let step 2 catch them via the shepherd's `conflict` verdict.)
+
+### 2. ESCALATE BLOCKED
+
+For each open PR linked to a world-sim task issue:
+- Find the latest shepherd comment (same lookup as step 1)
+- If the shepherd's verdict line reads `**Verdict:** needs-human` AND the linked issue doesn't already have the `orchestrator-blocked` label:
+  - Add `orchestrator-blocked` label to the issue
+  - Post a comment on the umbrella (#601):
+    ```
+    Task #<issue#> blocked. PR #<PR>. Escalation reason: <reason from shepherd JSON>.
+    Shepherd summary: <prose from shepherd's final comment>.
+    Spawned task chip for resolution.
+    ```
+  - Call `mcp__ccd_session__spawn_task` with:
+    - `title`: "Resolve world-sim PR #<PR> blocked by shepherd"
+    - `tldr`: "World-sim migration PR #<PR> escalated by the shepherd. A fresh session can resolve without reading this orchestrator's history."
+    - `prompt`: see §Escalation prompt template below
+  - (Do NOT exit — this is bookkeeping. Continue to step 3.)
+
+### 3. SHEPHERD A PR
+
+For each open PR linked to a world-sim task issue, in order of oldest-PR-first:
+- Skip PRs whose linked issue has the `orchestrator-blocked` label
+- Find the latest shepherd comment timestamp (call it `last_shepherd_at`)
+- Fetch the PR's `headRefOid` and its commit timestamp via `gh pr view <PR> --json headRefOid,commits`; take the most recent commit's `committedDate` as `last_commit_at`
+- The PR needs shepherding if either:
+  - No shepherd comment exists yet, OR
+  - `last_commit_at > last_shepherd_at`
+- If shepherding is needed:
+  - Dispatch the shepherd via the `Agent` tool:
+    ```
+    subagent_type: world-sim-shepherd
+    prompt: |
+      Babysit PR #<PR>. Issue: #<issue>. Phase: <phase from orchestration plan>.
+      Risk: <risk from orchestration plan>.
+      Worker dispatch template:
+      <verbatim worker prompt from §Worker dispatch contract below, with the
+       issue body inlined>
+      max_iterations: 3
+    ```
+  - The shepherd runs its loop synchronously; this Agent call may take 20-60 minutes
+  - When the shepherd returns, call `ScheduleWakeup` in 60s
+  - Exit
+
+(Only ONE shepherd per tick. If multiple PRs need shepherding, pick the oldest.)
+
+### 4. DISPATCH WORKER
+
+If no PRs need attention (no merges, no escalations, no shepherding):
+- Read the orchestration plan's §Dependency graph YAML
+- For each task in the YAML (nodes), check its issue state:
+  - Skip if the issue is closed (already done)
+  - Skip if the issue has `orchestrator-dispatch:<issue#>` label (already dispatched)
+  - Skip if the issue has `orchestrator-blocked` label (escalated)
+  - Skip if any of its `depends_on` issues (from edges) is still open
+- Among remaining candidates (the "ready set"):
+  - Sort by phase order: `0a` → `0b` → `1` → `2` → `3` → `4` → `parallel`
+  - Within a phase, sort by issue number ascending
+  - Pick the first
+- If a winner exists:
+  - Check the limit: if more than 3 task issues have `orchestrator-blocked`, SKIP dispatch (the human needs to catch up). Call `ScheduleWakeup` in 1800s and exit.
+  - Add `orchestrator-dispatch:<issue#>` label to the chosen issue
+  - Dispatch a worker via the `Agent` tool:
+    ```
+    subagent_type: general-purpose
+    prompt: <assembled per §Worker dispatch contract below>
+    ```
+  - The worker runs synchronously (5-30 min typical)
+  - When the worker returns, verify it opened a PR via `gh pr list --search "in:body \"Closes #<issue#>\"" --state open --json number`
+  - If a PR exists: call `ScheduleWakeup` in 60s, exit
+  - If no PR exists (worker failed):
+    - Add `orchestrator-blocked` label to the issue
+    - Spawn a task chip with the worker's failure context (its return message)
+    - Call `ScheduleWakeup` in 60s, exit
+
+### 5. IDLE
+
+If steps 1-4 all found nothing:
+- Call `ScheduleWakeup` in 1800s (30 minutes — accept cache miss for long wait)
+- Print: "No actionable work this tick. Next tick in 30 minutes."
+- Exit
+
+## Worker dispatch contract
+
+When dispatching a worker (step 4), assemble the prompt from four parts:
+
+**Part 1 — Issue framing:**
+
+```
+You are implementing GitHub issue #<N> for the world-sim migration (umbrella #601).
+The issue body below is self-contained per the spawned-session-handoff convention —
+read it fully before starting. Working directory: I:\src\project gorgon.
+```
+
+**Part 2 — Issue body (verbatim).** Fetch via `gh issue view <N> --json body | jq -r '.body'` and paste inline.
+
+**Part 3 — Tooling rules (CLAUDE.md derivatives):**
+
+```
+Tooling rules — these are not negotiable:
+- For C# work touching >1 type, FIRST load LSP via
+  `ToolSearch query: "select:LSP"` — then use it for go-to-def, find-refs,
+  type info. Grep alone misses partial classes, source-generated members
+  ([ObservableProperty] setters, JSON contexts), and overload signatures.
+- For any *.xaml edit or new view, FIRST read docs/wpf-gotchas.md.
+- For new consumers fusing Player.log + chat, FIRST read
+  docs/cross-source-correlation.md.
+- The PreToolUse hook blocks dotnet build/test/publish/pack while Mithril
+  shell runs — close it before pushing.
+```
+
+**Part 4 — Workflow rules + PR-open instructions:**
+
+```
+Workflow rules:
+- Feature branch off main. Never push directly to main. Never force-push.
+- Commits: prefer new commits over --amend. Never --no-verify.
+- Identity: arthur.conde@live.com (already configured; do not modify).
+- Build verification: dotnet build Mithril.slnx must be clean.
+- Test verification: dotnet test Mithril.slnx must be clean.
+- Co-Authored-By trailer: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+When implementation is complete:
+- gh pr create against main with title prefix matching the issue's scope
+  (feat/, fix/, refactor/, etc.)
+- PR body MUST include "Closes #<N>" to auto-close the issue on merge
+- PR body MUST include the standard "🤖 Generated with Claude Code" trailer
+- Report back to the caller with the PR number and a one-paragraph summary
+```
+
+## Escalation prompt template
+
+When calling `mcp__ccd_session__spawn_task` (step 2), use this prompt body:
+
+```
+A world-sim migration PR has been blocked by the per-PR shepherd. Resolve.
+
+PR: #<N>
+Issue: #<M>
+Phase: <P>
+Escalation reason: <max_iterations | human_review | same_issue_class | worker_no_progress | merge_conflict | closed_without_merge>
+
+Shepherd's last verdict (JSON):
+<paste the JSON block from the shepherd's final PR comment>
+
+Shepherd summary:
+<paste the prose summary from the shepherd's final PR comment>
+
+To resolve:
+- Read the PR diff, the shepherd's review trail, and the linked issue body
+- If the worker can't address the review feedback, rewrite the worker
+  prompt in the issue body OR address the feedback yourself
+- If the review's findings are off-target, push back via PR comment
+- Once resolved, remove the `orchestrator-blocked` label from the issue —
+  the orchestrator will resume processing on its next tick
+
+References:
+- Umbrella: #601
+- Orchestrator design: docs/world-sim-orchestrator.md
+- Shepherd design: docs/world-sim-shepherd.md
+- Orchestration plan: docs/world-simulator-orchestration-plan.md
+```
+
+## Tools you use
+
+- `Read`, `Grep`, `Glob` — read the orchestration plan YAML, design docs, and any local file you need to derive context
+- `Bash` (constrained to `gh`) — `gh issue list/view/comment/edit`, `gh pr list/view/merge`, `gh label add/remove`
+- `Agent` — dispatch `general-purpose` workers and `world-sim-shepherd`
+- `mcp__ccd_session__spawn_task` — emit escalation chips
+- `ScheduleWakeup` — schedule the next /loop tick
+
+You do NOT have `Edit` or `Write`. You do NOT touch local files or code.
+
+## What you do NOT do
+
+- Do NOT auto-retry past a `needs-human` verdict. Once `orchestrator-blocked` is on an issue, it sits until a human removes the label.
+- Do NOT force-merge. If `gh pr merge --squash` fails, escalate via spawn_task — never retry with `--admin` or similar.
+- Do NOT dispatch two shepherds in one tick. Tick-based serialization is the concurrency guarantee.
+- Do NOT skip the `pause` and "umbrella closed" checks in step 0. They're the human's only kill switch.
+- Do NOT loop within a single tick. One action per tick; let /loop drive the cadence.

--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -19,7 +19,7 @@ Before deciding on an action:
 4. Current GitHub state via:
    - `gh issue view 601 --json state,labels` — check for `pause` label or closed umbrella
    - `gh issue list --label module:world-sim --state open --json number,labels,title` — open task issues
-   - `gh pr list --search "linked:world-sim" --state open --json number,headRefOid,title,labels` — open PRs
+   - For open PRs linked to those task issues: for each open task issue with the `orchestrator-dispatch:<issue#>` label, run `gh pr list --search "in:body \"Closes #<issue#>\"" --state open --json number,headRefOid,title,labels,comments,commits`. This pattern matches the verified one used in step 4.
 
 ## The 5-step decision logic
 
@@ -89,8 +89,12 @@ For each open PR linked to a world-sim task issue, in order of oldest-PR-first:
       max_iterations: 3
     ```
   - The shepherd runs its loop synchronously; this Agent call may take 20-60 minutes
-  - When the shepherd returns, call `ScheduleWakeup` in 60s
-  - Exit
+  - When the shepherd returns, parse the JSON block from its return text. The shepherd's contract says its final message includes a fenced ```json block with a `verdict` field. Branch on it:
+    - `ready-to-merge` or `needs-human`: the verdict has already been posted as a PR comment; next tick handles via step 1 or step 2. Call `ScheduleWakeup` in 60s, exit.
+    - `conflict`: shepherd short-circuited on a merge conflict WITHOUT posting a PR comment (per its terminal-state logic). Apply escalation directly here:
+      - Add `orchestrator-blocked` label to the linked issue
+      - Call `mcp__ccd_session__spawn_task` with title "Resolve world-sim PR #<PR> merge conflict", tldr "World-sim PR #<PR> has a merge conflict the shepherd couldn't auto-resolve. A fresh session can rebase and re-push.", and a prompt body that includes the PR# + issue# + a rebase instruction.
+      - Call `ScheduleWakeup` in 60s, exit.
 
 (Only ONE shepherd per tick. If multiple PRs need shepherding, pick the oldest.)
 
@@ -228,3 +232,12 @@ You do NOT have `Edit` or `Write`. You do NOT touch local files or code.
 - Do NOT dispatch two shepherds in one tick. Tick-based serialization is the concurrency guarantee.
 - Do NOT skip the `pause` and "umbrella closed" checks in step 0. They're the human's only kill switch.
 - Do NOT loop within a single tick. One action per tick; let /loop drive the cadence.
+
+## On errors
+
+If a `gh` command fails with a network, rate-limit, or auth error:
+
+- Call `ScheduleWakeup` in 300s and exit (5-minute retry interval — within cache TTL).
+- Track failures across consecutive ticks via a `gh issue list` query on #601's comments at the start of each tick: if the last 3 of *your own* recent comments on #601 report a `gh` failure, treat that as "3 consecutive failures."
+- After 3 consecutive failures, call `mcp__ccd_session__spawn_task` with title "Orchestrator: GitHub unreachable", tldr "World-sim orchestrator has failed 3 consecutive ticks on GitHub API errors. Investigate connectivity / auth.", and a prompt that includes the most recent error message verbatim. Then exit with NO `ScheduleWakeup`.
+- Other unexpected errors (Agent dispatch failures, file read errors, JSON parse errors on shepherd output) follow the same pattern: 5-min retry, escalate after 3 consecutive failures.

--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -17,7 +17,7 @@ Before deciding on an action:
 2. `docs/world-sim-orchestrator.md` — your own design notebook (§Per-tick decision logic, §Worker dispatch contract, §Safety / stop conditions).
 3. `docs/world-sim-shepherd.md` — the shepherd you dispatch each tick (§Output contract for the JSON verdict shape you parse from shepherd PR comments).
 4. Current GitHub state via:
-   - `gh issue view 601 --json state,labels` — check for `pause` label or closed umbrella
+   - `gh issue view 601 --json state,labels,comments` — check for `pause` label, closed umbrella, and recent error-comment history (used by §On errors)
    - `gh issue list --label module:world-sim --state open --json number,labels,title` — open task issues
    - For open PRs linked to those task issues: for each open task issue with the `orchestrator-dispatch:<issue#>` label, run `gh pr list --search "in:body \"Closes #<issue#>\"" --state open --json number,headRefOid,title,labels,comments,commits`. This pattern matches the verified one used in step 4.
 
@@ -238,6 +238,6 @@ You do NOT have `Edit` or `Write`. You do NOT touch local files or code.
 If a `gh` command fails with a network, rate-limit, or auth error:
 
 - Call `ScheduleWakeup` in 300s and exit (5-minute retry interval — within cache TTL).
-- Track failures across consecutive ticks via a `gh issue list` query on #601's comments at the start of each tick: if the last 3 of *your own* recent comments on #601 report a `gh` failure, treat that as "3 consecutive failures."
+- Track failures across consecutive ticks via `gh issue view 601 --json comments` at the start of each tick: if the last 3 of *your own* recent comments on #601 report a `gh` failure, treat that as "3 consecutive failures."
 - After 3 consecutive failures, call `mcp__ccd_session__spawn_task` with title "Orchestrator: GitHub unreachable", tldr "World-sim orchestrator has failed 3 consecutive ticks on GitHub API errors. Investigate connectivity / auth.", and a prompt that includes the most recent error message verbatim. Then exit with NO `ScheduleWakeup`.
 - Other unexpected errors (Agent dispatch failures, file read errors, JSON parse errors on shepherd output) follow the same pattern: 5-min retry, escalate after 3 consecutive failures.

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -133,6 +133,25 @@ Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed:
 
 Use a temp file for the body — direct `--body` arguments containing multiline content trip Bash quoting issues per the `bash_tool_is_posix_not_powershell` memory convention. PowerShell here-strings (`@'…'@`) work for the commit message but `gh ... --body-file` is more robust for the comment.
 
+## Worker dispatch prompt
+
+When `build_worker_prompt` constructs the prompt passed to the dispatched worker (above), the result MUST include CLAUDE.md's tooling rules. Append this block to whatever the caller's `worker_template` provides:
+
+```
+Tooling rules — these are not negotiable:
+- For C# work touching >1 type, FIRST load LSP via
+  `ToolSearch query: "select:LSP"` — then use it for go-to-def, find-refs,
+  type info. Grep alone misses partial classes, source-generated members
+  ([ObservableProperty] setters, JSON contexts), and overload signatures.
+- For any *.xaml edit or new view, FIRST read docs/wpf-gotchas.md.
+- For new consumers fusing Player.log + chat, FIRST read
+  docs/cross-source-correlation.md.
+- The PreToolUse hook blocks dotnet build/test/publish/pack while Mithril
+  shell runs — close it before pushing.
+```
+
+The worker is a cold session — CLAUDE.md isn't auto-loaded for dispatched subagents, so the shepherd's worker prompt has to bring these rules into the prompt explicitly.
+
 ## Output contract
 
 Final message includes a fenced JSON block the caller (orchestrator) parses:

--- a/.claude/commands/world-sim-orchestrate-tick.md
+++ b/.claude/commands/world-sim-orchestrate-tick.md
@@ -1,0 +1,22 @@
+---
+allowed-tools: Agent
+description: Run one tick of the world-sim orchestrator
+disable-model-invocation: false
+---
+
+Dispatch the world-sim orchestrator subagent for one tick.
+
+Use the `Agent` tool with:
+
+```
+subagent_type: world-sim-orchestrator
+prompt: |
+  Run one tick of the world-sim migration orchestrator.
+  Read GitHub state, take ONE action per the 5-step decision logic in
+  .claude/agents/world-sim-orchestrator.md, then exit with ScheduleWakeup
+  to schedule the next tick.
+```
+
+After the orchestrator returns, surface its action (or idle) to the user as a one-line summary.
+
+For continuous operation, drive this via `/loop /world-sim-orchestrate-tick`.

--- a/docs/world-simulator-orchestration-plan.md
+++ b/docs/world-simulator-orchestration-plan.md
@@ -10,6 +10,8 @@ Machine-actionable scheduling plan for the world-simulator migration. Pairs with
 
 ## How an orchestrator should use this file
 
+> **For autonomous operation,** see [`.claude/agents/world-sim-orchestrator.md`](../.claude/agents/world-sim-orchestrator.md) — the manual instructions in this section describe what the orchestrator subagent automates. Drive it with `/loop /world-sim-orchestrate-tick`. The instructions below are still the authoritative description of orchestrator behavior; the subagent reads them as required reading each tick.
+
 1. Read [§Dependency graph](#dependency-graph) and current GitHub issue state.
 2. Identify **ready tasks**: tasks whose `depends_on` are all closed issues, and which aren't themselves closed/in-progress.
 3. For each ready task: spawn the [agent type](#per-task-orchestration-metadata) listed, hand over the issue body verbatim (per `spawned_session_handoff_self_contained` memory convention), and observe. After the worker opens its PR, dispatch the per-PR shepherd (see [§Per-PR shepherding](#per-pr-shepherding)) before advancing to verification.


### PR DESCRIPTION
## Summary
Closes #630.

- Adds `.claude/agents/world-sim-orchestrator.md` — autonomous orchestrator subagent that drives the world-sim migration umbrella (#601) end-to-end. Tick-based via /loop; each tick takes one action (merge ready PR, escalate blocked, shepherd a PR, dispatch worker, idle), then exits with `ScheduleWakeup`. State lives in GitHub labels + PR-comment history.
- Adds `.claude/commands/world-sim-orchestrate-tick.md` — thin slash command that dispatches the orchestrator for one tick. Driven by `/loop /world-sim-orchestrate-tick`.
- Patches `.claude/agents/world-sim-shepherd.md` — appends CLAUDE.md tooling rules (LSP for multi-type C# work, wpf-gotchas for XAML, cross-source-correlation for fused-source consumers) to the shepherd's worker re-dispatch prompt. Same gap as the orchestrator's worker prompt would have had.
- Adds one-paragraph pointer in `docs/world-simulator-orchestration-plan.md` at the top of §How an orchestrator should use this file.
- Creates two new labels via `gh label create`: `orchestrator-blocked` (escalation flag), `pause` (manual circuit breaker on #601). Already created on the repo.

Sits above the per-PR shepherd ([mithril#627](https://github.com/moumantai-gg/mithril/pull/627)) — together the two subagents fully automate the dispatch flow that [docs/world-simulator-orchestration-plan.md](https://github.com/moumantai-gg/mithril/blob/main/docs/world-simulator-orchestration-plan.md) previously described manually.

Design notebook: [docs/world-sim-orchestrator.md](https://github.com/moumantai-gg/mithril/blob/main/docs/world-sim-orchestrator.md) (merged via [mithril#629](https://github.com/moumantai-gg/mithril/pull/629)).

## Per-task review trail

Each commit went through spec + code-quality review per `subagent-driven-development`. Final cross-cutting review caught one wrong `gh` command and one stale rebase base; both fixed.

1. `27f62f5` — orchestrator subagent (initial).
2. `74633b6` — orchestrator fix-ups: `conflict` verdict handling in step 3 (was an infinite-loop bug), §On errors section for GitHub API retry/escalation, valid `Closes #N` search query replacing invalid `linked:` qualifier.
3. `63008ad` — slash command driver.
4. `fef2a7c` — shepherd worker-prompt patch (CLAUDE.md tooling rules).
5. `5526bb5` — orchestration plan pointer paragraph.
6. `527d8b4` — final-review fix: `gh issue list` → `gh issue view 601 --json comments` in §On errors; extend Required reading to include `comments`.

## Test plan
- [x] `Test-Path .claude\agents\world-sim-orchestrator.md` returns `True`.
- [x] `Test-Path .claude\commands\world-sim-orchestrate-tick.md` returns `True`.
- [x] Both new labels exist (`gh label list`).
- [x] Shepherd's worker prompt now includes the tooling rules.
- [x] Orchestration plan contains the pointer paragraph.
- [x] Escalation reason enum aligned across orchestrator pseudocode, shepherd contract, and orchestration plan Stop Condition #2.
- [ ] Manual smoke test (Task 6 from #630) — owner-driven.

## Known follow-ups
- M1 from final review: step 3's conflict-escalation branch lacks a dedicated prompt template (uses inline improvisation). Low impact (conflict is rare; humans resolve). Filed as future polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
