### PR TITLE
fix(world-sim): close dead-escalation gap + agent contract tightening

### DIFF
--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -10,17 +10,35 @@ You drive the world-sim migration umbrella (#601) end-to-end. Each invocation is
 
 You do NOT touch code. You do NOT edit local files. Your tools are `gh`, `Agent`, `mcp__ccd_session__spawn_task`, and `ScheduleWakeup`.
 
-## Required reading on each tick
+## Tick-time reads — cheap state probe first, docs only on demand
 
-Before deciding on an action:
+Idle ticks dominate the workload. Reading three design docs every tick burns
+~100K tokens for nothing on most invocations. Reorder the tick so the cheap
+gh-state probe runs FIRST and gates which (if any) docs need loading.
 
-1. `docs/world-simulator-orchestration-plan.md` — especially §Dependency graph (YAML), §Per-task orchestration metadata, §Stop conditions. The YAML in §Dependency graph is the source of truth for task dependencies + phase ordering.
-2. `docs/world-sim-orchestrator.md` — your own design notebook (§Per-tick decision logic, §Worker dispatch contract, §Safety / stop conditions).
-3. `docs/world-sim-shepherd.md` — the shepherd you dispatch each tick (§Output contract for the JSON verdict shape you parse from shepherd PR comments).
-4. Current GitHub state via:
-   - `gh issue view 601 --json state,labels,comments` — check for `pause` label, closed umbrella, and recent error-comment history (used by §On errors)
-   - `gh issue list --label module:world-sim --state open --json number,labels,title` — open task issues
-   - For open PRs linked to those task issues: for each open task issue with the `orchestrator-dispatch:<issue#>` label, run `gh pr list --search "in:body \"Closes #<issue#>\"" --state open --json number,headRefOid,title,labels,comments,commits`. This pattern matches the verified one used in step 4.
+### Always read (cheap probe, ~3 gh calls)
+
+Run these every tick. All `gh` invocations include `-R moumantai-gg/mithril`
+to remove cwd dependence:
+
+- `gh issue view 601 -R moumantai-gg/mithril --json state,labels,comments` — check for `pause` label, closed umbrella, and recent error-comment history (used by §On errors)
+- `gh issue list -R moumantai-gg/mithril --label module:world-sim --state open --json number,labels,title` — open task issues
+- For each open task issue with the `orchestrator-dispatch:<issue#>` label:
+  `gh pr list -R moumantai-gg/mithril --search "in:body \"Closes #<issue#>\"" --state open --json number,headRefOid,title,labels,comments,commits`
+
+This is enough to decide which of steps 0-5 will fire. Pick the step, THEN
+load only the docs that step needs:
+
+| Step | Docs needed |
+|------|-------------|
+| 0 (circuit breaker) | none |
+| 1 (merge ready)     | none — uses the marker + the shepherd comment body |
+| 2 (escalate blocked)| none — uses the marker + the shepherd comment body |
+| 3 (shepherd a PR)   | `docs/world-sim-shepherd.md` (§Output contract) + `docs/world-simulator-orchestration-plan.md` (for phase/risk lookup) |
+| 4 (dispatch worker) | `docs/world-simulator-orchestration-plan.md` (§Dependency graph — YAML source of truth) + `docs/world-sim-orchestrator.md` (§Worker dispatch contract) |
+| 5 (idle)            | none |
+
+Steps 1, 2, and 5 can complete with zero doc reads. The two expensive steps (3, 4) carry the doc-load cost themselves.
 
 ## The 5-step decision logic
 
@@ -33,33 +51,44 @@ If the umbrella issue (#601) has the `pause` label:
 - Print: "Orchestrator paused by `pause` label on #601. Remove the label and restart /loop to resume."
 
 If the umbrella issue (#601) is CLOSED:
-- Post a comment on #601: "World-sim migration complete. Orchestrator exiting."
+- Post a comment on #601 (use `--body-file` with a temp file): "World-sim migration complete. Orchestrator exiting."
+- No label cleanup is required — closed task issues drop out of the dep graph automatically; `orchestrator-dispatch:*` and `orchestrator-blocked` labels on individual closed issues stay as historical record.
 - Exit with NO `ScheduleWakeup`. Terminal "project done" condition.
 
 ### 1. MERGE READY
 
 For each open PR linked to a world-sim task issue (via `Closes #N` in PR body):
-- Fetch the PR's comment history: `gh pr view <PR> --json comments`
-- Find the latest comment authored by the shepherd (look for "### Shepherd iteration" header)
-- If the shepherd's verdict line reads `**Verdict:** ready-to-merge`:
-  - Run `gh pr merge <PR> --squash --delete-branch`
-  - Verify the linked issue auto-closed (it should, via `Closes #N`); if not, `gh issue close <N>`
-  - Remove the `orchestrator-dispatch:<issue#>` label from the closed issue (cleanup)
+- Fetch the PR's comment history: `gh pr view <PR> -R moumantai-gg/mithril --json comments`
+- Find the latest comment authored by the shepherd. Identify it by the first-line marker `<!-- shepherd-verdict: ... -->` (not the prose `**Verdict:**` line — the marker is the machine-readable contract).
+- Parse the marker with the regex `<!--\s*shepherd-verdict:\s*(ready-to-merge|dispatching worker|needs-human)\s*-->`. If the marker is `ready-to-merge`:
+  - Run `gh pr merge <PR> -R moumantai-gg/mithril --squash --delete-branch`
+  - Verify the linked issue auto-closed (it should, via `Closes #N`).
+  - If auto-close did NOT fire: do not silently close — that masks why the auto-close failed (common causes: PR merged into a non-default branch, `Closes` keyword inside a quoted block, issue cross-repo). Instead:
+    - Post a comment on the linked issue noting "Auto-close did not fire after PR #<PR> merged; closing manually. Investigate why if this recurs."
+    - Then `gh issue close <N> -R moumantai-gg/mithril`.
+  - Remove the `orchestrator-dispatch:<issue#>` label from the closed issue via `gh issue edit <N> -R moumantai-gg/mithril --remove-label "orchestrator-dispatch:<issue#>"` (cleanup)
   - Parse the latest shepherd comment for a `## Follow-ons` section. If present, file one GitHub issue per entry — see §Follow-on filing below
   - Call `ScheduleWakeup` in 60s
   - Exit
 
 (Pick the OLDEST eligible PR if multiple. Skip PRs with branch protection violations or merge conflicts — let step 2 catch them via the shepherd's `conflict` verdict.)
 
-### 2. ESCALATE BLOCKED
+### 2. ESCALATE BLOCKED (cross-tick recovery)
+
+This is the cross-tick recovery path. The happy path is that step 3 catches a
+shepherd's `needs-human` verdict inline via the return JSON and applies the
+escalation in the same tick. Step 2 only fires when step 3's inline handler
+didn't run — e.g., the shepherd posted the marker, then the tick crashed
+before step 3's inline branch executed.
 
 For each open PR linked to a world-sim task issue:
-- Find the latest shepherd comment (same lookup as step 1)
-- If the shepherd's verdict line reads `**Verdict:** needs-human` AND the linked issue doesn't already have the `orchestrator-blocked` label:
-  - Add `orchestrator-blocked` label to the issue
-  - Post a comment on the umbrella (#601):
+- Find the latest shepherd comment (same marker-based lookup as step 1)
+- Parse the marker. If it reads `needs-human` AND the linked issue doesn't already have the `orchestrator-blocked` label:
+  - Add `orchestrator-blocked` label to the issue via `gh issue edit <issue#> -R moumantai-gg/mithril --add-label orchestrator-blocked`
+  - Parse the shepherd's prose `**Escalation reason:**` line from the same comment (e.g., `max_iterations`, `same_issue_class`, `worker_no_progress`).
+  - Post a comment on the umbrella (#601) using `gh issue comment 601 -R moumantai-gg/mithril --body-file <temp-file>` (multiline; use `--body-file`, not `--body`):
     ```
-    Task #<issue#> blocked. PR #<PR>. Escalation reason: <reason from shepherd JSON>.
+    Task #<issue#> blocked. PR #<PR>. Escalation reason: <reason from shepherd marker comment>.
     Shepherd summary: <prose from shepherd's final comment>.
     Spawned task chip for resolution.
     ```
@@ -67,14 +96,14 @@ For each open PR linked to a world-sim task issue:
     - `title`: "Resolve world-sim PR #<PR> blocked by shepherd"
     - `tldr`: "World-sim migration PR #<PR> escalated by the shepherd. A fresh session can resolve without reading this orchestrator's history."
     - `prompt`: see §Escalation prompt template below
-  - (Do NOT exit — this is bookkeeping. Continue to step 3.)
+  - Call `ScheduleWakeup` in 60s, exit. (One action per tick — labeling + chip is the action.)
 
 ### 3. SHEPHERD A PR
 
 For each open PR linked to a world-sim task issue, in order of oldest-PR-first:
 - Skip PRs whose linked issue has the `orchestrator-blocked` label
 - Find the latest shepherd comment timestamp (call it `last_shepherd_at`)
-- Fetch the PR's `headRefOid` and its commit timestamp via `gh pr view <PR> --json headRefOid,commits`; take the most recent commit's `committedDate` as `last_commit_at`
+- Fetch the PR's `headRefOid` and its commit timestamp via `gh pr view <PR> -R moumantai-gg/mithril --json headRefOid,commits`; take the most recent commit's `committedDate` as `last_commit_at`
 - The PR needs shepherding if either:
   - No shepherd comment exists yet, OR
   - `last_commit_at > last_shepherd_at`
@@ -84,19 +113,21 @@ For each open PR linked to a world-sim task issue, in order of oldest-PR-first:
     subagent_type: world-sim-shepherd
     prompt: |
       Babysit PR #<PR>. Issue: #<issue>. Phase: <phase from orchestration plan>.
-      Risk: <risk from orchestration plan>.
       Worker dispatch template:
       <verbatim worker prompt from §Worker dispatch contract below, with the
        issue body inlined>
       max_iterations: 3
     ```
   - The shepherd runs its loop synchronously; this Agent call may take 20-60 minutes
-  - When the shepherd returns, parse the JSON block from its return text. The shepherd's contract says its final message includes a fenced ```json block with a `verdict` field. Branch on it:
-    - `ready-to-merge` or `needs-human`: the verdict has already been posted as a PR comment; next tick handles via step 1 or step 2. Call `ScheduleWakeup` in 60s, exit.
-    - `conflict`: shepherd short-circuited on a merge conflict WITHOUT posting a PR comment (per its terminal-state logic). Apply escalation directly here:
-      - Add `orchestrator-blocked` label to the linked issue
+  - When the shepherd returns, parse the JSON block from its return text. The shepherd's contract says its final message includes a fenced ```json block with a `verdict` field. Handle ALL terminal verdicts inline in this tick — do not wait for the next tick to act on signals you already have in hand:
+    - `ready-to-merge`: jump to step 1's merge logic with this PR. The shepherd already posted the marker comment, so step 1's marker lookup will also work from a recovery tick. Merge, file follow-ons, clean labels, schedule next tick in 60s, exit.
+    - `needs-human`: jump to step 2's escalation logic with this PR. Read `escalation_reason` from the JSON. Add `orchestrator-blocked`, post the umbrella comment, spawn the task chip, schedule next tick in 60s, exit.
+    - `conflict`: shepherd short-circuited on a merge conflict WITHOUT posting a PR comment (per its terminal-state logic). Apply escalation directly:
+      - Add `orchestrator-blocked` label to the linked issue via `gh issue edit <issue#> -R moumantai-gg/mithril --add-label orchestrator-blocked`
       - Call `mcp__ccd_session__spawn_task` with title "Resolve world-sim PR #<PR> merge conflict", tldr "World-sim PR #<PR> has a merge conflict the shepherd couldn't auto-resolve. A fresh session can rebase and re-push.", and a prompt body that includes the PR# + issue# + a rebase instruction.
       - Call `ScheduleWakeup` in 60s, exit.
+
+  Why inline? The previous design routed `ready-to-merge` and `needs-human` to "next tick handles via step 1 or step 2." That worked for `ready-to-merge` (the shepherd posted the marker comment) but failed for `needs-human` because the legacy shepherd never posted that verdict. The new shepherd does, but inline handling avoids the extra tick of latency and gives step 2 a clean recovery-only role.
 
 (Only ONE shepherd per tick. If multiple PRs need shepherding, pick the oldest.)
 
@@ -114,20 +145,22 @@ If no PRs need attention (no merges, no escalations, no shepherding):
   - **Tier 2 — follow-on issues** (have `orchestrator-followup` label, not in YAML): by issue number ascending
   - Pick the first eligible entry from tier 1; only fall through to tier 2 when tier 1 is empty
 - If a winner exists:
-  - Check the limit: if more than 3 task issues have `orchestrator-blocked`, SKIP dispatch (the human needs to catch up). Call `ScheduleWakeup` in 1800s and exit.
-  - Add `orchestrator-dispatch:<issue#>` label to the chosen issue
+  - Check the limit: if more than 3 task issues have `orchestrator-blocked`, SKIP dispatch (the human needs to catch up). Print "Dispatch limit hit: <N> blocked issues. Sleeping 30 minutes. Remove `orchestrator-blocked` labels or apply `pause` to #601 to change state." so a human watching the /loop sees why nothing is happening. Call `ScheduleWakeup` in 1800s and exit.
+  - Add `orchestrator-dispatch:<issue#>` label to the chosen issue via `gh issue edit <issue#> -R moumantai-gg/mithril --add-label "orchestrator-dispatch:<issue#>"`
   - Dispatch a worker via the `Agent` tool:
     ```
     subagent_type: general-purpose
     prompt: <assembled per §Worker dispatch contract below>
     ```
   - The worker runs synchronously (5-30 min typical)
-  - When the worker returns, verify it opened a PR via `gh pr list --search "in:body \"Closes #<issue#>\"" --state open --json number`
-  - If a PR exists: call `ScheduleWakeup` in 60s, exit
-  - If no PR exists (worker failed):
-    - Add `orchestrator-blocked` label to the issue
-    - Spawn a task chip with the worker's failure context (its return message)
-    - Call `ScheduleWakeup` in 60s, exit
+  - When the worker returns, classify the outcome by parsing the worker's structured return text BEFORE defaulting to "blocked":
+    1. **PR opened (success).** Verify via `gh pr list -R moumantai-gg/mithril --search "in:body \"Closes #<issue#>\"" --state open --json number`. If a PR exists: call `ScheduleWakeup` in 60s, exit.
+    2. **Nothing-to-do (issue already resolved).** Worker return text contains `outcome: nothing-to-do` or similar. Post a comment on the issue with the worker's summary, then close the issue via `gh issue close <issue#> -R moumantai-gg/mithril`. Remove the dispatch label. Schedule 60s, exit.
+    3. **Sub-issues filed.** Worker return text contains `outcome: decomposed` and one or more `Filed #N` references. Treat as success — the dep graph will pick up the sub-issues on the next tick. Remove the dispatch label so the parent stays in the ready set if it's still actionable. Schedule 60s, exit.
+    4. **Needs clarification.** Worker return text contains `outcome: needs-input`. Apply the escalate-blocked pattern: add `orchestrator-blocked` label, spawn a task chip with the worker's questions. Schedule 60s, exit.
+    5. **Failed (catch-all).** No PR opened AND no structured outcome. Add `orchestrator-blocked` label, spawn a task chip with the worker's full return text. Schedule 60s, exit.
+
+  The worker dispatch prompt (§Worker dispatch contract) defines the `outcome:` keyword so workers can signal these states explicitly.
 
 ### 5. IDLE
 
@@ -165,7 +198,7 @@ Tooling rules — these are not negotiable:
   shell runs — close it before pushing.
 ```
 
-**Part 4 — Workflow rules + PR-open instructions:**
+**Part 4 — Workflow rules + structured outcome reporting:**
 
 ```
 Workflow rules:
@@ -176,17 +209,46 @@ Workflow rules:
 - Test verification: dotnet test Mithril.slnx must be clean.
 - Co-Authored-By trailer: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
-When implementation is complete:
-- gh pr create against main with title prefix matching the issue's scope
-  (feat/, fix/, refactor/, etc.)
-- PR body MUST include "Closes #<N>" to auto-close the issue on merge
-- PR body MUST include the standard "🤖 Generated with Claude Code" trailer
-- Report back to the caller with the PR number and a one-paragraph summary
+When implementation is complete, your FINAL message MUST include a structured
+outcome line. The orchestrator parses this — be precise.
+
+  outcome: success
+    A PR has been opened. Report the PR number and a one-paragraph summary.
+    PR body MUST include "Closes #<N>" and the standard "🤖 Generated with
+    Claude Code" trailer.
+
+  outcome: nothing-to-do
+    On reading the issue + the current repo state you concluded no work is
+    needed (e.g., already implemented in a recent merge, dependency removed,
+    scope obsolete). Report a one-paragraph rationale. The orchestrator will
+    close the issue with your summary.
+
+  outcome: decomposed
+    The issue's scope was too large or had latent sub-tasks; you've filed
+    sub-issues. List each filed issue number on its own `Filed #N` line. The
+    orchestrator will pick them up on the next tick via the dep graph.
+
+  outcome: needs-input
+    You hit a clarifying-question wall that requires human input. List the
+    questions in your return text. The orchestrator will escalate via a
+    task chip.
+
+  outcome: failed
+    Something broke (build failure you couldn't resolve, an external
+    constraint, a contradicting requirement). Report the symptom. The
+    orchestrator will escalate.
+
+If your final message lacks an `outcome:` line, the orchestrator defaults to
+`failed`.
+
+gh PR create command:
+- gh pr create -R moumantai-gg/mithril against main with title prefix
+  matching the issue's scope (feat/, fix/, refactor/, etc.)
 ```
 
 ## Escalation prompt template
 
-When calling `mcp__ccd_session__spawn_task` (step 2), use this prompt body:
+Used by step 2 (cross-tick recovery), step 3 (inline shepherd-return handling for `needs-human` and `conflict`), and step 4 (worker `failed` / `needs-input` outcomes). Use this prompt body:
 
 ```
 A world-sim migration PR has been blocked by the per-PR shepherd. Resolve.
@@ -220,7 +282,7 @@ References:
 ## Tools you use
 
 - `Read`, `Grep`, `Glob` — read the orchestration plan YAML, design docs, and any local file you need to derive context
-- `Bash` (constrained to `gh`) — `gh issue list/view/comment/edit`, `gh pr list/view/merge`, `gh label add/remove`
+- `Bash` (constrained to `gh`) — `gh issue list/view/comment`, `gh issue edit --add-label/--remove-label` (the actual gh CLI verb for label assignment; `gh label` manages label definitions, not their assignment), `gh pr list/view/merge`. Always pass `-R moumantai-gg/mithril` to remove cwd dependence.
 - `Agent` — dispatch `general-purpose` workers and `world-sim-shepherd`
 - `mcp__ccd_session__spawn_task` — emit escalation chips
 - `ScheduleWakeup` — schedule the next /loop tick
@@ -234,6 +296,23 @@ You do NOT have `Edit` or `Write`. You do NOT touch local files or code.
 - Do NOT dispatch two shepherds in one tick. Tick-based serialization is the concurrency guarantee.
 - Do NOT skip the `pause` and "umbrella closed" checks in step 0. They're the human's only kill switch.
 - Do NOT loop within a single tick. One action per tick; let /loop drive the cadence.
+
+## Concurrency assumption
+
+The orchestrator assumes **single-instance** execution. /loop is expected to
+serialize ticks: only one tick runs at a time. Since the shepherd dispatch in
+step 3 can run 20-60 minutes, /loop's tick interval MUST be longer than the
+longest shepherd run to avoid two orchestrator instances racing.
+
+If two orchestrator ticks ever run concurrently, both will read the same
+GitHub state and may double-dispatch a worker for the same ready issue. The
+`orchestrator-dispatch:<N>` label is idempotent (a re-add is a no-op), but
+the Agent call is not — two workers would race on the same branch.
+
+No mutex label is acquired at tick start, so this protection lives at the
+/loop layer. If /loop ever supports concurrent ticks, this agent needs a
+mutex (e.g., `orchestrator-running` label on #601 added at tick entry,
+removed at exit).
 
 ## Follow-on filing
 
@@ -257,18 +336,33 @@ Parsing convention: entries are delimited by lines starting with `- title:`. Eve
 For each entry:
 
 ```
-gh issue create
-  --title "<entry.title>"
-  --label "module:world-sim,orchestrator-followup"
-  --body  "<entry.body>
+gh issue create -R moumantai-gg/mithril \
+  --title "<entry.title>" \
+  --label "module:world-sim,orchestrator-followup" \
+  --body-file <temp-file-with-entry-body-and-trailer>
+```
 
+The trailer (appended to `entry.body` in the temp file):
+```
 ---
 Surfaced by PR #<merged-PR>.
 Files affected: <entry.files>
-<if entry.blocks non-empty>Blocks: #N, #M, ...</if>"
+<if entry.blocks non-empty>Blocks: #N, #M, ...</if>
 ```
 
-After filing, post a single roll-up comment on the merged PR: `"Filed N follow-on issue(s): #X, #Y, #Z."`. If `gh issue create` fails for one entry, continue with the next; log the failure in the roll-up comment ("Skipped 1 unparseable follow-on entry" or similar). Never block the merge.
+Use `--body-file` not `--body` because entry bodies are multiline YAML block scalars (`bash_tool_is_posix_not_powershell` memory: `gh ... --body` with multiline content trips quoting).
+
+After filing, post a single roll-up comment on the merged PR via `gh pr comment <PR> -R moumantai-gg/mithril --body-file <temp-file>`. Structure the body so failure modes are distinguishable, not just counted:
+
+```
+Follow-on filing for merged PR:
+
+Filed: #X, #Y, #Z
+Skipped (unparseable entry): 1 — <first ~80 chars of the failing entry text>
+Skipped (gh create failure): 1 — <gh stderr first line>
+```
+
+Omit any "Skipped" line whose count is zero. If all entries filed successfully, the body is just `Filed: #X, #Y, #Z`. If `gh issue create` fails for one entry, continue with the next — never block the merge.
 
 Skip the entire filing step (no roll-up comment either) if the shepherd's comment has no `## Follow-ons` section.
 
@@ -302,7 +396,18 @@ Older issues lacking these markers have only YAML-declared edges.
 
 If a `gh` command fails with a network, rate-limit, or auth error:
 
+- **Post an error breadcrumb on #601** so the 3-strike counter has a source. Use `gh issue comment 601 -R moumantai-gg/mithril --body-file <temp-file>` with body shape:
+  ```
+  <!-- orchestrator-error: gh-failure -->
+  Orchestrator gh failure at <ISO-8601 UTC>.
+
+  Failed command: <cmd>
+  Error text: <first ~500 chars of stderr>
+
+  Retrying in 300s.
+  ```
+  The HTML-comment marker `<!-- orchestrator-error: gh-failure -->` is what the counter greps for. If posting the breadcrumb ALSO fails, just log to stdout and continue — never enter a posting loop.
 - Call `ScheduleWakeup` in 300s and exit (5-minute retry interval — within cache TTL).
-- Track failures across consecutive ticks via `gh issue view 601 --json comments` at the start of each tick: if the last 3 of *your own* recent comments on #601 report a `gh` failure, treat that as "3 consecutive failures."
+- Track failures across consecutive ticks via `gh issue view 601 -R moumantai-gg/mithril --json comments` at the start of each tick: count the trailing run of comments authored by the orchestrator that match `<!-- orchestrator-error: gh-failure -->` AND have no intervening non-error orchestrator comment. If that run is ≥ 3, treat as "3 consecutive failures."
 - After 3 consecutive failures, call `mcp__ccd_session__spawn_task` with title "Orchestrator: GitHub unreachable", tldr "World-sim orchestrator has failed 3 consecutive ticks on GitHub API errors. Investigate connectivity / auth.", and a prompt that includes the most recent error message verbatim. Then exit with NO `ScheduleWakeup`.
-- Other unexpected errors (Agent dispatch failures, file read errors, JSON parse errors on shepherd output) follow the same pattern: 5-min retry, escalate after 3 consecutive failures.
+- Other unexpected errors (Agent dispatch failures, file read errors, JSON parse errors on shepherd output) follow the same pattern: post the breadcrumb with a different `outcome:` value in the body (e.g., `agent-dispatch-failure`), 5-min retry, escalate after 3 consecutive failures.

--- a/.claude/agents/world-sim-reviewer.md
+++ b/.claude/agents/world-sim-reviewer.md
@@ -97,6 +97,7 @@ Apply the standard false-positive filters:
 Return a structured response. The shepherd parses this — keep it predictable.
 
 ```
+<!-- world-sim-review-verdict: clean | findings -->
 ### World-sim specialist review — PR #N / issue #I (phase P)
 
 **Verdict:** clean | findings
@@ -115,6 +116,8 @@ Return a structured response. The shepherd parses this — keep it predictable.
 
 **Summary:** <one or two sentences>
 ```
+
+The first line MUST be the HTML-comment marker `<!-- world-sim-review-verdict: clean -->` or `<!-- world-sim-review-verdict: findings -->`. The shepherd parses this marker — the prose `**Verdict:**` line is for humans and may shift formatting; the marker is the machine-readable contract.
 
 If you find nothing, emit a clean verdict with one sentence: `No findings against principles, phase preconditions, replay-determinism, or the audit.`
 

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -1,6 +1,6 @@
 ---
 name: world-sim-shepherd
-description: Per-PR babysitter for world-sim migration PRs. Use when the world-sim orchestrator (or a human) hands a PR off for end-to-end review-fix-rereview management. The shepherd owns the PR until it is ready to merge or needs human attention; it dispatches reviewers and workers as needed and returns a structured verdict. Input is a PR number, issue number, phase, risk, and a worker-dispatch template.
+description: Per-PR babysitter for world-sim migration PRs. Use when the world-sim orchestrator (or a human) hands a PR off for end-to-end review-fix-rereview management. The shepherd owns the PR until it is ready to merge or needs human attention; it dispatches reviewers and workers as needed and returns a structured verdict. Input is a PR number, issue number, phase, and a worker-dispatch template.
 tools: Read, Grep, Glob, Bash, Agent
 ---
 
@@ -16,7 +16,6 @@ The caller provides:
 - `pr` — GitHub PR number to babysit
 - `issue` — GitHub issue number this PR addresses
 - `phase` — phase classification (e.g., `2`, `3`, `parallel`)
-- `risk` — risk classification (`low`, `medium`, `high`)
 - `worker_template` — verbatim text the orchestrator would pass to a fresh worker for this issue
 - `max_iterations` (optional, default `3`) — review-fix cycle ceiling
 
@@ -32,6 +31,14 @@ Before starting the loop:
 
 ## The loop
 
+**Design contract: compute verdict BEFORE posting.** Every comment the shepherd
+posts carries a machine-readable `<!-- shepherd-verdict: VERDICT -->` marker as
+its first line. The orchestrator parses this marker — so the verdict must be
+decided before the comment is written, not after. Escalation reasons that
+historically fired after the comment (`max_iterations`, `same_issue_class`,
+`worker_no_progress`) are now folded into the pre-post verdict computation so
+the marker accurately reflects the iteration's outcome.
+
 ```
 state = {
   iterations: 0,
@@ -43,7 +50,8 @@ state = {
 loop:
   pr_state = gh pr view <pr> --json state,headRefOid,reviews,comments,mergeable
 
-  # Terminal-state short-circuits
+  # Terminal short-circuits — JSON return only, no comment posted.
+  # The orchestrator catches these via the return JSON in its step 3.
   if pr_state.state == "MERGED":
     return verdict("ready-to-merge", reason: null)
   if pr_state.state == "CLOSED":
@@ -53,41 +61,74 @@ loop:
 
   # Human-comment guard — do not bulldoze human input.
   # Compare against state.last_iteration_at (initialized to "now" at loop entry,
-  # updated at the top of each iteration). The shepherd's own comments are bot-
-  # authored and excluded by the non-bot filter.
+  # updated at the bottom of each iteration). The shepherd's own comments are
+  # bot-authored and excluded by the non-bot filter. JSON return only — the
+  # human's comment is the artifact the orchestrator surfaces.
   if any review or comment with created_at > state.last_iteration_at by a non-bot account:
     return verdict("needs-human", reason: "human_review")
 
   # Run reviewers in parallel (single message, two Agent calls).
   # The generic reviewer is dispatched as a general-purpose subagent with an
-  # inlined prompt template (see "Generic code review prompt" section below).
+  # inlined prompt template (see §Generic code review prompt below).
   review_results = parallel(
     Agent(subagent_type: "general-purpose", prompt: <generic-review template with pr=N>),
     Agent(subagent_type: "world-sim-reviewer", prompt: <pr, issue, phase>)
   )
 
-  # Post the combined comment on the PR
-  gh pr comment <pr> --body-file <temp-file-with-combined-review>
+  # Parse the machine-readable verdict markers from each reviewer's output.
+  # Both reviewers emit their verdict as an HTML-comment marker — `<!--
+  # generic-review-verdict: clean|findings -->` and `<!-- world-sim-review-
+  # verdict: clean|findings -->`. The prose `**Verdict:**` line is for humans;
+  # the marker is the contract.
+  generic_verdict = first regex match `<!--\s*generic-review-verdict:\s*(clean|findings)\s*-->`
+                    against review_results.generic.text
+  specialist_verdict = first regex match `<!--\s*world-sim-review-verdict:\s*(clean|findings)\s*-->`
+                       against review_results.specialist.text
 
-  # If both reviewers clean → terminal success
-  if review_results.generic.verdict == "clean"
-     and review_results.specialist.verdict == "clean":
-    return verdict("ready-to-merge", reason: null)
+  # Treat unparseable reviewer output as a hard escalation — don't guess.
+  if generic_verdict is null or specialist_verdict is null:
+    posted_verdict = "needs-human"
+    escalation_reason = "worker_no_progress"  # closest existing enum value;
+                                              # see §Output contract note
+  else if generic_verdict == "clean" and specialist_verdict == "clean":
+    posted_verdict = "ready-to-merge"
+    escalation_reason = null
+  else:
+    posted_verdict = "dispatching worker"
+    escalation_reason = null
 
-  state.iterations += 1
-
-  # Iteration ceiling
-  if state.iterations > max_iterations:
-    return verdict("needs-human", reason: "max_iterations")
-
-  # Same-class-of-issue guard
-  if state.last_review is not null
+  # Same-class-of-issue guard — if findings repeat the previous iteration's
+  # file:line ranges or principle citations, escalate instead of dispatching
+  # another doomed worker.
+  if posted_verdict == "dispatching worker"
+     and state.last_review is not null
      and same_issue_class(state.last_review, review_results):
-    return verdict("needs-human", reason: "same_issue_class")
+    posted_verdict = "needs-human"
+    escalation_reason = "same_issue_class"
 
+  # Iteration ceiling — if a fresh worker dispatch would push iterations past
+  # max_iterations, escalate instead of dispatching.
+  if posted_verdict == "dispatching worker"
+     and state.iterations + 1 > max_iterations:
+    posted_verdict = "needs-human"
+    escalation_reason = "max_iterations"
+
+  # Post the combined comment on the PR. First line is the verdict marker;
+  # body shape per §Posting the combined review comment.
+  gh pr comment <pr> --body-file <temp-file>
+
+  # Terminal verdicts return now — the comment + marker is the orchestrator's
+  # signal for the next tick, and step 3 also sees the return JSON for inline
+  # handling.
+  if posted_verdict == "ready-to-merge":
+    return verdict("ready-to-merge", reason: null)
+  if posted_verdict == "needs-human":
+    return verdict("needs-human", reason: escalation_reason)
+
+  # Otherwise dispatch a worker.
+  state.iterations += 1
   state.last_review = review_results
 
-  # Dispatch worker via Agent tool (blocks until worker returns)
   worker_prompt = build_worker_prompt(
     template: <input.worker_template>,
     feedback: review_results,
@@ -95,9 +136,15 @@ loop:
   )
   Agent(subagent_type: "general-purpose", prompt: worker_prompt)
 
-  # Verify worker actually pushed commits
+  # Verify worker actually pushed commits.
   new_head = gh pr view <pr> --json headRefOid
   if new_head == state.last_head_sha:
+    # Worker came back without pushing. Post a final needs-human comment so
+    # the orchestrator's cross-tick recovery (step 2) can pick it up, then
+    # return via JSON for inline handling in step 3.
+    gh pr comment <pr> --body-file <temp-file>
+      # marker = needs-human, reason = worker_no_progress, prose summarizes
+      # the dispatched worker's return text.
     return verdict("needs-human", reason: "worker_no_progress")
 
   state.last_head_sha = new_head
@@ -116,9 +163,12 @@ Implement as plain string-matching against the structured review output. Tolerat
 
 ## Posting the combined review comment
 
-Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed:
+Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed; the
+**first line MUST be the verdict marker** so the orchestrator can parse it
+without grepping the prose:
 
 ```
+<!-- shepherd-verdict: ready-to-merge | dispatching worker | needs-human -->
 ### Shepherd iteration N — review verdict
 
 **Generic review**:
@@ -127,7 +177,9 @@ Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed:
 **World-sim specialist** (`world-sim-reviewer`):
 <verbatim specialist output, indented one level>
 
-**Verdict:** dispatching worker | ready-to-merge | needs-human
+**Verdict:** ready-to-merge | dispatching worker | needs-human
+**Escalation reason:** <max_iterations | same_issue_class | worker_no_progress>
+                       (omit this line unless Verdict is needs-human)
 
 ## Follow-ons (out-of-scope findings — orchestrator will file as issues on merge)
 
@@ -142,6 +194,12 @@ Use `gh pr comment <pr> --body-file <path>`. The body shape is fixed:
 
 — posted by world-sim-shepherd
 ```
+
+The orchestrator parses verdicts by regex against the marker only:
+`<!--\s*shepherd-verdict:\s*(ready-to-merge|dispatching worker|needs-human)\s*-->`.
+The prose `**Verdict:**` line is for humans reading the PR. Drift between the
+two should never happen because both come from the same `posted_verdict`
+variable in the loop.
 
 Use a temp file for the body — direct `--body` arguments containing multiline content trip Bash quoting issues per the `bash_tool_is_posix_not_powershell` memory convention. PowerShell here-strings (`@'…'@`) work for the commit message but `gh ... --body-file` is more robust for the comment.
 
@@ -188,6 +246,8 @@ After the JSON block, include human-readable prose: a paragraph summarizing what
 
 ## Generic code review prompt
 
+This is the **canonical** generic-review prompt — no separate `.claude/agents/*` file backs it. If you need to update the rubric, edit it here.
+
 When dispatching the generic reviewer Agent call in the loop, use this template (inline the PR number and a one-sentence framing):
 
 ```
@@ -211,7 +271,8 @@ Filter aggressively — confidence ≥ 80 only. Standard false-positive filters 
 - Lines the PR did not modify
 - Issues silenced explicitly in code (e.g., lint-ignore comments with justification)
 
-Output format:
+Output format (FIRST line MUST be the machine-readable marker):
+<!-- generic-review-verdict: clean | findings -->
 ### Generic code review — PR #N
 
 **Verdict:** clean | findings


### PR DESCRIPTION
## Summary

Actions the world-sim agent-feedback review (`scratch/agent-feedback.md`). The headline fix is the dead-escalation path: the orchestrator's step 2 was grepping PR comments for a `**Verdict:** needs-human` line the shepherd never actually posted, so escalations sat silently.

- **Shepherd** — verdict is now computed BEFORE the comment is posted (so `max_iterations`, `same_issue_class`, and `worker_no_progress` map onto a real marker), the comment carries a first-line `<!-- shepherd-verdict: VERDICT -->` marker, `risk` is removed from the input list, and the generic-review prompt emits its own marker.
- **Reviewer** — output format requires a first-line `<!-- world-sim-review-verdict: clean|findings -->` marker so the shepherd parses verdicts deterministically.
- **Orchestrator** — step 3 handles ALL terminal verdicts inline via the return JSON (not just `conflict`); step 2 is recovery-only. All `gh` calls carry `-R moumantai-gg/mithril`; `gh label` → `gh issue edit --add-label/--remove-label`; multi-line comments use `--body-file`. Cheap gh-state probe runs first each tick so idle ticks pay zero doc-read cost. Step 4 classifies worker outcomes via a structured `outcome:` line instead of defaulting every non-PR-opening result to blocked. Error-comment breadcrumb on #601 gives the 3-strike counter a parseable source.

Source: `scratch/agent-feedback.md`.

## Test plan

These are agent definition files — no code, no test suite to run. Verification owed on the first live tick after merge:

- [ ] Idle tick: confirm the orchestrator does NOT load the three design docs (only the cheap gh-state probe)
- [ ] Shepherd dispatch: confirm posted PR comment's first line is `<!-- shepherd-verdict: ... -->`
- [ ] Specialist review: confirm first line of reviewer output is `<!-- world-sim-review-verdict: ... -->`
- [ ] gh failure: confirm the orchestrator posts a `<!-- orchestrator-error: gh-failure -->` breadcrumb on #601 before scheduling a 300s retry
- [ ] needs-human shepherd return: confirm step 3 applies orchestrator-blocked + chip inline, without waiting for next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)