### PR TITLE
docs: retarget dangling ClassifiedPlayerLogProducer see-crefs at WorldClockTickProducer

### DIFF
--- a/src/Mithril.GameState/Skills/Producers/SkillFrameProducer.cs
+++ b/src/Mithril.GameState/Skills/Producers/SkillFrameProducer.cs
@@ -19,7 +19,7 @@ namespace Mithril.GameState.Skills.Producers;
 /// frames.
 ///
 /// <para><b>Mode awareness.</b> Mirrors
-/// <see cref="Mithril.WorldSim.Player.Producers.ClassifiedPlayerLogProducer"/>'s
+/// <see cref="Mithril.WorldSim.Player.Producers.WorldClockTickProducer"/>'s
 /// shape — <see cref="ReachedLive"/> completes the moment the producer reads
 /// the first non-replay envelope from the L1 driver, irrespective of whether
 /// that envelope is itself a skill line. PG's <c>ProcessLoadSkills</c> only
@@ -128,7 +128,7 @@ public sealed class SkillFrameProducer : IFrameProducer<SkillFrame>, IModeAwareF
             subscription.Dispose();
             // Guarantee ReachedLive completes even if the stream ended without
             // ever flipping (degenerate test fixture, or a replay-only file
-            // tail). Matches ClassifiedPlayerLogProducer's terminal fallback.
+            // tail). Matches WorldClockTickProducer's terminal fallback.
             _reachedLive.TrySetResult();
         }
     }

--- a/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs
@@ -179,7 +179,7 @@ public sealed class PlayerWorldTests
 
         // Two replay frames followed by one live frame. The stub signals
         // ReachedLive inline at the moment it yields the live entry —
-        // matching ClassifiedPlayerLogProducer's L1-envelope behaviour.
+        // matching WorldClockTickProducer's L1-envelope behaviour.
         producer.PostReplay(new Frame<string>(Ts(10), "r1"));
         producer.PostReplay(new Frame<string>(Ts(11), "r2"));
         producer.PostLive(new Frame<string>(Ts(12), "L1"));

--- a/tests/Mithril.WorldSim.Player.Tests/TestSupport/StubFrameProducer.cs
+++ b/tests/Mithril.WorldSim.Player.Tests/TestSupport/StubFrameProducer.cs
@@ -10,7 +10,7 @@ namespace Mithril.WorldSim.Player.Tests.TestSupport;
 /// <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/> the moment it
 /// yields the first non-replay entry, *before* the yield returns control to
 /// the world's merger. This matches
-/// <see cref="Mithril.WorldSim.Player.Producers.ClassifiedPlayerLogProducer"/>'s
+/// <see cref="Mithril.WorldSim.Player.Producers.WorldClockTickProducer"/>'s
 /// signalling shape exactly, so tests exercise the same boundary the
 /// production producer drives.
 /// </summary>
@@ -53,7 +53,7 @@ internal sealed class StubFrameProducer<T> : IFrameProducer<T>, IModeAwareFrameP
     /// triggers the
     /// <see cref="IModeAwareFrameProducer{TPayload}.ReachedLive"/> signal
     /// immediately before the yield — matching the production
-    /// <see cref="Mithril.WorldSim.Player.Producers.ClassifiedPlayerLogProducer"/>
+    /// <see cref="Mithril.WorldSim.Player.Producers.WorldClockTickProducer"/>
     /// behaviour against the L1 envelope.
     /// </summary>
     public void PostLive(Frame<T> frame)


### PR DESCRIPTION
## Summary

PR #668 (#655) renamed `ClassifiedPlayerLogProducer` → `WorldClockTickProducer` and deleted the old type. Five doc-comment `<see cref>` cross-references survived the rename — they don't fire `CS1574` because the repo doesn't set `GenerateDocumentationFile`, so warnings-as-errors doesn't catch them.

Each surrounding sentence still makes sense referring to the new owner (the mode-signalling shape and L1-envelope behaviour carried over from the old producer verbatim), so all five are straight swaps to `WorldClockTickProducer`:

| File | Site | What the sentence describes |
| --- | --- | --- |
| `src/Mithril.GameState/Skills/Producers/SkillFrameProducer.cs:22` | class doc, **Mode awareness** para | "Mirrors `…`'s shape — `ReachedLive` completes the moment the producer reads the first non-replay envelope" |
| `src/Mithril.GameState/Skills/Producers/SkillFrameProducer.cs:131` | comment in `finally` block | "Matches `…`'s terminal fallback" (degenerate replay-only stream) |
| `tests/Mithril.WorldSim.Player.Tests/TestSupport/StubFrameProducer.cs:13` | class summary | "matches `…`'s signalling shape exactly, so tests exercise the same boundary the production producer drives" |
| `tests/Mithril.WorldSim.Player.Tests/TestSupport/StubFrameProducer.cs:56` | `PostLive` summary | "matching the production `…` behaviour against the L1 envelope" |
| `tests/Mithril.WorldSim.Player.Tests/PlayerWorldTests.cs:182` | inline comment, late-replay-then-live test | "matching `…`'s L1-envelope behaviour" |

## Deliberately left alone

- **`src/Mithril.WorldSim.Player/Producers/WorldClockTickProducer.cs:27`** — the new producer's own class doc carries a "matching the **historical** `ClassifiedPlayerLogProducer`'s mode-signalling shape" lineage note. The word "historical" makes the reference intentional; this documents *why* the new producer keeps the old shape and reads correctly as a deliberate backstop, not a dangling pointer.
- **`docs/world-simulator.md`** and **`docs/glossary.md`** — the decision log and glossary mention the old name on purpose (record of what was reshaped, when, and why).

## Verification

- `dotnet build Mithril.slnx` — clean, 0 warnings, 0 errors.
- `dotnet test Mithril.slnx` — full suite green except one pre-existing flake (`Mithril.Shared.Tests.Icons.IconCachePreloadTests.PreloadAsync_downloads_missing_ids_and_reports_progress`, an HTTP-mocked icon-cache test in a file this PR doesn't touch). Re-running that test in isolation passes 1/1. Unrelated to the doc-comment-only changes here.

Closes #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
