### PR TITLE
fix(world-sim): widen orchestrator probe to union YAML node IDs

### DIFF
--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -21,12 +21,17 @@ You do NOT call `gh pr merge` (the shepherd does). You do NOT dispatch generic-p
 
 Idle ticks dominate the workload. Reading design docs every tick burns ~100K tokens for nothing on most invocations. Reorder the tick so the cheap gh-state probe runs FIRST and gates which (if any) docs need loading.
 
-### Always read (cheap probe, ~2 gh calls)
+### Always read (cheap probe, ~2 gh calls + 1 batched union)
 
 Run these every tick. All `gh` invocations include `-R moumantai-gg/mithril` to remove cwd dependence:
 
 - `gh issue view 601 -R moumantai-gg/mithril --json state,labels,comments` — check for `pause` label, closed umbrella, and recent error-comment history (used by §On errors)
-- `gh issue list -R moumantai-gg/mithril --label module:world-sim --state open --json number,labels,title` — open task issues + their labels (used to detect `orchestrator-dispatch:*`, `orchestrator-blocked` for ready-set filtering and cross-tick recovery)
+- `gh issue list -R moumantai-gg/mithril --label module:world-sim --state open --json number,labels,title` — open follow-on / orchestrator infra issues that carry the `module:world-sim` label
+- Grep `docs/world-simulator-orchestration-plan.md` §Dependency graph for `id:` lines to extract the YAML node list (~16 issue numbers — phase tasks, all phases). Then batched: `gh issue view <N> -R moumantai-gg/mithril --json number,state,labels,title` for each. These are needed because planned phase tasks carry module-specific labels (e.g., #607 → `module:mithril.gamestate`, #608 → `module:arwen`, #613 → `module:gandalf`, #603 → `module:saruman`, #606 → `module:legolas`) rather than `module:world-sim`, so the label-filtered list above does NOT find them.
+  - Optimization: a single `gh issue list -R moumantai-gg/mithril --state open --json number,state,labels,title --search "<comma-list of issue numbers>"` may collapse the ~16 view calls into one, if gh's search syntax supports an explicit issue-number list. Verify the behaviour before relying on it; the batched-view path is the safe default.
+- Union both sets, deduplicating by issue number; the union is the open-issue set for step 1 (PR linkage scan) and step 2 (ready-set + dep-graph computation). Treat a YAML node whose `gh issue view` reports closed state as out-of-scope for ready-set filtering but still eligible for step 1's auto-close check.
+
+This union aligns the probe with §Dep graph derivation below, which already declares the dep graph is the UNION of `module:world-sim`-labeled issues and YAML nodes. The narrower label-only enumeration is the cycle-12 (2026-05-22) bug that left PR #648 → #607 invisible to steps 1–3, since #607 carries only `module:mithril.gamestate`.
 
 This is enough to decide which of steps 0-3 will fire. Pick the step, THEN load only the docs that step needs:
 
@@ -34,10 +39,10 @@ This is enough to decide which of steps 0-3 will fire. Pick the step, THEN load 
 |------|-------------|
 | 0 (circuit breaker)              | none |
 | 1 (cross-tick recovery)          | none — pure label + comment-marker work |
-| 2 (dispatch shepherd)            | `docs/world-simulator-orchestration-plan.md` (§Dependency graph — YAML source of truth for the planned-migration chain, phase ordering) |
+| 2 (dispatch shepherd)            | `docs/world-simulator-orchestration-plan.md` (§Dependency graph — YAML source of truth for the planned-migration chain, phase ordering). The probe already grepped `id:` lines for node enumeration; step 2 additionally needs the `phase:` field and the edges block. |
 | 3 (idle)                         | none |
 
-Steps 0, 1, and 3 complete with zero doc reads.
+Steps 0, 1, and 3 complete with zero further doc reads beyond the probe's `id:`-line grep.
 
 ## The 3-step decision logic
 


### PR DESCRIPTION
## Summary

- Widens the world-sim orchestrator's `Always read (cheap probe)` section to UNION the `module:world-sim`-labeled issue list with a batched `gh issue view` over the ~16 YAML node IDs grepped from `docs/world-simulator-orchestration-plan.md` §Dependency graph.
- Aligns the probe with §Dep graph derivation, which already declares the dep graph as a UNION of `module:world-sim`-labeled issues + YAML nodes — the probe was the only piece still doing label-only enumeration.
- Fixes the cycle-12 (2026-05-22) gap where PR #648 → #607 was invisible to steps 1–3 because #607 carries only `module:mithril.gamestate`.

Closes #649

## Test plan

Doc-only change; verification is structural rather than runtime.

- [x] Read the resulting orchestrator doc end-to-end; §Tick-time reads, step 1 (PR linkage scan), step 2 (ready-set + dep-graph), and §Dep graph derivation are mutually consistent.
- [x] Heading updated to reflect the new probe shape (`~2 gh calls + 1 batched union`).
- [x] Step-needs matrix annotated to note the probe's `id:`-line grep so step 2's doc-load is no longer the only way the YAML enters the tick.
- [ ] Next orchestrator tick after merge: probe enumerates phase tasks (e.g., #607, #608, #613); PR #648 becomes visible to step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
