### PR TITLE
fix(world-sim): declare tools: in agent frontmatter

### DIFF
--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -1,6 +1,7 @@
 ---
 name: world-sim-orchestrator
 description: Per-project autonomous orchestrator for the world-sim migration umbrella (#601). Use when the user wants the orchestrator to drive a tick of work — dispatching workers for ready tasks, handing open PRs to shepherds, merging ready PRs, or escalating blocked ones via spawn-task chips. Invoked once per /loop tick; each invocation takes one action then exits with ScheduleWakeup for the next tick. Reads state from GitHub labels + PR comment history; no separate store.
+tools: Read, Grep, Glob, Bash, Agent, mcp__ccd_session__spawn_task, ScheduleWakeup
 ---
 
 # World-sim orchestrator

--- a/.claude/agents/world-sim-reviewer.md
+++ b/.claude/agents/world-sim-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: world-sim-reviewer
 description: World-sim migration specialist reviewer. Use when a world-sim migration PR needs review against principles 1-13, phase-aware migration checks, replay-determinism inspection, and the migration audit. Input is a PR number, issue number, and phase. Reports structured findings; does not edit code or post PR comments — the caller (typically world-sim-shepherd) handles posting and dispatching.
+tools: Read, Grep, Glob, Bash, ToolSearch
 ---
 
 # World-sim migration specialist reviewer

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -1,6 +1,7 @@
 ---
 name: world-sim-shepherd
 description: Per-PR babysitter for world-sim migration PRs. Use when the world-sim orchestrator (or a human) hands a PR off for end-to-end review-fix-rereview management. The shepherd owns the PR until it is ready to merge or needs human attention; it dispatches reviewers and workers as needed and returns a structured verdict. Input is a PR number, issue number, phase, risk, and a worker-dispatch template.
+tools: Read, Grep, Glob, Bash, Agent
 ---
 
 # World-sim shepherd


### PR DESCRIPTION
## Summary

Surfaced during the shepherd's first real run on [mithril#634](https://github.com/moumantai-gg/mithril/pull/634): custom subagents in `.claude/agents/` that don't declare an explicit `tools:` frontmatter don't get `Agent` (or other tools) surfaced by the harness. Pre-installed agents like `general-purpose` get `Tools: *` by default; custom ones don't inherit that.

The shepherd's first review iteration cleared clean by coincidence, so the bug didn't bite that run — but had a fix-iteration been needed, the shepherd would have escalated `needs-human` with reason `cannot_dispatch_worker` instead of dispatching a worker. The orchestrator (not yet exercised) would hit the same wall on every action.

Three one-line frontmatter fixes:

| File | tools |
|---|---|
| `.claude/agents/world-sim-orchestrator.md` | `Read, Grep, Glob, Bash, Agent, mcp__ccd_session__spawn_task, ScheduleWakeup` |
| `.claude/agents/world-sim-shepherd.md` | `Read, Grep, Glob, Bash, Agent` |
| `.claude/agents/world-sim-reviewer.md` | `Read, Grep, Glob, Bash, ToolSearch` |

Each list contains exactly what that agent's prompt body actually uses — no more, no less.

## Test plan
- [x] All three frontmatter blocks have the `tools:` field (`grep -c "^tools:" .claude/agents/world-sim-*.md` returns 3).
- [ ] Next shepherd run dispatches the generic reviewer + specialist via the `Agent` tool (rather than performing reviews in-session).
- [ ] Next orchestrator tick is able to call `mcp__ccd_session__spawn_task` and `ScheduleWakeup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
