### PR TITLE
feat(world-sim): share ChatLogClock banner offset across files in a session

### DIFF
--- a/src/Mithril.Shared/Logging/ChatLogClock.cs
+++ b/src/Mithril.Shared/Logging/ChatLogClock.cs
@@ -74,7 +74,7 @@ internal sealed partial class ChatLogClock : ILogSourceClock
     // banner (PG re-login during the same Mithril run).
     private TimeSpan? _bannerOffset;
 
-    public ChatLogClock(TimeProvider time, TimeZoneInfo? fallbackTz = null)
+    public ChatLogClock(TimeProvider time, TimeZoneInfo? fallbackTz = null, TimeSpan? seededBannerOffset = null)
     {
         _time = time;
         // Late-bind TimeZoneInfo.Local so a test can inject a fixed-offset
@@ -84,6 +84,16 @@ internal sealed partial class ChatLogClock : ILogSourceClock
         // host's). The banner-derived offset, once seen, supersedes this
         // for the cross-machine-replay case (see #538).
         _fallbackTz = fallbackTz ?? TimeZoneInfo.Local;
+        // Optional seed: a caller that has already scanned the session's
+        // canonical login banner (e.g. ChatLogReplaySource, which scans
+        // every chat file at attach to find the globally-most-recent
+        // banner) can pre-seed the offset so all per-file clocks in the
+        // session fold timestamps via the same offset from the very first
+        // line. Without this, each file's first banner anchors its own
+        // clock independently — files without a banner fall through to
+        // `_fallbackTz`, which is wrong when the originating session's
+        // offset differs from the replay host's local TZ. See #639.
+        _bannerOffset = seededBannerOffset;
     }
 
     public void EnsureAnchored(IReadOnlyList<string> lines, Func<DateTime> mtimeUtcAccessor)

--- a/src/Mithril.WorldSim.Chat/Producers/ChatLogReplaySource.cs
+++ b/src/Mithril.WorldSim.Chat/Producers/ChatLogReplaySource.cs
@@ -8,14 +8,15 @@ namespace Mithril.WorldSim.Chat.Producers;
 
 /// <summary>
 /// Concrete <see cref="IChatLogReplaySource"/> over <see cref="GameConfig.ChatLogDirectory"/>.
-/// On attach: enumerates every existing file in the directory, reads each via
-/// <see cref="LogSourceTailer"/> from byte 0 (so all existing lines are pulled
-/// with TZ-correct timestamps via <see cref="ChatLogClock"/>), then scans the
+/// On attach: enumerates every existing file in the directory, raw-scans the
 /// pooled content for the chat-side login banner
-/// (<see cref="ChatLoginBannerParser"/>). The globally most-recent banner's
-/// timestamp becomes the replay cutoff (principle 9 — "seek to the most recent
-/// chat banner matching the current Player.log session"); lines at-or-after
-/// that timestamp are yielded in timestamp-merged order with
+/// (<see cref="ChatLoginBannerParser"/>) to identify the globally most-recent
+/// banner, then drains each file through a <see cref="LogSourceTailer"/> from
+/// byte 0 with all per-file <see cref="ChatLogClock"/> instances pre-seeded
+/// with the canonical session offset (per #639). The cutoff timestamp folded
+/// via the session offset (principle 9 — "seek to the most recent chat banner
+/// matching the current Player.log session") gates the replay window; lines
+/// at-or-after the cutoff are yielded in timestamp-merged order with
 /// <see cref="LogEnvelope{T}.IsReplay"/> set to <c>true</c>. After the replay
 /// drain the source transitions to live-tail and yields subsequent appends with
 /// <c>IsReplay = false</c>.
@@ -25,11 +26,26 @@ namespace Mithril.WorldSim.Chat.Producers;
 /// self-scope independently). This source's job is the chat-intrinsic "most
 /// recent banner" decision.</para>
 ///
+/// <para><b>Session-shared clock offset (#639).</b> All per-file tailers in
+/// a session share the same canonical offset, so a chat file that doesn't
+/// itself contain a banner — or whose leading lines precede its own banner —
+/// still folds its local-date prefixes via the session-canonical offset
+/// rather than the host TZ fallback. Without this, a cross-machine replay
+/// (chat written on UTC-7, replayed on a UTC+1 host) would mis-stamp every
+/// no-banner file's lines by 8 hours. Each per-file clock keeps
+/// <c>_lastEmitted</c> tailer-local (so an unprefixed leading line in file B
+/// doesn't inherit file A's stamp), and the immutability of the seeded
+/// offset within a session matches the issue's "set once + reconcile on
+/// mismatch" intent for the seed path (a subsequent banner mid-session would
+/// re-anchor via the existing PG-re-login semantics, which is unchanged).</para>
+///
 /// <para><b>Phase 0 scope limits.</b> Files that exist at attach are tailed
 /// for the rest of the session; new files created post-attach (channels added
 /// mid-session — rare for PG) are not picked up. FileSystemWatcher-driven new-
 /// file pickup is a follow-on enhancement once a real world-sim consumer
-/// (#602 / #603) needs it.</para>
+/// (#602 / #603) needs it. Mid-session banner-mismatch warn-and-discard (the
+/// "step 4" in #639's fix sketch) is also deferred — current behaviour
+/// re-anchors on second banner, matching the chat-clock's pre-#639 semantics.</para>
 /// </summary>
 public sealed class ChatLogReplaySource : IChatLogReplaySource
 {
@@ -60,17 +76,75 @@ public sealed class ChatLogReplaySource : IChatLogReplaySource
             yield break;
         }
 
-        // 1. Snapshot files + drain each via LogSourceTailer.
-        var tailers = new List<(string Path, LogSourceTailer Tailer, List<RawLogLine> Lines)>();
+        // 1. Pre-scan banners. Per #639: all per-file clocks in the session
+        //    must share the same canonical session offset, so we identify
+        //    the globally-most-recent banner before stamping any line. We
+        //    read raw text here (one cheap pass per file) and look only at
+        //    the banner-line offset + local-date prefix; the actual stamped
+        //    lines are produced in pass 2 with the shared seeded offset, so
+        //    every chat-derived RawLogLine.Timestamp in the session folds
+        //    via the same offset — even unprefixed leading lines and lines
+        //    in files that don't themselves carry the banner.
+        var fileRawLines = new List<(string Path, string[] RawLines)>();
         foreach (var path in Directory.EnumerateFiles(directory))
         {
             try
             {
-                var tailer = new LogSourceTailer(path, new ChatLogClock(_time, _fallbackTz), _time);
+                // FileShare.ReadWrite | Delete matches LogSourceTailer so a
+                // concurrently-appending PG client doesn't lock us out.
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(fs);
+                var text = reader.ReadToEnd();
+                fileRawLines.Add((path, text.Split('\n')));
+            }
+            catch (IOException ex)
+            {
+                _diag?.Warn("ChatLogReplaySource", $"Skipping unreadable file '{path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _diag?.Warn("ChatLogReplaySource", $"Skipping inaccessible file '{path}': {ex.Message}");
+            }
+        }
+
+        // 2. Find globally most-recent banner by parsing local-date prefixes
+        //    directly (offset is set per the banner itself, so we compare
+        //    *local* timestamps — every banner is consistent with itself).
+        //    Capture the canonical session offset from that banner.
+        DateTime? bannerCutoffLocal = null;
+        TimeSpan? sessionOffset = null;
+        foreach (var (_, rawLines) in fileRawLines)
+        {
+            foreach (var raw in rawLines)
+            {
+                var line = raw.EndsWith('\r') ? raw[..^1] : raw;
+                if (line.Length == 0) continue;
+                if (!ChatLoginBannerParser.TryParse(line, out var banner)) continue;
+                if (!ChatLogClock.TryParseLocalDatePrefix(line, out var local)) continue;
+                if (bannerCutoffLocal is null || local > bannerCutoffLocal)
+                {
+                    bannerCutoffLocal = local;
+                    sessionOffset = banner.Offset;
+                }
+            }
+        }
+
+        // 3. Snapshot files + drain each via LogSourceTailer, using
+        //    `ChatLogClock` instances all pre-seeded with the canonical
+        //    session offset (when known). Per-file clock instances keep
+        //    `_lastEmitted` tailer-local — only `_bannerOffset` is shared
+        //    state, and it's seeded once + immutable for the seed path
+        //    (subsequent banners would re-anchor, which is the intended
+        //    PG-re-login behaviour and unchanged from prior semantics).
+        var tailers = new List<(string Path, LogSourceTailer Tailer, List<RawLogLine> Lines)>();
+        foreach (var (path, _) in fileRawLines)
+        {
+            try
+            {
+                var clock = new ChatLogClock(_time, _fallbackTz, sessionOffset);
+                var tailer = new LogSourceTailer(path, clock, _time);
                 var lines = new List<RawLogLine>();
-                // ReadNew may return in batches (the file is small enough that
-                // a single call gets it all, but the contract is no-guarantee;
-                // loop until empty to be safe).
                 while (true)
                 {
                     var batch = tailer.ReadNew();
@@ -89,23 +163,16 @@ public sealed class ChatLogReplaySource : IChatLogReplaySource
             }
         }
 
-        // 2. Find globally most-recent banner.
+        // 4. Compute the cross-source replay cutoff in UTC terms. The
+        //    cutoff banner's local timestamp folded by the session offset
+        //    is the UTC instant downstream events are compared against.
         DateTimeOffset? bannerCutoff = null;
-        foreach (var (_, _, lines) in tailers)
+        if (bannerCutoffLocal is { } cutoffLocal && sessionOffset is { } off)
         {
-            foreach (var l in lines)
-            {
-                if (ChatLoginBannerParser.TryParse(l.Line, out _))
-                {
-                    if (bannerCutoff is null || l.Timestamp > bannerCutoff)
-                    {
-                        bannerCutoff = l.Timestamp;
-                    }
-                }
-            }
+            bannerCutoff = new DateTimeOffset(cutoffLocal, off);
         }
 
-        // 3. Replay phase — yield lines at-or-after the cutoff, merged across
+        // 5. Replay phase — yield lines at-or-after the cutoff, merged across
         //    files by timestamp. If no banner, replay is empty (matches the
         //    legacy "skip what's already there" seed behaviour for pre-banner
         //    cold attaches).
@@ -136,7 +203,7 @@ public sealed class ChatLogReplaySource : IChatLogReplaySource
                 $"No banner across {tailers.Count} file(s); skipping replay phase.");
         }
 
-        // 4. Live phase — poll the same tailers. They've already advanced their
+        // 6. Live phase — poll the same tailers. They've already advanced their
         //    offsets past the replay batch, so ReadNew() now returns appended
         //    content only.
         var pollInterval = TimeSpan.FromSeconds(Math.Max(0.25, _config.PollIntervalSeconds));

--- a/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogReplaySourceTests.cs
+++ b/tests/Mithril.WorldSim.Chat.Tests/Producers/ChatLogReplaySourceTests.cs
@@ -204,6 +204,90 @@ public sealed class ChatLogReplaySourceTests : IDisposable
         replayLines[4].Should().Contain("a-at-5");
     }
 
+    // ── #639: session-shared clock offset across files ────────────────
+
+    [Fact]
+    public async Task Session_banner_offset_applies_to_files_without_a_banner_of_their_own()
+    {
+        // Cross-machine replay: chat written on UTC-7 (alt machine), replayed
+        // on a UTC+1 host. The banner is in file A; file B is a channel that
+        // only carries post-banner content (no banner of its own). Without
+        // a shared session-canonical offset (#639), file B's clock would
+        // fall through to the host's fallback TZ (UTC+1 here) and mis-stamp
+        // every B-line by 8 hours. Test asserts B's lines fold via the
+        // banner's UTC-7 offset, not the UTC+1 fallback.
+        Write("chat-A.log",
+            "26-05-19 09:36:04\t**** Logged In As Praxi. Server Laeth. Timezone Offset -07:00:00.\n" +
+            "26-05-19 09:36:05\t[Status] a-after-banner\n");
+        Write("chat-B.log",
+            "26-05-19 09:36:06\t[General] b-after-banner\n" +
+            "26-05-19 09:36:07\t[General] b-also-after-banner\n");
+
+        var replayHostTz = FixedOffsetZone(TimeSpan.FromHours(1));
+        var source = new ChatLogReplaySource(Config(), fallbackTz: replayHostTz);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(750));
+
+        var envelopes = await CollectAsync(source, cts.Token);
+        var replayLines = envelopes.Where(e => e.IsReplay).ToList();
+
+        // All replayed lines (from both files) must carry the banner's
+        // UTC-7 offset — the canonical session offset.
+        replayLines.Should().NotBeEmpty();
+        replayLines.Should().AllSatisfy(e =>
+            e.Payload.Timestamp.Offset.Should().Be(TimeSpan.FromHours(-7),
+                $"every chat line in the session folds via the banner offset, not the host fallback TZ; got {e.Payload.Line}"));
+
+        // The B-file lines are 09:36:06 local; folded via UTC-7 ⇒ 16:36:06 UTC.
+        // (Mis-folding via the UTC+1 host TZ would give 08:36:06 UTC — 8h off.)
+        var bLine = replayLines.Single(e => e.Payload.Line.Contains("b-after-banner"));
+        bLine.Payload.Timestamp.UtcDateTime
+            .Should().Be(new DateTime(2026, 5, 19, 16, 36, 6, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Replay_envelopes_are_deterministic_across_runs_for_identical_input()
+    {
+        // Principle 9: identical input directories produce identical event
+        // streams. Pre-#639, a chat file without a banner stamped via the
+        // host TZ — replay determinism was conditional on the host. With
+        // the session-shared offset, the input directory fully determines
+        // the output timestamps.
+        Write("chat-A.log",
+            "26-05-19 09:36:04\t**** Logged In As Praxi. Server Laeth. Timezone Offset -07:00:00.\n" +
+            "26-05-19 09:36:05\t[Status] a-line\n");
+        Write("chat-B.log",
+            "26-05-19 09:36:06\t[General] b-line\n");
+
+        var hostTz = FixedOffsetZone(TimeSpan.FromHours(1));
+
+        var run1 = await RunReplay(hostTz);
+        var run2 = await RunReplay(hostTz);
+
+        var seq1 = run1.Where(e => e.IsReplay)
+            .Select(e => (e.Payload.Line, e.Payload.Timestamp.UtcDateTime, e.Payload.Timestamp.Offset))
+            .ToList();
+        var seq2 = run2.Where(e => e.IsReplay)
+            .Select(e => (e.Payload.Line, e.Payload.Timestamp.UtcDateTime, e.Payload.Timestamp.Offset))
+            .ToList();
+
+        seq2.Should().BeEquivalentTo(seq1, opts => opts.WithStrictOrdering());
+
+        async Task<List<LogEnvelope<RawLogLine>>> RunReplay(TimeZoneInfo tz)
+        {
+            var src = new ChatLogReplaySource(Config(), fallbackTz: tz);
+            using var c = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+            return await CollectAsync(src, c.Token);
+        }
+    }
+
+    private static TimeZoneInfo FixedOffsetZone(TimeSpan offset)
+    {
+        // CreateCustomTimeZone returns a fresh instance per call, so the id
+        // only needs to be human-readable, not globally unique.
+        var id = $"FixedOffsetTestZone_{offset.Ticks}";
+        return TimeZoneInfo.CreateCustomTimeZone(id, offset, id, id);
+    }
+
     private static async Task<List<LogEnvelope<RawLogLine>>> CollectAsync(
         IChatLogReplaySource source, CancellationToken ct)
     {


### PR DESCRIPTION
## Summary

`ChatLogReplaySource` now pre-scans every chat file in the directory at attach to find the globally-most-recent login banner, captures that banner's signed `Timezone Offset`, and pre-seeds every per-file `ChatLogClock` instance with it. All per-file tailers in the session fold their local-date prefixes via the same canonical session offset — including files that don't themselves carry a banner.

## Why

Before this change, a chat file without its own banner fell through to the host's fallback `TimeZoneInfo`. In the cross-machine replay case (chat written on UTC-7, replayed on a UTC+1 host) every no-banner file would mis-stamp its lines by 8 hours, breaking cross-source agreement with Player.log timestamps. This must land before any non-chat-internal consumer fuses chat + Player.log per `docs/cross-source-correlation.md` — i.e. before #602 (chat folder ingestion) or #603 (multi-character chat sessions) is consumed downstream.

## Design notes

- The session-canonical offset is a *seed* on each per-file `ChatLogClock`, not a shared instance. Each per-file clock still owns its own `_lastEmitted` field, so an unprefixed leading line in file B doesn't inherit file A's stamp — only `_bannerOffset` is shared state.
- A new optional `seededBannerOffset` constructor parameter on `ChatLogClock` carries the seed; default-null preserves existing call sites (`ChatLogTailReader` is unchanged).
- The pre-scan extracts the banner offset via `ChatLoginBannerParser.TryParse` and `ChatLogClock.TryParseLocalDatePrefix` on the raw text, then re-stamps in a second pass through `LogSourceTailer`. Bound: the canonical session offset is established before any line is stamped, rather than relying on each file's own first banner.
- The fix-sketch step 4 in the issue ("mid-session banner-mismatch warn-and-discard") is deferred — current behaviour re-anchors on a subsequent banner, matching the chat-clock's pre-#639 semantics for PG re-login. The class XML doc explicitly flags this.

## Test plan

- [x] New `Session_banner_offset_applies_to_files_without_a_banner_of_their_own` — two-file session with a UTC-7 banner in file A; verifies file B's lines stamp to UTC-7, not the UTC+1 host fallback. Pre-#639 would mis-stamp by 8h.
- [x] New `Replay_envelopes_are_deterministic_across_runs_for_identical_input` — principle 9 guard. Two runs against the same directory produce bit-identical (line, UTC, offset) sequences.
- [x] All 9 existing `ChatLogReplaySourceTests` still pass (unchanged behaviour for single-file / host-machine cases).
- [x] All 7 existing `ChatLogClockTests` still pass (the new ctor parameter is opt-in).
- [x] Full `dotnet test Mithril.slnx` clean.

## Out of scope

- Cross-source merge with Player.log — consumer's responsibility per the cross-source-correlation tier doc.
- Mid-session banner-mismatch warn-and-discard (issue's fix-sketch step 4). Current re-anchor-on-new-banner behaviour is unchanged.
- FileSystemWatcher-driven new-file pickup (existing Phase 0 limit).

Closes #639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
