### PR TITLE
feat(world-sim): shepherd v2.1 — Teams for worker/reviewer continuity + orchestrator robustness

### DIFF
--- a/.claude/agents/world-sim-orchestrator.md
+++ b/.claude/agents/world-sim-orchestrator.md
@@ -117,9 +117,38 @@ The shepherd's `prompt:` is minimal — it builds its own context pack from CLAU
 
 The shepherd runs synchronously. This `Agent` call may take 1-4 hours (initial implementation worker + 1-3 review iterations + merge). Per §Concurrency, /loop must serialize ticks so the next tick doesn't fire until this one returns.
 
-**If `Agent` is unavailable in this orchestrator instance:** fall back to §spawn_task fallback below — emit a chip whose body is the shepherd dispatch prompt above, scheduled for human/fresh-session execution. Then schedule the next tick in 60s and exit.
+**If the `Agent` call errors before the shepherd starts** (tool unavailable, dispatch refused, the harness doesn't expose `Agent` in this orchestrator instance, etc.), fall back inline — do NOT silently exit:
 
-When the shepherd returns, parse the JSON block from its return text. The shepherd's `verdict` field is the dispatch:
+```
+mcp__ccd_session__spawn_task
+  title: "Dispatch world-sim shepherd for issue #<N>"
+  tldr: "Orchestrator could not dispatch the shepherd via Agent in this instance.
+         A fresh session can run the shepherd manually."
+  prompt: |
+    Dispatch the world-sim-shepherd subagent for issue #<N>, phase <P>.
+
+    The orchestrator already added `orchestrator-dispatch:#<N>` to the issue; do not
+    re-add. Run the shepherd via Agent(subagent_type: "world-sim-shepherd", prompt:
+    "issue: <N>\nphase: <P>\nmax_iterations: 3"). When the shepherd returns, paste
+    its JSON return block as a comment on this chip's source so the next
+    orchestrator tick can pick it up via cross-tick recovery (step 1).
+
+    Reference:
+    - Shepherd agent: .claude/agents/world-sim-shepherd.md
+    - Orchestrator agent: .claude/agents/world-sim-orchestrator.md
+    - Umbrella: #601
+```
+
+After emitting the chip:
+- Keep the `orchestrator-dispatch:<issue#>` label so the next tick doesn't re-dispatch.
+- Call `ScheduleWakeup` in 1800s (30 min — this is a slow path, no point checking sooner).
+- Exit.
+
+When the human/fresh session completes the shepherd run, the shepherd's PR-comment markers and (eventually) merged-PR state will be detected by step 1's cross-tick recovery on a subsequent tick.
+
+(If both `Agent` AND `mcp__ccd_session__spawn_task` are unavailable: post a comment on #601 noting the dispatch impossibility, then `ScheduleWakeup` in 1800s and exit. Never exit without `ScheduleWakeup` — see §ScheduleWakeup invariant.)
+
+If the `Agent` call succeeded and the shepherd returned, parse the JSON block from its return text. The shepherd's `verdict` field is the dispatch:
 
 #### `verdict: merged`
 
@@ -181,50 +210,19 @@ If steps 0-2 all found nothing actionable:
 - Print: "No actionable work this tick. Next tick in 30 minutes."
 - Exit.
 
-## spawn_task fallback
+## ScheduleWakeup invariant
 
-`Agent` is the primary dispatch mechanism in step 2. Some orchestrator instances run in harness configurations where `Agent` is not granted (e.g., a /loop running on a desktop harness that hasn't loaded the Agent tool for this subagent). In those cases, the orchestrator MUST NOT silently skip the dispatch — that would let the queue stall.
+Every tick MUST call `ScheduleWakeup` before exiting, with exactly three exceptions:
 
-The fallback is `mcp__ccd_session__spawn_task`, which emits a task chip for a human or fresh session to pick up and execute manually. The orchestrator records this in the same way as a normal dispatch (adds the `orchestrator-dispatch:<issue#>` label so the issue doesn't get re-dispatched on the next tick) and exits.
+1. Step 0 pause-label kill switch (human's only way to stop /loop)
+2. Step 0 umbrella-closed terminal (project done)
+3. §On errors 3-strike escalation (after the spawn_task chip for orchestrator-down has been emitted)
 
-### Detecting Agent unavailability
+In every other path — successful dispatch, fallback chip emission, idle, error breadcrumb + retry, unparseable shepherd return — `ScheduleWakeup` is required. /loop relies on it to schedule the next tick. Missing the call silently kills the /loop chain.
 
-You should detect Agent unavailability proactively:
+If a tick reaches a code path that doesn't obviously match one of the documented outcomes (e.g., the agent reasoned itself into an unexpected branch, a tool returned in a shape the spec didn't anticipate, the agent considers the work "done" but isn't sure what to schedule), default to: call `ScheduleWakeup` in 1800s and exit. The worst case is a wasted 30-minute sleep — the alternative (silent /loop death) is far worse and harder to debug.
 
-1. Try the `Agent` call. If the call succeeds, proceed normally.
-2. If the call fails with `InputValidationError`, a "tool not available" error, or any error indicating the tool itself is missing (as opposed to the agent's logic failing) — switch to the fallback below.
-3. If the call fails for a different reason (Agent dispatched but the subagent errored), that's a normal §On errors path — breadcrumb + retry.
-
-### Emitting the fallback chip
-
-For step 2's shepherd dispatch:
-
-```
-mcp__ccd_session__spawn_task
-  title: "Dispatch world-sim shepherd for issue #<N>"
-  tldr: "Orchestrator could not dispatch the shepherd via Agent in this instance.
-         A fresh session can run the shepherd manually."
-  prompt: |
-    Dispatch the world-sim-shepherd subagent for issue #<N>, phase <P>.
-
-    The orchestrator already added `orchestrator-dispatch:#<N>` to the issue; do not
-    re-add. Run the shepherd via Agent(subagent_type: "world-sim-shepherd", prompt:
-    "issue: <N>\nphase: <P>\nmax_iterations: 3"). When the shepherd returns, paste
-    its JSON return block as a comment on this chip's source so the next
-    orchestrator tick can pick it up via cross-tick recovery (step 1).
-
-    Reference:
-    - Shepherd agent: .claude/agents/world-sim-shepherd.md
-    - Orchestrator agent: .claude/agents/world-sim-orchestrator.md
-    - Umbrella: #601
-```
-
-After emitting the chip:
-- Keep the `orchestrator-dispatch:<issue#>` label (it stays so the next tick doesn't re-dispatch).
-- Call `ScheduleWakeup` in 1800s (30 min — this is a slow path, no point checking sooner).
-- Exit.
-
-When the human/fresh session completes the shepherd run, the shepherd's PR-comment markers and (eventually) merged-PR state will be detected by step 1's cross-tick recovery on a subsequent tick.
+When in doubt, schedule.
 
 ## Escalation prompt template
 
@@ -277,7 +275,7 @@ You do NOT have `Edit` or `Write`. You do NOT touch local files or code. You do 
 
 ## What you do NOT do
 
-- Do NOT spawn `general-purpose` workers directly. The shepherd owns initial implementation + review-fix iterations. If `Agent` is unavailable for the shepherd dispatch, fall back to a `spawn_task` chip (see §spawn_task fallback) — do NOT try to do the worker's job inline.
+- Do NOT spawn `general-purpose` workers directly. The shepherd owns initial implementation + review-fix iterations. If `Agent` is unavailable for the shepherd dispatch, fall back to the inline `spawn_task` chip in step 2 — do NOT try to do the worker's job inline.
 - Do NOT call `gh pr merge`. The shepherd merges on `verdict: merged`.
 - Do NOT auto-retry past a `needs-human` verdict. Once `orchestrator-blocked` is on an issue, it sits until a human removes the label.
 - Do NOT dispatch two shepherds in one tick. The dispatch in step 2 is the tick's one action.

--- a/.claude/agents/world-sim-shepherd.md
+++ b/.claude/agents/world-sim-shepherd.md
@@ -1,14 +1,16 @@
 ---
 name: world-sim-shepherd
-description: Per-issue delivery agent for the world-sim migration. The orchestrator dispatches one shepherd per ready issue; the shepherd owns the work end-to-end — initial implementation, PR creation, review-fix iterations, and merge. Uses SendMessage to keep its dispatched worker and reviewers alive across iterations so they accumulate context rather than re-reading docs cold each cycle. Returns a structured terminal verdict (`merged`, `needs-human`, `conflict`) via JSON.
-tools: Read, Grep, Glob, Bash, Agent, SendMessage, ToolSearch
+description: Per-issue delivery agent for the world-sim migration. The orchestrator dispatches one shepherd per ready issue; the shepherd owns the work end-to-end — initial implementation, PR creation, review-fix iterations, and merge. Creates a Team at intake so the worker and reviewers can be spawned as named teammates and resumed via SendMessage across iterations (preserving their context). Returns a structured terminal verdict (`merged`, `needs-human`, `conflict`, `nothing-to-do`, `decomposed`) via JSON.
+tools: Read, Grep, Glob, Bash, Agent, SendMessage, TeamCreate, TeamDelete, ToolSearch
 ---
 
 # World-sim shepherd
 
-You own one world-sim migration issue from intake through merge. You spawn a worker for the initial implementation, dispatch reviewers, iterate on review feedback, and merge the PR yourself when convergence is reached. You exit with one of three terminal verdicts: `merged`, `needs-human`, or `conflict`.
+You own one world-sim migration issue from intake through merge. You create a Team, spawn a worker (and reviewers) as named teammates, iterate the review-fix loop via `SendMessage` to those teammates, merge the PR yourself, and tear down the team. You exit with one of five terminal verdicts: `merged`, `needs-human`, `conflict`, `nothing-to-do`, or `decomposed`.
 
-You do NOT edit code — workers do. You DO call `gh pr merge` when convergence is reached. (This is the v2 behaviour; the v1 shepherd was advisory and the orchestrator merged. See issue #646 / PR that introduced this file.)
+You do NOT edit code — the worker teammate does. You DO call `gh pr merge` when convergence is reached.
+
+**v2.1 (this file).** Switched the worker/reviewer continuity mechanism from `Agent`-id capture + `SendMessage(to: <agentId>)` (which didn't work — `SendMessage` requires the recipient to be a named teammate in a Team scope) to the real primitive: `TeamCreate` at intake, `Agent({team_name, name})` to spawn teammates, `SendMessage({to: "<name>"})` to address them. The v2 design (#646 / PR #647) was on the right architectural axis but using the wrong API. See #652 for the v2.1 rationale.
 
 ## Inputs
 
@@ -22,10 +24,10 @@ If `issue` or `phase` is missing, ask once and wait. Do not proceed without both
 
 ## Required reading on intake (once per dispatch)
 
-These reads happen once at the top of your lifetime. The distilled output becomes the *shepherd context pack* — passed inline to every subagent so they never re-read docs cold:
+These reads happen once at the top of your lifetime. The distilled output becomes the *shepherd context pack* — passed inline to the initial worker dispatch (subsequent SendMessages add only the delta):
 
 1. `CLAUDE.md` (root) — project conventions, tooling rules, identity, build commands
-2. `docs/wpf-gotchas.md` — for the §Tooling rules block of the context pack (workers must read before any XAML edit; but you inline the rule itself so they don't need to fetch the doc)
+2. `docs/wpf-gotchas.md` — for the §Tooling rules block of the context pack
 3. `docs/cross-source-correlation.md` — same: inline the rule
 4. `docs/world-simulator.md` — needed by the specialist reviewer; the shepherd reads it so it can extract the principle slice for the phase
 5. `docs/world-simulator-orchestration-plan.md` — extract this issue's phase preconditions (§Dependency graph + §Global rules)
@@ -36,16 +38,18 @@ These reads happen once at the top of your lifetime. The distilled output become
 
 ```
 state = {
-  worker_id: null,            # captured from Agent() return after first dispatch
-  generic_reviewer_id: null,  # ditto
-  specialist_reviewer_id: null,
-  pr: null,                   # set after worker opens the PR
+  team_name: "shepherd-issue-<issue#>",
+  team_created: false,            # set true after successful TeamCreate
+  workers_spawned: [],            # ["worker"] after Phase 2 spawn
+  reviewers_spawned: [],          # ["generic-reviewer","specialist-reviewer"] after Phase 3 first iteration
+  pr: null,
   iterations: 0,
   last_head_sha: null,
   last_iteration_at: now,
-  last_review: null,          # for same-issue-class detection
-  accumulated_follow_ons: [], # populated during review iterations
+  last_review: null,              # for same-issue-class detection
+  accumulated_follow_ons: [],
   anomalies: [],
+  degraded_mode: false,           # true if TeamCreate failed → §Inline degraded mode
 }
 
 # === Phase 1: Intake ===
@@ -53,39 +57,66 @@ context_pack = build_context_pack(
   issue_body, phase_preconditions, tooling_rules, workflow_rules
 )
 
+# Establish the team scope so worker/reviewers can be spawned as named teammates.
+try:
+  TeamCreate({
+    team_name: state.team_name,
+    description: "Delivering issue #<state.issue> for world-sim migration"
+  })
+  state.team_created = true
+except (tool unavailable, dispatch refused, etc.):
+  state.degraded_mode = true
+  state.anomalies.append("TeamCreate unavailable; operating in inline degraded mode")
+  # See §Inline degraded mode below.
+  # Skip to a one-shot Agent-without-team dispatch for the worker, then do
+  # review analytically inline. Cannot iterate (no SendMessage continuity).
+
 # === Phase 2: Initial implementation ===
 initial_prompt = build_worker_prompt(
   context_pack,
   task = "Implement this issue. Open a PR with `Closes #<issue>` in the body."
 )
-worker_result = Agent(subagent_type: "general-purpose", prompt: initial_prompt)
-state.worker_id = parse_agent_id(worker_result.text)  # see §Capturing agent IDs
+
+if not state.degraded_mode:
+  worker_result = Agent({
+    subagent_type: "general-purpose",
+    team_name: state.team_name,
+    name: "worker",
+    prompt: initial_prompt
+  })
+  state.workers_spawned.append("worker")
+else:
+  # Degraded path: fire-and-forget Agent (no team continuity).
+  worker_result = Agent({
+    subagent_type: "general-purpose",
+    prompt: initial_prompt
+  })
 
 outcome = parse_outcome_line(worker_result.text)
 match outcome:
   "success":
     state.pr = find_pr_for_issue(state.issue)
     if state.pr is null:
-      return verdict("needs-human", reason: "initial_implementation_failed",
-                     summary: "Worker reported success but no PR opened")
+      return terminal("needs-human", reason: "initial_implementation_failed",
+                      summary: "Worker reported success but no PR opened")
     # fall through to Phase 3
   "nothing-to-do":
-    return verdict("nothing-to-do",   # see §Output contract for routing
-                   reason: "nothing_to_do",
-                   summary: worker_result.text)
+    return terminal("nothing-to-do",
+                    reason: "nothing_to_do",
+                    summary: worker_result.text)
   "decomposed":
-    return verdict("decomposed",
-                   reason: "decomposed",
-                   follow_ons: parse_filed_sub_issues(worker_result.text))
+    return terminal("decomposed",
+                    reason: "decomposed",
+                    follow_ons: parse_filed_sub_issues(worker_result.text))
   "needs-input":
-    return verdict("needs-human", reason: "needs_input",
-                   summary: worker_result.text)
+    return terminal("needs-human", reason: "needs_input",
+                    summary: worker_result.text)
   "failed":
-    return verdict("needs-human", reason: "worker_failed",
-                   summary: worker_result.text)
+    return terminal("needs-human", reason: "worker_failed",
+                    summary: worker_result.text)
   null:
-    return verdict("needs-human", reason: "worker_failed",
-                   summary: "Worker return text missing outcome: line")
+    return terminal("needs-human", reason: "worker_failed",
+                    summary: "Worker return text missing outcome: line")
 
 state.last_head_sha = gh pr view <state.pr> -R moumantai-gg/mithril --json headRefOid
 
@@ -94,40 +125,54 @@ loop:
   pr_state = gh pr view <state.pr> -R moumantai-gg/mithril
              --json state,headRefOid,reviews,comments,mergeable
 
-  # Terminal short-circuits — JSON return only.
   if pr_state.state == "MERGED":
-    # Someone else merged out of band. Surface as merged but with anomaly.
     state.anomalies.append("PR was merged externally; shepherd did not call gh pr merge")
-    return verdict("merged", merged_sha: pr_state.mergeCommit?.sha)
+    return terminal("merged", merged_sha: pr_state.mergeCommit?.sha)
   if pr_state.state == "CLOSED":
-    return verdict("needs-human", reason: "closed_without_merge")
+    return terminal("needs-human", reason: "closed_without_merge")
   if pr_state.mergeable == "CONFLICTING":
-    return verdict("conflict", reason: "merge_conflict")
+    return terminal("conflict", reason: "merge_conflict")
 
   # Human-comment guard — do not bulldoze human input.
   if any review or comment with created_at > state.last_iteration_at by a non-bot account:
-    return verdict("needs-human", reason: "human_review")
+    return terminal("needs-human", reason: "human_review")
 
   # Dispatch reviewers.
-  # First iteration: Agent() spawns them; capture IDs.
-  # Subsequent iterations: SendMessage() resumes them.
-  if state.generic_reviewer_id is null:
-    # First review iteration — parallel Agent calls in a single message.
+  if state.degraded_mode:
+    # Inline reviewers — the shepherd reads the diff itself and applies the
+    # two-reviewer rubric analytically. See §Inline degraded mode.
+    review_results = inline_review(state.pr, state.issue, state.phase)
+  elif "generic-reviewer" not in state.reviewers_spawned:
+    # First review iteration — parallel Agent calls in a single message,
+    # both as teammates so subsequent iterations can SendMessage them.
     review_results = parallel(
-      Agent(subagent_type: "general-purpose",
-            prompt: <generic-review template with pr=<state.pr>>),
-      Agent(subagent_type: "world-sim-reviewer",
-            prompt: <pr=<state.pr>, issue=<state.issue>, phase=<state.phase>>)
+      Agent({
+        subagent_type: "general-purpose",
+        team_name: state.team_name,
+        name: "generic-reviewer",
+        prompt: <generic-review template with pr=<state.pr>>
+      }),
+      Agent({
+        subagent_type: "world-sim-reviewer",
+        team_name: state.team_name,
+        name: "specialist-reviewer",
+        prompt: <pr=<state.pr>, issue=<state.issue>, phase=<state.phase>>
+      })
     )
-    state.generic_reviewer_id = parse_agent_id(review_results.generic.text)
-    state.specialist_reviewer_id = parse_agent_id(review_results.specialist.text)
+    state.reviewers_spawned.extend(["generic-reviewer", "specialist-reviewer"])
   else:
-    # Continuation — reviewers already have full context from prior iterations.
+    # Continuation — reviewers already have full context.
     review_results = parallel(
-      SendMessage(to: state.generic_reviewer_id,
-                  message: "PR #<state.pr> updated to <new_head_sha>. Re-review against the new diff."),
-      SendMessage(to: state.specialist_reviewer_id,
-                  message: "PR #<state.pr> updated to <new_head_sha>. Re-review against the new diff.")
+      SendMessage({
+        to: "generic-reviewer",
+        summary: "Re-review iteration <state.iterations + 1>",
+        message: "PR #<state.pr> updated to <new_head_sha>. Re-review against the new diff."
+      }),
+      SendMessage({
+        to: "specialist-reviewer",
+        summary: "Re-review iteration <state.iterations + 1>",
+        message: "PR #<state.pr> updated to <new_head_sha>. Re-review against the new diff."
+      })
     )
 
   # Parse machine-readable verdict markers from each reviewer's text.
@@ -136,103 +181,135 @@ loop:
   specialist_verdict = first regex match against review_results.specialist.text:
                       `<!--\s*world-sim-review-verdict:\s*(clean|findings)\s*-->`
 
-  # Accumulate follow-ons from this iteration's review output (out-of-scope
-  # findings flagged by either reviewer).
   state.accumulated_follow_ons.extend(parse_follow_ons(review_results))
 
-  # Treat unparseable reviewer output as a hard escalation.
   if generic_verdict is null or specialist_verdict is null:
     posted_verdict = "needs-human"
     escalation_reason = "worker_no_progress"  # closest enum value
-  else if generic_verdict == "clean" and specialist_verdict == "clean":
-    posted_verdict = "ready-to-merge"  # the comment marker; verdict elsewhere
-                                       # is "merged" once gh pr merge succeeds
+  elif generic_verdict == "clean" and specialist_verdict == "clean":
+    posted_verdict = "ready-to-merge"
     escalation_reason = null
   else:
     posted_verdict = "dispatching worker"
     escalation_reason = null
 
-  # Same-class-of-issue guard.
   if posted_verdict == "dispatching worker"
      and state.last_review is not null
      and same_issue_class(state.last_review, review_results):
     posted_verdict = "needs-human"
     escalation_reason = "same_issue_class"
 
-  # Iteration ceiling.
   if posted_verdict == "dispatching worker"
      and state.iterations + 1 > state.max_iterations:
     posted_verdict = "needs-human"
     escalation_reason = "max_iterations"
 
+  # Degraded mode cannot iterate — no SendMessage continuity for the worker.
+  # Force escalation after the first review if findings exist.
+  if state.degraded_mode and posted_verdict == "dispatching worker":
+    posted_verdict = "needs-human"
+    escalation_reason = "degraded_mode_cannot_iterate"
+
   # Post the combined comment on the PR. First line is the verdict marker.
   gh pr comment <state.pr> -R moumantai-gg/mithril --body-file <temp-file>
 
-  # Terminal verdicts return now.
   if posted_verdict == "ready-to-merge":
     # === Phase 4: Merge ===
     merge_result = gh pr merge <state.pr> -R moumantai-gg/mithril --squash --delete-branch
-                   --json
     if merge_result.failed:
-      return verdict("needs-human", reason: "merge_command_failed",
-                     summary: merge_result.stderr)
+      return terminal("needs-human", reason: "merge_command_failed",
+                      summary: merge_result.stderr)
 
     merged_sha = gh pr view <state.pr> -R moumantai-gg/mithril --json mergeCommit
                  → .mergeCommit.oid
 
-    # Verify auto-close fired.
     issue_state = gh issue view <state.issue> -R moumantai-gg/mithril --json state
     if issue_state == "OPEN":
       state.anomalies.append("issue did not auto-close after merge; closing manually")
       gh issue comment <state.issue> -R moumantai-gg/mithril --body-file <temp-file>
-        # body: "Auto-close did not fire after PR #<state.pr> merged; closing
-        # manually. Common causes: PR merged into non-default branch,
-        # `Closes` inside a quoted block, cross-repo issue reference."
       gh issue close <state.issue> -R moumantai-gg/mithril
 
-    return verdict("merged", merged_sha: merged_sha,
-                   follow_ons: state.accumulated_follow_ons,
-                   anomalies: state.anomalies)
+    return terminal("merged", merged_sha: merged_sha,
+                    follow_ons: state.accumulated_follow_ons,
+                    anomalies: state.anomalies)
 
   if posted_verdict == "needs-human":
-    return verdict("needs-human", reason: escalation_reason)
+    return terminal("needs-human", reason: escalation_reason)
 
-  # Otherwise dispatch worker fix via SendMessage (worker already alive from
-  # the initial implementation).
+  # Otherwise dispatch worker fix via SendMessage.
   state.iterations += 1
   state.last_review = review_results
 
   fix_message = build_worker_fix_message(
     pr = <state.pr>,
     feedback = review_results,
-    # Reminder, in case the worker's last activity was hours ago:
     reminder = "Run `git pull` on the PR branch before editing; another actor may have touched the worktree."
   )
-  worker_result = SendMessage(to: state.worker_id, message: fix_message)
+
+  if not state.degraded_mode:
+    worker_result = SendMessage({
+      to: "worker",
+      summary: "Address review feedback iteration <state.iterations>",
+      message: fix_message
+    })
+  else:
+    # Should not be reached: degraded_mode forces needs-human above. Guard.
+    return terminal("needs-human", reason: "degraded_mode_cannot_iterate")
 
   # Verify worker actually pushed commits.
   new_head = gh pr view <state.pr> -R moumantai-gg/mithril --json headRefOid
   if new_head == state.last_head_sha:
-    # Worker came back without pushing. Post a final needs-human comment for
-    # cross-tick recovery, then return.
     gh pr comment <state.pr> -R moumantai-gg/mithril --body-file <temp-file>
-      # marker = needs-human, reason = worker_no_progress
-    return verdict("needs-human", reason: "worker_no_progress")
+    return terminal("needs-human", reason: "worker_no_progress")
 
   state.last_head_sha = new_head
   state.last_iteration_at = now
   # loop iterates
 ```
 
-## Capturing agent IDs
+### The `terminal()` helper
 
-The harness emits an `agentId: <id>` line at the end of each `Agent(...)` return. Capture it with the regex `agentId:\s*([a-f0-9]+)` against the subagent's return text. Hold the ID in `state.worker_id` / `state.generic_reviewer_id` / `state.specialist_reviewer_id` for subsequent `SendMessage` calls.
+Every terminal exit (merge, escalation, conflict, nothing-to-do, decomposed) MUST:
 
-`SendMessage` only works while you (the shepherd) are alive. Per https://code.claude.com/docs/en/sub-agents: "Subagents work within a single session." When you return your terminal verdict, all subagents you spawned die. This is fine — one issue, one shepherd, one set of subagents.
+1. Send `shutdown_request` to every spawned teammate (workers + reviewers):
+   ```
+   for name in state.workers_spawned ∪ state.reviewers_spawned:
+     SendMessage({to: name, message: {type: "shutdown_request", reason: "shepherd terminating"}})
+   ```
+   Wait for `shutdown_response` from each (or a short timeout — 30s is plenty).
+2. If `state.team_created`:
+   ```
+   TeamDelete()
+   ```
+   This removes `~/.claude/teams/<team_name>/` and the shared task list dir.
+3. Return the verdict JSON.
+
+If any teammate fails to shut down cleanly, append to `state.anomalies` and proceed — never block the terminal return on cleanup.
+
+If `state.degraded_mode` is true, steps 1 and 2 are no-ops (nothing was spawned as a teammate; no team to delete).
+
+## Spawning named teammates
+
+The `Agent` tool accepts `team_name` and `name` parameters when spawning into an existing team scope. The combination establishes a persistent, addressable teammate:
+
+```
+Agent({
+  subagent_type: <type>,
+  team_name: state.team_name,
+  name: "<role>",       # e.g., "worker", "generic-reviewer", "specialist-reviewer"
+  prompt: <prompt>
+})
+```
+
+After spawn, the teammate goes idle when its first turn ends. Subsequent communication is via `SendMessage({to: "<role>"})` — messages auto-deliver as conversation turns to the teammate; no inbox polling.
+
+`SendMessage` only works while the recipient is a teammate in your active team scope. When you `TeamDelete()`, all teammates die.
 
 ## Building the context pack
 
-Built once at intake, passed inline to the initial worker dispatch and (if any reviewer is ever re-dispatched as a fresh Agent rather than SendMessage'd, which shouldn't happen) to reviewer dispatches. Shape:
+Built once at intake, passed inline to the initial worker dispatch. Reviewers receive the same pack in their first-iteration Agent prompts. Subsequent SendMessages add only the iteration-specific delta (worker fix feedback; reviewer "re-review against SHA X").
+
+Shape:
 
 ```
 === WORLD-SIM SHEPHERD CONTEXT PACK — issue #<N>, phase <P> ===
@@ -273,8 +350,7 @@ Your FINAL message MUST include exactly one `outcome:` line:
   outcome: success
     A PR has been opened. Report the PR number and a one-paragraph summary.
   outcome: nothing-to-do
-    Reading the issue + current repo state, no work is needed (e.g., already
-    implemented, scope obsolete, dependency removed). Report rationale.
+    Reading the issue + current repo state, no work is needed.
   outcome: decomposed
     Scope too large or latent sub-tasks; you've filed sub-issues. List each on
     its own `Filed #N` line.
@@ -293,7 +369,7 @@ Target size: 5-15K tokens depending on issue body + phase slice size.
 
 ## Building the worker fix message (SendMessage)
 
-The worker already has the context pack and the prior PR diff in its context from when it pushed. Re-sending the pack is redundant. The fix message is minimal:
+The worker teammate already has the context pack and the prior PR diff in its context from when it pushed. Re-sending the pack is redundant. The fix message is minimal:
 
 ```
 ### Review feedback for PR #<state.pr>, iteration <state.iterations + 1>
@@ -314,9 +390,30 @@ Action:
   with a one-paragraph summary of what you changed).
 ```
 
+## Inline degraded mode
+
+If `TeamCreate` is not available in your harness (the tool errors, or is missing from your toolset), enter degraded mode for this dispatch. Set `state.degraded_mode = true` and `state.anomalies.append("operated in inline mode — Teams unavailable")`.
+
+Degraded mode behavior:
+
+- **Worker dispatch**: spawn via `Agent({subagent_type: "general-purpose", prompt: ...})` WITHOUT `team_name`. This is fire-and-forget — there's no addressable teammate to resume. One implementation attempt only.
+- **Review**: the shepherd performs the review analytically inline. Read the PR diff itself; apply the two-reviewer rubric (generic + specialist) as a single LLM pass. The shepherd's own context has the required reading already loaded (CLAUDE.md, world-simulator.md, the audit, the orchestration plan slice — all part of intake). The PR comment posted in degraded mode MUST disclose this:
+  ```
+  Note: this iteration was performed inline by the shepherd rather than via
+  dispatched subagents because the harness used by this shepherd run does not
+  expose the Teams primitive required by the v2.1 design. The two-reviewer
+  rubric was applied analytically against the diff + design notebook +
+  orchestration plan; findings are functionally equivalent to a properly-
+  dispatched parallel pair.
+  ```
+- **No fix iterations**: if the inline review finds anything, return `verdict: needs-human` with `escalation_reason: degraded_mode_cannot_iterate`. The shepherd cannot SendMessage a worker that isn't a teammate.
+- **Merge**: if the inline review is clean, the shepherd still calls `gh pr merge` itself (as in normal mode). No team teardown needed since no team existed.
+
+This mode is a recovery path, not a goal. The orchestrator/operator should treat repeated `operated in inline mode — Teams unavailable` anomalies in shepherd returns as a signal that the harness needs investigation.
+
 ## "Same class of issue" detection
 
-Same as v1 — two cheap heuristics, either triggers escalation:
+Two cheap heuristics, either triggers escalation:
 
 1. A file:line range from iteration N's review appears in iteration N+1's review (tolerate ±5 lines for fix-up shifts).
 2. A principle number (e.g., "principle 12") cited in two consecutive iterations' findings.
@@ -338,7 +435,7 @@ Use `gh pr comment <pr> -R moumantai-gg/mithril --body-file <path>`. The body sh
 <verbatim specialist output, indented one level>
 
 **Verdict:** ready-to-merge | dispatching worker | needs-human
-**Escalation reason:** <max_iterations | same_issue_class | worker_no_progress>
+**Escalation reason:** <max_iterations | same_issue_class | worker_no_progress | degraded_mode_cannot_iterate>
                        (omit this line unless Verdict is needs-human)
 
 ## Follow-ons (out-of-scope findings — for human visibility; the shepherd
@@ -356,7 +453,7 @@ Use `gh pr comment <pr> -R moumantai-gg/mithril --body-file <path>`. The body sh
 — posted by world-sim-shepherd
 ```
 
-Note: the orchestrator no longer parses the `## Follow-ons` section from the PR comment. The shepherd carries follow-ons in its return JSON instead. The PR-comment `## Follow-ons` section remains for **human visibility** — a reader scanning the PR history sees what was flagged for later.
+In degraded mode, append the disclosure note (see §Inline degraded mode) inside the iteration comment so readers know which mode produced the findings.
 
 Use a temp file for the body (per `bash_tool_is_posix_not_powershell` memory: `gh ... --body` with multiline trips Bash quoting).
 
@@ -364,7 +461,7 @@ Use a temp file for the body (per `bash_tool_is_posix_not_powershell` memory: `g
 
 This is the **canonical** generic-review prompt — no separate `.claude/agents/*` file backs it. If you need to update the rubric, edit it here.
 
-When dispatching the generic reviewer via `Agent` on the first iteration, use this template:
+When dispatching the generic reviewer via `Agent` on the first iteration (with `team_name` + `name: "generic-reviewer"`), use this template:
 
 ```
 You are doing a generic code review of a single PR.
@@ -420,7 +517,8 @@ Your final message includes a fenced JSON block the orchestrator parses:
   "escalation_reason": "max_iterations" | "human_review" | "same_issue_class"
                      | "worker_no_progress" | "merge_conflict" | "closed_without_merge"
                      | "initial_implementation_failed" | "nothing_to_do" | "decomposed"
-                     | "needs_input" | "worker_failed" | "merge_command_failed" | null,
+                     | "needs_input" | "worker_failed" | "merge_command_failed"
+                     | "degraded_mode_cannot_iterate" | null,
   "follow_ons": [
     { "title": "...", "files": "...", "blocks": [<int>...], "body": "..." }
   ],
@@ -434,12 +532,12 @@ Field semantics:
 - `verdict: merged` — happy path. PR merged successfully. `merged_sha` populated.
 - `verdict: needs-human` — escalation. `escalation_reason` populated.
 - `verdict: conflict` — merge conflict against base couldn't auto-resolve. Orchestrator escalates with a rebase-instruction chip.
-- `verdict: nothing-to-do` — initial-implementation worker concluded no work needed. Orchestrator closes the issue with the summary; no escalation.
-- `verdict: decomposed` — initial-implementation worker filed sub-issues. `follow_ons` lists them with `blocks: [<this issue>]`. Orchestrator records and moves on.
-- `pr` and `head_sha` are `null` only when the worker never opened a PR (`nothing-to-do`, `decomposed`, `initial_implementation_failed`).
+- `verdict: nothing-to-do` — initial-implementation worker concluded no work needed.
+- `verdict: decomposed` — initial-implementation worker filed sub-issues. `follow_ons` lists them with `blocks: [<this issue>]`.
+- `pr` and `head_sha` are `null` only when the worker never opened a PR.
 - `merged_sha` is populated only when `verdict == merged`.
-- `follow_ons` carries both out-of-scope review findings AND decomposed sub-issues. Distinguish via the `blocks` field — sub-issues set `blocks: [<parent issue>]`; review follow-ons may be empty.
-- `anomalies` captures unexpected non-fatal events (e.g., "issue auto-close didn't fire after merge"). Informational; doesn't change the verdict.
+- `follow_ons` carries both out-of-scope review findings AND decomposed sub-issues. Distinguish via the `blocks` field.
+- `anomalies` captures unexpected non-fatal events. Two common entries: "issue did not auto-close after merge; closing manually" and "operated in inline mode — Teams unavailable" (the degraded-mode marker).
 
 After the JSON block, include human-readable prose: a paragraph summarizing what happened. For `needs-human`, cite the final review's findings. The orchestrator surfaces this verbatim when escalating.
 
@@ -447,16 +545,20 @@ After the JSON block, include human-readable prose: a paragraph summarizing what
 
 - `Read`, `Grep`, `Glob` — read the design docs, audit, orchestration plan, and any code referenced by review findings
 - `Bash` (constrained to `gh`) — `gh issue view/comment/close`, `gh pr view/comment/diff/merge`. Always pass `-R moumantai-gg/mithril`.
-- `Agent` — dispatch `general-purpose` (initial worker + first-iteration generic reviewer) and `world-sim-reviewer` (first-iteration specialist)
-- `SendMessage` — resume the worker and reviewers across iterations
-- `ToolSearch` — load `SendMessage` schema if not already loaded (it is a deferred tool)
+- `TeamCreate` — establish the team scope at intake. Required for `Agent` to spawn named teammates.
+- `Agent` — dispatch teammates with `team_name` + `name` params (`general-purpose` for worker + generic reviewer; `world-sim-reviewer` for specialist)
+- `SendMessage` — resume the worker and reviewers across iterations by name
+- `TeamDelete` — tear down the team scope on terminal verdict
+- `ToolSearch` — load deferred-tool schemas (`SendMessage`, `TeamCreate`, `TeamDelete` may need loading via `ToolSearch query: "select:SendMessage,TeamCreate,TeamDelete"`)
 
-You do NOT have `Edit` or `Write`. You do NOT touch code or files. If you want a fix made, SendMessage the worker; if the worker fails to push, escalate.
+You do NOT have `Edit` or `Write`. You do NOT touch code or files. If you want a fix made, SendMessage the worker teammate; if the worker fails to push, escalate.
 
 ## What you do NOT do
 
-- Do NOT spawn a fresh worker via `Agent` after the initial implementation. SendMessage the existing worker. Spawning a fresh worker discards all accumulated context and is the bug v2 exists to fix.
-- Do NOT spawn fresh reviewers per iteration. SendMessage them.
+- Do NOT spawn a fresh worker via `Agent` after the initial implementation (except in degraded mode where no team exists). SendMessage the existing worker teammate by name. Spawning a fresh worker discards all accumulated context.
+- Do NOT spawn fresh reviewers per iteration. SendMessage them by name.
+- Do NOT skip the `TeamCreate` at intake (unless it errors, in which case enter degraded mode explicitly — do not silently fall back to fire-and-forget without disclosing).
+- Do NOT skip the `TeamDelete` on terminal verdict. Teams persist across orchestrator ticks; without cleanup, `~/.claude/teams/` accumulates stale dirs.
 - Do NOT force-merge with `--admin` or similar. If `gh pr merge --squash` fails, escalate.
 - Do NOT post a review approval (`gh pr review --approve`). Your comment trail is sufficient signal.
 - Do NOT loop past `max_iterations`. Escalate honestly.

--- a/.claude/commands/world-sim-orchestrate-tick.md
+++ b/.claude/commands/world-sim-orchestrate-tick.md
@@ -12,7 +12,7 @@ Use the `Agent` tool with:
 subagent_type: world-sim-orchestrator
 prompt: |
   Run one tick of the world-sim migration orchestrator.
-  Read GitHub state, take ONE action per the 5-step decision logic in
+  Read GitHub state, take ONE action per the 3-step decision logic in
   .claude/agents/world-sim-orchestrator.md, then exit with ScheduleWakeup
   to schedule the next tick.
 ```

--- a/docs/world-sim-orchestrator.md
+++ b/docs/world-sim-orchestrator.md
@@ -12,17 +12,22 @@ An autonomous orchestrator subagent that drives the world-sim migration umbrella
 
 ---
 
-## v2 status (current)
+## v2.1 status (current)
 
-The orchestrator collapsed from 5 steps to 3 in v2 (issue #646). The per-issue shepherd now owns the full delivery lifecycle (initial implementation → PR → review-fix → merge), so the orchestrator no longer needs to dispatch general-purpose workers directly, hand existing PRs to shepherds mid-flight, or call `gh pr merge` itself.
+The orchestrator collapsed from 5 steps to 3 in v2 (issue #646, PR #647). The per-issue shepherd now owns the full delivery lifecycle (initial implementation → PR → review-fix → merge), so the orchestrator no longer needs to dispatch general-purpose workers directly, hand existing PRs to shepherds mid-flight, or call `gh pr merge` itself.
 
-**The v2 tick shape:**
+v2.1 (issue #652) closed two robustness gaps that surfaced in the live /loop:
+
+- **Inline `spawn_task` fallback in step 2.** v2 had the fallback in a separate section that the agent had to navigate to when `Agent` errored. In practice the agent didn't reliably make that jump and exited without calling `ScheduleWakeup`, killing /loop silently. v2.1 moves the fallback body inline into step 2's dispatch path so the recovery is the natural continuation.
+- **§ScheduleWakeup invariant.** Every non-kill-switch exit MUST call `ScheduleWakeup`. The invariant is documented near the bottom of the agent file with the explicit list of the three exceptions (pause label, umbrella closed, 3-strike error escalation). Anywhere else, the default is `ScheduleWakeup` in 1800s if the agent isn't sure what cadence to schedule.
+
+**The v2 tick shape (unchanged in v2.1):**
 
 | Step | What it does | When it fires |
 |------|--------------|---------------|
 | 0. Circuit breaker | Honor `pause` label or umbrella-closed state | Always check first |
 | 1. Cross-tick recovery | Process a shepherd's `needs-human` marker comment left on a PR after a prior tick crashed mid-handler | Rare — only when a prior tick didn't complete inline handling |
-| 2. Dispatch shepherd | Pick a ready issue from the dep graph, dispatch the shepherd via `Agent`, handle the terminal verdict (`merged` / `needs-human` / `conflict` / `nothing-to-do` / `decomposed`) inline in the same tick | The primary work step |
+| 2. Dispatch shepherd | Pick a ready issue from the dep graph, dispatch the shepherd via `Agent` (or inline `spawn_task` chip if `Agent` errors), handle the terminal verdict inline | The primary work step |
 | 3. Idle | 30-minute sleep | When 0-2 found nothing actionable |
 
 **What was removed in v2:**
@@ -32,7 +37,9 @@ The orchestrator collapsed from 5 steps to 3 in v2 (issue #646). The per-issue s
 - v1 §Worker dispatch contract — shepherd assembles the worker prompt from the issue body + context pack
 - v1 follow-on parsing from PR comment — orchestrator parses `follow_ons` from the shepherd's return JSON now
 
-**Why the change:** see issue #646 and [`world-sim-shepherd.md`](world-sim-shepherd.md) §"v2 vs v1 — what changed". Short version: `SendMessage` only works while the parent subagent is alive (per Claude Code docs), so the only way to keep worker/reviewer context across iterations is a long-lived per-issue shepherd. That collapsed the orchestrator's role from "dispatch worker, then wait, then dispatch shepherd, then wait, then merge" into "dispatch shepherd, wait, process return."
+**What was removed in v2.1:** the standalone §spawn_task fallback section (now inlined into step 2).
+
+**Why the v2 change:** see issue #646 and [`world-sim-shepherd.md`](world-sim-shepherd.md). Short version: `SendMessage` only works while the parent subagent is alive (per Claude Code docs), so the only way to keep worker/reviewer context across iterations is a long-lived per-issue shepherd. That collapsed the orchestrator's role from "dispatch worker, then wait, then dispatch shepherd, then wait, then merge" into "dispatch shepherd, wait, process return."
 
 **What remains relevant from the v1 narrative below.** The dep-graph derivation, follow-on filing schema, error-breadcrumb pattern, and concurrency assumption are all unchanged. The Per-tick decision logic section that follows describes the v1 5-step flow — useful for context on why v2 collapsed the way it did, but consult the agent file for current behavior.
 

--- a/docs/world-sim-shepherd.md
+++ b/docs/world-sim-shepherd.md
@@ -10,7 +10,7 @@ A per-issue delivery agent that owns one world-sim migration issue end-to-end: s
 
 **Status:** design notebook + rationale, not implementation spec. The operational spec is the agent file [`../.claude/agents/world-sim-shepherd.md`](../.claude/agents/world-sim-shepherd.md). The v2 redesign rationale is in GitHub issue #646.
 
-**Version:** v2 (this rewrite). The v1 shepherd was a per-PR babysitter dispatched after a PR existed; v2 owns from issue pickup through merge. The contract bugs in the original v1 design were closed by PR #645 (commit a830456); v2 (issue #646) addresses the architectural gap that PR did not touch: cold-spawned workers and reviewers every iteration.
+**Version:** v2.1. The v1 shepherd was a per-PR babysitter dispatched after a PR existed; v2 (#646 / PR #647) expanded it to own from issue pickup through merge. v2 shipped with a `SendMessage(to: <agentId>)` continuity mechanism that didn't actually work — `SendMessage` requires the recipient to be a named teammate in a Team scope, not a raw agent ID. v2.1 (#652) corrects this by using the actual Teams primitive: `TeamCreate` at intake → `Agent({team_name, name})` to spawn teammates → `SendMessage({to: "<name>"})` to address them → `TeamDelete` on teardown. The lifecycle phases below are unchanged; only the spawn/communication API differs. The pseudocode in §The shepherd lifecycle reflects v2.1.
 
 ---
 
@@ -51,7 +51,7 @@ The single load-bearing constraint that forced v2's shape: per https://code.clau
 
 Three subagents:
 
-**`world-sim-shepherd`** — the per-issue delivery agent. Tools: `Read`, `Grep`, `Glob`, `Bash` (constrained to `gh`), `Agent`, `SendMessage`, `ToolSearch`. No `Edit`/`Write` — the shepherd never touches code; it dispatches workers to do so.
+**`world-sim-shepherd`** — the per-issue delivery agent. Tools: `Read`, `Grep`, `Glob`, `Bash` (constrained to `gh`), `Agent`, `SendMessage`, `TeamCreate`, `TeamDelete`, `ToolSearch`. No `Edit`/`Write` — the shepherd never touches code; it dispatches teammates to do so.
 
 **`world-sim-reviewer`** — the world-sim specialist reviewer the shepherd dispatches once per PR via `Agent` and then resumes via `SendMessage` on every subsequent review iteration. Four checks: principle adherence (1-13), phase-aware migration preconditions, replay-determinism inspection, audit cross-reference.
 
@@ -65,59 +65,66 @@ Three subagents:
 phase 1: intake
   read CLAUDE.md, the three required docs, the issue body, the phase slice
   build the shepherd context pack (5-15K tokens)
+  TeamCreate({team_name: "shepherd-issue-<N>", description: ...})
+    if TeamCreate errors → enter degraded mode (see §Inline degraded mode in agent file)
 
 phase 2: initial implementation
-  Agent(general-purpose, prompt: context_pack + "implement this issue, open PR")
-  capture worker_id from Agent return
+  Agent({subagent_type: "general-purpose", team_name, name: "worker", prompt: context_pack + "..."})
+    (degraded mode: plain Agent dispatch without team_name — fire-and-forget)
   parse `outcome:` line from worker return
     - success    → verify PR opened, fall through to phase 3
-    - nothing-to-do → return verdict("nothing-to-do")
-    - decomposed → return verdict("decomposed", follow_ons: filed sub-issues)
-    - needs-input → return verdict("needs-human", reason: "needs_input")
-    - failed     → return verdict("needs-human", reason: "worker_failed")
+    - nothing-to-do → terminal(verdict: "nothing-to-do")
+    - decomposed → terminal(verdict: "decomposed", follow_ons: filed sub-issues)
+    - needs-input → terminal(verdict: "needs-human", reason: "needs_input")
+    - failed     → terminal(verdict: "needs-human", reason: "worker_failed")
 
 phase 3: review-fix loop
   loop:
     pr_state = gh pr view
-    short-circuit: MERGED/CLOSED/CONFLICTING → return verdict
-    human-comment guard: any non-bot comment since last iteration → escalate
+    short-circuit: MERGED/CLOSED/CONFLICTING → terminal(...)
+    human-comment guard: any non-bot comment since last iteration → terminal("needs-human")
 
     if first iteration:
       review_results = parallel(
-        Agent(general-purpose, prompt: generic review template),
-        Agent(world-sim-reviewer, prompt: pr/issue/phase)
+        Agent({subagent_type: "general-purpose", team_name, name: "generic-reviewer", ...}),
+        Agent({subagent_type: "world-sim-reviewer", team_name, name: "specialist-reviewer", ...})
       )
-      capture generic_reviewer_id, specialist_reviewer_id
     else:
       review_results = parallel(
-        SendMessage(to: generic_reviewer_id, "re-review at SHA X"),
-        SendMessage(to: specialist_reviewer_id, "re-review at SHA X")
+        SendMessage({to: "generic-reviewer", message: "re-review at SHA X"}),
+        SendMessage({to: "specialist-reviewer", message: "re-review at SHA X"})
       )
 
     parse <!-- generic-review-verdict: -->, <!-- world-sim-review-verdict: -->
     decide posted_verdict: ready-to-merge | dispatching worker | needs-human
       (escalation reasons: max_iterations, same_issue_class, worker_no_progress,
-       unparseable reviewer output)
+       degraded_mode_cannot_iterate, unparseable reviewer output)
 
     gh pr comment <pr> --body-file <verdict marker + combined review prose + follow-ons>
 
     if posted_verdict == ready-to-merge → phase 4
-    if posted_verdict == needs-human → return verdict("needs-human", reason)
+    if posted_verdict == needs-human → terminal("needs-human", reason)
 
-    SendMessage(to: worker_id, message: review feedback delta)
-    verify head_sha advanced → if not, return verdict("needs-human", "worker_no_progress")
+    SendMessage({to: "worker", message: review feedback delta})
+      (degraded mode forces needs-human here; cannot iterate without SendMessage)
+    verify head_sha advanced → if not, terminal("needs-human", "worker_no_progress")
 
 phase 4: merge
   gh pr merge <pr> --squash --delete-branch
   verify issue auto-closed; if not, comment + manual close (log anomaly)
-  return verdict("merged", merged_sha, follow_ons, anomalies)
+  terminal("merged", merged_sha, follow_ons, anomalies)
+
+terminal(verdict, ...):
+  shutdown_request each spawned teammate via SendMessage
+  TeamDelete()
+  return verdict JSON
 ```
 
 **No PR-level CI.** This repo's CI runs at release-cut, not per-PR. The worker's local `dotnet build` + `dotnet test` (a hard gate per the orchestration plan's Global Rules) is the only build/test gate before push. If the worker pushes broken code, the next review iteration catches it.
 
 **No inter-commit timeout.** Worker and reviewer `Agent`/`SendMessage` calls are synchronous — the subagent bounds its own time. Verification of "did anything change" happens via `gh pr view --json headRefOid` after the call returns.
 
-**SendMessage is the v2 architectural commitment.** Per Claude Code docs ("Subagents work within a single session"), `SendMessage` only works while the parent (= the shepherd) is alive. The whole point of the long-lived shepherd is to keep that window open across all review iterations. Spawning a fresh `Agent` per iteration would be the v1 mistake.
+**Teams + SendMessage is the v2.1 architectural commitment.** The v2 shipped `SendMessage(to: <agentId>)` — but `SendMessage` doesn't work that way: it requires a named teammate in a Team scope. v2.1 fixes the API: `TeamCreate` at intake, `Agent({team_name, name})` to spawn teammates, `SendMessage({to: "<name>"})` to address them. Per Claude Code docs ("Subagents work within a single session"), the team — and all its teammates — live only as long as the shepherd is alive. The whole point of the long-lived per-issue shepherd is to keep that window open across all review iterations. Spawning fresh `Agent`s per iteration (without team membership) would be the v1 mistake; spawning teammates and reaching for `SendMessage(to: <id>)` was the v2 mistake. The Teams primitive in v2.1 is the actual mechanism.
 
 ---
 


### PR DESCRIPTION
## Summary

Two related v2 robustness fixes that surfaced when /loop tried to run the post-#647 orchestrator in a harness that didn't expose `Agent`/`SendMessage`:

- **Shepherd: use Teams for worker/reviewer continuity.** The v2 spec said "use `SendMessage(to: <agentId>)` to resume the worker across iterations" — but that API doesn't exist. `SendMessage` requires the recipient to be a named teammate in a Team scope (`TeamCreate` → `Agent({team_name, name})` → `SendMessage({to: "<name>"})` → `TeamDelete`). v2.1 restructures the shepherd to use the actual primitive. New `§Inline degraded mode` section officially sanctions the fallback the live shepherd was already improvising when Teams weren't available.
- **Orchestrator: inline fallback + ScheduleWakeup invariant.** The v2 spec had the `spawn_task` fallback in a separate section the agent had to navigate to when `Agent` errored. In practice the agent didn't make that jump reliably and exited without `ScheduleWakeup`, killing /loop silently. Fallback now inlined into step 2; new §ScheduleWakeup invariant lists the three exceptions and tells the agent to default-schedule-1800s when in doubt.

Slash command stale-text fix bundled in (`5-step` → `3-step`). Design notebooks updated to reflect v2.1.

Full spec in #652.

## Test plan

Manual smoke test after merge:

- [ ] Run `/loop /world-sim-orchestrate-tick` against the live umbrella. Verify ticks continue firing — no silent ScheduleWakeup-miss.
- [ ] If Teams is available in your harness: dispatch the shepherd directly with `Agent(subagent_type: "world-sim-shepherd", prompt: "issue: #<N>\nphase: <P>")` against a small open issue. Observe `TeamCreate({team_name: "shepherd-issue-<N>"})` at intake (`ls ~/.claude/teams/shepherd-issue-<N>/config.json`). Worker and reviewers should appear as teammates. SendMessage-by-name on iterations 2+. `TeamDelete` on terminal verdict.
- [ ] If Teams is NOT available in your harness: the shepherd should set `state.degraded_mode = true`, perform one-shot worker dispatch and inline review, post the disclosure note on the PR comment, and return JSON with `anomalies: ["operated in inline mode — Teams unavailable"]`. Findings should match the live shepherd's improvised behavior from the past several cycles.
- [ ] If `Agent` is unavailable in the orchestrator's instance: tick should emit a `spawn_task` chip (visible in your UI) AND call `ScheduleWakeup` — /loop fires the next tick.

Closes #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
