### PR TITLE
fix(world-sim): require SendMessage to team-lead for worker/reviewer outcome reporting

### DIFF
--- a/.claude/agents/world-sim-reviewer.md
+++ b/.claude/agents/world-sim-reviewer.md
@@ -123,18 +123,35 @@ The first line MUST be the HTML-comment marker `<!-- world-sim-review-verdict: c
 
 If you find nothing, emit a clean verdict with one sentence: `No findings against principles, phase preconditions, replay-determinism, or the audit.`
 
+## Returning your verdict to the caller (Teams model)
+
+In v4 of the driver, you are spawned as a teammate of `team-lead` (top-level Claude, the driver). Your text turn output is invisible to the lead. To return your verdict, you MUST use `SendMessage` to the lead.
+
+After producing your structured review output (per §Output format above), send it via:
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "world-sim review: <clean|findings>",
+  message: <your full output block — verdict marker on the first line, then prose>
+})
+```
+
+Then go idle. The driver waits for this SendMessage; if you only produce text and idle, the driver doesn't see your verdict and the delivery stalls.
+
 ## SendMessage continuation
 
-The shepherd dispatches you once per PR via `Agent` (capturing your agent ID), then resumes you via `SendMessage` on subsequent review iterations of the same PR. When you receive a SendMessage continuation:
+The driver dispatches you once per PR via `Agent({team_name, name: "specialist-reviewer"})`, then resumes you via `SendMessage({to: "specialist-reviewer"})` on subsequent review iterations of the same PR. When you receive a SendMessage continuation:
 
 - The prior PR diff and your earlier findings are already in your conversation context — you do not need to re-fetch the required-reading docs (CLAUDE.md, the orchestration plan, the audit). Those are loaded.
 - The message body identifies the updated PR head SHA. Run `gh pr diff <pr> -R moumantai-gg/mithril` once to see the new diff.
-- Re-review against the updated diff. Your accumulated context means you can naturally surface "I flagged this principle-X violation last iteration; the worker shifted the code without addressing the root cause" — this signal is more reliable than the shepherd's string-matching same-issue-class heuristic, so call it out explicitly when it applies.
-- Emit the same output format with the `<!-- world-sim-review-verdict: -->` marker on the first line.
+- Re-review against the updated diff. Your accumulated context means you can naturally surface "I flagged this principle-X violation last iteration; the worker shifted the code without addressing the root cause" — this signal is more reliable than the driver's string-matching same-issue-class heuristic, so call it out explicitly when it applies.
+- Emit the same output format with the `<!-- world-sim-review-verdict: -->` marker on the first line, and send it to team-lead via `SendMessage` (per §Returning your verdict above).
 
 ## What you do NOT do
 
-- Do NOT post PR comments. The shepherd does that.
+- Do NOT post PR comments. The driver does that.
 - Do NOT edit code or push commits.
 - Do NOT dispatch other agents.
+- Do NOT skip the SendMessage to team-lead at end of turn — plain text output is invisible to the driver in Teams mode.
 - Do NOT run `dotnet build` or `dotnet test`. The worker runs those before push; CI runs them at release-cut. Your role is static analysis of the diff against the four checks.

--- a/docs/world-sim-driver-playbook.md
+++ b/docs/world-sim-driver-playbook.md
@@ -525,8 +525,23 @@ Shape:
 - PR body MUST include "Closes #<issue>" and the "🤖 Generated with Claude
   Code" trailer.
 
-### Structured outcome reporting
-Your FINAL message MUST include exactly one `outcome:` line:
+### Structured outcome reporting (CRITICAL — read carefully)
+
+When you reach a terminal outcome (you've finished — either you opened a PR, concluded nothing-to-do, decomposed into sub-issues, hit a wall, or failed), you MUST report the outcome to the team-lead via `SendMessage`. Putting `outcome:` in your plain text output is NOT enough — your text output ends a turn and you go idle, but the team-lead does not see your turn output unless you explicitly send a message.
+
+**Required final action:**
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<outcome>: <one-line>",     # e.g., "success: PR #710 opened"
+  message: "outcome: <enum-value>\n\n<details — PR number / rationale / questions / symptom>"
+})
+```
+
+Then go idle. The team-lead waits for this SendMessage; without it, the driver doesn't know you're done and the delivery stalls until iteration ceilings escalate.
+
+**Outcome enum values** (use the `outcome: <X>` line as the literal first line of your SendMessage body):
 
   outcome: success
     A PR has been opened. Report the PR number and a one-paragraph summary.
@@ -541,7 +556,9 @@ Your FINAL message MUST include exactly one `outcome:` line:
     Build/test failure you couldn't resolve, external constraint, contradicting
     requirement. Report symptom.
 
-If your final message lacks an `outcome:` line, the driver treats it as `failed`.
+If your SendMessage to team-lead is missing or lacks an `outcome:` line, the driver treats your dispatch as `failed`.
+
+**Fallback for fire-and-forget mode** (no `team_name` was set on your invocation — degraded CLI mode): if `SendMessage` to "team-lead" errors with "no team context" or similar, fall back to including the `outcome:` line as the first line of your plain text final output. The driver's degraded-mode handler parses text output instead.
 
 === END CONTEXT PACK ===
 ```
@@ -591,8 +608,11 @@ Action:
 - Address the findings above.
 - Run dotnet build + dotnet test; both must be clean.
 - Push to the same PR branch (do NOT open a new PR).
-- Return with the same `outcome:` line convention (typically `outcome: success`
-  with a one-paragraph summary of what you changed).
+- Report completion via `SendMessage({to: "team-lead", summary: "outcome:
+  <X>: <one-line>", message: "outcome: <X>\n\n<details>"})`. Same outcome
+  enum and same reporting requirement as the initial implementation (see
+  context pack §Structured outcome reporting). Plain text output alone is
+  NOT enough — the lead doesn't see your turn output, only your SendMessages.
 ```
 
 ## Spawning named teammates
@@ -728,6 +748,8 @@ Output format (FIRST line MUST be the machine-readable marker):
 If you are receiving this prompt via SendMessage (i.e., this is iteration ≥ 2):
 - The above "Read" steps are NOT needed — your prior context already has them.
 - Just `gh pr diff <N>` again to see the updated diff and re-review.
+
+Report your verdict to team-lead via `SendMessage({to: "team-lead", summary: "generic review: <clean|findings>", message: <your full output above including the verdict marker, the verdict line, findings, and summary>})`. Plain text output alone is NOT enough — the lead doesn't see your turn output, only your SendMessages.
 
 Do NOT run `dotnet build` or `dotnet test`. Do NOT post PR comments. Do NOT edit code.
 ```


### PR DESCRIPTION
## Summary

Production fix for v4 (PR #667). The worker has failed to report completion to the driver twice — observed after v4 merged.

**Root cause**: the v4 playbook's `§Structured outcome reporting` told workers to "include an `outcome:` line in your FINAL message" but didn't explicitly require `SendMessage` to `team-lead`. In Teams mode, a teammate's plain-text turn output is **invisible** to the lead — only SendMessages auto-deliver as conversation turns. So workers correctly put `outcome: success` in their final text output and went idle, but the message never reached the driver. Delivery stalled until iteration ceilings escalated.

This pattern was a clean miss in the v3.1 → v4 transition. v3.1 assumed the shepherd would parse the worker's Agent return text. v4 moved the driver to depth 0 and workers became Teams teammates, but the playbook didn't fully internalize that text output stops being a communication channel in the new model.

## Fix

Make the SendMessage requirement explicit in three places:

1. `docs/world-sim-driver-playbook.md` §Structured outcome reporting (the context pack inlined into worker prompts) — requires `SendMessage({to: "team-lead", summary, message: "outcome: <X>..."})` on any terminal outcome. Plain text alone is **not** enough. Includes a fallback for fire-and-forget mode (no `team_name` set) where the worker falls back to text output.
2. `docs/world-sim-driver-playbook.md` §Building the worker fix message — same SendMessage requirement on fix-iteration completion.
3. `docs/world-sim-driver-playbook.md` §Generic code review prompt — the generic reviewer (`general-purpose` teammate) must SendMessage its verdict to team-lead.
4. `.claude/agents/world-sim-reviewer.md` — adds §Returning your verdict to the caller (Teams model) section; updates SendMessage continuation section to reinforce the SendMessage-at-end-of-turn requirement.

## Test plan

- [ ] Dispatch the v4 driver in Desktop against a small open world-sim issue (`/world-sim-orchestrate-tick`).
- [ ] Observe: when the worker reaches `outcome: success`, it calls `SendMessage({to: "team-lead", summary, message})` BEFORE going idle. Verify by checking the worker's session output for the SendMessage call.
- [ ] Observe: the SendMessage arrives at the driver as a new conversation turn (visible in the driver's transcript).
- [ ] Observe: driver parses the `outcome:` line from the message body and proceeds to Phase 3 (review-fix loop) without timing out or escalating.
- [ ] If reviewers find anything, observe: each reviewer also SendMessages its verdict to team-lead at end of turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)