### PR TITLE
feat(world-sim): Phase 0 IChatWorld shell — banner-seek replay + scope (#617)

### DIFF
--- a/Mithril.slnx
+++ b/Mithril.slnx
@@ -5,6 +5,7 @@
     <Project Path="src/Mithril.Shared/Mithril.Shared.csproj" />
     <Project Path="src/Mithril.WorldSim.Core/Mithril.WorldSim.Core.csproj" />
     <Project Path="src/Mithril.WorldSim.Player/Mithril.WorldSim.Player.csproj" />
+    <Project Path="src/Mithril.WorldSim.Chat/Mithril.WorldSim.Chat.csproj" />
     <Project Path="src/Mithril.Shared.Wpf/Mithril.Shared.Wpf.csproj" />
     <Project Path="src/Mithril.GameState/Mithril.GameState.csproj" />
     <Project Path="src/Mithril.Leveling/Mithril.Leveling.csproj" />
@@ -34,6 +35,7 @@
     <Project Path="tests/Mithril.Shared.Tests/Mithril.Shared.Tests.csproj" />
     <Project Path="tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj" />
     <Project Path="tests/Mithril.WorldSim.Player.Tests/Mithril.WorldSim.Player.Tests.csproj" />
+    <Project Path="tests/Mithril.WorldSim.Chat.Tests/Mithril.WorldSim.Chat.Tests.csproj" />
     <Project Path="tests/Mithril.Leveling.Tests/Mithril.Leveling.Tests.csproj" />
     <Project Path="tests/Mithril.LogSanitizer.Tests/Mithril.LogSanitizer.Tests.csproj" />
     <Project Path="tests/Mithril.Planning.Tests/Mithril.Planning.Tests.csproj" />

--- a/src/Mithril.Shared/AssemblyInfo.cs
+++ b/src/Mithril.Shared/AssemblyInfo.cs
@@ -1,3 +1,11 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Mithril.Shared.Tests")]
+// Mithril.WorldSim.Chat needs ChatLogClock + LogSourceTailer (both internal)
+// to drive its replay-aware chat source — the world-sim layer is the second
+// in-repo consumer of those primitives, after Mithril.Shared's own L1
+// pipeline. Exposing them broadly would invite reuse for the wrong reasons
+// (their semantics are subtle); InternalsVisibleTo to one downstream is the
+// surgical scope.
+[assembly: InternalsVisibleTo("Mithril.WorldSim.Chat")]
+[assembly: InternalsVisibleTo("Mithril.WorldSim.Chat.Tests")]

--- a/src/Mithril.WorldSim.Chat/AssemblyInfo.cs
+++ b/src/Mithril.WorldSim.Chat/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mithril.WorldSim.Chat.Tests")]

--- a/src/Mithril.WorldSim.Chat/ChatSession.cs
+++ b/src/Mithril.WorldSim.Chat/ChatSession.cs
@@ -1,0 +1,34 @@
+namespace Mithril.WorldSim.Chat;
+
+/// <summary>
+/// Identifies a PG chat session by the <c>(Server, Character)</c> pair declared
+/// on the chat-side login banner <c>**** Logged In As X. Server Y. Timezone
+/// Offset Z.</c> Banner-derived: chat's own intra-source self-scope (principle 7).
+/// </summary>
+/// <param name="Server">
+/// PG server name as declared on the banner (e.g., <c>Laeth</c>). Verbatim
+/// from the log — no normalisation, since the same string is what
+/// <see cref="IServerCatalogService"/> would key on for cross-source agreement
+/// checks at the view layer.
+/// </param>
+/// <param name="Character">
+/// Character name as declared on the banner (e.g., <c>Emraell</c>). Verbatim
+/// from the log.
+/// </param>
+/// <param name="At">
+/// Banner-line timestamp (chat-prefix-derived). The
+/// <see cref="Mithril.Shared.Logging.RawLogLine.Timestamp"/> of the banner
+/// line itself — TZ-correct via <see cref="Mithril.Shared.Logging.ChatLogClock"/>
+/// folding the <c>yy-MM-dd HH:mm:ss\t</c> prefix over <see cref="Offset"/>.
+/// </param>
+/// <param name="Offset">
+/// Originating session's <c>Timezone Offset</c> (signed <c>HH:MM:SS</c>).
+/// Captured verbatim from the banner's <c>Timezone Offset</c> field; used by
+/// <see cref="Mithril.Shared.Logging.ChatLogClock"/> for cross-machine replay
+/// timestamp folding (#538).
+/// </param>
+public sealed record ChatSession(
+    string Server,
+    string Character,
+    DateTimeOffset At,
+    TimeSpan Offset);

--- a/src/Mithril.WorldSim.Chat/ChatWorld.cs
+++ b/src/Mithril.WorldSim.Chat/ChatWorld.cs
@@ -1,0 +1,362 @@
+using Mithril.WorldSim.Chat.Internal;
+
+namespace Mithril.WorldSim.Chat;
+
+/// <summary>
+/// Concrete <see cref="IChatWorld"/> implementation (issue #617 — Phase 0
+/// shell, sibling of <c>PlayerWorld</c> from #616). Owns the merger over
+/// registered producers, the clock, the bus, and the dispatch graph. Folders
+/// and composers register here but the shell itself wires no specific folders
+/// — those land via #602 (chat-inventory mirror) and #603 (chat-WoP spent).
+///
+/// <para><b>Implementation note.</b> The merger / dispatch-graph code is
+/// duplicated from <c>PlayerWorld</c> by design (principle 2 — "sealed at the
+/// bus"). A future third world or a stress-tested second-world bug would
+/// justify extracting a shared base in <c>Mithril.WorldSim.Core</c>;
+/// pre-extraction at the second-mover boundary risks over-fitting the
+/// abstraction to the two existing shapes.</para>
+///
+/// <para><b>Determinism</b> — frames are merged by timestamp; ties broken by
+/// declared <see cref="IFrameProducer{TPayload}.Priority"/> (lower first),
+/// then by registration order. Producers must emit in ascending timestamp
+/// order per the producer contract; the world clamps late frames to the
+/// current clock value.</para>
+///
+/// <para><b>Mode</b> — the world starts in <see cref="WorldMode.Replaying"/>
+/// when any mode-aware producer is registered, else <see cref="WorldMode.Live"/>.
+/// Each time a mode-aware producer's <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/>
+/// task completes, the world re-evaluates: if all are live, it flips and
+/// emits a <see cref="ModeChanged"/> frame on the bus before dispatching the
+/// next frame.</para>
+///
+/// <para><b>Dispatch graph</b> — per applied frame: route by payload type to
+/// its folder (one folder per type) → collect change events → enqueue each
+/// event onto a work-queue → for each event, dispatch to composers whose
+/// <see cref="IComposer.Subscribes"/> contains the event's runtime type →
+/// publish each composer-emitted <see cref="IFrame"/> to the bus AND enqueue
+/// its payload for downstream composers. Resolution ends when the queue
+/// drains (principle 11 — finite DAG, no merger re-entry).</para>
+/// </summary>
+public sealed class ChatWorld : IChatWorld, IAsyncDisposable
+{
+    private readonly WorldClock _clock = new();
+    private readonly WorldEventBus _bus = new();
+
+    private readonly List<RegisteredProducer> _producers = new();
+    private readonly Dictionary<Type, IFolderInvoker> _folders = new();
+    private readonly Dictionary<Type, List<IComposer>> _composersByType = new();
+    private readonly List<IComposer> _composers = new();
+
+    private bool _started;
+
+    public IWorldClock Clock => _clock;
+    public IWorldEventBus Bus => _bus;
+
+    public void RegisterProducer<T>(IFrameProducer<T> producer)
+    {
+        ArgumentNullException.ThrowIfNull(producer);
+        EnsureNotStarted();
+        _producers.Add(new RegisteredProducer(
+            new ProducerAdapter<T>(producer),
+            producer.Priority,
+            _producers.Count,
+            (producer as IModeAwareFrameProducer<T>)?.ReachedLive));
+    }
+
+    public void RegisterFolder<T>(IFolder<T> folder)
+    {
+        ArgumentNullException.ThrowIfNull(folder);
+        EnsureNotStarted();
+        if (_folders.ContainsKey(typeof(T)))
+        {
+            throw new InvalidOperationException(
+                $"A folder is already registered for payload type {typeof(T).FullName}. " +
+                "One folder per payload type — see IWorld.RegisterFolder doc.");
+        }
+        _folders[typeof(T)] = new FolderInvoker<T>(folder);
+    }
+
+    public void RegisterComposer(IComposer composer)
+    {
+        ArgumentNullException.ThrowIfNull(composer);
+        EnsureNotStarted();
+        _composers.Add(composer);
+        foreach (var t in composer.Subscribes)
+        {
+            if (!_composersByType.TryGetValue(t, out var list))
+            {
+                list = new List<IComposer>();
+                _composersByType[t] = list;
+            }
+            list.Add(composer);
+        }
+    }
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        EnsureNotStarted();
+        _started = true;
+
+        if (!_producers.Any(p => p.ReachedLive is not null))
+        {
+            _clock.SetMode(WorldMode.Live);
+        }
+
+        await RunMergerAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task RunMergerAsync(CancellationToken ct)
+    {
+        if (_producers.Count == 0)
+        {
+            UpdateModeIfReady();
+            return;
+        }
+
+        var states = _producers
+            .Select(p => new ProducerRuntimeState(p, p.Adapter.GetEnumerator(ct)))
+            .ToList();
+
+        try
+        {
+            foreach (var s in states)
+            {
+                s.PendingFetch = s.Enumerator.MoveNextAsync(ct);
+            }
+
+            while (!ct.IsCancellationRequested)
+            {
+                foreach (var s in states)
+                {
+                    if (s.Exhausted || s.HasHead) continue;
+                    bool hasMore;
+                    try
+                    {
+                        hasMore = await s.PendingFetch.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        s.Exhausted = true;
+                        continue;
+                    }
+                    if (!hasMore)
+                    {
+                        s.Exhausted = true;
+                    }
+                    else
+                    {
+                        s.Head = s.Enumerator.Current;
+                        s.HasHead = true;
+                    }
+                }
+
+                UpdateModeIfReady();
+
+                ProducerRuntimeState? winner = null;
+                foreach (var s in states)
+                {
+                    if (!s.HasHead) continue;
+                    if (winner is null || Compare(s, winner) < 0)
+                    {
+                        winner = s;
+                    }
+                }
+
+                if (winner is null) break;
+
+                var frame = winner.Head!;
+                winner.HasHead = false;
+                winner.Head = null;
+                winner.PendingFetch = winner.Enumerator.MoveNextAsync(ct);
+
+                DispatchFrame(frame);
+            }
+        }
+        finally
+        {
+            foreach (var s in states)
+            {
+                try
+                {
+                    await s.Enumerator.DisposeAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Enumerator disposal failures are not load-bearing — the
+                    // cancellation token is the merger's primary shutdown
+                    // signal; producers must honour it.
+                }
+            }
+        }
+    }
+
+    private static int Compare(ProducerRuntimeState a, ProducerRuntimeState b)
+    {
+        var byTs = a.Head!.Timestamp.CompareTo(b.Head!.Timestamp);
+        if (byTs != 0) return byTs;
+        var byPriority = a.Registered.Priority.CompareTo(b.Registered.Priority);
+        if (byPriority != 0) return byPriority;
+        return a.Registered.RegisteredIndex.CompareTo(b.Registered.RegisteredIndex);
+    }
+
+    private void UpdateModeIfReady()
+    {
+        if (_clock.Mode == WorldMode.Live) return;
+
+        foreach (var p in _producers)
+        {
+            if (p.ReachedLive is { IsCompleted: false }) return;
+        }
+
+        var transitionAt = _clock.Now;
+        _clock.SetMode(WorldMode.Live);
+
+        if (_clock.Frame > 0)
+        {
+            _bus.Publish(new Frame<ModeChanged>(
+                transitionAt,
+                new ModeChanged(WorldMode.Replaying, WorldMode.Live, transitionAt)));
+        }
+    }
+
+    private void DispatchFrame(IFrame frame)
+    {
+        _clock.Advance(frame.Timestamp);
+
+        if (!_folders.TryGetValue(frame.PayloadType, out var folder))
+        {
+            return;
+        }
+
+        var changes = folder.Apply(frame, _clock);
+        if (changes.Count == 0) return;
+
+        var workQueue = new Queue<object>(changes.Count);
+        foreach (var c in changes) workQueue.Enqueue(c);
+
+        while (workQueue.Count > 0)
+        {
+            var payload = workQueue.Dequeue();
+            var payloadType = payload.GetType();
+            if (!_composersByType.TryGetValue(payloadType, out var composers)) continue;
+
+            var snapshot = composers.ToArray();
+            foreach (var composer in snapshot)
+            {
+                var emissions = composer.Observe(payload, _clock);
+                if (emissions.Count == 0) continue;
+                foreach (var emitted in emissions)
+                {
+                    _bus.Publish(emitted);
+                    workQueue.Enqueue(emitted.Payload);
+                }
+            }
+        }
+    }
+
+    private void EnsureNotStarted()
+    {
+        if (_started)
+        {
+            throw new InvalidOperationException(
+                "Cannot register producers/folders/composers after StartAsync — " +
+                "the registration set closes at start (IWorld.StartAsync doc).");
+        }
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private readonly record struct RegisteredProducer(
+        IProducerAdapter Adapter,
+        int Priority,
+        int RegisteredIndex,
+        Task? ReachedLive);
+
+    private sealed class ProducerRuntimeState
+    {
+        public RegisteredProducer Registered { get; }
+        public IProducerAdapterEnumerator Enumerator { get; }
+        public ValueTask<bool> PendingFetch;
+        public IFrame? Head;
+        public bool HasHead;
+        public bool Exhausted;
+
+        public ProducerRuntimeState(RegisteredProducer registered, IProducerAdapterEnumerator enumerator)
+        {
+            Registered = registered;
+            Enumerator = enumerator;
+        }
+    }
+
+    // ── Producer adapter ─────────────────────────────────────────────────
+    // Same shape as PlayerWorld's adapter — boxes typed IAsyncEnumerable
+    // behind a non-generic surface so the merger holds a heterogeneous
+    // producer list without going generic over every payload type.
+
+    private interface IProducerAdapter
+    {
+        IProducerAdapterEnumerator GetEnumerator(CancellationToken ct);
+    }
+
+    private interface IProducerAdapterEnumerator : IAsyncDisposable
+    {
+        ValueTask<bool> MoveNextAsync(CancellationToken ct);
+        IFrame Current { get; }
+    }
+
+    private sealed class ProducerAdapter<T> : IProducerAdapter
+    {
+        private readonly IFrameProducer<T> _producer;
+
+        public ProducerAdapter(IFrameProducer<T> producer) => _producer = producer;
+
+        public IProducerAdapterEnumerator GetEnumerator(CancellationToken ct)
+        {
+            var inner = _producer.SubscribeAsync(ct).GetAsyncEnumerator(ct);
+            return new Enumerator(inner);
+        }
+
+        private sealed class Enumerator : IProducerAdapterEnumerator
+        {
+            private readonly IAsyncEnumerator<Frame<T>> _inner;
+            private Frame<T> _current;
+
+            public Enumerator(IAsyncEnumerator<Frame<T>> inner) => _inner = inner;
+
+            public IFrame Current => _current;
+
+            public async ValueTask<bool> MoveNextAsync(CancellationToken ct)
+            {
+                _ = ct; // honoured by the inner enumerator already
+                if (await _inner.MoveNextAsync().ConfigureAwait(false))
+                {
+                    _current = _inner.Current;
+                    return true;
+                }
+                return false;
+            }
+
+            public ValueTask DisposeAsync() => _inner.DisposeAsync();
+        }
+    }
+
+    // ── Folder invoker ───────────────────────────────────────────────────
+
+    private interface IFolderInvoker
+    {
+        IReadOnlyList<IChangeEvent> Apply(IFrame frame, IWorldClock clock);
+    }
+
+    private sealed class FolderInvoker<T> : IFolderInvoker
+    {
+        private readonly IFolder<T> _folder;
+
+        public FolderInvoker(IFolder<T> folder) => _folder = folder;
+
+        public IReadOnlyList<IChangeEvent> Apply(IFrame frame, IWorldClock clock)
+        {
+            var typed = (Frame<T>)frame;
+            return _folder.Apply(typed, clock);
+        }
+    }
+}

--- a/src/Mithril.WorldSim.Chat/DependencyInjection/ChatWorldServiceCollectionExtensions.cs
+++ b/src/Mithril.WorldSim.Chat/DependencyInjection/ChatWorldServiceCollectionExtensions.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mithril.WorldSim.Chat.Internal;
+using Mithril.WorldSim.Chat.Producers;
+
+namespace Mithril.WorldSim.Chat.DependencyInjection;
+
+/// <summary>
+/// DI registration for the Phase 0 ChatWorld shell (issue #617, sibling of
+/// <c>AddPlayerWorld</c> from #616). Registers the world singleton, the
+/// chat-replay source + producer, the session service, and a
+/// <see cref="BackgroundService"/> shim that calls <see cref="IWorld.StartAsync"/>
+/// once the host boots. Per-folder migrations (#602 chat-inventory, #603
+/// chat-WoP) wire their folder / composer registrations against the same
+/// world singleton.
+/// </summary>
+public static class ChatWorldServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the ChatWorld shell and bind it to a file-based
+    /// <see cref="ChatLogReplaySource"/> over
+    /// <see cref="Mithril.Shared.Game.GameConfig.ChatLogDirectory"/>. Must be
+    /// called after <c>AddMithrilGameServices</c> (which registers
+    /// <see cref="Mithril.Shared.Game.GameConfig"/> and the diagnostics sink).
+    /// </summary>
+    public static IServiceCollection AddChatWorld(this IServiceCollection services)
+    {
+        services
+            .AddSingleton<ChatSessionService>()
+            .AddSingleton<IChatSessionService>(sp => sp.GetRequiredService<ChatSessionService>())
+            .AddSingleton<IChatLogReplaySource>(sp => new ChatLogReplaySource(
+                config: sp.GetRequiredService<Mithril.Shared.Game.GameConfig>(),
+                diag: sp.GetService<Mithril.Shared.Diagnostics.IDiagnosticsSink>(),
+                time: sp.GetService<TimeProvider>()))
+            .AddSingleton<ChatLogProducer>(sp => new ChatLogProducer(
+                sp.GetRequiredService<IChatLogReplaySource>(),
+                sp.GetRequiredService<ChatSessionService>()))
+            .AddSingleton<ChatWorld>(sp =>
+            {
+                var world = new ChatWorld();
+                world.RegisterProducer(sp.GetRequiredService<ChatLogProducer>());
+                return world;
+            })
+            .AddSingleton<IChatWorld>(sp => sp.GetRequiredService<ChatWorld>())
+            .AddHostedService<ChatWorldHostedService>();
+
+        return services;
+    }
+
+    private sealed class ChatWorldHostedService : BackgroundService
+    {
+        private readonly ChatWorld _world;
+
+        public ChatWorldHostedService(ChatWorld world) => _world = world;
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            => _world.StartAsync(stoppingToken);
+    }
+}

--- a/src/Mithril.WorldSim.Chat/IChatSessionService.cs
+++ b/src/Mithril.WorldSim.Chat/IChatSessionService.cs
@@ -1,0 +1,37 @@
+namespace Mithril.WorldSim.Chat;
+
+/// <summary>
+/// Read-side surface for the chat world's self-identified <see cref="ChatSession"/>
+/// — the <c>(Server, Character)</c> pair derived from the most recent chat banner
+/// observed by the world's producer (principle 7 — chat self-scopes independently
+/// of Player.log via its own intra-source signals). Updated by
+/// <see cref="Producers.ChatLogProducer"/> as banner lines flow through; consumers
+/// read <see cref="Current"/> for snapshot state or subscribe via
+/// <see cref="Subscribe"/> for change notifications.
+///
+/// <para>This is the Phase 0 chat-side analog of <c>IGameSessionService</c> on
+/// the Player.log world. Mode-agnostic — banners observed during the world's
+/// <see cref="WorldMode.Replaying"/> drain update <see cref="Current"/>
+/// identically to live banners (state derivation is mode-agnostic per
+/// principle 12; only side-effect-emitting consumers gate on
+/// <see cref="WorldMode.Live"/>).</para>
+/// </summary>
+public interface IChatSessionService
+{
+    /// <summary>
+    /// Most recently observed chat session, or <c>null</c> if no banner has
+    /// been observed since attach. <c>null</c> is also the value before the
+    /// world's producer starts emitting frames.
+    /// </summary>
+    ChatSession? Current { get; }
+
+    /// <summary>
+    /// Subscribe to <see cref="Current"/> changes. The handler fires on every
+    /// new banner observation — including re-banner observations for the same
+    /// <c>(Server, Character)</c> when PG re-logs into the same character mid-
+    /// session (the timestamps differ so the <see cref="ChatSession"/> records
+    /// are distinct). Handlers fire synchronously on the world's dispatch
+    /// thread; subscribers must not block.
+    /// </summary>
+    IDisposable Subscribe(Action<ChatSession> handler);
+}

--- a/src/Mithril.WorldSim.Chat/IChatWorld.cs
+++ b/src/Mithril.WorldSim.Chat/IChatWorld.cs
@@ -1,0 +1,24 @@
+namespace Mithril.WorldSim.Chat;
+
+/// <summary>
+/// The world reconstructed from PG's chat log files (design notebook §Contracts
+/// — "Concrete worlds"). Subscribes to <see cref="Producers.IChatLogReplaySource"/>
+/// as its source-stream producer; merges frames by timestamp; dispatches to
+/// registered folders; resolves composers; publishes domain frames on its bus.
+///
+/// <para>This is the Phase 0 shell (issue #617, sibling of #616's
+/// <c>IPlayerWorld</c>) — no folders or composers are registered yet. The two
+/// chat-side folders the architecture calls for — chat-inventory mirror and
+/// chat-WoP spent — land in #602 / #603 respectively and add their
+/// corresponding folder + property pair to this interface at that time. Until
+/// then the shell carries the clock + bus + merger only.</para>
+///
+/// <para>Self-scope (Server, Character) is identified intra-source from the
+/// chat banner <c>**** Logged In As X. Server Y. Timezone Offset Z.</c> and
+/// exposed via the sibling <see cref="IChatSessionService"/> registered
+/// alongside the world (principle 7 — both streams self-scope
+/// independently).</para>
+/// </summary>
+public interface IChatWorld : IWorld
+{
+}

--- a/src/Mithril.WorldSim.Chat/Internal/ChatSessionService.cs
+++ b/src/Mithril.WorldSim.Chat/Internal/ChatSessionService.cs
@@ -1,0 +1,87 @@
+namespace Mithril.WorldSim.Chat.Internal;
+
+/// <summary>
+/// Concrete <see cref="IChatSessionService"/>. Writeable via
+/// <see cref="Update"/> — called by <see cref="Producers.ChatLogProducer"/>
+/// every time a banner line flows through the producer's envelope stream.
+/// Read-side via <see cref="Current"/> + <see cref="Subscribe"/> — handlers
+/// fire synchronously on the producer's emit thread (= the world's merger
+/// thread once the producer is plugged into the world).
+/// </summary>
+internal sealed class ChatSessionService : IChatSessionService
+{
+    private readonly object _gate = new();
+    private readonly List<Subscription> _subs = new();
+    private ChatSession? _current;
+
+    public ChatSession? Current
+    {
+        get
+        {
+            lock (_gate) return _current;
+        }
+    }
+
+    public IDisposable Subscribe(Action<ChatSession> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        var sub = new Subscription(handler, this);
+        lock (_gate) _subs.Add(sub);
+        return sub;
+    }
+
+    /// <summary>
+    /// Replace <see cref="Current"/> with the supplied session and notify
+    /// subscribers. Idempotent against value-equal sessions: a repeat call
+    /// with the same record short-circuits without notifying. This keeps
+    /// replay drain from firing N redundant notifications when the same
+    /// banner is encountered repeatedly (PG only writes one banner per
+    /// login, but defending against bug-class duplicates is cheap).
+    /// </summary>
+    public void Update(ChatSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        Subscription[] snapshot;
+        lock (_gate)
+        {
+            if (_current is not null && _current.Equals(session)) return;
+            _current = session;
+            snapshot = _subs.ToArray();
+        }
+
+        foreach (var sub in snapshot)
+        {
+            if (sub.IsDisposed) continue;
+            sub.Invoke(session);
+        }
+    }
+
+    private void Remove(Subscription sub)
+    {
+        lock (_gate) _subs.Remove(sub);
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action<ChatSession> _handler;
+        private readonly ChatSessionService _owner;
+
+        public Subscription(Action<ChatSession> handler, ChatSessionService owner)
+        {
+            _handler = handler;
+            _owner = owner;
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        public void Invoke(ChatSession session) => _handler(session);
+
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+            IsDisposed = true;
+            _owner.Remove(this);
+        }
+    }
+}

--- a/src/Mithril.WorldSim.Chat/Internal/WorldClock.cs
+++ b/src/Mithril.WorldSim.Chat/Internal/WorldClock.cs
@@ -1,0 +1,34 @@
+namespace Mithril.WorldSim.Chat.Internal;
+
+/// <summary>
+/// Mutable <see cref="IWorldClock"/> implementation owned by the chat world's
+/// merger loop. Same shape as the Player-side world clock — single-threaded
+/// mutator, frame-driven advancement, mode-flip via <see cref="SetMode"/>. The
+/// two worlds intentionally duplicate this small class rather than share a
+/// base, matching principle 2's "sealed at the bus" framing: a clock bug in
+/// one world cannot accidentally couple to the other.
+/// </summary>
+internal sealed class WorldClock : IWorldClock
+{
+    public DateTimeOffset Now { get; private set; } = DateTimeOffset.MinValue;
+    public long Frame { get; private set; }
+    public WorldMode Mode { get; private set; } = WorldMode.Replaying;
+
+    /// <summary>
+    /// Apply one frame's timestamp to the clock. <see cref="Now"/> takes the
+    /// frame's timestamp; <see cref="Frame"/> ticks once. Late frames
+    /// (timestamp earlier than the current <see cref="Now"/>) clamp to
+    /// <see cref="Now"/> — per producer contract, late-stamped frames are
+    /// "clamped + warned by the world."
+    /// </summary>
+    public void Advance(DateTimeOffset frameTimestamp)
+    {
+        if (frameTimestamp > Now)
+        {
+            Now = frameTimestamp;
+        }
+        Frame++;
+    }
+
+    public void SetMode(WorldMode mode) => Mode = mode;
+}

--- a/src/Mithril.WorldSim.Chat/Internal/WorldEventBus.cs
+++ b/src/Mithril.WorldSim.Chat/Internal/WorldEventBus.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+
+namespace Mithril.WorldSim.Chat.Internal;
+
+/// <summary>
+/// Typed pub-sub bus for the chat world's domain frames. Same shape as the
+/// Player-side world bus — handlers fire synchronously on the publishing
+/// thread (the world's merger thread) in subscription order. Subscribers must
+/// not block; per principle 11 — bus delivery happens inside the world's
+/// frame-resolution loop and any blocking work stalls the merger.
+/// </summary>
+internal sealed class WorldEventBus : IWorldEventBus
+{
+    private readonly ConcurrentDictionary<Type, List<Subscription>> _subscriptions = new();
+    private readonly object _mutationLock = new();
+
+    public IDisposable Subscribe<T>(Action<Frame<T>> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var subscription = new Subscription(typeof(T), boxed =>
+        {
+            // The bus stores handlers as Action<IFrame> wrappers (post-cast to
+            // the concrete generic Frame<T>) so a single dictionary covers all
+            // payload types without reflection at publish-time.
+            var typed = (Frame<T>)boxed;
+            handler(typed);
+        });
+
+        var list = _subscriptions.GetOrAdd(typeof(T), _ => new List<Subscription>());
+        lock (_mutationLock)
+        {
+            list.Add(subscription);
+        }
+        return subscription;
+    }
+
+    /// <summary>
+    /// Publish a frame to all matching subscribers. The frame's
+    /// <see cref="IFrame.PayloadType"/> determines which subscriber list
+    /// fires. Subscriptions added during a handler invocation do NOT observe
+    /// the in-flight publish (snapshot is taken before dispatch).
+    /// </summary>
+    public void Publish(IFrame frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+
+        if (!_subscriptions.TryGetValue(frame.PayloadType, out var list))
+        {
+            return;
+        }
+
+        Subscription[] snapshot;
+        lock (_mutationLock)
+        {
+            snapshot = list.ToArray();
+        }
+
+        foreach (var sub in snapshot)
+        {
+            if (sub.IsDisposed) continue;
+            sub.Invoke(frame);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Type _payloadType;
+        private readonly Action<IFrame> _handler;
+
+        public Subscription(Type payloadType, Action<IFrame> handler)
+        {
+            _payloadType = payloadType;
+            _handler = handler;
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        public void Invoke(IFrame frame) => _handler(frame);
+
+        public void Dispose() => IsDisposed = true;
+    }
+}

--- a/src/Mithril.WorldSim.Chat/Mithril.WorldSim.Chat.csproj
+++ b/src/Mithril.WorldSim.Chat/Mithril.WorldSim.Chat.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>Mithril.WorldSim.Chat</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mithril.WorldSim.Core\Mithril.WorldSim.Core.csproj" />
+    <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+</Project>

--- a/src/Mithril.WorldSim.Chat/Producers/ChatLogProducer.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/ChatLogProducer.cs
@@ -1,0 +1,112 @@
+using System.Runtime.CompilerServices;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Chat.Internal;
+
+namespace Mithril.WorldSim.Chat.Producers;
+
+/// <summary>
+/// Bridges <see cref="IChatLogReplaySource"/> into the world simulator as an
+/// <see cref="IFrameProducer{TPayload}"/> over <see cref="RawLogLine"/>. The
+/// replay-vs-live boundary on the envelope's <see cref="LogEnvelope{T}.IsReplay"/>
+/// flag drives the chat world's <see cref="WorldMode"/> transition via
+/// <see cref="IModeAwareFrameProducer{TPayload}"/> — <see cref="ReachedLive"/>
+/// completes the moment the producer reads the first non-replay envelope from
+/// the underlying source.
+///
+/// <para><b>Banner side-effect.</b> As envelopes flow through, the producer
+/// parses each line via <see cref="ChatLoginBannerParser"/> and updates the
+/// injected <see cref="ChatSessionService"/> on every hit. This makes the
+/// chat-side <c>(Server, Character)</c> scope (principle 7) observable via
+/// <see cref="IChatSessionService"/> without a Phase 1+ folder needing to land
+/// first. Banner observations are mode-agnostic — replay banners update
+/// <see cref="IChatSessionService.Current"/> identically to live banners
+/// (principle 12 — state derivation is mode-agnostic; only side-effect-
+/// emitting consumers gate on Live).</para>
+///
+/// <para>The frame's payload is the <see cref="RawLogLine"/> itself; future
+/// chat folders (chat-inventory mirror #602, chat-WoP-spent #603) consume
+/// <see cref="Frame{TPayload}"/> for <see cref="RawLogLine"/> and dispatch by
+/// inspecting <see cref="RawLogLine.Line"/>. Phase 0 ships no folders so
+/// frames flow through the merger / clock only.</para>
+/// </summary>
+public sealed class ChatLogProducer : IFrameProducer<RawLogLine>, IModeAwareFrameProducer<RawLogLine>
+{
+    private readonly IChatLogReplaySource _source;
+    private readonly ChatSessionService _session;
+    private readonly TaskCompletionSource _reachedLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    internal ChatLogProducer(IChatLogReplaySource source, ChatSessionService session)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+    }
+
+    /// <summary>
+    /// Public ctor for DI — resolves the concrete session service via
+    /// <see cref="IChatSessionService"/> downcast (the DI extension registers
+    /// the same instance under both interfaces, so the downcast is safe by
+    /// construction).
+    /// </summary>
+    public ChatLogProducer(IChatLogReplaySource source, IChatSessionService session)
+        : this(source, AsConcrete(session))
+    {
+    }
+
+    private static ChatSessionService AsConcrete(IChatSessionService session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        if (session is ChatSessionService concrete) return concrete;
+        throw new InvalidOperationException(
+            $"ChatLogProducer requires the concrete {nameof(ChatSessionService)} " +
+            "(which is what the DI extension registers under IChatSessionService). " +
+            "A custom IChatSessionService implementation isn't supported — the " +
+            "producer needs write access via the concrete service's Update method.");
+    }
+
+    /// <summary>
+    /// The single producer registered on the chat world today carries priority 0.
+    /// Future producers (e.g., a chat-side filesystem-reconcile producer) would
+    /// declare strictly-higher numeric priorities so this producer wins
+    /// timestamp ties for chat-line-derived events.
+    /// </summary>
+    public int Priority => 0;
+
+    public Task ReachedLive => _reachedLive.Task;
+
+    public async IAsyncEnumerable<Frame<RawLogLine>> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var envelope in _source.SubscribeWithReplayMarkerAsync(ct).ConfigureAwait(false))
+        {
+            // Signal "reached live" BEFORE yielding the first live frame so
+            // the world flips Mode → Live before dispatching it. The source
+            // contract guarantees IsReplay flips false-onward only once and
+            // never re-arms, so TrySetResult is idempotent past that boundary.
+            if (!envelope.IsReplay)
+            {
+                _reachedLive.TrySetResult();
+            }
+
+            // Update session service on banner observations — both replay
+            // (so consumers observing replay drain see scope updates) and
+            // live (so PG re-login mid-session refreshes scope).
+            if (ChatLoginBannerParser.TryParse(envelope.Payload.Line, out var banner))
+            {
+                _session.Update(new ChatSession(
+                    Server: banner.Server,
+                    Character: banner.Character,
+                    At: envelope.Payload.Timestamp,
+                    Offset: banner.Offset));
+            }
+
+            yield return new Frame<RawLogLine>(
+                envelope.Payload.Timestamp,
+                envelope.Payload);
+        }
+
+        // Source ended without ever flipping (degenerate — replay-only file
+        // tail with no live channel). Mark live anyway so the world isn't
+        // stuck in Replaying forever after exhaustion.
+        _reachedLive.TrySetResult();
+    }
+}

--- a/src/Mithril.WorldSim.Chat/Producers/ChatLogReplaySource.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/ChatLogReplaySource.cs
@@ -1,0 +1,171 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+
+namespace Mithril.WorldSim.Chat.Producers;
+
+/// <summary>
+/// Concrete <see cref="IChatLogReplaySource"/> over <see cref="GameConfig.ChatLogDirectory"/>.
+/// On attach: enumerates every existing file in the directory, reads each via
+/// <see cref="LogSourceTailer"/> from byte 0 (so all existing lines are pulled
+/// with TZ-correct timestamps via <see cref="ChatLogClock"/>), then scans the
+/// pooled content for the chat-side login banner
+/// (<see cref="ChatLoginBannerParser"/>). The globally most-recent banner's
+/// timestamp becomes the replay cutoff (principle 9 — "seek to the most recent
+/// chat banner matching the current Player.log session"); lines at-or-after
+/// that timestamp are yielded in timestamp-merged order with
+/// <see cref="LogEnvelope{T}.IsReplay"/> set to <c>true</c>. After the replay
+/// drain the source transitions to live-tail and yields subsequent appends with
+/// <c>IsReplay = false</c>.
+///
+/// <para>"Matching the current Player.log session" is delegated to the
+/// cross-source agreement check at the view layer (principle 7 — both streams
+/// self-scope independently). This source's job is the chat-intrinsic "most
+/// recent banner" decision.</para>
+///
+/// <para><b>Phase 0 scope limits.</b> Files that exist at attach are tailed
+/// for the rest of the session; new files created post-attach (channels added
+/// mid-session — rare for PG) are not picked up. FileSystemWatcher-driven new-
+/// file pickup is a follow-on enhancement once a real world-sim consumer
+/// (#602 / #603) needs it.</para>
+/// </summary>
+public sealed class ChatLogReplaySource : IChatLogReplaySource
+{
+    private readonly GameConfig _config;
+    private readonly TimeProvider _time;
+    private readonly IDiagnosticsSink? _diag;
+    private readonly TimeZoneInfo? _fallbackTz;
+
+    public ChatLogReplaySource(
+        GameConfig config,
+        IDiagnosticsSink? diag = null,
+        TimeProvider? time = null,
+        TimeZoneInfo? fallbackTz = null)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _time = time ?? TimeProvider.System;
+        _diag = diag;
+        _fallbackTz = fallbackTz;
+    }
+
+    public async IAsyncEnumerable<LogEnvelope<RawLogLine>> SubscribeWithReplayMarkerAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var directory = _config.ChatLogDirectory;
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            _diag?.Info("ChatLogReplaySource", $"Chat directory unavailable: '{directory}'. No frames will be emitted.");
+            yield break;
+        }
+
+        // 1. Snapshot files + drain each via LogSourceTailer.
+        var tailers = new List<(string Path, LogSourceTailer Tailer, List<RawLogLine> Lines)>();
+        foreach (var path in Directory.EnumerateFiles(directory))
+        {
+            try
+            {
+                var tailer = new LogSourceTailer(path, new ChatLogClock(_time, _fallbackTz), _time);
+                var lines = new List<RawLogLine>();
+                // ReadNew may return in batches (the file is small enough that
+                // a single call gets it all, but the contract is no-guarantee;
+                // loop until empty to be safe).
+                while (true)
+                {
+                    var batch = tailer.ReadNew();
+                    if (batch.Count == 0) break;
+                    lines.AddRange(batch);
+                }
+                tailers.Add((path, tailer, lines));
+            }
+            catch (IOException ex)
+            {
+                _diag?.Warn("ChatLogReplaySource", $"Skipping unreadable file '{path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _diag?.Warn("ChatLogReplaySource", $"Skipping inaccessible file '{path}': {ex.Message}");
+            }
+        }
+
+        // 2. Find globally most-recent banner.
+        DateTimeOffset? bannerCutoff = null;
+        foreach (var (_, _, lines) in tailers)
+        {
+            foreach (var l in lines)
+            {
+                if (ChatLoginBannerParser.TryParse(l.Line, out _))
+                {
+                    if (bannerCutoff is null || l.Timestamp > bannerCutoff)
+                    {
+                        bannerCutoff = l.Timestamp;
+                    }
+                }
+            }
+        }
+
+        // 3. Replay phase — yield lines at-or-after the cutoff, merged across
+        //    files by timestamp. If no banner, replay is empty (matches the
+        //    legacy "skip what's already there" seed behaviour for pre-banner
+        //    cold attaches).
+        if (bannerCutoff is not null)
+        {
+            var replay = new List<RawLogLine>();
+            foreach (var (_, _, lines) in tailers)
+            {
+                foreach (var l in lines)
+                {
+                    if (l.Timestamp >= bannerCutoff) replay.Add(l);
+                }
+            }
+            replay.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+
+            _diag?.Info("ChatLogReplaySource",
+                $"Replay: banner @ {bannerCutoff:O}, {replay.Count} line(s) across {tailers.Count} file(s).");
+
+            foreach (var line in replay)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return new LogEnvelope<RawLogLine>(line, IsReplay: true);
+            }
+        }
+        else
+        {
+            _diag?.Info("ChatLogReplaySource",
+                $"No banner across {tailers.Count} file(s); skipping replay phase.");
+        }
+
+        // 4. Live phase — poll the same tailers. They've already advanced their
+        //    offsets past the replay batch, so ReadNew() now returns appended
+        //    content only.
+        var pollInterval = TimeSpan.FromSeconds(Math.Max(0.25, _config.PollIntervalSeconds));
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(pollInterval, _time, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { yield break; }
+
+            foreach (var (_, tailer, _) in tailers)
+            {
+                IReadOnlyList<RawLogLine> appended;
+                try
+                {
+                    appended = tailer.ReadNew();
+                }
+                catch (IOException)
+                {
+                    continue; // rotated mid-read; retry next tick
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
+                foreach (var line in appended)
+                {
+                    yield return new LogEnvelope<RawLogLine>(line, IsReplay: false);
+                }
+            }
+        }
+    }
+}

--- a/src/Mithril.WorldSim.Chat/Producers/ChatLoginBanner.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/ChatLoginBanner.cs
@@ -1,0 +1,19 @@
+namespace Mithril.WorldSim.Chat.Producers;
+
+/// <summary>
+/// Successful parse of a chat-side login banner — <c>**** Logged In As X.
+/// Server Y. Timezone Offset Z.</c> — by <see cref="ChatLoginBannerParser"/>.
+/// Distinct from <see cref="ChatSession"/> in that this is a per-line parser
+/// output; <see cref="ChatSession"/> is the session-service-tracked
+/// canonical state (the producer projects every parser hit into a
+/// <see cref="ChatSession"/> by attaching the banner-line's timestamp).
+/// </summary>
+/// <param name="Server">PG server name as declared on the banner.</param>
+/// <param name="Character">Character name as declared on the banner.</param>
+/// <param name="Offset">
+/// Signed <c>HH:MM:SS</c> timezone offset as declared on the banner.
+/// </param>
+public readonly record struct ChatLoginBanner(
+    string Server,
+    string Character,
+    TimeSpan Offset);

--- a/src/Mithril.WorldSim.Chat/Producers/ChatLoginBannerParser.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/ChatLoginBannerParser.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Mithril.WorldSim.Chat.Producers;
+
+/// <summary>
+/// Recognises the chat-side login banner that PG writes at the head of every
+/// chat session: <c>**** Logged In As &lt;Character&gt;. Server &lt;Server&gt;.
+/// Timezone Offset &lt;HH:MM:SS&gt;.</c> (the literal <c>****</c> star bar
+/// varies in length, so the regex matches the textual fields only). Used by
+/// <see cref="ChatLogProducer"/> to update <see cref="IChatSessionService"/>
+/// as banners flow past, and by <see cref="ChatLogReplaySource"/> to find the
+/// seek-point for session-replay (principle 9).
+///
+/// <para>The existing <c>Mithril.Shared.Logging.ChatLogClock</c> has a sibling
+/// regex that captures the <c>Timezone Offset</c> only — its concern is
+/// timestamp folding, not <c>(Server, Character)</c> identification, so it
+/// intentionally doesn't capture those fields. This parser captures all three.</para>
+/// </summary>
+public static partial class ChatLoginBannerParser
+{
+    // Capture both the character name and the server name. The fields are
+    // terminated by `.` per PG's banner format. `[^.]+` greedy is sufficient
+    // because no PG name contains a literal period in either field. The
+    // offset is signed `HH:MM:SS` (PG omits the `+` for east-of-UTC),
+    // matching the LoginBannerParser shape on the Player-log side.
+    [GeneratedRegex(
+        @"Logged In As (?<character>[^.]+)\. Server (?<server>[^.]+)\. Timezone Offset (?<off>-?\d{1,2}:\d{2}:\d{2})",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex BannerRx();
+
+    /// <summary>
+    /// Try to parse the chat-banner fields from a chat-log line. Returns
+    /// <c>true</c> with <paramref name="banner"/> populated if the line is
+    /// a banner; <c>false</c> otherwise.
+    /// </summary>
+    public static bool TryParse(string line, out ChatLoginBanner banner)
+    {
+        banner = default;
+        if (line is null) return false;
+
+        // Cheap negative-match short-circuit: the literal substring is
+        // present in every banner and absent from every non-banner chat
+        // line. Skips the regex entirely on the 99%+ common case (every
+        // non-banner line in every channel file).
+        if (line.IndexOf("Logged In As ", StringComparison.Ordinal) < 0) return false;
+
+        var m = BannerRx().Match(line);
+        if (!m.Success) return false;
+
+        if (!TimeSpan.TryParse(m.Groups["off"].Value, CultureInfo.InvariantCulture, out var offset))
+            return false;
+
+        banner = new ChatLoginBanner(
+            Server: m.Groups["server"].Value,
+            Character: m.Groups["character"].Value,
+            Offset: offset);
+        return true;
+    }
+}

--- a/src/Mithril.WorldSim.Chat/Producers/IChatLogReplaySource.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/IChatLogReplaySource.cs
@@ -1,0 +1,45 @@
+using Mithril.Shared.Logging;
+
+namespace Mithril.WorldSim.Chat.Producers;
+
+/// <summary>
+/// Chat-side analog of <see cref="IClassifiedPlayerLogStream"/> — the
+/// session-replay-aware source that <see cref="ChatLogProducer"/> wraps to
+/// feed the chat world. Yields raw chat lines wrapped in
+/// <see cref="LogEnvelope{T}"/> so the structural <c>IsReplay</c> bit is
+/// sourced authoritatively from the source's own session-replay-vs-live
+/// boundary, matching the Player-side L1 envelope contract.
+///
+/// <para><b>Why this exists separately from <see cref="IChatLogStream"/>.</b>
+/// The legacy <see cref="IChatLogStream"/> is live-only by design — it
+/// <c>SeedDirectoryToCurrentEnd</c>s on attach so long-running chat files
+/// don't flood new sessions. Principle 9 of the world simulator design
+/// notebook explicitly replaces that choice for world-sim consumers: the
+/// chat world must drain from the PG-session-start chat banner, symmetric
+/// with Player.log's session replay, so views that fuse the two streams can
+/// claim determinism over their joined source set. The world's replay-aware
+/// source therefore lives at the world-sim layer (this assembly), keeping the
+/// legacy live-only stream available for its existing consumers (Saruman,
+/// Smaug, etc.) without behaviour drift.</para>
+/// </summary>
+public interface IChatLogReplaySource
+{
+    /// <summary>
+    /// Subscribe to the chat session's lines. On attach, seeks to the most
+    /// recent chat banner (principle 9) and yields lines from there forward
+    /// with <see cref="LogEnvelope{T}.IsReplay"/> set to <c>true</c>. Once
+    /// the replay backlog is drained — every existing line from the banner
+    /// onward has been yielded — the source transitions to live-tail and
+    /// yields subsequent appended lines with <c>IsReplay = false</c>. The
+    /// flag flips exactly once and never re-arms.
+    ///
+    /// <para>Sources with no replay phase (no banner found, empty
+    /// directory, …) yield directly in live mode — the first envelope
+    /// carries <c>IsReplay = false</c>. Sources whose replay phase exhausts
+    /// without ever transitioning to live (the underlying source stream
+    /// closes mid-replay) complete the enumeration without ever yielding
+    /// a live envelope; consumers handle this via the producer's
+    /// <c>ReachedLive</c> completion contract (degenerate live-only path).</para>
+    /// </summary>
+    IAsyncEnumerable<LogEnvelope<RawLogLine>> SubscribeWithReplayMarkerAsync(CancellationToken ct);
+}

--- a/tests/Mithril.WorldSim.Chat.Tests/ChatLoginBannerParserTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/ChatLoginBannerParserTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Mithril.WorldSim.Chat.Producers;
+using Xunit;
+
+namespace Mithril.WorldSim.Chat.Tests;
+
+public sealed class ChatLoginBannerParserTests
+{
+    [Fact]
+    public void Extracts_character_server_and_offset_from_canonical_banner()
+    {
+        // PG's canonical banner shape captured from a real chat log
+        // (see ChatLogClock.cs and ChatLogRulesTests for corroboration).
+        var line = "26-05-19 21:01:14\t**************************************** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00.";
+
+        ChatLoginBannerParser.TryParse(line, out var banner).Should().BeTrue();
+        banner.Character.Should().Be("Emraell");
+        banner.Server.Should().Be("Laeth");
+        banner.Offset.Should().Be(TimeSpan.FromHours(1));
+    }
+
+    [Fact]
+    public void Captures_negative_offset()
+    {
+        var line = "26-05-19 09:36:04\t**************************************** Logged In As Praxi. Server Laeth. Timezone Offset -07:00:00.";
+
+        ChatLoginBannerParser.TryParse(line, out var banner).Should().BeTrue();
+        banner.Offset.Should().Be(TimeSpan.FromHours(-7));
+    }
+
+    [Theory]
+    [InlineData("26-05-19 21:01:14\t[Trade] Foo: WTS something")]
+    [InlineData("26-05-19 21:01:14\t[Status] X x5 added to inventory.")]
+    [InlineData("")]
+    [InlineData("Logged in as character Emraell. Time UTC=05/19/2026 20:01:14. Timezone Offset 01:00:00")]  // Player-side banner (different capitalisation), should NOT match
+    public void Rejects_non_banner_lines(string line)
+    {
+        ChatLoginBannerParser.TryParse(line, out var banner).Should().BeFalse();
+        banner.Server.Should().BeNull();
+        banner.Character.Should().BeNull();
+    }
+
+    [Fact]
+    public void Rejects_malformed_offset()
+    {
+        var line = "26-05-19 21:01:14\t**** Logged In As Emraell. Server Laeth. Timezone Offset garbage.";
+        ChatLoginBannerParser.TryParse(line, out _).Should().BeFalse();
+    }
+}

--- a/tests/Mithril.WorldSim.Chat.Tests/ChatWorldTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/ChatWorldTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Chat.Internal;
+using Mithril.WorldSim.Chat.Producers;
+using Mithril.WorldSim.Chat.Tests.TestSupport;
+using Xunit;
+
+namespace Mithril.WorldSim.Chat.Tests;
+
+public sealed class ChatWorldTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 5, 19, 21, 0, sec, TimeSpan.FromHours(1));
+    private static RawLogLine Line(int sec, string content) => new(Ts(sec), content);
+
+    // ── Drain order ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Drains_chat_producer_frames_in_timestamp_order()
+    {
+        var source = new StubChatLogReplaySource();
+        source.PostLive(Line(1, "26-05-19 21:00:01\tone"));
+        source.PostLive(Line(2, "26-05-19 21:00:02\ttwo"));
+        source.PostLive(Line(3, "26-05-19 21:00:03\tthree"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        var folder = new RecordingFolder<RawLogLine>();
+
+        var world = new ChatWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        folder.Applied.Select(a => a.Frame.Payload.Line).Should().Equal(
+            "26-05-19 21:00:01\tone",
+            "26-05-19 21:00:02\ttwo",
+            "26-05-19 21:00:03\tthree");
+        folder.Applied.Select(a => a.ClockNow).Should().Equal(Ts(1), Ts(2), Ts(3));
+        folder.Applied.Select(a => a.ClockFrame).Should().Equal(1L, 2L, 3L);
+    }
+
+    // ── Mode transition ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Replay_drain_then_live_emits_ModeChanged_on_bus()
+    {
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(10, "replay-1"));
+        source.PostReplay(Line(11, "replay-2"));
+        source.PostLive(Line(12, "live-1"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        var folder = new RecordingFolder<RawLogLine>();
+
+        var world = new ChatWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var modeChanges = new List<Frame<ModeChanged>>();
+        using var _sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        modeChanges.Should().HaveCount(1);
+        modeChanges[0].Payload.From.Should().Be(WorldMode.Replaying);
+        modeChanges[0].Payload.To.Should().Be(WorldMode.Live);
+        modeChanges[0].Payload.At.Should().Be(Ts(11));   // last replay frame timestamp
+        modeChanges[0].Timestamp.Should().Be(Ts(11));
+
+        // Per-frame mode: replay frames dispatched as Replaying, the first
+        // live frame dispatched as Live.
+        var byPayload = folder.Applied.ToDictionary(a => a.Frame.Payload.Line);
+        byPayload["replay-1"].Mode.Should().Be(WorldMode.Replaying);
+        byPayload["replay-2"].Mode.Should().Be(WorldMode.Replaying);
+        byPayload["live-1"].Mode.Should().Be(WorldMode.Live);
+
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+    }
+
+    [Fact]
+    public async Task World_with_no_replay_starts_Live_without_emitting_ModeChanged()
+    {
+        // Live-only stream: every envelope is IsReplay=false. The producer
+        // signals ReachedLive on the first emission; the world flips mode
+        // before applying the first frame, so no ModeChanged is emitted
+        // (Frame == 0 at the flip).
+        var source = new StubChatLogReplaySource();
+        source.PostLive(Line(1, "live-only"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        var folder = new RecordingFolder<RawLogLine>();
+
+        var world = new ChatWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var modeChanges = new List<Frame<ModeChanged>>();
+        using var sub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        modeChanges.Should().BeEmpty();
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+        folder.Applied.Single().Mode.Should().Be(WorldMode.Live);
+    }
+
+    // ── Scope identification ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Banner_observed_via_world_dispatch_updates_session_service()
+    {
+        // End-to-end: the producer is registered with the world, the world
+        // drains it, and the banner line flows through the dispatch loop.
+        // The session service should reflect the scope by world-start completion.
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(1, "26-05-19 21:00:01\t[Status] preamble"));
+        source.PostReplay(Line(2, "26-05-19 21:00:02\t**** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00."));
+        source.PostLive(Line(3, "26-05-19 21:00:03\t[Trade] post-banner"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        var folder = new RecordingFolder<RawLogLine>();
+
+        var world = new ChatWorld();
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        session.Current.Should().NotBeNull();
+        session.Current!.Server.Should().Be("Laeth");
+        session.Current.Character.Should().Be("Emraell");
+
+        folder.Applied.Should().HaveCount(3);
+    }
+
+    // ── Registration discipline ─────────────────────────────────────────
+
+    [Fact]
+    public void Registering_two_folders_for_the_same_payload_type_throws()
+    {
+        var world = new ChatWorld();
+        world.RegisterFolder(new RecordingFolder<RawLogLine>());
+
+        var act = () => world.RegisterFolder(new RecordingFolder<RawLogLine>());
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already registered*");
+    }
+
+    [Fact]
+    public async Task Registrations_after_start_throw()
+    {
+        var source = new StubChatLogReplaySource();
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+
+        var world = new ChatWorld();
+        world.RegisterProducer(producer);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await world.StartAsync(cts.Token);
+
+        var folderAct = () => world.RegisterFolder(new RecordingFolder<RawLogLine>());
+        folderAct.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot register*after StartAsync*");
+    }
+}

--- a/tests/Mithril.WorldSim.Chat.Tests/Mithril.WorldSim.Chat.Tests.csproj
+++ b/tests/Mithril.WorldSim.Chat.Tests/Mithril.WorldSim.Chat.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Mithril.WorldSim.Chat.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mithril.WorldSim.Core\Mithril.WorldSim.Core.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.WorldSim.Chat\Mithril.WorldSim.Chat.csproj" />
+    <ProjectReference Include="..\..\src\Mithril.Shared\Mithril.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogProducerTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogProducerTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Chat.Internal;
+using Mithril.WorldSim.Chat.Producers;
+using Mithril.WorldSim.Chat.Tests.TestSupport;
+using Xunit;
+
+namespace Mithril.WorldSim.Chat.Tests.Producers;
+
+public sealed class ChatLogProducerTests
+{
+    private static DateTimeOffset Ts(int sec) => new(2026, 5, 19, 21, 0, sec, TimeSpan.FromHours(1));
+
+    private static RawLogLine Line(int sec, string content) => new(Ts(sec), content);
+
+    [Fact]
+    public async Task Yields_one_frame_per_envelope_carrying_envelope_payload_timestamp()
+    {
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(1, "26-05-19 21:00:01\t[Trade] alpha"));
+        source.PostLive(Line(2, "26-05-19 21:00:02\t[Trade] beta"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var yielded = new List<Frame<RawLogLine>>();
+        await foreach (var frame in producer.SubscribeAsync(cts.Token))
+        {
+            yielded.Add(frame);
+        }
+
+        yielded.Should().HaveCount(2);
+        yielded[0].Timestamp.Should().Be(Ts(1));
+        yielded[0].Payload.Line.Should().Contain("alpha");
+        yielded[1].Timestamp.Should().Be(Ts(2));
+        yielded[1].Payload.Line.Should().Contain("beta");
+    }
+
+    [Fact]
+    public async Task ReachedLive_completes_on_first_non_replay_envelope()
+    {
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(1, "replay-1"));
+        source.PostReplay(Line(2, "replay-2"));
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var consumer = Task.Run(async () =>
+        {
+            await foreach (var _ in producer.SubscribeAsync(cts.Token)) { }
+        });
+
+        // Replay-only — must NOT signal ReachedLive yet.
+        await Task.Delay(50);
+        producer.ReachedLive.IsCompleted.Should().BeFalse();
+
+        source.PostLive(Line(3, "live-1"));
+
+        var completed = await Task.WhenAny(producer.ReachedLive, Task.Delay(2000));
+        completed.Should().BeSameAs(producer.ReachedLive);
+
+        source.Complete();
+        await consumer;
+    }
+
+    [Fact]
+    public async Task ReachedLive_completes_when_source_ends_without_any_live_envelope()
+    {
+        // Degenerate: replay drain exhausts and the source closes without
+        // ever yielding a live envelope. The producer must still complete
+        // ReachedLive so a world isn't stuck in Replaying after exhaustion.
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(1, "only"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(source, session);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var _ in producer.SubscribeAsync(cts.Token)) { }
+
+        producer.ReachedLive.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Banner_observation_updates_session_service()
+    {
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(1, "26-05-19 21:00:01\t[Trade] pre-banner"));
+        source.PostReplay(Line(2, "26-05-19 21:00:02\t**************************************** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00."));
+        source.PostLive(Line(3, "26-05-19 21:00:03\t[Trade] post-banner"));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var observed = new List<ChatSession>();
+        using var sub = session.Subscribe(observed.Add);
+
+        var producer = new ChatLogProducer(source, session);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var _ in producer.SubscribeAsync(cts.Token)) { }
+
+        session.Current.Should().NotBeNull();
+        session.Current!.Server.Should().Be("Laeth");
+        session.Current.Character.Should().Be("Emraell");
+        session.Current.Offset.Should().Be(TimeSpan.FromHours(1));
+        session.Current.At.Should().Be(Ts(2));
+
+        observed.Should().HaveCount(1);
+        observed[0].Server.Should().Be("Laeth");
+    }
+
+    [Fact]
+    public async Task Mid_session_relogin_re_anchors_session()
+    {
+        // PG re-logging into a different character mid-Mithril-run produces
+        // a second banner; the session service tracks the latest one.
+        var source = new StubChatLogReplaySource();
+        source.PostReplay(Line(1, "26-05-19 21:00:01\t**** Logged In As Alice. Server Laeth. Timezone Offset 01:00:00."));
+        source.PostLive(Line(2, "26-05-19 21:00:02\t**** Logged In As Bob. Server Cernunnos. Timezone Offset -07:00:00."));
+        source.Complete();
+
+        var session = new ChatSessionService();
+        var observed = new List<ChatSession>();
+        using var sub = session.Subscribe(observed.Add);
+
+        var producer = new ChatLogProducer(source, session);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var _ in producer.SubscribeAsync(cts.Token)) { }
+
+        observed.Should().HaveCount(2);
+        observed[0].Character.Should().Be("Alice");
+        observed[1].Character.Should().Be("Bob");
+        session.Current!.Character.Should().Be("Bob");
+        session.Current.Server.Should().Be("Cernunnos");
+    }
+
+    [Fact]
+    public void Public_constructor_rejects_non_concrete_session_service()
+    {
+        // The DI extension registers ChatSessionService under IChatSessionService,
+        // so the public ctor's downcast is structurally safe. But the producer
+        // must still reject a hand-rolled IChatSessionService impl that bypasses
+        // the writer-capable concrete type.
+        var source = new StubChatLogReplaySource();
+        var fake = new FakeSessionService();
+
+        var act = () => new ChatLogProducer(source, fake);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ChatSessionService*");
+    }
+
+    private sealed class FakeSessionService : IChatSessionService
+    {
+        public ChatSession? Current => null;
+        public IDisposable Subscribe(Action<ChatSession> handler) => new Sub();
+        private sealed class Sub : IDisposable { public void Dispose() { } }
+    }
+
+    [Fact]
+    public void Priority_is_zero_so_future_producers_can_strictly_outrank_or_undercut()
+    {
+        var session = new ChatSessionService();
+        var producer = new ChatLogProducer(new StubChatLogReplaySource(), session);
+        producer.Priority.Should().Be(0);
+    }
+}

--- a/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogReplaySourceTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogReplaySourceTests.cs
@@ -1,0 +1,221 @@
+using System.IO;
+using FluentAssertions;
+using Mithril.Shared.Game;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Chat.Producers;
+using Xunit;
+
+namespace Mithril.WorldSim.Chat.Tests.Producers;
+
+public sealed class ChatLogReplaySourceTests : IDisposable
+{
+    private readonly string _gameRoot;
+    private readonly string _chatDir;
+
+    public ChatLogReplaySourceTests()
+    {
+        _gameRoot = Path.Combine(Path.GetTempPath(), $"mithril-chatreplay-{Guid.NewGuid():N}");
+        _chatDir = Path.Combine(_gameRoot, "ChatLogs");
+        Directory.CreateDirectory(_chatDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_gameRoot, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private GameConfig Config(double pollSeconds = 0.25) => new()
+    {
+        GameRoot = _gameRoot,
+        PollIntervalSeconds = pollSeconds,
+    };
+
+    private void Write(string fileName, string content)
+        => File.WriteAllText(Path.Combine(_chatDir, fileName), content);
+
+    private void Append(string fileName, string content)
+        => File.AppendAllText(Path.Combine(_chatDir, fileName), content);
+
+    [Fact]
+    public async Task Empty_directory_yields_no_envelopes_in_replay_phase()
+    {
+        var source = new ChatLogReplaySource(Config(pollSeconds: 0.25));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+
+        var envelopes = await CollectAsync(source, cts.Token);
+
+        envelopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Missing_directory_yields_no_envelopes()
+    {
+        // Point at a directory that doesn't exist — source must yield no
+        // frames (logged diagnostic) rather than throwing.
+        var config = new GameConfig
+        {
+            GameRoot = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}"),
+            PollIntervalSeconds = 0.25,
+        };
+        var source = new ChatLogReplaySource(config);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var envelopes = await CollectAsync(source, cts.Token);
+
+        envelopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task No_banner_skips_replay_phase_and_emits_only_appended_lines_live()
+    {
+        // Existing files have no banner — replay phase is empty. Appends
+        // post-attach come through as IsReplay=false.
+        Write("chat-Status.log",
+            "26-05-19 21:00:01\t[Status] pre-existing line 1\n" +
+            "26-05-19 21:00:02\t[Status] pre-existing line 2\n");
+
+        var source = new ChatLogReplaySource(Config(pollSeconds: 0.25));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1500));
+
+        var collector = CollectAsync(source, cts.Token);
+
+        await Task.Delay(500);  // let the source enter live mode
+        Append("chat-Status.log", "26-05-19 21:00:03\t[Status] appended\n");
+
+        var envelopes = await collector;
+        envelopes.Where(e => e.IsReplay).Should().BeEmpty();
+        envelopes.Where(e => !e.IsReplay)
+            .Select(e => e.Payload.Line)
+            .Should().Contain(l => l.Contains("appended"));
+    }
+
+    [Fact]
+    public async Task Most_recent_banner_anchors_replay_and_emits_at_or_after_lines()
+    {
+        // Banner line at 21:00:02 — pre-banner line should NOT replay;
+        // banner + post-banner lines should.
+        Write("chat-Status.log",
+            "26-05-19 21:00:00\t[Status] pre-banner-A\n" +
+            "26-05-19 21:00:01\t[Status] pre-banner-B\n" +
+            "26-05-19 21:00:02\t**** Logged In As Emraell. Server Laeth. Timezone Offset 01:00:00.\n" +
+            "26-05-19 21:00:03\t[Status] post-banner-A\n" +
+            "26-05-19 21:00:04\t[Status] post-banner-B\n");
+
+        var source = new ChatLogReplaySource(Config());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+
+        var envelopes = await CollectAsync(source, cts.Token);
+
+        var replayed = envelopes.Where(e => e.IsReplay).Select(e => e.Payload.Line).ToList();
+        replayed.Should().HaveCount(3);
+        replayed[0].Should().Contain("Logged In As Emraell");
+        replayed[1].Should().Contain("post-banner-A");
+        replayed[2].Should().Contain("post-banner-B");
+
+        // pre-banner lines must NOT appear at all
+        envelopes.Should().NotContain(e => e.Payload.Line.Contains("pre-banner"));
+    }
+
+    [Fact]
+    public async Task Most_recent_banner_chosen_globally_across_multiple_files()
+    {
+        // Three channel files. The newer banner is in the second file; the
+        // older banner in the first file. The seek anchor must be the newer
+        // one, even though its file isn't the lex-first file in the directory.
+        Write("chat-Trade.log",
+            "26-05-19 20:00:00\t**** Logged In As Old. Server X. Timezone Offset 01:00:00.\n" +
+            "26-05-19 20:00:01\t[Trade] old-session-line\n");
+        Write("chat-Status.log",
+            "26-05-19 21:00:00\t**** Logged In As New. Server X. Timezone Offset 01:00:00.\n" +
+            "26-05-19 21:00:01\t[Status] new-session-line\n");
+        Write("chat-General.log",
+            "26-05-19 21:00:02\t[General] also-new-session\n" +
+            "26-05-19 20:30:00\t[General] mid-session-orphan\n");
+
+        var source = new ChatLogReplaySource(Config());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+
+        var envelopes = await CollectAsync(source, cts.Token);
+
+        var replayed = envelopes.Where(e => e.IsReplay).Select(e => e.Payload.Line).ToList();
+
+        // The newer banner anchors the replay window to 21:00:00 onward.
+        replayed.Should().Contain(l => l.Contains("Logged In As New"));
+        replayed.Should().Contain(l => l.Contains("new-session-line"));
+        replayed.Should().Contain(l => l.Contains("also-new-session"));
+
+        // Older session lines (before the newer banner's timestamp) must NOT
+        // appear in the replay set.
+        replayed.Should().NotContain(l => l.Contains("Logged In As Old"));
+        replayed.Should().NotContain(l => l.Contains("old-session-line"));
+        replayed.Should().NotContain(l => l.Contains("mid-session-orphan"));
+    }
+
+    [Fact]
+    public async Task Replay_envelopes_carry_IsReplay_true_and_live_envelopes_carry_IsReplay_false()
+    {
+        Write("chat-Status.log",
+            "26-05-19 21:00:00\t**** Logged In As Em. Server Laeth. Timezone Offset 01:00:00.\n" +
+            "26-05-19 21:00:01\t[Status] replay-line\n");
+
+        var source = new ChatLogReplaySource(Config(pollSeconds: 0.25));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1500));
+        var collector = CollectAsync(source, cts.Token);
+
+        await Task.Delay(500);
+        Append("chat-Status.log", "26-05-19 21:00:05\t[Status] live-line\n");
+
+        var envelopes = await collector;
+        var replayLines = envelopes.Where(e => e.IsReplay).Select(e => e.Payload.Line).ToList();
+        var liveLines = envelopes.Where(e => !e.IsReplay).Select(e => e.Payload.Line).ToList();
+
+        replayLines.Should().Contain(l => l.Contains("Logged In As Em"));
+        replayLines.Should().Contain(l => l.Contains("replay-line"));
+        liveLines.Should().Contain(l => l.Contains("live-line"));
+    }
+
+    [Fact]
+    public async Task Replay_emits_lines_in_timestamp_order_across_files()
+    {
+        // Two files share the post-banner window; their lines should
+        // interleave by timestamp in the replay stream.
+        Write("chat-A.log",
+            "26-05-19 21:00:00\t**** Logged In As Em. Server Laeth. Timezone Offset 01:00:00.\n" +
+            "26-05-19 21:00:02\t[A] a-at-2\n" +
+            "26-05-19 21:00:05\t[A] a-at-5\n");
+        Write("chat-B.log",
+            "26-05-19 21:00:03\t[B] b-at-3\n" +
+            "26-05-19 21:00:04\t[B] b-at-4\n");
+
+        var source = new ChatLogReplaySource(Config());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+
+        var envelopes = await CollectAsync(source, cts.Token);
+        var replayLines = envelopes.Where(e => e.IsReplay).Select(e => e.Payload.Line).ToList();
+
+        // Banner at :00, [A] at :02, [B] at :03, [B] at :04, [A] at :05.
+        replayLines.Should().HaveCount(5);
+        replayLines[0].Should().Contain("Logged In As Em");
+        replayLines[1].Should().Contain("a-at-2");
+        replayLines[2].Should().Contain("b-at-3");
+        replayLines[3].Should().Contain("b-at-4");
+        replayLines[4].Should().Contain("a-at-5");
+    }
+
+    private static async Task<List<LogEnvelope<RawLogLine>>> CollectAsync(
+        IChatLogReplaySource source, CancellationToken ct)
+    {
+        var envelopes = new List<LogEnvelope<RawLogLine>>();
+        try
+        {
+            await foreach (var e in source.SubscribeWithReplayMarkerAsync(ct))
+            {
+                envelopes.Add(e);
+            }
+        }
+        catch (OperationCanceledException) { /* expected on poll-timeout */ }
+        return envelopes;
+    }
+}

--- a/tests/Mithril.WorldSim.Chat.Tests/TestSupport/RecordingFolder.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/TestSupport/RecordingFolder.cs
@@ -1,0 +1,23 @@
+namespace Mithril.WorldSim.Chat.Tests.TestSupport;
+
+/// <summary>
+/// Folder that captures every frame applied + the clock snapshot at apply
+/// time. Used to assert drain order, clock advancement, and the per-frame
+/// mode visible to folders during dispatch.
+/// </summary>
+internal sealed class RecordingFolder<T> : IFolder<T>
+{
+    public List<AppliedFrame<T>> Applied { get; } = new();
+
+    public IReadOnlyList<IChangeEvent> Apply(Frame<T> frame, IWorldClock clock)
+    {
+        Applied.Add(new AppliedFrame<T>(frame, clock.Now, clock.Frame, clock.Mode));
+        return Array.Empty<IChangeEvent>();
+    }
+}
+
+internal readonly record struct AppliedFrame<T>(
+    Frame<T> Frame,
+    DateTimeOffset ClockNow,
+    long ClockFrame,
+    WorldMode Mode);

--- a/tests/Mithril.WorldSim.Chat.Tests/TestSupport/StubChatLogReplaySource.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/TestSupport/StubChatLogReplaySource.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim.Chat.Producers;
+
+namespace Mithril.WorldSim.Chat.Tests.TestSupport;
+
+/// <summary>
+/// In-memory <see cref="IChatLogReplaySource"/> for tests. Mirrors the
+/// behaviour the real <see cref="ChatLogReplaySource"/> exposes: posted
+/// envelopes carry an <c>IsReplay</c> bit that drives the producer's
+/// <c>ReachedLive</c> signal on the first <c>IsReplay = false</c> entry —
+/// matching <see cref="LogEnvelope{T}.IsReplay"/>'s "true until the first
+/// live envelope; never re-armed" contract.
+/// </summary>
+internal sealed class StubChatLogReplaySource : IChatLogReplaySource
+{
+    private readonly Channel<LogEnvelope<RawLogLine>> _channel = Channel.CreateUnbounded<LogEnvelope<RawLogLine>>(
+        new UnboundedChannelOptions { SingleReader = true });
+
+    public void PostReplay(RawLogLine line) => _channel.Writer.TryWrite(new LogEnvelope<RawLogLine>(line, IsReplay: true));
+    public void PostLive(RawLogLine line) => _channel.Writer.TryWrite(new LogEnvelope<RawLogLine>(line, IsReplay: false));
+    public void Complete() => _channel.Writer.TryComplete();
+
+    public async IAsyncEnumerable<LogEnvelope<RawLogLine>> SubscribeWithReplayMarkerAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var e in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            yield return e;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 shell for `IChatWorld` — the concrete world-simulator runtime that consumes PG's chat logs. Sibling of #616's `IPlayerWorld`. No folders or composers register here; chat-inventory mirror (#602) and chat-WoP spent (#603) attach later.

- **New assembly** `Mithril.WorldSim.Chat` (sibling of `Mithril.WorldSim.Player`):
  - `ChatWorld` — same k-way timestamp-merger + BFS composer resolution shape as `PlayerWorld` (sealed-at-bus duplication; extract a shared base only if a third world ever lands).
  - `ChatLogReplaySource` — `IChatLogReplaySource` implementation that snapshots every file in `GameConfig.ChatLogDirectory`, scans for the globally most-recent chat banner across all channel files (principle 9), and replays lines at-or-after that timestamp in merged order with `IsReplay=true`. Then transitions to live-tail via `LogSourceTailer.ReadNew()` polls.
  - `ChatLogProducer` — wraps `IChatLogReplaySource`, emits `Frame<RawLogLine>`, signals `ReachedLive` on the first non-replay envelope, parses each line via `ChatLoginBannerParser` and feeds banner observations to the session service (mode-agnostic — replay banners update `Current` identically to live banners).
  - `IChatSessionService` / `ChatSession` — banner-derived `(Server, Character)` scope exposed via the standard service surface (principle 7 — chat self-scopes intra-source).
  - `ChatLoginBannerParser` — captures Character + Server + signed Offset from the `**** Logged In As X. Server Y. Timezone Offset Z.` banner.
  - `AddChatWorld()` DI extension + `BackgroundService` shim that calls `IWorld.StartAsync` once the host boots.
- **`Mithril.Shared` `InternalsVisibleTo` added** for `Mithril.WorldSim.Chat` (+ its tests). The world-sim layer is the second in-repo consumer of `ChatLogClock` + `LogSourceTailer` after `Mithril.Shared`'s own L1 pipeline; broadening to `public` would invite reuse for the wrong reasons (their semantics are subtle).
- **27 tests** in a new `tests/Mithril.WorldSim.Chat.Tests` project:
  - Banner parser (4): canonical line, negative offsets, non-banner rejections, malformed-offset rejection
  - Producer (7): envelope→frame bridge, `ReachedLive` timing, degenerate live-only completion, banner→session updates, mid-session re-login re-anchor, hand-rolled-`IChatSessionService` rejection, priority
  - Replay source (7, temp-file driven): empty-dir, missing-dir, no-banner skip path, most-recent-banner anchor, global cross-file banner selection, `IsReplay` flag semantics, replay timestamp-merge ordering across files
  - World (5): drain ordering, replay→live `ModeChanged` emission, live-only no-`ModeChanged`, end-to-end banner→session via the dispatch graph, registration discipline

### Design choices documented in code

- Sibling assembly (`Mithril.WorldSim.Chat`) rather than extending `Mithril.WorldSim.Player` — mirrors the layered architecture and matches the design notebook's two-world framing.
- `IChatWorld` is a marker (`: IWorld`) for Phase 0 — folder properties (`Inventory`, `WordsOfPower`, etc.) attach via per-folder Phase 1+ migration issues, consistent with how `IPlayerWorld` shipped empty in #635.
- `IChatSessionService` is registered alongside the world rather than as a property on `IChatWorld` — same shape as `IGameSessionService` on the Player side. The producer side-effects into the session service because banner detection is naturally producer-internal (the replay source already needs to find banners for the seek anchor; double-parsing across observer + producer is wasteful).
- `ChatLogReplaySource` snapshots files at attach time; new files created post-attach (rare for PG — channels don't typically rotate mid-session) are deferred. FileSystemWatcher-driven new-file pickup is a follow-on enhancement once a real world-sim consumer (#602 / #603) needs it; documented in the class summary.
- Live-tail uses `LogSourceTailer.ReadNew()` polls reusing the same tailer instances that drained the replay phase — so per-file byte offsets carry forward and the replay-vs-live boundary is structural (offset advances exactly once past the snapshotted content).

## Test plan

- [x] `dotnet build Mithril.slnx` clean (warnings-as-errors), 0 warnings, 0 errors.
- [x] `dotnet test tests/Mithril.WorldSim.Chat.Tests` — 27/27 passing.
- [x] `dotnet test tests/Mithril.WorldSim.Player.Tests` — 17/17 passing (sibling assembly unaffected).
- [x] `dotnet test Mithril.slnx` — all other suites green (Samwise `GardenIngestionHighWaterTests.Persisted_high_water_round_trips_through_samwise_json` flaked once under parallel execution; passes in isolation, unrelated to this PR — I touched no Samwise code).
- [ ] Wire-up smoke (Phase 1 work): once #602 or #603 migrates a folder to `ChatWorld`, verify it observes frames + clock + mode end-to-end on a real chat-log replay.

Closes #617.
Part of the foundation umbrella + #601 (architecture migration umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
