### PR TITLE
feat(world-sim): Phase 0 IPlayerWorld shell — clock, merger, bus, dispatch graph (#616)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/Mithril.GameReports/Mithril.GameReports.csproj" />
     <Project Path="src/Mithril.Shared/Mithril.Shared.csproj" />
     <Project Path="src/Mithril.WorldSim.Core/Mithril.WorldSim.Core.csproj" />
+    <Project Path="src/Mithril.WorldSim.Player/Mithril.WorldSim.Player.csproj" />
     <Project Path="src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj" />
     <Project Path="src/Mithril.GameState/Mithril.GameState.csproj" />
     <Project Path="src/Mithril.Leveling/Mithril.Leveling.csproj" />
@@ -32,6 +33,7 @@
     <Project Path="tests/Mithril.GameReports.Tests/Mithril.GameReports.Tests.csproj" />
     <Project Path="tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj" />
     <Project Path="tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj" />
+    <Project Path="tests/Mithril.WorldSim.Player.Tests/Mithril.WorldSim.Player.Tests.csproj" />
     <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
     <Project Path="tests/Mithril.LogSanitizer.Tests/Mithril.LogSanitizer.Tests.csproj" />
     <Project Path="tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj" />

--- a/src/Mithril.WorldSim.Core/IModeAwareFrameProducer.cs
+++ b/src/Mithril.WorldSim.Core/IModeAwareFrameProducer.cs
@@ -1,0 +1,37 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// Optional companion to <see cref="IFrameProducer{TPayload}"/> for producers
+/// with an explicit "draining recorded backlog vs blocking on live tail"
+/// boundary (e.g., the L1 classified-pipe reader's <c>IsReplay</c> flip — see
+/// <c>Mithril.Shared.Logging.LogEnvelope{T}.IsReplay</c>).
+///
+/// <para>The world's clock flips from <see cref="WorldMode.Replaying"/> to
+/// <see cref="WorldMode.Live"/> once every registered mode-aware producer's
+/// <see cref="ReachedLive"/> task has completed. Non-mode-aware producers
+/// are treated as live from t=0 (they have no replay phase to drain).
+/// Producers signal catch-up by completing this task; the world polls
+/// <see cref="Task.IsCompleted"/> between frame dispatches (principle 12 —
+/// "the mechanism a world uses to detect 'drained, now on the live tail'
+/// is producer-implementation-specific; the world just observes the
+/// result").</para>
+///
+/// <para>Implementers must complete the task BEFORE yielding the first live
+/// frame from <see cref="IFrameProducer{TPayload}.SubscribeAsync"/>, so that
+/// the world flips mode before dispatching that first live frame.</para>
+/// </summary>
+/// <typeparam name="TPayload">
+/// The frame payload type — must match the underlying
+/// <see cref="IFrameProducer{TPayload}"/>.
+/// </typeparam>
+public interface IModeAwareFrameProducer<TPayload> : IFrameProducer<TPayload>
+{
+    /// <summary>
+    /// Completes when the producer has drained its replay backlog and is now
+    /// blocking on its live source-stream tail. The task transitions only
+    /// once — from incomplete to completed — and is never re-armed. If the
+    /// underlying source has no replay phase (live from the start), the
+    /// implementer should complete the task immediately at construction.
+    /// </summary>
+    Task ReachedLive { get; }
+}

--- a/src/Mithril.WorldSim.Core/ModeChanged.cs
+++ b/src/Mithril.WorldSim.Core/ModeChanged.cs
@@ -11,13 +11,21 @@ namespace Mithril.WorldSim;
 /// re-arm or arm-for-the-first-time. State-deriving consumers (folders,
 /// composers, views) ignore mode changes — their behaviour is mode-agnostic
 /// by contract.</para>
+///
+/// <para><b>Emission contract:</b> a <see cref="ModeChanged"/> frame is
+/// emitted only when the world actually experienced the source mode — i.e.,
+/// at least one frame was applied while <c>Mode == Replaying</c>. A world
+/// that starts <see cref="WorldMode.Live"/> (no mode-aware producers, every
+/// mode-aware producer's <c>ReachedLive</c> already complete at start, or the
+/// source stream's replay phase is empty) emits no <see cref="ModeChanged"/>
+/// — consumers read <see cref="IWorldClock.Mode"/> for the initial state and
+/// subscribe to the bus only for actual transitions.</para>
 /// </summary>
 /// <param name="From">The mode the world was in before the transition.</param>
 /// <param name="To">The mode the world is in after the transition.</param>
 /// <param name="At">
-/// Simulated wall-clock at the moment of transition (<see cref="IWorldClock.Now"/>
-/// of the world's clock at the transition point — typically the timestamp of
-/// the most recently applied replay frame, or the first live frame if no
-/// replay phase preceded it).
+/// Simulated wall-clock at the moment of transition
+/// (<see cref="IWorldClock.Now"/> of the world's clock at the transition
+/// point — the timestamp of the most recently applied frame before the flip).
 /// </param>
 public readonly record struct ModeChanged(WorldMode From, WorldMode To, DateTimeOffset At);

--- a/src/Mithril.WorldSim.Core/ModeChanged.cs
+++ b/src/Mithril.WorldSim.Core/ModeChanged.cs
@@ -1,0 +1,23 @@
+namespace Mithril.WorldSim;
+
+/// <summary>
+/// Domain frame payload emitted on a world's bus when the world transitions
+/// between <see cref="WorldMode.Replaying"/> and <see cref="WorldMode.Live"/>
+/// (principle 12). Each world emits its own <c>Frame&lt;ModeChanged&gt;</c>
+/// independently — PlayerWorld may catch up at T1, ChatWorld at T2.
+///
+/// <para>Side-effect-emitting consumers gate on <c>Mode == Live</c>; the
+/// <see cref="ModeChanged"/> frame is the structural signal they use to
+/// re-arm or arm-for-the-first-time. State-deriving consumers (folders,
+/// composers, views) ignore mode changes — their behaviour is mode-agnostic
+/// by contract.</para>
+/// </summary>
+/// <param name="From">The mode the world was in before the transition.</param>
+/// <param name="To">The mode the world is in after the transition.</param>
+/// <param name="At">
+/// Simulated wall-clock at the moment of transition (<see cref="IWorldClock.Now"/>
+/// of the world's clock at the transition point — typically the timestamp of
+/// the most recently applied replay frame, or the first live frame if no
+/// replay phase preceded it).
+/// </param>
+public readonly record struct ModeChanged(WorldMode From, WorldMode To, DateTimeOffset At);

--- a/src/Mithril.WorldSim.Player/DependencyInjection/PlayerWorldServiceCollectionExtensions.cs
+++ b/src/Mithril.WorldSim.Player/DependencyInjection/PlayerWorldServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Player.Producers;
+
+namespace Mithril.WorldSim.Player.DependencyInjection;
+
+/// <summary>
+/// DI registration for the Phase 0 PlayerWorld shell (issue #616). Registers
+/// the world singleton, the classified-pipe producer, and a
+/// <see cref="BackgroundService"/> shim that calls <see cref="IWorld.StartAsync"/>
+/// once the host boots. Per-folder migrations (Phase 1+) wire their folder /
+/// composer registrations against the same world singleton — typically via
+/// dedicated DI extensions of their own that resolve the world and call
+/// <see cref="IWorld.RegisterFolder{T}"/> / <see cref="IWorld.RegisterComposer"/>
+/// before the host starts.
+/// </summary>
+public static class PlayerWorldServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the PlayerWorld shell and bind it to the L1 classified pipe.
+    /// Must be called after <c>AddMithrilGameServices</c> (which registers
+    /// <see cref="IClassifiedPlayerLogStream"/>).
+    /// </summary>
+    public static IServiceCollection AddPlayerWorld(this IServiceCollection services)
+    {
+        services
+            .AddSingleton<ClassifiedPlayerLogProducer>()
+            .AddSingleton<PlayerWorld>(sp =>
+            {
+                var world = new PlayerWorld();
+                world.RegisterProducer(sp.GetRequiredService<ClassifiedPlayerLogProducer>());
+                return world;
+            })
+            .AddSingleton<IPlayerWorld>(sp => sp.GetRequiredService<PlayerWorld>())
+            .AddHostedService<PlayerWorldHostedService>();
+
+        return services;
+    }
+
+    private sealed class PlayerWorldHostedService : BackgroundService
+    {
+        private readonly PlayerWorld _world;
+
+        public PlayerWorldHostedService(PlayerWorld world) => _world = world;
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            => _world.StartAsync(stoppingToken);
+    }
+}

--- a/src/Mithril.WorldSim.Player/IPlayerWorld.cs
+++ b/src/Mithril.WorldSim.Player/IPlayerWorld.cs
@@ -1,0 +1,19 @@
+namespace Mithril.WorldSim.Player;
+
+/// <summary>
+/// The world reconstructed from <c>Player.log</c> (design notebook §Contracts
+/// — "Concrete worlds"). Subscribes to the L1 classified pipe
+/// (<c>IClassifiedPlayerLogStream</c>) as its source-stream producer; merges
+/// frames by timestamp; dispatches to registered folders; resolves composers;
+/// publishes domain frames on its bus.
+///
+/// <para>This is the Phase 0 shell (issue #616) — no folders or composers
+/// are registered yet. Per-folder migrations (skills, recipes, inventory,
+/// effects, position, pins, weather, areas, celestial, sessions, quests,
+/// WoP-discovery, …) land in Phase 1+ issues and add their corresponding
+/// folder + property pair to this interface at that time. Until then the
+/// shell carries the clock + bus + merger only.</para>
+/// </summary>
+public interface IPlayerWorld : IWorld
+{
+}

--- a/src/Mithril.WorldSim.Player/Internal/WorldClock.cs
+++ b/src/Mithril.WorldSim.Player/Internal/WorldClock.cs
@@ -1,0 +1,37 @@
+namespace Mithril.WorldSim.Player.Internal;
+
+/// <summary>
+/// Mutable <see cref="IWorldClock"/> implementation owned by the world's
+/// merger loop. Advances only through <see cref="Advance"/> (called when a
+/// frame is applied) and <see cref="SetMode"/> (called when the world flips
+/// between <see cref="WorldMode.Replaying"/> and <see cref="WorldMode.Live"/>).
+///
+/// <para>Not thread-safe by design — single-threaded mutator (the merger
+/// loop). External readers see the publicly-immutable view (<see cref="Now"/>,
+/// <see cref="Frame"/>, <see cref="Mode"/>) which the merger writes between
+/// frame dispatches.</para>
+/// </summary>
+internal sealed class WorldClock : IWorldClock
+{
+    public DateTimeOffset Now { get; private set; } = DateTimeOffset.MinValue;
+    public long Frame { get; private set; }
+    public WorldMode Mode { get; private set; } = WorldMode.Replaying;
+
+    /// <summary>
+    /// Apply one frame's timestamp to the clock. <see cref="Now"/> takes the
+    /// frame's timestamp; <see cref="Frame"/> ticks once. Late frames
+    /// (timestamp earlier than the current <see cref="Now"/>) clamp to
+    /// <see cref="Now"/> — per producer contract, late-stamped frames are
+    /// "clamped + warned by the world."
+    /// </summary>
+    public void Advance(DateTimeOffset frameTimestamp)
+    {
+        if (frameTimestamp > Now)
+        {
+            Now = frameTimestamp;
+        }
+        Frame++;
+    }
+
+    public void SetMode(WorldMode mode) => Mode = mode;
+}

--- a/src/Mithril.WorldSim.Player/Internal/WorldEventBus.cs
+++ b/src/Mithril.WorldSim.Player/Internal/WorldEventBus.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+
+namespace Mithril.WorldSim.Player.Internal;
+
+/// <summary>
+/// Typed pub-sub bus for a world's domain frames. Subscribers register a
+/// handler for a payload type <c>T</c>; the bus routes
+/// <see cref="Frame{TPayload}"/> emissions to handlers whose <c>T</c>
+/// matches the frame's payload type.
+///
+/// <para>Handlers fire synchronously on the publishing thread (the world's
+/// merger thread) in subscription order. Subscribers must not block; per
+/// principle 11 — bus delivery happens inside the world's frame-resolution
+/// loop and any blocking work stalls the merger.</para>
+/// </summary>
+internal sealed class WorldEventBus : IWorldEventBus
+{
+    private readonly ConcurrentDictionary<Type, List<Subscription>> _subscriptions = new();
+    private readonly object _mutationLock = new();
+
+    public IDisposable Subscribe<T>(Action<Frame<T>> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var subscription = new Subscription(typeof(T), boxed =>
+        {
+            // The bus stores handlers as Action<IFrame> wrappers (post-cast to
+            // the concrete generic Frame<T>) so a single dictionary covers all
+            // payload types without reflection at publish-time.
+            var typed = (Frame<T>)boxed;
+            handler(typed);
+        });
+
+        var list = _subscriptions.GetOrAdd(typeof(T), _ => new List<Subscription>());
+        lock (_mutationLock)
+        {
+            list.Add(subscription);
+        }
+        return subscription;
+    }
+
+    /// <summary>
+    /// Publish a frame to all matching subscribers. The frame's
+    /// <see cref="IFrame.PayloadType"/> determines which subscriber list
+    /// fires. Subscriptions added during a handler invocation do NOT
+    /// observe the in-flight publish (snapshot is taken before dispatch).
+    /// </summary>
+    public void Publish(IFrame frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+
+        if (!_subscriptions.TryGetValue(frame.PayloadType, out var list))
+        {
+            return;
+        }
+
+        // Snapshot the list under the mutation lock so handlers can subscribe
+        // / unsubscribe without corrupting the iteration. The dispatch cost
+        // is one List<>.ToArray() per publish; the bus is on the merger hot
+        // path so we keep it allocation-light when there are no subscribers
+        // by skipping the snapshot above.
+        Subscription[] snapshot;
+        lock (_mutationLock)
+        {
+            snapshot = list.ToArray();
+        }
+
+        foreach (var sub in snapshot)
+        {
+            if (sub.IsDisposed) continue;
+            sub.Invoke(frame);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Type _payloadType;
+        private readonly Action<IFrame> _handler;
+
+        public Subscription(Type payloadType, Action<IFrame> handler)
+        {
+            _payloadType = payloadType;
+            _handler = handler;
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        public void Invoke(IFrame frame)
+        {
+            // Pattern-match on the concrete generic Frame<T> via the boxed
+            // IFrame to keep the typed payload unboxed at the consumer
+            // (Frame<T> is a readonly record struct — unboxing is free here
+            // because the JIT sees the concrete cast in WorldEventBus.Subscribe).
+            _handler(frame);
+        }
+
+        public void Dispose() => IsDisposed = true;
+    }
+}

--- a/src/Mithril.WorldSim.Player/Mithril.WorldSim.Player.csproj
+++ b/src/Mithril.WorldSim.Player/Mithril.WorldSim.Player.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.WorldSim.Player</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.WorldSim.Core\Mithril.WorldSim.Core.csproj" />
+    <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+</Project>

--- a/src/Mithril.WorldSim.Player/PlayerWorld.cs
+++ b/src/Mithril.WorldSim.Player/PlayerWorld.cs
@@ -1,0 +1,403 @@
+using System.Collections.Concurrent;
+using Mithril.WorldSim.Player.Internal;
+
+namespace Mithril.WorldSim.Player;
+
+/// <summary>
+/// Concrete <see cref="IPlayerWorld"/> implementation (issue #616 — Phase 0
+/// shell). Owns the merger over registered producers, the clock, the bus, and
+/// the dispatch graph. Folders and composers register here but the shell
+/// itself wires no specific folders — those land via per-folder Phase 1+
+/// migration issues.
+///
+/// <para><b>Determinism</b> — frames are merged by timestamp; ties broken by
+/// declared <see cref="IFrameProducer{TPayload}.Priority"/> (lower first),
+/// then by registration order. Producers must emit in ascending timestamp
+/// order per the producer contract; the world clamps late frames to the
+/// current clock value.</para>
+///
+/// <para><b>Mode</b> — the world starts in <see cref="WorldMode.Replaying"/>
+/// when any mode-aware producer is registered, else <see cref="WorldMode.Live"/>.
+/// Each time a mode-aware producer's <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/>
+/// task completes, the world re-evaluates: if all are live, it flips and
+/// emits a <see cref="ModeChanged"/> frame on the bus before dispatching the
+/// next frame.</para>
+///
+/// <para><b>Dispatch graph</b> — per applied frame: route by payload type to
+/// its folder (one folder per type) → collect change events → enqueue each
+/// event onto a work-queue → for each event, dispatch to composers whose
+/// <see cref="IComposer.Subscribes"/> contains the event's runtime type →
+/// publish each composer-emitted <see cref="IFrame"/> to the bus AND enqueue
+/// its payload for downstream composers. Resolution ends when the queue
+/// drains (principle 11 — finite DAG, no merger re-entry).</para>
+/// </summary>
+public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
+{
+    private readonly WorldClock _clock = new();
+    private readonly WorldEventBus _bus = new();
+
+    private readonly List<RegisteredProducer> _producers = new();
+    private readonly Dictionary<Type, IFolderInvoker> _folders = new();
+    private readonly Dictionary<Type, List<IComposer>> _composersByType = new();
+    private readonly List<IComposer> _composers = new();
+
+    private bool _started;
+
+    public IWorldClock Clock => _clock;
+    public IWorldEventBus Bus => _bus;
+
+    public void RegisterProducer<T>(IFrameProducer<T> producer)
+    {
+        ArgumentNullException.ThrowIfNull(producer);
+        EnsureNotStarted();
+        _producers.Add(new RegisteredProducer(
+            new ProducerAdapter<T>(producer),
+            producer.Priority,
+            _producers.Count,
+            (producer as IModeAwareFrameProducer<T>)?.ReachedLive));
+    }
+
+    public void RegisterFolder<T>(IFolder<T> folder)
+    {
+        ArgumentNullException.ThrowIfNull(folder);
+        EnsureNotStarted();
+        if (_folders.ContainsKey(typeof(T)))
+        {
+            throw new InvalidOperationException(
+                $"A folder is already registered for payload type {typeof(T).FullName}. " +
+                "One folder per payload type — see IWorld.RegisterFolder doc.");
+        }
+        _folders[typeof(T)] = new FolderInvoker<T>(folder);
+    }
+
+    public void RegisterComposer(IComposer composer)
+    {
+        ArgumentNullException.ThrowIfNull(composer);
+        EnsureNotStarted();
+        _composers.Add(composer);
+        foreach (var t in composer.Subscribes)
+        {
+            if (!_composersByType.TryGetValue(t, out var list))
+            {
+                list = new List<IComposer>();
+                _composersByType[t] = list;
+            }
+            list.Add(composer);
+        }
+    }
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        EnsureNotStarted();
+        _started = true;
+
+        // If no mode-aware producers were registered, the world is implicitly
+        // live from t=0 (nothing to drain). Otherwise it starts Replaying
+        // and flips once every mode-aware ReachedLive task completes.
+        if (!_producers.Any(p => p.ReachedLive is not null))
+        {
+            _clock.SetMode(WorldMode.Live);
+        }
+
+        await RunMergerAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task RunMergerAsync(CancellationToken ct)
+    {
+        if (_producers.Count == 0)
+        {
+            // Empty world — nothing to dispatch. Still useful for tests
+            // exercising the bus / clock surface in isolation.
+            UpdateModeIfReady();
+            return;
+        }
+
+        var states = _producers
+            .Select(p => new ProducerRuntimeState(p, p.Adapter.GetEnumerator(ct)))
+            .ToList();
+
+        try
+        {
+            // Prime each producer.
+            foreach (var s in states)
+            {
+                s.PendingFetch = s.Enumerator.MoveNextAsync(ct);
+            }
+
+            while (!ct.IsCancellationRequested)
+            {
+                // Wait until every non-exhausted producer has a head frame (or
+                // has gone exhausted). For multi-producer correctness we
+                // cannot dispatch until we know the minimum-timestamp frame
+                // across all producers — see design notebook §Determinism +
+                // principle 1.
+                foreach (var s in states)
+                {
+                    if (s.Exhausted || s.HasHead) continue;
+                    bool hasMore;
+                    try
+                    {
+                        hasMore = await s.PendingFetch.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        s.Exhausted = true;
+                        continue;
+                    }
+                    if (!hasMore)
+                    {
+                        s.Exhausted = true;
+                    }
+                    else
+                    {
+                        s.Head = s.Enumerator.Current;
+                        s.HasHead = true;
+                    }
+                }
+
+                // Re-evaluate mode now that we've potentially seen the first
+                // live frame from one of the producers (mode-aware producers
+                // signal ReachedLive *before* yielding the first live frame).
+                UpdateModeIfReady();
+
+                // Find the min by (Timestamp, Priority, RegisteredIndex).
+                ProducerRuntimeState? winner = null;
+                foreach (var s in states)
+                {
+                    if (!s.HasHead) continue;
+                    if (winner is null || Compare(s, winner) < 0)
+                    {
+                        winner = s;
+                    }
+                }
+
+                if (winner is null)
+                {
+                    // All producers exhausted.
+                    break;
+                }
+
+                var frame = winner.Head!;
+                winner.HasHead = false;
+                winner.Head = null;
+                winner.PendingFetch = winner.Enumerator.MoveNextAsync(ct);
+
+                DispatchFrame(frame);
+            }
+        }
+        finally
+        {
+            foreach (var s in states)
+            {
+                try
+                {
+                    await s.Enumerator.DisposeAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Enumerator disposal failures are not load-bearing — the
+                    // cancellation token is the merger's primary shutdown
+                    // signal; producers must honour it.
+                }
+            }
+        }
+    }
+
+    private static int Compare(ProducerRuntimeState a, ProducerRuntimeState b)
+    {
+        var byTs = a.Head!.Timestamp.CompareTo(b.Head!.Timestamp);
+        if (byTs != 0) return byTs;
+        var byPriority = a.Registered.Priority.CompareTo(b.Registered.Priority);
+        if (byPriority != 0) return byPriority;
+        return a.Registered.RegisteredIndex.CompareTo(b.Registered.RegisteredIndex);
+    }
+
+    private void UpdateModeIfReady()
+    {
+        if (_clock.Mode == WorldMode.Live) return;
+
+        foreach (var p in _producers)
+        {
+            if (p.ReachedLive is { IsCompleted: false })
+            {
+                return;
+            }
+        }
+
+        var transitionAt = _clock.Now;
+        _clock.SetMode(WorldMode.Live);
+        _bus.Publish(new Frame<ModeChanged>(
+            transitionAt,
+            new ModeChanged(WorldMode.Replaying, WorldMode.Live, transitionAt)));
+    }
+
+    private void DispatchFrame(IFrame frame)
+    {
+        _clock.Advance(frame.Timestamp);
+
+        if (!_folders.TryGetValue(frame.PayloadType, out var folder))
+        {
+            // No folder registered for this payload type — the world's
+            // Phase 0 shell expects this for nearly every payload type.
+            // Frames flow through the clock without state mutation; mode
+            // tracking still operates. Per-folder migrations (Phase 1+)
+            // attach folders to specific payload types.
+            return;
+        }
+
+        var changes = folder.Apply(frame, _clock);
+        if (changes.Count == 0) return;
+
+        var workQueue = new Queue<object>(changes.Count);
+        foreach (var c in changes)
+        {
+            workQueue.Enqueue(c);
+        }
+
+        // Resolve composers in BFS order. The IComposer contract guarantees
+        // no merger re-entry, so this terminates whenever no composer emits
+        // a new IFrame for a type the queue can still match.
+        while (workQueue.Count > 0)
+        {
+            var payload = workQueue.Dequeue();
+            var payloadType = payload.GetType();
+            if (!_composersByType.TryGetValue(payloadType, out var composers))
+            {
+                continue;
+            }
+
+            // Snapshot — composer.Observe must not mutate the dispatch graph
+            // (registrations close at StartAsync), so a direct iteration is
+            // safe; the snapshot guards against accidental future changes
+            // to that invariant.
+            var snapshot = composers.ToArray();
+            foreach (var composer in snapshot)
+            {
+                var emissions = composer.Observe(payload, _clock);
+                if (emissions.Count == 0) continue;
+                foreach (var emitted in emissions)
+                {
+                    _bus.Publish(emitted);
+                    workQueue.Enqueue(emitted.Payload);
+                }
+            }
+        }
+    }
+
+    private void EnsureNotStarted()
+    {
+        if (_started)
+        {
+            throw new InvalidOperationException(
+                "Cannot register producers/folders/composers after StartAsync — " +
+                "the registration set closes at start (IWorld.StartAsync doc).");
+        }
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private readonly record struct RegisteredProducer(
+        IProducerAdapter Adapter,
+        int Priority,
+        int RegisteredIndex,
+        Task? ReachedLive);
+
+    private sealed class ProducerRuntimeState
+    {
+        public RegisteredProducer Registered { get; }
+        public IProducerAdapterEnumerator Enumerator { get; }
+        public ValueTask<bool> PendingFetch;
+        public IFrame? Head;
+        public bool HasHead;
+        public bool Exhausted;
+
+        public ProducerRuntimeState(RegisteredProducer registered, IProducerAdapterEnumerator enumerator)
+        {
+            Registered = registered;
+            Enumerator = enumerator;
+        }
+    }
+
+    // ── Producer adapter ─────────────────────────────────────────────────
+    // Boxes the typed IAsyncEnumerable<Frame<T>> to a non-generic enumerator
+    // surface so the merger can hold a heterogeneous producer list without
+    // the merger becoming generic over every payload type.
+
+    private interface IProducerAdapter
+    {
+        IProducerAdapterEnumerator GetEnumerator(CancellationToken ct);
+    }
+
+    private interface IProducerAdapterEnumerator : IAsyncDisposable
+    {
+        ValueTask<bool> MoveNextAsync(CancellationToken ct);
+        IFrame Current { get; }
+    }
+
+    private sealed class ProducerAdapter<T> : IProducerAdapter
+    {
+        private readonly IFrameProducer<T> _producer;
+
+        public ProducerAdapter(IFrameProducer<T> producer) => _producer = producer;
+
+        public IProducerAdapterEnumerator GetEnumerator(CancellationToken ct)
+        {
+            var inner = _producer.SubscribeAsync(ct).GetAsyncEnumerator(ct);
+            return new Enumerator(inner);
+        }
+
+        private sealed class Enumerator : IProducerAdapterEnumerator
+        {
+            private readonly IAsyncEnumerator<Frame<T>> _inner;
+            private Frame<T> _current;
+
+            public Enumerator(IAsyncEnumerator<Frame<T>> inner) => _inner = inner;
+
+            public IFrame Current => _current;
+
+            public async ValueTask<bool> MoveNextAsync(CancellationToken ct)
+            {
+                // ct is honoured by the inner async enumerator (subscribed
+                // with the same token in GetEnumerator above); duplicate
+                // wiring here would risk a double-throw on cancellation.
+                _ = ct;
+                if (await _inner.MoveNextAsync().ConfigureAwait(false))
+                {
+                    _current = _inner.Current;
+                    return true;
+                }
+                return false;
+            }
+
+            public ValueTask DisposeAsync() => _inner.DisposeAsync();
+        }
+    }
+
+    // ── Folder invoker ───────────────────────────────────────────────────
+    // Boxes the typed IFolder<T>.Apply behind a non-generic interface so
+    // _folders[type].Apply(frame, clock) works without per-type generic
+    // dispatch on the hot path.
+
+    private interface IFolderInvoker
+    {
+        IReadOnlyList<IChangeEvent> Apply(IFrame frame, IWorldClock clock);
+    }
+
+    private sealed class FolderInvoker<T> : IFolderInvoker
+    {
+        private readonly IFolder<T> _folder;
+
+        public FolderInvoker(IFolder<T> folder) => _folder = folder;
+
+        public IReadOnlyList<IChangeEvent> Apply(IFrame frame, IWorldClock clock)
+        {
+            // The merger only routes a frame to its registered folder via
+            // exact PayloadType match (DispatchFrame → _folders[frame.PayloadType]),
+            // so this cast is structurally guaranteed and a mismatch indicates
+            // a programmer error (e.g., two folders sharing a type slot,
+            // which RegisterFolder also forbids).
+            var typed = (Frame<T>)frame;
+            return _folder.Apply(typed, clock);
+        }
+    }
+}

--- a/src/Mithril.WorldSim.Player/PlayerWorld.cs
+++ b/src/Mithril.WorldSim.Player/PlayerWorld.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Mithril.WorldSim.Player.Internal;
 
 namespace Mithril.WorldSim.Player;
@@ -226,9 +225,22 @@ public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
 
         var transitionAt = _clock.Now;
         _clock.SetMode(WorldMode.Live);
-        _bus.Publish(new Frame<ModeChanged>(
-            transitionAt,
-            new ModeChanged(WorldMode.Replaying, WorldMode.Live, transitionAt)));
+
+        // Only emit ModeChanged if the world actually experienced a Replaying
+        // phase — i.e., at least one frame was applied while Mode == Replaying.
+        // If we flip before any frame applies (empty L1 seed: producer signals
+        // ReachedLive on the first envelope, which is itself live; or every
+        // mode-aware producer was already complete at registration time),
+        // there is no transition to report. Consumers read Clock.Mode for
+        // initial state and subscribe to ModeChanged only for actual
+        // transitions — symmetric with the no-mode-aware-producers branch in
+        // StartAsync which sets Live up front without emitting.
+        if (_clock.Frame > 0)
+        {
+            _bus.Publish(new Frame<ModeChanged>(
+                transitionAt,
+                new ModeChanged(WorldMode.Replaying, WorldMode.Live, transitionAt)));
+        }
     }
 
     private void DispatchFrame(IFrame frame)

--- a/src/Mithril.WorldSim.Player/Producers/ClassifiedPlayerLogProducer.cs
+++ b/src/Mithril.WorldSim.Player/Producers/ClassifiedPlayerLogProducer.cs
@@ -1,0 +1,67 @@
+using System.Runtime.CompilerServices;
+using Mithril.Shared.Logging;
+
+namespace Mithril.WorldSim.Player.Producers;
+
+/// <summary>
+/// Bridges the L1 classified Player.log pipe (<see cref="IClassifiedPlayerLogStream"/>)
+/// into the world simulator as an <see cref="IFrameProducer{TPayload}"/> over
+/// <see cref="IClassifiedPlayerLogLine"/>. The replay-vs-live boundary on the
+/// envelope's <see cref="LogEnvelope{T}.IsReplay"/> flag drives the world's
+/// <see cref="WorldMode"/> transition via <see cref="IModeAwareFrameProducer{TPayload}"/>
+/// — <see cref="ReachedLive"/> completes the moment the producer reads the
+/// first non-replay envelope from the underlying stream.
+///
+/// <para>The frame's payload is the line itself; folders inspect the
+/// <see cref="IClassifiedPlayerLogLine"/> discriminator (cast to one of
+/// <c>LocalPlayerLogLine</c> / <c>CombatActorLogLine</c> / <c>SystemSignalLogLine</c>)
+/// to route within the Player.log world during Phase 1+ folder migrations.
+/// Phase 0 ships no folders, so frames flow through the merger / clock only.</para>
+/// </summary>
+public sealed class ClassifiedPlayerLogProducer : IFrameProducer<IClassifiedPlayerLogLine>, IModeAwareFrameProducer<IClassifiedPlayerLogLine>
+{
+    private readonly IClassifiedPlayerLogStream _stream;
+    private readonly TaskCompletionSource _reachedLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public ClassifiedPlayerLogProducer(IClassifiedPlayerLogStream stream)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+    }
+
+    /// <summary>
+    /// The single producer registered on PlayerWorld today carries priority 0.
+    /// Additional producers (future filesystem-reconcile, etc.) declare
+    /// strictly-higher numeric priorities so the L1 pipe always wins
+    /// timestamp ties — matching the L1 producer's source-Sequence ordering
+    /// for native Player.log frames.
+    /// </summary>
+    public int Priority => 0;
+
+    public Task ReachedLive => _reachedLive.Task;
+
+    public async IAsyncEnumerable<Frame<IClassifiedPlayerLogLine>> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var envelope in _stream.SubscribeWithReplayMarkerAsync(ct).ConfigureAwait(false))
+        {
+            // Signal "reached live" BEFORE yielding the first live frame so
+            // the world flips Mode → Live before dispatching it. The L1
+            // contract guarantees IsReplay flips false-onward only once and
+            // never re-arms (per LogEnvelope.IsReplay doc), so TrySetResult
+            // is idempotent past that boundary.
+            if (!envelope.IsReplay)
+            {
+                _reachedLive.TrySetResult();
+            }
+
+            yield return new Frame<IClassifiedPlayerLogLine>(
+                envelope.Payload.Timestamp,
+                envelope.Payload);
+        }
+
+        // Stream ended without ever flipping (degenerate — replay-only file
+        // tail with no live channel). Mark live anyway so the world isn't
+        // stuck in Replaying forever after exhaustion.
+        _reachedLive.TrySetResult();
+    }
+}

--- a/tests/Mithril.WorldSim.Player.Tests/Mithril.WorldSim.Player.Tests.csproj
+++ b/tests/Mithril.WorldSim.Player.Tests/Mithril.WorldSim.Player.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.WorldSim.Player.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.WorldSim.Core\Mithril.WorldSim.Core.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.WorldSim.Player\Mithril.WorldSim.Player.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
@@ -1,0 +1,352 @@
+using FluentAssertions;
+using Mithril.WorldSim.Player.Tests.TestSupport;
+using Xunit;
+
+namespace Mithril.WorldSim.Player.Tests;
+
+public sealed class PlayerWorldTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 1, 1, 12, 0, sec, TimeSpan.Zero);
+
+    // ── Drain order ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Merger_drains_single_producer_frames_in_timestamp_order()
+    {
+        var producer = new StubFrameProducer<string>(
+            priority: 0,
+            modeAware: false,
+            new Frame<string>(Ts(1), "a"),
+            new Frame<string>(Ts(2), "b"),
+            new Frame<string>(Ts(3), "c"));
+        producer.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        folder.Applied.Select(a => a.Frame.Payload).Should().Equal("a", "b", "c");
+        folder.Applied.Select(a => a.ClockNow).Should().Equal(Ts(1), Ts(2), Ts(3));
+        folder.Applied.Select(a => a.ClockFrame).Should().Equal(1L, 2L, 3L);
+    }
+
+    [Fact]
+    public async Task Merger_drains_two_producers_in_timestamp_order_across_producers()
+    {
+        var a = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,
+            new Frame<string>(Ts(1), "a1"),
+            new Frame<string>(Ts(3), "a3"));
+        var b = new StubFrameProducer<string>(
+            priority: 1, modeAware: false,
+            new Frame<string>(Ts(2), "b2"),
+            new Frame<string>(Ts(4), "b4"));
+        a.Complete();
+        b.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(a);
+        world.RegisterProducer(b);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        folder.Applied.Select(x => x.Frame.Payload).Should().Equal("a1", "b2", "a3", "b4");
+    }
+
+    [Fact]
+    public async Task Producer_priority_breaks_timestamp_ties()
+    {
+        // Same timestamp on every frame — only producer priority decides order.
+        var hi = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,  // lower priority dispatches first
+            new Frame<string>(Ts(5), "hi-1"),
+            new Frame<string>(Ts(5), "hi-2"));
+        var lo = new StubFrameProducer<string>(
+            priority: 5, modeAware: false,
+            new Frame<string>(Ts(5), "lo-1"),
+            new Frame<string>(Ts(5), "lo-2"));
+        hi.Complete();
+        lo.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(hi);
+        world.RegisterProducer(lo);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        // Within the same timestamp: every priority-0 frame fires before any
+        // priority-5 frame. Within a single producer the producer's own
+        // emission order is preserved (the IFrameProducer contract).
+        folder.Applied.Select(x => x.Frame.Payload).Should().Equal(
+            "hi-1", "hi-2", "lo-1", "lo-2");
+    }
+
+    [Fact]
+    public async Task Producer_registration_order_breaks_priority_ties()
+    {
+        // Same timestamp AND same priority — only registration order decides.
+        var first = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,
+            new Frame<string>(Ts(7), "first"));
+        var second = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,
+            new Frame<string>(Ts(7), "second"));
+        first.Complete();
+        second.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(first);
+        world.RegisterProducer(second);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        folder.Applied.Select(x => x.Frame.Payload).Should().Equal("first", "second");
+    }
+
+    // ── Mode transition ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task World_with_no_mode_aware_producers_starts_Live()
+    {
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,
+            new Frame<string>(Ts(1), "x"));
+        producer.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+        folder.Applied.Single().Mode.Should().Be(WorldMode.Live);
+    }
+
+    [Fact]
+    public async Task World_with_mode_aware_producer_starts_Replaying()
+    {
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: true);
+        // Replay-only frames; never flip to live; channel stays open so the
+        // merger keeps blocking until the cancellation token cuts it.
+        producer.PostReplay(new Frame<string>(Ts(1), "x"));
+        producer.PostReplay(new Frame<string>(Ts(2), "y"));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var run = world.StartAsync(cts.Token);
+        try { await run; }
+        catch (OperationCanceledException) { /* expected */ }
+
+        world.Clock.Mode.Should().Be(WorldMode.Replaying);
+        folder.Applied.Should().NotBeEmpty();
+        folder.Applied.Should().AllSatisfy(a => a.Mode.Should().Be(WorldMode.Replaying));
+    }
+
+    [Fact]
+    public async Task Mode_flips_to_Live_when_ReachedLive_completes_and_emits_ModeChanged_on_bus()
+    {
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: true);
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var modeChanges = new List<Frame<ModeChanged>>();
+        using var _sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
+
+        // Two replay frames followed by one live frame. The stub signals
+        // ReachedLive inline at the moment it yields the live entry —
+        // matching ClassifiedPlayerLogProducer's L1-envelope behaviour.
+        producer.PostReplay(new Frame<string>(Ts(10), "r1"));
+        producer.PostReplay(new Frame<string>(Ts(11), "r2"));
+        producer.PostLive(new Frame<string>(Ts(12), "L1"));
+        producer.Complete();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        // World caught up at the timestamp of the last replay frame (Ts(11)) —
+        // the mode flip is observed between dispatches, so the bus emission's
+        // `At` is the world clock right after the last replay frame applied.
+        modeChanges.Should().HaveCount(1);
+        modeChanges[0].Payload.From.Should().Be(WorldMode.Replaying);
+        modeChanges[0].Payload.To.Should().Be(WorldMode.Live);
+        modeChanges[0].Payload.At.Should().Be(Ts(11));
+        modeChanges[0].Timestamp.Should().Be(Ts(11));
+
+        // The first live frame (L1) is dispatched in Live mode; replay
+        // frames before it dispatched in Replaying mode.
+        var byPayload = folder.Applied.ToDictionary(a => a.Frame.Payload);
+        byPayload["r1"].Mode.Should().Be(WorldMode.Replaying);
+        byPayload["r2"].Mode.Should().Be(WorldMode.Replaying);
+        byPayload["L1"].Mode.Should().Be(WorldMode.Live);
+
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+    }
+
+    // ── Bus delivery order ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Bus_delivers_composer_emissions_in_resolution_order()
+    {
+        // Two composers cascade: one subscribed to a folder-emitted change,
+        // one subscribed to the first composer's emission. The test asserts
+        // the bus subscribers see the cascading domain frames in the order
+        // they were emitted.
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,
+            new Frame<string>(Ts(1), "go"));
+        producer.Complete();
+
+        var folder = new EmittingFolder();
+        var firstComposer = new TransformingComposer<TriggerEvent, FirstDomainFrame>(
+            t => new FirstDomainFrame(t.Tag + "->1"));
+        var secondComposer = new TransformingComposer<FirstDomainFrame, SecondDomainFrame>(
+            f => new SecondDomainFrame(f.Tag + "->2"));
+
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+        world.RegisterComposer(firstComposer);
+        world.RegisterComposer(secondComposer);
+
+        var observed = new List<string>();
+        using var s1 = world.Bus.Subscribe<FirstDomainFrame>(f => observed.Add("first:" + f.Payload.Tag));
+        using var s2 = world.Bus.Subscribe<SecondDomainFrame>(f => observed.Add("second:" + f.Payload.Tag));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        // First composer fires on TriggerEvent → emits FirstDomainFrame.
+        // Second composer (subscribed to FirstDomainFrame) cascades →
+        // SecondDomainFrame. Bus observes them in emission order.
+        observed.Should().Equal("first:go->1", "second:go->1->2");
+    }
+
+    [Fact]
+    public async Task Bus_delivers_to_multiple_subscribers_in_registration_order()
+    {
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: false,
+            new Frame<string>(Ts(1), "ping"));
+        producer.Complete();
+
+        var folder = new EmittingFolder();
+        var composer = new TransformingComposer<TriggerEvent, FirstDomainFrame>(
+            t => new FirstDomainFrame(t.Tag));
+
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+        world.RegisterComposer(composer);
+
+        var observed = new List<string>();
+        using var s1 = world.Bus.Subscribe<FirstDomainFrame>(f => observed.Add("A:" + f.Payload.Tag));
+        using var s2 = world.Bus.Subscribe<FirstDomainFrame>(f => observed.Add("B:" + f.Payload.Tag));
+        using var s3 = world.Bus.Subscribe<FirstDomainFrame>(f => observed.Add("C:" + f.Payload.Tag));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        observed.Should().Equal("A:ping", "B:ping", "C:ping");
+    }
+
+    // ── Registration discipline ─────────────────────────────────────────
+
+    [Fact]
+    public void Registering_two_folders_for_the_same_payload_type_throws()
+    {
+        var world = new PlayerWorld();
+        world.RegisterFolder(new RecordingFolder<string>());
+
+        var act = () => world.RegisterFolder(new RecordingFolder<string>());
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already registered*");
+    }
+
+    [Fact]
+    public async Task Registrations_after_start_throw()
+    {
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: false);
+        producer.Complete();
+
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        var folderAct = () => world.RegisterFolder(new RecordingFolder<string>());
+        folderAct.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot register*after StartAsync*");
+
+        var producerAct = () => world.RegisterProducer(new StubFrameProducer<int>(modeAware: false));
+        producerAct.Should().Throw<InvalidOperationException>();
+
+        var composerAct = () => world.RegisterComposer(new TransformingComposer<TriggerEvent, FirstDomainFrame>(_ => new FirstDomainFrame("")));
+        composerAct.Should().Throw<InvalidOperationException>();
+    }
+
+    // ── Test composer + folder used above ────────────────────────────────
+
+    private sealed record TriggerEvent(string Tag) : IChangeEvent;
+    private sealed record FirstDomainFrame(string Tag);
+    private sealed record SecondDomainFrame(string Tag);
+
+    /// <summary>
+    /// Folder that emits a single <see cref="TriggerEvent"/> for every applied
+    /// frame, carrying the frame's string payload. Lets the cascade test fire
+    /// a chain without depending on a real game-state folder.
+    /// </summary>
+    private sealed class EmittingFolder : IFolder<string>
+    {
+        public IReadOnlyList<IChangeEvent> Apply(Frame<string> frame, IWorldClock clock)
+            => new IChangeEvent[] { new TriggerEvent(frame.Payload) };
+    }
+
+    /// <summary>
+    /// Composer that observes one event type and emits one frame per event,
+    /// with the payload computed by the supplied projection. Lets the cascade
+    /// test chain composers without needing a real domain-specific composer.
+    /// </summary>
+    private sealed class TransformingComposer<TIn, TOut> : IComposer
+        where TIn : class
+        where TOut : notnull
+    {
+        private readonly Func<TIn, TOut> _project;
+
+        public TransformingComposer(Func<TIn, TOut> project) => _project = project;
+
+        public IReadOnlyCollection<Type> Subscribes => new[] { typeof(TIn) };
+
+        public IReadOnlyList<IFrame> Observe(object eventPayload, IWorldClock clock)
+        {
+            if (eventPayload is not TIn input) return Array.Empty<IFrame>();
+            return new IFrame[] { new Frame<TOut>(clock.Now, _project(input)) };
+        }
+    }
+}

--- a/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
@@ -207,6 +207,65 @@ public sealed class PlayerWorldTests
         world.Clock.Mode.Should().Be(WorldMode.Live);
     }
 
+    [Fact]
+    public async Task World_with_pre_completed_mode_aware_producer_starts_Live_without_emitting_ModeChanged()
+    {
+        // Pre-completing ReachedLive before StartAsync is the synchronous
+        // analogue of "L1 seed is empty" — there is no Replaying phase to
+        // transition out of. The world starts Live and emits no ModeChanged.
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: true);
+        producer.SignalReachedLive();
+        producer.PostLive(new Frame<string>(Ts(1), "x"));
+        producer.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var modeChanges = new List<Frame<ModeChanged>>();
+        using var sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+        modeChanges.Should().BeEmpty();
+        folder.Applied.Single().Mode.Should().Be(WorldMode.Live);
+    }
+
+    [Fact]
+    public async Task World_does_not_emit_ModeChanged_when_first_frame_is_already_live()
+    {
+        // L1 with an empty initial replay snapshot: the producer signals
+        // ReachedLive inline with the first envelope (which is live). The
+        // world flips before any frame applies — Clock.Frame == 0 at the
+        // flip — so no ModeChanged is emitted. Consumers see Mode = Live
+        // from the start.
+        var producer = new StubFrameProducer<string>(
+            priority: 0, modeAware: true);
+        producer.PostLive(new Frame<string>(Ts(5), "live-1"));
+        producer.PostLive(new Frame<string>(Ts(6), "live-2"));
+        producer.Complete();
+
+        var folder = new RecordingFolder<string>();
+        var world = new PlayerWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var modeChanges = new List<Frame<ModeChanged>>();
+        using var sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        modeChanges.Should().BeEmpty();
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+        folder.Applied.Should().AllSatisfy(a => a.Mode.Should().Be(WorldMode.Live));
+        folder.Applied.Select(a => a.Frame.Payload).Should().Equal("live-1", "live-2");
+    }
+
     // ── Bus delivery order ──────────────────────────────────────────────
 
     [Fact]

--- a/tests/Mithril.WorldSim.Player.Tests/Producers/ClassifiedPlayerLogProducerTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/Producers/ClassifiedPlayerLogProducerTests.cs
@@ -1,0 +1,139 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Player.Producers;
+using Xunit;
+
+namespace Mithril.WorldSim.Player.Tests.Producers;
+
+public sealed class ClassifiedPlayerLogProducerTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 1, 1, 12, 0, sec, TimeSpan.Zero);
+
+    [Fact]
+    public async Task Yields_one_frame_per_envelope_carrying_envelope_payload_timestamp()
+    {
+        var stream = new ScriptedClassifiedStream(
+            new LogEnvelope<IClassifiedPlayerLogLine>(
+                new ScriptedLine(Ts(1), "line-a"), IsReplay: true),
+            new LogEnvelope<IClassifiedPlayerLogLine>(
+                new ScriptedLine(Ts(2), "line-b"), IsReplay: false));
+        stream.Complete();
+
+        var producer = new ClassifiedPlayerLogProducer(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var yielded = new List<Frame<IClassifiedPlayerLogLine>>();
+        await foreach (var frame in producer.SubscribeAsync(cts.Token))
+        {
+            yielded.Add(frame);
+        }
+
+        yielded.Should().HaveCount(2);
+        yielded[0].Timestamp.Should().Be(Ts(1));
+        yielded[0].Payload.Data.Should().Be("line-a");
+        yielded[1].Timestamp.Should().Be(Ts(2));
+        yielded[1].Payload.Data.Should().Be("line-b");
+    }
+
+    [Fact]
+    public async Task ReachedLive_completes_on_first_non_replay_envelope()
+    {
+        var stream = new ScriptedClassifiedStream(
+            new LogEnvelope<IClassifiedPlayerLogLine>(
+                new ScriptedLine(Ts(1), "replay-1"), IsReplay: true),
+            new LogEnvelope<IClassifiedPlayerLogLine>(
+                new ScriptedLine(Ts(2), "replay-2"), IsReplay: true));
+
+        var producer = new ClassifiedPlayerLogProducer(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Start consuming on a background task so the producer can read its
+        // first batch from the stream channel.
+        var consumer = Task.Run(async () =>
+        {
+            await foreach (var _ in producer.SubscribeAsync(cts.Token)) { }
+        });
+
+        // While we only ever fed replay envelopes, the producer must not
+        // signal ReachedLive yet — the L1 contract is "true until the first
+        // live envelope; never re-armed."
+        await Task.Delay(50);
+        producer.ReachedLive.IsCompleted.Should().BeFalse();
+
+        // First live envelope flips the bit.
+        stream.Post(new LogEnvelope<IClassifiedPlayerLogLine>(
+            new ScriptedLine(Ts(3), "live-1"), IsReplay: false));
+
+        // Wait briefly for the producer's loop to observe the envelope.
+        var completed = await Task.WhenAny(producer.ReachedLive, Task.Delay(2000));
+        completed.Should().BeSameAs(producer.ReachedLive);
+
+        stream.Complete();
+        await consumer;
+    }
+
+    [Fact]
+    public async Task ReachedLive_completes_when_stream_ends_without_any_live_envelope()
+    {
+        // Degenerate case — the stream closes mid-replay. We still complete
+        // ReachedLive so a world isn't stuck in Replaying after exhaustion.
+        var stream = new ScriptedClassifiedStream(
+            new LogEnvelope<IClassifiedPlayerLogLine>(
+                new ScriptedLine(Ts(1), "only"), IsReplay: true));
+        stream.Complete();
+
+        var producer = new ClassifiedPlayerLogProducer(stream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var _ in producer.SubscribeAsync(cts.Token)) { }
+
+        producer.ReachedLive.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Priority_is_zero_so_future_producers_can_strictly_outrank_or_undercut()
+    {
+        var producer = new ClassifiedPlayerLogProducer(new ScriptedClassifiedStream());
+        producer.Priority.Should().Be(0);
+    }
+
+    // ── Test stream ──────────────────────────────────────────────────────
+
+    private sealed record ScriptedLine(
+        DateTimeOffset Timestamp,
+        string Data,
+        long Sequence = 0,
+        long ReadMonotonicTicks = 0,
+        string? Raw = null) : IClassifiedPlayerLogLine;
+
+    private sealed class ScriptedClassifiedStream : IClassifiedPlayerLogStream
+    {
+        private readonly Channel<LogEnvelope<IClassifiedPlayerLogLine>> _channel
+            = Channel.CreateUnbounded<LogEnvelope<IClassifiedPlayerLogLine>>(
+                new UnboundedChannelOptions { SingleReader = true });
+
+        public ScriptedClassifiedStream(params LogEnvelope<IClassifiedPlayerLogLine>[] initial)
+        {
+            foreach (var e in initial)
+            {
+                _channel.Writer.TryWrite(e);
+            }
+        }
+
+        public void Post(LogEnvelope<IClassifiedPlayerLogLine> envelope)
+            => _channel.Writer.TryWrite(envelope);
+
+        public void Complete() => _channel.Writer.TryComplete();
+
+        public async IAsyncEnumerable<LogEnvelope<IClassifiedPlayerLogLine>>
+            SubscribeWithReplayMarkerAsync([EnumeratorCancellation] CancellationToken ct)
+        {
+            await foreach (var e in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return e;
+            }
+        }
+    }
+}

--- a/tests/Mithril.WorldSim.Player.Tests/TestSupport/RecordingFolder.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/TestSupport/RecordingFolder.cs
@@ -1,0 +1,23 @@
+namespace Mithril.WorldSim.Player.Tests.TestSupport;
+
+/// <summary>
+/// Folder that captures every <see cref="Frame{TPayload}"/> applied and the
+/// clock snapshot at apply-time. Used to assert (a) draining order, (b)
+/// clock advancement, (c) per-frame mode visible to folders.
+/// </summary>
+internal sealed class RecordingFolder<T> : IFolder<T>
+{
+    public List<AppliedFrame<T>> Applied { get; } = new();
+
+    public IReadOnlyList<IChangeEvent> Apply(Frame<T> frame, IWorldClock clock)
+    {
+        Applied.Add(new AppliedFrame<T>(frame, clock.Now, clock.Frame, clock.Mode));
+        return Array.Empty<IChangeEvent>();
+    }
+}
+
+internal readonly record struct AppliedFrame<T>(
+    Frame<T> Frame,
+    DateTimeOffset ClockNow,
+    long ClockFrame,
+    WorldMode Mode);

--- a/tests/Mithril.WorldSim.Player.Tests/TestSupport/StubFrameProducer.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/TestSupport/StubFrameProducer.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace Mithril.WorldSim.Player.Tests.TestSupport;
+
+/// <summary>
+/// In-memory <see cref="IFrameProducer{TPayload}"/> for tests. Each posted
+/// entry carries a frame plus an <c>IsReplay</c> bit mimicking the real
+/// L1 envelope's behaviour: the producer signals
+/// <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/> the moment it
+/// yields the first non-replay entry, *before* the yield returns control to
+/// the world's merger. This matches
+/// <see cref="Mithril.WorldSim.Player.Producers.ClassifiedPlayerLogProducer"/>'s
+/// signalling shape exactly, so tests exercise the same boundary the
+/// production producer drives.
+/// </summary>
+internal sealed class StubFrameProducer<T> : IFrameProducer<T>, IModeAwareFrameProducer<T>
+{
+    private readonly Channel<Entry> _channel = Channel.CreateUnbounded<Entry>(
+        new UnboundedChannelOptions { SingleReader = true });
+    private readonly TaskCompletionSource _reachedLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly bool _modeAware;
+
+    public StubFrameProducer(int priority = 0, bool modeAware = true, params Frame<T>[] initialLiveFrames)
+    {
+        Priority = priority;
+        _modeAware = modeAware;
+        // Convenience: bare frame ctors are treated as live for simple drain
+        // / priority / order tests that don't care about mode boundaries.
+        foreach (var f in initialLiveFrames)
+        {
+            _channel.Writer.TryWrite(new Entry(f, IsReplay: false));
+        }
+    }
+
+    public int Priority { get; }
+
+    Task IModeAwareFrameProducer<T>.ReachedLive
+        => _modeAware ? _reachedLive.Task : Task.CompletedTask;
+
+    public bool IsModeAware => _modeAware;
+
+    /// <summary>
+    /// Post a frame as a replay-phase entry. The producer does NOT signal
+    /// <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/> when
+    /// yielding this entry.
+    /// </summary>
+    public void PostReplay(Frame<T> frame)
+        => _channel.Writer.TryWrite(new Entry(frame, IsReplay: true));
+
+    /// <summary>
+    /// Post a frame as a live-phase entry. The first live entry yielded
+    /// triggers the
+    /// <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/> signal
+    /// immediately before the yield — matching the production
+    /// <see cref="Mithril.WorldSim.Player.Producers.ClassifiedPlayerLogProducer"/>
+    /// behaviour against the L1 envelope.
+    /// </summary>
+    public void PostLive(Frame<T> frame)
+        => _channel.Writer.TryWrite(new Entry(frame, IsReplay: false));
+
+    /// <summary>
+    /// Force-signal
+    /// <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/> without
+    /// yielding any frame.
+    /// </summary>
+    public void SignalReachedLive() => _reachedLive.TrySetResult();
+
+    public void Complete() => _channel.Writer.TryComplete();
+
+    public async IAsyncEnumerable<Frame<T>> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var entry in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            if (!entry.IsReplay)
+            {
+                _reachedLive.TrySetResult();
+            }
+            yield return entry.Frame;
+        }
+        // Stream ended — degenerate live-only completion path.
+        _reachedLive.TrySetResult();
+    }
+
+    private readonly record struct Entry(Frame<T> Frame, bool IsReplay);
+}


### PR DESCRIPTION
## Summary

Phase 0 shell for `IPlayerWorld` — the concrete world-simulator runtime that consumes the L1 classified `Player.log` pipe. No folders or composers register here; per-folder migrations land in Phase 1+ issues.

- **New assembly** `Mithril.WorldSim.Player` (sibling of `Mithril.WorldSim.Core`).
  - `PlayerWorld` — k-way timestamp-merger across producers; BFS-style composer resolution per applied frame (folder → change events → composers → domain frames published to the bus + cascaded for downstream composers).
  - `WorldClock` — frame-driven `Now`/`Frame`/`Mode`; no real-wall-clock leaks into dispatch.
  - `WorldEventBus` — typed pub/sub with snapshot-on-publish.
  - `ClassifiedPlayerLogProducer` — wraps `IClassifiedPlayerLogStream`; signals `ReachedLive` on the first non-replay `LogEnvelope`.
  - `AddPlayerWorld()` DI extension + `BackgroundService` shim that calls `StartAsync`.
- **Additions to `Mithril.WorldSim.Core`** (shared shape across both worlds):
  - `ModeChanged` — domain frame payload for the `Replaying`↔`Live` transition.
  - `IModeAwareFrameProducer<T>` — optional sibling of `IFrameProducer<T>` exposing a `ReachedLive` task; the world flips to `Live` only after every mode-aware producer's task completes. Non-mode-aware producers are treated as live from t=0.
- **15 tests** in a new `tests/Mithril.WorldSim.Player.Tests` project covering drain order (single + multi-producer), producer priority + registration-order tie-breaking, mode flip timing, `ModeChanged` emission timestamp, bus delivery order (cascading composers + multiple subscribers), registration discipline, and the classified-log producer's envelope→frame bridge.

### Design choices documented in code

- Sibling assembly (`Mithril.WorldSim.Player`) chosen over evolving `Mithril.GameState` in place — keeps the layered architecture explicit and mirrors the planned `Mithril.WorldSim.Chat` for #617.
- `IPlayerWorld` is a marker (`: IWorld`) for now; folder properties (Skills, Recipes, Inventory, …) attach via per-folder Phase 1+ migration issues.
- Multi-producer correctness uses the standard "await all producer heads, then dispatch min" pattern. For Phase 0 the only producer is the L1 wrapper, so the watermark concern is theoretical; documented in `RunMergerAsync`.
- `ModeChanged.At` = `Clock.Now` at the transition point (i.e., the timestamp of the last replay frame). The first live frame dispatches in `Live` mode; preceding replay frames in `Replaying`.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (warnings-as-errors).
- [x] `dotnet test Mithril.slnx` — all suites green, 15 new tests in `Mithril.WorldSim.Player.Tests`.
- [ ] Wire-up smoke (Phase 1 work): once a folder migrates to `PlayerWorld`, verify it observes frames + clock + mode end-to-end on a real `Player.log` replay.

Closes #616.
Part of the foundation umbrella + #601 (architecture migration umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
