### PR TITLE
feat(world-sim): Phase 1 — PlayerSkillStateService as IFolder + bus

### DIFF
--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -16,8 +16,11 @@ using Mithril.GameState.Servers.Parsing;
 using Mithril.GameState.Sessions;
 using Mithril.GameState.Skills;
 using Mithril.GameState.Skills.Parsing;
+using Mithril.GameState.Skills.Producers;
 using Mithril.GameState.Weather;
 using Mithril.Shared.DependencyInjection;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -94,11 +97,23 @@ public static class GameStateServiceCollectionExtensions
         // Shared live skill state from Player.log (ProcessLoadSkills /
         // ProcessUpdateSkill) — no character re-export required. Single parser,
         // single tracker; consumers inject IPlayerSkillState. See issue #462.
+        //
+        // World-simulator migration (issue #618 — Phase 1): the service is now
+        // an IFolder<SkillFrame> registered with IPlayerWorld; a sibling
+        // SkillFrameProducer owns the L1 subscription and feeds skill frames
+        // into the world's merger. The PlayerSkillStateWorldRegistration
+        // hosted service wires both into the world before the world's own
+        // hosted service drains (hosted services run in registration order,
+        // and AddPlayerWorld is called BEFORE AddMithrilGameState in
+        // ShellComposition, so the world singleton is already constructed by
+        // the time this runs but its StartAsync hasn't fired yet).
         services.AddSingleton<SkillLogParser>();
         services
             .AddSingleton<PlayerSkillStateService>()
             .AddSingleton<IPlayerSkillState>(sp => sp.GetRequiredService<PlayerSkillStateService>())
-            .AddHostedService(sp => sp.GetRequiredService<PlayerSkillStateService>());
+            .AddSingleton<IFolder<SkillFrame>>(sp => sp.GetRequiredService<PlayerSkillStateService>())
+            .AddSingleton<SkillFrameProducer>()
+            .AddHostedService<PlayerSkillStateWorldRegistration>();
 
         // Shared live recipe state from Player.log (ProcessLoadRecipes /
         // ProcessUpdateRecipe) — known recipes + per-recipe completion counts,
@@ -190,5 +205,43 @@ public static class GameStateServiceCollectionExtensions
             .AddHostedService(sp => sp.GetRequiredService<QuestService>());
 
         return services;
+    }
+
+    /// <summary>
+    /// Hosted service that wires <see cref="PlayerSkillStateService"/> (as a
+    /// folder) and <see cref="SkillFrameProducer"/> (as a producer) into the
+    /// <see cref="IPlayerWorld"/> singleton at host start, before
+    /// <c>PlayerWorld.StartAsync</c> fires. Ordering relies on
+    /// <c>ShellComposition</c> calling <c>AddPlayerWorld</c> before
+    /// <c>AddMithrilGameState</c>: registration order = hosted-service start
+    /// order, so this registration runs first; the world's own hosted service
+    /// (which calls <c>world.StartAsync</c>) runs second and observes the
+    /// folder + producer already attached. Registrations must close before
+    /// <c>StartAsync</c>; the world enforces that explicitly.
+    /// </summary>
+    private sealed class PlayerSkillStateWorldRegistration : IHostedService
+    {
+        private readonly IPlayerWorld _world;
+        private readonly IFolder<SkillFrame> _folder;
+        private readonly SkillFrameProducer _producer;
+
+        public PlayerSkillStateWorldRegistration(
+            IPlayerWorld world,
+            IFolder<SkillFrame> folder,
+            SkillFrameProducer producer)
+        {
+            _world = world;
+            _folder = folder;
+            _producer = producer;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _world.RegisterProducer(_producer);
+            _world.RegisterFolder(_folder);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/Mithril.GameState/Mithril.GameState.csproj
+++ b/src/Mithril.GameState/Mithril.GameState.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mithril.Shared\Mithril.Shared.csproj" />
+    <ProjectReference Include="..\Mithril.WorldSim.Core\Mithril.WorldSim.Core.csproj" />
+    <ProjectReference Include="..\Mithril.WorldSim.Player\Mithril.WorldSim.Player.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
+++ b/src/Mithril.GameState/Skills/PlayerSkillStateService.cs
@@ -1,18 +1,29 @@
-using Microsoft.Extensions.Hosting;
 using Mithril.GameState.Skills.Parsing;
 using Mithril.Shared.Diagnostics;
-using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
+using Mithril.WorldSim;
 
 namespace Mithril.GameState.Skills;
 
 /// <summary>
-/// Eagerly subscribes to the L1 (#550) driver's LocalPlayer pipe at shell
-/// startup and maintains the canonical live <see cref="PlayerSkillSnapshot"/>
-/// from <c>ProcessLoadSkills</c> (full replace) and
-/// <c>ProcessUpdateSkill</c> (per-skill upsert) lines. The single owner of
-/// player skill state derived from the log — modules depend on
+/// Player.log skill-state folder + service surface. The single owner of player
+/// skill state derived from the log — modules depend on
 /// <see cref="IPlayerSkillState"/> rather than re-parsing the stream.
+///
+/// <para><b>World-simulator migration (issue #618 — Phase 1).</b> Pre-migration
+/// this class was a <see cref="Microsoft.Extensions.Hosting.BackgroundService"/>
+/// that owned its own L1-driver subscription. Post-migration it is an
+/// <see cref="IFolder{TPayload}"/> registered with <c>IPlayerWorld</c> for the
+/// <see cref="SkillFrame"/> payload type: a sibling
+/// <see cref="Producers.SkillFrameProducer"/> owns the L1 subscription, parses
+/// each line via <see cref="SkillLogParser"/>, and emits one
+/// <see cref="SkillsSnapshotFrame"/> per <c>ProcessLoadSkills</c> /
+/// <see cref="SkillProgressUpdateFrame"/> per <c>ProcessUpdateSkill</c>. The
+/// world drives <see cref="Apply"/> per applied frame in source order; the
+/// folder returns <see cref="SkillChange"/> change events which the world
+/// publishes on its bus (<c>IPlayerWorld.Bus.Subscribe&lt;SkillChange&gt;</c>)
+/// in addition to invoking the legacy
+/// <see cref="IPlayerSkillState.SubscribeChanges"/> handlers.</para>
 ///
 /// <para><b>Self-heal / warm-up.</b> <c>ProcessLoadSkills</c> is emitted at
 /// login and again on every zone / session transition, so a wholesale replace
@@ -23,27 +34,25 @@ namespace Mithril.GameState.Skills;
 /// snapshot (better than nothing — the next <c>ProcessLoadSkills</c> makes it
 /// whole). This window is the documented contract.</para>
 ///
-/// <para><b>Threading.</b> The L1 driver delivers envelopes on its pump
-/// thread (archetype-A default = <c>DeliveryContext.Inline</c>). The
-/// snapshot reference is swapped under <see cref="_lock"/>;
-/// <see cref="Current"/> reads are lock-free (reference read of an immutable
-/// object). <see cref="Subscribe"/> replays and attaches atomically under
-/// the same lock the ingestion loop fires under, which closes the
-/// late-subscribe race exactly as <c>InventoryService</c> does.</para>
+/// <para><b>Threading.</b> The world drives <see cref="Apply"/> from its
+/// merger thread; folder mutations + legacy handler dispatch run under
+/// <see cref="_lock"/>. <see cref="Current"/> reads are lock-free (reference
+/// read of an immutable object). <see cref="Subscribe"/> replays and attaches
+/// atomically under the same lock the dispatch loop fires under, which closes
+/// the late-subscribe race exactly as the pre-migration shape did.</para>
 ///
-/// <para><b>Containment.</b> The L1 driver wraps each handler invocation
-/// in try/catch + rate-limited Warn, retiring the per-service
-/// <see cref="ThrottledWarn"/> instance this service used to hold (#550
-/// capability C). Failures surface on <c>IDiagnosticsSink</c> under the
-/// <c>GameState.Skills</c> category via the driver's
-/// <see cref="LogSubscriptionOptions.DiagnosticCategory"/> override. The
-/// parser's own <see cref="ThrottledWarn"/> (per-row numeric-overflow
-/// guard, #525) is unrelated and stays.</para>
+/// <para><b>Two consumer channels, one truth.</b>
+/// <see cref="SubscribeChanges"/> + <see cref="Subscribe"/> remain the
+/// idiomatic surfaces for snapshot / event delivery. The world's bus carries
+/// the same <see cref="SkillChange"/> stream for cross-cutting consumers that
+/// prefer the architectural <c>IPlayerWorld.Bus.Subscribe&lt;SkillChange&gt;</c>
+/// path (design notebook principle 4 — single-world consumers may subscribe
+/// directly to the world's bus). Both channels fire on identical events with
+/// identical content; back-compat consumers keep working; new code can
+/// choose either.</para>
 /// </summary>
-public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillState
+public sealed class PlayerSkillStateService : IFolder<SkillFrame>, IPlayerSkillState
 {
-    private readonly ILogStreamDriver _driver;
-    private readonly SkillLogParser _parser;
     private readonly IReferenceDataService? _refData;
     private readonly IDiagnosticsSink? _diag;
 
@@ -51,22 +60,16 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
     private readonly List<Action<PlayerSkillSnapshot>> _handlers = new();
     private readonly List<Action<SkillChange>> _changeHandlers = new();
     private volatile PlayerSkillSnapshot _current = PlayerSkillSnapshot.Empty;
-    private ILogSubscription? _subscription;
 
     /// <param name="refData">Optional (#470). When present, each projected
     /// <see cref="SkillProgressSnapshot"/> is enriched with authoritative
     /// <see cref="SkillReference"/> metadata (display name, XpTable/umbrella).
     /// Absent (tests, or reference data not yet loaded) → the snapshot keeps
-    /// the verified log-only proxies. Mirrors <c>InventoryService</c>'s
-    /// optional <c>IReferenceDataService?</c> dependency.</param>
+    /// the verified log-only proxies.</param>
     public PlayerSkillStateService(
-        ILogStreamDriver driver,
-        SkillLogParser parser,
         IReferenceDataService? refData = null,
         IDiagnosticsSink? diag = null)
     {
-        _driver = driver;
-        _parser = parser;
         _refData = refData;
         _diag = diag;
     }
@@ -96,56 +99,37 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
         }
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    /// <summary>
+    /// Apply one frame to internal state. The world routes
+    /// <see cref="SkillFrame"/> frames here in source-stream order; the folder
+    /// mutates state, fires the legacy <see cref="Subscribe"/> /
+    /// <see cref="SubscribeChanges"/> handlers, and returns the
+    /// <see cref="SkillChange"/> events for the world to surface on its bus.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="clock"/> is unused — the folder's state derivation is
+    /// driven entirely by the frame's own timestamp (which equals
+    /// <c>clock.Now</c> at apply-time per the framework). Keeping
+    /// frame-timestamp-only ensures the snapshot's
+    /// <see cref="PlayerSkillSnapshot.MeasuredAt"/> reads identically before
+    /// and after this migration.
+    /// </remarks>
+    public IReadOnlyList<IChangeEvent> Apply(Frame<SkillFrame> frame, IWorldClock clock)
     {
-        _diag?.Info("GameState.Skills", "Subscribing to L1 driver (LocalPlayer pipe) for skill-state events");
-        // archetype-A defaults — FromSessionStart replay + Inline delivery.
-        // The parser consumes the envelope-stripped LocalPlayerLogLine.Data
-        // directly — L0.5 (#532) owns actor classification, downstream
-        // never re-matches the envelope (#550 PR #555 review).
-        _subscription = _driver.Subscribe<LocalPlayerLogLine>(
-            envelope =>
-            {
-                var ts = envelope.Payload.Timestamp.UtcDateTime;
-                switch (_parser.TryParse(envelope.Payload.Data, ts))
-                {
-                    case SkillsSnapshotEvent snap:
-                        ReplaceAll(snap);
-                        break;
-                    case SkillProgressUpdateEvent upd:
-                        Upsert(upd);
-                        break;
-                }
-                return ValueTask.CompletedTask;
-            },
-            new LogSubscriptionOptions
-            {
-                ReplayMode = ReplayMode.FromSessionStart,
-                DeliveryContext = DeliveryContext.Inline,
-                DiagnosticCategory = "GameState.Skills",
-            });
-
-        try { await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false); }
-        catch (OperationCanceledException) { /* expected on host stop */ }
-        finally
+        _ = clock;
+        return frame.Payload switch
         {
-            _subscription?.Dispose();
-            _subscription = null;
-        }
-    }
-
-    public override void Dispose()
-    {
-        _subscription?.Dispose();
-        _subscription = null;
-        base.Dispose();
+            SkillsSnapshotFrame snap => ReplaceAll(snap, frame.Timestamp.UtcDateTime),
+            SkillProgressUpdateFrame upd => Upsert(upd, frame.Timestamp.UtcDateTime),
+            _ => Array.Empty<IChangeEvent>(),
+        };
     }
 
     /// <summary>Wholesale replace from a <c>ProcessLoadSkills</c> dump. Emits a
     /// <see cref="SkillChangeKind.SnapshotReplace"/> only for skills whose
     /// projection actually differs from (or is new vs.) the prior state — a
     /// no-op re-sync produces no change events.</summary>
-    private void ReplaceAll(SkillsSnapshotEvent snap)
+    private IReadOnlyList<IChangeEvent> ReplaceAll(SkillsSnapshotFrame snap, DateTime timestamp)
     {
         var map = new Dictionary<string, SkillProgressSnapshot>(snap.Skills.Count, StringComparer.Ordinal);
         foreach (var r in snap.Skills)
@@ -155,37 +139,35 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
             map[r.SkillKey] = Project(r);
         }
 
+        List<IChangeEvent> changes = new();
         lock (_lock)
         {
             var prev = _current.Skills;
-            List<SkillChange>? changes = _changeHandlers.Count == 0 ? null : new();
-            if (changes is not null)
+            foreach (var (key, cur) in map)
             {
-                foreach (var (key, cur) in map)
-                {
-                    bool had = prev.TryGetValue(key, out var before);
-                    if (had && before.Equals(cur)) continue; // unchanged — skip
-                    changes.Add(new SkillChange(
-                        key, had ? before : null, cur, XpGained: 0,
-                        SkillChangeKind.SnapshotReplace, snap.Timestamp));
-                }
+                bool had = prev.TryGetValue(key, out var before);
+                if (had && before.Equals(cur)) continue; // unchanged — skip
+                changes.Add(new SkillChange(
+                    key, had ? before : null, cur, XpGained: 0,
+                    SkillChangeKind.SnapshotReplace, timestamp));
             }
 
-            _current = new PlayerSkillSnapshot(map, snap.Timestamp, SkillStateSource.LiveLog);
+            _current = new PlayerSkillSnapshot(map, timestamp, SkillStateSource.LiveLog);
             _diag?.Trace("GameState.Skills",
-                $"Skill snapshot replaced: {map.Count} skills @ {snap.Timestamp:O}");
+                $"Skill snapshot replaced: {map.Count} skills @ {timestamp:O}");
             Fire(_current);
-            if (changes is not null)
-                foreach (var c in changes) FireChange(c);
+            foreach (var c in changes) FireChange((SkillChange)c);
         }
+        return changes;
     }
 
     /// <summary>Single-skill upsert from a <c>ProcessUpdateSkill</c> delta.
     /// Accepted even before the first full snapshot — the resulting partial
     /// state is intentional (see the type docs). Emits one
     /// <see cref="SkillChangeKind.Delta"/> carrying the tick's XP.</summary>
-    private void Upsert(SkillProgressUpdateEvent upd)
+    private IReadOnlyList<IChangeEvent> Upsert(SkillProgressUpdateFrame upd, DateTime timestamp)
     {
+        SkillChange change;
         lock (_lock)
         {
             var key = upd.Skill.SkillKey;
@@ -199,13 +181,17 @@ public sealed class PlayerSkillStateService : BackgroundService, IPlayerSkillSta
             {
                 [key] = cur,
             };
-            _current = new PlayerSkillSnapshot(map, upd.Timestamp, SkillStateSource.LiveLog);
+            _current = new PlayerSkillSnapshot(map, timestamp, SkillStateSource.LiveLog);
             _diag?.Trace("GameState.Skills",
-                $"Skill upsert: {key} raw={upd.Skill.Level} +{upd.XpGained}xp @ {upd.Timestamp:O}");
+                $"Skill upsert: {key} raw={upd.Skill.Level} +{upd.XpGained}xp @ {timestamp:O}");
+
+            change = new SkillChange(
+                key, before, cur, upd.XpGained, SkillChangeKind.Delta, timestamp);
+
             Fire(_current);
-            FireChange(new SkillChange(
-                key, before, cur, upd.XpGained, SkillChangeKind.Delta, upd.Timestamp));
+            FireChange(change);
         }
+        return new IChangeEvent[] { change };
     }
 
     private SkillProgressSnapshot Project(SkillProgressRecord r) => new(

--- a/src/Mithril.GameState/Skills/Producers/SkillFrameProducer.cs
+++ b/src/Mithril.GameState/Skills/Producers/SkillFrameProducer.cs
@@ -1,0 +1,135 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Mithril.GameState.Skills.Parsing;
+using Mithril.Shared.Diagnostics;
+using Mithril.Shared.Logging;
+using Mithril.WorldSim;
+
+namespace Mithril.GameState.Skills.Producers;
+
+/// <summary>
+/// World-simulator producer that adapts the L1 driver's
+/// <see cref="ILogStreamDriver"/> push-based <c>LocalPlayer</c> subscription
+/// into the world's pull-based <see cref="IFrameProducer{TPayload}"/> contract
+/// for the Player.log skill folder (issue #618 — Phase 1 of the world-sim
+/// migration). The producer parses every classified LocalPlayer line via
+/// <see cref="SkillLogParser"/>; only <c>ProcessLoadSkills</c> /
+/// <c>ProcessUpdateSkill</c> yield <see cref="SkillFrame"/> emissions, every
+/// other line is dropped at this boundary so the world sees only skill
+/// frames.
+///
+/// <para><b>Mode awareness.</b> Mirrors
+/// <see cref="Mithril.WorldSim.Player.Producers.ClassifiedPlayerLogProducer"/>'s
+/// shape — <see cref="ReachedLive"/> completes the moment the producer reads
+/// the first non-replay envelope from the L1 driver, irrespective of whether
+/// that envelope is itself a skill line. PG's <c>ProcessLoadSkills</c> only
+/// fires at login + zone transitions; a player-idle live tail could go
+/// minutes without any skill emission, and we mustn't stall the world's mode
+/// flip waiting for one.</para>
+///
+/// <para><b>L1 subscription disposition.</b> Archetype-A defaults
+/// (<see cref="ReplayMode.FromSessionStart"/> + <see cref="DeliveryContext.Inline"/>),
+/// matching the pre-migration <c>PlayerSkillStateService</c> exactly — the
+/// L0.5 router strips the <c>LocalPlayer:</c> envelope, the parser consumes
+/// <see cref="LocalPlayerLogLine.Data"/> directly, and L1 owns
+/// containment around each handler invocation.</para>
+///
+/// <para><b>Channel buffer.</b> An unbounded single-reader channel sits
+/// between the push-callback and the IAsyncEnumerable yield. The L1 driver
+/// already throttles by the source-stream rate (Player.log emit rate is
+/// human-real-time bounded), so unbounded is acceptable and avoids the
+/// deadlock risk a bounded buffer would introduce (callback would block the
+/// L1 pump waiting for the world's merger to drain).</para>
+/// </summary>
+public sealed class SkillFrameProducer : IFrameProducer<SkillFrame>, IModeAwareFrameProducer<SkillFrame>
+{
+    private readonly ILogStreamDriver _driver;
+    private readonly SkillLogParser _parser;
+    private readonly IDiagnosticsSink? _diag;
+    private readonly TaskCompletionSource _reachedLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public SkillFrameProducer(
+        ILogStreamDriver driver,
+        SkillLogParser parser,
+        IDiagnosticsSink? diag = null)
+    {
+        _driver = driver ?? throw new ArgumentNullException(nameof(driver));
+        _parser = parser ?? throw new ArgumentNullException(nameof(parser));
+        _diag = diag;
+    }
+
+    /// <summary>
+    /// Producer priority for the merger's tie-breaking. Matches the
+    /// classified-pipe producer's priority (0) because the skill producer
+    /// also derives from the L1 stream — same source, same ordering rights.
+    /// Distinct frame types mean the two producers never share a folder slot,
+    /// but they may share timestamps under PG's 1-second resolution; priority
+    /// 0 keeps the tie-break stable across runs.
+    /// </summary>
+    public int Priority => 0;
+
+    public Task ReachedLive => _reachedLive.Task;
+
+    public async IAsyncEnumerable<Frame<SkillFrame>> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        // SingleReader: only the world's merger reads via the async enumerator.
+        // Unbounded: see the class-doc rationale (L1 already paces by source).
+        var channel = Channel.CreateUnbounded<Frame<SkillFrame>>(
+            new UnboundedChannelOptions { SingleReader = true });
+
+        _diag?.Info("GameState.Skills",
+            "SkillFrameProducer subscribing to L1 driver (LocalPlayer pipe) for skill-state frames");
+
+        var subscription = _driver.Subscribe<LocalPlayerLogLine>(
+            envelope =>
+            {
+                // Mode flip is driven by envelope-shape, not skill-shape (see
+                // class doc). The L1 contract guarantees IsReplay transitions
+                // once and never re-arms, so TrySetResult is idempotent past
+                // that boundary.
+                if (!envelope.IsReplay)
+                {
+                    _reachedLive.TrySetResult();
+                }
+
+                var line = envelope.Payload;
+                var evt = _parser.TryParse(line.Data, line.Timestamp.UtcDateTime);
+                SkillFrame? payload = evt switch
+                {
+                    SkillsSnapshotEvent snap => new SkillsSnapshotFrame(snap.Skills),
+                    SkillProgressUpdateEvent upd => new SkillProgressUpdateFrame(upd.Skill, upd.XpGained),
+                    _ => null,
+                };
+                if (payload is null) return ValueTask.CompletedTask;
+
+                // TryWrite on an unbounded channel can only fail post-Complete,
+                // and we never complete from inside the callback. Discarding
+                // the result keeps the hot path branch-free.
+                _ = channel.Writer.TryWrite(new Frame<SkillFrame>(line.Timestamp, payload));
+                return ValueTask.CompletedTask;
+            },
+            new LogSubscriptionOptions
+            {
+                ReplayMode = ReplayMode.FromSessionStart,
+                DeliveryContext = DeliveryContext.Inline,
+                DiagnosticCategory = "GameState.Skills",
+            });
+
+        try
+        {
+            await foreach (var frame in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return frame;
+            }
+        }
+        finally
+        {
+            subscription.Dispose();
+            // Guarantee ReachedLive completes even if the stream ended without
+            // ever flipping (degenerate test fixture, or a replay-only file
+            // tail). Matches ClassifiedPlayerLogProducer's terminal fallback.
+            _reachedLive.TrySetResult();
+        }
+    }
+}

--- a/src/Mithril.GameState/Skills/SkillChange.cs
+++ b/src/Mithril.GameState/Skills/SkillChange.cs
@@ -1,3 +1,5 @@
+using Mithril.WorldSim;
+
 namespace Mithril.GameState.Skills;
 
 /// <summary>How a <see cref="SkillChange"/> was produced.</summary>
@@ -55,4 +57,4 @@ public readonly record struct SkillChange(
     SkillProgressSnapshot Current,
     long XpGained,
     SkillChangeKind Kind,
-    DateTime Timestamp);
+    DateTime Timestamp) : IChangeEvent;

--- a/src/Mithril.GameState/Skills/SkillFrame.cs
+++ b/src/Mithril.GameState/Skills/SkillFrame.cs
@@ -1,0 +1,51 @@
+using Mithril.GameState.Skills.Parsing;
+
+namespace Mithril.GameState.Skills;
+
+/// <summary>
+/// World-simulator frame payload for the Player.log skill folder
+/// (<see cref="PlayerSkillStateService"/>). The folder is registered with
+/// <c>IPlayerWorld</c> for this payload type (issue #618 — Phase 1 of the
+/// world-sim migration, validates the foundation end-to-end before the
+/// bigger Phase 2 splits proceed). A skill-aware producer
+/// (<see cref="Producers.SkillFrameProducer"/>) reads classified
+/// LocalPlayer log envelopes, parses them via <see cref="SkillLogParser"/>,
+/// and emits one of the two subtypes below for every skill-relevant line.
+///
+/// <para>The closed hierarchy keeps the folder's switch exhaustive at
+/// compile time and lets a consumer pattern-match without an open-world
+/// downcast.</para>
+/// </summary>
+public abstract record SkillFrame
+{
+    // Closed hierarchy — only the nested subtypes can extend this record.
+    // (Using a non-public ctor would also forbid external derivation, but
+    // the doc note on the abstract record carries the intent.)
+    private protected SkillFrame() { }
+}
+
+/// <summary>
+/// Frame payload representing a full <c>ProcessLoadSkills</c> snapshot. PG
+/// emits this at login and on every zone / session transition; the folder
+/// treats it as a wholesale replace, never a merge — same semantics as the
+/// pre-migration <see cref="PlayerSkillStateService"/> (see the type docs
+/// there).
+/// </summary>
+/// <param name="Skills">Every parsed skill row, in log order. Carries the
+/// raw <see cref="SkillProgressRecord"/> tuples; the folder's projection
+/// applies the caveat interpretation (capped / trainable / reference
+/// enrichment).</param>
+public sealed record SkillsSnapshotFrame(IReadOnlyList<SkillProgressRecord> Skills) : SkillFrame;
+
+/// <summary>
+/// Frame payload representing a single <c>ProcessUpdateSkill</c> delta.
+/// Carries the absolute post-tick state of one skill plus the gross
+/// <see cref="XpGained"/> on this tick (chat-corroborated within a level —
+/// see <see cref="SkillProgressUpdateEvent"/>).
+/// </summary>
+/// <param name="Skill">The single skill record from the line's struct.</param>
+/// <param name="XpGained">XP earned on this tick (the line's third
+/// positional). Always <c>&gt;= 0</c>; <c>0</c> when the parser couldn't
+/// parse the tail (treated as a no-gain delta — the struct remains
+/// authoritative for state).</param>
+public sealed record SkillProgressUpdateFrame(SkillProgressRecord Skill, long XpGained) : SkillFrame;

--- a/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
+++ b/src/Mithril.Shell/DependencyInjection/ShellComposition.cs
@@ -10,6 +10,7 @@ using Mithril.Shared.Reference;
 using Mithril.Shared.Settings;
 using Mithril.Shared.Wpf;
 using Mithril.Shared.Wpf.DependencyInjection;
+using Mithril.WorldSim.Player.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Mithril.Shell.DependencyInjection;
@@ -60,6 +61,14 @@ public static class ShellComposition
             // the typed pipes + the unified pipe — #556) and
             // AddMithrilGameState (whose producers depend on ILogStreamDriver).
             .AddMithrilLogStreamDriver()
+            // PlayerWorld is registered BEFORE AddMithrilGameState so the
+            // skill-folder + producer registration (#618 — Phase 1 of the
+            // world-sim migration) can wire into the world via its own
+            // IHostedService at startup, before PlayerWorld.StartAsync fires.
+            // Hosted services run in registration order; the registration
+            // hosted service inside AddMithrilGameState therefore runs
+            // strictly before PlayerWorldHostedService.
+            .AddPlayerWorld()
             .AddMithrilGameState()
             .AddMithrilPerCharacterStorage(o.CharactersRootDir)
             .AddMithrilReferenceData(o.ReferenceCacheDir)

--- a/src/Mithril.WorldSim.Chat/ChatWorld.cs
+++ b/src/Mithril.WorldSim.Chat/ChatWorld.cs
@@ -232,7 +232,14 @@ public sealed class ChatWorld : IChatWorld, IAsyncDisposable
         if (changes.Count == 0) return;
 
         var workQueue = new Queue<object>(changes.Count);
-        foreach (var c in changes) workQueue.Enqueue(c);
+        foreach (var c in changes)
+        {
+            // Surface folder change events on the bus AS WELL AS routing them
+            // to intra-world composers — parity with PlayerWorld. See
+            // PlayerWorld.DispatchFrame for the design rationale (principle 4).
+            _bus.PublishChangeEvent(c, frame.Timestamp);
+            workQueue.Enqueue(c);
+        }
 
         while (workQueue.Count > 0)
         {

--- a/src/Mithril.WorldSim.Chat/Internal/WorldEventBus.cs
+++ b/src/Mithril.WorldSim.Chat/Internal/WorldEventBus.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq.Expressions;
 
 namespace Mithril.WorldSim.Chat.Internal;
 
@@ -12,6 +13,7 @@ namespace Mithril.WorldSim.Chat.Internal;
 internal sealed class WorldEventBus : IWorldEventBus
 {
     private readonly ConcurrentDictionary<Type, List<Subscription>> _subscriptions = new();
+    private readonly ConcurrentDictionary<Type, Func<DateTimeOffset, object, IFrame>> _changeEventWrappers = new();
     private readonly object _mutationLock = new();
 
     public IDisposable Subscribe<T>(Action<Frame<T>> handler)
@@ -61,6 +63,34 @@ internal sealed class WorldEventBus : IWorldEventBus
             if (sub.IsDisposed) continue;
             sub.Invoke(frame);
         }
+    }
+
+    /// <summary>
+    /// Surface a folder change event on the bus as a typed
+    /// <see cref="Frame{TPayload}"/>. Mirrors the PlayerWorld bus implementation;
+    /// see that copy for the design rationale (principle 4 — single-world
+    /// consumers subscribe directly to the world's bus).
+    /// </summary>
+    public void PublishChangeEvent(object changeEvent, DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(changeEvent);
+
+        var wrapper = _changeEventWrappers.GetOrAdd(changeEvent.GetType(), MakeWrapper);
+        Publish(wrapper(timestamp, changeEvent));
+    }
+
+    private static Func<DateTimeOffset, object, IFrame> MakeWrapper(Type runtimeType)
+    {
+        var frameType = typeof(Frame<>).MakeGenericType(runtimeType);
+        var ctor = frameType.GetConstructor(new[] { typeof(DateTimeOffset), runtimeType })
+            ?? throw new InvalidOperationException(
+                $"Frame<{runtimeType.FullName}> is missing the expected (DateTimeOffset, T) constructor.");
+        var tsParam = Expression.Parameter(typeof(DateTimeOffset), "timestamp");
+        var payloadParam = Expression.Parameter(typeof(object), "payload");
+        var body = Expression.Convert(
+            Expression.New(ctor, tsParam, Expression.Convert(payloadParam, runtimeType)),
+            typeof(IFrame));
+        return Expression.Lambda<Func<DateTimeOffset, object, IFrame>>(body, tsParam, payloadParam).Compile();
     }
 
     private sealed class Subscription : IDisposable

--- a/src/Mithril.WorldSim.Player/Internal/WorldEventBus.cs
+++ b/src/Mithril.WorldSim.Player/Internal/WorldEventBus.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq.Expressions;
 
 namespace Mithril.WorldSim.Player.Internal;
 
@@ -16,6 +17,7 @@ namespace Mithril.WorldSim.Player.Internal;
 internal sealed class WorldEventBus : IWorldEventBus
 {
     private readonly ConcurrentDictionary<Type, List<Subscription>> _subscriptions = new();
+    private readonly ConcurrentDictionary<Type, Func<DateTimeOffset, object, IFrame>> _changeEventWrappers = new();
     private readonly object _mutationLock = new();
 
     public IDisposable Subscribe<T>(Action<Frame<T>> handler)
@@ -70,6 +72,55 @@ internal sealed class WorldEventBus : IWorldEventBus
             if (sub.IsDisposed) continue;
             sub.Invoke(frame);
         }
+    }
+
+    /// <summary>
+    /// Publish a folder-emitted change event as a typed
+    /// <see cref="Frame{TPayload}"/> on the bus. The payload's runtime type
+    /// determines <c>T</c>: <c>changeEvent.GetType() == typeof(TConcrete)</c>
+    /// produces a <c>Frame&lt;TConcrete&gt;</c> stamped with
+    /// <paramref name="timestamp"/>. Subscribers registered via
+    /// <see cref="Subscribe{T}(Action{Frame{T}})"/> for the concrete change-event
+    /// type see the emission; subscribers for a base type or
+    /// <see cref="IChangeEvent"/> itself do not (the routing key is the
+    /// concrete payload type, matching how composer emissions are routed).
+    ///
+    /// <para>This is the bridge that surfaces folder change events on the
+    /// world's bus — without it, single-world consumers (per design notebook
+    /// principle 4) would have to register a pass-through composer for every
+    /// folder. The folder still returns <see cref="IChangeEvent"/> lists so
+    /// the runtime-type lookup is one cached <c>Func</c> per concrete
+    /// change-event type (first publish compiles, subsequent ones are direct
+    /// delegate calls).</para>
+    /// </summary>
+    public void PublishChangeEvent(object changeEvent, DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(changeEvent);
+
+        var wrapper = _changeEventWrappers.GetOrAdd(changeEvent.GetType(), MakeWrapper);
+        Publish(wrapper(timestamp, changeEvent));
+    }
+
+    /// <summary>
+    /// Build a compiled delegate that, for a fixed runtime type <c>T</c>,
+    /// projects <c>(timestamp, boxedPayload) =&gt; (IFrame) new Frame&lt;T&gt;(timestamp, (T)boxedPayload)</c>.
+    /// One allocation per change-event type on first use; cached for the
+    /// lifetime of the bus. Equivalent to a hand-rolled
+    /// <c>MakeGenericMethod</c> + <c>Delegate.CreateDelegate</c> pair, but the
+    /// expression tree is easier to read at the call site.
+    /// </summary>
+    private static Func<DateTimeOffset, object, IFrame> MakeWrapper(Type runtimeType)
+    {
+        var frameType = typeof(Frame<>).MakeGenericType(runtimeType);
+        var ctor = frameType.GetConstructor(new[] { typeof(DateTimeOffset), runtimeType })
+            ?? throw new InvalidOperationException(
+                $"Frame<{runtimeType.FullName}> is missing the expected (DateTimeOffset, T) constructor.");
+        var tsParam = Expression.Parameter(typeof(DateTimeOffset), "timestamp");
+        var payloadParam = Expression.Parameter(typeof(object), "payload");
+        var body = Expression.Convert(
+            Expression.New(ctor, tsParam, Expression.Convert(payloadParam, runtimeType)),
+            typeof(IFrame));
+        return Expression.Lambda<Func<DateTimeOffset, object, IFrame>>(body, tsParam, payloadParam).Compile();
     }
 
     private sealed class Subscription : IDisposable

--- a/src/Mithril.WorldSim.Player/PlayerWorld.cs
+++ b/src/Mithril.WorldSim.Player/PlayerWorld.cs
@@ -263,6 +263,16 @@ public sealed class PlayerWorld : IPlayerWorld, IAsyncDisposable
         var workQueue = new Queue<object>(changes.Count);
         foreach (var c in changes)
         {
+            // Surface folder change events on the bus AS WELL AS routing them
+            // to intra-world composers. Single-world consumers (per design
+            // notebook principle 4 — "modules needing only one source's
+            // state may subscribe directly to that world's bus") subscribe
+            // to the concrete change-event type; the bus wraps the runtime
+            // type into Frame<T> via a cached compiled delegate, so no
+            // pass-through composer is needed per folder. Composer emissions
+            // continue to publish via Bus.Publish in the resolution loop
+            // below; both flow through the same subscriber pipeline.
+            _bus.PublishChangeEvent(c, frame.Timestamp);
             workQueue.Enqueue(c);
         }
 

--- a/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/PlayerSkillStateServiceTests.cs
@@ -1,28 +1,37 @@
-using System.Threading.Channels;
 using FluentAssertions;
 using Mithril.GameState.Skills;
 using Mithril.GameState.Skills.Parsing;
-using Mithril.GameState.Tests.TestSupport;
-using Mithril.Shared.Logging;
 using Mithril.Shared.Reference;
 using Mithril.TestSupport;
+using Mithril.WorldSim;
 using Xunit;
 
 namespace Mithril.GameState.Tests.Skills;
 
+/// <summary>
+/// Folder-level tests for <see cref="PlayerSkillStateService"/>. Post-#618
+/// (Phase 1 of the world-sim migration) the service is an
+/// <see cref="IFolder{TPayload}"/> for <see cref="SkillFrame"/>; the world's
+/// merger drives <see cref="PlayerSkillStateService.Apply"/> per applied frame.
+/// These tests drive <c>Apply</c> directly with synthetic
+/// <see cref="SkillFrame"/> payloads — the producer + world wiring is covered
+/// separately in <see cref="SkillFolderEndToEndTests"/>. Behaviour expectations
+/// (snapshot semantics, change-event emission, reference enrichment) are
+/// preserved from the pre-migration test suite.
+/// </summary>
 public sealed class PlayerSkillStateServiceTests
 {
+    // The original parser-fed test lines, preserved so we can re-parse them
+    // via SkillLogParser when convenient (e.g. real captures) and feed the
+    // parsed events as SkillFrame payloads.
     private const string LoadLine =
-        "[08:22:21] LocalPlayer: ProcessLoadSkills(" +
+        "ProcessLoadSkills(" +
         "{type=Toolcrafting,raw=15,bonus=0,xp=26,tnl=680,max=50}, " +
         "{type=Tanning,raw=50,bonus=3,xp=0,tnl=5280,max=50}, " +
         "{type=Augmentation,raw=0,bonus=2,xp=0,tnl=1,max=0})";
 
-    private static PlayerSkillStateService NewService(ScriptedStream stream)
-        => new(stream.Driver, new SkillLogParser());
-
-    private static PlayerSkillStateService NewService(ScriptedStream stream, IReferenceDataService refData)
-        => new(stream.Driver, new SkillLogParser(), refData);
+    private static PlayerSkillStateService NewService() => new();
+    private static PlayerSkillStateService NewService(IReferenceDataService refData) => new(refData);
 
     private static SkillEntry SkillRef(string key, string display, string xpTable, int maxBonus = 25)
         => new(key, display, Id: 0, Combat: false, XpTable: xpTable, MaxBonusLevels: maxBonus,
@@ -35,10 +44,35 @@ public sealed class PlayerSkillStateServiceTests
         return f;
     }
 
+    private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Parse a real log line via <see cref="SkillLogParser"/> and apply it to
+    /// the folder as a <see cref="SkillFrame"/>. Keeps the test surface
+    /// close to the pre-migration "feed a line through the L1 driver" path:
+    /// the producer in production code does exactly this projection, so
+    /// driving the folder through it exercises the same final shape with
+    /// none of the async / lifetime ceremony.
+    /// </summary>
+    private static IReadOnlyList<IChangeEvent> ApplyLine(PlayerSkillStateService svc, DateTime timestamp, string line)
+    {
+        var parser = new SkillLogParser();
+        var evt = parser.TryParse(line, timestamp);
+        SkillFrame payload = evt switch
+        {
+            SkillsSnapshotEvent snap => new SkillsSnapshotFrame(snap.Skills),
+            SkillProgressUpdateEvent upd => new SkillProgressUpdateFrame(upd.Skill, upd.XpGained),
+            _ => throw new InvalidOperationException(
+                $"Test line did not parse as a skill event: {line}"),
+        };
+        var frame = new Frame<SkillFrame>(new DateTimeOffset(timestamp, TimeSpan.Zero), payload);
+        return ((IFolder<SkillFrame>)svc).Apply(frame, NoopClock.Instance);
+    }
+
     [Fact]
     public void Cold_start_is_Empty_with_no_measurement()
     {
-        var svc = NewService(new ScriptedStream());
+        var svc = NewService();
         svc.Current.Should().BeSameAs(PlayerSkillSnapshot.Empty);
         svc.Current.Source.Should().Be(SkillStateSource.None);
         svc.Current.MeasuredAt.Should().BeNull();
@@ -46,11 +80,10 @@ public sealed class PlayerSkillStateServiceTests
     }
 
     [Fact]
-    public async Task ProcessLoadSkills_populates_full_snapshot_with_caveat_flags()
+    public void ProcessLoadSkills_populates_full_snapshot_with_caveat_flags()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
-        var svc = NewService(stream);
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 22, 21), LoadLine);
 
         var cur = svc.Current;
         cur.Source.Should().Be(SkillStateSource.LiveLog);
@@ -72,29 +105,25 @@ public sealed class PlayerSkillStateServiceTests
     }
 
     [Fact]
-    public async Task ProcessLoadSkills_is_a_wholesale_replace_not_a_merge()
+    public void ProcessLoadSkills_is_a_wholesale_replace_not_a_merge()
     {
-        var stream = new ScriptedStream(
-            new RawLogLine(Ts(8, 0, 0),
-                "LocalPlayer: ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})"),
-            new RawLogLine(Ts(9, 0, 0),
-                "LocalPlayer: ProcessLoadSkills({type=Cooking,raw=20,bonus=0,xp=1,tnl=2,max=50})"));
-        var svc = NewService(stream);
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 0, 0),
+            "ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})");
+        ApplyLine(svc, Ts(9, 0, 0),
+            "ProcessLoadSkills({type=Cooking,raw=20,bonus=0,xp=1,tnl=2,max=50})");
 
         svc.Current.Skills.Keys.Should().Equal("Cooking"); // Sword gone
         svc.Current.MeasuredAt.Should().Be(Ts(9, 0, 0));
     }
 
     [Fact]
-    public async Task ProcessUpdateSkill_upserts_one_skill_keeping_the_rest()
+    public void ProcessUpdateSkill_upserts_one_skill_keeping_the_rest()
     {
-        var stream = new ScriptedStream(
-            new RawLogLine(Ts(8, 22, 21), LoadLine),
-            new RawLogLine(Ts(8, 30, 0),
-                "LocalPlayer: ProcessUpdateSkill({type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)"));
-        var svc = NewService(stream);
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 22, 21), LoadLine);
+        ApplyLine(svc, Ts(8, 30, 0),
+            "ProcessUpdateSkill({type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)");
 
         svc.Current.Skills.Should().HaveCount(3); // Tanning + Augmentation untouched
         svc.Current.TryGet("Toolcrafting", out var tool).Should().BeTrue();
@@ -104,25 +133,21 @@ public sealed class PlayerSkillStateServiceTests
     }
 
     [Fact]
-    public async Task ProcessUpdateSkill_before_any_snapshot_yields_partial_state()
+    public void ProcessUpdateSkill_before_any_snapshot_yields_partial_state()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 30, 0),
-            "LocalPlayer: ProcessUpdateSkill({type=NatureAppreciation,raw=26,bonus=2,xp=315,tnl=1350,max=50}, True, 110, 0, 0)"));
-        var svc = NewService(stream);
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 30, 0),
+            "ProcessUpdateSkill({type=NatureAppreciation,raw=26,bonus=2,xp=315,tnl=1350,max=50}, True, 110, 0, 0)");
 
         svc.Current.Source.Should().Be(SkillStateSource.LiveLog);
         svc.Current.Skills.Keys.Should().Equal("NatureAppreciation");
     }
 
     [Fact]
-    public async Task Subscribe_replays_current_then_delivers_live_changes()
+    public void Subscribe_replays_current_then_delivers_live_changes()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 22, 21), LoadLine);
 
         var seen = new List<PlayerSkillSnapshot>();
         using (svc.Subscribe(seen.Add))
@@ -130,53 +155,43 @@ public sealed class PlayerSkillStateServiceTests
             seen.Should().HaveCount(1); // replay of current
             seen[0].Skills.Should().HaveCount(3);
 
-            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
-            await stream.WaitForDrainAsync(cts.Token);
+            ApplyLine(svc, Ts(8, 30, 0),
+                "ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
         }
 
         seen.Should().HaveCount(2);
         seen[1].TryGet("Sword", out _).Should().BeTrue();
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Disposed_subscription_stops_receiving()
+    public void Disposed_subscription_stops_receiving()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 22, 21), LoadLine);
 
         var seen = new List<PlayerSkillSnapshot>();
         var sub = svc.Subscribe(seen.Add);
         sub.Dispose();
 
-        stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
-        await stream.WaitForDrainAsync(cts.Token);
+        ApplyLine(svc, Ts(8, 30, 0),
+            "ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
 
         seen.Should().HaveCount(1); // only the replay; no live event after dispose
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task SubscribeChanges_has_no_replay_then_delivers_Delta_with_XpGained()
+    public void SubscribeChanges_has_no_replay_then_delivers_Delta_with_XpGained()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 22, 21), LoadLine);
 
         var changes = new List<SkillChange>();
         using (svc.SubscribeChanges(changes.Add))
         {
             changes.Should().BeEmpty(); // no replay — a change is an event, not state
 
-            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)");
-            await stream.WaitForDrainAsync(cts.Token);
+            ApplyLine(svc, Ts(8, 30, 0),
+                "ProcessUpdateSkill({type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)");
         }
 
         changes.Should().HaveCount(1);
@@ -186,50 +201,40 @@ public sealed class PlayerSkillStateServiceTests
         c.Previous!.Value.Level.Should().Be(15); // from LoadLine
         c.Current.Level.Should().Be(16);
         c.XpGained.Should().Be(4);
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Delta_for_never_seen_skill_has_null_Previous()
+    public void Delta_for_never_seen_skill_has_null_Previous()
     {
-        var stream = new ScriptedStream();
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
+        var svc = NewService();
 
         var changes = new List<SkillChange>();
         using (svc.SubscribeChanges(changes.Add))
         {
-            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
-            await stream.WaitForDrainAsync(cts.Token);
+            ApplyLine(svc, Ts(8, 30, 0),
+                "ProcessUpdateSkill({type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
         }
 
         changes.Should().ContainSingle();
         changes[0].Previous.Should().BeNull();
         changes[0].Current.Level.Should().Be(2);
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task SnapshotReplace_emits_only_skills_that_actually_changed()
+    public void SnapshotReplace_emits_only_skills_that_actually_changed()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0),
-            "LocalPlayer: ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})"));
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 0, 0),
+            "ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})");
 
         var changes = new List<SkillChange>();
         using (svc.SubscribeChanges(changes.Add))
         {
             // Re-sync: Sword identical (no-op), Cooking new.
-            stream.Push("LocalPlayer: ProcessLoadSkills(" +
-                        "{type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50}, " +
-                        "{type=Cooking,raw=20,bonus=0,xp=3,tnl=4,max=50})");
-            await stream.WaitForDrainAsync(cts.Token);
+            ApplyLine(svc, Ts(8, 30, 0),
+                "ProcessLoadSkills(" +
+                "{type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50}, " +
+                "{type=Cooking,raw=20,bonus=0,xp=3,tnl=4,max=50})");
         }
 
         changes.Should().ContainSingle(); // Sword unchanged → suppressed
@@ -237,59 +242,43 @@ public sealed class PlayerSkillStateServiceTests
         changes[0].SkillKey.Should().Be("Cooking");
         changes[0].Previous.Should().BeNull();
         changes[0].XpGained.Should().Be(0); // snapshot is not a gain event
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Capped_tick_emits_IsCapped_transition_then_skill_goes_silent()
+    public void Capped_tick_emits_IsCapped_transition_then_skill_goes_silent()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0),
-            "LocalPlayer: ProcessLoadSkills({type=Sword,raw=49,bonus=0,xp=10,tnl=20,max=50})"));
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 0, 0),
+            "ProcessLoadSkills({type=Sword,raw=49,bonus=0,xp=10,tnl=20,max=50})");
 
         var changes = new List<SkillChange>();
         using (svc.SubscribeChanges(changes.Add))
         {
-            // The capping tick: raw reaches max. PG then emits no further
-            // ProcessUpdateSkill for Sword — modelled by a subsequent unrelated
-            // skill update producing no Sword change.
-            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Sword,raw=50,bonus=0,xp=0,tnl=20,max=50}, True, 5, 0, 0)");
-            stream.Push("LocalPlayer: ProcessUpdateSkill({type=Cooking,raw=3,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
-            await stream.WaitForDrainAsync(cts.Token);
+            ApplyLine(svc, Ts(8, 30, 0),
+                "ProcessUpdateSkill({type=Sword,raw=50,bonus=0,xp=0,tnl=20,max=50}, True, 5, 0, 0)");
+            ApplyLine(svc, Ts(8, 31, 0),
+                "ProcessUpdateSkill({type=Cooking,raw=3,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)");
         }
 
         var swordChanges = changes.Where(c => c.SkillKey == "Sword").ToList();
         swordChanges.Should().ContainSingle();
         swordChanges[0].Previous!.Value.IsCapped.Should().BeFalse(); // 49 < 50
         swordChanges[0].Current.IsCapped.Should().BeTrue();          // 50 == 50
-        // No further Sword event despite later activity — the "goes silent" contract.
         changes.Count(c => c.SkillKey == "Sword").Should().Be(1);
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Real_Tailoring_level_up_emits_level_up_SkillChange_with_gross_XpGained()
+    public void Real_Tailoring_level_up_emits_level_up_SkillChange_with_gross_XpGained()
     {
-        // The captured Tailoring level-up, fed through the service. Asserts the
-        // level-up is detectable purely from raw incrementing (no dedicated
-        // log line) and XpGained is the gross 160 (chat-matched), not split.
-        var stream = new ScriptedStream(new RawLogLine(Ts(12, 38, 57),
-            "[12:38:57] LocalPlayer: ProcessUpdateSkill({type=Tailoring,raw=9,bonus=2,xp=199,tnl=210,max=50}, True, 160, 0, 0)"));
-        var svc = NewService(stream);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
+        var svc = NewService();
+        ApplyLine(svc, Ts(12, 38, 57),
+            "ProcessUpdateSkill({type=Tailoring,raw=9,bonus=2,xp=199,tnl=210,max=50}, True, 160, 0, 0)");
 
         var changes = new List<SkillChange>();
         using (svc.SubscribeChanges(changes.Add))
         {
-            stream.Push("[12:39:02] LocalPlayer: ProcessUpdateSkill({type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)");
-            await stream.WaitForDrainAsync(cts.Token);
+            ApplyLine(svc, Ts(12, 39, 2),
+                "ProcessUpdateSkill({type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)");
         }
 
         changes.Should().ContainSingle();
@@ -301,28 +290,23 @@ public sealed class PlayerSkillStateServiceTests
         (c.Previous!.Value.Level < c.Current.Level).Should().BeTrue(); // level-up signal
         c.Current.XpTowardNextLevel.Should().Be(149);
         c.XpGained.Should().Be(160); // gross gain across the rollover
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     // ── #470: reference-data enrichment ───────────────────────────────────
 
     private const string ProxyVsAuthLine =
-        "LocalPlayer: ProcessLoadSkills(" +
-        // log proxy (max==0) → not trainable, but reference says it IS:
+        "ProcessLoadSkills(" +
         "{type=Foo,raw=0,bonus=2,xp=0,tnl=1,max=0}, " +
-        // log proxy (max>0) → trainable, but reference says umbrella:
         "{type=Bar,raw=10,bonus=0,xp=1,tnl=2,max=50})";
 
     [Fact]
-    public async Task Reference_enrichment_makes_IsTrainable_authoritative_over_the_log_proxy()
+    public void Reference_enrichment_makes_IsTrainable_authoritative_over_the_log_proxy()
     {
         var refData = RefDataWith(
             SkillRef("Foo", "Foocraft", xpTable: "TypicalNoncombatSkill", maxBonus: 25),
             SkillRef("Bar", "Bar (umbrella)", xpTable: "None", maxBonus: 125));
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0), ProxyVsAuthLine));
-        var svc = NewService(stream, refData);
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService(refData);
+        ApplyLine(svc, Ts(8, 0, 0), ProxyVsAuthLine);
 
         svc.Current.TryGet("Foo", out var foo).Should().BeTrue();
         foo.MaxLevel.Should().Be(0);          // log proxy would say not trainable…
@@ -335,16 +319,13 @@ public sealed class PlayerSkillStateServiceTests
         bar.IsTrainable.Should().BeFalse();   // …reference (XpTable == None) overrides
         bar.DisplayName.Should().Be("Bar (umbrella)");
         bar.Reference!.MaxBonusLevels.Should().Be(125);
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Without_reference_data_falls_back_to_the_verified_log_proxy()
+    public void Without_reference_data_falls_back_to_the_verified_log_proxy()
     {
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0), ProxyVsAuthLine));
-        var svc = NewService(stream); // no refData
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 0, 0), ProxyVsAuthLine);
 
         svc.Current.TryGet("Foo", out var foo).Should().BeTrue();
         foo.Reference.Should().BeNull();
@@ -353,34 +334,27 @@ public sealed class PlayerSkillStateServiceTests
 
         svc.Current.TryGet("Bar", out var bar).Should().BeTrue();
         bar.IsTrainable.Should().BeTrue();  // proxy: max>0
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Skill_absent_from_catalog_falls_back_to_proxy()
+    public void Skill_absent_from_catalog_falls_back_to_proxy()
     {
-        // refData present but doesn't know "Foo"/"Bar" → null Reference, proxy used.
-        var stream = new ScriptedStream(new RawLogLine(Ts(8, 0, 0), ProxyVsAuthLine));
-        var svc = NewService(stream, RefDataWith(SkillRef("Unrelated", "Unrelated", "None")));
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService(RefDataWith(SkillRef("Unrelated", "Unrelated", "None")));
+        ApplyLine(svc, Ts(8, 0, 0), ProxyVsAuthLine);
 
         svc.Current.TryGet("Foo", out var foo).Should().BeTrue();
         foo.Reference.Should().BeNull();
         foo.IsTrainable.Should().BeFalse(); // proxy fallback
-
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
     }
 
     [Fact]
-    public async Task Real_skill_delta_carries_authoritative_DisplayName_and_Reference()
+    public void Real_skill_delta_carries_authoritative_DisplayName_and_Reference()
     {
         var refData = RefDataWith(
             SkillRef("Tailoring", "Tailoring", xpTable: "TypicalNoncombatSkill", maxBonus: 25));
-        var stream = new ScriptedStream(new RawLogLine(Ts(12, 39, 2),
-            "[12:39:02] LocalPlayer: ProcessUpdateSkill({type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)"));
-        var svc = NewService(stream, refData);
-        await RunUntilDrainedAsync(svc, stream);
+        var svc = NewService(refData);
+        ApplyLine(svc, Ts(12, 39, 2),
+            "ProcessUpdateSkill({type=Tailoring,raw=10,bonus=2,xp=149,tnl=420,max=50}, True, 160, 0, 0)");
 
         svc.Current.TryGet("Tailoring", out var t).Should().BeTrue();
         t.DisplayName.Should().Be("Tailoring");
@@ -390,95 +364,74 @@ public sealed class PlayerSkillStateServiceTests
     }
 
     /// <summary>
-    /// Byte-equivalence regression test (#550 PR 2 + PR #555 review): the
-    /// producer is a state-rebuilder, so feeding the same backlog twice
-    /// (cold start, then split replay→live like the production
-    /// FromSessionStart shape) must yield identical snapshot state on both
-    /// runs. Splitting the input across the replay boundary catches a
-    /// regression where a handler early-outs on
-    /// <c>envelope.IsReplay == true</c>.
+    /// Replay idempotence — a folder is a state-rebuilder, so feeding the
+    /// same payload twice (cold start, then re-applied with identical
+    /// content) must produce identical snapshot state and no spurious
+    /// change events on the second application. Replaces the pre-migration
+    /// L1-replay byte-equivalence test (which exercised the L1 driver's
+    /// replay→live split — now covered by
+    /// <see cref="SkillFolderEndToEndTests"/>'s producer + world test).
     /// </summary>
     [Fact]
-    public async Task L1_replay_idempotence_byte_equivalence()
+    public void Apply_is_idempotent_under_identical_re_emission()
     {
-        IReadOnlyDictionary<string, SkillProgressSnapshot> firstPass;
-        DateTime firstMeasured;
+        var svc1 = NewService();
+        ApplyLine(svc1, Ts(8, 22, 21), LoadLine);
+        var firstPass = svc1.Current.Skills;
+        var firstMeasured = svc1.Current.MeasuredAt!.Value;
+
+        var svc2 = NewService();
+        ApplyLine(svc2, Ts(8, 22, 21), LoadLine);
+        // Second application of the SAME content: assert state stays equal
+        // AND no per-skill change events fire (SnapshotReplace path skips
+        // unchanged projections by construction).
+        var changes = new List<SkillChange>();
+        using (svc2.SubscribeChanges(changes.Add))
         {
-            using var stream = new ScriptedStream(new RawLogLine(Ts(8, 22, 21), LoadLine));
-            var svc = NewService(stream);
-            await RunUntilDrainedAsync(svc, stream);
-            firstPass = svc.Current.Skills;
-            firstMeasured = svc.Current.MeasuredAt!.Value;
+            ApplyLine(svc2, Ts(8, 22, 21), LoadLine);
         }
 
-        // Second pass — split input across the replay→live boundary. The full
-        // skill snapshot arrives as IsReplay=true; a subsequent re-emit of
-        // the same ProcessLoadSkills line arrives as live. The state-rebuilder
-        // must yield identical final state (the second snapshot replaces
-        // with the same content at the same timestamp, so MeasuredAt also
-        // matches the first pass).
-        {
-            using var stream = new ScriptedStream();
-            stream.Driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(LoadLine, Ts(8, 22, 21)));
-            var svc = NewService(stream);
-            try
-            {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                await svc.StartAsync(cts.Token);
-                await stream.WaitForDrainAsync(cts.Token);
-
-                // Live tail: same line, same timestamp. Snapshot replaces
-                // with identical content → no spurious state change.
-                stream.Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(LoadLine, Ts(8, 22, 21)));
-                await stream.WaitForDrainAsync(cts.Token);
-
-                svc.Current.Skills.Should().BeEquivalentTo(firstPass);
-                svc.Current.MeasuredAt!.Value.Should().Be(firstMeasured);
-
-                try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
-            }
-            catch
-            {
-                try { await svc.StopAsync(CancellationToken.None); } catch { }
-                throw;
-            }
-        }
-    }
-
-    private static DateTime Ts(int h, int m, int s) => new(2026, 5, 18, h, m, s, DateTimeKind.Utc);
-
-    private static async Task RunUntilDrainedAsync(PlayerSkillStateService svc, ScriptedStream stream)
-    {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await svc.StartAsync(cts.Token);
-        await stream.WaitForDrainAsync(cts.Token);
-        try { await svc.StopAsync(CancellationToken.None); } catch (OperationCanceledException) { }
+        svc2.Current.Skills.Should().BeEquivalentTo(firstPass);
+        svc2.Current.MeasuredAt!.Value.Should().Be(firstMeasured);
+        changes.Should().BeEmpty(
+            "a re-emission with identical content must produce no per-skill change events");
     }
 
     /// <summary>
-    /// Post-#550 PR 2: thin adapter that lets the existing test fixtures keep
-    /// scripting <see cref="RawLogLine"/>s while the service-under-test
-    /// consumes <see cref="LocalPlayerLogLine"/>s via the L1 driver.
-    /// Stripping is delegated to <see cref="TestLogEnvelopeFactory"/> so all
-    /// four producer-tests share one strip semantics.
+    /// Apply returns the same <see cref="SkillChange"/> set that legacy
+    /// <see cref="IPlayerSkillState.SubscribeChanges"/> subscribers see —
+    /// pinning the contract that the world's bus emissions and the legacy
+    /// channel deliver identical content.
     /// </summary>
-    private sealed class ScriptedStream : IDisposable
+    [Fact]
+    public void Apply_returns_change_events_equal_to_legacy_SubscribeChanges_deliveries()
     {
-        public TestLogStreamDriver Driver { get; } = new();
+        var svc = NewService();
+        ApplyLine(svc, Ts(8, 0, 0),
+            "ProcessLoadSkills({type=Sword,raw=10,bonus=0,xp=1,tnl=2,max=50})");
 
-        public ScriptedStream(params RawLogLine[] lines)
-        {
-            foreach (var line in lines) Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(line));
-        }
+        var legacy = new List<SkillChange>();
+        using var _ = svc.SubscribeChanges(legacy.Add);
 
-        public void Push(string line) =>
-            Driver.PushLive(TestLogEnvelopeFactory.FromRawLine(new RawLogLine(DateTime.UtcNow, line)));
+        var returned = ApplyLine(svc, Ts(8, 30, 0),
+            "ProcessUpdateSkill({type=Sword,raw=11,bonus=0,xp=2,tnl=3,max=50}, True, 50, 0, 0)");
 
-        public Task WaitForDrainAsync(CancellationToken ct) =>
-            Driver.DrainLocalPlayerAsync().WaitAsync(ct);
-        public Task WaitForDrainAsync(TimeSpan timeout) =>
-            Driver.DrainLocalPlayerAsync(timeout);
+        returned.Should().HaveCount(1);
+        legacy.Should().HaveCount(1);
+        returned[0].Should().BeOfType<SkillChange>();
+        ((SkillChange)returned[0]).Should().Be(legacy[0]);
+    }
 
-        public void Dispose() => Driver.Dispose();
+    /// <summary>
+    /// Stand-in clock for direct folder tests — Apply never reads the clock
+    /// surface (the folder uses the frame's own timestamp), so a zero-valued
+    /// stub is sufficient to satisfy the parameter.
+    /// </summary>
+    private sealed class NoopClock : IWorldClock
+    {
+        public static readonly NoopClock Instance = new();
+        public DateTimeOffset Now => DateTimeOffset.MinValue;
+        public long Frame => 0;
+        public WorldMode Mode => WorldMode.Live;
     }
 }

--- a/tests/Mithril.GameState.Tests/Skills/SkillFolderEndToEndTests.cs
+++ b/tests/Mithril.GameState.Tests/Skills/SkillFolderEndToEndTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+using Mithril.GameState.Skills;
+using Mithril.GameState.Skills.Parsing;
+using Mithril.GameState.Skills.Producers;
+using Mithril.GameState.Tests.TestSupport;
+using Mithril.WorldSim;
+using Mithril.WorldSim.Player;
+using Xunit;
+
+namespace Mithril.GameState.Tests.Skills;
+
+/// <summary>
+/// End-to-end tests that wire <see cref="SkillFrameProducer"/> →
+/// <see cref="PlayerWorld"/> → <see cref="PlayerSkillStateService"/> folder →
+/// <see cref="IWorldEventBus"/> together, and assert the pipeline delivers
+/// <see cref="SkillChange"/> emissions on the world's bus in source order
+/// (issue #618 — Phase 1 acceptance: "New test exercises the IPlayerWorld →
+/// folder → bus pipeline end-to-end"). The folder-side semantics (snapshot
+/// mutation, reference enrichment) are pinned by
+/// <see cref="PlayerSkillStateServiceTests"/>; this file is about wiring.
+/// </summary>
+public sealed class SkillFolderEndToEndTests
+{
+    private const string LoadLine =
+        "[08:22:21] LocalPlayer: ProcessLoadSkills(" +
+        "{type=Toolcrafting,raw=15,bonus=0,xp=26,tnl=680,max=50}, " +
+        "{type=Tanning,raw=50,bonus=3,xp=0,tnl=5280,max=50})";
+
+    private const string LiveUpdateLine =
+        "[08:30:00] LocalPlayer: ProcessUpdateSkill(" +
+        "{type=Toolcrafting,raw=16,bonus=0,xp=5,tnl=700,max=50}, True, 4, 0, 0)";
+
+    private const string LiveNewSkillLine =
+        "[08:31:00] LocalPlayer: ProcessUpdateSkill(" +
+        "{type=Sword,raw=2,bonus=0,xp=1,tnl=9,max=50}, True, 1, 0, 0)";
+
+    private static DateTime Ts(int h, int m, int s) =>
+        new(2026, 5, 22, h, m, s, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Replay_envelopes_flow_through_producer_world_folder_to_bus_subscribers()
+    {
+        using var driver = new TestLogStreamDriver();
+        var folder = new PlayerSkillStateService();
+        var producer = new SkillFrameProducer(driver, new SkillLogParser());
+        var world = new PlayerWorld();
+
+        // Push everything as REPLAY before start so the producer's L1 callback
+        // sees them as replay envelopes — the test exercises the cold-start
+        // backlog drain end-to-end.
+        driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(LoadLine, Ts(8, 22, 21)));
+        driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(LiveUpdateLine, Ts(8, 30, 0)));
+
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        // Two expected emissions: one SnapshotReplace (Toolcrafting from
+        // LoadLine) + Tanning (capped, also SnapshotReplace) plus the Delta
+        // from the LiveUpdateLine. The folder's diff against PlayerSkillSnapshot.Empty
+        // emits one SnapshotReplace per skill in the snapshot.
+        var observed = new List<Frame<SkillChange>>();
+        var allReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        const int expectedCount = 3;
+        using var _sub = world.Bus.Subscribe<SkillChange>(frame =>
+        {
+            observed.Add(frame);
+            if (observed.Count >= expectedCount) allReceived.TrySetResult();
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = world.StartAsync(cts.Token);
+
+        // Drive the L1 pump to drain its backlog into the producer's channel.
+        await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+        // Wait until all expected SkillChange emissions reach the bus
+        // (the world's merger pulls frames from the producer's channel and
+        // dispatches them; the bus subscriber appends synchronously).
+        await allReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Tear the world down cleanly — the producer's channel never naturally
+        // completes (the L1 driver stays open), so cancellation is the only
+        // way out.
+        cts.Cancel();
+        try { await run; } catch (OperationCanceledException) { /* expected */ }
+
+        observed.Should().HaveCount(expectedCount);
+
+        // Order matters: SnapshotReplace events for Toolcrafting + Tanning fire
+        // FIRST (in log order — the snapshot's diff visits the dictionary
+        // built from snap.Skills, which iterates insertion order on
+        // <Dictionary> in netcoreapp+), then the Delta from the live update.
+        // Asserting the multiset rather than the dictionary-iteration order
+        // keeps the test stable if the folder's diff ever switches to
+        // a sorted projection.
+        var snapshotChanges = observed
+            .Where(f => f.Payload.Kind == SkillChangeKind.SnapshotReplace)
+            .ToList();
+        var deltaChanges = observed
+            .Where(f => f.Payload.Kind == SkillChangeKind.Delta)
+            .ToList();
+
+        snapshotChanges.Select(f => f.Payload.SkillKey).Should().BeEquivalentTo(
+            new[] { "Toolcrafting", "Tanning" });
+        deltaChanges.Should().ContainSingle();
+        deltaChanges[0].Payload.SkillKey.Should().Be("Toolcrafting");
+        deltaChanges[0].Payload.Current.Level.Should().Be(16);
+        deltaChanges[0].Payload.XpGained.Should().Be(4);
+
+        // Frame timestamps preserve source order — Delta must follow the
+        // snapshot in event-time.
+        var snapshotTs = snapshotChanges[0].Timestamp;
+        deltaChanges[0].Timestamp.Should().BeOnOrAfter(snapshotTs);
+    }
+
+    [Fact]
+    public async Task Live_envelopes_after_replay_flip_world_to_Live_and_reach_bus_subscribers()
+    {
+        using var driver = new TestLogStreamDriver();
+        var folder = new PlayerSkillStateService();
+        var producer = new SkillFrameProducer(driver, new SkillLogParser());
+        var world = new PlayerWorld();
+
+        // Replay phase: one snapshot frame.
+        driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(LoadLine, Ts(8, 22, 21)));
+
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var observed = new List<Frame<SkillChange>>();
+        var observedModes = new List<WorldMode>();
+        var liveDeltaReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var modeChanges = new List<Frame<ModeChanged>>();
+        using var _sub = world.Bus.Subscribe<SkillChange>(frame =>
+        {
+            observed.Add(frame);
+            observedModes.Add(world.Clock.Mode);
+            if (frame.Payload.Kind == SkillChangeKind.Delta) liveDeltaReceived.TrySetResult();
+        });
+        using var _modeSub = world.Bus.Subscribe<ModeChanged>(modeChanges.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = world.StartAsync(cts.Token);
+
+        // Drain the replay phase first; the producer signals ReachedLive
+        // immediately on the first non-replay envelope it sees, so we push the
+        // live one AFTER replay drains to keep the mode boundary deterministic.
+        await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+
+        driver.PushLive(TestLogEnvelopeFactory.FromRawLine(LiveNewSkillLine, Ts(8, 31, 0)));
+        await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+        await liveDeltaReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        try { await run; } catch (OperationCanceledException) { }
+
+        // The live Sword delta is observable on the bus.
+        var swordChange = observed.Should()
+            .Contain(f => f.Payload.SkillKey == "Sword").Subject;
+        swordChange.Payload.Kind.Should().Be(SkillChangeKind.Delta);
+        swordChange.Payload.Current.Level.Should().Be(2);
+        swordChange.Payload.XpGained.Should().Be(1);
+
+        // Mode flipped: at least one ModeChanged emission on the bus (the
+        // world fires it between dispatches once every mode-aware producer's
+        // ReachedLive completes), and the live delta dispatched in Live mode.
+        modeChanges.Should().NotBeEmpty();
+        modeChanges[0].Payload.From.Should().Be(WorldMode.Replaying);
+        modeChanges[0].Payload.To.Should().Be(WorldMode.Live);
+
+        // The mode-tagged observation at the time the Sword delta fired must
+        // be Live — that's the whole point of the mode bit (side-effect
+        // consumers gate on it).
+        var swordIndex = observed.FindIndex(f => f.Payload.SkillKey == "Sword");
+        observedModes[swordIndex].Should().Be(WorldMode.Live);
+
+        world.Clock.Mode.Should().Be(WorldMode.Live);
+    }
+
+    [Fact]
+    public async Task Folder_state_is_observable_via_legacy_IPlayerSkillState_after_bus_dispatch()
+    {
+        // Back-compat: the folder also serves as IPlayerSkillState. Existing
+        // consumers (Smaug snapshot-Subscribe, Samwise SubscribeChanges)
+        // see the SAME content the bus carries. Pin both surfaces on one
+        // exercised pipeline.
+        using var driver = new TestLogStreamDriver();
+        var folder = new PlayerSkillStateService();
+        var producer = new SkillFrameProducer(driver, new SkillLogParser());
+        var world = new PlayerWorld();
+
+        driver.PushReplay(TestLogEnvelopeFactory.FromRawLine(LoadLine, Ts(8, 22, 21)));
+
+        world.RegisterProducer(producer);
+        world.RegisterFolder(folder);
+
+        var busChanges = new List<SkillChange>();
+        var legacyChanges = new List<SkillChange>();
+        var allDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        const int expectedCount = 2; // Toolcrafting + Tanning SnapshotReplace from LoadLine
+
+        using var _bus = world.Bus.Subscribe<SkillChange>(f =>
+        {
+            busChanges.Add(f.Payload);
+            if (busChanges.Count >= expectedCount) allDelivered.TrySetResult();
+        });
+        using var _legacy = ((IPlayerSkillState)folder).SubscribeChanges(legacyChanges.Add);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = world.StartAsync(cts.Token);
+
+        await driver.DrainLocalPlayerAsync(TimeSpan.FromSeconds(5));
+        await allDelivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        try { await run; } catch (OperationCanceledException) { }
+
+        busChanges.Should().BeEquivalentTo(legacyChanges,
+            "the world bus and the legacy SubscribeChanges channel must deliver identical content");
+
+        // IPlayerSkillState.Current carries the folder's current state — read
+        // via the legacy surface that Smaug and other snapshot consumers use.
+        ((IPlayerSkillState)folder).Current.Skills
+            .Should().ContainKeys("Toolcrafting", "Tanning");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 validation of the world-simulator architecture migration (umbrella #601, foundation umbrella). Converts the first leaf service — `PlayerSkillStateService` — from its `BackgroundService` shell to an `IFolder<SkillFrame>` registered with `IPlayerWorld`, validating that the foundation works end-to-end before the bigger Phase 2 splits (#602 Inventory, #603 Saruman codebook) proceed.

The change has three layers:

- **Producer + folder split.** A new `SkillFrameProducer` owns the L1-driver subscription and adapts the push-based callback into the world's pull-based `IFrameProducer<SkillFrame>` contract via an unbounded `Channel`. The fold logic from the old `PlayerSkillStateService.ExecuteAsync` moves into `PlayerSkillStateService.Apply(Frame<SkillFrame>, IWorldClock)` — same `ReplaceAll` / `Upsert` semantics, same `SkillChange` emissions, no behavioural change.
- **Framework: folder change events on the bus.** `PlayerWorld` and `ChatWorld` now publish folder-emitted `IChangeEvent`s on the world's bus as typed `Frame<TConcrete>` via a cached compiled expression-tree delegate per runtime type. Lets single-world consumers subscribe directly via `world.Bus.Subscribe<SkillChange>(...)` (design notebook principle 4) without a pass-through composer per folder. `SkillChange` gets an `IChangeEvent` marker; composer emissions continue to flow through the same bus pipeline.
- **DI wiring.** `AddPlayerWorld` (orphaned in Phase 0) is now called from `ShellComposition` before `AddMithrilGameState`. A new `PlayerSkillStateWorldRegistration` hosted service wires the producer + folder into `IPlayerWorld` before `PlayerWorldHostedService` calls `world.StartAsync` (hosted services run in registration order).

Back-compat preserved: `PlayerSkillStateService` still implements `IPlayerSkillState`, and `Apply` fires the legacy `Subscribe` / `SubscribeChanges` handlers in addition to returning change events for the world. Samwise, Smaug, and Elrond consumers continue to use the existing surface unchanged.

## Test plan

- [x] `dotnet build Mithril.slnx` clean (warnings-as-errors enforced)
- [x] `dotnet test Mithril.slnx` clean — 23 test projects, ~3,700 tests, zero failures
- [x] New `SkillFolderEndToEndTests` exercises the full pipeline: `SkillFrameProducer` → `PlayerWorld` → `PlayerSkillStateService` (folder) → `IWorldEventBus` → bus subscriber observes `SkillChange` emissions
  - replay backlog reaches bus subscribers in source order
  - live envelopes after replay flip the world to `Live` mode (bus emits `ModeChanged`) and skill deltas continue to reach subscribers
  - legacy `IPlayerSkillState.SubscribeChanges` delivers identical content to the bus's `Subscribe<SkillChange>`
- [x] `PlayerSkillStateServiceTests` rewritten to drive `Apply` directly — all pre-migration behaviour pinned (cold-start Empty, wholesale-replace, per-skill Delta with `XpGained`, level-up across rollover, cap-then-silent, reference enrichment authority over the log proxy) plus two new contracts: `Apply` is idempotent under identical re-emission, and returned change events equal legacy `SubscribeChanges` deliveries
- [x] Existing Samwise (`GardeningXpSkillStateBridgeTests`), Smaug (`VendorIngestionServiceSkillStateTests`), and Elrond tests pass unchanged

Closes #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
