### PR TITLE
refactor(world-sim): extract IPlayerQuestJournalService + retire char-switch synthesis

### DIFF
--- a/docs/module-charters.md
+++ b/docs/module-charters.md
@@ -58,7 +58,7 @@ services that have emerged organically through the project's arc —
 [`IPlayerRecipeState`](../src/Mithril.GameState/Recipes/IPlayerRecipeState.cs)
 ([#475](https://github.com/moumantai-gg/mithril/pull/475)),
 [`IGameSessionService`](../src/Mithril.GameState/Sessions/IGameSessionService.cs),
-[`IQuestService`](../src/Mithril.GameState/Quests/IQuestService.cs),
+[`IPlayerQuestJournalService`](../src/Mithril.GameState/Quests/IPlayerQuestJournalService.cs),
 [`PlayerAreaTracker`](../src/Mithril.GameState/Areas/PlayerAreaTracker.cs),
 and [`INpcStateTracker`](https://github.com/moumantai-gg/mithril/issues/552)
 (#552, in flight) — are **not** parallel abstractions of their domains;
@@ -631,7 +631,7 @@ libraries; the charter follows the code:
   emulated game from logs, and the GameState services that emerged through the project's
   arc (`IPlayerPositionTracker` #454, `IPlayerSkillState` #462/#465, `IPlayerPinTracker`
   #468, `IInventoryService`, `IPlayerWeatherTracker`, `IPlayerCelestialState` #490,
-  `IPlayerRecipeState` #475, `IGameSessionService`, `IQuestService`, `PlayerAreaTracker`,
+  `IPlayerRecipeState` #475, `IGameSessionService`, `IPlayerQuestJournalService` #607, `PlayerAreaTracker`,
   and `INpcStateTracker` #552 in flight) are the canonical model of that emulated game.
   Articulating the principle explicitly clarifies that modules are *projections* of
   subsets for UX — they consume the canonical model, they don't parallel-emulate it.

--- a/docs/module-signal-map.md
+++ b/docs/module-signal-map.md
@@ -58,7 +58,7 @@ Two streams (Player.log and chat) each **self-scope** via their own intra-source
 | `IPlayerPositionTracker` | character |
 | `IPlayerPinTracker` | character (user pins) |
 | `IInventoryService` | character |
-| `IQuestService` | character |
+| `IPlayerQuestJournalService` | character |
 
 The `Player*` naming on the world-scope services (`IPlayerWeatherTracker`, `IPlayerCelestialStateService`, parts of `IPlayerAreaTracker`) is misleading under this partition — they're actually world-scope readings of "what the active character can observe of the world." Rename target if/when the world-sim refactor lands; not worth churning ahead of that.
 
@@ -255,25 +255,21 @@ Design notes: [`player-pin-service.md`](player-pin-service.md). Pin grammar: no 
 
 ---
 
-### `IQuestService`
+### `IPlayerQuestJournalService`
 
 **Inputs**
 - Log: `LocalPlayer` pipe (`QuestAccepted`, `QuestCompleted`, `QuestJournalLoad`)
-- Identity: `PerCharacterView<QuestServiceState>.CurrentChanged` — character-switch reload synthesizes `Abandoned` / `Accepted` / `Completed` events
 
 **State machines**
-- Quest-ledger fold — per-character active + completed sets, derived from log events
-- Character-switch reload synthesis — second event source; fires synthetic events at character boundary from a diff against the new character's persisted view, NOT from the log
+- Quest-ledger fold — per-character active + completed sets, derived from Player.log events only
 
 **Outputs**
 - `Subscribe(Action<QuestEvent>)`
 - Persisted: per-character JSON (synchronous save per mutation)
 
-⚠️ **The character-switch synthesis is a current-architecture workaround**, not a permanent topology feature. It exists because today there's only one in-memory ledger and the UI binds via a shared view that swaps content on character change. Under per-character sim scope (each character has its own ledger; "switching" is a binding swap, not a state-mutation), this whole path collapses: no `OnViewCurrentChanged` listener, no `_time.GetUtcNow()` synthesized events, no reload. The `HandleJournalLoaded` log-derived synthesis (deriving `Abandoned` for quests missing from a `ProcessLoadQuests` snapshot) is a separate question and stays — that's a necessary inference from a real log event.
+✅ Extracted via #607 (world-sim migration item #6): the legacy `IQuestService` is gone. Reference data (what is quest X?) lives in `IReferenceDataService.Quests`; this service owns only state (am I on quest X?). Consumers join the two surfaces explicitly. The previous `PerCharacterView<…>.CurrentChanged` listener and its `_time.GetUtcNow()`-stamped synthetic `Abandoned`/`Accepted`/`Completed` events retired with the extraction — character switch is now a UI binding swap, not a state mutation.
 
-⚠️ This service also conflates two roles: reference (what is quest X?) and state (am I on quest X?). The reference half is already owned by `IReferenceDataService.Quests` and the state half is what should remain here. Splitting probably ships as an `IPlayerQuestJournalService` extraction; tracked separately.
-
-⚠️ `_time.GetUtcNow()` stamps on synthesized `Abandoned` events are **record stamps**, not transition gates. Disk write inside the handler is the only synchronous I/O in any `Mithril.GameState` service.
+ℹ️ The `HandleJournalLoaded` log-derived `Abandoned`-inference (deriving `Abandoned` for quests missing from a `ProcessLoadQuests` snapshot) **stays** — that's a necessary inference from a real log event, stamped on the log line's timestamp, not on wall-clock.
 
 ---
 
@@ -440,7 +436,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 
 **Inputs**
 - Log: `LocalPlayer` pipe via `LootIngestionService` (chest interactions, boss kill credit, defeat cooldowns)
-- GameState: `IQuestService.Subscribe` (quest cooldowns), `IPlayerAreaTracker.CurrentArea` (chest area stamping)
+- GameState: `IPlayerQuestJournalService.Subscribe` (quest cooldowns), `IPlayerAreaTracker.CurrentArea` (chest area stamping)
 - Settings: `GandalfSettings`, `GandalfShiftSettings`, user-defined timer definitions, `IShiftCatalog`
 - Reference: `ICommunityCalibrationService` (chest cooldown community data)
 - Wall-clock: `IGameClock` (PG's in-game time-of-day for shift alarms), `TimeProvider` for timer expiration
@@ -450,7 +446,7 @@ The simplest module — one input, one fold, no peeks, no wall-clock.
 - `LootBracketTracker` — pure synchronous SM that brackets loot lines after a chest interaction (2s `SoftTimeout`, **event-time** gated — replay-safe)
 - `LootIngestionService` — Player.log fan-in; dispatches to `LootBracketTracker`
 - `LootSource` — projects bracketed loot into chest cooldown timers
-- `QuestSource` — projects `IQuestService` events into quest cooldown timers
+- `QuestSource` — projects `IPlayerQuestJournalService` events into quest cooldown timers
 - `UserTimerSource` — projects user-created timer definitions into timer rows
 - `DerivedTimerProgressService` — composes the heterogeneous timer sources
 - `TimerProgressService` — **wall-clock-driven** expiration; transitions timers between Armed / Firing / Expired / Recurring
@@ -534,7 +530,7 @@ A handful of patterns are worth seeing all at once after the per-component scan.
 - **Both streams self-scope independently.** Player.log identifies its `(Server, Character)` from its own intra-source signals (`Servers:` catalog + `EVENT(Ok): connected, url=…` + `LoginBanner` — the latter two planned). Chat identifies its `(Server, Character)` from its own `**** Logged In As X. Server Y. Timezone Offset Z.` banner. No cross-source coupling for scope determination. Cross-source agreement (both banners' character names match) is verification, not derivation.
 - **View-layer correlators must scope-check.** Once the splits land and cross-source correlation lives in the view layer, every cross-world join must assert both sides are in the same `(Server, Character)` before firing — otherwise it's pairing across a session boundary. In single-server play this is implicitly safe; under multi-server use it's a latent correctness gap that needs the scope check to land alongside the connect-event / catalog parsers.
 - **Wall-clock-gated transitions live in five places.** `IInventoryService` correlator TTL (5s, the only foundation-layer wall-clock gate); `Samwise.GardenStateMachine.PruneWithered` + `AlarmService.IsLikelyGarbageCollected`; `Gandalf.TimerProgressService.CheckExpirations` + `TimerExpirationScheduler` + `ShiftAlarmService`; `Legolas.MotherlodeMeasurementCoordinator` (event-time but compared against a fresh foreign-FSM timestamp, which is wall-clock-shaped). Everything else uses event-time arithmetic on payload timestamps. **Under the worlds**, all of these migrate from `_time.GetUtcNow()` to `IWorldClock.Now` and become replay-deterministic — a mechanical search-replace.
-- **Second event sources (non-log inputs that mutate state).** `IInventoryService` `FileSystemWatcher` for export-reconcile; `IQuestService` `PerCharacterView.CurrentChanged` for character-switch reload (collapses under per-character world scope — see entry); `Gandalf` three wakeup schedulers; user-input commands across every UI-bearing module. Under the worlds these become **timestamped producer-emitted frames** for a world's merger (filesystem reconcile, wake-at-T) or move out of world scope entirely (user input mutates adjacent state directly).
+- **Second event sources (non-log inputs that mutate state).** `IInventoryService` `FileSystemWatcher` for export-reconcile; `Gandalf` three wakeup schedulers; user-input commands across every UI-bearing module. (The legacy `IQuestService` `PerCharacterView.CurrentChanged` character-switch reload was a second event source until #607 — see the `IPlayerQuestJournalService` entry — and is now retired under per-character world scope.) Under the worlds these become **timestamped producer-emitted frames** for a world's merger (filesystem reconcile, wake-at-T) or move out of world scope entirely (user input mutates adjacent state directly).
 - **Module → GameState dependency graph is shallow.** No module depends on more than four GameState services. The deepest consumer (`Legolas.MotherlodeMeasurementCoordinator` — 4 services) is *today* the only Tier-2 SM in the repo; post-migration (item 3 in the world-simulator design plan) it becomes single-source and the Tier-2 reference vanishes. Arwen depends on 2 (`IInventoryService`, `IGameSessionService`). Samwise on 1 (`IInventoryService`). Saruman on 0 GameState services (consumes reference + per-character view only, despite being a cross-source consumer). Pippin / Bilbo / Silmarillion / Celebrimbor / Elrond on 0.
 - **Five of ten modules are pure projectors** (Pippin, Elrond, Bilbo, Silmarillion, Celebrimbor) — no log subscriptions, no GameState subscriptions for state mutation. They consume reference data + persisted JSON + user input only.
 

--- a/docs/player-skill-state-service.md
+++ b/docs/player-skill-state-service.md
@@ -202,7 +202,7 @@ lock — do non-trivial work off-thread.
   registered in `GameStateServiceCollectionExtensions.AddMithrilGameState`.
   Takes an **optional** `IReferenceDataService?` (#470, mirrors
   `InventoryService`) — DI auto-injects the registered singleton (already
-  required by `QuestService` in the same extension, so no new boot risk);
+  required by `PlayerQuestJournalService` in the same extension, so no new boot risk);
   absent in unit tests → proxy fallback.
 
 ## Reference enrichment (#470)

--- a/src/Gandalf.Module/GandalfModule.cs
+++ b/src/Gandalf.Module/GandalfModule.cs
@@ -7,9 +7,10 @@ using Gandalf.Views;
 using Mithril.GameState.Areas;
 using Mithril.Shared.Character;
 using Mithril.Shared.DependencyInjection;
-// Mithril.GameState now owns the quest parsers + IQuestService; Gandalf only
-// consumes IQuestService via QuestSource. The parser singletons + the old
-// QuestIngestionService no longer need to be registered here.
+// Mithril.GameState now owns the quest parsers + IPlayerQuestJournalService;
+// Gandalf only consumes IPlayerQuestJournalService via QuestSource. The
+// parser singletons + the old QuestIngestionService no longer need to be
+// registered here.
 using Mithril.Shared.Modules;
 using Mithril.Shared.Wpf.Dialogs;
 using MahApps.Metro.IconPacks;
@@ -118,10 +119,10 @@ public sealed class GandalfModule : IMithrilModule
         services.AddHostedService<GandalfSplitMigration>();
 
         // Quest source — projects Quest POCO ReuseTime_* timers from
-        // IQuestService.ActiveQuests ∪ keys-with-progress. Ingestion and
-        // per-character journal persistence live in Mithril.GameState; this
-        // source is purely a Gandalf-side projector that anchors cooldowns
-        // via DerivedTimerProgressService.
+        // IPlayerQuestJournalService.ActiveQuests ∪ keys-with-progress.
+        // Ingestion and per-character journal persistence live in
+        // Mithril.GameState; this source is purely a Gandalf-side projector
+        // that anchors cooldowns via DerivedTimerProgressService.
         services.AddSingleton<QuestSource>();
         services.AddSingleton<QuestTimersViewModel>();
 

--- a/src/Gandalf.Module/Services/QuestSource.cs
+++ b/src/Gandalf.Module/Services/QuestSource.cs
@@ -8,10 +8,10 @@ namespace Gandalf.Services;
 
 /// <summary>
 /// <see cref="ITimerSource"/> for repeatable-quest cooldowns. Pure projector
-/// over <see cref="IQuestService"/> + <see cref="DerivedTimerProgressService"/>:
+/// over <see cref="IPlayerQuestJournalService"/> + <see cref="DerivedTimerProgressService"/>:
 /// catalog enumerates <c>ActiveQuests ∪ keys-with-progress</c> joined against
 /// <see cref="IReferenceDataService.QuestsByInternalName"/> for static fields.
-/// Active set comes from <see cref="IQuestService.ActiveQuests"/> (per-character,
+/// Active set comes from <see cref="IPlayerQuestJournalService.ActiveQuests"/> (per-character,
 /// persisted in Mithril.GameState); cooldown progress stays Gandalf-internal
 /// via <see cref="DerivedTimerProgressService"/>.
 ///
@@ -30,7 +30,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
 
     private readonly DerivedTimerProgressService _derived;
     private readonly IReferenceDataService _refData;
-    private readonly IQuestService _questSvc;
+    private readonly IPlayerQuestJournalService _questSvc;
     private readonly TimeProvider _time;
     private readonly object _lock = new();
     private readonly IDisposable _questSubscription;
@@ -41,7 +41,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
     public QuestSource(
         DerivedTimerProgressService derived,
         IReferenceDataService refData,
-        IQuestService questSvc,
+        IPlayerQuestJournalService questSvc,
         TimeProvider? time = null)
     {
         _derived = derived;
@@ -178,7 +178,7 @@ public sealed class QuestSource : ITimerSource, IDisposable
 
     /// <summary>
     /// Project the rendered universe: every quest currently in
-    /// <see cref="IQuestService.ActiveQuests"/> joined with reference data,
+    /// <see cref="IPlayerQuestJournalService.ActiveQuests"/> joined with reference data,
     /// PLUS every key with non-null cooldown progress (so a completed-but-
     /// still-cooling quest stays visible after it leaves the active journal).
     /// Quests with no <c>Reuse*</c> duration are filtered out — nothing to

--- a/src/Gandalf.Module/Services/TimerSourceBinder.cs
+++ b/src/Gandalf.Module/Services/TimerSourceBinder.cs
@@ -28,8 +28,8 @@ namespace Gandalf.Services;
 /// to skip the ~2,000 repeatable quests the player has never touched).
 /// LootSource and UserTimerSource pass null — every catalog row materialises.
 /// When the predicate's external inputs change (the QuestSource pending set
-/// today; <see cref="Mithril.Shared.Quests.IQuestService"/> in the planned
-/// follow-up), the host VM calls <see cref="RecheckRelevance"/>.</para>
+/// today; <see cref="Mithril.GameState.Quests.IPlayerQuestJournalService"/>
+/// in the planned follow-up), the host VM calls <see cref="RecheckRelevance"/>.</para>
 ///
 /// <para>Refresh signal: fires <see cref="RefreshRequired"/> at the end of
 /// each delta batch when an existing row's GroupKey or State changed (the
@@ -91,7 +91,7 @@ public sealed class TimerSourceBinder : IDisposable
     /// <summary>
     /// Re-evaluate the relevance predicate against every catalog row. Call
     /// when an external input to the predicate has changed (e.g. the
-    /// QuestSource pending set, after #155 lands the <c>IQuestService</c>
+    /// QuestSource pending set, after #155 lands the <c>IPlayerQuestJournalService</c>
     /// active-set reshape removes the need for this entirely).
     /// </summary>
     public void RecheckRelevance()

--- a/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
+++ b/src/Gandalf.Module/ViewModels/QuestTimersViewModel.cs
@@ -14,7 +14,7 @@ namespace Gandalf.ViewModels;
 /// (Pending / Cooling / Ready / All) plus bulk dismiss commands.
 ///
 /// Post-#155 the source's catalog IS the active set
-/// (<c>IQuestService.ActiveQuests ∪ keys-with-progress</c>) — no need for the
+/// (<c>IPlayerQuestJournalService.ActiveQuests ∪ keys-with-progress</c>) — no need for the
 /// VM to re-filter the universe of repeatable quests, so the old
 /// <c>IsRelevant</c> predicate and the <c>PendingChanged</c> subscription are
 /// gone. Pending in the State filter just means <see cref="TimerState.Idle"/>:

--- a/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
+++ b/src/Mithril.GameState/DependencyInjection/GameStateServiceCollectionExtensions.cs
@@ -194,15 +194,19 @@ public static class GameStateServiceCollectionExtensions
             .AddSingleton<IServerCatalogService>(sp => sp.GetRequiredService<ServerCatalogService>())
             .AddHostedService(sp => sp.GetRequiredService<ServerCatalogService>());
 
+        // Per-character quest journal — Player.log only (state half of the
+        // split that retired the old IQuestService reference/state conflation,
+        // world-sim migration item #6, issue #607). Reference data lives in
+        // IReferenceDataService.Quests; consumers join the two surfaces.
         services.AddSingleton<QuestJournalLoadParser>();
         services.AddSingleton<QuestAcceptedParser>();
         services.AddSingleton<QuestCompletedParser>();
-        services.AddPerCharacterStore<QuestServiceState>(
-            "quests.json", QuestServiceStateJsonContext.Default.QuestServiceState);
+        services.AddPerCharacterStore<PlayerQuestJournalState>(
+            "quests.json", PlayerQuestJournalStateJsonContext.Default.PlayerQuestJournalState);
         services
-            .AddSingleton<QuestService>()
-            .AddSingleton<IQuestService>(sp => sp.GetRequiredService<QuestService>())
-            .AddHostedService(sp => sp.GetRequiredService<QuestService>());
+            .AddSingleton<PlayerQuestJournalService>()
+            .AddSingleton<IPlayerQuestJournalService>(sp => sp.GetRequiredService<PlayerQuestJournalService>())
+            .AddHostedService(sp => sp.GetRequiredService<PlayerQuestJournalService>());
 
         return services;
     }

--- a/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
+++ b/src/Mithril.GameState/Movement/PlayerPositionTracker.cs
@@ -17,7 +17,7 @@ namespace Mithril.GameState.Movement;
 /// teleport — last-writer-wins keeps it advancing as the player relogs/zones.
 ///
 /// <para><b>Why a self-feeding BackgroundService.</b> Mirrors
-/// <see cref="Sessions.GameSessionService"/> / <c>QuestService</c>: the
+/// <see cref="Sessions.GameSessionService"/> / <c>PlayerQuestJournalService</c>: the
 /// position is shared live game-state and must be available to consumers
 /// (e.g. Palantir's debug surface) without depending on any other module
 /// being activated.</para>

--- a/src/Mithril.GameState/Quests/IPlayerQuestJournalService.cs
+++ b/src/Mithril.GameState/Quests/IPlayerQuestJournalService.cs
@@ -21,8 +21,8 @@ public enum QuestEventKind
     /// anchor applies.</summary>
     Abandoned,
     /// <summary>Quest was turned in. Removes from active set and stamps
-    /// <see cref="IQuestService.CompletionHistory"/>; downstream cooldown
-    /// clocks anchor on <see cref="QuestEvent.Timestamp"/>.</summary>
+    /// <see cref="IPlayerQuestJournalService.CompletionHistory"/>; downstream
+    /// cooldown clocks anchor on <see cref="QuestEvent.Timestamp"/>.</summary>
     Completed,
 }
 
@@ -34,15 +34,22 @@ public sealed record QuestCompletionState(string InternalName, DateTimeOffset La
 
 /// <summary>
 /// Canonical "quests in journal" + "when did I last complete X?" map for the
-/// active character, derived by tailing <c>ProcessLoadQuests</c> /
-/// <c>ProcessBook("New Quest:" …)</c> / <c>ProcessCompleteQuest</c> on
+/// active character, derived by folding the Player.log quest events
+/// (<c>ProcessLoadQuests</c> / <c>ProcessBook("New Quest:" …)</c> /
+/// <c>ProcessCompleteQuest</c>) from
 /// <see cref="Mithril.Shared.Logging.IPlayerLogStream"/>. Persisted per-character
-/// to <c>characters/{slug}/quests.json</c> so completion anchors survive
-/// across sessions (a quest completed three days ago needs a remembered
-/// timestamp; today's session log won't carry that <c>ProcessCompleteQuest</c>
-/// line).
+/// to <c>characters/{slug}/quests.json</c> so completion anchors survive across
+/// sessions (a quest completed three days ago needs a remembered timestamp;
+/// today's session log won't carry that <c>ProcessCompleteQuest</c> line).
 ///
-/// Owning this centrally — rather than letting each quest-aware module
+/// State half of the (state, reference) split surfaced by world-sim migration
+/// item #6 (see <c>docs/world-simulator.md</c>): this service owns the live
+/// per-character ledger, while quest *reference* data (definitions, names,
+/// reuse times, requirements) continues to live in
+/// <c>IReferenceDataService.Quests</c>. Quest-aware modules join the two
+/// surfaces explicitly; the service no longer conflates them.
+///
+/// Owning the journal centrally — rather than letting each quest-aware module
 /// re-parse the log — avoids fan-out of the same journal state and lets
 /// downstream consumers (<c>QuestSource</c> for repeatable cooldowns, future
 /// Smaug repeatable-quest tracking, future quest planners) read a single
@@ -51,7 +58,7 @@ public sealed record QuestCompletionState(string InternalName, DateTimeOffset La
 /// <see cref="TryGetActive"/> / <see cref="TryGetCompletion"/>, or
 /// <see cref="Subscribe"/> for an atomic replay-then-live event stream.
 /// </summary>
-public interface IQuestService
+public interface IPlayerQuestJournalService
 {
     /// <summary>
     /// Snapshot of quests currently in the active character's journal, keyed
@@ -83,14 +90,6 @@ public interface IQuestService
     /// replay (on the subscribing thread) and during live dispatch (on the
     /// ingestion-loop thread). Subscribers that do non-trivial work should
     /// dispatch off-thread immediately to avoid blocking ingestion.
-    ///
-    /// On character switch the service atomically swaps to the new character's
-    /// state and fires diff-events: <see cref="QuestEventKind.Abandoned"/> for
-    /// quests in the old active set that aren't in the new,
-    /// <see cref="QuestEventKind.Accepted"/> for the new entries, and
-    /// <see cref="QuestEventKind.Completed"/> for every entry in the new
-    /// completion history (subscribers maintaining mirrors should idempotently
-    /// apply these).
     ///
     /// Dispose the returned subscription to stop receiving further events.
     /// </summary>

--- a/src/Mithril.GameState/Quests/Parsing/QuestAcceptedParser.cs
+++ b/src/Mithril.GameState/Quests/Parsing/QuestAcceptedParser.cs
@@ -14,7 +14,7 @@ namespace Mithril.GameState.Quests.Parsing;
 ///
 /// Resolves the integer quest id to the quest's InternalName via
 /// <see cref="IReferenceDataService.Quests"/> so downstream consumers
-/// (e.g. <c>QuestService</c>) can track the journal by stable name.
+/// (e.g. <c>PlayerQuestJournalService</c>) can track the journal by stable name.
 ///
 /// <para>Post-#550 L1 migration: consumes the envelope-stripped
 /// <see cref="LocalPlayerLogLine.Data"/> payload — L0.5 (#532) has already

--- a/src/Mithril.GameState/Quests/Parsing/QuestEvents.cs
+++ b/src/Mithril.GameState/Quests/Parsing/QuestEvents.cs
@@ -6,8 +6,8 @@ namespace Mithril.GameState.Quests.Parsing;
 /// Bulk login signal: the player's full quest journal as the server reports
 /// it on character connect. Two ID lists ride along — WorkOrder bulletin-board
 /// quests (list A) and everything else (list B). Drives a snapshot-replace
-/// of the active-quest set in <c>IQuestService</c> so the journal stays in
-/// sync with the game across restarts and character switches.
+/// of the active-quest set in <c>IPlayerQuestJournalService</c> so the journal
+/// stays in sync with the game across restarts and character switches.
 /// </summary>
 public sealed record QuestJournalLoadedEvent(
     DateTime Timestamp,
@@ -19,14 +19,14 @@ public sealed record QuestJournalLoadedEvent(
 /// Player accepted a quest. Recovered from the companion <c>ProcessBook</c>
 /// line that fires alongside <c>ProcessAddQuest</c> — the unresolved
 /// <c>&lt;&lt;&lt;quest_NNNNN_Name&gt;&gt;&gt;</c> localization template carries the quest id.
-/// Drives an incremental add to <c>IQuestService.ActiveQuests</c>.
+/// Drives an incremental add to <c>IPlayerQuestJournalService.ActiveQuests</c>.
 /// </summary>
 public sealed record QuestAcceptedEvent(DateTime Timestamp, string QuestInternalName)
     : LogEvent(Timestamp);
 
 /// <summary>
 /// Player completed (turned in) a repeatable quest. Removes the quest from the
-/// active journal and stamps <c>IQuestService.CompletionHistory</c> with this
+/// active journal and stamps <c>IPlayerQuestJournalService.CompletionHistory</c> with this
 /// timestamp; downstream cooldown clocks anchor on it.
 /// </summary>
 public sealed record QuestCompletedEvent(DateTime Timestamp, string QuestInternalName)

--- a/src/Mithril.GameState/Quests/PlayerQuestJournalService.cs
+++ b/src/Mithril.GameState/Quests/PlayerQuestJournalService.cs
@@ -23,22 +23,27 @@ namespace Mithril.GameState.Quests;
 /// session). Saving on each mutation; quest events arrive at most every few
 /// seconds, no debouncing needed.
 ///
+/// Character switch is a UI binding swap, not a state mutation. The service
+/// hydrates from <see cref="PerCharacterView{T}.Current"/> once at
+/// construction (so a post-restart <c>Subscribe</c> sees the persisted
+/// history before any live log line arrives) and never listens for
+/// <see cref="PerCharacterView{T}.CurrentChanged"/> — under the world-sim's
+/// per-character scope (see <c>docs/world-simulator.md</c> migration item #6),
+/// each character has its own ledger and the UI rebinds to the new
+/// character's instance rather than mutating this one.
+///
 /// Threading: ingestion runs on the L1 driver's pump thread (archetype-A
-/// default = <c>DeliveryContext.Inline</c>), character-switch reloads run on
-/// the <see cref="PerCharacterView{T}.CurrentChanged"/> callback thread
-/// (typically the active-character service thread). Both dispatch to
-/// subscribers under the same lock as the snapshot accessors — subscribers
-/// must dispatch off-thread for non-trivial work.
+/// default = <c>DeliveryContext.Inline</c>). Subscribers dispatch under the
+/// same lock as the snapshot accessors — non-trivial work must hop off-thread.
 /// </summary>
-public sealed class QuestService : BackgroundService, IQuestService
+public sealed class PlayerQuestJournalService : BackgroundService, IPlayerQuestJournalService
 {
     private readonly ILogStreamDriver _driver;
     private readonly QuestJournalLoadParser _journalLoadParser;
     private readonly QuestAcceptedParser _acceptedParser;
     private readonly QuestCompletedParser _completedParser;
-    private readonly PerCharacterView<QuestServiceState> _view;
+    private readonly PerCharacterView<PlayerQuestJournalState> _view;
     private readonly IReferenceDataService _refData;
-    private readonly TimeProvider _time;
     private readonly IDiagnosticsSink? _diag;
 
     private readonly object _lock = new();
@@ -47,14 +52,13 @@ public sealed class QuestService : BackgroundService, IQuestService
     private readonly List<Action<QuestEvent>> _handlers = [];
     private ILogSubscription? _subscription;
 
-    public QuestService(
+    public PlayerQuestJournalService(
         ILogStreamDriver driver,
         QuestJournalLoadParser journalLoadParser,
         QuestAcceptedParser acceptedParser,
         QuestCompletedParser completedParser,
-        PerCharacterView<QuestServiceState> view,
+        PerCharacterView<PlayerQuestJournalState> view,
         IReferenceDataService refData,
-        TimeProvider? time = null,
         IDiagnosticsSink? diag = null)
     {
         _driver = driver;
@@ -63,14 +67,12 @@ public sealed class QuestService : BackgroundService, IQuestService
         _completedParser = completedParser;
         _view = view;
         _refData = refData;
-        _time = time ?? TimeProvider.System;
         _diag = diag;
 
-        // Hydrate from disk for the active character (if any) before any
-        // subscriber attaches. CurrentChanged covers later character switches
-        // and the case where no character is selected yet at construction.
-        ReloadFromView();
-        _view.CurrentChanged += OnViewCurrentChanged;
+        // Hydrate from disk for the active character before any subscriber
+        // attaches. No event firing here — Subscribe replays the current
+        // active/completed sets atomically when consumers attach.
+        HydrateFromView();
     }
 
     public IReadOnlyDictionary<string, QuestJournalEntry> ActiveQuests
@@ -173,7 +175,8 @@ public sealed class QuestService : BackgroundService, IQuestService
     /// ids are dropped silently (game-data drift). Fires
     /// <see cref="QuestEventKind.Accepted"/> for newly-present entries and
     /// <see cref="QuestEventKind.Abandoned"/> for entries that were active
-    /// before but aren't anymore.
+    /// before but aren't anymore — a real inference from a real log event,
+    /// stamped on the <see cref="QuestJournalLoadedEvent.Timestamp"/>.
     /// </summary>
     private void HandleJournalLoaded(QuestJournalLoadedEvent loaded)
     {
@@ -259,46 +262,20 @@ public sealed class QuestService : BackgroundService, IQuestService
         if (persist) PersistAfterMutation();
     }
 
-    private void OnViewCurrentChanged(object? sender, EventArgs e)
-    {
-        try { ReloadFromView(); }
-        catch (Exception ex) { _diag?.Warn("Quests", $"Character switch reload failed: {ex.Message}"); }
-    }
-
     /// <summary>
-    /// Atomically swap the in-memory state to whatever
-    /// <see cref="PerCharacterView{T}.Current"/> reports, firing diff events
-    /// (<see cref="QuestEventKind.Abandoned"/> for old-active-only,
-    /// <see cref="QuestEventKind.Accepted"/> for new-active-only,
-    /// <see cref="QuestEventKind.Completed"/> for new/changed completion
-    /// entries) so subscribers can update mirrors without re-subscribing.
+    /// Construction-time hydration from the persisted per-character view. No
+    /// event firing — no subscribers exist yet, and there is no prior
+    /// in-memory state to diff against. Called once from the ctor.
     /// </summary>
-    private void ReloadFromView()
+    private void HydrateFromView()
     {
         var current = _view.Current;
-        var newActive = current?.ActiveQuests ?? new Dictionary<string, QuestJournalEntry>(StringComparer.OrdinalIgnoreCase);
-        var newCompleted = current?.CompletionHistory ?? new Dictionary<string, QuestCompletionState>(StringComparer.OrdinalIgnoreCase);
+        if (current is null) return;
 
-        var events = new List<QuestEvent>();
-        var nowStamp = _time.GetUtcNow().UtcDateTime;
         lock (_lock)
         {
-            foreach (var (name, _) in _active)
-                if (!newActive.ContainsKey(name))
-                    events.Add(new QuestEvent(QuestEventKind.Abandoned, name, nowStamp));
-            foreach (var (name, entry) in newActive)
-                if (!_active.ContainsKey(name))
-                    events.Add(new QuestEvent(QuestEventKind.Accepted, name, entry.AcceptedAt.UtcDateTime));
-            foreach (var (name, c) in newCompleted)
-                if (!_completed.TryGetValue(name, out var oc) || oc.LastCompletedAt != c.LastCompletedAt)
-                    events.Add(new QuestEvent(QuestEventKind.Completed, name, c.LastCompletedAt.UtcDateTime));
-
-            _active.Clear();
-            foreach (var (k, v) in newActive) _active[k] = v;
-            _completed.Clear();
-            foreach (var (k, v) in newCompleted) _completed[k] = v;
-
-            if (events.Count > 0) FireAll(events);
+            foreach (var (k, v) in current.ActiveQuests) _active[k] = v;
+            foreach (var (k, v) in current.CompletionHistory) _completed[k] = v;
         }
     }
 
@@ -343,7 +320,6 @@ public sealed class QuestService : BackgroundService, IQuestService
 
     public override void Dispose()
     {
-        _view.CurrentChanged -= OnViewCurrentChanged;
         _subscription?.Dispose();
         _subscription = null;
         base.Dispose();
@@ -351,9 +327,9 @@ public sealed class QuestService : BackgroundService, IQuestService
 
     private sealed class Subscription : IDisposable
     {
-        private readonly QuestService _svc;
+        private readonly PlayerQuestJournalService _svc;
         private Action<QuestEvent>? _handler;
-        public Subscription(QuestService svc, Action<QuestEvent> handler) { _svc = svc; _handler = handler; }
+        public Subscription(PlayerQuestJournalService svc, Action<QuestEvent> handler) { _svc = svc; _handler = handler; }
         public void Dispose()
         {
             var h = Interlocked.Exchange(ref _handler, null);

--- a/src/Mithril.GameState/Quests/PlayerQuestJournalState.cs
+++ b/src/Mithril.GameState/Quests/PlayerQuestJournalState.cs
@@ -17,13 +17,13 @@ namespace Mithril.GameState.Quests;
 ///   today's session log won't carry that <c>ProcessCompleteQuest</c> line).</item>
 /// </list>
 /// </summary>
-public sealed class QuestServiceState : IVersionedState<QuestServiceState>
+public sealed class PlayerQuestJournalState : IVersionedState<PlayerQuestJournalState>
 {
     public const int Version = 1;
 
     public static int CurrentVersion => Version;
 
-    public static QuestServiceState Migrate(QuestServiceState loaded) => loaded;
+    public static PlayerQuestJournalState Migrate(PlayerQuestJournalState loaded) => loaded;
 
     public int SchemaVersion { get; set; } = Version;
 
@@ -35,5 +35,5 @@ public sealed class QuestServiceState : IVersionedState<QuestServiceState>
 }
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
-[JsonSerializable(typeof(QuestServiceState))]
-public partial class QuestServiceStateJsonContext : JsonSerializerContext { }
+[JsonSerializable(typeof(PlayerQuestJournalState))]
+public partial class PlayerQuestJournalStateJsonContext : JsonSerializerContext { }

--- a/src/Mithril.GameState/Sessions/GameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/GameSessionService.cs
@@ -111,7 +111,7 @@ public sealed class GameSessionService : BackgroundService, IGameSessionService
         {
             // Replay the current session before going live so the subscriber
             // observes the same `Current` view that already-attached handlers
-            // see. Mirrors InventoryService.Subscribe / QuestService.Subscribe.
+            // see. Mirrors InventoryService.Subscribe / PlayerQuestJournalService.Subscribe.
             if (_current is not null) Invoke(handler, _current);
             _handlers.Add(handler);
             return new Subscription(this, handler);

--- a/src/Mithril.GameState/Sessions/IGameSessionService.cs
+++ b/src/Mithril.GameState/Sessions/IGameSessionService.cs
@@ -5,8 +5,9 @@ namespace Mithril.GameState.Sessions;
 /// for the <c>Logged in as character X. Time UTC=… Timezone Offset …</c> banner,
 /// publishes the current <see cref="GameSession"/>, and re-anchors on every
 /// fresh login. Sibling of <see cref="Mithril.GameState.Inventory.IInventoryService"/>
-/// and <see cref="Mithril.GameState.Quests.IQuestService"/>: same atomic-replay
-/// Subscribe pattern so late joiners observe the current session synchronously.
+/// and <see cref="Mithril.GameState.Quests.IPlayerQuestJournalService"/>: same
+/// atomic-replay Subscribe pattern so late joiners observe the current session
+/// synchronously.
 ///
 /// Also surfaces as <see cref="Mithril.Shared.Logging.ISessionAnchor"/> so
 /// <see cref="Mithril.Shared.Logging.PlayerLogClock"/> (the Player.log L0

--- a/tests/Celebrimbor.Tests/CelebrimborSettingsVersioningTests.cs
+++ b/tests/Celebrimbor.Tests/CelebrimborSettingsVersioningTests.cs
@@ -33,7 +33,7 @@ public class CelebrimborSettingsVersioningTests
         var loaded = JsonSerializer.Deserialize(legacy, Ti)!;
 
         // Per the codebase's IVersionedState pattern (cf. ArwenFavorState /
-        // QuestServiceState), SchemaVersion initialises to CurrentVersion, so an
+        // PlayerQuestJournalState), SchemaVersion initialises to CurrentVersion, so an
         // omitted field loads as v1 — migration *safety* is that Migrate tolerates
         // that (identity) and no legacy data is dropped, NOT a 0 sentinel.
         loaded.SchemaVersion.Should().Be(CelebrimborSettings.CurrentVersion);

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
              Link="TestSupport\TestPaths.cs" />
   </ItemGroup>
 
-  <!-- Heavier test helpers (FakeReferenceData, FakeQuestService) opt in
+  <!-- Heavier test helpers (FakeReferenceData, FakePlayerQuestJournalService) opt in
        per-project via <Compile Include /> in the test csproj. They depend on
        Mithril.Shared / Mithril.GameState, which not every test project
        references — broadcasting them via Directory.Build.props would break

--- a/tests/Gandalf.Tests/Gandalf.Tests.csproj
+++ b/tests/Gandalf.Tests/Gandalf.Tests.csproj
@@ -18,7 +18,7 @@
     <!-- Shared test helpers opted into per-project (see tests/Directory.Build.props). -->
     <Compile Include="..\TestSupport\FakeReferenceData.cs"
              Link="TestSupport\FakeReferenceData.cs" />
-    <Compile Include="..\TestSupport\FakeQuestService.cs"
-             Link="TestSupport\FakeQuestService.cs" />
+    <Compile Include="..\TestSupport\FakePlayerQuestJournalService.cs"
+             Link="TestSupport\FakePlayerQuestJournalService.cs" />
   </ItemGroup>
 </Project>

--- a/tests/Gandalf.Tests/QuestSourceTests.cs
+++ b/tests/Gandalf.Tests/QuestSourceTests.cs
@@ -9,12 +9,13 @@ using Xunit;
 namespace Gandalf.Tests;
 
 /// <summary>
-/// Post-#155 QuestSource is a pure projector over <see cref="Mithril.GameState.Quests.IQuestService"/>
-/// + <see cref="DerivedTimerProgressService"/>. Catalog =
+/// Post-#155 QuestSource is a pure projector over
+/// <see cref="Mithril.GameState.Quests.IPlayerQuestJournalService"/> +
+/// <see cref="DerivedTimerProgressService"/>. Catalog =
 /// <c>ActiveQuests ∪ keys-with-progress</c>; ingestion (the old
 /// <c>OnQuestJournalLoaded</c> / <c>OnQuestAccepted</c> / <c>OnQuestCompleted</c>
-/// entry points) lives in QuestService now and is exercised via
-/// <see cref="FakeQuestService"/> here.
+/// entry points) lives in PlayerQuestJournalService now and is exercised via
+/// <see cref="FakePlayerQuestJournalService"/> here.
 /// </summary>
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
@@ -36,7 +37,7 @@ public class QuestSourceTests : IDisposable
     }
 
     private (QuestSource src, DerivedTimerProgressService derived, FakeReferenceData refData,
-             FakeQuestService questSvc, ManualTime time)
+             FakePlayerQuestJournalService questSvc, ManualTime time)
         Build(params (string Key, Mithril.Reference.Models.Quests.Quest Quest)[] quests)
     {
         var active = new FakeActiveCharacterService();
@@ -49,7 +50,7 @@ public class QuestSourceTests : IDisposable
         var derived = new DerivedTimerProgressService(derivedView, time);
 
         var refData = new FakeReferenceData(quests);
-        var questSvc = new FakeQuestService();
+        var questSvc = new FakePlayerQuestJournalService();
         var src = new QuestSource(derived, refData, questSvc, time);
         return (src, derived, refData, questSvc, time);
     }
@@ -179,7 +180,7 @@ public class QuestSourceTests : IDisposable
             src.Progress[key].DismissedAt.Should().NotBeNull();
 
             // Same Completed event re-fires (Subscribe replay on a fresh
-            // subscriber, or QuestService dispatching a duplicate). Dismissal
+            // subscriber, or PlayerQuestJournalService dispatching a duplicate). Dismissal
             // must survive — clearing it would resurrect a row the user X'd.
             questSvc.RaiseCompleted("Q1", completedAt);
             src.Progress[key].DismissedAt.Should().NotBeNull(

--- a/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
+++ b/tests/Gandalf.Tests/QuestTimersViewModelTests.cs
@@ -35,7 +35,7 @@ public class QuestTimersViewModelTests : IDisposable
     }
 
     private (QuestTimersViewModel vm, QuestSource src, DerivedTimerProgressService derived,
-             FakeQuestService questSvc, ManualTime time)
+             FakePlayerQuestJournalService questSvc, ManualTime time)
         Build(params (string Key, Mithril.Reference.Models.Quests.Quest Quest)[] quests)
     {
         var active = new FakeActiveCharacterService();
@@ -49,7 +49,7 @@ public class QuestTimersViewModelTests : IDisposable
         var derived = new DerivedTimerProgressService(derivedView, time);
 
         var refData = new FakeReferenceData(quests);
-        var questSvc = new FakeQuestService();
+        var questSvc = new FakePlayerQuestJournalService();
         var src = new QuestSource(derived, refData, questSvc, time);
         var vm = new QuestTimersViewModel(src, derived, time);
         return (vm, src, derived, questSvc, time);

--- a/tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj
+++ b/tests/Mithril.GameState.Tests/Mithril.GameState.Tests.csproj
@@ -26,7 +26,7 @@
          for why these aren't broadcast to every test project). -->
     <Compile Include="..\TestSupport\FakeReferenceData.cs"
              Link="TestSupport\FakeReferenceData.cs" />
-    <Compile Include="..\TestSupport\FakeQuestService.cs"
-             Link="TestSupport\FakeQuestService.cs" />
+    <Compile Include="..\TestSupport\FakePlayerQuestJournalService.cs"
+             Link="TestSupport\FakePlayerQuestJournalService.cs" />
   </ItemGroup>
 </Project>

--- a/tests/Mithril.GameState.Tests/Quests/PlayerQuestJournalServiceTests.cs
+++ b/tests/Mithril.GameState.Tests/Quests/PlayerQuestJournalServiceTests.cs
@@ -14,12 +14,12 @@ namespace Mithril.GameState.Tests.Quests;
 
 [Trait("Category", "FileIO")]
 [Collection("FileIO")]
-public sealed class QuestServiceTests : IDisposable
+public sealed class PlayerQuestJournalServiceTests : IDisposable
 {
     private readonly string _dir;
     private readonly string _charactersDir;
 
-    public QuestServiceTests()
+    public PlayerQuestJournalServiceTests()
     {
         _dir = TestPaths.CreateTempDir("quests_service");
         _charactersDir = Path.Combine(_dir, "characters");
@@ -31,8 +31,8 @@ public sealed class QuestServiceTests : IDisposable
         try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
     }
 
-    private (QuestService svc, ScriptedStream stream, FakeActiveCharacterService active,
-             FakeReferenceData refData, PerCharacterView<QuestServiceState> view)
+    private (PlayerQuestJournalService svc, ScriptedStream stream, FakeActiveCharacterService active,
+             FakeReferenceData refData, PerCharacterView<PlayerQuestJournalState> view)
         Build(IReadOnlyList<(string Key, Mithril.Reference.Models.Quests.Quest Quest)>? quests = null,
               string character = "Arthur", string server = "Kwatoxi")
     {
@@ -40,12 +40,12 @@ public sealed class QuestServiceTests : IDisposable
         var active = new FakeActiveCharacterService();
         active.SetActiveCharacter(character, server);
 
-        var store = new PerCharacterStore<QuestServiceState>(_charactersDir, "quests.json",
-            QuestServiceStateJsonContext.Default.QuestServiceState);
-        var view = new PerCharacterView<QuestServiceState>(active, store);
+        var store = new PerCharacterStore<PlayerQuestJournalState>(_charactersDir, "quests.json",
+            PlayerQuestJournalStateJsonContext.Default.PlayerQuestJournalState);
+        var view = new PerCharacterView<PlayerQuestJournalState>(active, store);
 
         var stream = new ScriptedStream(Array.Empty<string>());
-        var svc = new QuestService(
+        var svc = new PlayerQuestJournalService(
             stream.Driver,
             new QuestJournalLoadParser(),
             new QuestAcceptedParser(refData),
@@ -122,32 +122,51 @@ public sealed class QuestServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkJournalLoad_FiresDiffEventsAgainstPriorActiveSet()
+    public async Task BulkJournalLoad_InfersAbandonedFromDroppedEntries_StampedOnLogTimestamp()
     {
+        // The Abandoned event here is a real inference from a real log event:
+        // ProcessLoadQuests is PG's authoritative snapshot of the journal, so
+        // anything that was active before and is absent from the new snapshot
+        // has been abandoned (or completed off-session, but Abandoned is the
+        // conservative observation given no ProcessCompleteQuest preceded).
+        // Timestamps come from the log line itself — no wall-clock leak. This
+        // is the inference that #607 explicitly preserves while retiring the
+        // character-switch synthesis path.
         var quests = new[]
         {
             QuestFactory.Repeatable("quest_1", "Q1", "Q1", TimeSpan.FromHours(1)),
             QuestFactory.Repeatable("quest_2", "Q2", "Q2", TimeSpan.FromHours(1)),
             QuestFactory.Repeatable("quest_3", "Q3", "Q3", TimeSpan.FromHours(1)),
         };
+        var firstLoadTs = new DateTime(2026, 5, 18, 10, 0, 0, DateTimeKind.Utc);
+        var secondLoadTs = new DateTime(2026, 5, 18, 11, 0, 0, DateTimeKind.Utc);
         var (svc, stream, _, _, _) = Build(quests);
         var runTask = svc.StartAsync(CancellationToken.None);
         try
         {
             // Pre-seed: Q1 + Q2 are active.
-            stream.Push("[10:00:00] LocalPlayer: ProcessLoadQuests(1, TransitionalQuestState[], [], [1,2,])");
+            stream.Push(new RawLogLine(firstLoadTs,
+                "LocalPlayer: ProcessLoadQuests(1, TransitionalQuestState[], [], [1,2,])"));
             await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
 
             var live = new List<QuestEvent>();
             using var sub = svc.Subscribe(live.Add);
             live.Clear(); // discard the Subscribe replay so we only see the next bulk diff
 
-            // New bulk load: Q1 stays, Q2 leaves, Q3 arrives → 1 Abandoned + 1 Accepted.
-            stream.Push("[11:00:00] LocalPlayer: ProcessLoadQuests(1, TransitionalQuestState[], [], [1,3,])");
+            // New bulk load: Q1 stays, Q2 leaves, Q3 arrives → 1 Abandoned + 1 Accepted,
+            // both stamped on the log-line timestamp (not wall-clock).
+            stream.Push(new RawLogLine(secondLoadTs,
+                "LocalPlayer: ProcessLoadQuests(1, TransitionalQuestState[], [], [1,3,])"));
             await stream.WaitForDrainAsync(TimeSpan.FromSeconds(2));
 
-            live.Should().Contain(e => e.Kind == QuestEventKind.Abandoned && e.InternalName == "Q2");
-            live.Should().Contain(e => e.Kind == QuestEventKind.Accepted && e.InternalName == "Q3");
+            live.Should().Contain(e =>
+                e.Kind == QuestEventKind.Abandoned
+                && e.InternalName == "Q2"
+                && e.Timestamp == secondLoadTs);
+            live.Should().Contain(e =>
+                e.Kind == QuestEventKind.Accepted
+                && e.InternalName == "Q3"
+                && e.Timestamp == secondLoadTs);
             live.Should().NotContain(e => e.Kind == QuestEventKind.Accepted && e.InternalName == "Q1");
             svc.ActiveQuests.Should().ContainKeys("Q1", "Q3").And.NotContainKey("Q2");
         }
@@ -264,8 +283,15 @@ public sealed class QuestServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CharacterSwitch_ReloadsStateAndFiresDiffToLiveSubscribers()
+    public async Task CharacterSwitch_DoesNotSynthesizeEvents()
     {
+        // Pre-#607 this service listened for PerCharacterView.CurrentChanged and
+        // synthesized Abandoned/Accepted/Completed events stamped with
+        // _time.GetUtcNow() so live subscribers could mirror the swap without
+        // re-subscribing. Under the world-sim's per-character scope the path
+        // collapses: character B's ledger was always character B's; binding
+        // the UI to it fires no events on character A's service instance.
+        // This regression guards the absence of that synthesis.
         var quests = new[]
         {
             QuestFactory.Repeatable("quest_1", "Q1", "Q1", TimeSpan.FromHours(1)),
@@ -277,11 +303,11 @@ public sealed class QuestServiceTests : IDisposable
             var refData = new FakeReferenceData(quests);
             var bobActive = new FakeActiveCharacterService();
             bobActive.SetActiveCharacter("Bob", "Kwatoxi");
-            var bobStore = new PerCharacterStore<QuestServiceState>(_charactersDir, "quests.json",
-                QuestServiceStateJsonContext.Default.QuestServiceState);
-            var bobView = new PerCharacterView<QuestServiceState>(bobActive, bobStore);
+            var bobStore = new PerCharacterStore<PlayerQuestJournalState>(_charactersDir, "quests.json",
+                PlayerQuestJournalStateJsonContext.Default.PlayerQuestJournalState);
+            var bobView = new PerCharacterView<PlayerQuestJournalState>(bobActive, bobStore);
             var bobStream = new ScriptedStream(Array.Empty<string>());
-            var bobSvc = new QuestService(bobStream.Driver, new QuestJournalLoadParser(),
+            var bobSvc = new PlayerQuestJournalService(bobStream.Driver, new QuestJournalLoadParser(),
                 new QuestAcceptedParser(refData), new QuestCompletedParser(refData), bobView, refData);
             try
             {
@@ -291,8 +317,6 @@ public sealed class QuestServiceTests : IDisposable
             finally { await StopAsync(bobSvc); }
         }
 
-        // Now run as Arthur, accept Q1, then switch to Bob → should see
-        // Abandoned(Q1) + Accepted(Q2) on the live subscriber.
         var (svc, stream, active, _, _) = Build(quests, character: "Arthur");
         try
         {
@@ -303,11 +327,15 @@ public sealed class QuestServiceTests : IDisposable
             using var sub = svc.Subscribe(live.Add);
             live.Clear(); // discard Subscribe replay
 
+            // Flip the active-character service. Pre-#607 this would have
+            // fanned out Abandoned(Q1) + Accepted(Q2) synthesised events;
+            // post-#607 nothing happens — the UI is expected to re-resolve
+            // the per-character service for the new character instead.
             active.SetActiveCharacter("Bob", "Kwatoxi");
 
-            live.Should().Contain(e => e.Kind == QuestEventKind.Abandoned && e.InternalName == "Q1");
-            live.Should().Contain(e => e.Kind == QuestEventKind.Accepted && e.InternalName == "Q2");
-            svc.ActiveQuests.Should().ContainKey("Q2").And.NotContainKey("Q1");
+            live.Should().BeEmpty("character switch must not synthesise events on the existing service");
+            svc.ActiveQuests.Should().ContainKey("Q1").And.NotContainKey("Q2",
+                "the service is bound to Arthur's hydrated state; Bob's ledger is not its concern");
         }
         finally { await StopAsync(svc); }
     }
@@ -340,7 +368,7 @@ public sealed class QuestServiceTests : IDisposable
         finally { await StopAsync(svc); _ = runTask; }
     }
 
-    private static async Task RunUntilDrainedAsync(QuestService svc, ScriptedStream stream)
+    private static async Task RunUntilDrainedAsync(PlayerQuestJournalService svc, ScriptedStream stream)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var runTask = svc.StartAsync(cts.Token);
@@ -350,7 +378,7 @@ public sealed class QuestServiceTests : IDisposable
         _ = runTask;
     }
 
-    private static async Task StopAsync(QuestService svc)
+    private static async Task StopAsync(PlayerQuestJournalService svc)
     {
         try { await svc.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2)); }
         catch { /* test cleanup */ }

--- a/tests/TestSupport/FakePlayerQuestJournalService.cs
+++ b/tests/TestSupport/FakePlayerQuestJournalService.cs
@@ -3,16 +3,16 @@ using Mithril.GameState.Quests;
 namespace Mithril.TestSupport;
 
 /// <summary>
-/// Minimal <see cref="IQuestService"/> stand-in for tests that need to drive
-/// QuestSource / quest-aware modules without spinning up the real
+/// Minimal <see cref="IPlayerQuestJournalService"/> stand-in for tests that need to
+/// drive <c>QuestSource</c> / quest-aware modules without spinning up the real
 /// log-tailing service. Exposes <see cref="RaiseAccepted"/> /
 /// <see cref="RaiseAbandoned"/> / <see cref="RaiseCompleted"/> to mutate the
 /// internal maps and fan out the matching <see cref="QuestEvent"/> to
 /// subscribers — same shape as the real service's per-event dispatch path.
 /// Subscribe atomically replays current state, mirroring the real
-/// <see cref="QuestService"/>.
+/// <see cref="PlayerQuestJournalService"/>.
 /// </summary>
-internal sealed class FakeQuestService : IQuestService
+internal sealed class FakePlayerQuestJournalService : IPlayerQuestJournalService
 {
     private readonly Dictionary<string, QuestJournalEntry> _active = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, QuestCompletionState> _completed = new(StringComparer.OrdinalIgnoreCase);
@@ -129,9 +129,9 @@ internal sealed class FakeQuestService : IQuestService
 
     private sealed class Subscription : IDisposable
     {
-        private readonly FakeQuestService _svc;
+        private readonly FakePlayerQuestJournalService _svc;
         private Action<QuestEvent>? _handler;
-        public Subscription(FakeQuestService svc, Action<QuestEvent> handler) { _svc = svc; _handler = handler; }
+        public Subscription(FakePlayerQuestJournalService svc, Action<QuestEvent> handler) { _svc = svc; _handler = handler; }
         public void Dispose()
         {
             var h = Interlocked.Exchange(ref _handler, null);


### PR DESCRIPTION
## Summary
- Renames `IQuestService` → `IPlayerQuestJournalService` (state half) and `QuestService` → `PlayerQuestJournalService`. Quest *reference* data continues to live in `IReferenceDataService.Quests`; consumers now join the two surfaces explicitly instead of conflating them in one service.
- Retires the `PerCharacterView<…>.CurrentChanged` listener + `ReloadFromView` synthesis path that minted `Abandoned`/`Accepted`/`Completed` events stamped on `_time.GetUtcNow()`. Under per-character world scope each character has its own ledger; character switch is a UI binding swap, not a state mutation. `TimeProvider` is no longer injected into the service.
- The log-derived `Abandoned`-inference inside `HandleJournalLoaded` **stays** — that is a real inference from a real `ProcessLoadQuests` snapshot, stamped on the log line's timestamp (no wall-clock leak).

## Closes
Closes #607 (part of #601 — world-sim migration umbrella, item #6 in `docs/world-simulator.md`).

## Acceptance (from the issue)
- [x] `IPlayerQuestJournalService` exists, folds Player.log quest events
- [x] `OnViewCurrentChanged` listener removed; no character-switch event synthesis
- [x] Character-switch is a UI binding swap, not a state mutation
- [x] `IQuestService` (the conflated service) deleted (cleanly renamed to `IPlayerQuestJournalService`)
- [x] Tests cover both natural log-driven mutations and the `ProcessLoadQuests` `Abandoned`-inference
- [x] No `_time.GetUtcNow()` calls in `PlayerQuestJournalService` state-decision paths (TimeProvider injection removed entirely)

## Notable details
- Construction-time hydration is a pure load from `PerCharacterView.Current` — no event firing (no subscribers exist yet anyway). `Persistence_StateSurvivesServiceRestart` continues to pass.
- Persisted JSON path (`characters/{slug}/quests.json`) and schema (`SchemaVersion = 1`) are unchanged; the rename is purely C#-type-level and doesn't migrate data on disk.
- Consumers updated: `QuestSource`, `FakePlayerQuestJournalService`, `Gandalf.Module` DI/xmldoc, `IGameSessionService` xmldoc, `PlayerPositionTracker` xmldoc, `module-signal-map.md`, `module-charters.md`, `player-skill-state-service.md`. The audit doc (`world-sim-migration-audit.md`) is left as the dated snapshot it advertises itself to be.

## Test plan
- [x] `dotnet build Mithril.slnx` — clean, 0 warnings 0 errors
- [x] `dotnet test Mithril.slnx` — full suite green (Mithril.GameState.Tests: 382 ✅; Gandalf.Tests: 306 ✅; everything else passing)
- [x] New regression test `CharacterSwitch_DoesNotSynthesizeEvents` — guards the absence of synthesis when the active character flips on a running service instance
- [x] `BulkJournalLoad_InfersAbandonedFromDroppedEntries_StampedOnLogTimestamp` — uses explicit log timestamps and asserts events carry the log-line timestamp, not wall-clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)